### PR TITLE
chore: exclude CHANGELOG.md from markdownlint

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -15,3 +15,4 @@ ignores:
   - ".worktrees/**"
   - ".git/**"
   - ".beads/**"
+  - "CHANGELOG.md"


### PR DESCRIPTION
## Summary

- Add `CHANGELOG.md` to markdownlint ignores (auto-generated by git-cliff)

## Test plan

- [x] `npx markdownlint-cli2 '**/*.md'` passes with 0 errors
- [x] Fixes CI failure on main
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/32" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * マークダウン検証ツールの設定を更新し、特定のファイルに対する警告報告を無視するよう設定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->