### PR TITLE
feat: add list marker rendering (ul/ol/li)

### DIFF
--- a/crates/fulgur-core/src/convert.rs
+++ b/crates/fulgur-core/src/convert.rs
@@ -49,6 +49,52 @@ fn convert_node(doc: &blitz_dom::BaseDocument, node_id: usize) -> Box<dyn Pageab
     let height = layout.size.height;
     let width = layout.size.width;
 
+    // Check if this is a list item with an outside marker (must be before inline root check)
+    if let Some(elem_data) = node.element_data()
+        && elem_data.list_item_data.is_some()
+    {
+        let (marker_lines, marker_width) = extract_marker_lines(doc, node);
+        let style = extract_block_style(node);
+
+        // Build body: if inline root, use paragraph; otherwise collect block children
+        let body: Box<dyn Pageable> = if node.flags.is_inline_root()
+            && let Some(paragraph) = extract_paragraph(doc, node)
+        {
+            let has_style = style.background_color.is_some()
+                || style.border_widths.iter().any(|&w| w > 0.0)
+                || style.padding.iter().any(|&p| p > 0.0);
+            if has_style {
+                let child = PositionedChild {
+                    child: Box::new(paragraph),
+                    x: 0.0,
+                    y: 0.0,
+                };
+                let mut block = BlockPageable::with_positioned_children(vec![child]).with_style(style);
+                block.wrap(width, height);
+                Box::new(block)
+            } else {
+                Box::new(paragraph)
+            }
+        } else {
+            let children: &[usize] = &node.children;
+            let positioned_children = collect_positioned_children(doc, children);
+            let mut block = BlockPageable::with_positioned_children(positioned_children).with_style(style);
+            block.wrap(width, 10000.0);
+            Box::new(block)
+        };
+
+        let mut item = ListItemPageable {
+            marker_lines,
+            marker_width,
+            body,
+            style: BlockStyle::default(),
+            width,
+            height: 0.0,
+        };
+        item.wrap(width, 10000.0);
+        return Box::new(item);
+    }
+
     // Check if this is an inline root (contains text layout)
     if node.flags.is_inline_root()
         && let Some(paragraph) = extract_paragraph(doc, node)
@@ -69,29 +115,6 @@ fn convert_node(doc: &blitz_dom::BaseDocument, node_id: usize) -> Box<dyn Pageab
             return Box::new(block);
         }
         return Box::new(paragraph);
-    }
-
-    // Check if this is a list item with an outside marker
-    if let Some(elem_data) = node.element_data()
-        && elem_data.list_item_data.is_some()
-    {
-        let (marker_lines, marker_width) = extract_marker_lines(doc, node);
-        let children: &[usize] = &node.children;
-        let positioned_children = collect_positioned_children(doc, children);
-        let style = extract_block_style(node);
-        let mut body = BlockPageable::with_positioned_children(positioned_children).with_style(style);
-        body.wrap(width, 10000.0);
-
-        let mut item = ListItemPageable {
-            marker_lines,
-            marker_width,
-            body: Box::new(body),
-            style: BlockStyle::default(),
-            width,
-            height: 0.0,
-        };
-        item.wrap(width, 10000.0);
-        return Box::new(item);
     }
 
     let children: &[usize] = &node.children;

--- a/crates/fulgur-core/src/convert.rs
+++ b/crates/fulgur-core/src/convert.rs
@@ -1,6 +1,6 @@
 //! Convert a Blitz DOM (after style resolution + layout) into a Pageable tree.
 
-use crate::pageable::{BlockPageable, BlockStyle, Pageable, PositionedChild, SpacerPageable};
+use crate::pageable::{BlockPageable, BlockStyle, ListItemPageable, Pageable, PositionedChild, SpacerPageable};
 use crate::paragraph::{ParagraphPageable, ShapedGlyph, ShapedGlyphRun, ShapedLine};
 use blitz_dom::{Node, NodeData};
 use blitz_html::HtmlDocument;
@@ -69,6 +69,29 @@ fn convert_node(doc: &blitz_dom::BaseDocument, node_id: usize) -> Box<dyn Pageab
             return Box::new(block);
         }
         return Box::new(paragraph);
+    }
+
+    // Check if this is a list item with an outside marker
+    if let Some(elem_data) = node.element_data()
+        && elem_data.list_item_data.is_some()
+    {
+        let (marker_lines, marker_width) = extract_marker_lines(doc, node);
+        let children: &[usize] = &node.children;
+        let positioned_children = collect_positioned_children(doc, children);
+        let style = extract_block_style(node);
+        let mut body = BlockPageable::with_positioned_children(positioned_children).with_style(style);
+        body.wrap(width, 10000.0);
+
+        let mut item = ListItemPageable {
+            marker_lines,
+            marker_width,
+            body: Box::new(body),
+            style: BlockStyle::default(),
+            width,
+            height: 0.0,
+        };
+        item.wrap(width, 10000.0);
+        return Box::new(item);
     }
 
     let children: &[usize] = &node.children;

--- a/crates/fulgur-core/src/convert.rs
+++ b/crates/fulgur-core/src/convert.rs
@@ -268,6 +268,89 @@ fn is_non_visual_element(node: &Node) -> bool {
     }
 }
 
+/// Extract shaped lines from a list marker's Parley layout.
+fn extract_marker_lines(
+    doc: &blitz_dom::BaseDocument,
+    node: &Node,
+) -> (Vec<ShapedLine>, f32) {
+    let elem_data = match node.element_data() {
+        Some(d) => d,
+        None => return (Vec::new(), 0.0),
+    };
+    let list_item_data = match &elem_data.list_item_data {
+        Some(d) => d,
+        None => return (Vec::new(), 0.0),
+    };
+    let parley_layout = match &list_item_data.position {
+        blitz_dom::node::ListItemLayoutPosition::Outside(layout) => layout,
+        blitz_dom::node::ListItemLayoutPosition::Inside => return (Vec::new(), 0.0),
+    };
+
+    let marker_text = match &list_item_data.marker {
+        blitz_dom::node::Marker::Char(c) => {
+            let mut buf = [0u8; 4];
+            c.encode_utf8(&mut buf).to_string()
+        }
+        blitz_dom::node::Marker::String(s) => s.clone(),
+    };
+
+    let mut shaped_lines = Vec::new();
+    let mut max_width: f32 = 0.0;
+
+    for line in parley_layout.lines() {
+        let metrics = line.metrics();
+        let mut glyph_runs = Vec::new();
+        let mut line_width: f32 = 0.0;
+
+        for item in line.items() {
+            if let parley::PositionedLayoutItem::GlyphRun(glyph_run) = item {
+                let run = glyph_run.run();
+                let font_data = run.font();
+                let font_bytes: Vec<u8> = font_data.data.data().to_vec();
+                let font_index = font_data.index;
+                let font_size = run.font_size();
+
+                let brush = &glyph_run.style().brush;
+                let color = get_text_color(doc, brush.id);
+
+                let text_len = marker_text.len();
+                let mut glyphs = Vec::new();
+                for g in glyph_run.glyphs() {
+                    line_width += g.advance;
+                    glyphs.push(ShapedGlyph {
+                        id: g.id,
+                        x_advance: g.advance / font_size,
+                        x_offset: g.x / font_size,
+                        y_offset: g.y / font_size,
+                        text_range: 0..text_len,
+                    });
+                }
+
+                if !glyphs.is_empty() {
+                    glyph_runs.push(ShapedGlyphRun {
+                        font_data: Arc::new(font_bytes),
+                        font_index,
+                        font_size,
+                        color,
+                        glyphs,
+                        text: marker_text.clone(),
+                        x_offset: glyph_run.offset(),
+                    });
+                }
+            }
+        }
+
+        max_width = max_width.max(line_width);
+        shaped_lines.push(ShapedLine {
+            height: metrics.line_height,
+            baseline: metrics.baseline,
+            glyph_runs,
+        });
+    }
+
+    (shaped_lines, max_width)
+}
+
 /// Get text color from a DOM node's computed styles.
 fn get_text_color(doc: &blitz_dom::BaseDocument, node_id: usize) -> [u8; 4] {
     if let Some(node) = doc.get_node(node_id)

--- a/crates/fulgur-core/src/convert.rs
+++ b/crates/fulgur-core/src/convert.rs
@@ -1,6 +1,8 @@
 //! Convert a Blitz DOM (after style resolution + layout) into a Pageable tree.
 
-use crate::pageable::{BlockPageable, BlockStyle, ListItemPageable, Pageable, PositionedChild, SpacerPageable};
+use crate::pageable::{
+    BlockPageable, BlockStyle, ListItemPageable, Pageable, PositionedChild, SpacerPageable,
+};
 use crate::paragraph::{ParagraphPageable, ShapedGlyph, ShapedGlyphRun, ShapedLine};
 use blitz_dom::{Node, NodeData};
 use blitz_html::HtmlDocument;
@@ -69,7 +71,8 @@ fn convert_node(doc: &blitz_dom::BaseDocument, node_id: usize) -> Box<dyn Pageab
                     x: 0.0,
                     y: 0.0,
                 };
-                let mut block = BlockPageable::with_positioned_children(vec![child]).with_style(style);
+                let mut block =
+                    BlockPageable::with_positioned_children(vec![child]).with_style(style);
                 block.wrap(width, height);
                 Box::new(block)
             } else {
@@ -78,7 +81,8 @@ fn convert_node(doc: &blitz_dom::BaseDocument, node_id: usize) -> Box<dyn Pageab
         } else {
             let children: &[usize] = &node.children;
             let positioned_children = collect_positioned_children(doc, children);
-            let mut block = BlockPageable::with_positioned_children(positioned_children).with_style(style);
+            let mut block =
+                BlockPageable::with_positioned_children(positioned_children).with_style(style);
             block.wrap(width, 10000.0);
             Box::new(block)
         };
@@ -315,10 +319,7 @@ fn is_non_visual_element(node: &Node) -> bool {
 }
 
 /// Extract shaped lines from a list marker's Parley layout.
-fn extract_marker_lines(
-    doc: &blitz_dom::BaseDocument,
-    node: &Node,
-) -> (Vec<ShapedLine>, f32) {
+fn extract_marker_lines(doc: &blitz_dom::BaseDocument, node: &Node) -> (Vec<ShapedLine>, f32) {
     let elem_data = match node.element_data() {
         Some(d) => d,
         None => return (Vec::new(), 0.0),

--- a/crates/fulgur-core/src/image.rs
+++ b/crates/fulgur-core/src/image.rs
@@ -95,4 +95,8 @@ impl Pageable for ImagePageable {
     fn height(&self) -> Pt {
         self.height
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }

--- a/crates/fulgur-core/src/pageable.rs
+++ b/crates/fulgur-core/src/pageable.rs
@@ -78,6 +78,9 @@ pub trait Pageable: Send + Sync {
 
     /// Measured height from last wrap() call.
     fn height(&self) -> Pt;
+
+    /// Downcast support for tests.
+    fn as_any(&self) -> &dyn std::any::Any;
 }
 
 impl Clone for Box<dyn Pageable> {
@@ -401,6 +404,10 @@ impl Pageable for BlockPageable {
     fn height(&self) -> Pt {
         self.cached_size.map(|s| s.height).unwrap_or(0.0)
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 // ─── SpacerPageable ──────────────────────────────────────
@@ -443,6 +450,94 @@ impl Pageable for SpacerPageable {
 
     fn height(&self) -> Pt {
         self.height
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+// ─── ListItemPageable ───────────────────────────────────
+
+use crate::paragraph::ShapedLine;
+
+/// A list item with an outside-positioned marker.
+#[derive(Clone)]
+pub struct ListItemPageable {
+    /// Shaped lines for the marker text (extracted from Blitz's Parley layout)
+    pub marker_lines: Vec<ShapedLine>,
+    /// Width of the marker (for positioning to the left of body)
+    pub marker_width: Pt,
+    /// The list item's body content
+    pub body: Box<dyn Pageable>,
+    /// Visual style (background, borders, padding)
+    pub style: BlockStyle,
+    /// Taffy-computed width
+    pub width: Pt,
+    /// Cached height from wrap()
+    pub height: Pt,
+}
+
+impl Pageable for ListItemPageable {
+    fn wrap(&mut self, avail_width: Pt, avail_height: Pt) -> Size {
+        let body_size = self.body.wrap(avail_width, avail_height);
+        self.height = body_size.height;
+        Size {
+            width: avail_width,
+            height: self.height,
+        }
+    }
+
+    fn split(
+        &self,
+        avail_width: Pt,
+        avail_height: Pt,
+    ) -> Option<(Box<dyn Pageable>, Box<dyn Pageable>)> {
+        let (top_body, bottom_body) = self.body.split(avail_width, avail_height)?;
+        Some((
+            Box::new(ListItemPageable {
+                marker_lines: self.marker_lines.clone(),
+                marker_width: self.marker_width,
+                body: top_body,
+                style: self.style.clone(),
+                width: self.width,
+                height: 0.0,
+            }),
+            Box::new(ListItemPageable {
+                marker_lines: Vec::new(),
+                marker_width: 0.0,
+                body: bottom_body,
+                style: self.style.clone(),
+                width: self.width,
+                height: 0.0,
+            }),
+        ))
+    }
+
+    fn draw(&self, canvas: &mut Canvas<'_, '_>, x: Pt, y: Pt, avail_width: Pt, avail_height: Pt) {
+        // Draw marker to the left of the body
+        if !self.marker_lines.is_empty() {
+            let marker_x = x - self.marker_width;
+            crate::paragraph::draw_shaped_lines(canvas, &self.marker_lines, marker_x, y);
+        }
+        // Draw body
+        self.body.draw(canvas, x, y, avail_width, avail_height);
+    }
+
+    fn pagination(&self) -> Pagination {
+        self.body.pagination()
+    }
+
+    fn clone_box(&self) -> Box<dyn Pageable> {
+        Box::new(self.clone())
+    }
+
+    fn height(&self) -> Pt {
+        self.height
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 
@@ -513,5 +608,48 @@ mod tests {
         block.wrap(200.0, 1000.0);
         // Even if it doesn't fit, split returns None
         assert!(block.split(200.0, 100.0).is_none());
+    }
+
+    #[test]
+    fn test_list_item_delegates_to_body() {
+        let body = make_spacer(100.0);
+        let mut item = ListItemPageable {
+            marker_lines: Vec::new(),
+            marker_width: 20.0,
+            body,
+            style: BlockStyle::default(),
+            width: 200.0,
+            height: 100.0,
+        };
+        let size = item.wrap(200.0, 1000.0);
+        assert!((size.height - 100.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_list_item_split_keeps_marker_on_first_part() {
+        let mut body = BlockPageable::new(vec![
+            make_spacer(100.0),
+            make_spacer(100.0),
+            make_spacer(100.0),
+        ]);
+        body.wrap(200.0, 1000.0);
+        let mut item = ListItemPageable {
+            marker_lines: vec![],
+            marker_width: 20.0,
+            body: Box::new(body),
+            style: BlockStyle::default(),
+            width: 200.0,
+            height: 300.0,
+        };
+        item.wrap(200.0, 1000.0);
+        let result = item.split(200.0, 250.0);
+        assert!(result.is_some());
+        let (first, second) = result.unwrap();
+        // First part keeps marker
+        let first_item = first.as_any().downcast_ref::<ListItemPageable>().unwrap();
+        assert!((first_item.marker_width - 20.0).abs() < 0.01);
+        // Second part has no marker
+        let second_item = second.as_any().downcast_ref::<ListItemPageable>().unwrap();
+        assert!((second_item.marker_width - 0.0).abs() < 0.01);
     }
 }

--- a/crates/fulgur-core/src/paragraph.rs
+++ b/crates/fulgur-core/src/paragraph.rs
@@ -182,4 +182,8 @@ impl Pageable for ParagraphPageable {
     fn height(&self) -> Pt {
         self.cached_height
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }

--- a/crates/fulgur-core/src/paragraph.rs
+++ b/crates/fulgur-core/src/paragraph.rs
@@ -53,6 +53,65 @@ impl ParagraphPageable {
     }
 }
 
+/// Draw pre-shaped text lines at the given position.
+pub fn draw_shaped_lines(canvas: &mut Canvas<'_, '_>, lines: &[ShapedLine], x: Pt, y: Pt) {
+    let mut current_y = y;
+
+    for line in lines {
+        let baseline_y = current_y + line.baseline;
+
+        for run in &line.glyph_runs {
+            // Create Krilla font from cached data
+            let data: krilla::Data = Arc::clone(&run.font_data).into();
+            let Some(font) = krilla::text::Font::new(data, run.font_index) else {
+                continue;
+            };
+
+            // Convert shaped glyphs to Krilla glyphs
+            // Values are already normalized (/ font_size) in convert.rs
+            let krilla_glyphs: Vec<krilla::text::KrillaGlyph> = run
+                .glyphs
+                .iter()
+                .map(|g| krilla::text::KrillaGlyph {
+                    glyph_id: krilla::text::GlyphId::new(g.id),
+                    text_range: g.text_range.clone(),
+                    x_advance: g.x_advance,
+                    x_offset: g.x_offset,
+                    y_offset: g.y_offset,
+                    y_advance: 0.0,
+                    location: None,
+                })
+                .collect();
+
+            if krilla_glyphs.is_empty() {
+                continue;
+            }
+
+            // Set text color
+            let fill = krilla::paint::Fill {
+                paint: krilla::color::rgb::Color::new(run.color[0], run.color[1], run.color[2])
+                    .into(),
+                opacity: krilla::num::NormalizedF32::new(run.color[3] as f32 / 255.0)
+                    .unwrap_or(krilla::num::NormalizedF32::ONE),
+                rule: Default::default(),
+            };
+            canvas.surface.set_fill(Some(fill));
+
+            let start = krilla::geom::Point::from_xy(x + run.x_offset, baseline_y);
+            canvas.surface.draw_glyphs(
+                start,
+                &krilla_glyphs,
+                font,
+                &run.text,
+                run.font_size,
+                false,
+            );
+        }
+
+        current_y += line.height;
+    }
+}
+
 impl Pageable for ParagraphPageable {
     fn wrap(&mut self, _avail_width: Pt, _avail_height: Pt) -> Size {
         self.cached_height = self.lines.iter().map(|l| l.height).sum();
@@ -109,61 +168,7 @@ impl Pageable for ParagraphPageable {
     }
 
     fn draw(&self, canvas: &mut Canvas<'_, '_>, x: Pt, y: Pt, _avail_width: Pt, _avail_height: Pt) {
-        let mut current_y = y;
-
-        for line in &self.lines {
-            let baseline_y = current_y + line.baseline;
-
-            for run in &line.glyph_runs {
-                // Create Krilla font from cached data
-                let data: krilla::Data = Arc::clone(&run.font_data).into();
-                let Some(font) = krilla::text::Font::new(data, run.font_index) else {
-                    continue;
-                };
-
-                // Convert shaped glyphs to Krilla glyphs
-                // Values are already normalized (/ font_size) in convert.rs
-                let krilla_glyphs: Vec<krilla::text::KrillaGlyph> = run
-                    .glyphs
-                    .iter()
-                    .map(|g| krilla::text::KrillaGlyph {
-                        glyph_id: krilla::text::GlyphId::new(g.id),
-                        text_range: g.text_range.clone(),
-                        x_advance: g.x_advance,
-                        x_offset: g.x_offset,
-                        y_offset: g.y_offset,
-                        y_advance: 0.0,
-                        location: None,
-                    })
-                    .collect();
-
-                if krilla_glyphs.is_empty() {
-                    continue;
-                }
-
-                // Set text color
-                let fill = krilla::paint::Fill {
-                    paint: krilla::color::rgb::Color::new(run.color[0], run.color[1], run.color[2])
-                        .into(),
-                    opacity: krilla::num::NormalizedF32::new(run.color[3] as f32 / 255.0)
-                        .unwrap_or(krilla::num::NormalizedF32::ONE),
-                    rule: Default::default(),
-                };
-                canvas.surface.set_fill(Some(fill));
-
-                let start = krilla::geom::Point::from_xy(x + run.x_offset, baseline_y);
-                canvas.surface.draw_glyphs(
-                    start,
-                    &krilla_glyphs,
-                    font,
-                    &run.text,
-                    run.font_size,
-                    false,
-                );
-            }
-
-            current_y += line.height;
-        }
+        draw_shaped_lines(canvas, &self.lines, x, y);
     }
 
     fn pagination(&self) -> Pagination {

--- a/crates/fulgur-core/tests/list_test.rs
+++ b/crates/fulgur-core/tests/list_test.rs
@@ -1,0 +1,81 @@
+use fulgur_core::config::{Margin, PageSize};
+use fulgur_core::engine::Engine;
+
+fn make_engine() -> Engine {
+    Engine::builder()
+        .page_size(PageSize::A4)
+        .margin(Margin::uniform(72.0))
+        .build()
+}
+
+#[test]
+fn test_unordered_list_renders() {
+    let engine = make_engine();
+    let html = r#"
+        <html><body>
+            <ul>
+                <li>Item one</li>
+                <li>Item two</li>
+                <li>Item three</li>
+            </ul>
+        </body></html>
+    "#;
+    let pdf = engine.render_html(html).unwrap();
+    assert!(pdf.starts_with(b"%PDF"));
+    assert!(pdf.len() > 100);
+}
+
+#[test]
+fn test_ordered_list_renders() {
+    let engine = make_engine();
+    let html = r#"
+        <html><body>
+            <ol>
+                <li>First</li>
+                <li>Second</li>
+                <li>Third</li>
+            </ol>
+        </body></html>
+    "#;
+    let pdf = engine.render_html(html).unwrap();
+    assert!(pdf.starts_with(b"%PDF"));
+    assert!(pdf.len() > 100);
+}
+
+#[test]
+fn test_nested_list_renders() {
+    let engine = make_engine();
+    let html = r#"
+        <html><body>
+            <ul>
+                <li>Parent item
+                    <ul>
+                        <li>Nested item</li>
+                    </ul>
+                </li>
+            </ul>
+        </body></html>
+    "#;
+    let pdf = engine.render_html(html).unwrap();
+    assert!(pdf.starts_with(b"%PDF"));
+    assert!(pdf.len() > 100);
+}
+
+#[test]
+fn test_mixed_list_styles_render() {
+    let engine = make_engine();
+    let html = r#"
+        <html><body>
+            <ol style="list-style-type: lower-alpha">
+                <li>Alpha item</li>
+                <li>Beta item</li>
+            </ol>
+            <ul style="list-style-type: square">
+                <li>Square item</li>
+            </ul>
+        </body></html>
+    "#;
+    let pdf = engine.render_html(html).unwrap();
+    assert!(pdf.starts_with(b"%PDF"));
+    assert!(pdf.len() > 100);
+}


### PR DESCRIPTION
## Summary
- Add `ListItemPageable` struct that renders outside-positioned list markers (disc, decimal, lower-alpha, etc.) to the left of list item body content
- Extract `draw_shaped_lines` helper from `ParagraphPageable` for shared glyph rendering between paragraphs and markers
- Add `extract_marker_lines` to read Blitz's pre-computed Parley layout for list markers and convert to `ShapedLine`s
- Wire list item detection into `convert_node`, handling both inline-root and block-container `<li>` elements

## Test Plan
- [x] 2 unit tests for `ListItemPageable` (wrap delegation, split keeps marker on first part)
- [x] 4 integration tests (unordered, ordered, nested, mixed styles)
- [x] All 28 existing tests pass
- [x] Clippy clean
- [x] Visual verification via PDF text extraction confirms markers render correctly