### PR TITLE
fix(ci): extract git-cliff to /tmp

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -30,8 +30,8 @@ jobs:
         env:
           GIT_CLIFF_VERSION: "2.7.0"
         run: |
-          curl -sSL "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-gnu.tar.gz" | tar xz
-          sudo mv git-cliff-*/git-cliff /usr/local/bin/
+          curl -sSL "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-gnu.tar.gz" | tar xz -C /tmp
+          sudo mv /tmp/git-cliff-*/git-cliff /usr/local/bin/
 
       - name: Determine version
         id: version


### PR DESCRIPTION
tar xz was extracting into the working directory, causing git-cliff files to be committed in release PRs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CDワークフローの改善: ビルドプロセスにおけるツールのインストール方法を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->