### PR TITLE
feat: introduce DomPass pipeline for HTML preprocessing

### DIFF
--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -67,41 +67,8 @@ pub fn parse_and_layout(
     _viewport_height: f32,
     font_data: &[Arc<Vec<u8>>],
 ) -> HtmlDocument {
-    let viewport = Viewport::new(
-        viewport_width as u32,
-        10000, // Large height — let Taffy lay out everything, we paginate later
-        1.0,
-        ColorScheme::Light,
-    );
-
-    // Build FontContext with bundled fonts
-    let font_ctx = if font_data.is_empty() {
-        None
-    } else {
-        let mut ctx = FontContext::new();
-        for data in font_data {
-            let blob: parley::fontique::Blob<u8> = (**data).clone().into();
-            ctx.collection.register_fonts(blob, None);
-        }
-        Some(ctx)
-    };
-
-    let config = DocumentConfig {
-        viewport: Some(viewport),
-        font_ctx,
-        // Set a base URL so Blitz can resolve relative <img src> paths
-        // without panicking. We use file:/// as a harmless placeholder
-        // since Fulgur resolves images through AssetBundle, not the network.
-        base_url: Some("file:///".to_string()),
-        ..DocumentConfig::default()
-    };
-
-    // Suppress Blitz's noisy "ERROR: Unexpected token" println output
-    let mut doc = suppress_stdout(|| HtmlDocument::from_html(html, config));
-
-    // Resolve styles (Stylo) and layout (Taffy)
-    doc.resolve(0.0);
-
+    let mut doc = parse(html, viewport_width, font_data);
+    resolve(&mut doc);
     doc
 }
 

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -154,6 +154,74 @@ pub fn resolve(doc: &mut HtmlDocument) {
     doc.resolve(0.0);
 }
 
+/// Walk the DOM tree to find the first element with the given tag name.
+/// Returns the node id if found.
+fn find_element_by_tag(doc: &HtmlDocument, tag: &str) -> Option<usize> {
+    let root = doc.root_element();
+    find_element_by_tag_recursive(doc, root.id, tag)
+}
+
+fn find_element_by_tag_recursive(doc: &HtmlDocument, node_id: usize, tag: &str) -> Option<usize> {
+    let node = doc.get_node(node_id)?;
+    if let Some(el) = node.element_data() {
+        if el.name.local.as_ref() == tag {
+            return Some(node_id);
+        }
+    }
+    for &child_id in &node.children {
+        if let Some(found) = find_element_by_tag_recursive(doc, child_id, tag) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn make_qual_name(local: &str) -> blitz_dom::QualName {
+    blitz_dom::QualName::new(
+        None,
+        blitz_dom::ns!(html),
+        blitz_dom::LocalName::from(local),
+    )
+}
+
+/// Injects CSS text as a `<style>` element into the document's `<head>`.
+pub struct InjectCssPass {
+    pub css: String,
+}
+
+impl DomPass for InjectCssPass {
+    fn apply(&self, doc: &mut HtmlDocument, _ctx: &PassContext<'_>) {
+        if self.css.is_empty() {
+            return;
+        }
+
+        // Find or create <head>
+        let head_id = match find_element_by_tag(doc, "head") {
+            Some(id) => id,
+            None => {
+                // Create <head> as first child of <html>
+                let html_id = doc.root_element().id;
+                let mut mutator = doc.mutate();
+                let head_id = mutator.create_element(make_qual_name("head"), vec![]);
+                let children = mutator.child_ids(html_id);
+                if let Some(&first_child) = children.first() {
+                    mutator.insert_nodes_before(first_child, &[head_id]);
+                } else {
+                    mutator.append_children(html_id, &[head_id]);
+                }
+                drop(mutator);
+                head_id
+            }
+        };
+
+        // Create <style> element, append to <head>, set innerHTML
+        let mut mutator = doc.mutate();
+        let style_id = mutator.create_element(make_qual_name("style"), vec![]);
+        mutator.append_children(head_id, &[style_id]);
+        mutator.set_inner_html(style_id, &self.css);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -184,5 +252,43 @@ mod tests {
         let doc = parse_and_layout(html, 400.0, 600.0, &[]);
         let root = doc.root_element();
         assert!(!root.children.is_empty());
+    }
+
+    #[test]
+    fn test_inject_css_pass_adds_style() {
+        let html = "<html><head></head><body><p>Hello</p></body></html>";
+        let mut doc = parse(html, 400.0, &[]);
+        let pass = InjectCssPass {
+            css: "p { color: red; }".to_string(),
+        };
+        let ctx = PassContext {
+            viewport_width: 400.0,
+            viewport_height: 10000.0,
+            font_data: &[],
+        };
+        apply_passes(&mut doc, &[Box::new(pass)], &ctx);
+        resolve(&mut doc);
+        assert!(
+            find_element_by_tag(&doc, "style").is_some(),
+            "Expected a <style> element to be injected into the DOM"
+        );
+    }
+
+    #[test]
+    fn test_inject_css_pass_empty_css_is_noop() {
+        let html = "<html><body><p>Hello</p></body></html>";
+        let mut doc = parse(html, 400.0, &[]);
+        let pass = InjectCssPass { css: String::new() };
+        let ctx = PassContext {
+            viewport_width: 400.0,
+            viewport_height: 10000.0,
+            font_data: &[],
+        };
+        apply_passes(&mut doc, &[Box::new(pass)], &ctx);
+        resolve(&mut doc);
+        assert!(
+            find_element_by_tag(&doc, "style").is_none(),
+            "Expected no <style> element when CSS is empty"
+        );
     }
 }

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -104,3 +104,85 @@ pub fn parse_and_layout(
 
     doc
 }
+
+/// Context available to each DOM pass.
+pub struct PassContext<'a> {
+    pub viewport_width: f32,
+    pub viewport_height: f32,
+    pub font_data: &'a [Arc<Vec<u8>>],
+}
+
+/// A single transformation step applied to the parsed DOM before layout resolution.
+pub trait DomPass {
+    fn apply(&self, doc: &mut HtmlDocument, ctx: &PassContext<'_>);
+}
+
+/// Parse HTML into a document without resolving styles or layout.
+pub fn parse(html: &str, viewport_width: f32, font_data: &[Arc<Vec<u8>>]) -> HtmlDocument {
+    let viewport = Viewport::new(viewport_width as u32, 10000, 1.0, ColorScheme::Light);
+
+    let font_ctx = if font_data.is_empty() {
+        None
+    } else {
+        let mut ctx = FontContext::new();
+        for data in font_data {
+            let blob: parley::fontique::Blob<u8> = (**data).clone().into();
+            ctx.collection.register_fonts(blob, None);
+        }
+        Some(ctx)
+    };
+
+    let config = DocumentConfig {
+        viewport: Some(viewport),
+        font_ctx,
+        base_url: Some("file:///".to_string()),
+        ..DocumentConfig::default()
+    };
+
+    suppress_stdout(|| HtmlDocument::from_html(html, config))
+}
+
+/// Apply a sequence of DOM passes to a parsed document.
+pub fn apply_passes(doc: &mut HtmlDocument, passes: &[Box<dyn DomPass>], ctx: &PassContext<'_>) {
+    for pass in passes {
+        pass.apply(doc, ctx);
+    }
+}
+
+/// Resolve styles (Stylo) and compute layout (Taffy).
+pub fn resolve(doc: &mut HtmlDocument) {
+    doc.resolve(0.0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct NoOpPass;
+    impl DomPass for NoOpPass {
+        fn apply(&self, _doc: &mut HtmlDocument, _ctx: &PassContext<'_>) {}
+    }
+
+    #[test]
+    fn test_parse_resolve_roundtrip() {
+        let html = "<html><body><p>Hello</p></body></html>";
+        let mut doc = parse(html, 400.0, &[]);
+        let ctx = PassContext {
+            viewport_width: 400.0,
+            viewport_height: 10000.0,
+            font_data: &[],
+        };
+        apply_passes(&mut doc, &[Box::new(NoOpPass)], &ctx);
+        resolve(&mut doc);
+        let root = doc.root_element();
+        assert!(!root.children.is_empty());
+    }
+
+    #[test]
+    fn test_parse_and_layout_unchanged() {
+        let html = "<html><body><p>Test</p></body></html>";
+        let doc = parse_and_layout(html, 400.0, 600.0, &[]);
+        let root = doc.root_element();
+        assert!(!root.children.is_empty());
+    }
+}

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -48,39 +48,40 @@ impl Engine {
         let gcpm = crate::gcpm::parser::parse_gcpm(&combined_css);
         let css_to_inject = &gcpm.cleaned_css;
 
-        let final_html = if css_to_inject.is_empty() {
-            html.to_string()
-        } else {
-            let style_block = format!("<style>{}</style>", css_to_inject);
-            if let Some(pos) = html.find("</head>") {
-                format!("{}{}{}", &html[..pos], style_block, &html[pos..])
-            } else if let Some(pos) = html.find("<body") {
-                format!("{}{}{}", &html[..pos], style_block, &html[pos..])
-            } else {
-                format!("{}{}", style_block, html)
-            }
-        };
-
+        // --- Pipeline: parse → DomPass → resolve ---
         let fonts = self
             .assets
             .as_ref()
             .map(|a| a.fonts.as_slice())
             .unwrap_or(&[]);
-        let doc = crate::blitz_adapter::parse_and_layout(
-            &final_html,
-            self.config.content_width(),
-            self.config.content_height(),
-            fonts,
-        );
 
+        let mut doc = crate::blitz_adapter::parse(html, self.config.content_width(), fonts);
+
+        // Build and apply DOM passes
+        let mut passes: Vec<Box<dyn crate::blitz_adapter::DomPass>> = Vec::new();
+        if !css_to_inject.is_empty() {
+            passes.push(Box::new(crate::blitz_adapter::InjectCssPass {
+                css: css_to_inject.clone(),
+            }));
+        }
+
+        let ctx = crate::blitz_adapter::PassContext {
+            viewport_width: self.config.content_width(),
+            viewport_height: self.config.content_height(),
+            font_data: fonts,
+        };
+        crate::blitz_adapter::apply_passes(&mut doc, &passes, &ctx);
+        crate::blitz_adapter::resolve(&mut doc);
+
+        // --- Convert DOM to Pageable and render ---
         let gcpm_opt = if gcpm.is_empty() { None } else { Some(&gcpm) };
         let mut running_store = crate::gcpm::running::RunningElementStore::new();
-        let mut ctx = ConvertContext {
+        let mut convert_ctx = ConvertContext {
             gcpm: gcpm_opt,
             running_store: &mut running_store,
             assets: self.assets.as_ref(),
         };
-        let root = crate::convert::dom_to_pageable(&doc, &mut ctx);
+        let root = crate::convert::dom_to_pageable(&doc, &mut convert_ctx);
 
         if gcpm.is_empty() {
             self.render_pageable(root)


### PR DESCRIPTION
## Summary

- `blitz_adapter.rs` に `DomPass` trait と `parse()`/`apply_passes()`/`resolve()` を追加し、`parse_and_layout()` を3段階に分割
- `InjectCssPass` を実装: Blitz DOM操作で `<style>` 要素を `<head>` に追加（テキストマッチング置き換え）
- `engine.rs` の `render_html()` から `html.find("</head>")` によるCSS注入を除去し、DomPassパイプラインに切り替え

Closes: fulgur-1f9

## Motivation

従来のCSS注入は `html.find("</head>")` によるテキストマッチングで、タグ誤検出やUTF-8境界の問題があった。Blitz DOMのDocumentMutator APIを使ったDOM操作に置き換えることで堅牢性を確保し、将来の前処理ステップ（`<link>` 解決、テンプレートエンジン等）を追加しやすいパイプライン基盤を導入。

## Test plan

- [x] ユニットテスト 64件パス（新規4件含む）
- [x] 結合テスト 39件パス（GCPM統合テスト含む）
- [x] cargo clippy 警告なし
- [x] cargo fmt チェック通過
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/33" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * DOM処理パイプラインを再構築し、解析・変換・レイアウトの段階を分離して柔軟性を向上しました。
  * CSS注入が新しいパイプライン経由で適用され、空のCSSは無視されるようになりました。
* **テスト**
  * 新しいパイプラインとスタイル注入の振る舞いを検証するテストを追加・拡張しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->