### PR TITLE
feat: match running elements by CSS selector instead of class name

### DIFF
--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -1,6 +1,7 @@
 //! Convert a Blitz DOM (after style resolution + layout) into a Pageable tree.
 
 use crate::gcpm::GcpmContext;
+use crate::gcpm::ParsedSelector;
 use crate::gcpm::running::{RunningElementStore, serialize_node};
 use crate::pageable::{
     BlockPageable, BlockStyle, BorderStyleValue, ListItemPageable, Pageable, PositionedChild, Size,
@@ -233,17 +234,16 @@ fn collect_positioned_children(
 
 /// Check if a node is a running element.
 /// Since the CSS preprocessor replaced `position: running(name)` with `display: none`,
-/// we identify running elements by checking if they have a class matching a known running name.
-/// Elements with `display: none` will typically have zero-size layout, but we rely on the
-/// class name match against `running_names` from the GCPM context.
+/// we identify running elements by matching them against parsed CSS selectors (class, id,
+/// or tag) from the GCPM context's `running_mappings`.
 fn is_running_element(node: &Node, ctx: &GcpmContext) -> bool {
-    if ctx.running_names.is_empty() {
+    if ctx.running_mappings.is_empty() {
         return false;
     }
     let Some(elem) = node.element_data() else {
         return false;
     };
-    has_matching_running_name(elem, ctx)
+    ctx.running_mappings.iter().any(|m| matches_selector(&m.parsed, elem))
 }
 
 fn get_class_attr(elem: &blitz_dom::node::ElementData) -> Option<&str> {
@@ -253,22 +253,41 @@ fn get_class_attr(elem: &blitz_dom::node::ElementData) -> Option<&str> {
         .map(|a| a.value.as_ref())
 }
 
-fn has_matching_running_name(elem: &blitz_dom::node::ElementData, ctx: &GcpmContext) -> bool {
-    let Some(class_attr) = get_class_attr(elem) else {
-        return false;
-    };
-    class_attr
-        .split_whitespace()
-        .any(|cls| ctx.running_names.contains(cls))
+fn get_id_attr(elem: &blitz_dom::node::ElementData) -> Option<&str> {
+    elem.attrs()
+        .iter()
+        .find(|a| a.name.local.as_ref() == "id")
+        .map(|a| a.value.as_ref())
+}
+
+fn get_tag_name(elem: &blitz_dom::node::ElementData) -> &str {
+    elem.name.local.as_ref()
+}
+
+fn matches_selector(selector: &ParsedSelector, elem: &blitz_dom::node::ElementData) -> bool {
+    match selector {
+        ParsedSelector::Class(name) => {
+            get_class_attr(elem)
+                .map(|cls| cls.split_whitespace().any(|c| c == name))
+                .unwrap_or(false)
+        }
+        ParsedSelector::Id(name) => {
+            get_id_attr(elem)
+                .map(|id| id == name)
+                .unwrap_or(false)
+        }
+        ParsedSelector::Tag(name) => {
+            get_tag_name(elem).eq_ignore_ascii_case(name)
+        }
+    }
 }
 
 fn get_running_name(node: &Node, ctx: &GcpmContext) -> Option<String> {
     let elem = node.element_data()?;
-    let class_attr = get_class_attr(elem)?;
-    class_attr
-        .split_whitespace()
-        .find(|cls| ctx.running_names.contains(*cls))
-        .map(|s| s.to_string())
+    ctx.running_mappings
+        .iter()
+        .find(|m| matches_selector(&m.parsed, elem))
+        .map(|m| m.running_name.clone())
 }
 
 /// Convert a table element into a TablePageable with header/body cell groups.

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -243,7 +243,9 @@ fn is_running_element(node: &Node, ctx: &GcpmContext) -> bool {
     let Some(elem) = node.element_data() else {
         return false;
     };
-    ctx.running_mappings.iter().any(|m| matches_selector(&m.parsed, elem))
+    ctx.running_mappings
+        .iter()
+        .any(|m| matches_selector(&m.parsed, elem))
 }
 
 fn get_class_attr(elem: &blitz_dom::node::ElementData) -> Option<&str> {
@@ -266,19 +268,11 @@ fn get_tag_name(elem: &blitz_dom::node::ElementData) -> &str {
 
 fn matches_selector(selector: &ParsedSelector, elem: &blitz_dom::node::ElementData) -> bool {
     match selector {
-        ParsedSelector::Class(name) => {
-            get_class_attr(elem)
-                .map(|cls| cls.split_whitespace().any(|c| c == name))
-                .unwrap_or(false)
-        }
-        ParsedSelector::Id(name) => {
-            get_id_attr(elem)
-                .map(|id| id == name)
-                .unwrap_or(false)
-        }
-        ParsedSelector::Tag(name) => {
-            get_tag_name(elem).eq_ignore_ascii_case(name)
-        }
+        ParsedSelector::Class(name) => get_class_attr(elem)
+            .map(|cls| cls.split_whitespace().any(|c| c == name))
+            .unwrap_or(false),
+        ParsedSelector::Id(name) => get_id_attr(elem).map(|id| id == name).unwrap_or(false),
+        ParsedSelector::Tag(name) => get_tag_name(elem).eq_ignore_ascii_case(name),
     }
 }
 

--- a/crates/fulgur/src/gcpm/mod.rs
+++ b/crates/fulgur/src/gcpm/mod.rs
@@ -3,9 +3,27 @@ pub mod margin_box;
 pub mod parser;
 pub mod running;
 
-use std::collections::HashSet;
-
 use margin_box::MarginBoxPosition;
+
+/// A simple CSS selector parsed from a style rule.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParsedSelector {
+    /// A class selector, e.g. `.header`
+    Class(String),
+    /// An ID selector, e.g. `#title`
+    Id(String),
+    /// A tag name selector, e.g. `header`
+    Tag(String),
+}
+
+/// Maps a CSS selector to a running element name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunningMapping {
+    /// The parsed CSS selector.
+    pub parsed: ParsedSelector,
+    /// The name from `position: running(name)`.
+    pub running_name: String,
+}
 
 /// A single content item inside a margin box rule's `content` property.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -45,8 +63,8 @@ pub struct MarginBoxRule {
 pub struct GcpmContext {
     /// All margin box rules found in `@page` rules.
     pub margin_boxes: Vec<MarginBoxRule>,
-    /// Names referenced by `position: running(...)` in the stylesheet.
-    pub running_names: HashSet<String>,
+    /// Mappings from CSS selectors to running element names.
+    pub running_mappings: Vec<RunningMapping>,
     /// The CSS with GCPM constructs stripped, suitable for normal rendering.
     pub cleaned_css: String,
 }
@@ -54,7 +72,7 @@ pub struct GcpmContext {
 impl GcpmContext {
     /// Returns `true` if no GCPM features were found.
     pub fn is_empty(&self) -> bool {
-        self.margin_boxes.is_empty() && self.running_names.is_empty()
+        self.margin_boxes.is_empty() && self.running_mappings.is_empty()
     }
 }
 
@@ -66,7 +84,7 @@ mod tests {
     fn test_gcpm_context_is_empty() {
         let ctx = GcpmContext {
             margin_boxes: vec![],
-            running_names: HashSet::new(),
+            running_mappings: vec![],
             cleaned_css: String::new(),
         };
         assert!(ctx.is_empty());
@@ -81,7 +99,7 @@ mod tests {
                 content: vec![ContentItem::Counter(CounterType::Page)],
                 declarations: String::new(),
             }],
-            running_names: HashSet::new(),
+            running_mappings: vec![],
             cleaned_css: String::new(),
         };
         assert!(!ctx.is_empty());
@@ -89,11 +107,12 @@ mod tests {
 
     #[test]
     fn test_gcpm_context_not_empty_with_running_name() {
-        let mut names = HashSet::new();
-        names.insert("header".to_string());
         let ctx = GcpmContext {
             margin_boxes: vec![],
-            running_names: names,
+            running_mappings: vec![RunningMapping {
+                parsed: ParsedSelector::Class("header".to_string()),
+                running_name: "header".to_string(),
+            }],
             cleaned_css: String::new(),
         };
         assert!(!ctx.is_empty());

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -101,18 +101,35 @@ impl<'i, 'a> QualifiedRuleParser<'i> for GcpmSheetParser<'a> {
         &mut self,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self::Prelude, ParseError<'i, ()>> {
-        let selector = match input.next_including_whitespace()?.clone() {
+        // Skip leading whitespace
+        let first = loop {
+            match input.next_including_whitespace()?.clone() {
+                Token::WhiteSpace(_) => continue,
+                tok => break tok,
+            }
+        };
+
+        let selector = match first {
             Token::Delim('.') => {
                 let name = input.expect_ident()?.clone();
-                Some(ParsedSelector::Class(name.to_string()))
+                ParsedSelector::Class(name.to_string())
             }
-            Token::IDHash(ref name) => Some(ParsedSelector::Id(name.to_string())),
-            Token::Ident(ref name) => Some(ParsedSelector::Tag(name.to_string())),
-            _ => None,
+            Token::IDHash(ref name) => ParsedSelector::Id(name.to_string()),
+            Token::Ident(ref name) => ParsedSelector::Tag(name.to_string()),
+            _ => {
+                while input.next_including_whitespace().is_ok() {}
+                return Ok(None);
+            }
         };
-        // Consume remaining prelude tokens
-        while input.next_including_whitespace().is_ok() {}
-        Ok(selector)
+        // Reject compound/group selectors — only simple selectors are supported.
+        // If any non-whitespace tokens remain, this is not a simple selector.
+        while let Ok(tok) = input.next_including_whitespace() {
+            match tok {
+                Token::WhiteSpace(_) => {}
+                _ => return Ok(None),
+            }
+        }
+        Ok(Some(selector))
     }
 
     fn parse_block<'t>(
@@ -746,5 +763,21 @@ mod tests {
             ParsedSelector::Tag("header".to_string())
         );
         assert_eq!(ctx.running_mappings[0].running_name, "pageHeader");
+    }
+
+    #[test]
+    fn test_compound_selector_not_matched() {
+        // Compound selectors like `.a .b` should not create a mapping
+        let css = ".a .b { position: running(hdr); }";
+        let ctx = parse_gcpm(css);
+        assert!(ctx.running_mappings.is_empty());
+    }
+
+    #[test]
+    fn test_group_selector_not_matched() {
+        // Group selectors like `.a, .b` should not create a mapping
+        let css = ".a, .b { position: running(hdr); }";
+        let ctx = parse_gcpm(css);
+        assert!(ctx.running_mappings.is_empty());
     }
 }

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -138,6 +138,14 @@ impl<'i, 'a> QualifiedRuleParser<'i> for GcpmSheetParser<'a> {
         _start: &cssparser::ParserState,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self::QualifiedRule, ParseError<'i, ()>> {
+        // Only scan for `position: running(...)` if the selector is supported.
+        // Otherwise, skip the block to avoid replacing declarations with
+        // `display: none` for elements that won't be registered as running.
+        let Some(selector) = prelude else {
+            while input.next().is_ok() {}
+            return Ok(TopLevelItem::StyleRule);
+        };
+
         let mut running_name: Option<String> = None;
 
         let mut parser = StyleRuleParser {
@@ -150,12 +158,10 @@ impl<'i, 'a> QualifiedRuleParser<'i> for GcpmSheetParser<'a> {
         }
 
         if let Some(running_name) = running_name {
-            if let Some(selector) = prelude {
-                self.running_mappings.push(RunningMapping {
-                    parsed: selector,
-                    running_name,
-                });
-            }
+            self.running_mappings.push(RunningMapping {
+                parsed: selector,
+                running_name,
+            });
         }
 
         Ok(TopLevelItem::StyleRule)

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -1,12 +1,10 @@
-use std::collections::HashSet;
-
 use cssparser::{
     AtRuleParser, BasicParseErrorKind, CowRcStr, DeclarationParser, ParseError, Parser,
     ParserInput, QualifiedRuleParser, RuleBodyItemParser, RuleBodyParser, StyleSheetParser, Token,
 };
 
 use super::margin_box::MarginBoxPosition;
-use super::{ContentItem, CounterType, GcpmContext, MarginBoxRule};
+use super::{ContentItem, CounterType, GcpmContext, MarginBoxRule, ParsedSelector, RunningMapping};
 
 // ---------------------------------------------------------------------------
 // Top-level result types
@@ -31,7 +29,7 @@ struct GcpmSheetParser<'a> {
     /// Byte ranges to remove (for `@page` blocks) or replace (for running decls).
     edits: &'a mut Vec<CssEdit>,
     margin_boxes: &'a mut Vec<MarginBoxRule>,
-    running_names: &'a mut HashSet<String>,
+    running_mappings: &'a mut Vec<RunningMapping>,
 }
 
 /// Describes a region in the original CSS to edit when building `cleaned_css`.
@@ -95,7 +93,7 @@ impl<'i, 'a> AtRuleParser<'i> for GcpmSheetParser<'a> {
 }
 
 impl<'i, 'a> QualifiedRuleParser<'i> for GcpmSheetParser<'a> {
-    type Prelude = ();
+    type Prelude = Option<ParsedSelector>;
     type QualifiedRule = TopLevelItem;
     type Error = ();
 
@@ -103,14 +101,23 @@ impl<'i, 'a> QualifiedRuleParser<'i> for GcpmSheetParser<'a> {
         &mut self,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self::Prelude, ParseError<'i, ()>> {
-        // Consume the prelude (selector) — we don't need it
+        let selector = match input.next_including_whitespace()?.clone() {
+            Token::Delim('.') => {
+                let name = input.expect_ident()?.clone();
+                Some(ParsedSelector::Class(name.to_string()))
+            }
+            Token::IDHash(ref name) => Some(ParsedSelector::Id(name.to_string())),
+            Token::Ident(ref name) => Some(ParsedSelector::Tag(name.to_string())),
+            _ => None,
+        };
+        // Consume remaining prelude tokens
         while input.next_including_whitespace().is_ok() {}
-        Ok(())
+        Ok(selector)
     }
 
     fn parse_block<'t>(
         &mut self,
-        _prelude: Self::Prelude,
+        prelude: Self::Prelude,
         _start: &cssparser::ParserState,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self::QualifiedRule, ParseError<'i, ()>> {
@@ -125,8 +132,13 @@ impl<'i, 'a> QualifiedRuleParser<'i> for GcpmSheetParser<'a> {
             let _ = item;
         }
 
-        if let Some(ref name) = running_name {
-            self.running_names.insert(name.clone());
+        if let Some(running_name) = running_name {
+            if let Some(selector) = prelude {
+                self.running_mappings.push(RunningMapping {
+                    parsed: selector,
+                    running_name,
+                });
+            }
         }
 
         Ok(TopLevelItem::StyleRule)
@@ -435,7 +447,7 @@ fn parse_content_value(input: &mut Parser<'_, '_>) -> Vec<ContentItem> {
 /// - All other CSS is preserved verbatim in `cleaned_css`
 pub fn parse_gcpm(css: &str) -> GcpmContext {
     let mut margin_boxes = Vec::new();
-    let mut running_names = HashSet::new();
+    let mut running_mappings = Vec::new();
     let mut edits: Vec<CssEdit> = Vec::new();
 
     // Run the cssparser-based parse to collect GCPM data and edit spans.
@@ -446,7 +458,7 @@ pub fn parse_gcpm(css: &str) -> GcpmContext {
         let mut parser = GcpmSheetParser {
             edits: &mut edits,
             margin_boxes: &mut margin_boxes,
-            running_names: &mut running_names,
+            running_mappings: &mut running_mappings,
         };
 
         let iter = StyleSheetParser::new(&mut input, &mut parser);
@@ -460,7 +472,7 @@ pub fn parse_gcpm(css: &str) -> GcpmContext {
 
     GcpmContext {
         margin_boxes,
-        running_names,
+        running_mappings,
         cleaned_css,
     }
 }
@@ -533,7 +545,7 @@ mod tests {
     fn test_empty_css() {
         let css = "body { color: red; }\np { margin: 0; }";
         let ctx = parse_gcpm(css);
-        assert!(ctx.running_names.is_empty());
+        assert!(ctx.running_mappings.is_empty());
         assert!(ctx.margin_boxes.is_empty());
         assert_eq!(ctx.cleaned_css, css);
     }
@@ -542,7 +554,11 @@ mod tests {
     fn test_extract_running_name() {
         let css = ".header { position: running(pageHeader); font-size: 12px; }";
         let ctx = parse_gcpm(css);
-        assert!(ctx.running_names.contains("pageHeader"));
+        assert!(
+            ctx.running_mappings
+                .iter()
+                .any(|m| m.running_name == "pageHeader")
+        );
         assert!(ctx.cleaned_css.contains("display: none"));
         assert!(!ctx.cleaned_css.contains("running"));
         assert!(ctx.cleaned_css.contains("font-size: 12px"));
@@ -629,7 +645,7 @@ mod tests {
     fn test_ignores_gcpm_in_string_literals() {
         let css = r#"body { content: "position: running(x)"; color: blue; }"#;
         let ctx = parse_gcpm(css);
-        assert!(ctx.running_names.is_empty());
+        assert!(ctx.running_mappings.is_empty());
     }
 
     #[test]
@@ -637,7 +653,11 @@ mod tests {
         // POSITION: Running(name) — プロパティ名の大文字小文字
         let css = ".header { POSITION: running(pageHeader); }";
         let ctx = parse_gcpm(css);
-        assert!(ctx.running_names.contains("pageHeader"));
+        assert!(
+            ctx.running_mappings
+                .iter()
+                .any(|m| m.running_name == "pageHeader")
+        );
         assert!(ctx.cleaned_css.contains("display: none"));
     }
 
@@ -645,8 +665,8 @@ mod tests {
     fn test_multiple_running_names() {
         let css = ".h { position: running(hdr); } .f { position: running(ftr); }";
         let ctx = parse_gcpm(css);
-        assert!(ctx.running_names.contains("hdr"));
-        assert!(ctx.running_names.contains("ftr"));
+        assert!(ctx.running_mappings.iter().any(|m| m.running_name == "hdr"));
+        assert!(ctx.running_mappings.iter().any(|m| m.running_name == "ftr"));
     }
 
     #[test]
@@ -654,7 +674,7 @@ mod tests {
         // running() 以外の宣言が cleaned_css に残ること
         let css = ".header { color: red; position: running(hdr); font-size: 14px; }";
         let ctx = parse_gcpm(css);
-        assert!(ctx.running_names.contains("hdr"));
+        assert!(ctx.running_mappings.iter().any(|m| m.running_name == "hdr"));
         assert!(ctx.cleaned_css.contains("color: red"));
         assert!(ctx.cleaned_css.contains("font-size: 14px"));
     }
@@ -690,5 +710,41 @@ mod tests {
             ctx.margin_boxes[1].page_selector,
             Some(":right".to_string())
         );
+    }
+
+    #[test]
+    fn test_class_selector_extraction() {
+        let css = ".my-header { position: running(pageHeader); }";
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.running_mappings.len(), 1);
+        assert_eq!(
+            ctx.running_mappings[0].parsed,
+            ParsedSelector::Class("my-header".to_string())
+        );
+        assert_eq!(ctx.running_mappings[0].running_name, "pageHeader");
+    }
+
+    #[test]
+    fn test_id_selector_extraction() {
+        let css = "#main-title { position: running(docTitle); }";
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.running_mappings.len(), 1);
+        assert_eq!(
+            ctx.running_mappings[0].parsed,
+            ParsedSelector::Id("main-title".to_string())
+        );
+        assert_eq!(ctx.running_mappings[0].running_name, "docTitle");
+    }
+
+    #[test]
+    fn test_tag_selector_extraction() {
+        let css = "header { position: running(pageHeader); }";
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.running_mappings.len(), 1);
+        assert_eq!(
+            ctx.running_mappings[0].parsed,
+            ParsedSelector::Tag("header".to_string())
+        );
+        assert_eq!(ctx.running_mappings[0].running_name, "pageHeader");
     }
 }

--- a/crates/fulgur/tests/gcpm_integration.rs
+++ b/crates/fulgur/tests/gcpm_integration.rs
@@ -155,3 +155,47 @@ fn test_deterministic_output() {
 
     assert_eq!(pdf1, pdf2, "Same input must produce identical PDF output");
 }
+
+#[test]
+fn test_gcpm_id_selector_running_element() {
+    let css = r#"
+        #doc-title { position: running(pageTitle); }
+        @page { @top-center { content: element(pageTitle); } }
+    "#;
+    let html = r#"<!DOCTYPE html>
+    <html><body>
+      <div id="doc-title">My Document</div>
+      <p>Body content</p>
+    </body></html>"#;
+
+    let mut assets = AssetBundle::new();
+    assets.add_css(css);
+
+    let engine = Engine::builder().assets(assets).build();
+    let pdf = engine
+        .render_html(html)
+        .expect("should render with ID selector running element");
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn test_gcpm_tag_selector_running_element() {
+    let css = r#"
+        header { position: running(pageHeader); }
+        @page { @top-center { content: element(pageHeader); } }
+    "#;
+    let html = r#"<!DOCTYPE html>
+    <html><body>
+      <header>Document Header</header>
+      <p>Body content</p>
+    </body></html>"#;
+
+    let mut assets = AssetBundle::new();
+    assets.add_css(css);
+
+    let engine = Engine::builder().assets(assets).build();
+    let pdf = engine
+        .render_html(html)
+        .expect("should render with tag selector running element");
+    assert!(!pdf.is_empty());
+}

--- a/crates/fulgur/tests/gcpm_integration.rs
+++ b/crates/fulgur/tests/gcpm_integration.rs
@@ -176,6 +176,7 @@ fn test_gcpm_id_selector_running_element() {
         .render_html(html)
         .expect("should render with ID selector running element");
     assert!(!pdf.is_empty());
+    assert!(pdf.starts_with(b"%PDF-"));
 }
 
 #[test]
@@ -198,4 +199,5 @@ fn test_gcpm_tag_selector_running_element() {
         .render_html(html)
         .expect("should render with tag selector running element");
     assert!(!pdf.is_empty());
+    assert!(pdf.starts_with(b"%PDF-"));
 }

--- a/docs/plans/2026-03-22-selector-mapping.md
+++ b/docs/plans/2026-03-22-selector-mapping.md
@@ -1,0 +1,303 @@
+# セレクタ→Running名マッピング 実装計画
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Running要素の検出をクラス名一致からCSSセレクタベースのマッチングに拡張し、`.my-header { position: running(pageHeader); }` で `class="my-header"` の要素を `pageHeader` として認識できるようにする。
+
+**Architecture:** `GcpmContext.running_names: HashSet<String>` を `running_mappings: Vec<RunningMapping>` に置換。パーサーでセレクタを抽出し `ParsedSelector` に変換。DOM照合を `ParsedSelector` variant分岐に変更。
+
+**Tech Stack:** cssparser 0.35（セレクタ抽出に使用）
+
+---
+
+### Task 1: データ構造の追加と GcpmContext の変更
+
+**Files:**
+- Modify: `crates/fulgur/src/gcpm/mod.rs`
+
+**Step 1: `ParsedSelector` と `RunningMapping` を追加し、`GcpmContext` を変更**
+
+`gcpm/mod.rs` に以下を追加:
+
+```rust
+/// A simple CSS selector parsed from a style rule.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParsedSelector {
+    /// A class selector, e.g. `.header`
+    Class(String),
+    /// An ID selector, e.g. `#title`
+    Id(String),
+    /// A tag name selector, e.g. `header`
+    Tag(String),
+}
+
+/// Maps a CSS selector to a running element name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunningMapping {
+    /// The parsed CSS selector.
+    pub parsed: ParsedSelector,
+    /// The name from `position: running(name)`.
+    pub running_name: String,
+}
+```
+
+`GcpmContext` を変更:
+- `running_names: HashSet<String>` → `running_mappings: Vec<RunningMapping>`
+- `is_empty()` の条件を `running_mappings.is_empty()` に変更
+- `use std::collections::HashSet;` が不要になったら削除
+
+`mod.rs` の既存テストも `running_names` → `running_mappings` に更新。
+
+**Step 2: ビルド確認（コンパイルエラーが出ることを確認 — parser.rs と convert.rs がまだ旧APIを参照）**
+
+Run: `cargo build -p fulgur 2>&1 | head -20`
+Expected: コンパイルエラー（`running_names` フィールドが見つからない）
+
+**Step 3: Commit**
+
+```bash
+git add crates/fulgur/src/gcpm/mod.rs
+git commit -m "refactor: replace running_names with running_mappings in GcpmContext"
+```
+
+---
+
+### Task 2: パーサーでセレクタを抽出して RunningMapping を生成
+
+**Files:**
+- Modify: `crates/fulgur/src/gcpm/parser.rs`
+
+**Step 1: パーサーを更新**
+
+変更ポイント:
+
+1. **`GcpmSheetParser` の `running_names` フィールドを `running_mappings: &'a mut Vec<RunningMapping>` に変更**
+
+2. **`QualifiedRuleParser::parse_prelude` でセレクタを抽出**:
+   - `type Prelude = ()` → `type Prelude = Option<ParsedSelector>`
+   - cssparser の `input` からトークンを読み、最初のトークンで判定:
+     - `Token::Delim('.')` + `Token::Ident(name)` → `ParsedSelector::Class(name)`
+     - `Token::IDHash(name)` → `ParsedSelector::Id(name)`
+     - `Token::Ident(name)` → `ParsedSelector::Tag(name)`
+   - 残りのトークンを消費（複合セレクタの後続部分は無視）
+   - パース不能なら `None` を返す
+
+3. **`QualifiedRuleParser::parse_block` で `RunningMapping` を生成**:
+   - `running_name` が `Some` で `prelude` が `Some(selector)` なら、`RunningMapping { parsed: selector, running_name }` を `running_mappings` に追加
+
+4. **`parse_gcpm()` 関数の出力を更新**: `running_names` → `running_mappings`
+
+5. **テストモジュールの更新**:
+   - `ctx.running_names.contains("pageHeader")` → `ctx.running_mappings.iter().any(|m| m.running_name == "pageHeader")` 等に変更
+   - セレクタが正しくパースされることを検証するテストを追加:
+     ```rust
+     #[test]
+     fn test_class_selector_extraction() {
+         let css = ".my-header { position: running(pageHeader); }";
+         let ctx = parse_gcpm(css);
+         assert_eq!(ctx.running_mappings.len(), 1);
+         assert_eq!(ctx.running_mappings[0].parsed, ParsedSelector::Class("my-header".to_string()));
+         assert_eq!(ctx.running_mappings[0].running_name, "pageHeader");
+     }
+
+     #[test]
+     fn test_id_selector_extraction() {
+         let css = "#main-title { position: running(docTitle); }";
+         let ctx = parse_gcpm(css);
+         assert_eq!(ctx.running_mappings.len(), 1);
+         assert_eq!(ctx.running_mappings[0].parsed, ParsedSelector::Id("main-title".to_string()));
+         assert_eq!(ctx.running_mappings[0].running_name, "docTitle");
+     }
+
+     #[test]
+     fn test_tag_selector_extraction() {
+         let css = "header { position: running(pageHeader); }";
+         let ctx = parse_gcpm(css);
+         assert_eq!(ctx.running_mappings.len(), 1);
+         assert_eq!(ctx.running_mappings[0].parsed, ParsedSelector::Tag("header".to_string()));
+         assert_eq!(ctx.running_mappings[0].running_name, "pageHeader");
+     }
+     ```
+
+**Step 2: テスト実行**
+
+Run: `cargo test --lib -p fulgur gcpm::parser`
+Expected: 全テストパス
+
+**Step 3: Commit**
+
+```bash
+git add crates/fulgur/src/gcpm/parser.rs
+git commit -m "feat: extract CSS selectors for running element mappings"
+```
+
+---
+
+### Task 3: convert.rs の DOM照合を ParsedSelector ベースに変更
+
+**Files:**
+- Modify: `crates/fulgur/src/convert.rs`
+
+**Step 1: ヘルパー関数を更新**
+
+1. **`get_id_attr` 関数を追加**（`get_class_attr` と同様）:
+   ```rust
+   fn get_id_attr(elem: &blitz_dom::node::ElementData) -> Option<&str> {
+       elem.attrs()
+           .iter()
+           .find(|a| a.name.local.as_ref() == "id")
+           .map(|a| a.value.as_ref())
+   }
+   ```
+
+2. **`get_tag_name` 関数を追加**:
+   ```rust
+   fn get_tag_name(elem: &blitz_dom::node::ElementData) -> &str {
+       elem.name.local.as_ref()
+   }
+   ```
+
+3. **`matches_selector` 関数を追加**:
+   ```rust
+   fn matches_selector(selector: &ParsedSelector, elem: &blitz_dom::node::ElementData) -> bool {
+       match selector {
+           ParsedSelector::Class(name) => {
+               get_class_attr(elem)
+                   .map(|cls| cls.split_whitespace().any(|c| c == name))
+                   .unwrap_or(false)
+           }
+           ParsedSelector::Id(name) => {
+               get_id_attr(elem)
+                   .map(|id| id == name)
+                   .unwrap_or(false)
+           }
+           ParsedSelector::Tag(name) => {
+               get_tag_name(elem).eq_ignore_ascii_case(name)
+           }
+       }
+   }
+   ```
+
+4. **`is_running_element` を更新**:
+   ```rust
+   fn is_running_element(node: &Node, ctx: &GcpmContext) -> bool {
+       if ctx.running_mappings.is_empty() {
+           return false;
+       }
+       let Some(elem) = node.element_data() else {
+           return false;
+       };
+       ctx.running_mappings.iter().any(|m| matches_selector(&m.parsed, elem))
+   }
+   ```
+
+5. **`get_running_name` を更新**:
+   ```rust
+   fn get_running_name(node: &Node, ctx: &GcpmContext) -> Option<String> {
+       let elem = node.element_data()?;
+       ctx.running_mappings
+           .iter()
+           .find(|m| matches_selector(&m.parsed, elem))
+           .map(|m| m.running_name.clone())
+   }
+   ```
+
+6. **`has_matching_running_name` を削除**（`matches_selector` に置換されたため不要）
+
+**Step 2: ビルドとテスト実行**
+
+Run: `cargo test --lib -p fulgur`
+Expected: 全テストパス
+
+Run: `cargo test -p fulgur --test gcpm_integration -- --test-threads=1`
+Expected: 全テストパス
+
+**Step 3: Commit**
+
+```bash
+git add crates/fulgur/src/convert.rs
+git commit -m "feat: match running elements by CSS selector instead of class name"
+```
+
+---
+
+### Task 4: 統合テストの追加 — セレクタ≠running名のケース
+
+**Files:**
+- Modify: `crates/fulgur/tests/gcpm_integration.rs`
+
+**Step 1: 既存テストの確認**
+
+既存の統合テストでは `class="header"` と `running(pageHeader)` のように、クラス名≠running名のケースがある。旧実装ではこれが動作しなかったが、新実装ではセレクタ `.header` でマッチするので動作するはず。
+
+**Step 2: セレクタ種別ごとの統合テストを追加**
+
+```rust
+#[test]
+fn test_gcpm_id_selector_running_element() {
+    let css = r#"
+        #doc-title { position: running(pageTitle); }
+        @page { @top-center { content: element(pageTitle); } }
+    "#;
+    let html = r#"<!DOCTYPE html>
+    <html><body>
+      <div id="doc-title">My Document</div>
+      <p>Body content</p>
+    </body></html>"#;
+
+    // Should not panic and should produce valid PDF
+    let pdf = Engine::new()
+        .css(css)
+        .render_html(html)
+        .expect("should render with ID selector running element");
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn test_gcpm_tag_selector_running_element() {
+    let css = r#"
+        header { position: running(pageHeader); }
+        @page { @top-center { content: element(pageHeader); } }
+    "#;
+    let html = r#"<!DOCTYPE html>
+    <html><body>
+      <header>Document Header</header>
+      <p>Body content</p>
+    </body></html>"#;
+
+    let pdf = Engine::new()
+        .css(css)
+        .render_html(html)
+        .expect("should render with tag selector running element");
+    assert!(!pdf.is_empty());
+}
+```
+
+**Step 3: テスト実行**
+
+Run: `cargo test -p fulgur --test gcpm_integration -- --test-threads=1`
+Expected: 全テストパス
+
+**Step 4: Commit**
+
+```bash
+git add crates/fulgur/tests/gcpm_integration.rs
+git commit -m "test: add integration tests for ID and tag selector running elements"
+```
+
+---
+
+### Task 5: 最終検証
+
+**Step 1: 全テスト実行**
+
+Run: `cargo test --lib -p fulgur`
+Run: `cargo test -p fulgur --test gcpm_integration -- --test-threads=1`
+
+**Step 2: clippy と fmt**
+
+Run: `cargo clippy -p fulgur && cargo fmt -p fulgur --check`
+
+**Step 3: 既存の統合テストが引き続きパスすることを確認**
+
+特に `test_gcpm_header_footer_generates_pdf` — このテストでは `.header { position: running(pageHeader); }` と `class="header"` を使用しており、セレクタは `.header`、running名は `pageHeader`。新実装ではセレクタ `.header` → `ParsedSelector::Class("header")` でマッチし、running名 `pageHeader` を返す。旧実装（クラス名 = running名の一致）では動作しなかったケースが、新実装で初めて正しく動作する。


### PR DESCRIPTION
## Summary
- `GcpmContext.running_names: HashSet<String>` を `running_mappings: Vec<RunningMapping>` に置換
- パーサーでCSSセレクタ（`.class`, `#id`, `tag`）を抽出し、running名とペアで保持
- `convert.rs` のDOM照合を `ParsedSelector` variant分岐に変更（class属性・id属性・タグ名）
- `.my-header { position: running(pageHeader); }` で `class="my-header"` の要素を `pageHeader` として認識可能に

## Motivation
従来はクラス名とrunning名が一致する場合のみ動作していた。セレクタベースのマッチングにより、IDセレクタやタグセレクタでもrunning要素を指定できるようになった。

Resolves: fulgur-iqn

## Test plan
- [x] 既存ユニットテスト全パス（55件）
- [x] セレクタ抽出テスト3件追加（class/id/tag）
- [x] 統合テスト2件追加（IDセレクタ、タグセレクタ）
- [x] 統合テスト全パス（7件）
- [x] clippy clean, cargo fmt clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * IDセレクタとタグセレクタを対象とした統合テストを2件追加し、running要素検出の実動作を検証します。

* **リファクタリング**
  * 実行中要素の検出ロジックを拡張し、クラス／ID／タグに基づくセレクタマッチングを使用して検出精度と柔軟性を向上させました。

* **ドキュメント**
  * セレクタマッピングに関する設計ノートを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->