### PR TITLE
feat: support <caption> element in tables

### DIFF
--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -3,7 +3,159 @@ use crate::config::{Config, ConfigBuilder, Margin, PageSize};
 use crate::error::Result;
 use crate::pageable::Pageable;
 use crate::render::render_to_pdf;
+use std::borrow::Cow;
 use std::path::Path;
+
+/// Rewrite `<caption>` inside `<table>` into a Taffy-layoutable wrapper structure.
+///
+/// Blitz/Taffy returns 0×0 for `<caption>`, so we rewrite it into an inline-block
+/// wrapper `<div>` with the caption as a regular `<div>` sibling of the table.
+/// Handles nested tables correctly and supports `caption-side: bottom`.
+fn rewrite_table_captions(html: &str) -> Cow<'_, str> {
+    if !html.contains("<caption") {
+        return Cow::Borrowed(html);
+    }
+
+    let mut result = String::with_capacity(html.len());
+    let mut remaining = html;
+
+    while let Some(table_start) = remaining.find("<table") {
+        let after_table_tag = &remaining[table_start..];
+        let Some(tag_end) = after_table_tag.find('>') else {
+            break;
+        };
+        let table_tag = &remaining[table_start..table_start + tag_end + 1];
+        let table_content_start = table_start + tag_end + 1;
+
+        // Find matching </table>, accounting for nested tables
+        let Some(table_close_abs) = find_matching_close_table(remaining, table_content_start)
+        else {
+            break;
+        };
+        let table_inner = &remaining[table_content_start..table_close_abs];
+
+        if let Some(cap) = extract_caption(table_inner) {
+            result.push_str(&remaining[..table_start]);
+
+            result.push_str("<div style=\"display: inline-block\">");
+            if cap.side == CaptionSideHint::Top {
+                result.push_str("<div>");
+                result.push_str(&table_inner[cap.content_start..cap.content_end]);
+                result.push_str("</div>");
+                result.push_str(table_tag);
+                result.push_str(&table_inner[..cap.tag_start]);
+                result.push_str(&table_inner[cap.tag_end..]);
+                result.push_str("</table>");
+            } else {
+                result.push_str(table_tag);
+                result.push_str(&table_inner[..cap.tag_start]);
+                result.push_str(&table_inner[cap.tag_end..]);
+                result.push_str("</table>");
+                result.push_str("<div>");
+                result.push_str(&table_inner[cap.content_start..cap.content_end]);
+                result.push_str("</div>");
+            }
+            result.push_str("</div>");
+
+            remaining = &remaining[table_close_abs + "</table>".len()..];
+        } else {
+            result.push_str(&remaining[..table_close_abs + "</table>".len()]);
+            remaining = &remaining[table_close_abs + "</table>".len()..];
+        }
+    }
+
+    result.push_str(remaining);
+    Cow::Owned(result)
+}
+
+/// Find the position of the matching `</table>` for a table starting at `content_start`,
+/// correctly skipping over nested `<table>...</table>` pairs.
+fn find_matching_close_table(html: &str, content_start: usize) -> Option<usize> {
+    let mut depth = 1u32;
+    let mut pos = content_start;
+    while pos < html.len() {
+        if html[pos..].starts_with("<table") {
+            depth += 1;
+            pos += 6;
+        } else if html[pos..].starts_with("</table>") {
+            depth -= 1;
+            if depth == 0 {
+                return Some(pos);
+            }
+            pos += 8;
+        } else {
+            pos += 1;
+        }
+    }
+    None
+}
+
+#[derive(Debug, PartialEq)]
+enum CaptionSideHint {
+    Top,
+    Bottom,
+}
+
+struct CaptionInfo {
+    /// Byte offset of `<caption` within table inner HTML
+    tag_start: usize,
+    /// Byte offset after `</caption>` within table inner HTML
+    tag_end: usize,
+    /// Byte offsets of caption inner content within table inner HTML
+    content_start: usize,
+    content_end: usize,
+    side: CaptionSideHint,
+}
+
+/// Extract the first `<caption>` that belongs to this table (not a nested table's).
+fn extract_caption(table_inner: &str) -> Option<CaptionInfo> {
+    let cap_start = table_inner.find("<caption")?;
+
+    // Ensure this caption appears before any nested <table> tag
+    if let Some(nested_table) = table_inner.find("<table") {
+        if cap_start > nested_table {
+            return None;
+        }
+    }
+
+    let after_cap = &table_inner[cap_start..];
+    let tag_end = after_cap.find('>')?;
+    let cap_tag = &after_cap[..tag_end];
+
+    // Parse caption-side from the style attribute value specifically
+    let side = detect_caption_side(cap_tag);
+
+    let content_start = cap_start + tag_end + 1;
+    let close_pos = table_inner[content_start..].find("</caption>")?;
+    let content_end = content_start + close_pos;
+    let tag_end_abs = content_end + "</caption>".len();
+
+    Some(CaptionInfo {
+        tag_start: cap_start,
+        tag_end: tag_end_abs,
+        content_start,
+        content_end,
+        side,
+    })
+}
+
+/// Detect `caption-side: bottom` from the opening tag's style attribute.
+fn detect_caption_side(cap_tag: &str) -> CaptionSideHint {
+    // Extract the style attribute value to avoid matching class names or data attributes
+    let Some(style_start) = cap_tag.find("style=\"") else {
+        return CaptionSideHint::Top;
+    };
+    let style_val = &cap_tag[style_start + 7..];
+    let Some(style_end) = style_val.find('"') else {
+        return CaptionSideHint::Top;
+    };
+    let style = &style_val[..style_end];
+    if style.contains("caption-side") && style.contains("bottom") {
+        CaptionSideHint::Bottom
+    } else {
+        CaptionSideHint::Top
+    }
+}
 
 /// Reusable PDF generation engine.
 pub struct Engine {
@@ -38,6 +190,9 @@ impl Engine {
     /// a 2-pass rendering pipeline is used: pass 1 paginates body content, pass 2
     /// renders each page with resolved margin boxes.
     pub fn render_html(&self, html: &str) -> Result<Vec<u8>> {
+        let html = rewrite_table_captions(html);
+        let html: &str = &html;
+
         let combined_css = self
             .assets
             .as_ref()
@@ -143,5 +298,86 @@ impl EngineBuilder {
             config: self.config_builder.build(),
             assets: self.assets,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rewrite_caption_top() {
+        let html = r#"<table border="1"><caption>Title</caption><tr><td>A</td></tr></table>"#;
+        let result = rewrite_table_captions(html);
+        assert!(result.contains(r#"<div style="display: inline-block">"#));
+        assert!(result.contains("<div>Title</div>"));
+        assert!(!result.contains("<caption"));
+        // Caption div comes before table
+        let cap_pos = result.find("<div>Title</div>").unwrap();
+        let table_pos = result.find("<table").unwrap();
+        assert!(cap_pos < table_pos);
+    }
+
+    #[test]
+    fn rewrite_caption_bottom() {
+        let html = r#"<table><caption style="caption-side: bottom">Footer</caption><tr><td>A</td></tr></table>"#;
+        let result = rewrite_table_captions(html);
+        // Caption div comes after table
+        let cap_pos = result.find("<div>Footer</div>").unwrap();
+        let table_close = result.find("</table>").unwrap();
+        assert!(cap_pos > table_close);
+    }
+
+    #[test]
+    fn rewrite_no_caption() {
+        let html = r#"<table border="1"><tr><td>A</td></tr></table>"#;
+        let result = rewrite_table_captions(html);
+        assert!(matches!(result, Cow::Borrowed(_)));
+        assert_eq!(&*result, html);
+    }
+
+    #[test]
+    fn rewrite_no_table() {
+        let html = "<p>No tables here</p>";
+        let result = rewrite_table_captions(html);
+        assert!(matches!(result, Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn rewrite_preserves_surrounding_html() {
+        let html =
+            r#"<p>Before</p><table><caption>T</caption><tr><td>A</td></tr></table><p>After</p>"#;
+        let result = rewrite_table_captions(html);
+        assert!(result.starts_with("<p>Before</p>"));
+        assert!(result.ends_with("<p>After</p>"));
+    }
+
+    #[test]
+    fn rewrite_nested_table() {
+        let html = r#"<table><caption>Outer</caption><tr><td><table><tr><td>inner</td></tr></table></td></tr></table>"#;
+        let result = rewrite_table_captions(html);
+        assert!(result.contains("<div>Outer</div>"));
+        // Inner table should be preserved intact
+        assert!(result.contains("<table><tr><td>inner</td></tr></table>"));
+    }
+
+    #[test]
+    fn rewrite_inner_table_caption_ignored() {
+        // Caption belongs to inner table, outer has none
+        let html = r#"<table><tr><td><table><caption>Inner</caption><tr><td>x</td></tr></table></td></tr></table>"#;
+        let result = rewrite_table_captions(html);
+        // Outer table has no caption so no wrapper
+        assert!(!result.contains(r#"display: inline-block"#));
+    }
+
+    #[test]
+    fn rewrite_caption_side_in_class_not_matched() {
+        // "bottom" in class name should not trigger caption-side: bottom
+        let html =
+            r#"<table><caption class="bottom-style">Title</caption><tr><td>A</td></tr></table>"#;
+        let result = rewrite_table_captions(html);
+        let cap_pos = result.find("<div>Title</div>").unwrap();
+        let table_pos = result.find("<table").unwrap();
+        assert!(cap_pos < table_pos, "should be top (default)");
     }
 }

--- a/crates/fulgur/tests/table_header_test.rs
+++ b/crates/fulgur/tests/table_header_test.rs
@@ -28,6 +28,48 @@ fn table_no_thead_renders() {
 }
 
 #[test]
+fn table_with_caption_renders() {
+    let html = r#"
+    <table border="1">
+        <caption>Table 1: Sample Data</caption>
+        <thead><tr><th>Name</th><th>Value</th></tr></thead>
+        <tbody><tr><td>A</td><td>1</td></tr></tbody>
+    </table>"#;
+    let pdf = render(html);
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn table_with_caption_bottom_renders() {
+    let html = r#"
+    <table border="1">
+        <caption style="caption-side: bottom">Table 1: Bottom Caption</caption>
+        <thead><tr><th>Name</th><th>Value</th></tr></thead>
+        <tbody><tr><td>A</td><td>1</td></tr></tbody>
+    </table>"#;
+    let pdf = render(html);
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn table_long_with_caption_renders() {
+    let mut rows = String::new();
+    for i in 0..50 {
+        rows.push_str(&format!("<tr><td>Row {i}</td><td>Value {i}</td></tr>"));
+    }
+    let html = format!(
+        r#"
+    <table border="1">
+        <caption style="font-weight: bold">Table 1: Long table with caption</caption>
+        <thead><tr><th>Name</th><th>Value</th></tr></thead>
+        <tbody>{rows}</tbody>
+    </table>"#
+    );
+    let pdf = render(&html);
+    assert!(!pdf.is_empty());
+}
+
+#[test]
 fn table_long_with_thead_renders() {
     let mut rows = String::new();
     for i in 0..50 {


### PR DESCRIPTION
## Summary

- テーブルの`<caption>`要素をPDF出力に反映する機能を追加
- Blitz/Taffyが`<caption>`のレイアウトを計算しない(0×0を返す)制約を、HTML前処理による書き換えで回避
- `<caption>`を`inline-block`ラッパー内の`<div>`に変換し、既存のBlockPageable/TablePageableのページ分割・ヘッダー繰り返し機構をそのまま活用
- `caption-side: top`(デフォルト)と`bottom`に対応
- ネストされたテーブルを正しく処理

## Approach

WeasyPrintの`TableWrapperBox`パターンを参考に、テーブルとキャプションを`inline-block`のラッパーdivで包む方式を採用。キャプションの幅がテーブル幅に連動する。

```html
<!-- Before -->
<table><caption>Title</caption>...</table>

<!-- After (preprocessed) -->
<div style="display: inline-block">
  <div>Title</div>
  <table>...</table>
</div>
```

## Test plan

- [x] `cargo test --lib` (54 tests pass)
- [x] `cargo test -p fulgur --test table_header_test -- --test-threads=1` (6 tests pass)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean
- [ ] caption-side: top のテーブルでcaptionがテーブル上部に表示されることを目視確認
- [ ] caption-side: bottom のテーブルでcaptionがテーブル下部に表示されることを目視確認
- [ ] 長いテーブル(50行)でページ分割時にcaptionが1ページ目のみに表示されることを確認

Closes fulgur-78o
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * HTMLテーブルのキャプション処理を改善しました。キャプション要素が自動的に変換され、`caption-side: bottom`スタイルに対応する形で配置されます。

* **テスト**
  * キャプション表示位置、複数行テーブル、ネストされたテーブルなど、さまざまなシナリオのテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->