### PR TITLE
feat: add Python-style format filter to MiniJinja templates

### DIFF
--- a/crates/fulgur-cli/src/main.rs
+++ b/crates/fulgur-cli/src/main.rs
@@ -14,6 +14,19 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Render HTML to PDF
+    #[command(after_long_help = "\
+\x1b[1;4mTemplate filters:\x1b[0m
+
+  When using --data, the input HTML is processed as a MiniJinja template.
+  In addition to MiniJinja built-in filters (upper, lower, join, etc.),
+  the following custom filter is available:
+
+  \x1b[1mformat(spec)\x1b[0m  Python-style numeric formatting
+    {{ price | format(\",\") }}      → 1,234,567       (comma separator)
+    {{ price | format(\",.2f\") }}   → 1,234,567.89    (comma + 2 decimals)
+    {{ rate  | format(\".2f\") }}    → 10.50            (2 decimal places)
+    {{ seq   | format(\"04d\") }}    → 0005             (zero-padded)
+")]
     Render {
         /// Input HTML file (omit for --stdin)
         #[arg()]

--- a/crates/fulgur-cli/src/main.rs
+++ b/crates/fulgur-cli/src/main.rs
@@ -18,14 +18,23 @@ enum Commands {
 \x1b[1;4mTemplate filters:\x1b[0m
 
   When using --data, the input HTML is processed as a MiniJinja template.
-  In addition to MiniJinja built-in filters (upper, lower, join, etc.),
-  the following custom filter is available:
+  The following filters are available:
 
-  \x1b[1mformat(spec)\x1b[0m  Python-style numeric formatting
-    {{ price | format(\",\") }}      → 1,234,567       (comma separator)
-    {{ price | format(\",.2f\") }}   → 1,234,567.89    (comma + 2 decimals)
-    {{ rate  | format(\".2f\") }}    → 10.50            (2 decimal places)
-    {{ seq   | format(\"04d\") }}    → 0005             (zero-padded)
+  \x1b[1mBuilt-in filters (MiniJinja):\x1b[0m
+    String:  upper, lower, title, capitalize, trim, replace, split, lines
+    List:    first, last, length, reverse, sort, unique, join, slice, batch
+    Select:  select, reject, selectattr, rejectattr, map, groupby, chain, zip
+    Dict:    items, dictsort, attr
+    Type:    int, float, bool, string, list, abs, round, sum, min, max
+    Format:  format (printf-style), tojson, pprint, urlencode, indent
+    Other:   default (d), safe, escape (e)
+
+  \x1b[1mCustom filters:\x1b[0m
+    numformat(spec)  Python-style numeric formatting
+      {{ price | numformat(\",\") }}      → 1,234,567       (comma separator)
+      {{ price | numformat(\",.2f\") }}   → 1,234,567.89    (comma + 2 decimals)
+      {{ rate  | numformat(\".2f\") }}    → 10.50            (2 decimal places)
+      {{ seq   | numformat(\"04d\") }}    → 0005             (zero-padded)
 ")]
     Render {
         /// Input HTML file (omit for --stdin)

--- a/crates/fulgur/src/template.rs
+++ b/crates/fulgur/src/template.rs
@@ -88,7 +88,7 @@ fn format_filter(value: &minijinja::Value, spec: &str) -> String {
 pub fn render_template(name: &str, template_str: &str, data: &serde_json::Value) -> Result<String> {
     let mut env = minijinja::Environment::new();
     env.set_auto_escape_callback(|_| minijinja::AutoEscape::Html);
-    env.add_filter("format", format_filter);
+    env.add_filter("numformat", format_filter);
     env.add_template(name, template_str)?;
     let tmpl = env.get_template(name)?;
     Ok(tmpl.render(data)?)
@@ -170,7 +170,7 @@ mod tests {
 
     #[test]
     fn test_format_comma() {
-        let tmpl = r#"{{ n | format(",") }}"#;
+        let tmpl = r#"{{ n | numformat(",") }}"#;
         let data = json!({"n": 1234567});
         let result = render_template("test.html", tmpl, &data).unwrap();
         assert_eq!(result, "1,234,567");
@@ -178,7 +178,7 @@ mod tests {
 
     #[test]
     fn test_format_comma_decimal() {
-        let tmpl = r#"{{ n | format(",.2f") }}"#;
+        let tmpl = r#"{{ n | numformat(",.2f") }}"#;
         let data = json!({"n": 1234567.891});
         let result = render_template("test.html", tmpl, &data).unwrap();
         assert_eq!(result, "1,234,567.89");
@@ -186,7 +186,7 @@ mod tests {
 
     #[test]
     fn test_format_decimal_only() {
-        let tmpl = r#"{{ n | format(".2f") }}"#;
+        let tmpl = r#"{{ n | numformat(".2f") }}"#;
         let data = json!({"n": 3.14159});
         let result = render_template("test.html", tmpl, &data).unwrap();
         assert_eq!(result, "3.14");
@@ -194,7 +194,7 @@ mod tests {
 
     #[test]
     fn test_format_zero_pad() {
-        let tmpl = r#"{{ n | format("04d") }}"#;
+        let tmpl = r#"{{ n | numformat("04d") }}"#;
         let data = json!({"n": 5});
         let result = render_template("test.html", tmpl, &data).unwrap();
         assert_eq!(result, "0005");
@@ -202,7 +202,7 @@ mod tests {
 
     #[test]
     fn test_format_comma_negative() {
-        let tmpl = r#"{{ n | format(",") }}"#;
+        let tmpl = r#"{{ n | numformat(",") }}"#;
         let data = json!({"n": -1234567});
         let result = render_template("test.html", tmpl, &data).unwrap();
         assert_eq!(result, "-1,234,567");
@@ -210,7 +210,7 @@ mod tests {
 
     #[test]
     fn test_format_comma_small() {
-        let tmpl = r#"{{ n | format(",") }}"#;
+        let tmpl = r#"{{ n | numformat(",") }}"#;
         let data = json!({"n": 42});
         let result = render_template("test.html", tmpl, &data).unwrap();
         assert_eq!(result, "42");

--- a/crates/fulgur/src/template.rs
+++ b/crates/fulgur/src/template.rs
@@ -76,7 +76,7 @@ fn format_filter(value: &minijinja::Value, spec: &str) -> String {
     if spec.starts_with('0') && spec.ends_with('d') {
         if let Ok(width) = spec[..spec.len() - 1].parse::<usize>() {
             if let Some(n) = as_i64 {
-                return format!("{:0>width$}", n);
+                return format!("{:0width$}", n);
             }
         }
     }
@@ -206,6 +206,14 @@ mod tests {
         let data = json!({"n": -1234567});
         let result = render_template("test.html", tmpl, &data).unwrap();
         assert_eq!(result, "-1,234,567");
+    }
+
+    #[test]
+    fn test_format_zero_pad_negative() {
+        let tmpl = r#"{{ n | numformat("04d") }}"#;
+        let data = json!({"n": -5});
+        let result = render_template("test.html", tmpl, &data).unwrap();
+        assert_eq!(result, "-005");
     }
 
     #[test]

--- a/crates/fulgur/src/template.rs
+++ b/crates/fulgur/src/template.rs
@@ -1,9 +1,94 @@
 use crate::error::Result;
 
+/// Insert commas as thousands separators into the integer part of a numeric string.
+fn insert_commas(s: &str) -> String {
+    let (integer, decimal) = match s.split_once('.') {
+        Some((int, dec)) => (int, Some(dec)),
+        None => (s, None),
+    };
+
+    let negative = integer.starts_with('-');
+    let digits = if negative { &integer[1..] } else { integer };
+
+    let mut result = String::new();
+    for (i, ch) in digits.chars().enumerate() {
+        if i > 0 && (digits.len() - i) % 3 == 0 {
+            result.push(',');
+        }
+        result.push(ch);
+    }
+
+    let mut out = String::new();
+    if negative {
+        out.push('-');
+    }
+    out.push_str(&result);
+    if let Some(dec) = decimal {
+        out.push('.');
+        out.push_str(dec);
+    }
+    out
+}
+
+/// Python-style numeric format filter.
+///
+/// Supports a subset of Python's format spec for numbers:
+/// - `","` — thousands comma separator (integer)
+/// - `",.Nf"` — comma separator with N decimal places
+/// - `".Nf"` — N decimal places without comma
+/// - `"0Nd"` — zero-padded integer to width N
+fn format_filter(value: &minijinja::Value, spec: &str) -> String {
+    let as_f64 = f64::try_from(value.clone()).ok();
+    let as_i64 = i64::try_from(value.clone()).ok();
+
+    // "," — comma-separated integer
+    if spec == "," {
+        return match as_i64 {
+            Some(n) => insert_commas(&n.to_string()),
+            None => match as_f64 {
+                Some(f) => insert_commas(&f.to_string()),
+                None => value.to_string(),
+            },
+        };
+    }
+
+    // ",.Nf" — comma + N decimal places
+    if let Some(rest) = spec.strip_prefix(',') {
+        if let Some(prec_str) = rest.strip_prefix('.').and_then(|s| s.strip_suffix('f')) {
+            if let Ok(prec) = prec_str.parse::<usize>() {
+                if let Some(f) = as_f64 {
+                    return insert_commas(&format!("{:.prec$}", f));
+                }
+            }
+        }
+    }
+
+    // ".Nf" — N decimal places
+    if let Some(inner) = spec.strip_prefix('.').and_then(|s| s.strip_suffix('f')) {
+        if let Ok(prec) = inner.parse::<usize>() {
+            if let Some(f) = as_f64 {
+                return format!("{:.prec$}", f);
+            }
+        }
+    }
+
+    // "0Nd" — zero-padded integer
+    if spec.starts_with('0') && spec.ends_with('d') {
+        if let Ok(width) = spec[..spec.len() - 1].parse::<usize>() {
+            if let Some(n) = as_i64 {
+                return format!("{:0>width$}", n);
+            }
+        }
+    }
+
+    value.to_string()
+}
+
 /// Render a MiniJinja template with JSON data.
 pub fn render_template(name: &str, template_str: &str, data: &serde_json::Value) -> Result<String> {
     let mut env = minijinja::Environment::new();
     env.set_auto_escape_callback(|_| minijinja::AutoEscape::Html);
+    env.add_filter("format", format_filter);
     env.add_template(name, template_str)?;
     let tmpl = env.get_template(name)?;
     Ok(tmpl.render(data)?)
@@ -81,6 +166,54 @@ mod tests {
         let data = json!({});
         let result = render_template("test.html", tmpl, &data).unwrap();
         assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_format_comma() {
+        let tmpl = r#"{{ n | format(",") }}"#;
+        let data = json!({"n": 1234567});
+        let result = render_template("test.html", tmpl, &data).unwrap();
+        assert_eq!(result, "1,234,567");
+    }
+
+    #[test]
+    fn test_format_comma_decimal() {
+        let tmpl = r#"{{ n | format(",.2f") }}"#;
+        let data = json!({"n": 1234567.891});
+        let result = render_template("test.html", tmpl, &data).unwrap();
+        assert_eq!(result, "1,234,567.89");
+    }
+
+    #[test]
+    fn test_format_decimal_only() {
+        let tmpl = r#"{{ n | format(".2f") }}"#;
+        let data = json!({"n": 3.14159});
+        let result = render_template("test.html", tmpl, &data).unwrap();
+        assert_eq!(result, "3.14");
+    }
+
+    #[test]
+    fn test_format_zero_pad() {
+        let tmpl = r#"{{ n | format("04d") }}"#;
+        let data = json!({"n": 5});
+        let result = render_template("test.html", tmpl, &data).unwrap();
+        assert_eq!(result, "0005");
+    }
+
+    #[test]
+    fn test_format_comma_negative() {
+        let tmpl = r#"{{ n | format(",") }}"#;
+        let data = json!({"n": -1234567});
+        let result = render_template("test.html", tmpl, &data).unwrap();
+        assert_eq!(result, "-1,234,567");
+    }
+
+    #[test]
+    fn test_format_comma_small() {
+        let tmpl = r#"{{ n | format(",") }}"#;
+        let data = json!({"n": 42});
+        let result = render_template("test.html", tmpl, &data).unwrap();
+        assert_eq!(result, "42");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- MiniJinjaテンプレートにPython書式指定互換の `format` フィルタを追加
- AIエージェントが `{{ price | format(",") }}` のように自然に数値フォーマットを記述可能に
- サポートする書式: `","` (カンマ区切り), `",.Nf"` (カンマ+小数), `".Nf"` (小数のみ), `"0Nd"` (ゼロ埋め)

## Motivation

AIエージェントがテンプレートを生成する際、Pythonの `format` 構文を自然に使おうとするが、MiniJinjaにはビルトインの数値フォーマットフィルタがない。データ側でフォーマット済み文字列を用意する回避策は冗長なため、テンプレート側で完結できるようにした。

## Test plan

- [x] `cargo test -p fulgur --lib template` — 全21テスト通過
- [ ] カンマ区切り: `1234567` → `1,234,567`
- [ ] カンマ+小数: `1234567.891` → `1,234,567.89`
- [ ] 小数のみ: `3.14159` → `3.14`
- [ ] ゼロ埋め: `5` → `0005`
- [ ] 負数: `-1234567` → `-1,234,567`
- [ ] 小さい数: `42` → `42` (カンマなし)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/52" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * テンプレート用の数値書式フィルタを追加しました。千区切り、固定小数点（N桁）、千区切り＋小数指定、整数の0埋めなど複数の書式に対応し、負数や小数も扱います。無効な書式時は文字列表現にフォールバックします。
* **ドキュメント**
  * CLIのヘルプにフィルタ使用例と出力例を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->