### PR TITLE
fix: use artifact-only for octocov central mode

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -17,5 +17,4 @@ diff:
 report:
   datastores:
     - artifact://${GITHUB_REPOSITORY}
-    - github://mitsuru/octocovs/reports
   if: is_default_branch


### PR DESCRIPTION
## Summary
- `.octocov.yml`からcross-repo push (`github://mitsuru/octocovs/reports`) を削除
- レポートはartifactのみに保存し、central repo (octocovs) 側からpullする構成に変更
- PAT不要でクロスリポジトリ連携が動作する

## Test plan
- [ ] mainマージ後のCIでoctocovジョブが成功すること
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/39" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * レポート出力先の設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->