### PR TITLE
chore: add CI, licenses, and CLAUDE.md for OSS setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo fmt --check
+      - run: cargo clippy -- -D warnings
+
+  test:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: amd64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+          - os: macos-13
+            arch: amd64
+          - os: macos-latest
+            arch: arm64
+          - os: windows-latest
+            arch: amd64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,6 @@ jobs:
             arch: amd64
           - os: ubuntu-24.04-arm
             arch: arm64
-          - os: macos-13
-            arch: amd64
           - os: macos-latest
             arch: arm64
           - os: windows-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Fulgur is an HTML/CSS to PDF conversion library and CLI tool written in Rust. It uses Blitz for HTML parsing/layout, Krilla for PDF generation, and Taffy/Parley for layout/text shaping.
+
+## Common Commands
+
+```bash
+# Build
+cargo build
+cargo build --release
+
+# Test (unit tests are in paginate.rs)
+cargo test --lib
+cargo test -p fulgur-core
+
+# Lint
+cargo clippy
+cargo fmt --check
+
+# Run CLI
+cargo run --bin fulgur -- render input.html -o output.pdf
+cargo run --bin fulgur -- render input.html --size A4 --landscape -o output.pdf
+```
+
+## Architecture
+
+The processing pipeline flows:
+
+```
+HTML string → Blitz (parse/style/layout) → Pageable tree → Page splitting → Krilla PDF
+```
+
+### Workspace Structure
+
+- `crates/fulgur-core/` — Library crate with the conversion engine
+- `crates/fulgur-cli/` — CLI binary using clap
+
+### Key Modules (fulgur-core)
+
+- **engine.rs** — `Engine` builder: configures and executes `render_html()` / `render_pageable()`
+- **blitz_adapter.rs** — Thin adapter isolating Blitz API changes from the rest of the codebase
+- **convert.rs** — Transforms Blitz DOM nodes into `Pageable` trait objects
+- **pageable.rs** — Core `Pageable` trait with `wrap()` (measure), `split()` (page break), `draw()` (render). Concrete types: `BlockPageable`, `ParagraphPageable`, `SpacerPageable`, `ImagePageable`
+- **paginate.rs** — Page splitting algorithm that walks the Pageable tree
+- **render.rs** — Draws paginated fragments onto Krilla surfaces
+- **config.rs** — Page size, margins, orientation, metadata
+- **asset.rs** — `AssetBundle` manages CSS, fonts, and images (offline-first, all assets explicitly registered)
+- **paragraph.rs** — Text line layout and drawing
+
+### Design Principles
+
+- **Offline-first**: No network access; all assets must be explicitly bundled
+- **Deterministic**: Same input always produces same output
+- **Hybrid layout**: Taffy pre-computes sizes, Pageable reuses them during pagination (no re-layout after splitting)
+- **Adapter isolation**: Blitz API surface is contained in `blitz_adapter.rs`

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,199 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to the Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by the Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding any notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. Please also get an
+   OpenSSL-style exception clause if needed.
+
+   Copyright 2026 Mitsuru Takigahira
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mitsuru Takigahira
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/fulgur-cli/Cargo.toml
+++ b/crates/fulgur-cli/Cargo.toml
@@ -2,6 +2,9 @@
 name = "fulgur-cli"
 version = "0.1.0"
 edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "HTML/CSS to PDF conversion CLI"
+repository = "https://github.com/mitsuru/fulgur"
 
 [[bin]]
 name = "fulgur"

--- a/crates/fulgur-cli/src/main.rs
+++ b/crates/fulgur-cli/src/main.rs
@@ -65,18 +65,26 @@ fn main() {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Render { input, stdin, output, size, landscape, title, fonts, css_files } => {
+        Commands::Render {
+            input,
+            stdin,
+            output,
+            size,
+            landscape,
+            title,
+            fonts,
+            css_files,
+        } => {
             let html = if stdin {
                 let mut buf = String::new();
                 std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
                     .expect("Failed to read stdin");
                 buf
             } else if let Some(input) = input {
-                std::fs::read_to_string(&input)
-                    .unwrap_or_else(|e| {
-                        eprintln!("Error reading {}: {e}", input.display());
-                        std::process::exit(1);
-                    })
+                std::fs::read_to_string(&input).unwrap_or_else(|e| {
+                    eprintln!("Error reading {}: {e}", input.display());
+                    std::process::exit(1);
+                })
             } else {
                 eprintln!("Error: provide an input HTML file or use --stdin");
                 std::process::exit(1);

--- a/crates/fulgur-core/Cargo.toml
+++ b/crates/fulgur-core/Cargo.toml
@@ -2,6 +2,9 @@
 name = "fulgur-core"
 version = "0.1.0"
 edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "HTML/CSS to PDF conversion library"
+repository = "https://github.com/mitsuru/fulgur"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/fulgur-core/src/asset.rs
+++ b/crates/fulgur-core/src/asset.rs
@@ -41,7 +41,11 @@ impl AssetBundle {
         self.images.insert(name.into(), Arc::new(data));
     }
 
-    pub fn add_image_file(&mut self, name: impl Into<String>, path: impl AsRef<Path>) -> Result<()> {
+    pub fn add_image_file(
+        &mut self,
+        name: impl Into<String>,
+        path: impl AsRef<Path>,
+    ) -> Result<()> {
         let data = std::fs::read(path)?;
         self.images.insert(name.into(), Arc::new(data));
         Ok(())

--- a/crates/fulgur-core/src/blitz_adapter.rs
+++ b/crates/fulgur-core/src/blitz_adapter.rs
@@ -27,7 +27,9 @@ fn suppress_stdout<F: FnOnce() -> T, T>(f: F) -> T {
         let saved_fd = devnull.as_ref().map(|_| {
             // dup(1) to save original stdout
             let saved = unsafe { libc::dup(1) };
-            if saved < 0 { return -1; }
+            if saved < 0 {
+                return -1;
+            }
             // dup2(devnull_fd, 1) to redirect stdout
             if let Some(ref dn) = devnull {
                 unsafe { libc::dup2(dn.as_raw_fd(), 1) };

--- a/crates/fulgur-core/src/config.rs
+++ b/crates/fulgur-core/src/config.rs
@@ -6,9 +6,18 @@ pub struct PageSize {
 }
 
 impl PageSize {
-    pub const A4: Self = Self { width: 595.28, height: 841.89 };
-    pub const LETTER: Self = Self { width: 612.0, height: 792.0 };
-    pub const A3: Self = Self { width: 841.89, height: 1190.55 };
+    pub const A4: Self = Self {
+        width: 595.28,
+        height: 841.89,
+    };
+    pub const LETTER: Self = Self {
+        width: 612.0,
+        height: 792.0,
+    };
+    pub const A3: Self = Self {
+        width: 841.89,
+        height: 1190.55,
+    };
 
     pub fn custom(width_mm: f32, height_mm: f32) -> Self {
         Self {
@@ -36,11 +45,21 @@ pub struct Margin {
 
 impl Margin {
     pub fn uniform(pt: f32) -> Self {
-        Self { top: pt, right: pt, bottom: pt, left: pt }
+        Self {
+            top: pt,
+            right: pt,
+            bottom: pt,
+            left: pt,
+        }
     }
 
     pub fn symmetric(vertical: f32, horizontal: f32) -> Self {
-        Self { top: vertical, right: horizontal, bottom: vertical, left: horizontal }
+        Self {
+            top: vertical,
+            right: horizontal,
+            bottom: vertical,
+            left: horizontal,
+        }
     }
 
     pub fn uniform_mm(mm: f32) -> Self {
@@ -89,13 +108,21 @@ impl Config {
 
     /// Content area width (page width minus left and right margins)
     pub fn content_width(&self) -> f32 {
-        let ps = if self.landscape { self.page_size.landscape() } else { self.page_size };
+        let ps = if self.landscape {
+            self.page_size.landscape()
+        } else {
+            self.page_size
+        };
         ps.width - self.margin.left - self.margin.right
     }
 
     /// Content area height (page height minus top and bottom margins)
     pub fn content_height(&self) -> f32 {
-        let ps = if self.landscape { self.page_size.landscape() } else { self.page_size };
+        let ps = if self.landscape {
+            self.page_size.landscape()
+        } else {
+            self.page_size
+        };
         ps.height - self.margin.top - self.margin.bottom
     }
 }

--- a/crates/fulgur-core/src/convert.rs
+++ b/crates/fulgur-core/src/convert.rs
@@ -53,22 +53,21 @@ fn convert_node(doc: &blitz_dom::BaseDocument, node_id: usize) -> Box<dyn Pageab
     if node.flags.is_inline_root()
         && let Some(paragraph) = extract_paragraph(doc, node)
     {
-            // Wrap in a BlockPageable to apply background/border/padding styles
-            let style = extract_block_style(node);
-            let has_style = style.background_color.is_some()
-                || style.border_widths.iter().any(|&w| w > 0.0)
-                || style.padding.iter().any(|&p| p > 0.0);
-            if has_style {
-                let child = PositionedChild {
-                    child: Box::new(paragraph),
-                    x: 0.0,
-                    y: 0.0,
-                };
-                let mut block =
-                    BlockPageable::with_positioned_children(vec![child]).with_style(style);
-                block.wrap(width, height);
-                return Box::new(block);
-            }
+        // Wrap in a BlockPageable to apply background/border/padding styles
+        let style = extract_block_style(node);
+        let has_style = style.background_color.is_some()
+            || style.border_widths.iter().any(|&w| w > 0.0)
+            || style.padding.iter().any(|&p| p > 0.0);
+        if has_style {
+            let child = PositionedChild {
+                child: Box::new(paragraph),
+                x: 0.0,
+                y: 0.0,
+            };
+            let mut block = BlockPageable::with_positioned_children(vec![child]).with_style(style);
+            block.wrap(width, height);
+            return Box::new(block);
+        }
         return Box::new(paragraph);
     }
 
@@ -274,11 +273,11 @@ fn get_text_color(doc: &blitz_dom::BaseDocument, node_id: usize) -> [u8; 4] {
     if let Some(node) = doc.get_node(node_id)
         && let Some(styles) = node.primary_styles()
     {
-            let color = styles.clone_color();
-            let r = (color.components.0.clamp(0.0, 1.0) * 255.0) as u8;
-            let g = (color.components.1.clamp(0.0, 1.0) * 255.0) as u8;
-            let b = (color.components.2.clamp(0.0, 1.0) * 255.0) as u8;
-            let a = (color.alpha.clamp(0.0, 1.0) * 255.0) as u8;
+        let color = styles.clone_color();
+        let r = (color.components.0.clamp(0.0, 1.0) * 255.0) as u8;
+        let g = (color.components.1.clamp(0.0, 1.0) * 255.0) as u8;
+        let b = (color.components.2.clamp(0.0, 1.0) * 255.0) as u8;
+        let a = (color.alpha.clamp(0.0, 1.0) * 255.0) as u8;
         return [r, g, b, a];
     }
     [0, 0, 0, 255] // Default: black

--- a/crates/fulgur-core/src/convert.rs
+++ b/crates/fulgur-core/src/convert.rs
@@ -50,8 +50,9 @@ fn convert_node(doc: &blitz_dom::BaseDocument, node_id: usize) -> Box<dyn Pageab
     let width = layout.size.width;
 
     // Check if this is an inline root (contains text layout)
-    if node.flags.is_inline_root() {
-        if let Some(paragraph) = extract_paragraph(doc, node) {
+    if node.flags.is_inline_root()
+        && let Some(paragraph) = extract_paragraph(doc, node)
+    {
             // Wrap in a BlockPageable to apply background/border/padding styles
             let style = extract_block_style(node);
             let has_style = style.background_color.is_some()
@@ -68,8 +69,7 @@ fn convert_node(doc: &blitz_dom::BaseDocument, node_id: usize) -> Box<dyn Pageab
                 block.wrap(width, height);
                 return Box::new(block);
             }
-            return Box::new(paragraph);
-        }
+        return Box::new(paragraph);
     }
 
     let children: &[usize] = &node.children;
@@ -211,21 +211,21 @@ fn extract_paragraph(doc: &blitz_dom::BaseDocument, node: &Node) -> Option<Parag
 /// Extract visual style (background, borders, padding) from a node.
 fn extract_block_style(node: &Node) -> BlockStyle {
     let layout = node.final_layout;
-    let mut style = BlockStyle::default();
-
-    // Read border widths and padding from Taffy layout
-    style.border_widths = [
-        layout.border.top,
-        layout.border.right,
-        layout.border.bottom,
-        layout.border.left,
-    ];
-    style.padding = [
-        layout.padding.top,
-        layout.padding.right,
-        layout.padding.bottom,
-        layout.padding.left,
-    ];
+    let mut style = BlockStyle {
+        border_widths: [
+            layout.border.top,
+            layout.border.right,
+            layout.border.bottom,
+            layout.border.left,
+        ],
+        padding: [
+            layout.padding.top,
+            layout.padding.right,
+            layout.padding.bottom,
+            layout.padding.left,
+        ],
+        ..Default::default()
+    };
 
     // Extract colors from computed styles
     if let Some(styles) = node.primary_styles() {
@@ -271,15 +271,15 @@ fn is_non_visual_element(node: &Node) -> bool {
 
 /// Get text color from a DOM node's computed styles.
 fn get_text_color(doc: &blitz_dom::BaseDocument, node_id: usize) -> [u8; 4] {
-    if let Some(node) = doc.get_node(node_id) {
-        if let Some(styles) = node.primary_styles() {
+    if let Some(node) = doc.get_node(node_id)
+        && let Some(styles) = node.primary_styles()
+    {
             let color = styles.clone_color();
             let r = (color.components.0.clamp(0.0, 1.0) * 255.0) as u8;
             let g = (color.components.1.clamp(0.0, 1.0) * 255.0) as u8;
             let b = (color.components.2.clamp(0.0, 1.0) * 255.0) as u8;
             let a = (color.alpha.clamp(0.0, 1.0) * 255.0) as u8;
-            return [r, g, b, a];
-        }
+        return [r, g, b, a];
     }
     [0, 0, 0, 255] // Default: black
 }

--- a/crates/fulgur-core/src/convert.rs
+++ b/crates/fulgur-core/src/convert.rs
@@ -18,7 +18,9 @@ pub fn dom_to_pageable(doc: &HtmlDocument) -> Box<dyn Pageable> {
 }
 
 fn debug_print_tree(doc: &blitz_dom::BaseDocument, node_id: usize, depth: usize) {
-    let Some(node) = doc.get_node(node_id) else { return };
+    let Some(node) = doc.get_node(node_id) else {
+        return;
+    };
     let layout = node.final_layout;
     let indent = "  ".repeat(depth);
     let tag = match &node.data {
@@ -27,9 +29,15 @@ fn debug_print_tree(doc: &blitz_dom::BaseDocument, node_id: usize, depth: usize)
         NodeData::Comment => "#comment".to_string(),
         _ => "#other".to_string(),
     };
-    eprintln!("{indent}{tag} id={} pos=({},{}) size={}x{} inline_root={}",
-        node_id, layout.location.x, layout.location.y,
-        layout.size.width, layout.size.height, node.flags.is_inline_root());
+    eprintln!(
+        "{indent}{tag} id={} pos=({},{}) size={}x{} inline_root={}",
+        node_id,
+        layout.location.x,
+        layout.location.y,
+        layout.size.width,
+        layout.size.height,
+        node.flags.is_inline_root()
+    );
     for &child_id in &node.children {
         debug_print_tree(doc, child_id, depth + 1);
     }
@@ -50,8 +58,13 @@ fn convert_node(doc: &blitz_dom::BaseDocument, node_id: usize) -> Box<dyn Pageab
                 || style.border_widths.iter().any(|&w| w > 0.0)
                 || style.padding.iter().any(|&p| p > 0.0);
             if has_style {
-                let child = PositionedChild { child: Box::new(paragraph), x: 0.0, y: 0.0 };
-                let mut block = BlockPageable::with_positioned_children(vec![child]).with_style(style);
+                let child = PositionedChild {
+                    child: Box::new(paragraph),
+                    x: 0.0,
+                    y: 0.0,
+                };
+                let mut block =
+                    BlockPageable::with_positioned_children(vec![child]).with_style(style);
                 block.wrap(width, height);
                 return Box::new(block);
             }
@@ -85,7 +98,9 @@ fn collect_positioned_children(
 ) -> Vec<PositionedChild> {
     let mut result = Vec::new();
     for &child_id in child_ids {
-        let Some(child_node) = doc.get_node(child_id) else { continue };
+        let Some(child_node) = doc.get_node(child_id) else {
+            continue;
+        };
 
         if matches!(&child_node.data, NodeData::Comment) {
             continue;
@@ -97,14 +112,16 @@ fn collect_positioned_children(
         let child_layout = child_node.final_layout;
 
         // Zero-size leaf nodes (whitespace text, etc.) — skip
-        if child_layout.size.height == 0.0 && child_layout.size.width == 0.0
+        if child_layout.size.height == 0.0
+            && child_layout.size.width == 0.0
             && child_node.children.is_empty()
         {
             continue;
         }
 
         // Zero-size container (thead, tbody, tr, etc.) — flatten children into parent
-        if child_layout.size.height == 0.0 && child_layout.size.width == 0.0
+        if child_layout.size.height == 0.0
+            && child_layout.size.width == 0.0
             && !child_node.children.is_empty()
         {
             let nested = collect_positioned_children(doc, &child_node.children);
@@ -243,7 +260,10 @@ fn extract_block_style(node: &Node) -> BlockStyle {
 fn is_non_visual_element(node: &Node) -> bool {
     if let Some(elem) = node.element_data() {
         let tag = elem.name.local.as_ref();
-        matches!(tag, "head" | "script" | "style" | "link" | "meta" | "title" | "noscript")
+        matches!(
+            tag,
+            "head" | "script" | "style" | "link" | "meta" | "title" | "noscript"
+        )
     } else {
         false
     }

--- a/crates/fulgur-core/src/engine.rs
+++ b/crates/fulgur-core/src/engine.rs
@@ -54,7 +54,9 @@ impl Engine {
             html.to_string()
         };
 
-        let fonts = self.assets.as_ref()
+        let fonts = self
+            .assets
+            .as_ref()
             .map(|a| a.fonts.as_slice())
             .unwrap_or(&[]);
         let doc = crate::blitz_adapter::parse_and_layout(
@@ -68,11 +70,7 @@ impl Engine {
     }
 
     /// Render HTML string to a PDF file.
-    pub fn render_html_to_file(
-        &self,
-        html: &str,
-        path: impl AsRef<Path>,
-    ) -> Result<()> {
+    pub fn render_html_to_file(&self, html: &str, path: impl AsRef<Path>) -> Result<()> {
         let pdf = self.render_html(html)?;
         std::fs::write(path, pdf)?;
         Ok(())

--- a/crates/fulgur-core/src/image.rs
+++ b/crates/fulgur-core/src/image.rs
@@ -62,14 +62,7 @@ impl Pageable for ImagePageable {
         None
     }
 
-    fn draw(
-        &self,
-        canvas: &mut Canvas<'_, '_>,
-        x: Pt,
-        y: Pt,
-        _avail_width: Pt,
-        _avail_height: Pt,
-    ) {
+    fn draw(&self, canvas: &mut Canvas<'_, '_>, x: Pt, y: Pt, _avail_width: Pt, _avail_height: Pt) {
         let data: krilla::Data = Arc::clone(&self.image_data).into();
         let image_result = match self.format {
             ImageFormat::Png => krilla::image::Image::from_png(data, true),

--- a/crates/fulgur-core/src/pageable.rs
+++ b/crates/fulgur-core/src/pageable.rs
@@ -235,28 +235,28 @@ impl Pageable for BlockPageable {
             if child_avail > 0.0
                 && let Some((first_part, second_part)) = pc.child.split(0.0, child_avail)
             {
-                    let first = vec![PositionedChild {
-                        child: first_part,
-                        x: pc.x,
-                        y: pc.y,
-                    }];
-                    let second = vec![PositionedChild {
-                        child: second_part,
-                        x: pc.x,
-                        y: 0.0,
-                    }];
-                    return Some((
-                        Box::new(
-                            BlockPageable::with_positioned_children(first)
-                                .with_pagination(self.pagination)
-                                .with_style(self.style.clone()),
-                        ),
-                        Box::new(
-                            BlockPageable::with_positioned_children(second)
-                                .with_pagination(self.pagination)
-                                .with_style(self.style.clone()),
-                        ),
-                    ));
+                let first = vec![PositionedChild {
+                    child: first_part,
+                    x: pc.x,
+                    y: pc.y,
+                }];
+                let second = vec![PositionedChild {
+                    child: second_part,
+                    x: pc.x,
+                    y: 0.0,
+                }];
+                return Some((
+                    Box::new(
+                        BlockPageable::with_positioned_children(first)
+                            .with_pagination(self.pagination)
+                            .with_style(self.style.clone()),
+                    ),
+                    Box::new(
+                        BlockPageable::with_positioned_children(second)
+                            .with_pagination(self.pagination)
+                            .with_style(self.style.clone()),
+                    ),
+                ));
             }
             return None;
         }

--- a/crates/fulgur-core/src/pageable.rs
+++ b/crates/fulgur-core/src/pageable.rs
@@ -232,8 +232,9 @@ impl Pageable for BlockPageable {
         if let Some(idx) = overflow_child_index {
             let pc = &self.children[idx];
             let child_avail = avail_height - pc.y;
-            if child_avail > 0.0 {
-                if let Some((first_part, second_part)) = pc.child.split(0.0, child_avail) {
+            if child_avail > 0.0
+                && let Some((first_part, second_part)) = pc.child.split(0.0, child_avail)
+            {
                     let first = vec![PositionedChild {
                         child: first_part,
                         x: pc.x,
@@ -256,7 +257,6 @@ impl Pageable for BlockPageable {
                                 .with_style(self.style.clone()),
                         ),
                     ));
-                }
             }
             return None;
         }
@@ -302,20 +302,20 @@ impl Pageable for BlockPageable {
         let total_height = self.cached_size.map(|s| s.height).unwrap_or(avail_height);
 
         // Draw background
-        if let Some(bg) = &self.style.background_color {
-            if let Some(rect) = krilla::geom::Rect::from_xywh(x, y, avail_width, total_height) {
-                let mut pb = krilla::geom::PathBuilder::new();
-                pb.push_rect(rect);
-                if let Some(path) = pb.finish() {
-                    canvas.surface.set_fill(Some(krilla::paint::Fill {
-                        paint: krilla::color::rgb::Color::new(bg[0], bg[1], bg[2]).into(),
-                        opacity: krilla::num::NormalizedF32::new(bg[3] as f32 / 255.0)
-                            .unwrap_or(krilla::num::NormalizedF32::ONE),
-                        rule: Default::default(),
-                    }));
-                    canvas.surface.set_stroke(None);
-                    canvas.surface.draw_path(&path);
-                }
+        if let Some(bg) = &self.style.background_color
+            && let Some(rect) = krilla::geom::Rect::from_xywh(x, y, avail_width, total_height)
+        {
+            let mut pb = krilla::geom::PathBuilder::new();
+            pb.push_rect(rect);
+            if let Some(path) = pb.finish() {
+                canvas.surface.set_fill(Some(krilla::paint::Fill {
+                    paint: krilla::color::rgb::Color::new(bg[0], bg[1], bg[2]).into(),
+                    opacity: krilla::num::NormalizedF32::new(bg[3] as f32 / 255.0)
+                        .unwrap_or(krilla::num::NormalizedF32::ONE),
+                    rule: Default::default(),
+                }));
+                canvas.surface.set_stroke(None);
+                canvas.surface.draw_path(&path);
             }
         }
 

--- a/crates/fulgur-core/src/pageable.rs
+++ b/crates/fulgur-core/src/pageable.rs
@@ -59,8 +59,11 @@ pub trait Pageable: Send + Sync {
 
     /// Split at page boundary. Returns None if element fits entirely
     /// or cannot be split.
-    fn split(&self, avail_width: Pt, avail_height: Pt)
-        -> Option<(Box<dyn Pageable>, Box<dyn Pageable>)>;
+    fn split(
+        &self,
+        avail_width: Pt,
+        avail_height: Pt,
+    ) -> Option<(Box<dyn Pageable>, Box<dyn Pageable>)>;
 
     /// Emit drawing commands.
     fn draw(&self, canvas: &mut Canvas<'_, '_>, x: Pt, y: Pt, avail_width: Pt, avail_height: Pt);
@@ -124,11 +127,18 @@ impl BlockPageable {
     pub fn new(children: Vec<Box<dyn Pageable>>) -> Self {
         // Legacy constructor: stack children vertically
         let mut y = 0.0;
-        let positioned: Vec<PositionedChild> = children.into_iter().map(|child| {
-            let child_y = y;
-            y += child.height();
-            PositionedChild { child, x: 0.0, y: child_y }
-        }).collect();
+        let positioned: Vec<PositionedChild> = children
+            .into_iter()
+            .map(|child| {
+                let child_y = y;
+                y += child.height();
+                PositionedChild {
+                    child,
+                    x: 0.0,
+                    y: child_y,
+                }
+            })
+            .collect();
         Self {
             children: positioned,
             pagination: Pagination::default(),
@@ -164,21 +174,27 @@ impl Pageable for BlockPageable {
             let child_h = pc.child.height();
             max_h.max(pc.y + child_h)
         });
-        let size = Size { width: avail_width, height: total_height };
+        let size = Size {
+            width: avail_width,
+            height: total_height,
+        };
         self.cached_size = Some(size);
         size
     }
 
-    fn split(&self, _avail_width: Pt, avail_height: Pt)
-        -> Option<(Box<dyn Pageable>, Box<dyn Pageable>)>
-    {
+    fn split(
+        &self,
+        _avail_width: Pt,
+        avail_height: Pt,
+    ) -> Option<(Box<dyn Pageable>, Box<dyn Pageable>)> {
         if self.pagination.break_inside == BreakInside::Avoid {
             return None;
         }
 
         let has_forced_break = self.children.iter().enumerate().any(|(i, pc)| {
             (pc.child.pagination().break_before == BreakBefore::Page && i > 0)
-                || (pc.child.pagination().break_after == BreakAfter::Page && i < self.children.len() - 1)
+                || (pc.child.pagination().break_after == BreakAfter::Page
+                    && i < self.children.len() - 1)
         });
 
         let total_height = self.cached_size.map(|s| s.height).unwrap_or(0.0);
@@ -218,11 +234,27 @@ impl Pageable for BlockPageable {
             let child_avail = avail_height - pc.y;
             if child_avail > 0.0 {
                 if let Some((first_part, second_part)) = pc.child.split(0.0, child_avail) {
-                    let first = vec![PositionedChild { child: first_part, x: pc.x, y: pc.y }];
-                    let second = vec![PositionedChild { child: second_part, x: pc.x, y: 0.0 }];
+                    let first = vec![PositionedChild {
+                        child: first_part,
+                        x: pc.x,
+                        y: pc.y,
+                    }];
+                    let second = vec![PositionedChild {
+                        child: second_part,
+                        x: pc.x,
+                        y: 0.0,
+                    }];
                     return Some((
-                        Box::new(BlockPageable::with_positioned_children(first).with_pagination(self.pagination).with_style(self.style.clone())),
-                        Box::new(BlockPageable::with_positioned_children(second).with_pagination(self.pagination).with_style(self.style.clone())),
+                        Box::new(
+                            BlockPageable::with_positioned_children(first)
+                                .with_pagination(self.pagination)
+                                .with_style(self.style.clone()),
+                        ),
+                        Box::new(
+                            BlockPageable::with_positioned_children(second)
+                                .with_pagination(self.pagination)
+                                .with_style(self.style.clone()),
+                        ),
                     ));
                 }
             }
@@ -235,16 +267,34 @@ impl Pageable for BlockPageable {
 
         let split_y = self.children[split_index].y;
 
-        let first: Vec<PositionedChild> = self.children[..split_index].iter()
-            .map(|pc| PositionedChild { child: pc.child.clone_box(), x: pc.x, y: pc.y })
+        let first: Vec<PositionedChild> = self.children[..split_index]
+            .iter()
+            .map(|pc| PositionedChild {
+                child: pc.child.clone_box(),
+                x: pc.x,
+                y: pc.y,
+            })
             .collect();
-        let second: Vec<PositionedChild> = self.children[split_index..].iter()
-            .map(|pc| PositionedChild { child: pc.child.clone_box(), x: pc.x, y: pc.y - split_y })
+        let second: Vec<PositionedChild> = self.children[split_index..]
+            .iter()
+            .map(|pc| PositionedChild {
+                child: pc.child.clone_box(),
+                x: pc.x,
+                y: pc.y - split_y,
+            })
             .collect();
 
         Some((
-            Box::new(BlockPageable::with_positioned_children(first).with_pagination(self.pagination).with_style(self.style.clone())),
-            Box::new(BlockPageable::with_positioned_children(second).with_pagination(self.pagination).with_style(self.style.clone())),
+            Box::new(
+                BlockPageable::with_positioned_children(first)
+                    .with_pagination(self.pagination)
+                    .with_style(self.style.clone()),
+            ),
+            Box::new(
+                BlockPageable::with_positioned_children(second)
+                    .with_pagination(self.pagination)
+                    .with_style(self.style.clone()),
+            ),
         ))
     }
 
@@ -283,39 +333,60 @@ impl Pageable for BlockPageable {
             canvas.surface.set_fill(None);
 
             if bt > 0.0 {
-                canvas.surface.set_stroke(Some(krilla::paint::Stroke { width: bt, ..stroke.clone() }));
+                canvas.surface.set_stroke(Some(krilla::paint::Stroke {
+                    width: bt,
+                    ..stroke.clone()
+                }));
                 let mut pb = krilla::geom::PathBuilder::new();
                 pb.move_to(x, y + bt / 2.0);
                 pb.line_to(x + avail_width, y + bt / 2.0);
-                if let Some(path) = pb.finish() { canvas.surface.draw_path(&path); }
+                if let Some(path) = pb.finish() {
+                    canvas.surface.draw_path(&path);
+                }
             }
             if bb > 0.0 {
-                canvas.surface.set_stroke(Some(krilla::paint::Stroke { width: bb, ..stroke.clone() }));
+                canvas.surface.set_stroke(Some(krilla::paint::Stroke {
+                    width: bb,
+                    ..stroke.clone()
+                }));
                 let mut pb = krilla::geom::PathBuilder::new();
                 pb.move_to(x, y + total_height - bb / 2.0);
                 pb.line_to(x + avail_width, y + total_height - bb / 2.0);
-                if let Some(path) = pb.finish() { canvas.surface.draw_path(&path); }
+                if let Some(path) = pb.finish() {
+                    canvas.surface.draw_path(&path);
+                }
             }
             if bl > 0.0 {
-                canvas.surface.set_stroke(Some(krilla::paint::Stroke { width: bl, ..stroke.clone() }));
+                canvas.surface.set_stroke(Some(krilla::paint::Stroke {
+                    width: bl,
+                    ..stroke.clone()
+                }));
                 let mut pb = krilla::geom::PathBuilder::new();
                 pb.move_to(x + bl / 2.0, y);
                 pb.line_to(x + bl / 2.0, y + total_height);
-                if let Some(path) = pb.finish() { canvas.surface.draw_path(&path); }
+                if let Some(path) = pb.finish() {
+                    canvas.surface.draw_path(&path);
+                }
             }
             if br > 0.0 {
-                canvas.surface.set_stroke(Some(krilla::paint::Stroke { width: br, ..stroke }));
+                canvas.surface.set_stroke(Some(krilla::paint::Stroke {
+                    width: br,
+                    ..stroke
+                }));
                 let mut pb = krilla::geom::PathBuilder::new();
                 pb.move_to(x + avail_width - br / 2.0, y);
                 pb.line_to(x + avail_width - br / 2.0, y + total_height);
-                if let Some(path) = pb.finish() { canvas.surface.draw_path(&path); }
+                if let Some(path) = pb.finish() {
+                    canvas.surface.draw_path(&path);
+                }
             }
             canvas.surface.set_stroke(None);
         }
 
         // Draw children at their Taffy-computed positions
         for pc in &self.children {
-            pc.child.draw(canvas, x + pc.x, y + pc.y, avail_width, pc.child.height());
+            pc.child
+                .draw(canvas, x + pc.x, y + pc.y, avail_width, pc.child.height());
         }
     }
 
@@ -348,12 +419,17 @@ impl SpacerPageable {
 
 impl Pageable for SpacerPageable {
     fn wrap(&mut self, avail_width: Pt, _avail_height: Pt) -> Size {
-        Size { width: avail_width, height: self.height }
+        Size {
+            width: avail_width,
+            height: self.height,
+        }
     }
 
-    fn split(&self, _avail_width: Pt, _avail_height: Pt)
-        -> Option<(Box<dyn Pageable>, Box<dyn Pageable>)>
-    {
+    fn split(
+        &self,
+        _avail_width: Pt,
+        _avail_height: Pt,
+    ) -> Option<(Box<dyn Pageable>, Box<dyn Pageable>)> {
         None
     }
 
@@ -382,10 +458,7 @@ mod tests {
 
     #[test]
     fn test_block_fits_on_one_page() {
-        let mut block = BlockPageable::new(vec![
-            make_spacer(100.0),
-            make_spacer(100.0),
-        ]);
+        let mut block = BlockPageable::new(vec![make_spacer(100.0), make_spacer(100.0)]);
         block.wrap(200.0, 300.0);
         assert!(block.split(200.0, 300.0).is_none());
     }
@@ -411,11 +484,10 @@ mod tests {
 
     #[test]
     fn test_break_before_page() {
-        let breaking = BlockPageable::new(vec![make_spacer(50.0)])
-            .with_pagination(Pagination {
-                break_before: BreakBefore::Page,
-                ..Pagination::default()
-            });
+        let breaking = BlockPageable::new(vec![make_spacer(50.0)]).with_pagination(Pagination {
+            break_before: BreakBefore::Page,
+            ..Pagination::default()
+        });
         let mut breaking = breaking;
         breaking.wrap(200.0, 1000.0);
 
@@ -433,11 +505,10 @@ mod tests {
 
     #[test]
     fn test_break_inside_avoid() {
-        let block = BlockPageable::new(vec![make_spacer(200.0)])
-            .with_pagination(Pagination {
-                break_inside: BreakInside::Avoid,
-                ..Pagination::default()
-            });
+        let block = BlockPageable::new(vec![make_spacer(200.0)]).with_pagination(Pagination {
+            break_inside: BreakInside::Avoid,
+            ..Pagination::default()
+        });
         let mut block = block;
         block.wrap(200.0, 1000.0);
         // Even if it doesn't fit, split returns None

--- a/crates/fulgur-core/src/paginate.rs
+++ b/crates/fulgur-core/src/paginate.rs
@@ -42,10 +42,7 @@ mod tests {
 
     #[test]
     fn test_paginate_single_page() {
-        let block = BlockPageable::new(vec![
-            make_spacer(100.0),
-            make_spacer(100.0),
-        ]);
+        let block = BlockPageable::new(vec![make_spacer(100.0), make_spacer(100.0)]);
         let pages = paginate(Box::new(block), 200.0, 300.0);
         assert_eq!(pages.len(), 1);
     }

--- a/crates/fulgur-core/src/paragraph.rs
+++ b/crates/fulgur-core/src/paragraph.rs
@@ -108,14 +108,7 @@ impl Pageable for ParagraphPageable {
         Some((Box::new(first), Box::new(second)))
     }
 
-    fn draw(
-        &self,
-        canvas: &mut Canvas<'_, '_>,
-        x: Pt,
-        y: Pt,
-        _avail_width: Pt,
-        _avail_height: Pt,
-    ) {
+    fn draw(&self, canvas: &mut Canvas<'_, '_>, x: Pt, y: Pt, _avail_width: Pt, _avail_height: Pt) {
         let mut current_y = y;
 
         for line in &self.lines {
@@ -150,12 +143,8 @@ impl Pageable for ParagraphPageable {
 
                 // Set text color
                 let fill = krilla::paint::Fill {
-                    paint: krilla::color::rgb::Color::new(
-                        run.color[0],
-                        run.color[1],
-                        run.color[2],
-                    )
-                    .into(),
+                    paint: krilla::color::rgb::Color::new(run.color[0], run.color[1], run.color[2])
+                        .into(),
                     opacity: krilla::num::NormalizedF32::new(run.color[3] as f32 / 255.0)
                         .unwrap_or(krilla::num::NormalizedF32::ONE),
                     rule: Default::default(),

--- a/crates/fulgur-core/src/render.rs
+++ b/crates/fulgur-core/src/render.rs
@@ -4,10 +4,7 @@ use crate::pageable::{Canvas, Pageable};
 use crate::paginate::paginate;
 
 /// Render a Pageable tree to PDF bytes.
-pub fn render_to_pdf(
-    root: Box<dyn Pageable>,
-    config: &Config,
-) -> Result<Vec<u8>> {
+pub fn render_to_pdf(root: Box<dyn Pageable>, config: &Config) -> Result<Vec<u8>> {
     let content_width = config.content_width();
     let content_height = config.content_height();
 
@@ -31,7 +28,9 @@ pub fn render_to_pdf(
         let mut surface = page.surface();
 
         // Pass margin offsets as x/y origin to draw
-        let mut canvas = Canvas { surface: &mut surface };
+        let mut canvas = Canvas {
+            surface: &mut surface,
+        };
         page_content.draw(
             &mut canvas,
             config.margin.left,
@@ -53,6 +52,8 @@ pub fn render_to_pdf(
 
     document.set_metadata(metadata);
 
-    let pdf_bytes = document.finish().map_err(|e| Error::PdfGeneration(format!("{e:?}")))?;
+    let pdf_bytes = document
+        .finish()
+        .map_err(|e| Error::PdfGeneration(format!("{e:?}")))?;
     Ok(pdf_bytes)
 }

--- a/crates/fulgur-core/tests/engine_test.rs
+++ b/crates/fulgur-core/tests/engine_test.rs
@@ -1,4 +1,4 @@
-use fulgur_core::config::{PageSize, Margin};
+use fulgur_core::config::{Margin, PageSize};
 use fulgur_core::engine::Engine;
 use fulgur_core::pageable::{BlockPageable, Pageable, SpacerPageable};
 

--- a/crates/fulgur-core/tests/html_test.rs
+++ b/crates/fulgur-core/tests/html_test.rs
@@ -1,4 +1,4 @@
-use fulgur_core::config::{PageSize, Margin};
+use fulgur_core::config::{Margin, PageSize};
 use fulgur_core::engine::Engine;
 
 #[test]

--- a/crates/fulgur-core/tests/render_test.rs
+++ b/crates/fulgur-core/tests/render_test.rs
@@ -1,4 +1,4 @@
-use fulgur_core::config::{Config, PageSize, Margin};
+use fulgur_core::config::{Config, Margin, PageSize};
 use fulgur_core::pageable::{BlockPageable, Pageable, SpacerPageable};
 use fulgur_core::render::render_to_pdf;
 

--- a/crates/fulgur-core/tests/text_test.rs
+++ b/crates/fulgur-core/tests/text_test.rs
@@ -1,4 +1,4 @@
-use fulgur_core::config::{PageSize, Margin};
+use fulgur_core::config::{Margin, PageSize};
 use fulgur_core::engine::Engine;
 
 #[test]


### PR DESCRIPTION
## Summary
- GitHub Actions CI: lint (fmt + clippy) + test matrix (Linux/macOS/Windows × amd64/arm64, 5 patterns)
- MIT OR Apache-2.0 dual license files
- Cargo.toml に license, description, repository を追加
- CLAUDE.md 追加

## Test plan
- [ ] CI が全プラットフォームで green になることを確認