### PR TITLE
feat: expand CLI with margin, metadata flags, and stdout output

### DIFF
--- a/crates/fulgur-cli/src/main.rs
+++ b/crates/fulgur-cli/src/main.rs
@@ -23,7 +23,7 @@ enum Commands {
         #[arg(long)]
         stdin: bool,
 
-        /// Output PDF file path
+        /// Output PDF file path (use "-" for stdout)
         #[arg(short, long)]
         output: PathBuf,
 
@@ -38,6 +38,38 @@ enum Commands {
         /// PDF title
         #[arg(long)]
         title: Option<String>,
+
+        /// Page margins in mm (CSS shorthand: "20", "20 30", "10 20 30", "10 20 30 40")
+        #[arg(long)]
+        margin: Option<String>,
+
+        /// Author name (can be specified multiple times)
+        #[arg(long = "author")]
+        authors: Vec<String>,
+
+        /// Document description
+        #[arg(long)]
+        description: Option<String>,
+
+        /// Keywords (can be specified multiple times)
+        #[arg(long = "keyword")]
+        keywords: Vec<String>,
+
+        /// Language code (e.g. ja, en)
+        #[arg(long)]
+        language: Option<String>,
+
+        /// Creator application name
+        #[arg(long)]
+        creator: Option<String>,
+
+        /// PDF producer (default: fulgur vX.Y.Z)
+        #[arg(long)]
+        producer: Option<String>,
+
+        /// Creation date in ISO 8601 format (e.g. 2026-03-22)
+        #[arg(long)]
+        creation_date: Option<String>,
 
         /// Font files to bundle (can be specified multiple times)
         #[arg(long = "font", short = 'f')]
@@ -61,6 +93,34 @@ fn parse_page_size(s: &str) -> PageSize {
     }
 }
 
+fn parse_margin(s: &str) -> Margin {
+    let values: Vec<f32> = s
+        .split_whitespace()
+        .filter_map(|v| v.parse().ok())
+        .collect();
+    let to_pt = |mm: f32| mm * 72.0 / 25.4;
+    match values.as_slice() {
+        [all] => Margin::uniform(to_pt(*all)),
+        [vert, horiz] => Margin::symmetric(to_pt(*vert), to_pt(*horiz)),
+        [top, horiz, bottom] => Margin {
+            top: to_pt(*top),
+            right: to_pt(*horiz),
+            bottom: to_pt(*bottom),
+            left: to_pt(*horiz),
+        },
+        [top, right, bottom, left] => Margin {
+            top: to_pt(*top),
+            right: to_pt(*right),
+            bottom: to_pt(*bottom),
+            left: to_pt(*left),
+        },
+        _ => {
+            eprintln!("Invalid margin '{}', using default 20mm", s);
+            Margin::default()
+        }
+    }
+}
+
 fn main() {
     let cli = Cli::parse();
 
@@ -72,6 +132,14 @@ fn main() {
             size,
             landscape,
             title,
+            margin,
+            authors,
+            description,
+            keywords,
+            language: _,
+            creator,
+            producer,
+            creation_date,
             fonts,
             css_files,
         } => {
@@ -110,11 +178,31 @@ fn main() {
 
             let mut builder = Engine::builder()
                 .page_size(parse_page_size(&size))
-                .margin(Margin::uniform_mm(20.0))
                 .landscape(landscape);
 
+            if let Some(ref m) = margin {
+                builder = builder.margin(parse_margin(m));
+            }
             if let Some(title) = title {
                 builder = builder.title(title);
+            }
+            if !authors.is_empty() {
+                builder = builder.authors(authors);
+            }
+            if let Some(description) = description {
+                builder = builder.description(description);
+            }
+            if !keywords.is_empty() {
+                builder = builder.keywords(keywords);
+            }
+            if let Some(creator) = creator {
+                builder = builder.creator(creator);
+            }
+            if let Some(producer) = producer {
+                builder = builder.producer(producer);
+            }
+            if let Some(creation_date) = creation_date {
+                builder = builder.creation_date(creation_date);
             }
             if let Some(assets) = assets {
                 builder = builder.assets(assets);
@@ -122,9 +210,24 @@ fn main() {
 
             let engine = builder.build();
 
-            match engine.render_html_to_file(&html, &output) {
-                Ok(()) => println!("PDF written to {}", output.display()),
-                Err(e) => eprintln!("Error: {e}"),
+            if output.as_os_str() == "-" {
+                let pdf = engine.render_html(&html).unwrap_or_else(|e| {
+                    eprintln!("Error: {e}");
+                    std::process::exit(1);
+                });
+                use std::io::Write;
+                std::io::stdout().write_all(&pdf).unwrap_or_else(|e| {
+                    eprintln!("Error writing to stdout: {e}");
+                    std::process::exit(1);
+                });
+            } else {
+                match engine.render_html_to_file(&html, &output) {
+                    Ok(()) => eprintln!("PDF written to {}", output.display()),
+                    Err(e) => {
+                        eprintln!("Error: {e}");
+                        std::process::exit(1);
+                    }
+                }
             }
         }
     }

--- a/crates/fulgur-cli/src/main.rs
+++ b/crates/fulgur-cli/src/main.rs
@@ -94,10 +94,15 @@ fn parse_page_size(s: &str) -> PageSize {
 }
 
 fn parse_margin(s: &str) -> Margin {
-    let values: Vec<f32> = s
-        .split_whitespace()
-        .filter_map(|v| v.parse().ok())
-        .collect();
+    let tokens: Vec<&str> = s.split_whitespace().collect();
+    let values: Vec<f32> = tokens.iter().filter_map(|v| v.parse().ok()).collect();
+    if values.len() != tokens.len() {
+        eprintln!(
+            "Invalid margin '{}': all values must be numbers (mm). Using default 20mm",
+            s
+        );
+        return Margin::default();
+    }
     let to_pt = |mm: f32| mm * 72.0 / 25.4;
     match values.as_slice() {
         [all] => Margin::uniform(to_pt(*all)),
@@ -136,7 +141,7 @@ fn main() {
             authors,
             description,
             keywords,
-            language: _,
+            language,
             creator,
             producer,
             creation_date,
@@ -194,6 +199,9 @@ fn main() {
             }
             if !keywords.is_empty() {
                 builder = builder.keywords(keywords);
+            }
+            if let Some(language) = language {
+                builder = builder.lang(language);
             }
             if let Some(creator) = creator {
                 builder = builder.creator(creator);

--- a/crates/fulgur/src/config.rs
+++ b/crates/fulgur/src/config.rs
@@ -80,7 +80,12 @@ pub struct Config {
     pub margin: Margin,
     pub landscape: bool,
     pub title: Option<String>,
-    pub author: Option<String>,
+    pub authors: Vec<String>,
+    pub description: Option<String>,
+    pub keywords: Vec<String>,
+    pub creator: Option<String>,
+    pub producer: Option<String>,
+    pub creation_date: Option<String>,
     pub lang: Option<String>,
 }
 
@@ -91,7 +96,12 @@ impl Default for Config {
             margin: Margin::default(),
             landscape: false,
             title: None,
-            author: None,
+            authors: vec![],
+            description: None,
+            keywords: vec![],
+            creator: None,
+            producer: Some(format!("fulgur v{}", env!("CARGO_PKG_VERSION"))),
+            creation_date: None,
             lang: None,
         }
     }
@@ -150,7 +160,41 @@ impl ConfigBuilder {
     }
 
     pub fn author(mut self, author: impl Into<String>) -> Self {
-        self.config.author = Some(author.into());
+        self.config.authors.push(author.into());
+        self
+    }
+
+    pub fn authors(mut self, authors: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.config
+            .authors
+            .extend(authors.into_iter().map(|a| a.into()));
+        self
+    }
+
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.config.description = Some(description.into());
+        self
+    }
+
+    pub fn keywords(mut self, keywords: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.config
+            .keywords
+            .extend(keywords.into_iter().map(|k| k.into()));
+        self
+    }
+
+    pub fn creator(mut self, creator: impl Into<String>) -> Self {
+        self.config.creator = Some(creator.into());
+        self
+    }
+
+    pub fn producer(mut self, producer: impl Into<String>) -> Self {
+        self.config.producer = Some(producer.into());
+        self
+    }
+
+    pub fn creation_date(mut self, creation_date: impl Into<String>) -> Self {
+        self.config.creation_date = Some(creation_date.into());
         self
     }
 

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -133,6 +133,36 @@ impl EngineBuilder {
         self
     }
 
+    pub fn authors(mut self, authors: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.config_builder = self.config_builder.authors(authors);
+        self
+    }
+
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.config_builder = self.config_builder.description(description);
+        self
+    }
+
+    pub fn keywords(mut self, keywords: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.config_builder = self.config_builder.keywords(keywords);
+        self
+    }
+
+    pub fn creator(mut self, creator: impl Into<String>) -> Self {
+        self.config_builder = self.config_builder.creator(creator);
+        self
+    }
+
+    pub fn producer(mut self, producer: impl Into<String>) -> Self {
+        self.config_builder = self.config_builder.producer(producer);
+        self
+    }
+
+    pub fn creation_date(mut self, date: impl Into<String>) -> Self {
+        self.config_builder = self.config_builder.creation_date(date);
+        self
+    }
+
     pub fn assets(mut self, assets: AssetBundle) -> Self {
         self.assets = Some(assets);
         self

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -133,6 +133,11 @@ impl EngineBuilder {
         self
     }
 
+    pub fn lang(mut self, lang: impl Into<String>) -> Self {
+        self.config_builder = self.config_builder.lang(lang);
+        self
+    }
+
     pub fn authors(mut self, authors: impl IntoIterator<Item = impl Into<String>>) -> Self {
         self.config_builder = self.config_builder.authors(authors);
         self

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -47,21 +47,40 @@ pub fn render_to_pdf(root: Box<dyn Pageable>, config: &Config) -> Result<Vec<u8>
         // Surface::finish is handled by Drop
     }
 
-    // Set metadata
-    let mut metadata = krilla::metadata::Metadata::new();
-    if let Some(ref title) = config.title {
-        metadata = metadata.title(title.clone());
-    }
-    if let Some(ref author) = config.author {
-        metadata = metadata.authors(vec![author.clone()]);
-    }
-
-    document.set_metadata(metadata);
+    document.set_metadata(build_metadata(config));
 
     let pdf_bytes = document
         .finish()
         .map_err(|e| Error::PdfGeneration(format!("{e:?}")))?;
     Ok(pdf_bytes)
+}
+
+/// Build krilla Metadata from Config.
+fn build_metadata(config: &Config) -> krilla::metadata::Metadata {
+    let mut metadata = krilla::metadata::Metadata::new();
+    if let Some(ref title) = config.title {
+        metadata = metadata.title(title.clone());
+    }
+    if !config.authors.is_empty() {
+        metadata = metadata.authors(config.authors.clone());
+    }
+    if let Some(ref description) = config.description {
+        metadata = metadata.description(description.clone());
+    }
+    if !config.keywords.is_empty() {
+        metadata = metadata.keywords(config.keywords.clone());
+    }
+    if let Some(ref lang) = config.lang {
+        metadata = metadata.language(lang.clone());
+    }
+    if let Some(ref creator) = config.creator {
+        metadata = metadata.creator(creator.clone());
+    }
+    if let Some(ref producer) = config.producer {
+        metadata = metadata.producer(producer.clone());
+    }
+    // TODO: creation_date requires parsing ISO 8601 string into krilla::metadata::DateTime
+    metadata
 }
 
 /// Cached max-content width and render Pageable for margin boxes.
@@ -292,15 +311,7 @@ pub fn render_to_pdf_with_gcpm(
         );
     }
 
-    // Set metadata (same as render_to_pdf)
-    let mut metadata = krilla::metadata::Metadata::new();
-    if let Some(ref title) = config.title {
-        metadata = metadata.title(title.clone());
-    }
-    if let Some(ref author) = config.author {
-        metadata = metadata.authors(vec![author.clone()]);
-    }
-    document.set_metadata(metadata);
+    document.set_metadata(build_metadata(config));
 
     let pdf_bytes = document
         .finish()

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -89,26 +89,34 @@ fn build_metadata(config: &Config) -> krilla::metadata::Metadata {
 
 /// Parse an ISO 8601 date string into a krilla DateTime.
 /// Supports: "YYYY", "YYYY-MM", "YYYY-MM-DD", "YYYY-MM-DDThh:mm:ss".
+/// Returns None if any component fails to parse.
 fn parse_datetime(s: &str) -> Option<krilla::metadata::DateTime> {
     let parts: Vec<&str> = s.splitn(2, 'T').collect();
-    let date_parts: Vec<u16> = parts[0].split('-').filter_map(|p| p.parse().ok()).collect();
-    let year = *date_parts.first()?;
+    let date_tokens: Vec<&str> = parts[0].split('-').collect();
+    let year: u16 = date_tokens.first()?.parse().ok()?;
     let mut dt = krilla::metadata::DateTime::new(year);
-    if let Some(&month) = date_parts.get(1) {
-        dt = dt.month(month as u8);
+    if let Some(month_str) = date_tokens.get(1) {
+        let month: u8 = month_str.parse().ok()?;
+        dt = dt.month(month);
     }
-    if let Some(&day) = date_parts.get(2) {
-        dt = dt.day(day as u8);
+    if let Some(day_str) = date_tokens.get(2) {
+        let day: u8 = day_str.parse().ok()?;
+        dt = dt.day(day);
     }
     if let Some(time_str) = parts.get(1) {
-        let time_parts: Vec<u8> = time_str.split(':').filter_map(|p| p.parse().ok()).collect();
-        if let Some(&hour) = time_parts.first() {
+        // Strip trailing 'Z' for UTC
+        let time_str = time_str.trim_end_matches('Z');
+        let time_tokens: Vec<&str> = time_str.split(':').collect();
+        if let Some(hour_str) = time_tokens.first() {
+            let hour: u8 = hour_str.parse().ok()?;
             dt = dt.hour(hour);
         }
-        if let Some(&minute) = time_parts.get(1) {
+        if let Some(minute_str) = time_tokens.get(1) {
+            let minute: u8 = minute_str.parse().ok()?;
             dt = dt.minute(minute);
         }
-        if let Some(&second) = time_parts.get(2) {
+        if let Some(second_str) = time_tokens.get(2) {
+            let second: u8 = second_str.parse().ok()?;
             dt = dt.second(second);
         }
     }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -79,8 +79,40 @@ fn build_metadata(config: &Config) -> krilla::metadata::Metadata {
     if let Some(ref producer) = config.producer {
         metadata = metadata.producer(producer.clone());
     }
-    // TODO: creation_date requires parsing ISO 8601 string into krilla::metadata::DateTime
+    if let Some(ref date_str) = config.creation_date {
+        if let Some(dt) = parse_datetime(date_str) {
+            metadata = metadata.creation_date(dt);
+        }
+    }
     metadata
+}
+
+/// Parse an ISO 8601 date string into a krilla DateTime.
+/// Supports: "YYYY", "YYYY-MM", "YYYY-MM-DD", "YYYY-MM-DDThh:mm:ss".
+fn parse_datetime(s: &str) -> Option<krilla::metadata::DateTime> {
+    let parts: Vec<&str> = s.splitn(2, 'T').collect();
+    let date_parts: Vec<u16> = parts[0].split('-').filter_map(|p| p.parse().ok()).collect();
+    let year = *date_parts.first()?;
+    let mut dt = krilla::metadata::DateTime::new(year);
+    if let Some(&month) = date_parts.get(1) {
+        dt = dt.month(month as u8);
+    }
+    if let Some(&day) = date_parts.get(2) {
+        dt = dt.day(day as u8);
+    }
+    if let Some(time_str) = parts.get(1) {
+        let time_parts: Vec<u8> = time_str.split(':').filter_map(|p| p.parse().ok()).collect();
+        if let Some(&hour) = time_parts.first() {
+            dt = dt.hour(hour);
+        }
+        if let Some(&minute) = time_parts.get(1) {
+            dt = dt.minute(minute);
+        }
+        if let Some(&second) = time_parts.get(2) {
+            dt = dt.second(second);
+        }
+    }
+    Some(dt)
 }
 
 /// Cached max-content width and render Pageable for margin boxes.

--- a/docs/plans/2026-03-22-cli-expand.md
+++ b/docs/plans/2026-03-22-cli-expand.md
@@ -1,0 +1,298 @@
+# CLI拡充 実装計画
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** CLIに `--margin`（CSS短縮形）、メタデータフラグ群、stdout出力（`-o -`）を追加する。
+
+**Architecture:** Config/ConfigBuilder にメタデータフィールドを追加し、render.rs で krilla Metadata に反映。CLIはclap引数として公開。`producer` はデフォルトで `fulgur vX.Y.Z` を設定。
+
+**Tech Stack:** clap (既存), krilla metadata API
+
+---
+
+### Task 1: Config にメタデータフィールドを追加
+
+**Files:**
+- Modify: `crates/fulgur/src/config.rs`
+
+**Step 1: Config 構造体にフィールド追加**
+
+```rust
+pub struct Config {
+    // ... existing fields ...
+    pub authors: Vec<String>,       // author を authors (Vec) に変更
+    pub description: Option<String>,
+    pub keywords: Vec<String>,
+    pub creator: Option<String>,
+    pub producer: Option<String>,
+    pub creation_date: Option<String>, // ISO 8601 文字列
+}
+```
+
+既存の `author: Option<String>` を `authors: Vec<String>` に変更（複数著者対応）。
+
+Default 実装を更新:
+- `authors: vec![]`
+- `description: None`
+- `keywords: vec![]`
+- `creator: None`
+- `producer: Some(format!("fulgur v{}", env!("CARGO_PKG_VERSION")))`
+- `creation_date: None`
+
+**Step 2: ConfigBuilder にセッター追加**
+
+```rust
+pub fn authors(mut self, authors: Vec<String>) -> Self { ... }
+pub fn description(mut self, description: impl Into<String>) -> Self { ... }
+pub fn keywords(mut self, keywords: Vec<String>) -> Self { ... }
+pub fn creator(mut self, creator: impl Into<String>) -> Self { ... }
+pub fn producer(mut self, producer: impl Into<String>) -> Self { ... }
+pub fn creation_date(mut self, date: impl Into<String>) -> Self { ... }
+```
+
+既存の `author()` セッターは `authors` に1要素追加する形に変更（後方互換）:
+```rust
+pub fn author(mut self, author: impl Into<String>) -> Self {
+    self.config.authors.push(author.into());
+    self
+}
+```
+
+**Step 3: テスト実行**
+
+Run: `cargo test --lib -p fulgur config`
+
+**Step 4: Commit**
+
+```bash
+git add crates/fulgur/src/config.rs
+git commit -m "feat: add metadata fields to Config (description, keywords, creator, producer, creation_date)"
+```
+
+---
+
+### Task 2: render.rs でメタデータを krilla に反映
+
+**Files:**
+- Modify: `crates/fulgur/src/render.rs`
+
+**Step 1: メタデータ構築ヘルパー関数を追加**
+
+2箇所（`render_to_pdf` と `render_to_pdf_with_gcpm`）で重複しているメタデータ設定を1つの関数に抽出:
+
+```rust
+fn build_metadata(config: &Config) -> krilla::metadata::Metadata {
+    let mut metadata = krilla::metadata::Metadata::new();
+    if let Some(ref title) = config.title {
+        metadata = metadata.title(title.clone());
+    }
+    if !config.authors.is_empty() {
+        metadata = metadata.authors(config.authors.clone());
+    }
+    if let Some(ref description) = config.description {
+        metadata = metadata.description(description.clone());
+    }
+    if !config.keywords.is_empty() {
+        metadata = metadata.keywords(config.keywords.clone());
+    }
+    if let Some(ref lang) = config.lang {
+        metadata = metadata.language(lang.clone());
+    }
+    if let Some(ref creator) = config.creator {
+        metadata = metadata.creator(creator.clone());
+    }
+    if let Some(ref producer) = config.producer {
+        metadata = metadata.producer(producer.clone());
+    }
+    // creation_date の krilla::metadata::DateTime 変換は省略（CLI から渡された ISO 8601 文字列をパースする必要がある）
+    // TODO: creation_date 対応
+    metadata
+}
+```
+
+両方の関数で `document.set_metadata(build_metadata(config));` に置換。
+
+**Step 2: テスト実行**
+
+Run: `cargo test --lib -p fulgur`
+
+**Step 3: Commit**
+
+```bash
+git add crates/fulgur/src/render.rs
+git commit -m "refactor: extract build_metadata helper, add new metadata fields to PDF output"
+```
+
+---
+
+### Task 3: EngineBuilder にメタデータセッター追加
+
+**Files:**
+- Modify: `crates/fulgur/src/engine.rs`
+
+**Step 1: 新しいメタデータセッターを追加**
+
+```rust
+pub fn authors(mut self, authors: Vec<String>) -> Self { ... }
+pub fn description(mut self, description: impl Into<String>) -> Self { ... }
+pub fn keywords(mut self, keywords: Vec<String>) -> Self { ... }
+pub fn creator(mut self, creator: impl Into<String>) -> Self { ... }
+pub fn producer(mut self, producer: impl Into<String>) -> Self { ... }
+pub fn creation_date(mut self, date: impl Into<String>) -> Self { ... }
+```
+
+既存の `author()` は ConfigBuilder に委譲（後方互換維持）。
+
+**Step 2: テスト実行**
+
+Run: `cargo test --lib -p fulgur`
+
+**Step 3: Commit**
+
+```bash
+git add crates/fulgur/src/engine.rs
+git commit -m "feat: add metadata setters to EngineBuilder"
+```
+
+---
+
+### Task 4: CLI に --margin フラグを追加
+
+**Files:**
+- Modify: `crates/fulgur-cli/src/main.rs`
+
+**Step 1: --margin 引数を追加**
+
+```rust
+/// Page margins in mm (CSS shorthand: "20", "20 30", "10 20 30", "10 20 30 40")
+#[arg(long)]
+margin: Option<String>,
+```
+
+**Step 2: parse_margin 関数を実装**
+
+```rust
+fn parse_margin(s: &str) -> Margin {
+    let values: Vec<f32> = s.split_whitespace()
+        .filter_map(|v| v.parse().ok())
+        .collect();
+    let to_pt = |mm: f32| mm * 72.0 / 25.4;
+    match values.as_slice() {
+        [all] => Margin::uniform(to_pt(*all)),
+        [vert, horiz] => Margin::symmetric(to_pt(*vert), to_pt(*horiz)),
+        [top, horiz, bottom] => Margin {
+            top: to_pt(*top), right: to_pt(*horiz),
+            bottom: to_pt(*bottom), left: to_pt(*horiz),
+        },
+        [top, right, bottom, left] => Margin {
+            top: to_pt(*top), right: to_pt(*right),
+            bottom: to_pt(*bottom), left: to_pt(*left),
+        },
+        _ => {
+            eprintln!("Invalid margin '{}', using default 20mm", s);
+            Margin::default()
+        }
+    }
+}
+```
+
+**Step 3: main() でマージンを適用**
+
+`--margin` が指定されていたら `parse_margin` で変換して `builder.margin()` に渡す。未指定時はデフォルト（20mm uniform）。
+
+**Step 4: ビルド確認**
+
+Run: `cargo build -p fulgur-cli`
+
+**Step 5: Commit**
+
+```bash
+git add crates/fulgur-cli/src/main.rs
+git commit -m "feat: add --margin CLI flag with CSS shorthand syntax"
+```
+
+---
+
+### Task 5: CLI にメタデータフラグと stdout 出力を追加
+
+**Files:**
+- Modify: `crates/fulgur-cli/src/main.rs`
+
+**Step 1: メタデータ引数を追加**
+
+```rust
+/// Author name (can be specified multiple times)
+#[arg(long = "author")]
+authors: Vec<String>,
+
+/// Document description
+#[arg(long)]
+description: Option<String>,
+
+/// Keywords (can be specified multiple times)
+#[arg(long = "keyword")]
+keywords: Vec<String>,
+
+/// Language code (e.g. ja, en)
+#[arg(long)]
+language: Option<String>,
+
+/// Creator application name
+#[arg(long)]
+creator: Option<String>,
+
+/// PDF producer (default: fulgur vX.Y.Z)
+#[arg(long)]
+producer: Option<String>,
+
+/// Creation date in ISO 8601 format (e.g. 2026-03-22)
+#[arg(long)]
+creation_date: Option<String>,
+```
+
+**Step 2: main() でメタデータを EngineBuilder に適用**
+
+各フラグの値をビルダーに渡す。
+
+**Step 3: stdout 出力対応**
+
+`-o -` の場合、stdout にバイナリ出力:
+```rust
+if output.as_os_str() == "-" {
+    let pdf = engine.render_html(&html)?;
+    use std::io::Write;
+    std::io::stdout().write_all(&pdf)?;
+} else {
+    engine.render_html_to_file(&html, &output)?;
+    println!("PDF written to {}", output.display());
+}
+```
+
+**Step 4: ビルド確認**
+
+Run: `cargo build -p fulgur-cli`
+
+**Step 5: Commit**
+
+```bash
+git add crates/fulgur-cli/src/main.rs
+git commit -m "feat: add metadata CLI flags and stdout output support"
+```
+
+---
+
+### Task 6: 最終検証
+
+**Step 1: 全テスト実行**
+
+Run: `cargo test --lib -p fulgur`
+Run: `cargo test -p fulgur --test gcpm_integration -- --test-threads=1`
+
+**Step 2: clippy と fmt**
+
+Run: `cargo clippy --workspace && cargo fmt --all --check`
+
+**Step 3: 手動テスト（CLIヘルプ確認）**
+
+Run: `cargo run --bin fulgur -- render --help`
+Expected: 新しいフラグがヘルプに表示される


### PR DESCRIPTION
## Summary
- `--margin` フラグ追加（CSS shorthand: 1〜4値、mm単位）
- メタデータフラグ追加: `--author`, `--description`, `--keyword`, `--language`, `--creator`, `--producer`, `--creation-date`
- `-o -` でstdout出力対応（パイプ利用可能）
- `Config` に `description`, `keywords`, `creator`, `producer`, `creation_date` フィールド追加
- `render.rs` のメタデータ構築を `build_metadata()` ヘルパーに抽出（重複解消）
- `producer` のデフォルト値: `fulgur vX.Y.Z`

## Test plan
- [x] ユニットテスト 57件全パス
- [x] 統合テスト 7件全パス
- [x] clippy clean
- [x] cargo fmt clean
- [x] `cargo run --bin fulgur -- render --help` で全フラグ表示確認
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/25" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * PDFメタデータの追加オプション：複数著者指定、description、keywords、language、creator、producer、creation-date（部分ISO8601解析対応）
  * --margin（mm指定、CSS短縮形式をサポート、指定時のみ適用）
  * `--output -` で生成PDFを標準出力へストリーム出力

* **改善**
  * メタデータ適用が任意フィールドのみ行われるように変更
  * ビルダーAPIを拡充しチェーン可能に
  * 出力失敗時はプロセスを終了、ファイル出力の成功・エラーメッセージを標準エラーへ移動

* **ドキュメント**
  * CLI拡張の実装計画ドキュメントを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->