### PR TITLE
fix: correct crate name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ use fulgur::engine::Engine;
 use fulgur::config::{PageSize, Margin};
 
 // Convert with default settings
-let engine = fulgur::engine::Engine::builder().build();
+let engine = Engine::builder().build();
 let pdf = engine.render_html("<h1>Hello</h1>")?;
 
 // Custom configuration

--- a/README.md
+++ b/README.md
@@ -53,10 +53,12 @@ fulgur render -o output.pdf -f fonts/NotoSansJP.ttf --css style.css input.html
 ## Library Usage
 
 ```rust
-use fulgur_core::{Engine, PageSize, Margin};
+use fulgur::engine::Engine;
+use fulgur::config::{PageSize, Margin};
 
 // Convert with default settings
-let pdf = fulgur_core::convert_html("<h1>Hello</h1>")?;
+let engine = fulgur::engine::Engine::builder().build();
+let pdf = engine.render_html("<h1>Hello</h1>")?;
 
 // Custom configuration
 let engine = Engine::builder()
@@ -89,7 +91,7 @@ PDF bytes
 
 ```
 crates/
-├── fulgur-core/   # Core library (conversion, layout, rendering)
+├── fulgur/        # Core library (conversion, layout, rendering)
 └── fulgur-cli/    # CLI tool
 ```
 


### PR DESCRIPTION
## Summary
- `fulgur_core` → `fulgur` に修正（3箇所）
- `fulgur-core/` → `fulgur/` にディレクトリ名修正
- 存在しない `convert_html()` を実際のEngine APIに修正
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/20" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * README の Rust ライブラリ使用例を更新しました。`fulgur_core` から `fulgur` への参照に変更し、Engine の構築・実行メソッドをアップデートしました。プロジェクト構造のディレクトリ名も併せて更新されています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->