### PR TITLE
feat: border-style support (dashed, dotted, double)

### DIFF
--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -559,13 +559,17 @@ fn extract_block_style(node: &Node) -> BlockStyle {
 
         // Border styles
         let convert_border_style = |bs: style::values::specified::BorderStyle| -> BorderStyleValue {
+            use style::values::specified::BorderStyle as BS;
             match bs {
-                style::values::specified::BorderStyle::None
-                | style::values::specified::BorderStyle::Hidden => BorderStyleValue::None,
-                style::values::specified::BorderStyle::Dashed => BorderStyleValue::Dashed,
-                style::values::specified::BorderStyle::Dotted => BorderStyleValue::Dotted,
-                style::values::specified::BorderStyle::Double => BorderStyleValue::Double,
-                _ => BorderStyleValue::Solid, // groove/ridge/inset/outset → solid fallback
+                BS::None | BS::Hidden => BorderStyleValue::None,
+                BS::Dashed => BorderStyleValue::Dashed,
+                BS::Dotted => BorderStyleValue::Dotted,
+                BS::Double => BorderStyleValue::Double,
+                BS::Groove => BorderStyleValue::Groove,
+                BS::Ridge => BorderStyleValue::Ridge,
+                BS::Inset => BorderStyleValue::Inset,
+                BS::Outset => BorderStyleValue::Outset,
+                BS::Solid => BorderStyleValue::Solid,
             }
         };
         style.border_styles = [

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -3,8 +3,8 @@
 use crate::gcpm::GcpmContext;
 use crate::gcpm::running::{RunningElementStore, serialize_node};
 use crate::pageable::{
-    BlockPageable, BlockStyle, ListItemPageable, Pageable, PositionedChild, Size, SpacerPageable,
-    TablePageable,
+    BlockPageable, BlockStyle, BorderStyleValue, ListItemPageable, Pageable, PositionedChild, Size,
+    SpacerPageable, TablePageable,
 };
 use crate::paragraph::{
     ParagraphPageable, ShapedGlyph, ShapedGlyphRun, ShapedLine, TextDecoration, TextDecorationLine,
@@ -555,6 +555,24 @@ fn extract_block_style(node: &Node) -> BlockStyle {
                 resolve_radius(&bl.0.width, width),
                 resolve_radius(&bl.0.height, height),
             ],
+        ];
+
+        // Border styles
+        let convert_border_style = |bs: style::values::specified::BorderStyle| -> BorderStyleValue {
+            match bs {
+                style::values::specified::BorderStyle::None
+                | style::values::specified::BorderStyle::Hidden => BorderStyleValue::None,
+                style::values::specified::BorderStyle::Dashed => BorderStyleValue::Dashed,
+                style::values::specified::BorderStyle::Dotted => BorderStyleValue::Dotted,
+                style::values::specified::BorderStyle::Double => BorderStyleValue::Double,
+                _ => BorderStyleValue::Solid, // groove/ridge/inset/outset → solid fallback
+            }
+        };
+        style.border_styles = [
+            convert_border_style(styles.clone_border_top_style()),
+            convert_border_style(styles.clone_border_right_style()),
+            convert_border_style(styles.clone_border_bottom_style()),
+            convert_border_style(styles.clone_border_left_style()),
         ];
     }
 

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -547,20 +547,27 @@ fn draw_border_line(
             let nx = -dy / len * half;
             let ny = dx / len * half;
             let half_w = width / 2.0;
+            // +normal points outward for top/left, inward for bottom/right.
+            // Swap direction for bottom/right so outer_color is always on the outside.
+            let (out_sign, in_sign) = if is_top_or_left {
+                (1.0, -1.0)
+            } else {
+                (-1.0, 1.0)
+            };
             stroke_line(
                 canvas,
-                x1 + nx,
-                y1 + ny,
-                x2 + nx,
-                y2 + ny,
+                x1 + nx * out_sign,
+                y1 + ny * out_sign,
+                x2 + nx * out_sign,
+                y2 + ny * out_sign,
                 colored_stroke(&outer_color, half_w, opacity),
             );
             stroke_line(
                 canvas,
-                x1 - nx,
-                y1 - ny,
-                x2 - nx,
-                y2 - ny,
+                x1 + nx * in_sign,
+                y1 + ny * in_sign,
+                x2 + nx * in_sign,
+                y2 + ny * in_sign,
                 colored_stroke(&inner_color, half_w, opacity),
             );
         }

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -122,6 +122,14 @@ pub enum BorderStyleValue {
     Dotted,
     /// Two parallel lines
     Double,
+    /// 3D grooved effect
+    Groove,
+    /// 3D ridged effect
+    Ridge,
+    /// 3D inset effect
+    Inset,
+    /// 3D outset effect
+    Outset,
 }
 
 impl BlockStyle {
@@ -361,7 +369,69 @@ fn draw_block_background(
     }
 }
 
-/// Draw the border stroke for a block or table element.
+/// Lighten an RGBA color by a factor (0.0–1.0). Higher factor = lighter.
+fn lighten_color(c: &[u8; 4], factor: f32) -> [u8; 4] {
+    [
+        (c[0] as f32 + (255.0 - c[0] as f32) * factor) as u8,
+        (c[1] as f32 + (255.0 - c[1] as f32) * factor) as u8,
+        (c[2] as f32 + (255.0 - c[2] as f32) * factor) as u8,
+        c[3],
+    ]
+}
+
+/// Darken an RGBA color by a factor (0.0–1.0). Higher factor = darker.
+fn darken_color(c: &[u8; 4], factor: f32) -> [u8; 4] {
+    [
+        (c[0] as f32 * (1.0 - factor)) as u8,
+        (c[1] as f32 * (1.0 - factor)) as u8,
+        (c[2] as f32 * (1.0 - factor)) as u8,
+        c[3],
+    ]
+}
+
+/// For 3D border styles, determine the light and dark colors for a given side.
+/// Returns (outer_color, inner_color) for groove/ridge, or just the single color for inset/outset.
+/// `is_top_or_left`: true for top/left sides, false for bottom/right sides.
+fn border_3d_colors(
+    base: &[u8; 4],
+    style: BorderStyleValue,
+    is_top_or_left: bool,
+) -> ([u8; 4], Option<[u8; 4]>) {
+    let light = lighten_color(base, 0.5);
+    let dark = darken_color(base, 0.5);
+    match style {
+        BorderStyleValue::Groove => {
+            if is_top_or_left {
+                (dark, Some(light))
+            } else {
+                (light, Some(dark))
+            }
+        }
+        BorderStyleValue::Ridge => {
+            if is_top_or_left {
+                (light, Some(dark))
+            } else {
+                (dark, Some(light))
+            }
+        }
+        BorderStyleValue::Inset => {
+            if is_top_or_left {
+                (dark, None)
+            } else {
+                (light, None)
+            }
+        }
+        BorderStyleValue::Outset => {
+            if is_top_or_left {
+                (light, None)
+            } else {
+                (dark, None)
+            }
+        }
+        _ => (*base, None),
+    }
+}
+
 /// Apply border-style dash settings to a stroke.
 fn apply_border_style(
     stroke: krilla::paint::Stroke,
@@ -389,11 +459,49 @@ fn apply_border_style(
             }),
             ..stroke
         }),
-        BorderStyleValue::Double => Some(stroke), // handled specially at call site
+        BorderStyleValue::Double
+        | BorderStyleValue::Groove
+        | BorderStyleValue::Ridge
+        | BorderStyleValue::Inset
+        | BorderStyleValue::Outset => Some(stroke), // handled specially at call site
     }
 }
 
-/// Draw a single border line (or double) between two points.
+/// Helper to draw a simple line segment with a given stroke.
+fn stroke_line(
+    canvas: &mut Canvas<'_, '_>,
+    x1: f32,
+    y1: f32,
+    x2: f32,
+    y2: f32,
+    stroke: krilla::paint::Stroke,
+) {
+    canvas.surface.set_stroke(Some(stroke));
+    let mut pb = krilla::geom::PathBuilder::new();
+    pb.move_to(x1, y1);
+    pb.line_to(x2, y2);
+    if let Some(path) = pb.finish() {
+        canvas.surface.draw_path(&path);
+    }
+}
+
+/// Create a stroke with a specific color and width, inheriting opacity from base.
+fn colored_stroke(
+    color: &[u8; 4],
+    width: f32,
+    opacity: krilla::num::NormalizedF32,
+) -> krilla::paint::Stroke {
+    krilla::paint::Stroke {
+        paint: krilla::color::rgb::Color::new(color[0], color[1], color[2]).into(),
+        width,
+        opacity,
+        ..Default::default()
+    }
+}
+
+/// Draw a single border line with style, handling double and 3D effects.
+/// `base_color` is the original RGBA border color (needed for 3D color computation).
+/// `is_top_or_left` determines the light/dark side for 3D styles.
 #[allow(clippy::too_many_arguments)]
 fn draw_border_line(
     canvas: &mut Canvas<'_, '_>,
@@ -403,56 +511,75 @@ fn draw_border_line(
     y2: f32,
     width: f32,
     style: BorderStyleValue,
-    base_stroke: &krilla::paint::Stroke,
+    base_color: &[u8; 4],
+    opacity: krilla::num::NormalizedF32,
+    is_top_or_left: bool,
 ) {
     if width <= 0.0 || style == BorderStyleValue::None {
         return;
     }
 
-    let stroke_with_width = krilla::paint::Stroke {
-        width,
-        ..base_stroke.clone()
-    };
-
-    if style == BorderStyleValue::Double {
-        let gap = width / 3.0;
-        // Compute perpendicular offset for the two lines
-        let dx = x2 - x1;
-        let dy = y2 - y1;
-        let len = (dx * dx + dy * dy).sqrt();
-        if len == 0.0 {
-            return;
+    match style {
+        BorderStyleValue::Double => {
+            let gap = width / 3.0;
+            let dx = x2 - x1;
+            let dy = y2 - y1;
+            let len = (dx * dx + dy * dy).sqrt();
+            if len == 0.0 {
+                return;
+            }
+            let nx = -dy / len * gap;
+            let ny = dx / len * gap;
+            let thin = colored_stroke(base_color, width / 3.0, opacity);
+            stroke_line(canvas, x1 + nx, y1 + ny, x2 + nx, y2 + ny, thin.clone());
+            stroke_line(canvas, x1 - nx, y1 - ny, x2 - nx, y2 - ny, thin);
         }
-        let nx = -dy / len * gap;
-        let ny = dx / len * gap;
-
-        let thin = krilla::paint::Stroke {
-            width: width / 3.0,
-            ..base_stroke.clone()
-        };
-        // Outer line
-        canvas.surface.set_stroke(Some(thin.clone()));
-        let mut pb = krilla::geom::PathBuilder::new();
-        pb.move_to(x1 + nx, y1 + ny);
-        pb.line_to(x2 + nx, y2 + ny);
-        if let Some(path) = pb.finish() {
-            canvas.surface.draw_path(&path);
+        BorderStyleValue::Groove | BorderStyleValue::Ridge => {
+            let (outer_color, inner_color) = border_3d_colors(base_color, style, is_top_or_left);
+            let inner_color = inner_color.unwrap_or(outer_color);
+            let dx = x2 - x1;
+            let dy = y2 - y1;
+            let len = (dx * dx + dy * dy).sqrt();
+            if len == 0.0 {
+                return;
+            }
+            let half = width / 4.0;
+            let nx = -dy / len * half;
+            let ny = dx / len * half;
+            let half_w = width / 2.0;
+            stroke_line(
+                canvas,
+                x1 + nx,
+                y1 + ny,
+                x2 + nx,
+                y2 + ny,
+                colored_stroke(&outer_color, half_w, opacity),
+            );
+            stroke_line(
+                canvas,
+                x1 - nx,
+                y1 - ny,
+                x2 - nx,
+                y2 - ny,
+                colored_stroke(&inner_color, half_w, opacity),
+            );
         }
-        // Inner line
-        canvas.surface.set_stroke(Some(thin));
-        let mut pb = krilla::geom::PathBuilder::new();
-        pb.move_to(x1 - nx, y1 - ny);
-        pb.line_to(x2 - nx, y2 - ny);
-        if let Some(path) = pb.finish() {
-            canvas.surface.draw_path(&path);
+        BorderStyleValue::Inset | BorderStyleValue::Outset => {
+            let (color, _) = border_3d_colors(base_color, style, is_top_or_left);
+            stroke_line(
+                canvas,
+                x1,
+                y1,
+                x2,
+                y2,
+                colored_stroke(&color, width, opacity),
+            );
         }
-    } else if let Some(styled) = apply_border_style(stroke_with_width, style, width) {
-        canvas.surface.set_stroke(Some(styled));
-        let mut pb = krilla::geom::PathBuilder::new();
-        pb.move_to(x1, y1);
-        pb.line_to(x2, y2);
-        if let Some(path) = pb.finish() {
-            canvas.surface.draw_path(&path);
+        _ => {
+            let base = colored_stroke(base_color, width, opacity);
+            if let Some(styled) = apply_border_style(base, style, width) {
+                stroke_line(canvas, x1, y1, x2, y2, styled);
+            }
         }
     }
 }
@@ -501,14 +628,11 @@ fn draw_block_border(
             }
         }
     } else {
-        let base_stroke = krilla::paint::Stroke {
-            paint: krilla::color::rgb::Color::new(bc[0], bc[1], bc[2]).into(),
-            opacity: krilla::num::NormalizedF32::new(bc[3] as f32 / 255.0)
-                .unwrap_or(krilla::num::NormalizedF32::ONE),
-            ..Default::default()
-        };
+        let opacity = krilla::num::NormalizedF32::new(bc[3] as f32 / 255.0)
+            .unwrap_or(krilla::num::NormalizedF32::ONE);
         canvas.surface.set_fill(None);
 
+        // top (top_or_left = true)
         draw_border_line(
             canvas,
             x,
@@ -517,8 +641,11 @@ fn draw_block_border(
             y + bt / 2.0,
             bt,
             st,
-            &base_stroke,
+            bc,
+            opacity,
+            true,
         );
+        // bottom (top_or_left = false)
         draw_border_line(
             canvas,
             x,
@@ -527,8 +654,11 @@ fn draw_block_border(
             y + h - bb / 2.0,
             bb,
             sb,
-            &base_stroke,
+            bc,
+            opacity,
+            false,
         );
+        // left (top_or_left = true)
         draw_border_line(
             canvas,
             x + bl / 2.0,
@@ -537,8 +667,11 @@ fn draw_block_border(
             y + h,
             bl,
             sl,
-            &base_stroke,
+            bc,
+            opacity,
+            true,
         );
+        // right (top_or_left = false)
         draw_border_line(
             canvas,
             x + w - br / 2.0,
@@ -547,7 +680,9 @@ fn draw_block_border(
             y + h,
             br,
             sr,
-            &base_stroke,
+            bc,
+            opacity,
+            false,
         );
 
         canvas.surface.set_stroke(None);

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -104,6 +104,24 @@ pub struct BlockStyle {
     pub padding: [f32; 4],
     /// Border radii: [top-left, top-right, bottom-right, bottom-left] × [rx, ry]
     pub border_radii: [[f32; 2]; 4],
+    /// Border styles: top, right, bottom, left
+    pub border_styles: [BorderStyleValue; 4],
+}
+
+/// CSS border-style values supported by fulgur.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum BorderStyleValue {
+    /// No border drawn
+    None,
+    /// Solid line (default when border-width > 0)
+    #[default]
+    Solid,
+    /// Dashed line
+    Dashed,
+    /// Dotted line
+    Dotted,
+    /// Two parallel lines
+    Double,
 }
 
 impl BlockStyle {
@@ -344,6 +362,101 @@ fn draw_block_background(
 }
 
 /// Draw the border stroke for a block or table element.
+/// Apply border-style dash settings to a stroke.
+fn apply_border_style(
+    stroke: krilla::paint::Stroke,
+    style: BorderStyleValue,
+    width: f32,
+) -> Option<krilla::paint::Stroke> {
+    match style {
+        BorderStyleValue::None => None,
+        BorderStyleValue::Solid => Some(stroke),
+        BorderStyleValue::Dashed => {
+            let dash_len = width * 3.0;
+            Some(krilla::paint::Stroke {
+                dash: Some(krilla::paint::StrokeDash {
+                    array: vec![dash_len, dash_len],
+                    offset: 0.0,
+                }),
+                ..stroke
+            })
+        }
+        BorderStyleValue::Dotted => Some(krilla::paint::Stroke {
+            line_cap: krilla::paint::LineCap::Round,
+            dash: Some(krilla::paint::StrokeDash {
+                array: vec![0.0, width * 2.0],
+                offset: 0.0,
+            }),
+            ..stroke
+        }),
+        BorderStyleValue::Double => Some(stroke), // handled specially at call site
+    }
+}
+
+/// Draw a single border line (or double) between two points.
+#[allow(clippy::too_many_arguments)]
+fn draw_border_line(
+    canvas: &mut Canvas<'_, '_>,
+    x1: f32,
+    y1: f32,
+    x2: f32,
+    y2: f32,
+    width: f32,
+    style: BorderStyleValue,
+    base_stroke: &krilla::paint::Stroke,
+) {
+    if width <= 0.0 || style == BorderStyleValue::None {
+        return;
+    }
+
+    let stroke_with_width = krilla::paint::Stroke {
+        width,
+        ..base_stroke.clone()
+    };
+
+    if style == BorderStyleValue::Double {
+        let gap = width / 3.0;
+        // Compute perpendicular offset for the two lines
+        let dx = x2 - x1;
+        let dy = y2 - y1;
+        let len = (dx * dx + dy * dy).sqrt();
+        if len == 0.0 {
+            return;
+        }
+        let nx = -dy / len * gap;
+        let ny = dx / len * gap;
+
+        let thin = krilla::paint::Stroke {
+            width: width / 3.0,
+            ..base_stroke.clone()
+        };
+        // Outer line
+        canvas.surface.set_stroke(Some(thin.clone()));
+        let mut pb = krilla::geom::PathBuilder::new();
+        pb.move_to(x1 + nx, y1 + ny);
+        pb.line_to(x2 + nx, y2 + ny);
+        if let Some(path) = pb.finish() {
+            canvas.surface.draw_path(&path);
+        }
+        // Inner line
+        canvas.surface.set_stroke(Some(thin));
+        let mut pb = krilla::geom::PathBuilder::new();
+        pb.move_to(x1 - nx, y1 - ny);
+        pb.line_to(x2 - nx, y2 - ny);
+        if let Some(path) = pb.finish() {
+            canvas.surface.draw_path(&path);
+        }
+    } else if let Some(styled) = apply_border_style(stroke_with_width, style, width) {
+        canvas.surface.set_stroke(Some(styled));
+        let mut pb = krilla::geom::PathBuilder::new();
+        pb.move_to(x1, y1);
+        pb.line_to(x2, y2);
+        if let Some(path) = pb.finish() {
+            canvas.surface.draw_path(&path);
+        }
+    }
+}
+
 fn draw_block_border(
     canvas: &mut Canvas<'_, '_>,
     style: &BlockStyle,
@@ -353,13 +466,15 @@ fn draw_block_border(
     h: f32,
 ) {
     let [bt, br, bb, bl] = style.border_widths;
+    let [st, sr, sb, sl] = style.border_styles;
     if !(bt > 0.0 || br > 0.0 || bb > 0.0 || bl > 0.0) {
         return;
     }
     let bc = &style.border_color;
 
     let uniform_width = bt == br && br == bb && bb == bl;
-    if style.has_radius() && uniform_width {
+    let uniform_style = st == sr && sr == sb && sb == sl;
+    if style.has_radius() && uniform_width && uniform_style && st != BorderStyleValue::None {
         let inset = bt / 2.0;
         let inset_radii = style
             .border_radii
@@ -371,73 +486,70 @@ fn draw_block_border(
             h - inset * 2.0,
             &inset_radii,
         ) {
-            canvas.surface.set_fill(None);
-            canvas.surface.set_stroke(Some(krilla::paint::Stroke {
+            let base = krilla::paint::Stroke {
                 paint: krilla::color::rgb::Color::new(bc[0], bc[1], bc[2]).into(),
                 width: bt,
                 opacity: krilla::num::NormalizedF32::new(bc[3] as f32 / 255.0)
                     .unwrap_or(krilla::num::NormalizedF32::ONE),
                 ..Default::default()
-            }));
-            canvas.surface.draw_path(&path);
-            canvas.surface.set_stroke(None);
+            };
+            if let Some(styled) = apply_border_style(base, st, bt) {
+                canvas.surface.set_fill(None);
+                canvas.surface.set_stroke(Some(styled));
+                canvas.surface.draw_path(&path);
+                canvas.surface.set_stroke(None);
+            }
         }
     } else {
-        let stroke = krilla::paint::Stroke {
+        let base_stroke = krilla::paint::Stroke {
             paint: krilla::color::rgb::Color::new(bc[0], bc[1], bc[2]).into(),
             opacity: krilla::num::NormalizedF32::new(bc[3] as f32 / 255.0)
                 .unwrap_or(krilla::num::NormalizedF32::ONE),
             ..Default::default()
         };
         canvas.surface.set_fill(None);
-        if bt > 0.0 {
-            canvas.surface.set_stroke(Some(krilla::paint::Stroke {
-                width: bt,
-                ..stroke.clone()
-            }));
-            let mut pb = krilla::geom::PathBuilder::new();
-            pb.move_to(x, y + bt / 2.0);
-            pb.line_to(x + w, y + bt / 2.0);
-            if let Some(path) = pb.finish() {
-                canvas.surface.draw_path(&path);
-            }
-        }
-        if bb > 0.0 {
-            canvas.surface.set_stroke(Some(krilla::paint::Stroke {
-                width: bb,
-                ..stroke.clone()
-            }));
-            let mut pb = krilla::geom::PathBuilder::new();
-            pb.move_to(x, y + h - bb / 2.0);
-            pb.line_to(x + w, y + h - bb / 2.0);
-            if let Some(path) = pb.finish() {
-                canvas.surface.draw_path(&path);
-            }
-        }
-        if bl > 0.0 {
-            canvas.surface.set_stroke(Some(krilla::paint::Stroke {
-                width: bl,
-                ..stroke.clone()
-            }));
-            let mut pb = krilla::geom::PathBuilder::new();
-            pb.move_to(x + bl / 2.0, y);
-            pb.line_to(x + bl / 2.0, y + h);
-            if let Some(path) = pb.finish() {
-                canvas.surface.draw_path(&path);
-            }
-        }
-        if br > 0.0 {
-            canvas.surface.set_stroke(Some(krilla::paint::Stroke {
-                width: br,
-                ..stroke
-            }));
-            let mut pb = krilla::geom::PathBuilder::new();
-            pb.move_to(x + w - br / 2.0, y);
-            pb.line_to(x + w - br / 2.0, y + h);
-            if let Some(path) = pb.finish() {
-                canvas.surface.draw_path(&path);
-            }
-        }
+
+        draw_border_line(
+            canvas,
+            x,
+            y + bt / 2.0,
+            x + w,
+            y + bt / 2.0,
+            bt,
+            st,
+            &base_stroke,
+        );
+        draw_border_line(
+            canvas,
+            x,
+            y + h - bb / 2.0,
+            x + w,
+            y + h - bb / 2.0,
+            bb,
+            sb,
+            &base_stroke,
+        );
+        draw_border_line(
+            canvas,
+            x + bl / 2.0,
+            y,
+            x + bl / 2.0,
+            y + h,
+            bl,
+            sl,
+            &base_stroke,
+        );
+        draw_border_line(
+            canvas,
+            x + w - br / 2.0,
+            y,
+            x + w - br / 2.0,
+            y + h,
+            br,
+            sr,
+            &base_stroke,
+        );
+
         canvas.surface.set_stroke(None);
     }
 }


### PR DESCRIPTION
## Summary
- BorderStyleValue enumを追加し、BlockStyleに4辺独立のborder-stylesフィールドを追加
- Styloのclone_border_*_style()から4辺のスタイルを抽出
- dashed/dotted/doubleの描画をdraw_block_borderに実装
- 角丸ボーダーは全辺同一style+widthの場合のみ対応
- groove/ridge/inset/outsetはsolidにフォールバック

## Test Plan
- [x] 既存ユニットテスト46件パス
- [x] cargo clippy 警告なし
- [x] cargo fmt --check パス
- [x] solid/dashed/dotted/double/none/mixedのPDF出力確認
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ボーダー描画を大幅に強化しました：破線・点線・二重線・実線に加え、Groove/Ridge/Inset/Outset 相当の3D風スタイルに対応。
  * 各辺ごとに異なるボーダースタイルを指定して正しく描画できます（計算済みスタイルからの反映を含む）。
  * 0幅や「none」相当のスタイルは描画を抑制。角丸かつ全辺共通条件時は高速経路を使用し、そうでない場合は辺毎に描画・色調整を行います。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->