### PR TITLE
chore: disable markdownlint for docs/plans/ in CodeRabbit

### DIFF
--- a/coderabbit.yaml
+++ b/coderabbit.yaml
@@ -1,0 +1,5 @@
+reviews:
+  tools:
+    markdownlint-cli2:
+      path_filters:
+        - "!docs/plans/**"


### PR DESCRIPTION
計画ドキュメント (docs/plans/) の markdownlint 指摘を抑制。コードレビュー自体は全ファイルで有効のまま。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/26" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 更新コード レビューツール設定にマークダウンリント フィルターを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->