### PR TITLE
fix(ci): use --unreleased for release notes generation

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Generate release notes for draft
         env:
           VERSION: ${{ steps.version.outputs.version }}
-        run: git-cliff --tag "v$VERSION" --latest --strip header -o RELEASE_NOTES.md
+        run: git-cliff --tag "v$VERSION" --unreleased --strip header -o RELEASE_NOTES.md
 
       - name: Create draft GitHub Release
         env:


### PR DESCRIPTION
## Summary
- release-prepare.ymlで`git-cliff --latest`を`--unreleased`に変更
- `--latest`はタグが存在する最新セクションを取得するが、prepare時点ではタグが未作成のため前バージョンのchangelogが出力されていた
- `--unreleased`は最新タグ以降のコミットをcurrent versionとして正しく出力する

## Impact
v0.2.0のドラフトリリースノートがv0.1.1の内容になっていた原因を修正
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# リリースノート

本プルリクエストには、エンドユーザーに対する変更はありません。内部開発ワークフローの最適化のみが含まれています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->