### PR TITLE
feat(gcpm): CSS Named Strings (string-set / string()) support

### DIFF
--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -299,7 +299,8 @@ impl DomPass for LinkStylesheetPass {
 }
 
 use crate::gcpm::running::{RunningElementStore, serialize_node};
-use crate::gcpm::{GcpmContext, ParsedSelector};
+use crate::gcpm::string_set::{StringSetEntry, StringSetStore, extract_text_content};
+use crate::gcpm::{GcpmContext, ParsedSelector, StringSetValue};
 use std::cell::RefCell;
 
 /// Extracts running elements from the DOM and stores their serialized HTML.
@@ -378,6 +379,121 @@ impl RunningElementPass {
             ParsedSelector::Id(name) => get_attr(elem, "id") == Some(name.as_str()),
             ParsedSelector::Tag(name) => elem.name.local.as_ref().eq_ignore_ascii_case(name),
         }
+    }
+}
+
+/// Extracts string-set values from the DOM by walking the tree and resolving text content.
+pub struct StringSetPass {
+    gcpm: GcpmContext,
+    store: RefCell<StringSetStore>,
+}
+
+impl StringSetPass {
+    pub fn new(gcpm: GcpmContext) -> Self {
+        Self {
+            gcpm,
+            store: RefCell::new(StringSetStore::new()),
+        }
+    }
+
+    pub fn into_store(self) -> StringSetStore {
+        self.store.into_inner()
+    }
+}
+
+impl DomPass for StringSetPass {
+    fn apply(&self, doc: &mut HtmlDocument, _ctx: &PassContext<'_>) {
+        if self.gcpm.string_set_mappings.is_empty() {
+            return;
+        }
+        let root = doc.root_element();
+        let root_id = root.id;
+        self.walk_tree(doc, root_id);
+    }
+}
+
+impl StringSetPass {
+    fn walk_tree(&self, doc: &HtmlDocument, node_id: usize) {
+        let Some(node) = doc.get_node(node_id) else {
+            return;
+        };
+
+        if let Some(elem) = node.element_data() {
+            if matches!(
+                elem.name.local.as_ref(),
+                "head" | "script" | "style" | "link" | "meta" | "title" | "noscript"
+            ) {
+                return;
+            }
+            if let Some((name, values)) = self.find_string_set(elem) {
+                let value = self.resolve_values(doc, node_id, elem, &values);
+                self.store.borrow_mut().push(StringSetEntry {
+                    name,
+                    value,
+                    node_id,
+                });
+            }
+        }
+
+        // Always recurse (string-set elements stay in document flow)
+        let children: Vec<usize> = doc
+            .get_node(node_id)
+            .map(|n| n.children.clone())
+            .unwrap_or_default();
+        for child_id in children {
+            self.walk_tree(doc, child_id);
+        }
+    }
+
+    fn find_string_set(
+        &self,
+        elem: &blitz_dom::node::ElementData,
+    ) -> Option<(String, Vec<StringSetValue>)> {
+        self.gcpm
+            .string_set_mappings
+            .iter()
+            .find(|m| self.matches_selector(&m.parsed, elem))
+            .map(|m| (m.name.clone(), m.values.clone()))
+    }
+
+    fn matches_selector(
+        &self,
+        selector: &ParsedSelector,
+        elem: &blitz_dom::node::ElementData,
+    ) -> bool {
+        match selector {
+            ParsedSelector::Class(name) => get_attr(elem, "class")
+                .is_some_and(|cls| cls.split_whitespace().any(|c| c == name.as_str())),
+            ParsedSelector::Id(name) => get_attr(elem, "id") == Some(name.as_str()),
+            ParsedSelector::Tag(name) => elem.name.local.as_ref().eq_ignore_ascii_case(name),
+        }
+    }
+
+    fn resolve_values(
+        &self,
+        doc: &HtmlDocument,
+        node_id: usize,
+        elem: &blitz_dom::node::ElementData,
+        values: &[StringSetValue],
+    ) -> String {
+        let mut out = String::new();
+        for val in values {
+            match val {
+                StringSetValue::ContentText => {
+                    out.push_str(&extract_text_content(doc, node_id));
+                }
+                StringSetValue::ContentBefore | StringSetValue::ContentAfter => {
+                    // Skip for now (requires Stylo computed styles, rarely used)
+                }
+                StringSetValue::Attr(attr_name) => {
+                    if let Some(v) = get_attr(elem, attr_name) {
+                        out.push_str(v);
+                    }
+                }
+                StringSetValue::Literal(s) => out.push_str(s),
+            }
+        }
+        out
     }
 }
 

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -300,19 +300,38 @@ impl DomPass for LinkStylesheetPass {
 
 use crate::gcpm::running::{RunningElementStore, serialize_node};
 use crate::gcpm::string_set::{StringSetEntry, StringSetStore, extract_text_content};
-use crate::gcpm::{GcpmContext, ParsedSelector, StringSetValue};
+use crate::gcpm::{ParsedSelector, RunningMapping, StringSetMapping, StringSetValue};
 use std::cell::RefCell;
+
+/// Returns true for elements that should never be walked for GCPM detection
+/// (head, script, style, etc.) — they contain no user-visible content.
+fn is_non_visual_tag(tag: &str) -> bool {
+    matches!(
+        tag,
+        "head" | "script" | "style" | "link" | "meta" | "title" | "noscript"
+    )
+}
+
+/// Check whether a `ParsedSelector` (simple class/id/tag selector) matches the given element.
+fn selector_matches(selector: &ParsedSelector, elem: &blitz_dom::node::ElementData) -> bool {
+    match selector {
+        ParsedSelector::Class(name) => get_attr(elem, "class")
+            .is_some_and(|cls| cls.split_whitespace().any(|c| c == name.as_str())),
+        ParsedSelector::Id(name) => get_attr(elem, "id") == Some(name.as_str()),
+        ParsedSelector::Tag(name) => elem.name.local.as_ref().eq_ignore_ascii_case(name),
+    }
+}
 
 /// Extracts running elements from the DOM and stores their serialized HTML.
 pub struct RunningElementPass {
-    gcpm: GcpmContext,
+    mappings: Vec<RunningMapping>,
     store: RefCell<RunningElementStore>,
 }
 
 impl RunningElementPass {
-    pub fn new(gcpm: GcpmContext) -> Self {
+    pub fn new(mappings: Vec<RunningMapping>) -> Self {
         Self {
-            gcpm,
+            mappings,
             store: RefCell::new(RunningElementStore::new()),
         }
     }
@@ -324,7 +343,7 @@ impl RunningElementPass {
 
 impl DomPass for RunningElementPass {
     fn apply(&self, doc: &mut HtmlDocument, _ctx: &PassContext<'_>) {
-        if self.gcpm.running_mappings.is_empty() {
+        if self.mappings.is_empty() {
             return;
         }
         let root = doc.root_element();
@@ -340,17 +359,13 @@ impl RunningElementPass {
         };
 
         if let Some(elem) = node.element_data() {
-            // Skip non-visual elements (head, script, style, etc.) to match
-            // the old convert.rs behavior and avoid false matches inside <head>.
-            if matches!(
-                elem.name.local.as_ref(),
-                "head" | "script" | "style" | "link" | "meta" | "title" | "noscript"
-            ) {
+            if is_non_visual_tag(elem.name.local.as_ref()) {
                 return;
             }
             if let Some(running_name) = self.find_running_name(elem) {
                 let html = serialize_node(doc, node_id);
                 self.store.borrow_mut().register(running_name, html);
+                // Running elements are removed from flow — don't recurse.
                 return;
             }
         }
@@ -361,37 +376,23 @@ impl RunningElementPass {
     }
 
     fn find_running_name(&self, elem: &blitz_dom::node::ElementData) -> Option<String> {
-        self.gcpm
-            .running_mappings
+        self.mappings
             .iter()
-            .find(|m| self.matches_selector(&m.parsed, elem))
+            .find(|m| selector_matches(&m.parsed, elem))
             .map(|m| m.running_name.clone())
-    }
-
-    fn matches_selector(
-        &self,
-        selector: &ParsedSelector,
-        elem: &blitz_dom::node::ElementData,
-    ) -> bool {
-        match selector {
-            ParsedSelector::Class(name) => get_attr(elem, "class")
-                .is_some_and(|cls| cls.split_whitespace().any(|c| c == name.as_str())),
-            ParsedSelector::Id(name) => get_attr(elem, "id") == Some(name.as_str()),
-            ParsedSelector::Tag(name) => elem.name.local.as_ref().eq_ignore_ascii_case(name),
-        }
     }
 }
 
 /// Extracts string-set values from the DOM by walking the tree and resolving text content.
 pub struct StringSetPass {
-    gcpm: GcpmContext,
+    mappings: Vec<StringSetMapping>,
     store: RefCell<StringSetStore>,
 }
 
 impl StringSetPass {
-    pub fn new(gcpm: GcpmContext) -> Self {
+    pub fn new(mappings: Vec<StringSetMapping>) -> Self {
         Self {
-            gcpm,
+            mappings,
             store: RefCell::new(StringSetStore::new()),
         }
     }
@@ -403,7 +404,7 @@ impl StringSetPass {
 
 impl DomPass for StringSetPass {
     fn apply(&self, doc: &mut HtmlDocument, _ctx: &PassContext<'_>) {
-        if self.gcpm.string_set_mappings.is_empty() {
+        if self.mappings.is_empty() {
             return;
         }
         let root = doc.root_element();
@@ -419,82 +420,55 @@ impl StringSetPass {
         };
 
         if let Some(elem) = node.element_data() {
-            if matches!(
-                elem.name.local.as_ref(),
-                "head" | "script" | "style" | "link" | "meta" | "title" | "noscript"
-            ) {
+            if is_non_visual_tag(elem.name.local.as_ref()) {
                 return;
             }
-            if let Some((name, values)) = self.find_string_set(elem) {
-                let value = self.resolve_values(doc, node_id, elem, &values);
+            if let Some(mapping) = self.find_string_set(elem) {
+                let value = resolve_string_set_values(doc, node_id, elem, &mapping.values);
                 self.store.borrow_mut().push(StringSetEntry {
-                    name,
+                    name: mapping.name.clone(),
                     value,
                     node_id,
                 });
             }
         }
 
-        // Always recurse (string-set elements stay in document flow)
-        let children: Vec<usize> = doc
-            .get_node(node_id)
-            .map(|n| n.children.clone())
-            .unwrap_or_default();
-        for child_id in children {
+        // string-set targets stay in document flow — always recurse into children.
+        for &child_id in &node.children {
             self.walk_tree(doc, child_id);
         }
     }
 
-    fn find_string_set(
-        &self,
-        elem: &blitz_dom::node::ElementData,
-    ) -> Option<(String, Vec<StringSetValue>)> {
-        self.gcpm
-            .string_set_mappings
+    fn find_string_set(&self, elem: &blitz_dom::node::ElementData) -> Option<&StringSetMapping> {
+        self.mappings
             .iter()
-            .find(|m| self.matches_selector(&m.parsed, elem))
-            .map(|m| (m.name.clone(), m.values.clone()))
+            .find(|m| selector_matches(&m.parsed, elem))
     }
+}
 
-    fn matches_selector(
-        &self,
-        selector: &ParsedSelector,
-        elem: &blitz_dom::node::ElementData,
-    ) -> bool {
-        match selector {
-            ParsedSelector::Class(name) => get_attr(elem, "class")
-                .is_some_and(|cls| cls.split_whitespace().any(|c| c == name.as_str())),
-            ParsedSelector::Id(name) => get_attr(elem, "id") == Some(name.as_str()),
-            ParsedSelector::Tag(name) => elem.name.local.as_ref().eq_ignore_ascii_case(name),
-        }
-    }
-
-    fn resolve_values(
-        &self,
-        doc: &HtmlDocument,
-        node_id: usize,
-        elem: &blitz_dom::node::ElementData,
-        values: &[StringSetValue],
-    ) -> String {
-        let mut out = String::new();
-        for val in values {
-            match val {
-                StringSetValue::ContentText => {
-                    out.push_str(&extract_text_content(doc, node_id));
-                }
-                StringSetValue::ContentBefore | StringSetValue::ContentAfter => {
-                    // Skip for now (requires Stylo computed styles, rarely used)
-                }
-                StringSetValue::Attr(attr_name) => {
-                    if let Some(v) = get_attr(elem, attr_name) {
-                        out.push_str(v);
-                    }
-                }
-                StringSetValue::Literal(s) => out.push_str(s),
+fn resolve_string_set_values(
+    doc: &HtmlDocument,
+    node_id: usize,
+    elem: &blitz_dom::node::ElementData,
+    values: &[StringSetValue],
+) -> String {
+    let mut out = String::new();
+    for val in values {
+        match val {
+            StringSetValue::ContentText => {
+                out.push_str(&extract_text_content(doc, node_id));
             }
+            // content(before)/content(after) require pseudo-element computed styles.
+            StringSetValue::ContentBefore | StringSetValue::ContentAfter => {}
+            StringSetValue::Attr(attr_name) => {
+                if let Some(v) = get_attr(elem, attr_name) {
+                    out.push_str(v);
+                }
+            }
+            StringSetValue::Literal(s) => out.push_str(s),
         }
-        out
     }
+    out
 }
 
 #[cfg(test)]
@@ -585,7 +559,7 @@ mod tests {
             cleaned_css: String::new(),
         };
 
-        let pass = RunningElementPass::new(gcpm);
+        let pass = RunningElementPass::new(gcpm.running_mappings);
         let ctx = PassContext {
             viewport_width: 400.0,
             viewport_height: 10000.0,
@@ -623,7 +597,7 @@ mod tests {
             cleaned_css: String::new(),
         };
 
-        let pass = RunningElementPass::new(gcpm);
+        let pass = RunningElementPass::new(gcpm.running_mappings);
         let ctx = PassContext {
             viewport_width: 400.0,
             viewport_height: 10000.0,
@@ -648,7 +622,7 @@ mod tests {
             cleaned_css: String::new(),
         };
 
-        let pass = RunningElementPass::new(gcpm);
+        let pass = RunningElementPass::new(gcpm.running_mappings);
         let ctx = PassContext {
             viewport_width: 400.0,
             viewport_height: 10000.0,
@@ -677,7 +651,7 @@ mod tests {
             cleaned_css: String::new(),
         };
 
-        let pass = RunningElementPass::new(gcpm);
+        let pass = RunningElementPass::new(gcpm.running_mappings);
         let ctx = PassContext {
             viewport_width: 400.0,
             viewport_height: 10000.0,

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -465,6 +465,7 @@ mod tests {
                 parsed: crate::gcpm::ParsedSelector::Class("header".to_string()),
                 running_name: "pageHeader".to_string(),
             }],
+            string_set_mappings: vec![],
             cleaned_css: String::new(),
         };
 
@@ -502,6 +503,7 @@ mod tests {
                 parsed: crate::gcpm::ParsedSelector::Id("title".to_string()),
                 running_name: "pageTitle".to_string(),
             }],
+            string_set_mappings: vec![],
             cleaned_css: String::new(),
         };
 
@@ -526,6 +528,7 @@ mod tests {
         let gcpm = crate::gcpm::GcpmContext {
             margin_boxes: vec![],
             running_mappings: vec![],
+            string_set_mappings: vec![],
             cleaned_css: String::new(),
         };
 
@@ -554,6 +557,7 @@ mod tests {
                 parsed: crate::gcpm::ParsedSelector::Id("injected".to_string()),
                 running_name: "shouldNotMatch".to_string(),
             }],
+            string_set_mappings: vec![],
             cleaned_css: String::new(),
         };
 

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -119,12 +119,20 @@ fn maybe_prepend_string_set(
 /// `.chapter { string-set: title attr(data-title); }` — would never reach the
 /// Pageable tree because `convert_node` is never called for the node.
 ///
+/// The `x`/`y` arguments are the node's Taffy-computed `final_layout.location`.
+/// They MUST be propagated to the `PositionedChild` because `BlockPageable::split`
+/// uses `children[split_index].y` as the rebase point for the next page; a
+/// marker hardcoded to `y = 0` would corrupt the y-offsets of all children
+/// following it on the next page when a split lands on its index.
+///
 /// Bare markers are appended directly (no `StringSetWrapperPageable` wrapper):
 /// there is no real child content to keep them attached to, and their
 /// position in the parent's child list already represents the point in the
 /// document flow where the string was set.
 fn emit_orphan_string_set_markers(
     node_id: usize,
+    x: f32,
+    y: f32,
     ctx: &mut ConvertContext<'_>,
     out: &mut Vec<PositionedChild>,
 ) {
@@ -132,8 +140,8 @@ fn emit_orphan_string_set_markers(
         for (name, value) in entries {
             out.push(PositionedChild {
                 child: Box::new(StringSetPageable::new(name, value)),
-                x: 0.0,
-                y: 0.0,
+                x,
+                y,
             });
         }
     }
@@ -320,7 +328,13 @@ fn collect_positioned_children(
             && child_layout.size.width == 0.0
             && child_node.children.is_empty()
         {
-            emit_orphan_string_set_markers(child_id, ctx, &mut result);
+            emit_orphan_string_set_markers(
+                child_id,
+                child_layout.location.x,
+                child_layout.location.y,
+                ctx,
+                &mut result,
+            );
             continue;
         }
 
@@ -331,7 +345,13 @@ fn collect_positioned_children(
             && child_layout.size.width == 0.0
             && !child_node.children.is_empty()
         {
-            emit_orphan_string_set_markers(child_id, ctx, &mut result);
+            emit_orphan_string_set_markers(
+                child_id,
+                child_layout.location.x,
+                child_layout.location.y,
+                ctx,
+                &mut result,
+            );
             let nested = collect_positioned_children(doc, &child_node.children, ctx);
             result.extend(nested);
             continue;

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -111,6 +111,34 @@ fn maybe_prepend_string_set(
     }
 }
 
+/// Emit bare `StringSetPageable` markers for a node that is about to be
+/// skipped by pagination (zero-size leaf) or flattened (zero-size container).
+///
+/// Without this, `string-set` on an empty element — e.g.
+/// `<div class="chapter" data-title="Ch 1"></div>` with
+/// `.chapter { string-set: title attr(data-title); }` — would never reach the
+/// Pageable tree because `convert_node` is never called for the node.
+///
+/// Bare markers are appended directly (no `StringSetWrapperPageable` wrapper):
+/// there is no real child content to keep them attached to, and their
+/// position in the parent's child list already represents the point in the
+/// document flow where the string was set.
+fn emit_orphan_string_set_markers(
+    node_id: usize,
+    ctx: &mut ConvertContext<'_>,
+    out: &mut Vec<PositionedChild>,
+) {
+    if let Some(entries) = ctx.string_set_by_node.remove(&node_id) {
+        for (name, value) in entries {
+            out.push(PositionedChild {
+                child: Box::new(StringSetPageable::new(name, value)),
+                x: 0.0,
+                y: 0.0,
+            });
+        }
+    }
+}
+
 fn convert_node_inner(
     doc: &blitz_dom::BaseDocument,
     node_id: usize,
@@ -285,19 +313,25 @@ fn collect_positioned_children(
 
         let child_layout = child_node.final_layout;
 
-        // Zero-size leaf nodes (whitespace text, etc.) — skip
+        // Zero-size leaf nodes (whitespace text, etc.) — skip, but first
+        // harvest any string-set entries so `string-set: name attr(...)` on
+        // an empty element still propagates into the page tree.
         if child_layout.size.height == 0.0
             && child_layout.size.width == 0.0
             && child_node.children.is_empty()
         {
+            emit_orphan_string_set_markers(child_id, ctx, &mut result);
             continue;
         }
 
-        // Zero-size container (thead, tbody, tr, etc.) — flatten children into parent
+        // Zero-size container (thead, tbody, tr, etc.) — flatten children
+        // into the parent. Harvest the container's own string-set entries
+        // before recursing so they aren't dropped.
         if child_layout.size.height == 0.0
             && child_layout.size.width == 0.0
             && !child_node.children.is_empty()
         {
+            emit_orphan_string_set_markers(child_id, ctx, &mut result);
             let nested = collect_positioned_children(doc, &child_node.children, ctx);
             result.extend(nested);
             continue;

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -92,6 +92,10 @@ fn convert_node(
 
 /// If the given node has string-set entries, wrap the pageable in a BlockPageable
 /// with StringSetPageable markers prepended. Otherwise return the pageable as-is.
+///
+/// The wrapper propagates `pagination()` from the original child so that
+/// `break-before`/`break-after`/`break-inside` properties on the string-set
+/// target element (e.g. `<h1>`) remain visible to the paginator.
 fn maybe_prepend_string_set(
     node_id: usize,
     child: Box<dyn Pageable>,
@@ -100,6 +104,7 @@ fn maybe_prepend_string_set(
     let entries = ctx.string_set_by_node.remove(&node_id);
     match entries {
         Some(entries) if !entries.is_empty() => {
+            let child_pagination = child.pagination();
             let mut children = Vec::with_capacity(entries.len() + 1);
             for (name, value) in entries {
                 children.push(PositionedChild {
@@ -113,7 +118,9 @@ fn maybe_prepend_string_set(
                 x: 0.0,
                 y: 0.0,
             });
-            Box::new(BlockPageable::with_positioned_children(children))
+            Box::new(
+                BlockPageable::with_positioned_children(children).with_pagination(child_pagination),
+            )
         }
         _ => child,
     }

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -6,7 +6,7 @@ use crate::image::ImagePageable;
 use crate::pageable::{
     BackgroundLayer, BgBox, BgClip, BgLengthPercentage, BgRepeat, BgSize, BlockPageable,
     BlockStyle, BorderStyleValue, ListItemPageable, Pageable, PositionedChild, Size,
-    SpacerPageable, StringSetPageable, TablePageable,
+    SpacerPageable, StringSetPageable, StringSetWrapperPageable, TablePageable,
 };
 use crate::paragraph::{
     ParagraphPageable, ShapedGlyph, ShapedGlyphRun, ShapedLine, TextDecoration, TextDecorationLine,
@@ -90,12 +90,9 @@ fn convert_node(
     maybe_prepend_string_set(node_id, result, ctx)
 }
 
-/// If the given node has string-set entries, wrap the pageable in a BlockPageable
-/// with StringSetPageable markers prepended. Otherwise return the pageable as-is.
-///
-/// The wrapper propagates `pagination()` from the original child so that
-/// `break-before`/`break-after`/`break-inside` properties on the string-set
-/// target element (e.g. `<h1>`) remain visible to the paginator.
+/// If the given node has string-set entries, wrap the pageable in a
+/// `StringSetWrapperPageable` that keeps markers attached to the child during
+/// pagination. Otherwise return the pageable as-is.
 fn maybe_prepend_string_set(
     node_id: usize,
     child: Box<dyn Pageable>,
@@ -104,23 +101,11 @@ fn maybe_prepend_string_set(
     let entries = ctx.string_set_by_node.remove(&node_id);
     match entries {
         Some(entries) if !entries.is_empty() => {
-            let child_pagination = child.pagination();
-            let mut children = Vec::with_capacity(entries.len() + 1);
-            for (name, value) in entries {
-                children.push(PositionedChild {
-                    child: Box::new(StringSetPageable::new(name, value)),
-                    x: 0.0,
-                    y: 0.0,
-                });
-            }
-            children.push(PositionedChild {
-                child,
-                x: 0.0,
-                y: 0.0,
-            });
-            Box::new(
-                BlockPageable::with_positioned_children(children).with_pagination(child_pagination),
-            )
+            let markers = entries
+                .into_iter()
+                .map(|(name, value)| StringSetPageable::new(name, value))
+                .collect();
+            Box::new(StringSetWrapperPageable::new(markers, child))
         }
         _ => child,
     }

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -6,7 +6,7 @@ use crate::image::ImagePageable;
 use crate::pageable::{
     BackgroundLayer, BgBox, BgClip, BgLengthPercentage, BgRepeat, BgSize, BlockPageable,
     BlockStyle, BorderStyleValue, ListItemPageable, Pageable, PositionedChild, Size,
-    SpacerPageable, TablePageable,
+    SpacerPageable, StringSetPageable, TablePageable,
 };
 use crate::paragraph::{
     ParagraphPageable, ShapedGlyph, ShapedGlyphRun, ShapedLine, TextDecoration, TextDecorationLine,
@@ -24,6 +24,8 @@ pub struct ConvertContext<'a> {
     pub assets: Option<&'a AssetBundle>,
     /// Cache font data by (data pointer address, font index) to avoid redundant .to_vec() copies.
     pub(crate) font_cache: HashMap<(usize, u32), Arc<Vec<u8>>>,
+    /// String-set entries from DOM walk, keyed by node_id for O(1) lookup.
+    pub string_set_by_node: HashMap<usize, Vec<(String, String)>>,
 }
 
 impl ConvertContext<'_> {
@@ -80,6 +82,44 @@ fn debug_print_tree(doc: &blitz_dom::BaseDocument, node_id: usize, depth: usize)
 }
 
 fn convert_node(
+    doc: &blitz_dom::BaseDocument,
+    node_id: usize,
+    ctx: &mut ConvertContext<'_>,
+) -> Box<dyn Pageable> {
+    let result = convert_node_inner(doc, node_id, ctx);
+    maybe_prepend_string_set(node_id, result, ctx)
+}
+
+/// If the given node has string-set entries, wrap the pageable in a BlockPageable
+/// with StringSetPageable markers prepended. Otherwise return the pageable as-is.
+fn maybe_prepend_string_set(
+    node_id: usize,
+    child: Box<dyn Pageable>,
+    ctx: &mut ConvertContext<'_>,
+) -> Box<dyn Pageable> {
+    let entries = ctx.string_set_by_node.remove(&node_id);
+    match entries {
+        Some(entries) if !entries.is_empty() => {
+            let mut children = Vec::with_capacity(entries.len() + 1);
+            for (name, value) in entries {
+                children.push(PositionedChild {
+                    child: Box::new(StringSetPageable::new(name, value)),
+                    x: 0.0,
+                    y: 0.0,
+                });
+            }
+            children.push(PositionedChild {
+                child,
+                x: 0.0,
+                y: 0.0,
+            });
+            Box::new(BlockPageable::with_positioned_children(children))
+        }
+        _ => child,
+    }
+}
+
+fn convert_node_inner(
     doc: &blitz_dom::BaseDocument,
     node_id: usize,
     ctx: &mut ConvertContext<'_>,

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -101,14 +101,34 @@ impl Engine {
             crate::gcpm::running::RunningElementStore::new()
         };
 
+        // Extract string-set values via DomPass (before resolve, after running elements)
+        let string_set_store = if !gcpm.string_set_mappings.is_empty() {
+            let pass = crate::blitz_adapter::StringSetPass::new(gcpm.clone());
+            pass.apply(&mut doc, &ctx);
+            pass.into_store()
+        } else {
+            crate::gcpm::string_set::StringSetStore::new()
+        };
+
         crate::blitz_adapter::resolve(&mut doc);
 
         // --- Convert DOM to Pageable and render ---
+        // Build string-set lookup map
+        let string_set_by_node: HashMap<usize, Vec<(String, String)>> = {
+            let mut map: HashMap<usize, Vec<(String, String)>> = HashMap::new();
+            for entry in string_set_store.entries() {
+                map.entry(entry.node_id)
+                    .or_default()
+                    .push((entry.name.clone(), entry.value.clone()));
+            }
+            map
+        };
+
         let mut convert_ctx = ConvertContext {
             running_store: &mut running_store,
             assets: self.assets.as_ref(),
             font_cache: HashMap::new(),
-            string_set_by_node: HashMap::new(),
+            string_set_by_node,
         };
         let root = crate::convert::dom_to_pageable(&doc, &mut convert_ctx);
 

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -108,6 +108,7 @@ impl Engine {
             running_store: &mut running_store,
             assets: self.assets.as_ref(),
             font_cache: HashMap::new(),
+            string_set_by_node: HashMap::new(),
         };
         let root = crate::convert::dom_to_pageable(&doc, &mut convert_ctx);
 

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -93,17 +93,17 @@ impl Engine {
         crate::blitz_adapter::apply_passes(&mut doc, &passes, &ctx);
 
         // Extract running elements via DomPass (before resolve)
-        let mut running_store = if !gcpm.is_empty() {
-            let pass = crate::blitz_adapter::RunningElementPass::new(gcpm.clone());
+        let mut running_store = if !gcpm.running_mappings.is_empty() {
+            let pass = crate::blitz_adapter::RunningElementPass::new(gcpm.running_mappings.clone());
             pass.apply(&mut doc, &ctx);
             pass.into_running_store()
         } else {
             crate::gcpm::running::RunningElementStore::new()
         };
 
-        // Extract string-set values via DomPass (before resolve, after running elements)
+        // Extract string-set values via DomPass
         let string_set_store = if !gcpm.string_set_mappings.is_empty() {
-            let pass = crate::blitz_adapter::StringSetPass::new(gcpm.clone());
+            let pass = crate::blitz_adapter::StringSetPass::new(gcpm.string_set_mappings.clone());
             pass.apply(&mut doc, &ctx);
             pass.into_store()
         } else {

--- a/crates/fulgur/src/gcpm/counter.rs
+++ b/crates/fulgur/src/gcpm/counter.rs
@@ -1,9 +1,16 @@
-use super::{ContentItem, CounterType};
+use super::{ContentItem, CounterType, StringPolicy};
+use crate::paginate::StringSetPageState;
+use std::collections::BTreeMap;
 
 /// Resolve content items to a plain string.
 ///
 /// `Element` references are skipped in plain string mode.
-pub fn resolve_content_to_string(items: &[ContentItem], page: usize, total_pages: usize) -> String {
+pub fn resolve_content_to_string(
+    items: &[ContentItem],
+    string_set_states: &BTreeMap<String, StringSetPageState>,
+    page: usize,
+    total_pages: usize,
+) -> String {
     let mut out = String::new();
     for item in items {
         match item {
@@ -14,7 +21,12 @@ pub fn resolve_content_to_string(items: &[ContentItem], page: usize, total_pages
             ContentItem::Counter(CounterType::Pages) => {
                 out.push_str(&total_pages.to_string());
             }
-            ContentItem::Element(_) | ContentItem::StringRef { .. } => {}
+            ContentItem::Element(_) => {}
+            ContentItem::StringRef { name, policy } => {
+                if let Some(state) = string_set_states.get(name) {
+                    out.push_str(&resolve_string_policy(state, *policy));
+                }
+            }
         }
     }
     out
@@ -27,6 +39,7 @@ pub fn resolve_content_to_string(items: &[ContentItem], page: usize, total_pages
 pub fn resolve_content_to_html(
     items: &[ContentItem],
     running_elements: &[(String, String)],
+    string_set_states: &BTreeMap<String, StringSetPageState>,
     page: usize,
     total_pages: usize,
 ) -> String {
@@ -45,10 +58,38 @@ pub fn resolve_content_to_html(
                     out.push_str(html);
                 }
             }
-            ContentItem::StringRef { .. } => {}
+            ContentItem::StringRef { name, policy } => {
+                if let Some(state) = string_set_states.get(name) {
+                    out.push_str(&resolve_string_policy(state, *policy));
+                }
+            }
         }
     }
     out
+}
+
+fn resolve_string_policy(state: &StringSetPageState, policy: StringPolicy) -> String {
+    match policy {
+        StringPolicy::Start => state.start.clone().unwrap_or_default(),
+        StringPolicy::First => state
+            .first
+            .clone()
+            .or_else(|| state.start.clone())
+            .unwrap_or_default(),
+        StringPolicy::Last => state
+            .last
+            .clone()
+            .or_else(|| state.first.clone())
+            .or_else(|| state.start.clone())
+            .unwrap_or_default(),
+        StringPolicy::FirstExcept => {
+            if state.first.is_some() {
+                String::new() // Empty on pages where string is set
+            } else {
+                state.start.clone().unwrap_or_default() // Same as First when not set
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -63,7 +104,10 @@ mod tests {
             ContentItem::String(" of ".into()),
             ContentItem::Counter(CounterType::Pages),
         ];
-        assert_eq!(resolve_content_to_string(&items, 3, 10), "Page 3 of 10");
+        assert_eq!(
+            resolve_content_to_string(&items, &BTreeMap::new(), 3, 10),
+            "Page 3 of 10"
+        );
     }
 
     #[test]
@@ -73,7 +117,10 @@ mod tests {
             ContentItem::Element("hdr".into()),
             ContentItem::String("After".into()),
         ];
-        assert_eq!(resolve_content_to_string(&items, 1, 5), "BeforeAfter");
+        assert_eq!(
+            resolve_content_to_string(&items, &BTreeMap::new(), 1, 5),
+            "BeforeAfter"
+        );
     }
 
     #[test]
@@ -81,7 +128,7 @@ mod tests {
         let items = vec![ContentItem::Element("hdr".into())];
         let running = vec![("hdr".to_string(), "<b>Header</b>".to_string())];
         assert_eq!(
-            resolve_content_to_html(&items, &running, 1, 1),
+            resolve_content_to_html(&items, &running, &BTreeMap::new(), 1, 1),
             "<b>Header</b>"
         );
     }
@@ -97,8 +144,140 @@ mod tests {
         ];
         let running = vec![("hdr".to_string(), "<span>Title</span>".to_string())];
         assert_eq!(
-            resolve_content_to_html(&items, &running, 2, 8),
+            resolve_content_to_html(&items, &running, &BTreeMap::new(), 2, 8),
             "<span>Title</span> - Page 2/8"
+        );
+    }
+
+    #[test]
+    fn test_resolve_string_ref_first() {
+        let items = vec![ContentItem::StringRef {
+            name: "title".to_string(),
+            policy: StringPolicy::First,
+        }];
+        let mut state = BTreeMap::new();
+        state.insert(
+            "title".to_string(),
+            StringSetPageState {
+                start: Some("Previous".to_string()),
+                first: Some("Current".to_string()),
+                last: Some("Current".to_string()),
+            },
+        );
+        assert_eq!(
+            resolve_content_to_html(&items, &[], &state, 1, 1),
+            "Current"
+        );
+    }
+
+    #[test]
+    fn test_resolve_string_ref_first_falls_back_to_start() {
+        let items = vec![ContentItem::StringRef {
+            name: "title".to_string(),
+            policy: StringPolicy::First,
+        }];
+        let mut state = BTreeMap::new();
+        state.insert(
+            "title".to_string(),
+            StringSetPageState {
+                start: Some("Inherited".to_string()),
+                first: None,
+                last: None,
+            },
+        );
+        assert_eq!(
+            resolve_content_to_html(&items, &[], &state, 1, 1),
+            "Inherited"
+        );
+    }
+
+    #[test]
+    fn test_resolve_string_ref_start() {
+        let items = vec![ContentItem::StringRef {
+            name: "title".to_string(),
+            policy: StringPolicy::Start,
+        }];
+        let mut state = BTreeMap::new();
+        state.insert(
+            "title".to_string(),
+            StringSetPageState {
+                start: Some("Start Value".to_string()),
+                first: Some("First Value".to_string()),
+                last: Some("Last Value".to_string()),
+            },
+        );
+        assert_eq!(
+            resolve_content_to_html(&items, &[], &state, 1, 1),
+            "Start Value"
+        );
+    }
+
+    #[test]
+    fn test_resolve_string_ref_last() {
+        let items = vec![ContentItem::StringRef {
+            name: "title".to_string(),
+            policy: StringPolicy::Last,
+        }];
+        let mut state = BTreeMap::new();
+        state.insert(
+            "title".to_string(),
+            StringSetPageState {
+                start: None,
+                first: Some("First".to_string()),
+                last: Some("Last".to_string()),
+            },
+        );
+        assert_eq!(resolve_content_to_html(&items, &[], &state, 1, 1), "Last");
+    }
+
+    #[test]
+    fn test_resolve_string_ref_first_except_on_set_page() {
+        let items = vec![ContentItem::StringRef {
+            name: "title".to_string(),
+            policy: StringPolicy::FirstExcept,
+        }];
+        let mut state = BTreeMap::new();
+        state.insert(
+            "title".to_string(),
+            StringSetPageState {
+                start: Some("Old".to_string()),
+                first: Some("New".to_string()),
+                last: Some("New".to_string()),
+            },
+        );
+        assert_eq!(resolve_content_to_html(&items, &[], &state, 1, 1), "");
+    }
+
+    #[test]
+    fn test_resolve_string_ref_first_except_on_no_set_page() {
+        let items = vec![ContentItem::StringRef {
+            name: "title".to_string(),
+            policy: StringPolicy::FirstExcept,
+        }];
+        let mut state = BTreeMap::new();
+        state.insert(
+            "title".to_string(),
+            StringSetPageState {
+                start: Some("Inherited".to_string()),
+                first: None,
+                last: None,
+            },
+        );
+        assert_eq!(
+            resolve_content_to_html(&items, &[], &state, 1, 1),
+            "Inherited"
+        );
+    }
+
+    #[test]
+    fn test_resolve_string_ref_unknown_name() {
+        let items = vec![ContentItem::StringRef {
+            name: "nonexistent".to_string(),
+            policy: StringPolicy::First,
+        }];
+        assert_eq!(
+            resolve_content_to_html(&items, &[], &BTreeMap::new(), 1, 1),
+            ""
         );
     }
 }

--- a/crates/fulgur/src/gcpm/counter.rs
+++ b/crates/fulgur/src/gcpm/counter.rs
@@ -24,7 +24,7 @@ pub fn resolve_content_to_string(
             ContentItem::Element(_) => {}
             ContentItem::StringRef { name, policy } => {
                 if let Some(state) = string_set_states.get(name) {
-                    out.push_str(&resolve_string_policy(state, *policy));
+                    out.push_str(resolve_string_policy(state, *policy));
                 }
             }
         }
@@ -60,7 +60,7 @@ pub fn resolve_content_to_html(
             }
             ContentItem::StringRef { name, policy } => {
                 if let Some(state) = string_set_states.get(name) {
-                    out.push_str(&resolve_string_policy(state, *policy));
+                    out.push_str(resolve_string_policy(state, *policy));
                 }
             }
         }
@@ -68,27 +68,24 @@ pub fn resolve_content_to_html(
     out
 }
 
-fn resolve_string_policy(state: &StringSetPageState, policy: StringPolicy) -> String {
+fn resolve_string_policy(state: &StringSetPageState, policy: StringPolicy) -> &str {
     match policy {
-        StringPolicy::Start => state.start.clone().unwrap_or_default(),
+        StringPolicy::Start => state.start.as_deref().unwrap_or(""),
         StringPolicy::First => state
             .first
-            .clone()
-            .or_else(|| state.start.clone())
-            .unwrap_or_default(),
+            .as_deref()
+            .or(state.start.as_deref())
+            .unwrap_or(""),
         StringPolicy::Last => state
             .last
-            .clone()
-            .or_else(|| state.first.clone())
-            .or_else(|| state.start.clone())
-            .unwrap_or_default(),
-        StringPolicy::FirstExcept => {
-            if state.first.is_some() {
-                String::new() // Empty on pages where string is set
-            } else {
-                state.start.clone().unwrap_or_default() // Same as First when not set
-            }
-        }
+            .as_deref()
+            .or(state.first.as_deref())
+            .or(state.start.as_deref())
+            .unwrap_or(""),
+        // first-except: empty on pages where the string was set this page,
+        // otherwise falls back to the inherited start value.
+        StringPolicy::FirstExcept if state.first.is_some() => "",
+        StringPolicy::FirstExcept => state.start.as_deref().unwrap_or(""),
     }
 }
 

--- a/crates/fulgur/src/gcpm/counter.rs
+++ b/crates/fulgur/src/gcpm/counter.rs
@@ -14,7 +14,7 @@ pub fn resolve_content_to_string(items: &[ContentItem], page: usize, total_pages
             ContentItem::Counter(CounterType::Pages) => {
                 out.push_str(&total_pages.to_string());
             }
-            ContentItem::Element(_) => {}
+            ContentItem::Element(_) | ContentItem::StringRef { .. } => {}
         }
     }
     out
@@ -45,6 +45,7 @@ pub fn resolve_content_to_html(
                     out.push_str(html);
                 }
             }
+            ContentItem::StringRef { .. } => {}
         }
     }
     out

--- a/crates/fulgur/src/gcpm/counter.rs
+++ b/crates/fulgur/src/gcpm/counter.rs
@@ -35,7 +35,9 @@ pub fn resolve_content_to_string(
 /// Resolve content items to an HTML string.
 ///
 /// `Element(name)` references are looked up in `running_elements` (a `&[(name, html)]` slice)
-/// and the matching HTML is appended.
+/// and the matching HTML is appended. `StringRef` values come from the DOM
+/// (via `string-set: content(text) | attr(...)`) and are HTML-escaped before
+/// concatenation so characters like `<` and `&` do not corrupt the margin box.
 pub fn resolve_content_to_html(
     items: &[ContentItem],
     running_elements: &[(String, String)],
@@ -60,12 +62,27 @@ pub fn resolve_content_to_html(
             }
             ContentItem::StringRef { name, policy } => {
                 if let Some(state) = string_set_states.get(name) {
-                    out.push_str(resolve_string_policy(state, *policy));
+                    push_escaped_html_text(&mut out, resolve_string_policy(state, *policy));
                 }
             }
         }
     }
     out
+}
+
+/// Append `text` to `out` with HTML special characters escaped.
+///
+/// Used for string-set values, which originate from arbitrary DOM text and
+/// would otherwise break the margin box HTML if they contained `<`, `>`, or `&`.
+fn push_escaped_html_text(out: &mut String, text: &str) {
+    for ch in text.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            _ => out.push(ch),
+        }
+    }
 }
 
 fn resolve_string_policy(state: &StringSetPageState, policy: StringPolicy) -> &str {
@@ -275,6 +292,27 @@ mod tests {
         assert_eq!(
             resolve_content_to_html(&items, &[], &BTreeMap::new(), 1, 1),
             ""
+        );
+    }
+
+    #[test]
+    fn test_resolve_string_ref_html_escapes_special_characters() {
+        let items = vec![ContentItem::StringRef {
+            name: "title".to_string(),
+            policy: StringPolicy::First,
+        }];
+        let mut state = BTreeMap::new();
+        state.insert(
+            "title".to_string(),
+            StringSetPageState {
+                start: None,
+                first: Some("A & B <script>".to_string()),
+                last: Some("A & B <script>".to_string()),
+            },
+        );
+        assert_eq!(
+            resolve_content_to_html(&items, &[], &state, 1, 1),
+            "A &amp; B &lt;script&gt;"
         );
     }
 }

--- a/crates/fulgur/src/gcpm/mod.rs
+++ b/crates/fulgur/src/gcpm/mod.rs
@@ -2,6 +2,7 @@ pub mod counter;
 pub mod margin_box;
 pub mod parser;
 pub mod running;
+pub mod string_set;
 
 use margin_box::MarginBoxPosition;
 

--- a/crates/fulgur/src/gcpm/mod.rs
+++ b/crates/fulgur/src/gcpm/mod.rs
@@ -29,13 +29,17 @@ pub struct RunningMapping {
 /// Policy for selecting which value of a named string to use.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StringPolicy {
-    /// The first assignment on the current page, or the last from the previous page if none.
+    /// The value inherited at the start of the current page
+    /// (i.e. the last assignment from a previous page).
     Start,
-    /// The first assignment on the current page.
+    /// The first assignment on the current page, falling back to `Start`
+    /// if no assignment happens on this page.
     First,
     /// The last assignment on the current page.
     Last,
-    /// Like `First`, but returns an empty string on the page where the string is first assigned.
+    /// Like `First`, but returns the empty string on pages where the
+    /// string is assigned (showing only the inherited value on pages
+    /// that don't reset it).
     FirstExcept,
 }
 

--- a/crates/fulgur/src/gcpm/mod.rs
+++ b/crates/fulgur/src/gcpm/mod.rs
@@ -25,6 +25,45 @@ pub struct RunningMapping {
     pub running_name: String,
 }
 
+/// Policy for selecting which value of a named string to use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StringPolicy {
+    /// The first assignment on the current page, or the last from the previous page if none.
+    Start,
+    /// The first assignment on the current page.
+    First,
+    /// The last assignment on the current page.
+    Last,
+    /// Like `First`, but returns an empty string on the page where the string is first assigned.
+    FirstExcept,
+}
+
+/// A single value component within a `string-set` declaration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StringSetValue {
+    /// The text content of the element.
+    ContentText,
+    /// The `::before` pseudo-element content.
+    ContentBefore,
+    /// The `::after` pseudo-element content.
+    ContentAfter,
+    /// The value of the named attribute.
+    Attr(String),
+    /// A literal string value.
+    Literal(String),
+}
+
+/// Maps a CSS selector to a named string via `string-set`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StringSetMapping {
+    /// The parsed CSS selector that triggers this mapping.
+    pub parsed: ParsedSelector,
+    /// The name of the string being set.
+    pub name: String,
+    /// The value components to concatenate.
+    pub values: Vec<StringSetValue>,
+}
+
 /// A single content item inside a margin box rule's `content` property.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ContentItem {
@@ -34,6 +73,13 @@ pub enum ContentItem {
     Counter(CounterType),
     /// A literal string, e.g. `"Page "`.
     String(String),
+    /// A named string reference, e.g. `string(chapter-title, first)`.
+    StringRef {
+        /// The name of the string to reference.
+        name: String,
+        /// The policy for selecting the string value.
+        policy: StringPolicy,
+    },
 }
 
 /// Counter types supported by GCPM.
@@ -65,6 +111,8 @@ pub struct GcpmContext {
     pub margin_boxes: Vec<MarginBoxRule>,
     /// Mappings from CSS selectors to running element names.
     pub running_mappings: Vec<RunningMapping>,
+    /// Mappings from CSS selectors to named strings via `string-set`.
+    pub string_set_mappings: Vec<StringSetMapping>,
     /// The CSS with GCPM constructs stripped, suitable for normal rendering.
     pub cleaned_css: String,
 }
@@ -72,7 +120,9 @@ pub struct GcpmContext {
 impl GcpmContext {
     /// Returns `true` if no GCPM features were found.
     pub fn is_empty(&self) -> bool {
-        self.margin_boxes.is_empty() && self.running_mappings.is_empty()
+        self.margin_boxes.is_empty()
+            && self.running_mappings.is_empty()
+            && self.string_set_mappings.is_empty()
     }
 }
 
@@ -85,6 +135,7 @@ mod tests {
         let ctx = GcpmContext {
             margin_boxes: vec![],
             running_mappings: vec![],
+            string_set_mappings: vec![],
             cleaned_css: String::new(),
         };
         assert!(ctx.is_empty());
@@ -100,6 +151,7 @@ mod tests {
                 declarations: String::new(),
             }],
             running_mappings: vec![],
+            string_set_mappings: vec![],
             cleaned_css: String::new(),
         };
         assert!(!ctx.is_empty());
@@ -113,6 +165,7 @@ mod tests {
                 parsed: ParsedSelector::Class("header".to_string()),
                 running_name: "header".to_string(),
             }],
+            string_set_mappings: vec![],
             cleaned_css: String::new(),
         };
         assert!(!ctx.is_empty());

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -390,11 +390,17 @@ impl<'i, 'a> DeclarationParser<'i> for StyleRuleParser<'a> {
             if let Ok((set_name, values)) = parse_string_set_value(input) {
                 *self.string_set = Some((set_name, values));
 
+                // Replace with an empty string rather than Remove: the skip-`}`
+                // logic in build_cleaned_css is only correct for @page block
+                // removals. string-set lives inside a style rule, so eating a
+                // trailing `}` would corrupt the rule's closing brace when the
+                // declaration has no terminating semicolon.
                 let decl_start_byte = decl_start.position().byte_index();
                 let end_byte = input.position().byte_index();
-                self.edits.push(CssEdit::Remove {
+                self.edits.push(CssEdit::Replace {
                     start: decl_start_byte,
                     end: end_byte,
+                    replacement: String::new(),
                 });
             } else {
                 while input.next().is_ok() {}
@@ -1022,6 +1028,32 @@ mod tests {
         assert_eq!(
             ctx.string_set_mappings[0].parsed,
             ParsedSelector::Class("chapter-heading".to_string())
+        );
+    }
+
+    /// Regression: when `string-set` is the last declaration in a rule and has
+    /// no trailing semicolon, the cleaned CSS must still contain the rule's
+    /// closing brace. Previously the CssEdit::Remove skip-`}` logic (written
+    /// for @page blocks) would eat the style rule's closing brace.
+    #[test]
+    fn test_string_set_last_declaration_without_semicolon() {
+        let css = "h1 { color: red; string-set: title content(text) }\np { margin: 0; }";
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.string_set_mappings.len(), 1);
+        assert!(
+            ctx.cleaned_css.contains("color: red"),
+            "color: red should remain in cleaned_css: {:?}",
+            ctx.cleaned_css
+        );
+        assert!(
+            ctx.cleaned_css.contains("p { margin: 0; }"),
+            "following rule must be intact — the h1 closing brace was not eaten: {:?}",
+            ctx.cleaned_css
+        );
+        assert!(
+            !ctx.cleaned_css.contains("string-set"),
+            "string-set declaration should be removed: {:?}",
+            ctx.cleaned_css
         );
     }
 }

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -492,7 +492,7 @@ fn parse_string_set_value<'i, 't>(
 // ---------------------------------------------------------------------------
 
 /// Parse a `content` property value into a list of `ContentItem`s using cssparser.
-/// Handles: `element(<name>)`, `counter(page)`, `counter(pages)`, `"string"`.
+/// Handles: `element(<name>)`, `counter(page)`, `counter(pages)`, `string(<name>, <policy>)`, `"string"`.
 fn parse_content_value(input: &mut Parser<'_, '_>) -> Vec<ContentItem> {
     let mut items = Vec::new();
 
@@ -525,7 +525,9 @@ fn parse_content_value(input: &mut Parser<'_, '_>) -> Vec<ContentItem> {
                                 .try_parse(|input| {
                                     input.expect_comma()?;
                                     let ident = input.expect_ident()?.clone();
-                                    let policy_str = if ident.eq_ignore_ascii_case("first") {
+                                    let policy_str = if ident.eq_ignore_ascii_case("first-except") {
+                                        "first-except".to_string()
+                                    } else if ident.eq_ignore_ascii_case("first") {
                                         input
                                             .try_parse(|input| {
                                                 input.expect_delim('-')?;

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -496,6 +496,7 @@ pub fn parse_gcpm(css: &str) -> GcpmContext {
     GcpmContext {
         margin_boxes,
         running_mappings,
+        string_set_mappings: Vec::new(),
         cleaned_css,
     }
 }

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -491,6 +491,41 @@ fn parse_string_set_value<'i, 't>(
 // 6. Content value parser
 // ---------------------------------------------------------------------------
 
+/// Parse the policy argument of `string(name, <policy>)`.
+///
+/// Handles cssparser tokenization of `first-except`, which may arrive either as
+/// a single ident or as `first` + `-` + `except` depending on context.
+fn parse_string_policy<'i>(input: &mut Parser<'i, '_>) -> Result<StringPolicy, ParseError<'i, ()>> {
+    let ident = input.expect_ident()?.clone();
+    if ident.eq_ignore_ascii_case("start") {
+        Ok(StringPolicy::Start)
+    } else if ident.eq_ignore_ascii_case("last") {
+        Ok(StringPolicy::Last)
+    } else if ident.eq_ignore_ascii_case("first-except") {
+        Ok(StringPolicy::FirstExcept)
+    } else if ident.eq_ignore_ascii_case("first") {
+        // Try to consume a trailing `-except` (cssparser may split the hyphenated ident).
+        let has_except = input
+            .try_parse(|input| {
+                input.expect_delim('-')?;
+                let next = input.expect_ident()?.clone();
+                if next.eq_ignore_ascii_case("except") {
+                    Ok(())
+                } else {
+                    Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid))
+                }
+            })
+            .is_ok();
+        Ok(if has_except {
+            StringPolicy::FirstExcept
+        } else {
+            StringPolicy::First
+        })
+    } else {
+        Err(input.new_error(BasicParseErrorKind::QualifiedRuleInvalid))
+    }
+}
+
 /// Parse a `content` property value into a list of `ContentItem`s using cssparser.
 /// Handles: `element(<name>)`, `counter(page)`, `counter(pages)`, `string(<name>, <policy>)`, `"string"`.
 fn parse_content_value(input: &mut Parser<'_, '_>) -> Vec<ContentItem> {
@@ -524,37 +559,7 @@ fn parse_content_value(input: &mut Parser<'_, '_>) -> Vec<ContentItem> {
                             let policy = input
                                 .try_parse(|input| {
                                     input.expect_comma()?;
-                                    let ident = input.expect_ident()?.clone();
-                                    let policy_str = if ident.eq_ignore_ascii_case("first-except") {
-                                        "first-except".to_string()
-                                    } else if ident.eq_ignore_ascii_case("first") {
-                                        input
-                                            .try_parse(|input| {
-                                                input.expect_delim('-')?;
-                                                let next = input.expect_ident()?;
-                                                if next.eq_ignore_ascii_case("except") {
-                                                    Ok("first-except".to_string())
-                                                } else {
-                                                    Err(input.new_error::<()>(
-                                                        BasicParseErrorKind::QualifiedRuleInvalid,
-                                                    ))
-                                                }
-                                            })
-                                            .unwrap_or_else(|_: ParseError<'_, ()>| {
-                                                "first".to_string()
-                                            })
-                                    } else {
-                                        ident.to_string()
-                                    };
-                                    match policy_str.as_str() {
-                                        "start" => Ok(StringPolicy::Start),
-                                        "first" => Ok(StringPolicy::First),
-                                        "last" => Ok(StringPolicy::Last),
-                                        "first-except" => Ok(StringPolicy::FirstExcept),
-                                        _ => Err(input.new_error::<()>(
-                                            BasicParseErrorKind::QualifiedRuleInvalid,
-                                        )),
-                                    }
+                                    parse_string_policy(input)
                                 })
                                 .unwrap_or(StringPolicy::First);
                             items.push(ContentItem::StringRef { name, policy });

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -4,7 +4,10 @@ use cssparser::{
 };
 
 use super::margin_box::MarginBoxPosition;
-use super::{ContentItem, CounterType, GcpmContext, MarginBoxRule, ParsedSelector, RunningMapping};
+use super::{
+    ContentItem, CounterType, GcpmContext, MarginBoxRule, ParsedSelector, RunningMapping,
+    StringPolicy, StringSetMapping, StringSetValue,
+};
 
 // ---------------------------------------------------------------------------
 // Top-level result types
@@ -30,6 +33,7 @@ struct GcpmSheetParser<'a> {
     edits: &'a mut Vec<CssEdit>,
     margin_boxes: &'a mut Vec<MarginBoxRule>,
     running_mappings: &'a mut Vec<RunningMapping>,
+    string_set_mappings: &'a mut Vec<StringSetMapping>,
 }
 
 /// Describes a region in the original CSS to edit when building `cleaned_css`.
@@ -147,10 +151,12 @@ impl<'i, 'a> QualifiedRuleParser<'i> for GcpmSheetParser<'a> {
         };
 
         let mut running_name: Option<String> = None;
+        let mut string_set: Option<(String, Vec<StringSetValue>)> = None;
 
         let mut parser = StyleRuleParser {
             edits: self.edits,
             running_name: &mut running_name,
+            string_set: &mut string_set,
         };
         let iter = RuleBodyParser::new(input, &mut parser);
         for item in iter {
@@ -159,8 +165,16 @@ impl<'i, 'a> QualifiedRuleParser<'i> for GcpmSheetParser<'a> {
 
         if let Some(running_name) = running_name {
             self.running_mappings.push(RunningMapping {
-                parsed: selector,
+                parsed: selector.clone(),
                 running_name,
+            });
+        }
+
+        if let Some((name, values)) = string_set {
+            self.string_set_mappings.push(StringSetMapping {
+                parsed: selector,
+                name,
+                values,
             });
         }
 
@@ -332,6 +346,7 @@ impl<'i, 'a> RuleBodyItemParser<'i, (), ()> for MarginBoxParser<'a> {
 struct StyleRuleParser<'a> {
     edits: &'a mut Vec<CssEdit>,
     running_name: &'a mut Option<String>,
+    string_set: &'a mut Option<(String, Vec<StringSetValue>)>,
 }
 
 impl<'i, 'a> DeclarationParser<'i> for StyleRuleParser<'a> {
@@ -344,38 +359,48 @@ impl<'i, 'a> DeclarationParser<'i> for StyleRuleParser<'a> {
         input: &mut Parser<'i, 't>,
         decl_start: &cssparser::ParserState,
     ) -> Result<(), ParseError<'i, ()>> {
-        if !name.eq_ignore_ascii_case("position") {
-            // Skip non-position declarations
-            while input.next().is_ok() {}
-            return Ok(());
-        }
-
-        // Try to parse `running(<name>)`
-        let result = input.try_parse(|input| {
-            let fn_name = input.expect_function()?.clone();
-            if !fn_name.eq_ignore_ascii_case("running") {
-                return Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid));
-            }
-            input.parse_nested_block(|input| {
-                let ident = input.expect_ident()?.clone();
-                Ok(ident.to_string())
-            })
-        });
-
-        if let Ok(running_name) = result {
-            *self.running_name = Some(running_name);
-
-            // Record the edit: replace `position: running(...)` with `display: none`
-            // The decl_start points to just before the property name (the ident token).
-            let decl_start_byte = decl_start.position().byte_index();
-            let end_byte = input.position().byte_index();
-            self.edits.push(CssEdit::Replace {
-                start: decl_start_byte,
-                end: end_byte,
-                replacement: "display: none".to_string(),
+        if name.eq_ignore_ascii_case("position") {
+            // Try to parse `running(<name>)`
+            let result = input.try_parse(|input| {
+                let fn_name = input.expect_function()?.clone();
+                if !fn_name.eq_ignore_ascii_case("running") {
+                    return Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid));
+                }
+                input.parse_nested_block(|input| {
+                    let ident = input.expect_ident()?.clone();
+                    Ok(ident.to_string())
+                })
             });
+
+            if let Ok(running_name) = result {
+                *self.running_name = Some(running_name);
+
+                let decl_start_byte = decl_start.position().byte_index();
+                let end_byte = input.position().byte_index();
+                self.edits.push(CssEdit::Replace {
+                    start: decl_start_byte,
+                    end: end_byte,
+                    replacement: "display: none".to_string(),
+                });
+            } else {
+                while input.next().is_ok() {}
+            }
+        } else if name.eq_ignore_ascii_case("string-set") {
+            // Parse `string-set: <name> <value>+`
+            if let Ok((set_name, values)) = parse_string_set_value(input) {
+                *self.string_set = Some((set_name, values));
+
+                let decl_start_byte = decl_start.position().byte_index();
+                let end_byte = input.position().byte_index();
+                self.edits.push(CssEdit::Remove {
+                    start: decl_start_byte,
+                    end: end_byte,
+                });
+            } else {
+                while input.next().is_ok() {}
+            }
         } else {
-            // Not running(...), skip the rest
+            // Skip other declarations
             while input.next().is_ok() {}
         }
 
@@ -405,7 +430,65 @@ impl<'i, 'a> RuleBodyItemParser<'i, (), ()> for StyleRuleParser<'a> {
 }
 
 // ---------------------------------------------------------------------------
-// 5. Content value parser
+// 5. string-set value parser
+// ---------------------------------------------------------------------------
+
+/// Parse the value of a `string-set` declaration: `<name> <value>+`.
+fn parse_string_set_value<'i, 't>(
+    input: &mut Parser<'i, 't>,
+) -> Result<(String, Vec<StringSetValue>), ParseError<'i, ()>> {
+    let name = input.expect_ident()?.clone().to_string();
+    let mut values = Vec::new();
+
+    loop {
+        if input.is_exhausted() {
+            break;
+        }
+
+        let result: Result<(), ParseError<'_, ()>> = input.try_parse(|input| {
+            let token = input.next_including_whitespace()?.clone();
+            match token {
+                Token::QuotedString(ref s) => {
+                    values.push(StringSetValue::Literal(s.to_string()));
+                }
+                Token::Function(ref fn_name) => {
+                    let fn_name = fn_name.clone();
+                    input.parse_nested_block(|input| {
+                        if fn_name.eq_ignore_ascii_case("content") {
+                            let arg = input.expect_ident()?.clone();
+                            match &*arg {
+                                "text" => values.push(StringSetValue::ContentText),
+                                "before" => values.push(StringSetValue::ContentBefore),
+                                "after" => values.push(StringSetValue::ContentAfter),
+                                _ => {}
+                            }
+                        } else if fn_name.eq_ignore_ascii_case("attr") {
+                            let arg = input.expect_ident()?.clone();
+                            values.push(StringSetValue::Attr(arg.to_string()));
+                        }
+                        Ok(())
+                    })?;
+                }
+                Token::WhiteSpace(_) | Token::Comment(_) => {}
+                _ => {}
+            }
+            Ok(())
+        });
+
+        if result.is_err() {
+            break;
+        }
+    }
+
+    if values.is_empty() {
+        return Err(input.new_error(BasicParseErrorKind::QualifiedRuleInvalid));
+    }
+
+    Ok((name, values))
+}
+
+// ---------------------------------------------------------------------------
+// 6. Content value parser
 // ---------------------------------------------------------------------------
 
 /// Parse a `content` property value into a list of `ContentItem`s using cssparser.
@@ -436,6 +519,43 @@ fn parse_content_value(input: &mut Parser<'_, '_>) -> Vec<ContentItem> {
                                 "pages" => items.push(ContentItem::Counter(CounterType::Pages)),
                                 _ => {} // unknown counter
                             }
+                        } else if fn_name.eq_ignore_ascii_case("string") {
+                            let name = arg.to_string();
+                            let policy = input
+                                .try_parse(|input| {
+                                    input.expect_comma()?;
+                                    let ident = input.expect_ident()?.clone();
+                                    let policy_str = if ident.eq_ignore_ascii_case("first") {
+                                        input
+                                            .try_parse(|input| {
+                                                input.expect_delim('-')?;
+                                                let next = input.expect_ident()?;
+                                                if next.eq_ignore_ascii_case("except") {
+                                                    Ok("first-except".to_string())
+                                                } else {
+                                                    Err(input.new_error::<()>(
+                                                        BasicParseErrorKind::QualifiedRuleInvalid,
+                                                    ))
+                                                }
+                                            })
+                                            .unwrap_or_else(|_: ParseError<'_, ()>| {
+                                                "first".to_string()
+                                            })
+                                    } else {
+                                        ident.to_string()
+                                    };
+                                    match policy_str.as_str() {
+                                        "start" => Ok(StringPolicy::Start),
+                                        "first" => Ok(StringPolicy::First),
+                                        "last" => Ok(StringPolicy::Last),
+                                        "first-except" => Ok(StringPolicy::FirstExcept),
+                                        _ => Err(input.new_error::<()>(
+                                            BasicParseErrorKind::QualifiedRuleInvalid,
+                                        )),
+                                    }
+                                })
+                                .unwrap_or(StringPolicy::First);
+                            items.push(ContentItem::StringRef { name, policy });
                         }
                         Ok(())
                     })?;
@@ -471,6 +591,7 @@ fn parse_content_value(input: &mut Parser<'_, '_>) -> Vec<ContentItem> {
 pub fn parse_gcpm(css: &str) -> GcpmContext {
     let mut margin_boxes = Vec::new();
     let mut running_mappings = Vec::new();
+    let mut string_set_mappings = Vec::new();
     let mut edits: Vec<CssEdit> = Vec::new();
 
     // Run the cssparser-based parse to collect GCPM data and edit spans.
@@ -482,6 +603,7 @@ pub fn parse_gcpm(css: &str) -> GcpmContext {
             edits: &mut edits,
             margin_boxes: &mut margin_boxes,
             running_mappings: &mut running_mappings,
+            string_set_mappings: &mut string_set_mappings,
         };
 
         let iter = StyleSheetParser::new(&mut input, &mut parser);
@@ -496,7 +618,7 @@ pub fn parse_gcpm(css: &str) -> GcpmContext {
     GcpmContext {
         margin_boxes,
         running_mappings,
-        string_set_mappings: Vec::new(),
+        string_set_mappings,
         cleaned_css,
     }
 }
@@ -786,5 +908,113 @@ mod tests {
         let css = ".a, .b { position: running(hdr); }";
         let ctx = parse_gcpm(css);
         assert!(ctx.running_mappings.is_empty());
+    }
+
+    #[test]
+    fn test_parse_string_set_content_text() {
+        let css = "h1 { string-set: chapter-title content(text); }";
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.string_set_mappings.len(), 1);
+        let m = &ctx.string_set_mappings[0];
+        assert_eq!(m.parsed, ParsedSelector::Tag("h1".to_string()));
+        assert_eq!(m.name, "chapter-title");
+        assert_eq!(m.values, vec![StringSetValue::ContentText]);
+        assert!(!ctx.cleaned_css.contains("string-set"));
+    }
+
+    #[test]
+    fn test_parse_string_set_multiple_values() {
+        let css = r#"h1 { string-set: title "Chapter " content(text) " - " attr(data-sub); }"#;
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.string_set_mappings.len(), 1);
+        let m = &ctx.string_set_mappings[0];
+        assert_eq!(m.name, "title");
+        assert_eq!(
+            m.values,
+            vec![
+                StringSetValue::Literal("Chapter ".to_string()),
+                StringSetValue::ContentText,
+                StringSetValue::Literal(" - ".to_string()),
+                StringSetValue::Attr("data-sub".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_string_set_content_before_after() {
+        let css = "h2 { string-set: sec content(before) content(text) content(after); }";
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.string_set_mappings.len(), 1);
+        assert_eq!(
+            ctx.string_set_mappings[0].values,
+            vec![
+                StringSetValue::ContentBefore,
+                StringSetValue::ContentText,
+                StringSetValue::ContentAfter,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_string_function_default_policy() {
+        let css = r#"@page { @top-center { content: string(chapter-title); } }"#;
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.margin_boxes.len(), 1);
+        assert_eq!(
+            ctx.margin_boxes[0].content,
+            vec![ContentItem::StringRef {
+                name: "chapter-title".to_string(),
+                policy: StringPolicy::First,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_parse_string_function_with_policy() {
+        let css = r#"@page { @top-center { content: string(title, last); } }"#;
+        let ctx = parse_gcpm(css);
+        assert_eq!(
+            ctx.margin_boxes[0].content,
+            vec![ContentItem::StringRef {
+                name: "title".to_string(),
+                policy: StringPolicy::Last,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_parse_string_function_all_policies() {
+        for (policy_str, policy) in [
+            ("first", StringPolicy::First),
+            ("start", StringPolicy::Start),
+            ("last", StringPolicy::Last),
+            ("first-except", StringPolicy::FirstExcept),
+        ] {
+            let css = format!(
+                r#"@page {{ @top-center {{ content: string(title, {}); }} }}"#,
+                policy_str
+            );
+            let ctx = parse_gcpm(&css);
+            assert_eq!(
+                ctx.margin_boxes[0].content,
+                vec![ContentItem::StringRef {
+                    name: "title".to_string(),
+                    policy,
+                }],
+                "Failed for policy: {}",
+                policy_str
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_string_set_with_class_selector() {
+        let css = ".chapter-heading { string-set: chapter content(text); }";
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.string_set_mappings.len(), 1);
+        assert_eq!(
+            ctx.string_set_mappings[0].parsed,
+            ParsedSelector::Class("chapter-heading".to_string())
+        );
     }
 }

--- a/crates/fulgur/src/gcpm/string_set.rs
+++ b/crates/fulgur/src/gcpm/string_set.rs
@@ -62,6 +62,17 @@ fn collect_text(doc: &blitz_dom::BaseDocument, node_id: usize, out: &mut String)
     let Some(node) = doc.get_node(node_id) else {
         return;
     };
+    // Skip non-rendered subtrees so <script>/<style> bodies don't leak into
+    // named strings when a broad selector (e.g. `body`) is used as the
+    // string-set target.
+    if let Some(elem) = node.element_data() {
+        if matches!(
+            elem.name.local.as_ref(),
+            "head" | "script" | "style" | "link" | "meta" | "title" | "noscript"
+        ) {
+            return;
+        }
+    }
     match &node.data {
         blitz_dom::NodeData::Text(text_data) => out.push_str(&text_data.content),
         _ => {

--- a/crates/fulgur/src/gcpm/string_set.rs
+++ b/crates/fulgur/src/gcpm/string_set.rs
@@ -1,0 +1,107 @@
+//! Named string support for CSS Generated Content for Paged Media (GCPM).
+//!
+//! Manages string-set values extracted from the DOM via `string-set: name content(text)`.
+//! Values are stored with their DOM node IDs for later insertion into the Pageable tree.
+
+/// A single string-set entry extracted from the DOM.
+#[derive(Debug, Clone)]
+pub struct StringSetEntry {
+    /// The named string identifier (e.g. "chapter-title").
+    pub name: String,
+    /// The resolved text value.
+    pub value: String,
+    /// Blitz DOM node ID, used to position the marker in the Pageable tree.
+    pub node_id: usize,
+}
+
+/// Stores string-set entries collected during DOM traversal.
+pub struct StringSetStore {
+    entries: Vec<StringSetEntry>,
+}
+
+impl StringSetStore {
+    pub fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+
+    pub fn push(&mut self, entry: StringSetEntry) {
+        self.entries.push(entry);
+    }
+
+    pub fn entries(&self) -> &[StringSetEntry] {
+        &self.entries
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+impl Default for StringSetStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Extract the text content of a DOM node (recursive).
+pub fn extract_text_content(doc: &blitz_dom::BaseDocument, node_id: usize) -> String {
+    let mut out = String::new();
+    collect_text(doc, node_id, &mut out);
+    out
+}
+
+fn collect_text(doc: &blitz_dom::BaseDocument, node_id: usize, out: &mut String) {
+    let Some(node) = doc.get_node(node_id) else {
+        return;
+    };
+    match &node.data {
+        blitz_dom::NodeData::Text(text_data) => out.push_str(&text_data.content),
+        _ => {
+            for &child_id in &node.children {
+                collect_text(doc, child_id, out);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_string_set_store_basic() {
+        let mut store = StringSetStore::new();
+        assert!(store.is_empty());
+        store.push(StringSetEntry {
+            name: "title".into(),
+            value: "Chapter 1".into(),
+            node_id: 42,
+        });
+        assert!(!store.is_empty());
+        assert_eq!(store.entries().len(), 1);
+        assert_eq!(store.entries()[0].name, "title");
+    }
+
+    #[test]
+    fn test_string_set_store_multiple() {
+        let mut store = StringSetStore::new();
+        store.push(StringSetEntry {
+            name: "title".into(),
+            value: "Ch1".into(),
+            node_id: 10,
+        });
+        store.push(StringSetEntry {
+            name: "title".into(),
+            value: "Ch2".into(),
+            node_id: 20,
+        });
+        store.push(StringSetEntry {
+            name: "section".into(),
+            value: "Intro".into(),
+            node_id: 30,
+        });
+        assert_eq!(store.entries().len(), 3);
+    }
+}

--- a/crates/fulgur/src/gcpm/string_set.rs
+++ b/crates/fulgur/src/gcpm/string_set.rs
@@ -45,11 +45,17 @@ impl Default for StringSetStore {
     }
 }
 
-/// Extract the text content of a DOM node (recursive).
+/// Extract the text content of a DOM subtree.
+///
+/// Runs of ASCII whitespace are collapsed to a single space and leading/
+/// trailing whitespace is trimmed, matching CSS's default white-space handling.
+/// Without this, indented templates like
+/// `<h1>\n    Chapter 1\n  </h1>` would produce a named string with stray
+/// newlines and indentation.
 pub fn extract_text_content(doc: &blitz_dom::BaseDocument, node_id: usize) -> String {
-    let mut out = String::new();
-    collect_text(doc, node_id, &mut out);
-    out
+    let mut raw = String::new();
+    collect_text(doc, node_id, &mut raw);
+    normalize_whitespace(&raw)
 }
 
 fn collect_text(doc: &blitz_dom::BaseDocument, node_id: usize, out: &mut String) {
@@ -64,6 +70,23 @@ fn collect_text(doc: &blitz_dom::BaseDocument, node_id: usize, out: &mut String)
             }
         }
     }
+}
+
+fn normalize_whitespace(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut in_space = false;
+    for ch in input.chars() {
+        if ch.is_ascii_whitespace() {
+            in_space = true;
+        } else {
+            if in_space && !out.is_empty() {
+                out.push(' ');
+            }
+            out.push(ch);
+            in_space = false;
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -103,5 +126,15 @@ mod tests {
             node_id: 30,
         });
         assert_eq!(store.entries().len(), 3);
+    }
+
+    #[test]
+    fn test_normalize_whitespace_collapses_runs() {
+        assert_eq!(normalize_whitespace("Chapter  1"), "Chapter 1");
+        assert_eq!(normalize_whitespace("  Chapter\n\t 1 "), "Chapter 1");
+        assert_eq!(normalize_whitespace("\n    Chapter 1\n  "), "Chapter 1");
+        assert_eq!(normalize_whitespace(""), "");
+        assert_eq!(normalize_whitespace("   "), "");
+        assert_eq!(normalize_whitespace("no-whitespace"), "no-whitespace");
     }
 }

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -1127,6 +1127,55 @@ impl Pageable for SpacerPageable {
     }
 }
 
+// ─── StringSetPageable ──────────────────────────────────
+
+/// Zero-size marker for named string values.
+/// Inserted into the Pageable tree to track string-set positions during pagination.
+#[derive(Clone)]
+pub struct StringSetPageable {
+    pub name: String,
+    pub value: String,
+}
+
+impl StringSetPageable {
+    pub fn new(name: String, value: String) -> Self {
+        Self { name, value }
+    }
+}
+
+impl Pageable for StringSetPageable {
+    fn wrap(&mut self, _avail_width: Pt, _avail_height: Pt) -> Size {
+        Size {
+            width: 0.0,
+            height: 0.0,
+        }
+    }
+
+    fn split(
+        &self,
+        _avail_width: Pt,
+        _avail_height: Pt,
+    ) -> Option<(Box<dyn Pageable>, Box<dyn Pageable>)> {
+        None
+    }
+
+    fn draw(&self, _canvas: &mut Canvas, _x: Pt, _y: Pt, _avail_width: Pt, _avail_height: Pt) {
+        // Markers are invisible
+    }
+
+    fn clone_box(&self) -> Box<dyn Pageable> {
+        Box::new(self.clone())
+    }
+
+    fn height(&self) -> Pt {
+        0.0
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
 // ─── ListItemPageable ───────────────────────────────────
 
 use crate::paragraph::ShapedLine;
@@ -1667,6 +1716,28 @@ mod tests {
             "expected y=80.0, got {}",
             second_table.body_cells[1].y
         );
+    }
+
+    #[test]
+    fn test_string_set_pageable_zero_size() {
+        let mut p = StringSetPageable::new("title".to_string(), "Chapter 1".to_string());
+        let size = p.wrap(100.0, 100.0);
+        assert_eq!(size.width, 0.0);
+        assert_eq!(size.height, 0.0);
+        assert_eq!(p.height(), 0.0);
+    }
+
+    #[test]
+    fn test_string_set_pageable_no_split() {
+        let p = StringSetPageable::new("title".to_string(), "Chapter 1".to_string());
+        assert!(p.split(100.0, 100.0).is_none());
+    }
+
+    #[test]
+    fn test_string_set_pageable_fields() {
+        let p = StringSetPageable::new("title".to_string(), "Chapter 1".to_string());
+        assert_eq!(p.name, "title");
+        assert_eq!(p.value, "Chapter 1");
     }
 }
 

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -1159,9 +1159,7 @@ impl Pageable for StringSetPageable {
         None
     }
 
-    fn draw(&self, _canvas: &mut Canvas, _x: Pt, _y: Pt, _avail_width: Pt, _avail_height: Pt) {
-        // Markers are invisible
-    }
+    fn draw(&self, _canvas: &mut Canvas, _x: Pt, _y: Pt, _avail_width: Pt, _avail_height: Pt) {}
 
     fn clone_box(&self) -> Box<dyn Pageable> {
         Box::new(self.clone())
@@ -1169,6 +1167,71 @@ impl Pageable for StringSetPageable {
 
     fn height(&self) -> Pt {
         0.0
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+// ─── StringSetWrapperPageable ──────────────────────────────
+
+/// Wraps a Pageable together with `StringSetPageable` markers that must stay
+/// attached to it during pagination.
+///
+/// Without this wrapper, a plain `BlockPageable` containing `[markers..., child]`
+/// could split such that the markers are left on the previous page while the
+/// real child is moved to the next page (when the child is unsplittable and
+/// larger than the available space). `collect_string_set_states` would then
+/// resolve `string()` one page too early.
+///
+/// The wrapper delegates `split()` to the inner child: if the child splits,
+/// markers travel with the first fragment; if the child cannot split, the
+/// wrapper is atomic and the whole thing moves to the next page together.
+#[derive(Clone)]
+pub struct StringSetWrapperPageable {
+    pub markers: Vec<StringSetPageable>,
+    pub child: Box<dyn Pageable>,
+}
+
+impl StringSetWrapperPageable {
+    pub fn new(markers: Vec<StringSetPageable>, child: Box<dyn Pageable>) -> Self {
+        Self { markers, child }
+    }
+}
+
+impl Pageable for StringSetWrapperPageable {
+    fn wrap(&mut self, avail_width: Pt, avail_height: Pt) -> Size {
+        self.child.wrap(avail_width, avail_height)
+    }
+
+    fn split(
+        &self,
+        avail_width: Pt,
+        avail_height: Pt,
+    ) -> Option<(Box<dyn Pageable>, Box<dyn Pageable>)> {
+        let (first, second) = self.child.split(avail_width, avail_height)?;
+        let first_wrapped = StringSetWrapperPageable {
+            markers: self.markers.clone(),
+            child: first,
+        };
+        Some((Box::new(first_wrapped), second))
+    }
+
+    fn draw(&self, canvas: &mut Canvas<'_, '_>, x: Pt, y: Pt, avail_width: Pt, avail_height: Pt) {
+        self.child.draw(canvas, x, y, avail_width, avail_height);
+    }
+
+    fn clone_box(&self) -> Box<dyn Pageable> {
+        Box::new(self.clone())
+    }
+
+    fn height(&self) -> Pt {
+        self.child.height()
+    }
+
+    fn pagination(&self) -> Pagination {
+        self.child.pagination()
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/crates/fulgur/src/paginate.rs
+++ b/crates/fulgur/src/paginate.rs
@@ -1,7 +1,8 @@
 use std::collections::BTreeMap;
 
 use crate::pageable::{
-    BlockPageable, ListItemPageable, Pageable, Pt, StringSetPageable, TablePageable,
+    BlockPageable, ListItemPageable, Pageable, Pt, StringSetPageable, StringSetWrapperPageable,
+    TablePageable,
 };
 
 /// Per-page state for a named string.
@@ -78,15 +79,20 @@ pub fn collect_string_set_states(
     result
 }
 
-/// Recursively find all StringSetPageable markers in a Pageable tree.
+/// Recursively find all string-set markers in a Pageable tree.
 ///
-/// Only traverses container types that can contain markers. Markers are always
-/// inserted as direct children of `BlockPageable` (see `convert::maybe_prepend_string_set`),
-/// but we also descend into `TablePageable` / `ListItemPageable` bodies to find
-/// markers inserted on descendants of table cells or list items.
+/// Markers are inserted via `StringSetWrapperPageable` in `convert.rs`. The
+/// wrapper also keeps markers attached to the first fragment of its child on
+/// split, so the markers always travel with the content they describe.
 fn collect_markers(pageable: &dyn Pageable, markers: &mut Vec<(String, String)>) {
     let any = pageable.as_any();
-    if let Some(marker) = any.downcast_ref::<StringSetPageable>() {
+    if let Some(wrapper) = any.downcast_ref::<StringSetWrapperPageable>() {
+        for m in &wrapper.markers {
+            markers.push((m.name.clone(), m.value.clone()));
+        }
+        collect_markers(wrapper.child.as_ref(), markers);
+    } else if let Some(marker) = any.downcast_ref::<StringSetPageable>() {
+        // Used by unit tests that construct markers directly.
         markers.push((marker.name.clone(), marker.value.clone()));
     } else if let Some(block) = any.downcast_ref::<BlockPageable>() {
         for child in &block.children {
@@ -214,5 +220,48 @@ mod tests {
         assert_eq!(states[0].len(), 2);
         assert_eq!(states[0]["chapter"].first, Some("Ch1".to_string()));
         assert_eq!(states[0]["section"].first, Some("Sec1".to_string()));
+    }
+
+    /// Regression: when an unsplittable child with a string-set marker is
+    /// pushed to the next page (because it cannot fit on the current one),
+    /// the marker must travel with it and NOT orphan on the previous page.
+    #[test]
+    fn test_string_set_wrapper_keeps_markers_with_unsplittable_child() {
+        use crate::pageable::StringSetWrapperPageable;
+
+        // Page height is 100pt.
+        // Page 1: 80pt filler + (wrapped 60pt spacer can't fit) -> wrapper moves to page 2.
+        let mut filler = SpacerPageable::new(80.0);
+        filler.wrap(100.0, 1000.0);
+
+        let mut content = SpacerPageable::new(60.0);
+        content.wrap(100.0, 1000.0);
+
+        let markers = vec![StringSetPageable::new("title".into(), "Ch2".into())];
+        let wrapper = StringSetWrapperPageable::new(markers, Box::new(content));
+
+        let mut block = BlockPageable::with_positioned_children(vec![
+            pos(Box::new(filler)),
+            PositionedChild {
+                child: Box::new(wrapper),
+                x: 0.0,
+                y: 80.0,
+            },
+        ]);
+        block.wrap(100.0, 1000.0);
+
+        let pages = paginate(Box::new(block), 100.0, 100.0);
+        let states = collect_string_set_states(&pages);
+
+        assert_eq!(pages.len(), 2, "content should span two pages");
+        assert!(
+            !states[0].contains_key("title"),
+            "marker must NOT be on page 1 (content was pushed to page 2)"
+        );
+        assert_eq!(
+            states[1].get("title").and_then(|s| s.first.clone()),
+            Some("Ch2".to_string()),
+            "marker must be on page 2 with its content"
+        );
     }
 }

--- a/crates/fulgur/src/paginate.rs
+++ b/crates/fulgur/src/paginate.rs
@@ -1,4 +1,19 @@
-use crate::pageable::{Pageable, Pt};
+use std::collections::BTreeMap;
+
+use crate::pageable::{
+    BlockPageable, ListItemPageable, Pageable, Pt, StringSetPageable, TablePageable,
+};
+
+/// Per-page state for a named string.
+#[derive(Debug, Clone, Default)]
+pub struct StringSetPageState {
+    /// Value at start of page (carried from previous page's `last`).
+    pub start: Option<String>,
+    /// First value set on this page.
+    pub first: Option<String>,
+    /// Last value set on this page.
+    pub last: Option<String>,
+}
 
 /// Split a Pageable tree into per-page fragments.
 pub fn paginate(
@@ -29,10 +44,68 @@ pub fn paginate(
     pages
 }
 
+/// Walk paginated pages and collect StringSetPageable markers per page.
+pub fn collect_string_set_states(
+    pages: &[Box<dyn Pageable>],
+) -> Vec<BTreeMap<String, StringSetPageState>> {
+    let mut result: Vec<BTreeMap<String, StringSetPageState>> = Vec::with_capacity(pages.len());
+    let mut carry: BTreeMap<String, String> = BTreeMap::new();
+
+    for page in pages {
+        let mut page_state: BTreeMap<String, StringSetPageState> = BTreeMap::new();
+
+        // Initialize start values from carry
+        for (name, value) in &carry {
+            page_state.entry(name.clone()).or_default().start = Some(value.clone());
+        }
+
+        // Collect markers from this page
+        let mut markers = Vec::new();
+        collect_markers(page.as_ref(), &mut markers);
+
+        for (name, value) in &markers {
+            let state = page_state.entry(name.clone()).or_default();
+            if state.first.is_none() {
+                state.first = Some(value.clone());
+            }
+            state.last = Some(value.clone());
+            carry.insert(name.clone(), value.clone());
+        }
+
+        result.push(page_state);
+    }
+
+    result
+}
+
+/// Recursively find all StringSetPageable markers in a Pageable tree.
+fn collect_markers(pageable: &dyn Pageable, markers: &mut Vec<(String, String)>) {
+    if let Some(marker) = pageable.as_any().downcast_ref::<StringSetPageable>() {
+        markers.push((marker.name.clone(), marker.value.clone()));
+        return;
+    }
+    if let Some(block) = pageable.as_any().downcast_ref::<BlockPageable>() {
+        for child in &block.children {
+            collect_markers(child.child.as_ref(), markers);
+        }
+    }
+    if let Some(table) = pageable.as_any().downcast_ref::<TablePageable>() {
+        for child in &table.header_cells {
+            collect_markers(child.child.as_ref(), markers);
+        }
+        for child in &table.body_cells {
+            collect_markers(child.child.as_ref(), markers);
+        }
+    }
+    if let Some(list_item) = pageable.as_any().downcast_ref::<ListItemPageable>() {
+        collect_markers(list_item.body.as_ref(), markers);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pageable::{BlockPageable, SpacerPageable};
+    use crate::pageable::{BlockPageable, PositionedChild, SpacerPageable, StringSetPageable};
 
     fn make_spacer(h: Pt) -> Box<dyn Pageable> {
         let mut s = SpacerPageable::new(h);
@@ -70,5 +143,74 @@ mod tests {
         // 500pt total, 200pt per page => 3 pages (200, 200, 100)
         let pages = paginate(Box::new(block), 200.0, 200.0);
         assert_eq!(pages.len(), 3);
+    }
+
+    // ─── String set collection tests ────────────────────────
+
+    fn make_marker(name: &str, value: &str) -> Box<dyn Pageable> {
+        Box::new(StringSetPageable::new(name.to_string(), value.to_string()))
+    }
+
+    fn pos(child: Box<dyn Pageable>) -> PositionedChild {
+        PositionedChild {
+            child,
+            x: 0.0,
+            y: 0.0,
+        }
+    }
+
+    #[test]
+    fn test_collect_string_sets_single_page() {
+        let block = BlockPageable::with_positioned_children(vec![
+            pos(make_marker("title", "Ch1")),
+            pos(make_spacer(50.0)),
+        ]);
+        let pages = paginate(Box::new(block), 100.0, 200.0);
+        let states = collect_string_set_states(&pages);
+        assert_eq!(states.len(), 1);
+        let page_state = &states[0]["title"];
+        assert_eq!(page_state.start, None);
+        assert_eq!(page_state.first, Some("Ch1".to_string()));
+        assert_eq!(page_state.last, Some("Ch1".to_string()));
+    }
+
+    #[test]
+    fn test_collect_string_sets_across_pages() {
+        // Create content that spans 2+ pages (page height = 100)
+        let block = BlockPageable::with_positioned_children(vec![
+            pos(make_marker("title", "Ch1")),
+            pos(make_spacer(150.0)),
+            pos(make_marker("title", "Ch2")),
+            pos(make_spacer(50.0)),
+        ]);
+        let pages = paginate(Box::new(block), 100.0, 100.0);
+        let states = collect_string_set_states(&pages);
+        assert!(states.len() >= 2);
+        // Page 2 should have start = "Ch1"
+        let p2 = &states[1]["title"];
+        assert_eq!(p2.start, Some("Ch1".to_string()));
+    }
+
+    #[test]
+    fn test_collect_string_sets_no_markers() {
+        let block = BlockPageable::with_positioned_children(vec![pos(make_spacer(50.0))]);
+        let pages = paginate(Box::new(block), 100.0, 200.0);
+        let states = collect_string_set_states(&pages);
+        assert_eq!(states.len(), 1);
+        assert!(states[0].is_empty());
+    }
+
+    #[test]
+    fn test_collect_string_sets_multiple_names() {
+        let block = BlockPageable::with_positioned_children(vec![
+            pos(make_marker("chapter", "Ch1")),
+            pos(make_marker("section", "Sec1")),
+            pos(make_spacer(50.0)),
+        ]);
+        let pages = paginate(Box::new(block), 100.0, 200.0);
+        let states = collect_string_set_states(&pages);
+        assert_eq!(states[0].len(), 2);
+        assert_eq!(states[0]["chapter"].first, Some("Ch1".to_string()));
+        assert_eq!(states[0]["section"].first, Some("Sec1".to_string()));
     }
 }

--- a/crates/fulgur/src/paginate.rs
+++ b/crates/fulgur/src/paginate.rs
@@ -79,25 +79,27 @@ pub fn collect_string_set_states(
 }
 
 /// Recursively find all StringSetPageable markers in a Pageable tree.
+///
+/// Only traverses container types that can contain markers. Markers are always
+/// inserted as direct children of `BlockPageable` (see `convert::maybe_prepend_string_set`),
+/// but we also descend into `TablePageable` / `ListItemPageable` bodies to find
+/// markers inserted on descendants of table cells or list items.
 fn collect_markers(pageable: &dyn Pageable, markers: &mut Vec<(String, String)>) {
-    if let Some(marker) = pageable.as_any().downcast_ref::<StringSetPageable>() {
+    let any = pageable.as_any();
+    if let Some(marker) = any.downcast_ref::<StringSetPageable>() {
         markers.push((marker.name.clone(), marker.value.clone()));
-        return;
-    }
-    if let Some(block) = pageable.as_any().downcast_ref::<BlockPageable>() {
+    } else if let Some(block) = any.downcast_ref::<BlockPageable>() {
         for child in &block.children {
             collect_markers(child.child.as_ref(), markers);
         }
-    }
-    if let Some(table) = pageable.as_any().downcast_ref::<TablePageable>() {
+    } else if let Some(table) = any.downcast_ref::<TablePageable>() {
         for child in &table.header_cells {
             collect_markers(child.child.as_ref(), markers);
         }
         for child in &table.body_cells {
             collect_markers(child.child.as_ref(), markers);
         }
-    }
-    if let Some(list_item) = pageable.as_any().downcast_ref::<ListItemPageable>() {
+    } else if let Some(list_item) = any.downcast_ref::<ListItemPageable>() {
         collect_markers(list_item.body.as_ref(), markers);
     }
 }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -182,6 +182,7 @@ pub fn render_to_pdf_with_gcpm(
     // Pass 1: paginate body content
     let pages = paginate(root, content_width, content_height);
     let total_pages = pages.len();
+    let string_set_states = crate::paginate::collect_string_set_states(&pages);
 
     let page_size = if config.landscape {
         config.page_size.landscape()
@@ -252,7 +253,7 @@ pub fn render_to_pdf_with_gcpm(
             let content_html = resolve_content_to_html(
                 &rule.content,
                 &running_pairs,
-                &std::collections::BTreeMap::new(),
+                &string_set_states[page_idx],
                 page_num,
                 total_pages,
             );

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -182,7 +182,11 @@ pub fn render_to_pdf_with_gcpm(
     // Pass 1: paginate body content
     let pages = paginate(root, content_width, content_height);
     let total_pages = pages.len();
-    let string_set_states = crate::paginate::collect_string_set_states(&pages);
+    let string_set_states = if gcpm.string_set_mappings.is_empty() {
+        vec![BTreeMap::new(); pages.len()]
+    } else {
+        crate::paginate::collect_string_set_states(&pages)
+    };
 
     let page_size = if config.landscape {
         config.page_size.landscape()

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -249,8 +249,13 @@ pub fn render_to_pdf_with_gcpm(
         // with the margin box's own declarations (font-size, color, margin, etc.)
         let mut resolved_htmls: BTreeMap<MarginBoxPosition, String> = BTreeMap::new();
         for (&pos, rule) in &effective_boxes {
-            let content_html =
-                resolve_content_to_html(&rule.content, &running_pairs, page_num, total_pages);
+            let content_html = resolve_content_to_html(
+                &rule.content,
+                &running_pairs,
+                &std::collections::BTreeMap::new(),
+                page_num,
+                total_pages,
+            );
             if !content_html.is_empty() {
                 let html = if rule.declarations.is_empty() {
                     content_html

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -371,6 +371,7 @@ pub fn render_to_pdf_with_gcpm(
                     running_store: &mut dummy_store,
                     assets: None,
                     font_cache: HashMap::new(),
+                    string_set_by_node: HashMap::new(),
                 };
                 let pageable = crate::convert::dom_to_pageable(&render_doc, &mut dummy_ctx);
                 render_cache.insert(cache_key.clone(), pageable);

--- a/crates/fulgur/tests/gcpm_integration.rs
+++ b/crates/fulgur/tests/gcpm_integration.rs
@@ -332,3 +332,139 @@ fn test_gcpm_side_boxes_asymmetric_margins() {
     assert!(!pdf.is_empty());
     assert!(pdf.starts_with(b"%PDF-"));
 }
+
+#[test]
+fn test_gcpm_string_set_chapter_title() {
+    let css = r#"
+        h1 { string-set: chapter-title content(text); }
+        @page {
+            @top-center { content: string(chapter-title); }
+            @bottom-center { content: "Page " counter(page) " of " counter(pages); }
+        }
+    "#;
+
+    let mut paragraphs = String::new();
+    for i in 0..3 {
+        paragraphs.push_str(&format!(
+            "<h1>Chapter {}</h1>\n<p>Content for chapter {}. This paragraph has enough text to take some space on the page.</p>\n",
+            i + 1, i + 1
+        ));
+        for j in 0..20 {
+            paragraphs.push_str(&format!(
+                "<p>Paragraph {} of chapter {}.</p>\n",
+                j + 1,
+                i + 1
+            ));
+        }
+    }
+
+    let html = format!(
+        r#"<!DOCTYPE html>
+<html>
+<head></head>
+<body>
+{}
+</body>
+</html>"#,
+        paragraphs
+    );
+
+    let mut assets = AssetBundle::new();
+    assets.add_css(css);
+
+    let engine = Engine::builder().assets(assets).build();
+    let pdf = engine.render_html(&html).unwrap();
+
+    assert!(!pdf.is_empty(), "PDF output should not be empty");
+    assert!(
+        pdf.starts_with(b"%PDF-"),
+        "PDF output should start with %PDF-"
+    );
+}
+
+#[test]
+fn test_gcpm_string_set_with_attr() {
+    let css = r#"
+        h1 { string-set: title attr(data-title); }
+        @page {
+            @top-left { content: string(title); }
+        }
+    "#;
+
+    let html = r#"<!DOCTYPE html>
+<html>
+<head></head>
+<body>
+  <h1 data-title="Custom Title">Visible Heading</h1>
+  <p>Some body content.</p>
+</body>
+</html>"#;
+
+    let mut assets = AssetBundle::new();
+    assets.add_css(css);
+
+    let engine = Engine::builder().assets(assets).build();
+    let pdf = engine.render_html(html).unwrap();
+
+    assert!(!pdf.is_empty());
+    assert!(pdf.starts_with(b"%PDF-"));
+}
+
+#[test]
+fn test_gcpm_string_set_with_literal_concat() {
+    let css = r#"
+        h1 { string-set: header "Section: " content(text); }
+        @page {
+            @top-center { content: string(header); }
+        }
+    "#;
+
+    let html = r#"<!DOCTYPE html>
+<html>
+<head></head>
+<body>
+  <h1>Introduction</h1>
+  <p>Body text.</p>
+</body>
+</html>"#;
+
+    let mut assets = AssetBundle::new();
+    assets.add_css(css);
+
+    let engine = Engine::builder().assets(assets).build();
+    let pdf = engine.render_html(html).unwrap();
+
+    assert!(!pdf.is_empty());
+    assert!(pdf.starts_with(b"%PDF-"));
+}
+
+#[test]
+fn test_gcpm_string_set_with_policies() {
+    let css = r#"
+        h2 { string-set: section content(text); }
+        @page {
+            @top-left { content: string(section, start); }
+            @top-right { content: string(section, last); }
+        }
+    "#;
+
+    let mut body = String::new();
+    for i in 0..30 {
+        body.push_str(&format!("<h2>Section {}</h2>\n<p>Content.</p>\n", i + 1));
+    }
+
+    let html = format!(
+        r#"<!DOCTYPE html>
+<html><head></head><body>{}</body></html>"#,
+        body
+    );
+
+    let mut assets = AssetBundle::new();
+    assets.add_css(css);
+
+    let engine = Engine::builder().assets(assets).build();
+    let pdf = engine.render_html(&html).unwrap();
+
+    assert!(!pdf.is_empty());
+    assert!(pdf.starts_with(b"%PDF-"));
+}

--- a/docs/plans/2026-04-05-gcpm-string-set-implementation.md
+++ b/docs/plans/2026-04-05-gcpm-string-set-implementation.md
@@ -1,0 +1,1645 @@
+# GCPM string-set/string() Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** CSS Named Strings (`string-set` property + `string()` function) support for dynamic page headers/footers that reflect document content (e.g. chapter titles).
+
+**Architecture:** DOM walk detects `string-set` declarations and extracts text values. Convert stage inserts zero-size `StringSetPageable` markers into the Pageable tree. Paginate collects per-page string states (start/first/last). Render resolves `string(name, policy)` in margin boxes using these states.
+
+**Tech Stack:** Rust, cssparser, Blitz DOM, existing GCPM infrastructure (parser.rs, counter.rs, running.rs, pageable.rs, paginate.rs, render.rs, engine.rs)
+
+---
+
+## Task 1: Data Types in gcpm/mod.rs
+
+**Files:**
+
+- Modify: `crates/fulgur/src/gcpm/mod.rs`
+
+**Step 1: Add StringSet types and extend ContentItem**
+
+Add the following types after the existing `RunningMapping` struct and extend `ContentItem`:
+
+```rust
+/// Policy for string() function — determines which value to use on a given page.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StringPolicy {
+    /// Value at start of page (inherited from previous page's last value).
+    Start,
+    /// First value set on this page (falls back to start).
+    First,
+    /// Last value set on this page.
+    Last,
+    /// Same as First, but empty on pages where the string is actually set.
+    FirstExcept,
+}
+
+/// A single value component in a string-set declaration.
+/// `string-set: title content(text) " - " attr(data-subtitle)`
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StringSetValue {
+    /// `content(text)` — element's text content.
+    ContentText,
+    /// `content(before)` — ::before pseudo-element content.
+    ContentBefore,
+    /// `content(after)` — ::after pseudo-element content.
+    ContentAfter,
+    /// `attr(<name>)` — HTML attribute value.
+    Attr(String),
+    /// A literal string, e.g. `"Chapter "`.
+    Literal(String),
+}
+
+/// Maps a CSS selector to a string-set declaration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StringSetMapping {
+    /// The parsed CSS selector.
+    pub parsed: ParsedSelector,
+    /// The named string identifier.
+    pub name: String,
+    /// Value components to concatenate.
+    pub values: Vec<StringSetValue>,
+}
+```
+
+Add a new variant to `ContentItem`:
+
+```rust
+pub enum ContentItem {
+    Element(String),
+    Counter(CounterType),
+    String(String),
+    /// A named string reference, e.g. `string(chapter-title, first)`.
+    StringRef { name: String, policy: StringPolicy },
+}
+```
+
+**Step 2: Add string_set_mappings to GcpmContext**
+
+```rust
+pub struct GcpmContext {
+    pub margin_boxes: Vec<MarginBoxRule>,
+    pub running_mappings: Vec<RunningMapping>,
+    pub string_set_mappings: Vec<StringSetMapping>,
+    pub cleaned_css: String,
+}
+```
+
+Update `is_empty()` to include `string_set_mappings`:
+
+```rust
+pub fn is_empty(&self) -> bool {
+    self.margin_boxes.is_empty()
+        && self.running_mappings.is_empty()
+        && self.string_set_mappings.is_empty()
+}
+```
+
+**Step 3: Update existing tests for new field**
+
+Add `string_set_mappings: vec![]` to all existing `GcpmContext` construction sites in tests.
+
+**Step 4: Run tests**
+
+```bash
+cargo test -p fulgur --lib gcpm::tests
+```
+
+Expected: All existing tests pass with the new field.
+
+**Step 5: Commit**
+
+```bash
+git add crates/fulgur/src/gcpm/mod.rs
+git commit -m "feat(gcpm): add StringSet data types and StringRef content item"
+```
+
+---
+
+## Task 2: Parser — string-set property and string() function
+
+**Files:**
+
+- Modify: `crates/fulgur/src/gcpm/parser.rs`
+
+**Step 1: Write tests for string-set parsing**
+
+Add to `mod tests` in parser.rs:
+
+```rust
+#[test]
+fn test_parse_string_set_content_text() {
+    let css = "h1 { string-set: chapter-title content(text); }";
+    let ctx = parse_gcpm(css);
+    assert_eq!(ctx.string_set_mappings.len(), 1);
+    let m = &ctx.string_set_mappings[0];
+    assert_eq!(m.parsed, ParsedSelector::Tag("h1".to_string()));
+    assert_eq!(m.name, "chapter-title");
+    assert_eq!(m.values, vec![StringSetValue::ContentText]);
+    // string-set should be removed from cleaned_css
+    assert!(!ctx.cleaned_css.contains("string-set"));
+}
+
+#[test]
+fn test_parse_string_set_multiple_values() {
+    let css = r#"h1 { string-set: title "Chapter " content(text) " - " attr(data-sub); }"#;
+    let ctx = parse_gcpm(css);
+    assert_eq!(ctx.string_set_mappings.len(), 1);
+    let m = &ctx.string_set_mappings[0];
+    assert_eq!(m.name, "title");
+    assert_eq!(
+        m.values,
+        vec![
+            StringSetValue::Literal("Chapter ".to_string()),
+            StringSetValue::ContentText,
+            StringSetValue::Literal(" - ".to_string()),
+            StringSetValue::Attr("data-sub".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn test_parse_string_set_content_before_after() {
+    let css = "h2 { string-set: sec content(before) content(text) content(after); }";
+    let ctx = parse_gcpm(css);
+    assert_eq!(ctx.string_set_mappings.len(), 1);
+    let m = &ctx.string_set_mappings[0];
+    assert_eq!(
+        m.values,
+        vec![
+            StringSetValue::ContentBefore,
+            StringSetValue::ContentText,
+            StringSetValue::ContentAfter,
+        ]
+    );
+}
+
+#[test]
+fn test_parse_string_function_default_policy() {
+    let css = r#"@page { @top-center { content: string(chapter-title); } }"#;
+    let ctx = parse_gcpm(css);
+    assert_eq!(ctx.margin_boxes.len(), 1);
+    assert_eq!(
+        ctx.margin_boxes[0].content,
+        vec![ContentItem::StringRef {
+            name: "chapter-title".to_string(),
+            policy: StringPolicy::First,
+        }]
+    );
+}
+
+#[test]
+fn test_parse_string_function_with_policy() {
+    let css = r#"@page { @top-center { content: string(title, last); } }"#;
+    let ctx = parse_gcpm(css);
+    assert_eq!(
+        ctx.margin_boxes[0].content,
+        vec![ContentItem::StringRef {
+            name: "title".to_string(),
+            policy: StringPolicy::Last,
+        }]
+    );
+}
+
+#[test]
+fn test_parse_string_function_all_policies() {
+    for (policy_str, policy) in [
+        ("first", StringPolicy::First),
+        ("start", StringPolicy::Start),
+        ("last", StringPolicy::Last),
+        ("first-except", StringPolicy::FirstExcept),
+    ] {
+        let css = format!(
+            r#"@page {{ @top-center {{ content: string(title, {}); }} }}"#,
+            policy_str
+        );
+        let ctx = parse_gcpm(&css);
+        assert_eq!(
+            ctx.margin_boxes[0].content,
+            vec![ContentItem::StringRef {
+                name: "title".to_string(),
+                policy,
+            }],
+            "Failed for policy: {}",
+            policy_str,
+        );
+    }
+}
+
+#[test]
+fn test_parse_string_set_with_class_selector() {
+    let css = ".chapter-heading { string-set: chapter content(text); }";
+    let ctx = parse_gcpm(css);
+    assert_eq!(ctx.string_set_mappings.len(), 1);
+    assert_eq!(
+        ctx.string_set_mappings[0].parsed,
+        ParsedSelector::Class("chapter-heading".to_string())
+    );
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+```bash
+cargo test -p fulgur --lib gcpm::parser::tests
+```
+
+Expected: Compilation errors (new types not yet used in parser).
+
+**Step 3: Implement string-set parsing in StyleRuleParser**
+
+Modify `StyleRuleParser` to also detect `string-set` declarations alongside `position: running(...)`.
+
+In the `StyleRuleParser` struct, add a field:
+
+```rust
+struct StyleRuleParser<'a> {
+    edits: &'a mut Vec<CssEdit>,
+    running_name: &'a mut Option<String>,
+    string_set: &'a mut Option<(String, Vec<StringSetValue>)>,
+}
+```
+
+In `StyleRuleParser::parse_value`, add handling for `string-set`:
+
+```rust
+if name.eq_ignore_ascii_case("string-set") {
+    // Parse: <ident> <value>+
+    let set_name = input.expect_ident()?.clone().to_string();
+    let mut values = Vec::new();
+    while !input.is_exhausted() {
+        let result: Result<(), ParseError<'_, ()>> = input.try_parse(|input| {
+            let token = input.next_including_whitespace()?.clone();
+            match token {
+                Token::QuotedString(ref s) => {
+                    values.push(StringSetValue::Literal(s.to_string()));
+                }
+                Token::Function(ref fn_name) => {
+                    let fn_name = fn_name.clone();
+                    input.parse_nested_block(|input| {
+                        if fn_name.eq_ignore_ascii_case("content") {
+                            let arg = input.expect_ident()?.clone();
+                            match &*arg {
+                                "text" => values.push(StringSetValue::ContentText),
+                                "before" => values.push(StringSetValue::ContentBefore),
+                                "after" => values.push(StringSetValue::ContentAfter),
+                                _ => {}
+                            }
+                        } else if fn_name.eq_ignore_ascii_case("attr") {
+                            let arg = input.expect_ident()?.clone();
+                            values.push(StringSetValue::Attr(arg.to_string()));
+                        }
+                        Ok(())
+                    })?;
+                }
+                Token::WhiteSpace(_) | Token::Comment(_) => {}
+                _ => {}
+            }
+            Ok(())
+        });
+        if result.is_err() {
+            break;
+        }
+    }
+    if !values.is_empty() {
+        *self.string_set = Some((set_name, values));
+        // Record edit to remove string-set declaration from cleaned_css
+        let start_byte = decl_start.position().byte_index();
+        let end_byte = input.position().byte_index();
+        self.edits.push(CssEdit::Remove {
+            start: start_byte,
+            end: end_byte,
+        });
+    }
+    return Ok(());
+}
+```
+
+Update `GcpmSheetParser::parse_block` for qualified rules to collect string_set:
+
+```rust
+fn parse_block<'t>(
+    &mut self,
+    prelude: Self::Prelude,
+    _start: &cssparser::ParserState,
+    input: &mut Parser<'i, 't>,
+) -> Result<Self::QualifiedRule, ParseError<'i, ()>> {
+    let Some(selector) = prelude else {
+        while input.next().is_ok() {}
+        return Ok(TopLevelItem::StyleRule);
+    };
+
+    let mut running_name: Option<String> = None;
+    let mut string_set: Option<(String, Vec<StringSetValue>)> = None;
+
+    let mut parser = StyleRuleParser {
+        edits: self.edits,
+        running_name: &mut running_name,
+        string_set: &mut string_set,
+    };
+    let iter = RuleBodyParser::new(input, &mut parser);
+    for item in iter {
+        let _ = item;
+    }
+
+    if let Some(running_name) = running_name {
+        self.running_mappings.push(RunningMapping {
+            parsed: selector.clone(),
+            running_name,
+        });
+    }
+
+    if let Some((name, values)) = string_set {
+        self.string_set_mappings.push(StringSetMapping {
+            parsed: selector,
+            name,
+            values,
+        });
+    }
+
+    Ok(TopLevelItem::StyleRule)
+}
+```
+
+Add `string_set_mappings` to `GcpmSheetParser` struct and `parse_gcpm` function.
+
+**Step 4: Implement string() function in parse_content_value**
+
+In `parse_content_value`, add handling for the `string()` function:
+
+```rust
+} else if fn_name.eq_ignore_ascii_case("string") {
+    input.parse_nested_block(|input| {
+        let name = input.expect_ident()?.clone().to_string();
+        let policy = input
+            .try_parse(|input| {
+                input.expect_comma()?;
+                let ident = input.expect_ident()?.clone();
+                match &*ident {
+                    "start" => Ok(StringPolicy::Start),
+                    "first" => Ok(StringPolicy::First),
+                    "last" => Ok(StringPolicy::Last),
+                    "first-except" => Ok(StringPolicy::FirstExcept),
+                    _ => Err(input.new_error::<()>(
+                        BasicParseErrorKind::QualifiedRuleInvalid,
+                    )),
+                }
+            })
+            .unwrap_or(StringPolicy::First);
+        items.push(ContentItem::StringRef { name, policy });
+        Ok(())
+    })?;
+}
+```
+
+**Step 5: Run tests**
+
+```bash
+cargo test -p fulgur --lib gcpm::parser::tests
+```
+
+Expected: All tests pass.
+
+**Step 6: Commit**
+
+```bash
+git add crates/fulgur/src/gcpm/parser.rs
+git commit -m "feat(gcpm): parse string-set property and string() function"
+```
+
+---
+
+## Task 3: StringSetPass — DOM walk for text extraction
+
+**Files:**
+
+- Create: `crates/fulgur/src/gcpm/string_set.rs`
+- Modify: `crates/fulgur/src/gcpm/mod.rs` (add `pub mod string_set;`)
+- Modify: `crates/fulgur/src/blitz_adapter.rs`
+
+**Step 1: Write tests for StringSetStore**
+
+Create `crates/fulgur/src/gcpm/string_set.rs`:
+
+```rust
+//! Named string support for CSS Generated Content for Paged Media (GCPM).
+//!
+//! Manages string-set values extracted from the DOM via `string-set: name content(text)`.
+//! Values are stored with their DOM node IDs for later insertion into the Pageable tree.
+
+/// A single string-set entry extracted from the DOM.
+#[derive(Debug, Clone)]
+pub struct StringSetEntry {
+    /// The named string identifier (e.g. "chapter-title").
+    pub name: String,
+    /// The resolved text value.
+    pub value: String,
+    /// Blitz DOM node ID, used to position the marker in the Pageable tree.
+    pub node_id: usize,
+}
+
+/// Stores string-set entries collected during DOM traversal.
+pub struct StringSetStore {
+    entries: Vec<StringSetEntry>,
+}
+
+impl StringSetStore {
+    pub fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+
+    pub fn push(&mut self, entry: StringSetEntry) {
+        self.entries.push(entry);
+    }
+
+    pub fn entries(&self) -> &[StringSetEntry] {
+        &self.entries
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+impl Default for StringSetStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Extract the text content of a DOM node (recursive).
+pub fn extract_text_content(doc: &blitz_dom::BaseDocument, node_id: usize) -> String {
+    let mut out = String::new();
+    collect_text(doc, node_id, &mut out);
+    out
+}
+
+fn collect_text(doc: &blitz_dom::BaseDocument, node_id: usize, out: &mut String) {
+    let Some(node) = doc.get_node(node_id) else {
+        return;
+    };
+    match &node.data {
+        blitz_dom::NodeData::Text(text_data) => {
+            out.push_str(&text_data.content);
+        }
+        _ => {
+            for &child_id in &node.children {
+                collect_text(doc, child_id, out);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_string_set_store_basic() {
+        let mut store = StringSetStore::new();
+        assert!(store.is_empty());
+
+        store.push(StringSetEntry {
+            name: "title".to_string(),
+            value: "Chapter 1".to_string(),
+            node_id: 42,
+        });
+        assert!(!store.is_empty());
+        assert_eq!(store.entries().len(), 1);
+        assert_eq!(store.entries()[0].name, "title");
+        assert_eq!(store.entries()[0].value, "Chapter 1");
+        assert_eq!(store.entries()[0].node_id, 42);
+    }
+
+    #[test]
+    fn test_string_set_store_multiple_entries() {
+        let mut store = StringSetStore::new();
+        store.push(StringSetEntry {
+            name: "title".to_string(),
+            value: "Ch1".to_string(),
+            node_id: 10,
+        });
+        store.push(StringSetEntry {
+            name: "title".to_string(),
+            value: "Ch2".to_string(),
+            node_id: 20,
+        });
+        store.push(StringSetEntry {
+            name: "section".to_string(),
+            value: "Intro".to_string(),
+            node_id: 30,
+        });
+        assert_eq!(store.entries().len(), 3);
+    }
+}
+```
+
+**Step 2: Add module to mod.rs**
+
+In `crates/fulgur/src/gcpm/mod.rs`, add:
+
+```rust
+pub mod string_set;
+```
+
+**Step 3: Run tests**
+
+```bash
+cargo test -p fulgur --lib gcpm::string_set::tests
+```
+
+Expected: Pass.
+
+**Step 4: Implement StringSetPass in blitz_adapter.rs**
+
+Add after the `RunningElementPass` implementation:
+
+```rust
+use crate::gcpm::string_set::{extract_text_content, StringSetEntry, StringSetStore};
+use crate::gcpm::{StringSetMapping, StringSetValue};
+
+/// Extracts string-set values from the DOM.
+pub struct StringSetPass {
+    gcpm: GcpmContext,
+    store: RefCell<StringSetStore>,
+}
+
+impl StringSetPass {
+    pub fn new(gcpm: GcpmContext) -> Self {
+        Self {
+            gcpm,
+            store: RefCell::new(StringSetStore::new()),
+        }
+    }
+
+    pub fn into_store(self) -> StringSetStore {
+        self.store.into_inner()
+    }
+}
+
+impl DomPass for StringSetPass {
+    fn apply(&self, doc: &mut HtmlDocument, _ctx: &PassContext<'_>) {
+        if self.gcpm.string_set_mappings.is_empty() {
+            return;
+        }
+        let root = doc.root_element();
+        let root_id = root.id;
+        self.walk_tree(doc, root_id);
+    }
+}
+
+impl StringSetPass {
+    fn walk_tree(&self, doc: &HtmlDocument, node_id: usize) {
+        let Some(node) = doc.get_node(node_id) else {
+            return;
+        };
+
+        if let Some(elem) = node.element_data() {
+            if matches!(
+                elem.name.local.as_ref(),
+                "head" | "script" | "style" | "link" | "meta" | "title" | "noscript"
+            ) {
+                return;
+            }
+            if let Some((name, values)) = self.find_string_set(elem) {
+                let value = self.resolve_values(doc, node_id, elem, &values);
+                self.store.borrow_mut().push(StringSetEntry {
+                    name,
+                    value,
+                    node_id,
+                });
+            }
+        }
+
+        // Always recurse (unlike RunningElementPass which stops at matched nodes)
+        let children: Vec<usize> = doc
+            .get_node(node_id)
+            .map(|n| n.children.clone())
+            .unwrap_or_default();
+        for child_id in children {
+            self.walk_tree(doc, child_id);
+        }
+    }
+
+    fn find_string_set(
+        &self,
+        elem: &blitz_dom::node::ElementData,
+    ) -> Option<(String, Vec<StringSetValue>)> {
+        self.gcpm
+            .string_set_mappings
+            .iter()
+            .find(|m| self.matches_selector(&m.parsed, elem))
+            .map(|m| (m.name.clone(), m.values.clone()))
+    }
+
+    fn matches_selector(
+        &self,
+        selector: &ParsedSelector,
+        elem: &blitz_dom::node::ElementData,
+    ) -> bool {
+        match selector {
+            ParsedSelector::Class(name) => get_attr(elem, "class")
+                .is_some_and(|cls| cls.split_whitespace().any(|c| c == name.as_str())),
+            ParsedSelector::Id(name) => get_attr(elem, "id") == Some(name.as_str()),
+            ParsedSelector::Tag(name) => elem.name.local.as_ref().eq_ignore_ascii_case(name),
+        }
+    }
+
+    fn resolve_values(
+        &self,
+        doc: &HtmlDocument,
+        node_id: usize,
+        elem: &blitz_dom::node::ElementData,
+        values: &[StringSetValue],
+    ) -> String {
+        let mut out = String::new();
+        for val in values {
+            match val {
+                StringSetValue::ContentText => {
+                    out.push_str(&extract_text_content(doc, node_id));
+                }
+                StringSetValue::ContentBefore | StringSetValue::ContentAfter => {
+                    // Pseudo-element content requires Stylo computed styles.
+                    // For now, skip — these are rarely used with string-set.
+                }
+                StringSetValue::Attr(attr_name) => {
+                    if let Some(v) = get_attr(elem, attr_name) {
+                        out.push_str(v);
+                    }
+                }
+                StringSetValue::Literal(s) => {
+                    out.push_str(s);
+                }
+            }
+        }
+        out
+    }
+}
+```
+
+**Step 5: Run tests**
+
+```bash
+cargo test -p fulgur --lib
+```
+
+Expected: All tests pass.
+
+**Step 6: Commit**
+
+```bash
+git add crates/fulgur/src/gcpm/string_set.rs crates/fulgur/src/gcpm/mod.rs crates/fulgur/src/blitz_adapter.rs
+git commit -m "feat(gcpm): add StringSetPass for DOM text extraction"
+```
+
+---
+
+## Task 4: StringSetPageable — zero-size marker
+
+**Files:**
+
+- Modify: `crates/fulgur/src/pageable.rs`
+
+**Step 1: Write tests**
+
+Add to the test module in pageable.rs:
+
+```rust
+#[test]
+fn test_string_set_pageable_zero_size() {
+    let mut p = StringSetPageable::new("title".to_string(), "Chapter 1".to_string());
+    let size = p.wrap(100.0, 100.0);
+    assert_eq!(size.width, 0.0);
+    assert_eq!(size.height, 0.0);
+    assert_eq!(p.height(), 0.0);
+}
+
+#[test]
+fn test_string_set_pageable_no_split() {
+    let p = StringSetPageable::new("title".to_string(), "Chapter 1".to_string());
+    assert!(p.split(100.0, 100.0).is_none());
+}
+
+#[test]
+fn test_string_set_pageable_fields() {
+    let p = StringSetPageable::new("title".to_string(), "Chapter 1".to_string());
+    assert_eq!(p.name, "title");
+    assert_eq!(p.value, "Chapter 1");
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+```bash
+cargo test -p fulgur --lib pageable::tests
+```
+
+Expected: Compilation error — `StringSetPageable` not defined.
+
+**Step 3: Implement StringSetPageable**
+
+Add after `SpacerPageable` in pageable.rs:
+
+```rust
+// ─── StringSetPageable ──────────────────────────────────────
+
+/// Zero-size marker for named string values.
+/// Inserted into the Pageable tree to track string-set positions during pagination.
+#[derive(Clone)]
+pub struct StringSetPageable {
+    pub name: String,
+    pub value: String,
+}
+
+impl StringSetPageable {
+    pub fn new(name: String, value: String) -> Self {
+        Self { name, value }
+    }
+}
+
+impl Pageable for StringSetPageable {
+    fn wrap(&mut self, _avail_width: Pt, _avail_height: Pt) -> Size {
+        Size {
+            width: 0.0,
+            height: 0.0,
+        }
+    }
+
+    fn split(
+        &self,
+        _avail_width: Pt,
+        _avail_height: Pt,
+    ) -> Option<(Box<dyn Pageable>, Box<dyn Pageable>)> {
+        None
+    }
+
+    fn draw(&self, _canvas: &mut Canvas, _x: Pt, _y: Pt, _avail_width: Pt, _avail_height: Pt) {
+        // Markers are invisible
+    }
+
+    fn clone_box(&self) -> Box<dyn Pageable> {
+        Box::new(self.clone())
+    }
+
+    fn height(&self) -> Pt {
+        0.0
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+cargo test -p fulgur --lib pageable::tests
+```
+
+Expected: All tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add crates/fulgur/src/pageable.rs
+git commit -m "feat(gcpm): add StringSetPageable zero-size marker"
+```
+
+---
+
+## Task 5: Convert — insert StringSetPageable markers
+
+**Files:**
+
+- Modify: `crates/fulgur/src/convert.rs`
+
+**Step 1: Add StringSetStore to ConvertContext**
+
+```rust
+pub struct ConvertContext<'a> {
+    pub running_store: &'a mut RunningElementStore,
+    pub assets: Option<&'a AssetBundle>,
+    pub(crate) font_cache: HashMap<(usize, u32), Arc<Vec<u8>>>,
+    /// String-set entries from DOM walk, keyed by node_id for O(1) lookup.
+    pub string_set_by_node: HashMap<usize, Vec<(String, String)>>,
+}
+```
+
+**Step 2: Insert markers in convert_node**
+
+At the top of `convert_node`, after getting the node, check for string-set entries for this node_id. If found, wrap the converted Pageable in a BlockPageable with a `StringSetPageable` inserted before the actual content:
+
+Find the location where children are built for a `BlockPageable` and insert `StringSetPageable` markers. The simplest approach: after `convert_node` produces the child Pageable, check if the node has string-set entries and prepend markers.
+
+Add a helper at the end of `convert_node` (before return):
+
+```rust
+fn maybe_prepend_string_set(
+    node_id: usize,
+    child: Box<dyn Pageable>,
+    ctx: &mut ConvertContext<'_>,
+) -> Box<dyn Pageable> {
+    let entries = ctx.string_set_by_node.remove(&node_id);
+    match entries {
+        Some(entries) if !entries.is_empty() => {
+            let mut children = Vec::with_capacity(entries.len() + 1);
+            for (name, value) in entries {
+                let marker = StringSetPageable::new(name, value);
+                children.push(PositionedChild {
+                    child: Box::new(marker),
+                    x: 0.0,
+                    y: 0.0,
+                });
+            }
+            children.push(PositionedChild {
+                child,
+                x: 0.0,
+                y: 0.0,
+            });
+            Box::new(BlockPageable::new(children))
+        }
+        _ => child,
+    }
+}
+```
+
+Call this at the end of `convert_node`:
+
+```rust
+let result = /* existing conversion logic */;
+maybe_prepend_string_set(node_id, result, ctx)
+```
+
+**Step 3: Run tests**
+
+```bash
+cargo test -p fulgur --lib
+```
+
+Expected: All tests pass. No behavior change when `string_set_by_node` is empty.
+
+**Step 4: Commit**
+
+```bash
+git add crates/fulgur/src/convert.rs
+git commit -m "feat(gcpm): insert StringSetPageable markers during convert"
+```
+
+---
+
+## Task 6: Paginate — collect per-page string states
+
+**Files:**
+
+- Modify: `crates/fulgur/src/paginate.rs`
+
+**Step 1: Add StringSetPageState type**
+
+```rust
+use std::collections::BTreeMap;
+use crate::pageable::StringSetPageable;
+
+/// Per-page state for a named string.
+#[derive(Debug, Clone, Default)]
+pub struct StringSetPageState {
+    /// Value at start of page (carried from previous page's `last`).
+    pub start: Option<String>,
+    /// First value set on this page.
+    pub first: Option<String>,
+    /// Last value set on this page.
+    pub last: Option<String>,
+}
+```
+
+**Step 2: Write tests**
+
+```rust
+#[cfg(test)]
+mod string_set_tests {
+    use super::*;
+    use crate::pageable::{BlockPageable, SpacerPageable, StringSetPageable, PositionedChild};
+
+    fn make_spacer(h: Pt) -> Box<dyn Pageable> {
+        let mut s = SpacerPageable::new(h);
+        s.wrap(100.0, 1000.0);
+        Box::new(s)
+    }
+
+    fn make_marker(name: &str, value: &str) -> Box<dyn Pageable> {
+        Box::new(StringSetPageable::new(name.to_string(), value.to_string()))
+    }
+
+    #[test]
+    fn test_collect_string_sets_single_page() {
+        // marker("title", "Ch1") + spacer(50)
+        let block = BlockPageable::new(vec![
+            PositionedChild { child: make_marker("title", "Ch1"), x: 0.0, y: 0.0 },
+            PositionedChild { child: make_spacer(50.0), x: 0.0, y: 0.0 },
+        ]);
+        let pages = paginate(Box::new(block), 100.0, 200.0);
+        let states = collect_string_set_states(&pages);
+        assert_eq!(states.len(), 1);
+        let page_state = &states[0]["title"];
+        assert_eq!(page_state.start, None);
+        assert_eq!(page_state.first, Some("Ch1".to_string()));
+        assert_eq!(page_state.last, Some("Ch1".to_string()));
+    }
+
+    #[test]
+    fn test_collect_string_sets_across_pages() {
+        // Page 1: marker("title", "Ch1") + spacer(150)
+        // Page 2: marker("title", "Ch2") + spacer(50)
+        let block = BlockPageable::new(vec![
+            PositionedChild { child: make_marker("title", "Ch1"), x: 0.0, y: 0.0 },
+            PositionedChild { child: make_spacer(150.0), x: 0.0, y: 0.0 },
+            PositionedChild { child: make_marker("title", "Ch2"), x: 0.0, y: 0.0 },
+            PositionedChild { child: make_spacer(50.0), x: 0.0, y: 0.0 },
+        ]);
+        let pages = paginate(Box::new(block), 100.0, 100.0);
+        let states = collect_string_set_states(&pages);
+        // Page 2 should have start = "Ch1" (from page 1's last)
+        assert!(states.len() >= 2);
+        let p2 = &states[1]["title"];
+        assert_eq!(p2.start, Some("Ch1".to_string()));
+    }
+
+    #[test]
+    fn test_collect_string_sets_no_markers() {
+        let block = BlockPageable::new(vec![
+            PositionedChild { child: make_spacer(50.0), x: 0.0, y: 0.0 },
+        ]);
+        let pages = paginate(Box::new(block), 100.0, 200.0);
+        let states = collect_string_set_states(&pages);
+        assert_eq!(states.len(), 1);
+        assert!(states[0].is_empty());
+    }
+}
+```
+
+**Step 3: Implement collect_string_set_states**
+
+```rust
+/// Walk a paginated Pageable tree and collect StringSetPageable markers per page.
+pub fn collect_string_set_states(
+    pages: &[Box<dyn Pageable>],
+) -> Vec<BTreeMap<String, StringSetPageState>> {
+    let mut result: Vec<BTreeMap<String, StringSetPageState>> = Vec::with_capacity(pages.len());
+    // Track the last known value for each name across pages (for `start` field)
+    let mut carry: BTreeMap<String, String> = BTreeMap::new();
+
+    for page in pages {
+        let mut page_state: BTreeMap<String, StringSetPageState> = BTreeMap::new();
+
+        // Initialize start values from carry
+        for (name, value) in &carry {
+            page_state
+                .entry(name.clone())
+                .or_default()
+                .start = Some(value.clone());
+        }
+
+        // Collect markers from this page
+        let mut markers = Vec::new();
+        collect_markers(page.as_ref(), &mut markers);
+
+        for (name, value) in &markers {
+            let state = page_state.entry(name.clone()).or_default();
+            if state.first.is_none() {
+                state.first = Some(value.clone());
+            }
+            state.last = Some(value.clone());
+            // Update carry for next page
+            carry.insert(name.clone(), value.clone());
+        }
+
+        result.push(page_state);
+    }
+
+    result
+}
+
+/// Recursively find all StringSetPageable markers in a Pageable tree.
+fn collect_markers(pageable: &dyn Pageable, markers: &mut Vec<(String, String)>) {
+    if let Some(marker) = pageable.as_any().downcast_ref::<StringSetPageable>() {
+        markers.push((marker.name.clone(), marker.value.clone()));
+        return;
+    }
+    if let Some(block) = pageable.as_any().downcast_ref::<BlockPageable>() {
+        for child in &block.children {
+            collect_markers(child.child.as_ref(), markers);
+        }
+    }
+    // Also check TablePageable, ListItemPageable if needed
+    if let Some(table) = pageable.as_any().downcast_ref::<TablePageable>() {
+        for child in &table.header_cells {
+            collect_markers(child.child.as_ref(), markers);
+        }
+        for child in &table.body_cells {
+            collect_markers(child.child.as_ref(), markers);
+        }
+    }
+    if let Some(list_item) = pageable.as_any().downcast_ref::<ListItemPageable>() {
+        collect_markers(list_item.body.as_ref(), markers);
+    }
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+cargo test -p fulgur --lib paginate
+```
+
+Expected: All tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add crates/fulgur/src/paginate.rs
+git commit -m "feat(gcpm): collect per-page string-set states during pagination"
+```
+
+---
+
+## Task 7: Counter resolution — resolve string() references
+
+**Files:**
+
+- Modify: `crates/fulgur/src/gcpm/counter.rs`
+
+**Step 1: Write tests**
+
+Add to `mod tests` in counter.rs:
+
+```rust
+#[test]
+fn test_resolve_string_ref_first() {
+    let items = vec![ContentItem::StringRef {
+        name: "title".to_string(),
+        policy: StringPolicy::First,
+    }];
+    let state = {
+        let mut m = BTreeMap::new();
+        m.insert("title".to_string(), StringSetPageState {
+            start: Some("Previous".to_string()),
+            first: Some("Current".to_string()),
+            last: Some("Current".to_string()),
+        });
+        m
+    };
+    assert_eq!(
+        resolve_content_to_html(&items, &[], &state, 1, 1),
+        "Current"
+    );
+}
+
+#[test]
+fn test_resolve_string_ref_first_falls_back_to_start() {
+    let items = vec![ContentItem::StringRef {
+        name: "title".to_string(),
+        policy: StringPolicy::First,
+    }];
+    let state = {
+        let mut m = BTreeMap::new();
+        m.insert("title".to_string(), StringSetPageState {
+            start: Some("Inherited".to_string()),
+            first: None,
+            last: None,
+        });
+        m
+    };
+    assert_eq!(
+        resolve_content_to_html(&items, &[], &state, 1, 1),
+        "Inherited"
+    );
+}
+
+#[test]
+fn test_resolve_string_ref_start() {
+    let items = vec![ContentItem::StringRef {
+        name: "title".to_string(),
+        policy: StringPolicy::Start,
+    }];
+    let state = {
+        let mut m = BTreeMap::new();
+        m.insert("title".to_string(), StringSetPageState {
+            start: Some("Start Value".to_string()),
+            first: Some("First Value".to_string()),
+            last: Some("Last Value".to_string()),
+        });
+        m
+    };
+    assert_eq!(
+        resolve_content_to_html(&items, &[], &state, 1, 1),
+        "Start Value"
+    );
+}
+
+#[test]
+fn test_resolve_string_ref_last() {
+    let items = vec![ContentItem::StringRef {
+        name: "title".to_string(),
+        policy: StringPolicy::Last,
+    }];
+    let state = {
+        let mut m = BTreeMap::new();
+        m.insert("title".to_string(), StringSetPageState {
+            start: None,
+            first: Some("First".to_string()),
+            last: Some("Last".to_string()),
+        });
+        m
+    };
+    assert_eq!(
+        resolve_content_to_html(&items, &[], &state, 1, 1),
+        "Last"
+    );
+}
+
+#[test]
+fn test_resolve_string_ref_first_except_on_set_page() {
+    let items = vec![ContentItem::StringRef {
+        name: "title".to_string(),
+        policy: StringPolicy::FirstExcept,
+    }];
+    let state = {
+        let mut m = BTreeMap::new();
+        m.insert("title".to_string(), StringSetPageState {
+            start: Some("Old".to_string()),
+            first: Some("New".to_string()),
+            last: Some("New".to_string()),
+        });
+        m
+    };
+    // first-except: empty on pages where string is set
+    assert_eq!(
+        resolve_content_to_html(&items, &[], &state, 1, 1),
+        ""
+    );
+}
+
+#[test]
+fn test_resolve_string_ref_first_except_on_no_set_page() {
+    let items = vec![ContentItem::StringRef {
+        name: "title".to_string(),
+        policy: StringPolicy::FirstExcept,
+    }];
+    let state = {
+        let mut m = BTreeMap::new();
+        m.insert("title".to_string(), StringSetPageState {
+            start: Some("Inherited".to_string()),
+            first: None,
+            last: None,
+        });
+        m
+    };
+    // first-except: same as first when not set on this page
+    assert_eq!(
+        resolve_content_to_html(&items, &[], &state, 1, 1),
+        "Inherited"
+    );
+}
+
+#[test]
+fn test_resolve_string_ref_unknown_name() {
+    let items = vec![ContentItem::StringRef {
+        name: "nonexistent".to_string(),
+        policy: StringPolicy::First,
+    }];
+    let state = BTreeMap::new();
+    assert_eq!(
+        resolve_content_to_html(&items, &[], &state, 1, 1),
+        ""
+    );
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+```bash
+cargo test -p fulgur --lib gcpm::counter::tests
+```
+
+Expected: Compilation error.
+
+**Step 3: Update resolve functions**
+
+Add the `string_set_states` parameter to `resolve_content_to_html` and `resolve_content_to_string`:
+
+```rust
+use super::{ContentItem, CounterType, StringPolicy};
+use crate::paginate::StringSetPageState;
+use std::collections::BTreeMap;
+
+pub fn resolve_content_to_string(
+    items: &[ContentItem],
+    string_set_states: &BTreeMap<String, StringSetPageState>,
+    page: usize,
+    total_pages: usize,
+) -> String {
+    let mut out = String::new();
+    for item in items {
+        match item {
+            ContentItem::String(s) => out.push_str(s),
+            ContentItem::Counter(CounterType::Page) => out.push_str(&page.to_string()),
+            ContentItem::Counter(CounterType::Pages) => out.push_str(&total_pages.to_string()),
+            ContentItem::Element(_) => {}
+            ContentItem::StringRef { name, policy } => {
+                if let Some(state) = string_set_states.get(name) {
+                    out.push_str(&resolve_string_policy(state, *policy));
+                }
+            }
+        }
+    }
+    out
+}
+
+pub fn resolve_content_to_html(
+    items: &[ContentItem],
+    running_elements: &[(String, String)],
+    string_set_states: &BTreeMap<String, StringSetPageState>,
+    page: usize,
+    total_pages: usize,
+) -> String {
+    let mut out = String::new();
+    for item in items {
+        match item {
+            ContentItem::String(s) => out.push_str(s),
+            ContentItem::Counter(CounterType::Page) => out.push_str(&page.to_string()),
+            ContentItem::Counter(CounterType::Pages) => out.push_str(&total_pages.to_string()),
+            ContentItem::Element(name) => {
+                if let Some((_, html)) = running_elements.iter().find(|(n, _)| n == name) {
+                    out.push_str(html);
+                }
+            }
+            ContentItem::StringRef { name, policy } => {
+                if let Some(state) = string_set_states.get(name) {
+                    out.push_str(&resolve_string_policy(state, *policy));
+                }
+            }
+        }
+    }
+    out
+}
+
+fn resolve_string_policy(state: &StringSetPageState, policy: StringPolicy) -> String {
+    match policy {
+        StringPolicy::Start => state.start.clone().unwrap_or_default(),
+        StringPolicy::First => state
+            .first
+            .clone()
+            .or_else(|| state.start.clone())
+            .unwrap_or_default(),
+        StringPolicy::Last => state
+            .last
+            .clone()
+            .or_else(|| state.first.clone())
+            .or_else(|| state.start.clone())
+            .unwrap_or_default(),
+        StringPolicy::FirstExcept => {
+            if state.first.is_some() {
+                // On pages where string is set, return empty
+                String::new()
+            } else {
+                // Same as First when not set on this page
+                state.start.clone().unwrap_or_default()
+            }
+        }
+    }
+}
+```
+
+**Step 4: Update existing tests to pass new parameter**
+
+Add `&BTreeMap::new()` to all existing `resolve_content_to_string` and `resolve_content_to_html` calls in the existing tests.
+
+**Step 5: Run tests**
+
+```bash
+cargo test -p fulgur --lib gcpm::counter::tests
+```
+
+Expected: All tests pass.
+
+**Step 6: Commit**
+
+```bash
+git add crates/fulgur/src/gcpm/counter.rs
+git commit -m "feat(gcpm): resolve string() references in content"
+```
+
+---
+
+## Task 8: Render — wire string-set states into margin box rendering
+
+**Files:**
+
+- Modify: `crates/fulgur/src/render.rs`
+
+**Step 1: Update render_to_pdf_with_gcpm**
+
+After pagination in Pass 1, collect string-set states:
+
+```rust
+let pages = paginate(root, content_width, content_height);
+let total_pages = pages.len();
+let string_set_states = crate::paginate::collect_string_set_states(&pages);
+```
+
+In Pass 2, pass the per-page state to `resolve_content_to_html`:
+
+```rust
+let page_string_state = &string_set_states[page_idx];
+let content_html = resolve_content_to_html(
+    &rule.content,
+    &running_pairs,
+    page_string_state,
+    page_num,
+    total_pages,
+);
+```
+
+**Step 2: Fix compilation errors**
+
+Update all call sites of `resolve_content_to_string` and `resolve_content_to_html` in render.rs to include the new parameter.
+
+**Step 3: Run tests**
+
+```bash
+cargo test -p fulgur --lib
+```
+
+Expected: All tests pass.
+
+**Step 4: Commit**
+
+```bash
+git add crates/fulgur/src/render.rs
+git commit -m "feat(gcpm): wire string-set states into margin box rendering"
+```
+
+---
+
+## Task 9: Engine — wire StringSetPass into pipeline
+
+**Files:**
+
+- Modify: `crates/fulgur/src/engine.rs`
+
+**Step 1: Add StringSetPass to render_html pipeline**
+
+After `RunningElementPass`, add `StringSetPass`:
+
+```rust
+use crate::blitz_adapter::StringSetPass;
+use crate::gcpm::string_set::StringSetStore;
+
+// Extract string-set values via DomPass (before resolve, after running elements)
+let string_set_store = if !gcpm.string_set_mappings.is_empty() {
+    let pass = StringSetPass::new(gcpm.clone());
+    pass.apply(&mut doc, &ctx);
+    pass.into_store()
+} else {
+    StringSetStore::new()
+};
+```
+
+Pass string_set_store to ConvertContext:
+
+```rust
+let mut convert_ctx = ConvertContext {
+    running_store: &mut running_store,
+    assets: self.assets.as_ref(),
+    font_cache: HashMap::new(),
+    string_set_by_node: build_string_set_by_node(&string_set_store),
+};
+```
+
+Add helper:
+
+```rust
+fn build_string_set_by_node(
+    store: &StringSetStore,
+) -> HashMap<usize, Vec<(String, String)>> {
+    let mut map: HashMap<usize, Vec<(String, String)>> = HashMap::new();
+    for entry in store.entries() {
+        map.entry(entry.node_id)
+            .or_default()
+            .push((entry.name.clone(), entry.value.clone()));
+    }
+    map
+}
+```
+
+**Step 2: Update GcpmContext.is_empty() usage**
+
+The condition `if gcpm.is_empty()` now also checks `string_set_mappings`, which is correct — if there are string-set mappings but no margin boxes, we still need the 2-pass rendering.
+
+Actually, review: string-set mappings alone without margin boxes using `string()` would be a no-op. The `is_empty()` check is fine as-is since string-set mappings only make sense when margin boxes exist.
+
+**Step 3: Run tests**
+
+```bash
+cargo test -p fulgur --lib
+```
+
+Expected: All tests pass.
+
+**Step 4: Commit**
+
+```bash
+git add crates/fulgur/src/engine.rs
+git commit -m "feat(gcpm): wire StringSetPass into engine pipeline"
+```
+
+---
+
+## Task 10: Integration test
+
+**Files:**
+
+- Modify: `crates/fulgur/tests/gcpm_integration.rs`
+
+**Step 1: Add integration test**
+
+```rust
+#[test]
+fn test_gcpm_string_set_chapter_title() {
+    let css = r#"
+        h1 { string-set: chapter-title content(text); }
+        @page {
+            @top-center { content: string(chapter-title); }
+            @bottom-center { content: "Page " counter(page) " of " counter(pages); }
+        }
+    "#;
+
+    let mut paragraphs = String::new();
+    for i in 0..3 {
+        paragraphs.push_str(&format!(
+            "<h1>Chapter {}</h1>\n<p>Content for chapter {}. This paragraph has enough text to take some space on the page.</p>\n",
+            i + 1, i + 1
+        ));
+        for j in 0..20 {
+            paragraphs.push_str(&format!(
+                "<p>Paragraph {} of chapter {}.</p>\n",
+                j + 1, i + 1
+            ));
+        }
+    }
+
+    let html = format!(
+        r#"<!DOCTYPE html>
+<html>
+<head></head>
+<body>
+{}
+</body>
+</html>"#,
+        paragraphs
+    );
+
+    let mut assets = AssetBundle::new();
+    assets.add_css(css);
+
+    let engine = Engine::builder().assets(assets).build();
+    let pdf = engine.render_html(&html).unwrap();
+
+    assert!(!pdf.is_empty(), "PDF output should not be empty");
+    assert!(
+        pdf.starts_with(b"%PDF-"),
+        "PDF output should start with %PDF-"
+    );
+}
+
+#[test]
+fn test_gcpm_string_set_with_attr() {
+    let css = r#"
+        h1 { string-set: title attr(data-title); }
+        @page {
+            @top-left { content: string(title); }
+        }
+    "#;
+
+    let html = r#"<!DOCTYPE html>
+<html>
+<head></head>
+<body>
+  <h1 data-title="Custom Title">Visible Heading</h1>
+  <p>Some body content.</p>
+</body>
+</html>"#;
+
+    let mut assets = AssetBundle::new();
+    assets.add_css(css);
+
+    let engine = Engine::builder().assets(assets).build();
+    let pdf = engine.render_html(html).unwrap();
+
+    assert!(!pdf.is_empty());
+    assert!(pdf.starts_with(b"%PDF-"));
+}
+
+#[test]
+fn test_gcpm_string_set_with_literal_concat() {
+    let css = r#"
+        h1 { string-set: header "Section: " content(text); }
+        @page {
+            @top-center { content: string(header); }
+        }
+    "#;
+
+    let html = r#"<!DOCTYPE html>
+<html>
+<head></head>
+<body>
+  <h1>Introduction</h1>
+  <p>Body text.</p>
+</body>
+</html>"#;
+
+    let mut assets = AssetBundle::new();
+    assets.add_css(css);
+
+    let engine = Engine::builder().assets(assets).build();
+    let pdf = engine.render_html(html).unwrap();
+
+    assert!(!pdf.is_empty());
+    assert!(pdf.starts_with(b"%PDF-"));
+}
+
+#[test]
+fn test_gcpm_string_set_with_policies() {
+    let css = r#"
+        h2 { string-set: section content(text); }
+        @page {
+            @top-left { content: string(section, start); }
+            @top-right { content: string(section, last); }
+        }
+    "#;
+
+    let mut body = String::new();
+    for i in 0..30 {
+        body.push_str(&format!("<h2>Section {}</h2>\n<p>Content.</p>\n", i + 1));
+    }
+
+    let html = format!(
+        r#"<!DOCTYPE html>
+<html><head></head><body>{}</body></html>"#,
+        body
+    );
+
+    let mut assets = AssetBundle::new();
+    assets.add_css(css);
+
+    let engine = Engine::builder().assets(assets).build();
+    let pdf = engine.render_html(&html).unwrap();
+
+    assert!(!pdf.is_empty());
+    assert!(pdf.starts_with(b"%PDF-"));
+}
+```
+
+**Step 2: Run integration tests**
+
+```bash
+cargo test -p fulgur --test gcpm_integration -- --test-threads=1
+```
+
+Expected: All tests pass (including existing ones).
+
+**Step 3: Commit**
+
+```bash
+git add crates/fulgur/tests/gcpm_integration.rs
+git commit -m "test(gcpm): add integration tests for string-set/string()"
+```
+
+---
+
+## Task 11: Final verification
+
+**Step 1: Run full test suite**
+
+```bash
+cargo test -p fulgur --lib
+cargo test -p fulgur --test gcpm_integration -- --test-threads=1
+```
+
+**Step 2: Run clippy and fmt**
+
+```bash
+cargo clippy
+cargo fmt --check
+```
+
+**Step 3: Fix any issues found**
+
+**Step 4: Final commit if needed**
+
+```bash
+git add -A
+git commit -m "chore: fix clippy warnings and formatting"
+```


### PR DESCRIPTION
## Summary

Implements CSS Generated Content for Paged Media (GCPM) **Named Strings** — `string-set` property and `string()` function — for dynamic page headers/footers (e.g. auto-updating chapter titles).

Closes fulgur-rgc.

## Features

- **`string-set`** CSS property on any element, with all value types:
  - `content(text)` — element text content
  - `content(before)` / `content(after)` — parsed but currently no-op (requires Stylo pseudo-element computed styles)
  - `attr(<name>)` — HTML attribute value
  - Literal strings (`\"...\"`) and concatenation of the above
- **`string(<name>, <policy>)`** function in `@page` margin boxes, with all 4 CSS policies:
  - `first` (default) — first value set on the page, falls back to `start`
  - `start` — value inherited from previous page
  - `last` — last value set on the page
  - `first-except` — `first`, but empty on pages where the string is assigned
- Selector support matches running elements: class, ID, tag (simple selectors only)

## Architecture

3-stage pipeline building on the existing GCPM infrastructure:

```text
DOM walk (StringSetPass) → convert (marker insertion) → paginate (per-page state) → render (resolve)
```

1. `StringSetPass` walks the DOM and extracts text values, keyed by node ID
2. `convert` inserts zero-size `StringSetPageable` markers into the Pageable tree at matched nodes
3. `paginate::collect_string_set_states` walks paginated pages and builds per-page `(start, first, last)` state
4. `render` resolves `string()` references against the per-page state when building margin box content

## Test plan

- [x] 7 parser unit tests (string-set value variants, all 4 policies, hyphenated \`first-except\`)
- [x] StringSetStore unit tests
- [x] StringSetPageable unit tests (zero-size, no-split)
- [x] 4 paginate unit tests (single page, cross-page start inheritance, multiple names, empty case)
- [x] 7 counter resolution unit tests (each policy + fallbacks + unknown name)
- [x] 4 integration tests (chapter title across pages, attr(), literal concat, start/last policies)
- [x] 161 lib tests + 15 integration tests pass
- [x] \`cargo fmt\` / \`cargo clippy\` clean

## Notes

- Non-trivial parser detail: cssparser may tokenize `first-except` as `first` + `-` + `except` depending on context. \`parse_string_policy\` handles both forms defensively.
- \`RunningElementPass\` was also refactored to take only \`Vec<RunningMapping>\` instead of cloning the full \`GcpmContext\` — a small incidental improvement.
- A shared implementation plan was committed to \`docs/plans/\` following the project convention.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * CSSの string-set とページマージンでの string() をサポート（start/first/last/first-except ポリシー対応）。
  * マージン出力にページ単位の文字列マーカーを埋め込み、レンダリング結果に反映。

* **改善**
  * ページ別の文字列参照選択と伝播を正確に処理。
  * テキスト抽出で空白を正規化し、マージン内でのHTML挿入時に安全にエスケープ。

* **テスト**
  * 複数の string-set／string() 統合テストを追加。

* **ドキュメント**
  * 実装計画ドキュメントを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->