### PR TITLE
docs: update README with template engine and positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,30 @@
 [![Code to Test Ratio](https://raw.githubusercontent.com/mitsuru/octocovs/main/badges/mitsuru/fulgur/ratio.svg)](https://github.com/mitsuru/octocovs)
 [![Test Execution Time](https://raw.githubusercontent.com/mitsuru/octocovs/main/badges/mitsuru/fulgur/time.svg)](https://github.com/mitsuru/octocovs)
 
-An HTML/CSS to PDF converter written in Rust.
+A modern, lightweight alternative to wkhtmltopdf. Converts HTML/CSS to PDF without a browser engine.
 
-Integrates [Blitz](https://github.com/nickelpack/blitz) (HTML parsing, CSS style resolution, layout) with [Krilla](https://github.com/LaurenzV/krilla) (PDF generation) through a pagination-aware layout abstraction.
+Built in Rust for server-side workloads where memory footprint and startup time matter.
+
+## Why Fulgur?
+
+- **No browser required** — No Chromium, no WebKit, no headless browser. Single binary, instant cold start.
+- **Low memory footprint** — Designed for server-side batch processing without blowing up your container's memory limits.
+- **Deterministic output** — Same input always produces the same PDF, byte for byte. Safe for CI/CD and automated pipelines.
+- **Template + JSON data** — Feed an HTML template and a JSON file to generate PDFs at scale. Built-in [MiniJinja](https://github.com/mitsuhiko/minijinja) engine.
+- **Offline by design** — No network access. All assets (fonts, images, CSS) are explicitly bundled.
 
 ## Features
 
-- HTML/CSS to PDF conversion
-- Automatic page splitting with CSS pagination control (`break-before`, `break-after`, `break-inside`, orphans/widows)
-- Text shaping via Parley
-- Background colors, borders, and padding
-- Deterministic output (same input always produces same PDF)
+- HTML/CSS to PDF conversion with automatic page splitting
+- CSS pagination control (`break-before`, `break-after`, `break-inside`, orphans/widows)
+- CSS Generated Content for Paged Media (page counters, running headers/footers, margin boxes)
+- Template engine with JSON data binding (MiniJinja)
 - Image embedding (PNG / JPEG / GIF)
-- Custom font bundling
-- External CSS file injection
+- Custom font bundling with subsetting
+- External CSS injection
 - Page sizes (A4 / Letter / A3) with landscape support
-- PDF metadata (title, author)
+- PDF metadata (title, author, keywords, language)
+- PDF bookmarks from heading structure
 
 ## Installation
 
@@ -30,47 +38,78 @@ cargo install --path crates/fulgur-cli
 ## CLI Usage
 
 ```bash
-# Convert from file
+# Basic conversion
 fulgur render -o output.pdf input.html
 
 # Read from stdin
 cat input.html | fulgur render --stdin -o output.pdf
 
-# With options
-fulgur render -o output.pdf -s Letter -l --title "My Document" input.html
+# Page options
+fulgur render -o output.pdf -s Letter -l --margin "20 30" input.html
 
 # Custom fonts and CSS
 fulgur render -o output.pdf -f fonts/NotoSansJP.ttf --css style.css input.html
 
-# With images
-fulgur render -o output.pdf -i logo.png=assets/logo.png -i photo.png=assets/photo.png input.html
+# Images
+fulgur render -o output.pdf -i logo.png=assets/logo.png input.html
+
+# Template + JSON data
+fulgur render -o invoice.pdf -d data.json template.html
+```
+
+### Template Example
+
+`template.html`:
+
+```html
+<h1>Invoice #{{ invoice_number }}</h1>
+<p>{{ customer_name }}</p>
+<table>
+  {% for item in items %}
+  <tr><td>{{ item.name }}</td><td>{{ item.price }}</td></tr>
+  {% endfor %}
+</table>
+```
+
+`data.json`:
+
+```json
+{
+  "invoice_number": "2026-001",
+  "customer_name": "Acme Corp",
+  "items": [
+    { "name": "Widget", "price": "$10.00" },
+    { "name": "Gadget", "price": "$25.00" }
+  ]
+}
 ```
 
 ### Options
 
 | Option | Description | Default |
 |---|---|---|
-| `-o, --output` | Output PDF file path (required) | — |
+| `-o, --output` | Output PDF file path (required, use `-` for stdout) | — |
 | `-s, --size` | Page size (A4, Letter, A3) | A4 |
 | `-l, --landscape` | Landscape orientation | false |
+| `--margin` | Page margins in mm (CSS shorthand: `"20"`, `"20 30"`, `"10 20 30 40"`) | — |
 | `--title` | PDF title metadata | — |
-| `-f, --font` | Bundle font files (repeatable) | — |
-| `--css` | External CSS files (repeatable) | — |
-| `-i, --image` | Bundle image files (name=path or path, repeatable) | — |
+| `-f, --font` | Font files to bundle (repeatable) | — |
+| `--css` | CSS files to include (repeatable) | — |
+| `-i, --image` | Image files to bundle as name=path (repeatable) | — |
+| `-d, --data` | JSON data file for template mode (use `-` for stdin) | — |
 | `--stdin` | Read HTML from stdin | false |
 
 ## Library Usage
 
 ```rust
 use fulgur::engine::Engine;
-use fulgur::asset::AssetBundle;
 use fulgur::config::{PageSize, Margin};
 
-// Convert with default settings
+// Basic conversion
 let engine = Engine::builder().build();
 let pdf = engine.render_html("<h1>Hello</h1>")?;
 
-// Custom configuration
+// With page options
 let engine = Engine::builder()
     .page_size(PageSize::A4)
     .margin(Margin::uniform_mm(20.0))
@@ -80,20 +119,21 @@ let engine = Engine::builder()
 let pdf = engine.render_html(html)?;
 engine.render_html_to_file(html, "output.pdf")?;
 
-// With images
-let mut assets = AssetBundle::new();
-assets.add_image_file("logo.png", "assets/logo.png")?;
-
+// Template + JSON
 let engine = Engine::builder()
-    .page_size(PageSize::A4)
-    .assets(assets)
+    .template("invoice.html", template_str)
     .build();
 
-let html = r#"<img src="logo.png" style="display:block;width:100px;height:100px">"#;
-let pdf = engine.render_html(html)?;
+let data = serde_json::json!({
+    "invoice_number": "2026-001",
+    "customer_name": "Acme Corp"
+});
+let pdf = engine.render_template(data)?;
 ```
 
 ## Architecture
+
+Fulgur integrates [Blitz](https://github.com/nickelpack/blitz) (HTML parsing, CSS style resolution, layout) with [Krilla](https://github.com/LaurenzV/krilla) (PDF generation) through a pagination-aware layout abstraction.
 
 ```text
 HTML/CSS input

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ fulgur render -o invoice.pdf -d data.json template.html
 | `-o, --output` | Output PDF file path (required, use `-` for stdout) | — |
 | `-s, --size` | Page size (A4, Letter, A3) | A4 |
 | `-l, --landscape` | Landscape orientation | false |
-| `--margin` | Page margins in mm (CSS shorthand: `"20"`, `"20 30"`, `"10 20 30 40"`) | — |
+| `--margin` | Page margins in mm (CSS shorthand: `"20"`, `"20 30"`, `"10 20 30"`, `"10 20 30 40"`) | — |
 | `--title` | PDF title metadata | — |
 | `-f, --font` | Font files to bundle (repeatable) | — |
 | `--css` | CSS files to include (repeatable) | — |

--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ engine.render_html_to_file(html, "output.pdf")?;
 // Template + JSON
 let engine = Engine::builder()
     .template("invoice.html", template_str)
+    .data(serde_json::json!({
+        "invoice_number": "2026-001",
+        "customer_name": "Acme Corp",
+    }))
     .build();
 
-let data = serde_json::json!({
-    "invoice_number": "2026-001",
-    "customer_name": "Acme Corp"
-});
-let pdf = engine.render_template(data)?;
+let pdf = engine.render()?;
 ```
 
 ## Architecture


### PR DESCRIPTION
## Summary

- テンプレートエンジン(MiniJinja)統合を反映し、「Why Fulgur?」セクションを追加してwkhtmltopdf代替としてのポジショニングを明確化
- Features一覧にGCPM、テンプレートエンジン、PDFブックマーク等の新機能を追加
- CLI/ライブラリの使用例にテンプレート+JSONデータのサンプルを追加
- CLIオプション表に `--margin`, `--data` フラグを反映

## Test plan

- [x] READMEのコードサンプルが実際のCLI/APIと一致していることを確認
- [x] markdownlintが通ること
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/45" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメンテーション**
  * README を更新。テンプレートエンジン（JSON バインディング対応）、ページング向けの CSS 生成コンテンツ（ページ番号・ヘッダー/フッター・余白ボックス）、PDF メタデータ（キーワード/言語）と見出し由来のブックマーク、フォントのサブセット化について追記。
  * CLI ドキュメントを整理（「基本変換」例、--margin、テンプレートモード -d/--data、画像指定 name=path、出力 - を明示）。
  * ライブラリ使用例をテンプレート設定とレンダリング呼び出しに合わせて更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->