### PR TITLE
refactor: rewrite GCPM parser to use cssparser crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,6 +663,7 @@ dependencies = [
  "blitz-dom",
  "blitz-html",
  "blitz-traits",
+ "cssparser",
  "krilla",
  "libc",
  "parley",

--- a/crates/fulgur/Cargo.toml
+++ b/crates/fulgur/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["text-processing", "command-line-utilities"]
 libc = "0.2"
 
 [dependencies]
+cssparser = "0.35"
 krilla = "0.6.0"
 blitz-html = "0.2"
 blitz-dom = "0.2"

--- a/crates/fulgur/src/gcpm/margin_box.rs
+++ b/crates/fulgur/src/gcpm/margin_box.rs
@@ -46,7 +46,10 @@ impl MarginBoxPosition {
     ///
     /// Accepts names like `"top-center"`, `"bottom-left-corner"`, etc.
     pub fn from_at_keyword(name: &str) -> Option<Self> {
-        match name {
+        // CSS at-rule names are ASCII case-insensitive.
+        // cssparser does not lowercase at-rule names before passing them here.
+        let lower = name.to_ascii_lowercase();
+        match lower.as_str() {
             "top-left-corner" => Some(Self::TopLeftCorner),
             "top-left" => Some(Self::TopLeft),
             "top-center" => Some(Self::TopCenter),

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -95,7 +95,7 @@ impl<'i, 'a> AtRuleParser<'i> for GcpmSheetParser<'a> {
 }
 
 impl<'i, 'a> QualifiedRuleParser<'i> for GcpmSheetParser<'a> {
-    type Prelude = usize; // byte offset of rule start (before selector)
+    type Prelude = ();
     type QualifiedRule = TopLevelItem;
     type Error = ();
 
@@ -103,10 +103,9 @@ impl<'i, 'a> QualifiedRuleParser<'i> for GcpmSheetParser<'a> {
         &mut self,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self::Prelude, ParseError<'i, ()>> {
-        let rule_start = input.position().byte_index();
         // Consume the prelude (selector) — we don't need it
         while input.next_including_whitespace().is_ok() {}
-        Ok(rule_start)
+        Ok(())
     }
 
     fn parse_block<'t>(
@@ -168,7 +167,6 @@ impl<'i, 'a> AtRuleParser<'i> for PageRuleParser<'a> {
         name: CowRcStr<'i>,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self::Prelude, ParseError<'i, ()>> {
-        let _ = input;
         MarginBoxPosition::from_at_keyword(&name)
             .ok_or_else(|| input.new_error(BasicParseErrorKind::AtRuleInvalid(name)))
     }

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -612,4 +612,64 @@ mod tests {
         let ctx = parse_gcpm(css);
         assert!(ctx.running_names.is_empty());
     }
+
+    #[test]
+    fn test_running_name_case_insensitive_property() {
+        // POSITION: Running(name) — プロパティ名の大文字小文字
+        let css = ".header { POSITION: running(pageHeader); }";
+        let ctx = parse_gcpm(css);
+        assert!(ctx.running_names.contains("pageHeader"));
+        assert!(ctx.cleaned_css.contains("display: none"));
+    }
+
+    #[test]
+    fn test_multiple_running_names() {
+        let css = ".h { position: running(hdr); } .f { position: running(ftr); }";
+        let ctx = parse_gcpm(css);
+        assert!(ctx.running_names.contains("hdr"));
+        assert!(ctx.running_names.contains("ftr"));
+    }
+
+    #[test]
+    fn test_running_with_other_declarations() {
+        // running() 以外の宣言が cleaned_css に残ること
+        let css = ".header { color: red; position: running(hdr); font-size: 14px; }";
+        let ctx = parse_gcpm(css);
+        assert!(ctx.running_names.contains("hdr"));
+        assert!(ctx.cleaned_css.contains("color: red"));
+        assert!(ctx.cleaned_css.contains("font-size: 14px"));
+    }
+
+    #[test]
+    fn test_page_with_multiple_margin_boxes() {
+        let css = "@page { @top-left { content: \"Left\"; } @top-center { content: element(hdr); } @top-right { content: counter(page); } }";
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.margin_boxes.len(), 3);
+    }
+
+    #[test]
+    fn test_margin_box_with_extra_declarations() {
+        let css = "@page { @top-center { content: element(hdr); font-size: 10pt; color: gray; } }";
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.margin_boxes.len(), 1);
+        let mb = &ctx.margin_boxes[0];
+        assert_eq!(mb.content, vec![ContentItem::Element("hdr".to_string())]);
+        assert!(mb.declarations.contains("font-size"));
+        assert!(mb.declarations.contains("color"));
+    }
+
+    #[test]
+    fn test_page_left_right_selectors() {
+        let css = r#"
+        @page :left { @bottom-left { content: counter(page); } }
+        @page :right { @bottom-right { content: counter(page); } }
+    "#;
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.margin_boxes.len(), 2);
+        assert_eq!(ctx.margin_boxes[0].page_selector, Some(":left".to_string()));
+        assert_eq!(
+            ctx.margin_boxes[1].page_selector,
+            Some(":right".to_string())
+        );
+    }
 }

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -506,6 +506,15 @@ fn build_cleaned_css(css: &str, edits: &mut [CssEdit]) -> String {
         }
 
         cursor = end;
+
+        // For Remove edits, cssparser's parse_block ends before the closing '}'.
+        // Skip the '}' that the framework consumes after parse_block returns.
+        if matches!(edit, CssEdit::Remove { .. })
+            && cursor < css.len()
+            && css.as_bytes()[cursor] == b'}'
+        {
+            cursor += 1;
+        }
     }
 
     // Copy any remaining text after the last edit
@@ -582,6 +591,16 @@ mod tests {
         assert!(ctx.cleaned_css.contains("body { color: red; }"));
         assert!(ctx.cleaned_css.contains("p { margin: 0; }"));
         assert!(!ctx.cleaned_css.contains("@page"));
+        // Verify no stray closing brace from @page removal
+        let without_rules = ctx
+            .cleaned_css
+            .replace("body { color: red; }", "")
+            .replace("p { margin: 0; }", "");
+        assert!(
+            !without_rules.contains('}'),
+            "stray brace in cleaned_css: {:?}",
+            ctx.cleaned_css
+        );
     }
 
     #[test]

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -1,7 +1,434 @@
 use std::collections::HashSet;
 
+use cssparser::{
+    AtRuleParser, BasicParseErrorKind, CowRcStr, DeclarationParser, ParseError, Parser,
+    ParserInput, QualifiedRuleParser, RuleBodyItemParser, RuleBodyParser, StyleSheetParser, Token,
+};
+
 use super::margin_box::MarginBoxPosition;
 use super::{ContentItem, CounterType, GcpmContext, MarginBoxRule};
+
+// ---------------------------------------------------------------------------
+// Top-level result types
+// ---------------------------------------------------------------------------
+
+/// A parsed item from the top-level stylesheet scan.
+/// The variants carry no data; results are accumulated via mutable references.
+enum TopLevelItem {
+    /// An `@page` rule was found.
+    PageRule,
+    /// A qualified rule (style rule) was found.
+    StyleRule,
+}
+
+// ---------------------------------------------------------------------------
+// 1. Top-level parser (GcpmSheetParser)
+// ---------------------------------------------------------------------------
+
+/// Collects byte-offset spans of `@page` rules and `position: running(...)` declarations
+/// so that `cleaned_css` can be assembled from the original source.
+struct GcpmSheetParser<'a> {
+    /// Byte ranges to remove (for `@page` blocks) or replace (for running decls).
+    edits: &'a mut Vec<CssEdit>,
+    margin_boxes: &'a mut Vec<MarginBoxRule>,
+    running_names: &'a mut HashSet<String>,
+}
+
+/// Describes a region in the original CSS to edit when building `cleaned_css`.
+enum CssEdit {
+    /// Remove the byte range entirely (used for `@page` blocks).
+    Remove { start: usize, end: usize },
+    /// Replace the byte range with the given text (used for `position: running(...)`).
+    Replace {
+        start: usize,
+        end: usize,
+        replacement: String,
+    },
+}
+
+impl<'i, 'a> AtRuleParser<'i> for GcpmSheetParser<'a> {
+    type Prelude = Option<String>; // page selector
+    type AtRule = TopLevelItem;
+    type Error = ();
+
+    fn parse_prelude<'t>(
+        &mut self,
+        name: CowRcStr<'i>,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Self::Prelude, ParseError<'i, ()>> {
+        if !name.eq_ignore_ascii_case("page") {
+            return Err(input.new_error(BasicParseErrorKind::AtRuleInvalid(name)));
+        }
+
+        // Optional page selector like `:first`
+        let page_selector = input
+            .try_parse(|input| -> Result<String, ParseError<'i, ()>> {
+                input.expect_colon()?;
+                let ident = input.expect_ident()?.clone();
+                Ok(format!(":{}", &*ident))
+            })
+            .ok();
+
+        Ok(page_selector)
+    }
+
+    fn parse_block<'t>(
+        &mut self,
+        page_selector: Self::Prelude,
+        start: &cssparser::ParserState,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Self::AtRule, ParseError<'i, ()>> {
+        let mut boxes = Vec::new();
+        parse_page_block(input, &page_selector, &mut boxes);
+
+        // Record the full @page rule span for removal.
+        let start_offset = start.position().byte_index();
+        let end_offset = input.position().byte_index();
+        self.edits.push(CssEdit::Remove {
+            start: start_offset,
+            end: end_offset,
+        });
+
+        self.margin_boxes.extend(boxes);
+        Ok(TopLevelItem::PageRule)
+    }
+}
+
+impl<'i, 'a> QualifiedRuleParser<'i> for GcpmSheetParser<'a> {
+    type Prelude = usize; // byte offset of rule start (before selector)
+    type QualifiedRule = TopLevelItem;
+    type Error = ();
+
+    fn parse_prelude<'t>(
+        &mut self,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Self::Prelude, ParseError<'i, ()>> {
+        let rule_start = input.position().byte_index();
+        // Consume the prelude (selector) — we don't need it
+        while input.next_including_whitespace().is_ok() {}
+        Ok(rule_start)
+    }
+
+    fn parse_block<'t>(
+        &mut self,
+        _prelude: Self::Prelude,
+        _start: &cssparser::ParserState,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Self::QualifiedRule, ParseError<'i, ()>> {
+        let mut running_name: Option<String> = None;
+
+        let mut parser = StyleRuleParser {
+            edits: self.edits,
+            running_name: &mut running_name,
+        };
+        let iter = RuleBodyParser::new(input, &mut parser);
+        for item in iter {
+            let _ = item;
+        }
+
+        if let Some(ref name) = running_name {
+            self.running_names.insert(name.clone());
+        }
+
+        Ok(TopLevelItem::StyleRule)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2. @page block parser (PageRuleParser) — uses RuleBodyParser
+// ---------------------------------------------------------------------------
+
+fn parse_page_block(
+    input: &mut Parser<'_, '_>,
+    page_selector: &Option<String>,
+    boxes: &mut Vec<MarginBoxRule>,
+) {
+    let mut parser = PageRuleParser {
+        page_selector,
+        boxes,
+    };
+    let iter = RuleBodyParser::new(input, &mut parser);
+    for item in iter {
+        let _ = item;
+    }
+}
+
+struct PageRuleParser<'a> {
+    page_selector: &'a Option<String>,
+    boxes: &'a mut Vec<MarginBoxRule>,
+}
+
+impl<'i, 'a> AtRuleParser<'i> for PageRuleParser<'a> {
+    type Prelude = MarginBoxPosition;
+    type AtRule = ();
+    type Error = ();
+
+    fn parse_prelude<'t>(
+        &mut self,
+        name: CowRcStr<'i>,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Self::Prelude, ParseError<'i, ()>> {
+        let _ = input;
+        MarginBoxPosition::from_at_keyword(&name)
+            .ok_or_else(|| input.new_error(BasicParseErrorKind::AtRuleInvalid(name)))
+    }
+
+    fn parse_block<'t>(
+        &mut self,
+        position: Self::Prelude,
+        _start: &cssparser::ParserState,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Self::AtRule, ParseError<'i, ()>> {
+        let mut content_items = Vec::new();
+        let mut declarations = String::new();
+
+        let mut parser = MarginBoxParser {
+            content: &mut content_items,
+            declarations: &mut declarations,
+        };
+        let iter = RuleBodyParser::new(input, &mut parser);
+        for item in iter {
+            let _ = item;
+        }
+
+        self.boxes.push(MarginBoxRule {
+            page_selector: self.page_selector.clone(),
+            position,
+            content: content_items,
+            declarations,
+        });
+
+        Ok(())
+    }
+}
+
+impl<'i, 'a> DeclarationParser<'i> for PageRuleParser<'a> {
+    type Declaration = ();
+    type Error = ();
+
+    fn parse_value<'t>(
+        &mut self,
+        name: CowRcStr<'i>,
+        input: &mut Parser<'i, 't>,
+        _start: &cssparser::ParserState,
+    ) -> Result<(), ParseError<'i, ()>> {
+        // Skip declarations directly inside @page (not inside margin boxes)
+        let _ = name;
+        while input.next().is_ok() {}
+        Ok(())
+    }
+}
+
+impl<'i, 'a> QualifiedRuleParser<'i> for PageRuleParser<'a> {
+    type Prelude = ();
+    type QualifiedRule = ();
+    type Error = ();
+}
+
+impl<'i, 'a> RuleBodyItemParser<'i, (), ()> for PageRuleParser<'a> {
+    fn parse_declarations(&self) -> bool {
+        true
+    }
+    fn parse_qualified(&self) -> bool {
+        false
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Margin box block parser (MarginBoxParser)
+// ---------------------------------------------------------------------------
+
+struct MarginBoxParser<'a> {
+    content: &'a mut Vec<ContentItem>,
+    declarations: &'a mut String,
+}
+
+impl<'i, 'a> DeclarationParser<'i> for MarginBoxParser<'a> {
+    type Declaration = ();
+    type Error = ();
+
+    fn parse_value<'t>(
+        &mut self,
+        name: CowRcStr<'i>,
+        input: &mut Parser<'i, 't>,
+        _start: &cssparser::ParserState,
+    ) -> Result<(), ParseError<'i, ()>> {
+        if name.eq_ignore_ascii_case("content") {
+            *self.content = parse_content_value(input);
+        } else {
+            // Accumulate other declarations as raw text
+            let start_pos = input.position();
+            while input.next_including_whitespace().is_ok() {}
+            let value_str = input.slice_from(start_pos).trim();
+            if !self.declarations.is_empty() {
+                self.declarations.push_str("; ");
+            }
+            self.declarations.push_str(&name);
+            self.declarations.push_str(": ");
+            self.declarations.push_str(value_str);
+        }
+        Ok(())
+    }
+}
+
+impl<'i, 'a> AtRuleParser<'i> for MarginBoxParser<'a> {
+    type Prelude = ();
+    type AtRule = ();
+    type Error = ();
+}
+
+impl<'i, 'a> QualifiedRuleParser<'i> for MarginBoxParser<'a> {
+    type Prelude = ();
+    type QualifiedRule = ();
+    type Error = ();
+}
+
+impl<'i, 'a> RuleBodyItemParser<'i, (), ()> for MarginBoxParser<'a> {
+    fn parse_declarations(&self) -> bool {
+        true
+    }
+    fn parse_qualified(&self) -> bool {
+        false
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 4. Style rule block parser (StyleRuleParser)
+// ---------------------------------------------------------------------------
+
+struct StyleRuleParser<'a> {
+    edits: &'a mut Vec<CssEdit>,
+    running_name: &'a mut Option<String>,
+}
+
+impl<'i, 'a> DeclarationParser<'i> for StyleRuleParser<'a> {
+    type Declaration = ();
+    type Error = ();
+
+    fn parse_value<'t>(
+        &mut self,
+        name: CowRcStr<'i>,
+        input: &mut Parser<'i, 't>,
+        decl_start: &cssparser::ParserState,
+    ) -> Result<(), ParseError<'i, ()>> {
+        if !name.eq_ignore_ascii_case("position") {
+            // Skip non-position declarations
+            while input.next().is_ok() {}
+            return Ok(());
+        }
+
+        // Try to parse `running(<name>)`
+        let result = input.try_parse(|input| {
+            let fn_name = input.expect_function()?.clone();
+            if !fn_name.eq_ignore_ascii_case("running") {
+                return Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid));
+            }
+            input.parse_nested_block(|input| {
+                let ident = input.expect_ident()?.clone();
+                Ok(ident.to_string())
+            })
+        });
+
+        if let Ok(running_name) = result {
+            *self.running_name = Some(running_name);
+
+            // Record the edit: replace `position: running(...)` with `display: none`
+            // The decl_start points to just before the property name (the ident token).
+            let decl_start_byte = decl_start.position().byte_index();
+            let end_byte = input.position().byte_index();
+            self.edits.push(CssEdit::Replace {
+                start: decl_start_byte,
+                end: end_byte,
+                replacement: "display: none".to_string(),
+            });
+        } else {
+            // Not running(...), skip the rest
+            while input.next().is_ok() {}
+        }
+
+        Ok(())
+    }
+}
+
+impl<'i, 'a> AtRuleParser<'i> for StyleRuleParser<'a> {
+    type Prelude = ();
+    type AtRule = ();
+    type Error = ();
+}
+
+impl<'i, 'a> QualifiedRuleParser<'i> for StyleRuleParser<'a> {
+    type Prelude = ();
+    type QualifiedRule = ();
+    type Error = ();
+}
+
+impl<'i, 'a> RuleBodyItemParser<'i, (), ()> for StyleRuleParser<'a> {
+    fn parse_declarations(&self) -> bool {
+        true
+    }
+    fn parse_qualified(&self) -> bool {
+        false
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Content value parser
+// ---------------------------------------------------------------------------
+
+/// Parse a `content` property value into a list of `ContentItem`s using cssparser.
+/// Handles: `element(<name>)`, `counter(page)`, `counter(pages)`, `"string"`.
+fn parse_content_value(input: &mut Parser<'_, '_>) -> Vec<ContentItem> {
+    let mut items = Vec::new();
+
+    loop {
+        if input.is_exhausted() {
+            break;
+        }
+
+        let result: Result<(), ParseError<'_, ()>> = input.try_parse(|input| {
+            let token = input.next_including_whitespace()?.clone();
+            match token {
+                Token::QuotedString(ref s) => {
+                    items.push(ContentItem::String(s.to_string()));
+                }
+                Token::Function(ref name) => {
+                    let fn_name = name.clone();
+                    input.parse_nested_block(|input| {
+                        let arg = input.expect_ident()?.clone();
+                        if fn_name.eq_ignore_ascii_case("element") {
+                            items.push(ContentItem::Element(arg.to_string()));
+                        } else if fn_name.eq_ignore_ascii_case("counter") {
+                            match &*arg {
+                                "page" => items.push(ContentItem::Counter(CounterType::Page)),
+                                "pages" => items.push(ContentItem::Counter(CounterType::Pages)),
+                                _ => {} // unknown counter
+                            }
+                        }
+                        Ok(())
+                    })?;
+                }
+                Token::WhiteSpace(_) | Token::Comment(_) => {
+                    // skip
+                }
+                _ => {
+                    // skip unknown tokens
+                }
+            }
+            Ok(())
+        });
+
+        if result.is_err() {
+            // If we can't parse the next token at all, break out
+            break;
+        }
+    }
+
+    items
+}
+
+// ---------------------------------------------------------------------------
+// 6. Main entry point
+// ---------------------------------------------------------------------------
 
 /// Parse a CSS string, extracting GCPM constructs and returning a `GcpmContext`.
 ///
@@ -9,97 +436,29 @@ use super::{ContentItem, CounterType, GcpmContext, MarginBoxRule};
 /// - `@page { @<position> { content: ...; } }` blocks are extracted as margin box rules
 /// - All other CSS is preserved verbatim in `cleaned_css`
 pub fn parse_gcpm(css: &str) -> GcpmContext {
-    let mut running_names = HashSet::new();
     let mut margin_boxes = Vec::new();
-    let mut cleaned_css = String::with_capacity(css.len());
+    let mut running_names = HashSet::new();
+    let mut edits: Vec<CssEdit> = Vec::new();
 
-    let len = css.len();
-    let mut i = 0;
+    // Run the cssparser-based parse to collect GCPM data and edit spans.
+    {
+        let mut input = ParserInput::new(css);
+        let mut input = Parser::new(&mut input);
 
-    while i < len {
-        let remaining = &css[i..];
-        let ch = remaining.chars().next().unwrap();
-        let ch_len = ch.len_utf8();
+        let mut parser = GcpmSheetParser {
+            edits: &mut edits,
+            margin_boxes: &mut margin_boxes,
+            running_names: &mut running_names,
+        };
 
-        // Skip CSS comments /* ... */
-        if remaining.starts_with("/*") {
-            if let Some(end) = css[i + 2..].find("*/") {
-                cleaned_css.push_str(&css[i..i + 2 + end + 2]);
-                i += 2 + end + 2;
-            } else {
-                // Unterminated comment — copy the rest
-                cleaned_css.push_str(remaining);
-                break;
-            }
-            continue;
+        let iter = StyleSheetParser::new(&mut input, &mut parser);
+        for item in iter {
+            let _ = item;
         }
-
-        // Skip string literals "..." and '...'
-        if ch == '"' || ch == '\'' {
-            let quote = ch;
-            let mut j = i + 1;
-            while j < len {
-                let c = css[j..].chars().next().unwrap();
-                if c == '\\' {
-                    j += c.len_utf8();
-                    if j < len {
-                        j += css[j..].chars().next().unwrap().len_utf8();
-                    }
-                } else if c == quote {
-                    j += 1;
-                    break;
-                } else {
-                    j += c.len_utf8();
-                }
-            }
-            cleaned_css.push_str(&css[i..j]);
-            i = j;
-            continue;
-        }
-
-        // Check for @page rule
-        if ch == '@' {
-            if let Some(rest) = css.get(i + 1..) {
-                if rest.starts_with("page") {
-                    let after_page = i + 5; // after "@page"
-                    let after_page_ch = css[after_page..].chars().next();
-                    // Make sure it's not @page-something (must be followed by whitespace, {, or :)
-                    if after_page >= len
-                        || matches!(after_page_ch, Some(c) if c.is_ascii_whitespace() || c == '{' || c == ':')
-                    {
-                        if let Some((consumed, page_sel, boxes)) = parse_page_rule(&css[i..]) {
-                            margin_boxes.extend(boxes);
-                            // Skip the entire @page block (don't add to cleaned_css)
-                            // but preserve a newline to avoid merging adjacent rules
-                            if !cleaned_css.is_empty()
-                                && !cleaned_css.ends_with('\n')
-                                && !cleaned_css.ends_with(' ')
-                            {
-                                cleaned_css.push('\n');
-                            }
-                            let _ = page_sel; // used inside parse_page_rule
-                            i += consumed;
-                            continue;
-                        }
-                    }
-                }
-            }
-        }
-
-        // Check for position: running(...)
-        if ch == 'p' || ch == 'P' {
-            if let Some(result) = try_parse_running(&css[i..]) {
-                let (name, replacement, consumed) = result;
-                running_names.insert(name);
-                cleaned_css.push_str(&replacement);
-                i += consumed;
-                continue;
-            }
-        }
-
-        cleaned_css.push_str(&css[i..i + ch_len]);
-        i += ch_len;
     }
+
+    // Build cleaned_css by applying edits to the original CSS.
+    let cleaned_css = build_cleaned_css(css, &mut edits);
 
     GcpmContext {
         margin_boxes,
@@ -108,342 +467,55 @@ pub fn parse_gcpm(css: &str) -> GcpmContext {
     }
 }
 
-/// Try to parse `position\s*:\s*running\s*(\s*<name>\s*)` at the current position.
-/// Returns (name, replacement_text, chars_consumed) or None.
-fn try_parse_running(s: &str) -> Option<(String, String, usize)> {
-    // Match "position" case-insensitively
-    let lower = s.get(..8)?;
-    if !lower.eq_ignore_ascii_case("position") {
-        return None;
+/// Build `cleaned_css` from the original CSS and a list of edits.
+/// Edits must not overlap. They are sorted by start position.
+fn build_cleaned_css(css: &str, edits: &mut [CssEdit]) -> String {
+    if edits.is_empty() {
+        return css.to_string();
     }
 
-    let rest = &s[8..];
-    let mut idx = 0;
+    // Sort by start position
+    edits.sort_by_key(|e| match e {
+        CssEdit::Remove { start, .. } => *start,
+        CssEdit::Replace { start, .. } => *start,
+    });
 
-    // Skip whitespace
-    while idx < rest.len() && rest.as_bytes()[idx].is_ascii_whitespace() {
-        idx += 1;
-    }
+    let mut result = String::with_capacity(css.len());
+    let mut cursor = 0;
 
-    // Expect ':'
-    if idx >= rest.len() || rest.as_bytes()[idx] != b':' {
-        return None;
-    }
-    idx += 1;
+    for edit in edits.iter() {
+        let (start, end) = match edit {
+            CssEdit::Remove { start, end } => (*start, *end),
+            CssEdit::Replace { start, end, .. } => (*start, *end),
+        };
 
-    // Skip whitespace
-    while idx < rest.len() && rest.as_bytes()[idx].is_ascii_whitespace() {
-        idx += 1;
-    }
-
-    // Expect "running"
-    let after_colon = &rest[idx..];
-    if !after_colon.starts_with("running") {
-        return None;
-    }
-    idx += 7;
-
-    // Skip whitespace
-    while idx < rest.len() && rest.as_bytes()[idx].is_ascii_whitespace() {
-        idx += 1;
-    }
-
-    // Expect '('
-    if idx >= rest.len() || rest.as_bytes()[idx] != b'(' {
-        return None;
-    }
-    idx += 1;
-
-    // Skip whitespace
-    while idx < rest.len() && rest.as_bytes()[idx].is_ascii_whitespace() {
-        idx += 1;
-    }
-
-    // Read name (alphanumeric, hyphen, underscore)
-    let name_start = idx;
-    while idx < rest.len() {
-        let c = rest.as_bytes()[idx];
-        if c.is_ascii_alphanumeric() || c == b'-' || c == b'_' {
-            idx += 1;
-        } else {
-            break;
+        // Copy verbatim text before this edit
+        if cursor < start {
+            result.push_str(&css[cursor..start]);
         }
-    }
-    let name = rest[name_start..idx].to_string();
-    if name.is_empty() {
-        return None;
-    }
 
-    // Skip whitespace
-    while idx < rest.len() && rest.as_bytes()[idx].is_ascii_whitespace() {
-        idx += 1;
-    }
-
-    // Expect ')'
-    if idx >= rest.len() || rest.as_bytes()[idx] != b')' {
-        return None;
-    }
-    idx += 1;
-
-    let total_consumed = 8 + idx; // "position" + rest consumed
-    Some((name, "display: none".to_string(), total_consumed))
-}
-
-/// Parse an `@page` rule starting at `s`.
-/// Returns (chars_consumed, page_selector, Vec<MarginBoxRule>) or None.
-fn parse_page_rule(s: &str) -> Option<(usize, Option<String>, Vec<MarginBoxRule>)> {
-    // s starts with "@page"
-    let mut idx = 5; // skip "@page"
-
-    // Skip whitespace
-    while idx < s.len() && s.as_bytes()[idx].is_ascii_whitespace() {
-        idx += 1;
-    }
-
-    // Check for optional page selector (e.g. ":first", ":left", ":right")
-    let mut page_selector = None;
-    if idx < s.len() && s.as_bytes()[idx] == b':' {
-        let sel_start = idx;
-        idx += 1;
-        // Read selector name
-        while idx < s.len() && s.as_bytes()[idx].is_ascii_alphanumeric() {
-            idx += 1;
-        }
-        page_selector = Some(s[sel_start..idx].to_string());
-
-        // Skip whitespace after selector
-        while idx < s.len() && s.as_bytes()[idx].is_ascii_whitespace() {
-            idx += 1;
-        }
-    }
-
-    // Expect '{'
-    if idx >= s.len() || s.as_bytes()[idx] != b'{' {
-        return None;
-    }
-
-    // Find matching brace
-    let (inner, end_pos) = find_matching_brace(&s[idx..])?;
-    let total_consumed = idx + end_pos + 1; // +1 for closing '}'
-
-    let mut boxes = Vec::new();
-    parse_margin_boxes(&inner, &page_selector, &mut boxes);
-
-    Some((total_consumed, page_selector, boxes))
-}
-
-/// Given a string starting with '{', find the matching '}' and return
-/// (inner_content_without_braces, position_of_closing_brace_relative_to_input).
-fn find_matching_brace(s: &str) -> Option<(String, usize)> {
-    if s.as_bytes().first()? != &b'{' {
-        return None;
-    }
-
-    let mut depth = 0;
-    for (i, c) in s.char_indices() {
-        match c {
-            '{' => depth += 1,
-            '}' => {
-                depth -= 1;
-                if depth == 0 {
-                    return Some((s[1..i].to_string(), i));
+        // Apply the edit
+        match edit {
+            CssEdit::Remove { .. } => {
+                // For @page removal, insert a newline separator if needed
+                if !result.is_empty() && !result.ends_with('\n') && !result.ends_with(' ') {
+                    result.push('\n');
                 }
             }
-            _ => {}
-        }
-    }
-    None
-}
-
-/// Parse the inner content of an `@page { ... }` block for margin box at-rules.
-fn parse_margin_boxes(
-    content: &str,
-    page_selector: &Option<String>,
-    boxes: &mut Vec<MarginBoxRule>,
-) {
-    let bytes = content.as_bytes();
-    let mut i = 0;
-
-    while i < bytes.len() {
-        // Look for @<keyword>
-        if bytes[i] == b'@' {
-            i += 1;
-            // Skip whitespace
-            while i < bytes.len() && bytes[i].is_ascii_whitespace() {
-                i += 1;
-            }
-            // Read keyword
-            let kw_start = i;
-            while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'-') {
-                i += 1;
-            }
-            let keyword = &content[kw_start..i];
-
-            // Skip whitespace
-            while i < bytes.len() && bytes[i].is_ascii_whitespace() {
-                i += 1;
-            }
-
-            // Expect '{'
-            if i < bytes.len() && bytes[i] == b'{' {
-                if let Some(position) = MarginBoxPosition::from_at_keyword(keyword) {
-                    if let Some((inner, end_pos)) = find_matching_brace(&content[i..]) {
-                        let (content_items, declarations) = parse_content_property(&inner);
-                        boxes.push(MarginBoxRule {
-                            page_selector: page_selector.clone(),
-                            position,
-                            content: content_items,
-                            declarations,
-                        });
-                        i += end_pos + 1;
-                        continue;
-                    }
-                }
-                // Unknown at-rule or parse failure — skip the block
-                if let Some((_, end_pos)) = find_matching_brace(&content[i..]) {
-                    i += end_pos + 1;
-                    continue;
-                }
+            CssEdit::Replace { replacement, .. } => {
+                result.push_str(replacement);
             }
         }
 
-        i += 1;
-    }
-}
-
-/// Parse the declarations block of a margin box, extracting the `content` property
-/// and returning (content_items, remaining_declarations).
-fn parse_content_property(block: &str) -> (Vec<ContentItem>, String) {
-    let mut content_items = Vec::new();
-    let mut declarations = String::new();
-
-    // Split by semicolons (simple approach — works for non-nested values)
-    for decl in block.split(';') {
-        let trimmed = decl.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-
-        // Split on first ':'
-        if let Some(colon_pos) = trimmed.find(':') {
-            let prop = trimmed[..colon_pos].trim();
-            let value = trimmed[colon_pos + 1..].trim();
-
-            if prop.eq_ignore_ascii_case("content") {
-                content_items = parse_content_value(value);
-            } else {
-                if !declarations.is_empty() {
-                    declarations.push_str("; ");
-                }
-                declarations.push_str(trimmed);
-            }
-        }
+        cursor = end;
     }
 
-    (content_items, declarations)
-}
-
-/// Parse a `content` property value into a list of ContentItems.
-/// Handles: `element(<name>)`, `counter(page)`, `counter(pages)`, `"string"`.
-fn parse_content_value(value: &str) -> Vec<ContentItem> {
-    let mut items = Vec::new();
-    let bytes = value.as_bytes();
-    let mut i = 0;
-
-    while i < bytes.len() {
-        // Skip whitespace
-        if bytes[i].is_ascii_whitespace() {
-            i += 1;
-            continue;
-        }
-
-        // String literal
-        if bytes[i] == b'"' {
-            i += 1;
-            let start = i;
-            while i < bytes.len() && bytes[i] != b'"' {
-                if bytes[i] == b'\\' {
-                    i += 1; // skip escaped char
-                }
-                i += 1;
-            }
-            items.push(ContentItem::String(value[start..i].to_string()));
-            if i < bytes.len() {
-                i += 1; // skip closing quote
-            }
-            continue;
-        }
-
-        // Single-quoted string
-        if bytes[i] == b'\'' {
-            i += 1;
-            let start = i;
-            while i < bytes.len() && bytes[i] != b'\'' {
-                if bytes[i] == b'\\' {
-                    i += 1;
-                }
-                i += 1;
-            }
-            items.push(ContentItem::String(value[start..i].to_string()));
-            if i < bytes.len() {
-                i += 1;
-            }
-            continue;
-        }
-
-        // Function-like: element(...) or counter(...)
-        if bytes[i].is_ascii_alphabetic() {
-            let fn_start = i;
-            while i < bytes.len()
-                && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'-' || bytes[i] == b'_')
-            {
-                i += 1;
-            }
-            let fn_name = &value[fn_start..i];
-
-            // Skip whitespace
-            while i < bytes.len() && bytes[i].is_ascii_whitespace() {
-                i += 1;
-            }
-
-            if i < bytes.len() && bytes[i] == b'(' {
-                i += 1;
-                // Skip whitespace
-                while i < bytes.len() && bytes[i].is_ascii_whitespace() {
-                    i += 1;
-                }
-                let arg_start = i;
-                while i < bytes.len() && bytes[i] != b')' && !bytes[i].is_ascii_whitespace() {
-                    i += 1;
-                }
-                let arg = value[arg_start..i].trim();
-                // Skip to closing paren
-                while i < bytes.len() && bytes[i] != b')' {
-                    i += 1;
-                }
-                if i < bytes.len() {
-                    i += 1; // skip ')'
-                }
-
-                match fn_name {
-                    "element" => {
-                        items.push(ContentItem::Element(arg.to_string()));
-                    }
-                    "counter" => match arg {
-                        "page" => items.push(ContentItem::Counter(CounterType::Page)),
-                        "pages" => items.push(ContentItem::Counter(CounterType::Pages)),
-                        _ => {} // unknown counter
-                    },
-                    _ => {} // unknown function
-                }
-            }
-            continue;
-        }
-
-        i += 1;
+    // Copy any remaining text after the last edit
+    if cursor < css.len() {
+        result.push_str(&css[cursor..]);
     }
 
-    items
+    result
 }
 
 #[cfg(test)]

--- a/docs/plans/2026-03-22-cssparser-rewrite.md
+++ b/docs/plans/2026-03-22-cssparser-rewrite.md
@@ -1,0 +1,215 @@
+# GCPM パーサー cssparser 化 実装計画
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 手書き文字ベースの `parse_gcpm()` を cssparser クレートベースに書き直す。機能変更なし（純粋リファクタ）。
+
+**Architecture:** cssparser の `StyleSheetParser` でトップレベルルールを走査し、`AtRuleParser` で `@page` とマージンボックス at-rule を、`QualifiedRuleParser` + `DeclarationParser` で通常ルール内の `position: running(name)` を検出する。出力する `GcpmContext` の構造は変更しない。
+
+**Tech Stack:** cssparser 0.35.0（Blitz 経由で依存ツリーに存在、直接依存として追加）
+
+---
+
+### Task 1: cssparser を直接依存に追加
+
+**Files:**
+- Modify: `crates/fulgur/Cargo.toml`
+
+**Step 1: Cargo.toml に cssparser を追加**
+
+`[dependencies]` セクションに追加:
+```toml
+cssparser = "0.35"
+```
+
+**Step 2: ビルド確認**
+
+Run: `cargo build -p fulgur`
+Expected: PASS（バージョンは Cargo.lock で既に 0.35.0 に固定されているので新規ダウンロードなし）
+
+**Step 3: Commit**
+
+```bash
+git add crates/fulgur/Cargo.toml
+git commit -m "chore: add cssparser as direct dependency for GCPM parser"
+```
+
+---
+
+### Task 2: cssparser ベースの parse_gcpm() を実装（テストは既存を流用）
+
+**Files:**
+- Modify: `crates/fulgur/src/gcpm/parser.rs`
+
+**注意:** 既存の `parser.rs` のテストモジュール（`mod tests`）は変更しない。このタスクでは `parse_gcpm()` 関数と内部ヘルパーの実装を書き直し、既存テストがそのまま通ることを確認する。
+
+**Step 1: 新しい parser.rs を実装**
+
+cssparser のトレイトを使った実装構造:
+
+1. **トップレベルパーサー** (`GcpmSheetParser`):
+   - `AtRuleParser`: `@page` を検出 → `parse_block` で内部をパース
+   - `QualifiedRuleParser`: セレクタ部分を読み飛ばし、`parse_block` で宣言をパース
+   - `DeclarationParser`: トップレベルでは不要（空実装）
+
+2. **@page ブロック内パーサー** (`PageRuleParser`):
+   - `AtRuleParser`: `@top-center` 等のマージンボックス at-rule を検出
+   - `DeclarationParser`: `@page` 直下の宣言は読み飛ばし
+   - `QualifiedRuleParser`: 不要（空実装）
+
+3. **マージンボックスブロック内パーサー** (`MarginBoxParser`):
+   - `DeclarationParser`: `content` プロパティを解析して `ContentItem` に変換、それ以外の宣言は `declarations` 文字列に蓄積
+   - `AtRuleParser` / `QualifiedRuleParser`: 不要（空実装）
+
+4. **通常ルールブロック内パーサー** (`StyleRuleParser`):
+   - `DeclarationParser`: `position: running(name)` を検出
+   - `AtRuleParser` / `QualifiedRuleParser`: 不要（空実装）
+
+5. **`cleaned_css` の生成**:
+   - cssparser はトークンを消費するため、元の CSS 文字列を再構築する必要がある
+   - アプローチ: `Parser::position()` と `Parser::slice_from()` を活用
+   - `position: running(...)` を含むルールは `display: none` に置き換え、`@page` ブロックは丸ごと除去
+   - 具体的には: トップレベルパースで各ルールの開始・終了位置を記録し、非 GCPM 部分はそのまま `cleaned_css` にコピー、GCPM ルールは変換済みテキストで置換
+
+6. **`parse_content_value()` 関数**:
+   - マージンボックス内の `content` プロパティ値をパースして `Vec<ContentItem>` を返す
+   - cssparser の `Parser` を使って `element(name)` / `counter(page)` / `counter(pages)` / 文字列リテラルを検出
+   - 既存の手書き実装と同等の動作
+
+公開 API:
+```rust
+pub fn parse_gcpm(css: &str) -> GcpmContext
+```
+
+シグネチャは変更しない。内部実装のみ cssparser 化。
+
+**Step 2: 既存テストを実行して全パス確認**
+
+Run: `cargo test --lib -p fulgur gcpm::parser`
+Expected: 既存の 7 テスト全パス
+
+**Step 3: Commit**
+
+```bash
+git add crates/fulgur/src/gcpm/parser.rs
+git commit -m "refactor: rewrite parse_gcpm() using cssparser crate"
+```
+
+---
+
+### Task 3: エッジケーステストの追加
+
+**Files:**
+- Modify: `crates/fulgur/src/gcpm/parser.rs`（テストモジュール）
+
+**Step 1: cssparser 化で正しく処理されることを確認するテストを追加**
+
+以下のケースを追加:
+
+```rust
+#[test]
+fn test_running_name_case_insensitive_property() {
+    // POSITION: Running(name) — プロパティ名の大文字小文字
+    let css = ".header { POSITION: running(pageHeader); }";
+    let ctx = parse_gcpm(css);
+    assert!(ctx.running_names.contains("pageHeader"));
+    assert!(ctx.cleaned_css.contains("display: none"));
+}
+
+#[test]
+fn test_multiple_running_names() {
+    let css = ".h { position: running(hdr); } .f { position: running(ftr); }";
+    let ctx = parse_gcpm(css);
+    assert!(ctx.running_names.contains("hdr"));
+    assert!(ctx.running_names.contains("ftr"));
+}
+
+#[test]
+fn test_running_with_other_declarations() {
+    // running() 以外の宣言が cleaned_css に残ること
+    let css = ".header { color: red; position: running(hdr); font-size: 14px; }";
+    let ctx = parse_gcpm(css);
+    assert!(ctx.running_names.contains("hdr"));
+    assert!(ctx.cleaned_css.contains("color: red"));
+    assert!(ctx.cleaned_css.contains("font-size: 14px"));
+}
+
+#[test]
+fn test_page_with_multiple_margin_boxes() {
+    let css = "@page { @top-left { content: \"Left\"; } @top-center { content: element(hdr); } @top-right { content: counter(page); } }";
+    let ctx = parse_gcpm(css);
+    assert_eq!(ctx.margin_boxes.len(), 3);
+}
+
+#[test]
+fn test_margin_box_with_extra_declarations() {
+    let css = "@page { @top-center { content: element(hdr); font-size: 10pt; color: gray; } }";
+    let ctx = parse_gcpm(css);
+    assert_eq!(ctx.margin_boxes.len(), 1);
+    let mb = &ctx.margin_boxes[0];
+    assert_eq!(mb.content, vec![ContentItem::Element("hdr".to_string())]);
+    assert!(mb.declarations.contains("font-size"));
+    assert!(mb.declarations.contains("color"));
+}
+
+#[test]
+fn test_page_left_right_selectors() {
+    let css = r#"
+        @page :left { @bottom-left { content: counter(page); } }
+        @page :right { @bottom-right { content: counter(page); } }
+    "#;
+    let ctx = parse_gcpm(css);
+    assert_eq!(ctx.margin_boxes.len(), 2);
+    assert_eq!(ctx.margin_boxes[0].page_selector, Some(":left".to_string()));
+    assert_eq!(ctx.margin_boxes[1].page_selector, Some(":right".to_string()));
+}
+```
+
+**Step 2: テスト実行**
+
+Run: `cargo test --lib -p fulgur gcpm::parser`
+Expected: 全テストパス
+
+**Step 3: Commit**
+
+```bash
+git add crates/fulgur/src/gcpm/parser.rs
+git commit -m "test: add edge case tests for cssparser-based GCPM parser"
+```
+
+---
+
+### Task 4: 統合テストの実行確認
+
+**Files:**
+- なし（既存テストの実行のみ）
+
+**Step 1: ユニットテスト全体を実行**
+
+Run: `cargo test --lib -p fulgur`
+Expected: 全テストパス（46+追加分）
+
+**Step 2: 統合テストを実行**
+
+Run: `cargo test -p fulgur --test gcpm_integration -- --test-threads=1`
+Expected: 全テストパス
+
+**Step 3: clippy と fmt を確認**
+
+Run: `cargo clippy -p fulgur && cargo fmt -p fulgur --check`
+Expected: 警告・エラーなし
+
+---
+
+### Task 5: 旧パーサーのコード削除確認
+
+**Step 1: parser.rs に旧コードが残っていないことを確認**
+
+`try_parse_running()`, `find_matching_brace()`, `parse_page_rule()`, `parse_margin_boxes()`, `parse_content_property()`, `parse_content_value()` — これらの手書き関数が Task 2 で全て置き換えられていることを確認。
+
+もし `parse_content_value()` 等を cssparser 化せず内部で流用している場合は、そのまま残して良い（`@page` 内の `content` プロパティパースは cssparser のトークナイザで十分だが、既存関数の再利用も許容）。
+
+**Step 2: 最終ビルド確認**
+
+Run: `cargo build -p fulgur`
+Expected: 警告なしでビルド成功


### PR DESCRIPTION
## Summary
- 手書き文字ベースの `parse_gcpm()` を cssparser 0.35 のトレイトベース実装に全面書き直し
- `AtRuleParser` / `QualifiedRuleParser` / `DeclarationParser` で `@page` マージンボックスと `position: running(name)` を構造的にパース
- `CssEdit` スパンベースの編集方式で `cleaned_css` を元のソースから忠実に再構築
- 6つのエッジケーステストを追加（case-insensitive, 複数running名, ページセレクタ等）
- 公開API・`GcpmContext` 構造体に変更なし（純粋リファクタ）

## Motivation
- 当初のdesignドキュメント (docs/plans/2026-03-21-gcpm-header-footer-design.md) でcssparser使用が意図されていた
- セレクタ→running名マッピング (fulgur-iqn) と `@media print` 対応の基盤整備

## Test plan
- [x] 既存ユニットテスト 8件 全パス
- [x] 新規エッジケーステスト 6件 全パス（計52件）
- [x] 統合テスト 5件 全パス
- [x] clippy 警告なし
- [x] cargo fmt --check パス
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/22" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * GCPM CSS パーサーを cssparser ベースで全面的に書き換え、@page やマージンボックス、position: running() の検出と処理をより堅牢化しました。複数のエッジケースを扱うテストを追加しています。
* **Bug Fixes**
  * マージンボックス位置キーワードの大文字小文字差を無視して正しく認識するよう修正しました。
* **Chore**
  * パーサー用の依存ライブラリを追加しました。
* **Documentation**
  * リライト計画と検証手順をドキュメントに追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->