### PR TITLE
feat: add octocov for PR coverage comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,15 +33,47 @@ jobs:
         include:
           - os: ubuntu-latest
             arch: amd64
+            coverage: true
           - os: ubuntu-24.04-arm
             arch: arm64
+            coverage: false
           - os: macos-latest
             arch: arm64
+            coverage: false
           - os: windows-latest
             arch: amd64
+            coverage: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test
+      - name: Install cargo-llvm-cov
+        if: matrix.coverage
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Run tests with coverage
+        if: matrix.coverage
+        run: cargo llvm-cov --lcov --output-path lcov.info
+      - name: Run tests
+        if: ${{ !matrix.coverage }}
+        run: cargo test
+      - name: Upload coverage artifact
+        if: matrix.coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: lcov
+          path: lcov.info
+
+  octocov:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: lcov
+      - uses: k1LoW/octocov-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-llvm-cov
         if: matrix.coverage
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@88ada01c46e65c47040a0ae865537cc76fcd0e1c # cargo-llvm-cov
       - name: Run tests with coverage
         if: matrix.coverage
         run: cargo llvm-cov --lcov --output-path lcov.info
@@ -76,4 +76,4 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: lcov
-      - uses: k1LoW/octocov-action@v1
+      - uses: k1LoW/octocov-action@73d561f65d59e66899ed5c87e4621a913b5d5c20 # v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,12 +51,18 @@ jobs:
       - name: Install cargo-llvm-cov
         if: matrix.coverage
         uses: taiki-e/install-action@88ada01c46e65c47040a0ae865537cc76fcd0e1c # cargo-llvm-cov
-      - name: Run tests with coverage
+      - name: Build tests
+        if: ${{ !matrix.coverage }}
+        run: cargo test --no-run
+      - name: Build tests with coverage
         if: matrix.coverage
-        run: cargo llvm-cov --lcov --output-path lcov.info
+        run: cargo llvm-cov --no-report --no-cfg-coverage
       - name: Run tests
         if: ${{ !matrix.coverage }}
         run: cargo test
+      - name: Run tests with coverage
+        if: matrix.coverage
+        run: cargo llvm-cov --no-clean --lcov --output-path lcov.info
       - name: Upload coverage artifact
         if: matrix.coverage
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,11 @@ jobs:
         with:
           name: lcov
           path: lcov.info
+          if-no-files-found: error
 
   octocov:
     needs: test
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,15 +54,12 @@ jobs:
       - name: Build tests
         if: ${{ !matrix.coverage }}
         run: cargo test --no-run
-      - name: Build tests with coverage
-        if: matrix.coverage
-        run: cargo llvm-cov --no-report --no-cfg-coverage
       - name: Run tests
         if: ${{ !matrix.coverage }}
         run: cargo test
       - name: Run tests with coverage
         if: matrix.coverage
-        run: cargo llvm-cov --no-clean --lcov --output-path lcov.info
+        run: cargo llvm-cov --lcov --output-path lcov.info
       - name: Upload coverage artifact
         if: matrix.coverage
         uses: actions/upload-artifact@v4

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,0 +1,8 @@
+coverage:
+  paths:
+    - lcov.info
+comment:
+  if: is_pull_request
+diff:
+  datastores:
+    - artifact://lcov

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -17,4 +17,5 @@ diff:
 report:
   datastores:
     - artifact://${GITHUB_REPOSITORY}
+    - github://mitsuru/octocovs/reports
   if: is_default_branch

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -3,6 +3,3 @@ coverage:
     - lcov.info
 comment:
   if: is_pull_request
-diff:
-  datastores:
-    - artifact://lcov

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,5 +1,20 @@
 coverage:
   paths:
     - lcov.info
+codeToTestRatio:
+  code:
+    - "crates/fulgur/src/**/*.rs"
+    - "!crates/fulgur/src/**/*test*"
+  test:
+    - "crates/fulgur/src/**/*test*"
+    - "crates/fulgur/tests/**/*.rs"
 comment:
   if: is_pull_request
+  deletePrevious: true
+diff:
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}
+report:
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}
+  if: is_default_branch


### PR DESCRIPTION
## Summary
- ubuntu-amd64のtestジョブで`cargo-llvm-cov`を実行しLCOVカバレッジを生成
- PR時のみ`octocov`ジョブが実行され、カバレッジサマリーをPRにコメント
- 他のOS/archのtestジョブは従来通り`cargo test`を実行（影響なし）

## Test plan
- [ ] PRのCIでoctocovジョブが正常に完了すること
- [ ] PRにカバレッジコメントが投稿されること
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/38" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CIでのコードカバレッジ生成・アップロードをOS/アーキテクチャごとに条件付きで実行するようになりました（対象は限定された環境のみカバレッジ有効）。
  * 生成したLCOVをアーティファクト化して後続ジョブで取得・送信できるようになりました。
  * PR時に外部カバレッジサービスへレポートを送信し、差分レポートの保存・公開と既存コメントの削除が可能になりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->