### PR TITLE
chore: add Claude Code settings with worktree hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "EnterWorktree",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_response.worktreePath // empty' | { read -r wt; [ -n \"$wt\" ] && git -C \"$wt\" sparse-checkout disable 2>/dev/null; cd \"$wt\" && mise trust 2>/dev/null; } || true"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- `.claude/settings.json` をリポジトリに追加
- PostToolUse hook: `EnterWorktree` 後に `sparse-checkout disable` と `mise trust` を自動実行
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
