### PR TITLE
feat(gcpm): element() 4-policy support (first/start/last/first-except)

### DIFF
--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -364,7 +364,9 @@ impl RunningElementPass {
             }
             if let Some(running_name) = self.find_running_name(elem) {
                 let html = serialize_node(doc, node_id);
-                self.store.borrow_mut().register(running_name, html);
+                self.store
+                    .borrow_mut()
+                    .register(node_id, running_name, html);
                 // Running elements are removed from flow — don't recurse.
                 return;
             }
@@ -568,11 +570,13 @@ mod tests {
         pass.apply(&mut doc, &ctx);
 
         let store = pass.into_running_store();
-        assert!(
-            store.get("pageHeader").is_some(),
-            "Expected running element 'pageHeader' to be extracted"
+        assert_eq!(
+            store.instance_count(),
+            1,
+            "Expected exactly one running element instance to be registered"
         );
-        let html_content = store.get("pageHeader").unwrap();
+        assert_eq!(store.name_of(0), Some("pageHeader"));
+        let html_content = store.get_html(0).unwrap();
         assert!(
             html_content.contains("Header Content"),
             "Expected serialized HTML to contain 'Header Content', got: {html_content}"
@@ -606,8 +610,9 @@ mod tests {
         pass.apply(&mut doc, &ctx);
 
         let store = pass.into_running_store();
-        assert!(store.get("pageTitle").is_some());
-        assert!(store.get("pageTitle").unwrap().contains("Doc Title"));
+        assert_eq!(store.instance_count(), 1);
+        assert_eq!(store.name_of(0), Some("pageTitle"));
+        assert!(store.get_html(0).unwrap().contains("Doc Title"));
     }
 
     #[test]
@@ -631,7 +636,7 @@ mod tests {
         pass.apply(&mut doc, &ctx);
 
         let store = pass.into_running_store();
-        assert!(store.get("anything").is_none());
+        assert_eq!(store.instance_count(), 0);
     }
 
     #[test]
@@ -660,8 +665,9 @@ mod tests {
         pass.apply(&mut doc, &ctx);
 
         let store = pass.into_running_store();
-        assert!(
-            store.get("shouldNotMatch").is_none(),
+        assert_eq!(
+            store.instance_count(),
+            0,
             "Elements inside <head> (like <style>) should not be matched as running elements"
         );
     }

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -5,8 +5,9 @@ use crate::gcpm::running::RunningElementStore;
 use crate::image::ImagePageable;
 use crate::pageable::{
     BackgroundLayer, BgBox, BgClip, BgLengthPercentage, BgRepeat, BgSize, BlockPageable,
-    BlockStyle, BorderStyleValue, ListItemPageable, Pageable, PositionedChild, Size,
-    SpacerPageable, StringSetPageable, StringSetWrapperPageable, TablePageable,
+    BlockStyle, BorderStyleValue, ListItemPageable, Pageable, PositionedChild,
+    RunningElementMarkerPageable, Size, SpacerPageable, StringSetPageable,
+    StringSetWrapperPageable, TablePageable,
 };
 use crate::paragraph::{
     ParagraphPageable, ShapedGlyph, ShapedGlyphRun, ShapedLine, TextDecoration, TextDecorationLine,
@@ -20,7 +21,7 @@ use std::sync::Arc;
 
 /// Context for DOM-to-Pageable conversion, bundling all shared state.
 pub struct ConvertContext<'a> {
-    pub running_store: &'a mut RunningElementStore,
+    pub running_store: &'a RunningElementStore,
     pub assets: Option<&'a AssetBundle>,
     /// Cache font data by (data pointer address, font index) to avoid redundant .to_vec() copies.
     pub(crate) font_cache: HashMap<(usize, u32), Arc<Vec<u8>>>,
@@ -144,6 +145,35 @@ fn emit_orphan_string_set_markers(
                 y,
             });
         }
+    }
+}
+
+/// Emit a `RunningElementMarkerPageable` when a zero-size node corresponds to
+/// a running element instance registered by `RunningElementPass`.
+///
+/// Running elements are rewritten to `display: none` by the GCPM parser,
+/// which means they land in the zero-size branches of
+/// `collect_positioned_children`. This helper preserves their source
+/// position in the Pageable tree as a zero-size marker so pagination can
+/// determine which running element instances fall on which page.
+fn emit_orphan_running_marker(
+    node_id: usize,
+    x: f32,
+    y: f32,
+    ctx: &ConvertContext<'_>,
+    out: &mut Vec<PositionedChild>,
+) {
+    if let Some(instance_id) = ctx.running_store.instance_for_node(node_id)
+        && let Some(name) = ctx.running_store.name_of(instance_id)
+    {
+        out.push(PositionedChild {
+            child: Box::new(RunningElementMarkerPageable::new(
+                name.to_string(),
+                instance_id,
+            )),
+            x,
+            y,
+        });
     }
 }
 
@@ -335,6 +365,13 @@ fn collect_positioned_children(
                 ctx,
                 &mut result,
             );
+            emit_orphan_running_marker(
+                child_id,
+                child_layout.location.x,
+                child_layout.location.y,
+                ctx,
+                &mut result,
+            );
             continue;
         }
 
@@ -346,6 +383,13 @@ fn collect_positioned_children(
             && !child_node.children.is_empty()
         {
             emit_orphan_string_set_markers(
+                child_id,
+                child_layout.location.x,
+                child_layout.location.y,
+                ctx,
+                &mut result,
+            );
+            emit_orphan_running_marker(
                 child_id,
                 child_layout.location.x,
                 child_layout.location.y,

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -177,6 +177,20 @@ fn emit_orphan_running_marker(
     }
 }
 
+/// Emit both string-set and running-element orphan markers for a zero-size
+/// node. They must always be emitted together because either marker kind may
+/// attach to the same source position.
+fn emit_orphan_markers(
+    node_id: usize,
+    x: f32,
+    y: f32,
+    ctx: &mut ConvertContext<'_>,
+    out: &mut Vec<PositionedChild>,
+) {
+    emit_orphan_string_set_markers(node_id, x, y, ctx, out);
+    emit_orphan_running_marker(node_id, x, y, ctx, out);
+}
+
 fn convert_node_inner(
     doc: &blitz_dom::BaseDocument,
     node_id: usize,
@@ -358,14 +372,7 @@ fn collect_positioned_children(
             && child_layout.size.width == 0.0
             && child_node.children.is_empty()
         {
-            emit_orphan_string_set_markers(
-                child_id,
-                child_layout.location.x,
-                child_layout.location.y,
-                ctx,
-                &mut result,
-            );
-            emit_orphan_running_marker(
+            emit_orphan_markers(
                 child_id,
                 child_layout.location.x,
                 child_layout.location.y,
@@ -382,14 +389,7 @@ fn collect_positioned_children(
             && child_layout.size.width == 0.0
             && !child_node.children.is_empty()
         {
-            emit_orphan_string_set_markers(
-                child_id,
-                child_layout.location.x,
-                child_layout.location.y,
-                ctx,
-                &mut result,
-            );
-            emit_orphan_running_marker(
+            emit_orphan_markers(
                 child_id,
                 child_layout.location.x,
                 child_layout.location.y,

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -6,8 +6,8 @@ use crate::image::ImagePageable;
 use crate::pageable::{
     BackgroundLayer, BgBox, BgClip, BgLengthPercentage, BgRepeat, BgSize, BlockPageable,
     BlockStyle, BorderStyleValue, ListItemPageable, Pageable, PositionedChild,
-    RunningElementMarkerPageable, Size, SpacerPageable, StringSetPageable,
-    StringSetWrapperPageable, TablePageable,
+    RunningElementMarkerPageable, RunningElementWrapperPageable, Size, SpacerPageable,
+    StringSetPageable, StringSetWrapperPageable, TablePageable,
 };
 use crate::paragraph::{
     ParagraphPageable, ShapedGlyph, ShapedGlyphRun, ShapedLine, TextDecoration, TextDecorationLine,
@@ -148,47 +148,26 @@ fn emit_orphan_string_set_markers(
     }
 }
 
-/// Emit a `RunningElementMarkerPageable` when a zero-size node corresponds to
-/// a running element instance registered by `RunningElementPass`.
+/// If `node_id` corresponds to a running element instance registered by
+/// `RunningElementPass`, return a fresh `RunningElementMarkerPageable` for it.
 ///
-/// Running elements are rewritten to `display: none` by the GCPM parser,
-/// which means they land in the zero-size branches of
-/// `collect_positioned_children`. This helper preserves their source
-/// position in the Pageable tree as a zero-size marker so pagination can
-/// determine which running element instances fall on which page.
-fn emit_orphan_running_marker(
+/// Running elements are rewritten to `display: none` by the GCPM parser, so
+/// their DOM nodes land in the zero-size branches of
+/// `collect_positioned_children`. Instead of pushing the marker directly into
+/// the parent's child list, the caller buffers it and attaches it to the
+/// following real child via `RunningElementWrapperPageable` — otherwise the
+/// marker could be stranded on the previous page when the following child
+/// overflows to the next page.
+fn take_running_marker(
     node_id: usize,
-    x: f32,
-    y: f32,
     ctx: &ConvertContext<'_>,
-    out: &mut Vec<PositionedChild>,
-) {
-    if let Some(instance_id) = ctx.running_store.instance_for_node(node_id)
-        && let Some(name) = ctx.running_store.name_of(instance_id)
-    {
-        out.push(PositionedChild {
-            child: Box::new(RunningElementMarkerPageable::new(
-                name.to_string(),
-                instance_id,
-            )),
-            x,
-            y,
-        });
-    }
-}
-
-/// Emit both string-set and running-element orphan markers for a zero-size
-/// node. They must always be emitted together because either marker kind may
-/// attach to the same source position.
-fn emit_orphan_markers(
-    node_id: usize,
-    x: f32,
-    y: f32,
-    ctx: &mut ConvertContext<'_>,
-    out: &mut Vec<PositionedChild>,
-) {
-    emit_orphan_string_set_markers(node_id, x, y, ctx, out);
-    emit_orphan_running_marker(node_id, x, y, ctx, out);
+) -> Option<RunningElementMarkerPageable> {
+    let instance_id = ctx.running_store.instance_for_node(node_id)?;
+    let name = ctx.running_store.name_of(instance_id)?;
+    Some(RunningElementMarkerPageable::new(
+        name.to_string(),
+        instance_id,
+    ))
 }
 
 fn convert_node_inner(
@@ -345,12 +324,19 @@ fn convert_node_inner(
 
 /// Collect positioned children, flattening zero-size pass-through containers
 /// (like thead, tbody, tr) so their children appear directly in the parent.
+///
+/// Running element markers discovered on zero-size nodes are buffered and
+/// attached to the next real child via `RunningElementWrapperPageable`. This
+/// keeps the marker with its associated content when pagination pushes the
+/// content to the next page.
 fn collect_positioned_children(
     doc: &blitz_dom::BaseDocument,
     child_ids: &[usize],
     ctx: &mut ConvertContext<'_>,
 ) -> Vec<PositionedChild> {
     let mut result = Vec::new();
+    let mut pending_running_markers: Vec<RunningElementMarkerPageable> = Vec::new();
+
     for &child_id in child_ids {
         let Some(child_node) = doc.get_node(child_id) else {
             continue;
@@ -372,13 +358,16 @@ fn collect_positioned_children(
             && child_layout.size.width == 0.0
             && child_node.children.is_empty()
         {
-            emit_orphan_markers(
+            emit_orphan_string_set_markers(
                 child_id,
                 child_layout.location.x,
                 child_layout.location.y,
                 ctx,
                 &mut result,
             );
+            if let Some(marker) = take_running_marker(child_id, ctx) {
+                pending_running_markers.push(marker);
+            }
             continue;
         }
 
@@ -389,25 +378,46 @@ fn collect_positioned_children(
             && child_layout.size.width == 0.0
             && !child_node.children.is_empty()
         {
-            emit_orphan_markers(
+            emit_orphan_string_set_markers(
                 child_id,
                 child_layout.location.x,
                 child_layout.location.y,
                 ctx,
                 &mut result,
             );
+            if let Some(marker) = take_running_marker(child_id, ctx) {
+                pending_running_markers.push(marker);
+            }
             let nested = collect_positioned_children(doc, &child_node.children, ctx);
             result.extend(nested);
             continue;
         }
 
-        let child_pageable = convert_node(doc, child_id, ctx);
+        let mut child_pageable = convert_node(doc, child_id, ctx);
+        if !pending_running_markers.is_empty() {
+            child_pageable = Box::new(RunningElementWrapperPageable::new(
+                std::mem::take(&mut pending_running_markers),
+                child_pageable,
+            ));
+        }
         result.push(PositionedChild {
             child: child_pageable,
             x: child_layout.location.x,
             y: child_layout.location.y,
         });
     }
+
+    // Running markers with no subsequent real child — emit as bare
+    // PositionedChild fallback so they aren't lost entirely. This covers the
+    // edge case of a running element at the very end of a parent.
+    for marker in pending_running_markers {
+        result.push(PositionedChild {
+            child: Box::new(marker),
+            x: 0.0,
+            y: 0.0,
+        });
+    }
+
     result
 }
 

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -388,7 +388,24 @@ fn collect_positioned_children(
             if let Some(marker) = take_running_marker(child_id, ctx) {
                 pending_running_markers.push(marker);
             }
-            let nested = collect_positioned_children(doc, &child_node.children, ctx);
+            let mut nested = collect_positioned_children(doc, &child_node.children, ctx);
+            // Flush pending running markers to the first real nested child so
+            // they travel with the flattened content on page break. Without
+            // this, the markers would skip over the container's children and
+            // incorrectly attach to the next outer sibling.
+            if !pending_running_markers.is_empty()
+                && let Some(first) = nested.first_mut()
+            {
+                let original = std::mem::replace(
+                    &mut first.child,
+                    // Temporary placeholder; overwritten below.
+                    Box::new(SpacerPageable::new(0.0)),
+                );
+                first.child = Box::new(RunningElementWrapperPageable::new(
+                    std::mem::take(&mut pending_running_markers),
+                    original,
+                ));
+            }
             result.extend(nested);
             continue;
         }

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -93,7 +93,7 @@ impl Engine {
         crate::blitz_adapter::apply_passes(&mut doc, &passes, &ctx);
 
         // Extract running elements via DomPass (before resolve)
-        let mut running_store = if !gcpm.running_mappings.is_empty() {
+        let running_store = if !gcpm.running_mappings.is_empty() {
             let pass = crate::blitz_adapter::RunningElementPass::new(gcpm.running_mappings.clone());
             pass.apply(&mut doc, &ctx);
             pass.into_running_store()
@@ -125,7 +125,7 @@ impl Engine {
         };
 
         let mut convert_ctx = ConvertContext {
-            running_store: &mut running_store,
+            running_store: &running_store,
             assets: self.assets.as_ref(),
             font_cache: HashMap::new(),
             string_set_by_node,

--- a/crates/fulgur/src/gcpm/counter.rs
+++ b/crates/fulgur/src/gcpm/counter.rs
@@ -118,7 +118,9 @@ fn resolve_string_policy(state: &StringSetPageState, policy: StringPolicy) -> &s
 /// running element instance for the given page (0-based `page_idx`).
 ///
 /// WeasyPrint-compatible semantics:
-/// - `first` / `start`: first instance assigned on the current page.
+/// - `first`: first instance assigned on the current page.
+/// - `start`: ignores current-page assignments and returns the last instance
+///   of the most recent preceding page (the value in effect at page start).
 /// - `last`: last instance assigned on the current page.
 /// - `first-except`: returns `None` if the current page has any assignment.
 /// - Fallback (any policy, no resolution on current page): the last instance

--- a/crates/fulgur/src/gcpm/counter.rs
+++ b/crates/fulgur/src/gcpm/counter.rs
@@ -1,5 +1,7 @@
 use super::{ContentItem, CounterType, StringPolicy};
-use crate::paginate::StringSetPageState;
+use crate::gcpm::running::RunningElementStore;
+use crate::gcpm::ElementPolicy;
+use crate::paginate::{PageRunningState, StringSetPageState};
 use std::collections::BTreeMap;
 
 /// Resolve content items to a plain string.
@@ -21,7 +23,7 @@ pub fn resolve_content_to_string(
             ContentItem::Counter(CounterType::Pages) => {
                 out.push_str(&total_pages.to_string());
             }
-            ContentItem::Element(_) => {}
+            ContentItem::Element { .. } => {}
             ContentItem::StringRef { name, policy } => {
                 if let Some(state) = string_set_states.get(name) {
                     out.push_str(resolve_string_policy(state, *policy));
@@ -34,29 +36,35 @@ pub fn resolve_content_to_string(
 
 /// Resolve content items to an HTML string.
 ///
-/// `Element(name)` references are looked up in `running_elements` (a `&[(name, html)]` slice)
-/// and the matching HTML is appended. `StringRef` values come from the DOM
-/// (via `string-set: content(text) | attr(...)`) and are HTML-escaped before
-/// concatenation so characters like `<` and `&` do not corrupt the margin box.
+/// `Element { name, policy }` references are resolved via the per-page
+/// running-element state and `RunningElementStore`, using the
+/// WeasyPrint-compatible policy rules (see `resolve_element_policy`).
+/// `StringRef` values come from the DOM (via `string-set: content(text) |
+/// attr(...)`) and are HTML-escaped before concatenation so characters like
+/// `<` and `&` do not corrupt the margin box.
 pub fn resolve_content_to_html(
     items: &[ContentItem],
-    running_elements: &[(String, String)],
+    store: &RunningElementStore,
+    running_states: &[BTreeMap<String, PageRunningState>],
     string_set_states: &BTreeMap<String, StringSetPageState>,
-    page: usize,
+    page_num: usize,
     total_pages: usize,
+    page_idx: usize,
 ) -> String {
     let mut out = String::new();
     for item in items {
         match item {
             ContentItem::String(s) => out.push_str(s),
             ContentItem::Counter(CounterType::Page) => {
-                out.push_str(&page.to_string());
+                out.push_str(&page_num.to_string());
             }
             ContentItem::Counter(CounterType::Pages) => {
                 out.push_str(&total_pages.to_string());
             }
-            ContentItem::Element(name) => {
-                if let Some((_, html)) = running_elements.iter().find(|(n, _)| n == name) {
+            ContentItem::Element { name, policy } => {
+                if let Some(html) =
+                    resolve_element_policy(name, *policy, page_idx, running_states, store)
+                {
                     out.push_str(html);
                 }
             }
@@ -106,6 +114,56 @@ fn resolve_string_policy(state: &StringSetPageState, policy: StringPolicy) -> &s
     }
 }
 
+/// Resolve an `element(name, policy)` reference to the HTML of the chosen
+/// running element instance for the given page (0-based `page_idx`).
+///
+/// WeasyPrint-compatible semantics:
+/// - `first` / `start`: first instance assigned on the current page.
+/// - `last`: last instance assigned on the current page.
+/// - `first-except`: returns `None` if the current page has any assignment.
+/// - Fallback (any policy, no resolution on current page): the last instance
+///   of the most recent preceding page that had an assignment.
+pub fn resolve_element_policy<'a>(
+    name: &str,
+    policy: ElementPolicy,
+    page_idx: usize,
+    page_states: &[BTreeMap<String, PageRunningState>],
+    store: &'a RunningElementStore,
+) -> Option<&'a str> {
+    let current = page_states.get(page_idx).and_then(|s| s.get(name));
+
+    let chosen_id: Option<usize> = match policy {
+        ElementPolicy::First | ElementPolicy::Start => {
+            current.and_then(|s| s.instance_ids.first().copied())
+        }
+        ElementPolicy::Last => current.and_then(|s| s.instance_ids.last().copied()),
+        ElementPolicy::FirstExcept => {
+            // If the current page contains an assignment, return nothing.
+            if current.map(|s| !s.instance_ids.is_empty()).unwrap_or(false) {
+                return None;
+            }
+            // No assignment on current page — fall through to the preceding
+            // page scan below.
+            None
+        }
+    };
+
+    if let Some(id) = chosen_id {
+        return store.get_html(id);
+    }
+
+    // Fallback: scan preceding pages for the most recent assignment.
+    for prev in (0..page_idx).rev() {
+        if let Some(state) = page_states.get(prev).and_then(|s| s.get(name)) {
+            if let Some(&last_id) = state.instance_ids.last() {
+                return store.get_html(last_id);
+            }
+        }
+    }
+
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -124,11 +182,27 @@ mod tests {
         );
     }
 
+    fn single_page_store(name: &str, html: &str) -> (RunningElementStore, Vec<BTreeMap<String, PageRunningState>>) {
+        let mut store = RunningElementStore::new();
+        let id = store.register(1, name.to_string(), html.to_string());
+        let mut page_state = BTreeMap::new();
+        page_state.insert(
+            name.to_string(),
+            PageRunningState {
+                instance_ids: vec![id],
+            },
+        );
+        (store, vec![page_state])
+    }
+
     #[test]
     fn test_element_becomes_empty() {
         let items = vec![
             ContentItem::String("Before".into()),
-            ContentItem::Element("hdr".into()),
+            ContentItem::Element {
+                name: "hdr".into(),
+                policy: ElementPolicy::First,
+            },
             ContentItem::String("After".into()),
         ];
         assert_eq!(
@@ -139,10 +213,13 @@ mod tests {
 
     #[test]
     fn test_resolve_html_with_running_element() {
-        let items = vec![ContentItem::Element("hdr".into())];
-        let running = vec![("hdr".to_string(), "<b>Header</b>".to_string())];
+        let items = vec![ContentItem::Element {
+            name: "hdr".into(),
+            policy: ElementPolicy::First,
+        }];
+        let (store, states) = single_page_store("hdr", "<b>Header</b>");
         assert_eq!(
-            resolve_content_to_html(&items, &running, &BTreeMap::new(), 1, 1),
+            resolve_content_to_html(&items, &store, &states, &BTreeMap::new(), 1, 1, 0),
             "<b>Header</b>"
         );
     }
@@ -150,15 +227,18 @@ mod tests {
     #[test]
     fn test_resolve_html_mixed() {
         let items = vec![
-            ContentItem::Element("hdr".into()),
+            ContentItem::Element {
+                name: "hdr".into(),
+                policy: ElementPolicy::First,
+            },
             ContentItem::String(" - Page ".into()),
             ContentItem::Counter(CounterType::Page),
             ContentItem::String("/".into()),
             ContentItem::Counter(CounterType::Pages),
         ];
-        let running = vec![("hdr".to_string(), "<span>Title</span>".to_string())];
+        let (store, states) = single_page_store("hdr", "<span>Title</span>");
         assert_eq!(
-            resolve_content_to_html(&items, &running, &BTreeMap::new(), 2, 8),
+            resolve_content_to_html(&items, &store, &states, &BTreeMap::new(), 2, 8, 0),
             "<span>Title</span> - Page 2/8"
         );
     }
@@ -179,7 +259,7 @@ mod tests {
             },
         );
         assert_eq!(
-            resolve_content_to_html(&items, &[], &state, 1, 1),
+            resolve_content_to_html(&items, &RunningElementStore::new(), &[], &state, 1, 1, 0),
             "Current"
         );
     }
@@ -200,7 +280,7 @@ mod tests {
             },
         );
         assert_eq!(
-            resolve_content_to_html(&items, &[], &state, 1, 1),
+            resolve_content_to_html(&items, &RunningElementStore::new(), &[], &state, 1, 1, 0),
             "Inherited"
         );
     }
@@ -221,7 +301,7 @@ mod tests {
             },
         );
         assert_eq!(
-            resolve_content_to_html(&items, &[], &state, 1, 1),
+            resolve_content_to_html(&items, &RunningElementStore::new(), &[], &state, 1, 1, 0),
             "Start Value"
         );
     }
@@ -241,7 +321,7 @@ mod tests {
                 last: Some("Last".to_string()),
             },
         );
-        assert_eq!(resolve_content_to_html(&items, &[], &state, 1, 1), "Last");
+        assert_eq!(resolve_content_to_html(&items, &RunningElementStore::new(), &[], &state, 1, 1, 0), "Last");
     }
 
     #[test]
@@ -259,7 +339,7 @@ mod tests {
                 last: Some("New".to_string()),
             },
         );
-        assert_eq!(resolve_content_to_html(&items, &[], &state, 1, 1), "");
+        assert_eq!(resolve_content_to_html(&items, &RunningElementStore::new(), &[], &state, 1, 1, 0), "");
     }
 
     #[test]
@@ -278,7 +358,7 @@ mod tests {
             },
         );
         assert_eq!(
-            resolve_content_to_html(&items, &[], &state, 1, 1),
+            resolve_content_to_html(&items, &RunningElementStore::new(), &[], &state, 1, 1, 0),
             "Inherited"
         );
     }
@@ -290,7 +370,7 @@ mod tests {
             policy: StringPolicy::First,
         }];
         assert_eq!(
-            resolve_content_to_html(&items, &[], &BTreeMap::new(), 1, 1),
+            resolve_content_to_html(&items, &RunningElementStore::new(), &[], &BTreeMap::new(), 1, 1, 0),
             ""
         );
     }
@@ -311,8 +391,125 @@ mod tests {
             },
         );
         assert_eq!(
-            resolve_content_to_html(&items, &[], &state, 1, 1),
+            resolve_content_to_html(&items, &RunningElementStore::new(), &[], &state, 1, 1, 0),
             "A &amp; B &lt;script&gt;"
+        );
+    }
+
+    #[test]
+    fn test_resolve_element_policy_scenarios() {
+        let mut store = RunningElementStore::new();
+        let id_a = store.register(1, "hdr".into(), "<h1>A</h1>".into());
+        let id_b = store.register(2, "hdr".into(), "<h1>B</h1>".into());
+        let id_c = store.register(3, "hdr".into(), "<h1>C</h1>".into());
+
+        // P0 = [A, B], P1 = [C], P2 = []
+        let mut p0 = BTreeMap::new();
+        p0.insert(
+            "hdr".to_string(),
+            PageRunningState {
+                instance_ids: vec![id_a, id_b],
+            },
+        );
+        let mut p1 = BTreeMap::new();
+        p1.insert(
+            "hdr".to_string(),
+            PageRunningState {
+                instance_ids: vec![id_c],
+            },
+        );
+        let p2 = BTreeMap::new();
+        let states = vec![p0, p1, p2];
+
+        // first
+        assert_eq!(
+            resolve_element_policy("hdr", ElementPolicy::First, 0, &states, &store),
+            Some("<h1>A</h1>")
+        );
+        assert_eq!(
+            resolve_element_policy("hdr", ElementPolicy::First, 1, &states, &store),
+            Some("<h1>C</h1>")
+        );
+        assert_eq!(
+            resolve_element_policy("hdr", ElementPolicy::First, 2, &states, &store),
+            Some("<h1>C</h1>")
+        );
+
+        // last
+        assert_eq!(
+            resolve_element_policy("hdr", ElementPolicy::Last, 0, &states, &store),
+            Some("<h1>B</h1>")
+        );
+        assert_eq!(
+            resolve_element_policy("hdr", ElementPolicy::Last, 1, &states, &store),
+            Some("<h1>C</h1>")
+        );
+        assert_eq!(
+            resolve_element_policy("hdr", ElementPolicy::Last, 2, &states, &store),
+            Some("<h1>C</h1>")
+        );
+
+        // start (same as first in our implementation)
+        assert_eq!(
+            resolve_element_policy("hdr", ElementPolicy::Start, 0, &states, &store),
+            Some("<h1>A</h1>")
+        );
+        assert_eq!(
+            resolve_element_policy("hdr", ElementPolicy::Start, 2, &states, &store),
+            Some("<h1>C</h1>")
+        );
+
+        // first-except: empty where assigned, fallback where unassigned
+        assert_eq!(
+            resolve_element_policy("hdr", ElementPolicy::FirstExcept, 0, &states, &store),
+            None
+        );
+        assert_eq!(
+            resolve_element_policy("hdr", ElementPolicy::FirstExcept, 1, &states, &store),
+            None
+        );
+        assert_eq!(
+            resolve_element_policy("hdr", ElementPolicy::FirstExcept, 2, &states, &store),
+            Some("<h1>C</h1>")
+        );
+    }
+
+    #[test]
+    fn test_resolve_element_policy_no_assignments_anywhere() {
+        let store = RunningElementStore::new();
+        let states: Vec<BTreeMap<String, PageRunningState>> = vec![BTreeMap::new(); 3];
+
+        for policy in [
+            ElementPolicy::First,
+            ElementPolicy::Start,
+            ElementPolicy::Last,
+            ElementPolicy::FirstExcept,
+        ] {
+            for page in 0..3 {
+                assert_eq!(
+                    resolve_element_policy("hdr", policy, page, &states, &store),
+                    None,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_resolve_element_policy_name_not_found() {
+        let mut store = RunningElementStore::new();
+        store.register(1, "other".into(), "<h1>X</h1>".into());
+        let mut p0 = BTreeMap::new();
+        p0.insert(
+            "other".to_string(),
+            PageRunningState {
+                instance_ids: vec![0],
+            },
+        );
+        let states = vec![p0];
+
+        assert_eq!(
+            resolve_element_policy("missing", ElementPolicy::First, 0, &states, &store),
+            None,
         );
     }
 }

--- a/crates/fulgur/src/gcpm/counter.rs
+++ b/crates/fulgur/src/gcpm/counter.rs
@@ -138,12 +138,12 @@ pub fn resolve_element_policy<'a>(
         }
         ElementPolicy::Last => current.and_then(|s| s.instance_ids.last().copied()),
         ElementPolicy::FirstExcept => {
-            // If the current page contains an assignment, return nothing.
-            if current.map(|s| !s.instance_ids.is_empty()).unwrap_or(false) {
+            // Current page has an assignment → suppress.
+            // (`collect_running_element_states` only inserts an entry when
+            // it pushes an instance_id, so `current.is_some()` suffices.)
+            if current.is_some() {
                 return None;
             }
-            // No assignment on current page — fall through to the preceding
-            // page scan below.
             None
         }
     };

--- a/crates/fulgur/src/gcpm/counter.rs
+++ b/crates/fulgur/src/gcpm/counter.rs
@@ -54,7 +54,7 @@ pub fn resolve_content_to_html(
     let mut out = String::new();
     for item in items {
         match item {
-            ContentItem::String(s) => out.push_str(s),
+            ContentItem::String(s) => push_escaped_html_text(&mut out, s),
             ContentItem::Counter(CounterType::Page) => {
                 out.push_str(&page_num.to_string());
             }
@@ -244,10 +244,41 @@ mod tests {
             ContentItem::String("/".into()),
             ContentItem::Counter(CounterType::Pages),
         ];
-        let (store, states) = single_page_store("hdr", "<span>Title</span>");
+
+        // Build 3 pages of state with distinct running-element instances per
+        // page so that mixing page_num (1-based, for counter(page)) with
+        // page_idx (0-based, for element policy) would be detectable if
+        // swapped.
+        let mut store = RunningElementStore::new();
+        let id0 = store.register(1, "hdr".into(), "<span>P1</span>".into());
+        let id1 = store.register(2, "hdr".into(), "<span>P2</span>".into());
+        let id2 = store.register(3, "hdr".into(), "<span>P3</span>".into());
+        let mk = |ids: Vec<usize>| -> BTreeMap<String, PageRunningState> {
+            let mut m = BTreeMap::new();
+            m.insert("hdr".to_string(), PageRunningState { instance_ids: ids });
+            m
+        };
+        let states = vec![mk(vec![id0]), mk(vec![id1]), mk(vec![id2])];
+
+        // page_num=2 (1-based), page_idx=1 (0-based) → must pick P2.
         assert_eq!(
-            resolve_content_to_html(&items, &store, &states, &BTreeMap::new(), 2, 8, 0),
-            "<span>Title</span> - Page 2/8"
+            resolve_content_to_html(&items, &store, &states, &BTreeMap::new(), 2, 3, 1),
+            "<span>P2</span> - Page 2/3"
+        );
+    }
+
+    #[test]
+    fn test_resolve_html_escapes_literal_string() {
+        // ContentItem::String comes from CSS `content: "literal"` and may
+        // contain `<`, `>`, `&`. It must be HTML-escaped before concatenation
+        // so attackers (or mischievous authors) cannot inject markup into the
+        // margin box via CSS string literals.
+        let items = vec![ContentItem::String("A & B <script>".into())];
+        let store = RunningElementStore::new();
+        let states: Vec<BTreeMap<String, PageRunningState>> = vec![BTreeMap::new()];
+        assert_eq!(
+            resolve_content_to_html(&items, &store, &states, &BTreeMap::new(), 1, 1, 0),
+            "A &amp; B &lt;script&gt;"
         );
     }
 

--- a/crates/fulgur/src/gcpm/counter.rs
+++ b/crates/fulgur/src/gcpm/counter.rs
@@ -1,6 +1,6 @@
 use super::{ContentItem, CounterType, StringPolicy};
-use crate::gcpm::running::RunningElementStore;
 use crate::gcpm::ElementPolicy;
+use crate::gcpm::running::RunningElementStore;
 use crate::paginate::{PageRunningState, StringSetPageState};
 use std::collections::BTreeMap;
 
@@ -182,7 +182,10 @@ mod tests {
         );
     }
 
-    fn single_page_store(name: &str, html: &str) -> (RunningElementStore, Vec<BTreeMap<String, PageRunningState>>) {
+    fn single_page_store(
+        name: &str,
+        html: &str,
+    ) -> (RunningElementStore, Vec<BTreeMap<String, PageRunningState>>) {
         let mut store = RunningElementStore::new();
         let id = store.register(1, name.to_string(), html.to_string());
         let mut page_state = BTreeMap::new();
@@ -321,7 +324,10 @@ mod tests {
                 last: Some("Last".to_string()),
             },
         );
-        assert_eq!(resolve_content_to_html(&items, &RunningElementStore::new(), &[], &state, 1, 1, 0), "Last");
+        assert_eq!(
+            resolve_content_to_html(&items, &RunningElementStore::new(), &[], &state, 1, 1, 0),
+            "Last"
+        );
     }
 
     #[test]
@@ -339,7 +345,10 @@ mod tests {
                 last: Some("New".to_string()),
             },
         );
-        assert_eq!(resolve_content_to_html(&items, &RunningElementStore::new(), &[], &state, 1, 1, 0), "");
+        assert_eq!(
+            resolve_content_to_html(&items, &RunningElementStore::new(), &[], &state, 1, 1, 0),
+            ""
+        );
     }
 
     #[test]
@@ -370,7 +379,15 @@ mod tests {
             policy: StringPolicy::First,
         }];
         assert_eq!(
-            resolve_content_to_html(&items, &RunningElementStore::new(), &[], &BTreeMap::new(), 1, 1, 0),
+            resolve_content_to_html(
+                &items,
+                &RunningElementStore::new(),
+                &[],
+                &BTreeMap::new(),
+                1,
+                1,
+                0
+            ),
             ""
         );
     }

--- a/crates/fulgur/src/gcpm/counter.rs
+++ b/crates/fulgur/src/gcpm/counter.rs
@@ -133,10 +133,13 @@ pub fn resolve_element_policy<'a>(
     let current = page_states.get(page_idx).and_then(|s| s.get(name));
 
     let chosen_id: Option<usize> = match policy {
-        ElementPolicy::First | ElementPolicy::Start => {
-            current.and_then(|s| s.instance_ids.first().copied())
-        }
+        ElementPolicy::First => current.and_then(|s| s.instance_ids.first().copied()),
         ElementPolicy::Last => current.and_then(|s| s.instance_ids.last().copied()),
+        // Start ignores assignments on the current page entirely — it must
+        // return the element that was in effect when this page began, which
+        // is the last instance of the most recent preceding page. Fall
+        // through to the fallback scan below.
+        ElementPolicy::Start => None,
         ElementPolicy::FirstExcept => {
             // Current page has an assignment → suppress.
             // (`collect_running_element_states` only inserts an entry when
@@ -466,14 +469,20 @@ mod tests {
             Some("<h1>C</h1>")
         );
 
-        // start (same as first in our implementation)
+        // start: ignores current-page assignments, returns the last
+        // instance of the most recent preceding page (i.e. the value in
+        // effect at the page boundary).
         assert_eq!(
             resolve_element_policy("hdr", ElementPolicy::Start, 0, &states, &store),
-            Some("<h1>A</h1>")
+            None, // no preceding pages
+        );
+        assert_eq!(
+            resolve_element_policy("hdr", ElementPolicy::Start, 1, &states, &store),
+            Some("<h1>B</h1>"), // P0.instance_ids.last()
         );
         assert_eq!(
             resolve_element_policy("hdr", ElementPolicy::Start, 2, &states, &store),
-            Some("<h1>C</h1>")
+            Some("<h1>C</h1>"), // P1.instance_ids.last()
         );
 
         // first-except: empty where assigned, fallback where unassigned

--- a/crates/fulgur/src/gcpm/mod.rs
+++ b/crates/fulgur/src/gcpm/mod.rs
@@ -43,6 +43,21 @@ pub enum StringPolicy {
     FirstExcept,
 }
 
+/// Policy for `element(name, <policy>)` — determines which running element
+/// instance to show on a given page. WeasyPrint-compatible semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ElementPolicy {
+    /// First instance assigned on the current page (default).
+    First,
+    /// Element in effect at start of page. Implemented identically to `First`
+    /// with fallback (WeasyPrint has the same effective behavior).
+    Start,
+    /// Last instance assigned on the current page.
+    Last,
+    /// Like `First`, but empty on pages where the element is assigned.
+    FirstExcept,
+}
+
 /// A single value component within a `string-set` declaration.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StringSetValue {
@@ -72,8 +87,13 @@ pub struct StringSetMapping {
 /// A single content item inside a margin box rule's `content` property.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ContentItem {
-    /// A running element reference, e.g. `element(title)`.
-    Element(String),
+    /// A running element reference, e.g. `element(title)` or `element(title, first)`.
+    Element {
+        /// The running element name.
+        name: String,
+        /// The policy for selecting which instance to show.
+        policy: ElementPolicy,
+    },
     /// A counter reference, e.g. `counter(page)`.
     Counter(CounterType),
     /// A literal string, e.g. `"Page "`.

--- a/crates/fulgur/src/gcpm/mod.rs
+++ b/crates/fulgur/src/gcpm/mod.rs
@@ -57,6 +57,15 @@ pub enum ElementPolicy {
     /// The element in effect at the start of the current page — i.e., the
     /// value inherited from the most recent assignment on a previous page if
     /// no assignment occurs on the current page.
+    ///
+    /// **Implementation note:** Currently resolved identically to `First`
+    /// (same match arm in `resolve_element_policy`). For the typical
+    /// running-element use case — chapter titles placed at the very top of
+    /// a page — this is indistinguishable from the strict WeasyPrint
+    /// interpretation. If a future use case needs the strict "value before
+    /// any assignment on this page" semantics, split the `Start` arm and
+    /// return the last instance of the most recent *preceding* page
+    /// unconditionally.
     Start,
     /// Last instance assigned on the current page; if no assignment occurs
     /// on the current page, falls back to the most recent prior assignment.

--- a/crates/fulgur/src/gcpm/mod.rs
+++ b/crates/fulgur/src/gcpm/mod.rs
@@ -44,17 +44,26 @@ pub enum StringPolicy {
 }
 
 /// Policy for `element(name, <policy>)` — determines which running element
-/// instance to show on a given page. WeasyPrint-compatible semantics.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// instance to show on a given page. Parallels [`StringPolicy`] but applies
+/// to running elements extracted via `position: running(name)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ElementPolicy {
-    /// First instance assigned on the current page (default).
+    /// First instance assigned on the current page; if no assignment occurs
+    /// on the current page, falls back to the most recent prior assignment.
+    /// This is the default when `element(name)` is written without a second
+    /// argument.
+    #[default]
     First,
-    /// Element in effect at start of page. Implemented identically to `First`
-    /// with fallback (WeasyPrint has the same effective behavior).
+    /// The element in effect at the start of the current page — i.e., the
+    /// value inherited from the most recent assignment on a previous page if
+    /// no assignment occurs on the current page.
     Start,
-    /// Last instance assigned on the current page.
+    /// Last instance assigned on the current page; if no assignment occurs
+    /// on the current page, falls back to the most recent prior assignment.
     Last,
-    /// Like `First`, but empty on pages where the element is assigned.
+    /// Returns the empty value on pages that contain an assignment to this
+    /// running element; otherwise falls back to the most recent prior
+    /// assignment (same as `First` on unassigned pages).
     FirstExcept,
 }
 

--- a/crates/fulgur/src/gcpm/mod.rs
+++ b/crates/fulgur/src/gcpm/mod.rs
@@ -55,17 +55,9 @@ pub enum ElementPolicy {
     #[default]
     First,
     /// The element in effect at the start of the current page — i.e., the
-    /// value inherited from the most recent assignment on a previous page if
-    /// no assignment occurs on the current page.
-    ///
-    /// **Implementation note:** Currently resolved identically to `First`
-    /// (same match arm in `resolve_element_policy`). For the typical
-    /// running-element use case — chapter titles placed at the very top of
-    /// a page — this is indistinguishable from the strict WeasyPrint
-    /// interpretation. If a future use case needs the strict "value before
-    /// any assignment on this page" semantics, split the `Start` arm and
-    /// return the last instance of the most recent *preceding* page
-    /// unconditionally.
+    /// last instance from the most recent *preceding* page. Unlike `First`,
+    /// `Start` ignores any assignments on the current page, so a heading
+    /// that switches mid-page does not affect the start-of-page value.
     Start,
     /// Last instance assigned on the current page; if no assignment occurs
     /// on the current page, falls back to the most recent prior assignment.

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -580,23 +580,17 @@ fn parse_content_value(input: &mut Parser<'_, '_>) -> Vec<ContentItem> {
                         let arg = input.expect_ident()?.clone();
                         if fn_name.eq_ignore_ascii_case("element") {
                             let name = arg.to_string();
-                            // Optional second argument: policy identifier.
-                            // If a comma is present but the policy is invalid,
-                            // drop the item entirely.
-                            //
-                            // Note: this is asymmetric with `string(name, <policy>)`
-                            // below, which silently falls back to `StringPolicy::First`
-                            // on invalid policy via `unwrap_or`. `element()` is stricter
-                            // because a mistyped running-element policy (e.g. `last`
-                            // typoed as `lsat`) should surface as a missing margin box
-                            // rather than silently defaulting to `first` — the running
-                            // element concept is newer and we prefer fail-loud here.
+                            // Asymmetric with `string(name, <policy>)` below:
+                            // invalid policy drops the item entirely here,
+                            // whereas `string()` falls back to `First` via
+                            // `unwrap_or`. Running element references are
+                            // stricter so a typo surfaces as a missing margin
+                            // box rather than silently defaulting.
                             let had_comma = input.try_parse(|input| input.expect_comma()).is_ok();
                             if had_comma {
                                 if let Ok(policy) = parse_element_policy(input) {
                                     items.push(ContentItem::Element { name, policy });
                                 }
-                                // Invalid policy — reject this call.
                             } else {
                                 items.push(ContentItem::Element {
                                     name,

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -497,19 +497,19 @@ fn parse_string_set_value<'i, 't>(
 // 6. Content value parser
 // ---------------------------------------------------------------------------
 
-/// Parse the policy argument of `string(name, <policy>)`.
+/// Parse a GCPM string/element policy identifier, handling cssparser's
+/// tokenization of `first-except` which may arrive either as a single ident
+/// or as `first` + `-` + `except`.
 ///
-/// Handles cssparser tokenization of `first-except`, which may arrive either as
-/// a single ident or as `first` + `-` + `except` depending on context.
-fn parse_string_policy<'i>(input: &mut Parser<'i, '_>) -> Result<StringPolicy, ParseError<'i, ()>> {
+/// `map_fn` converts the canonical lowercase identifier (`"first"`, `"start"`,
+/// `"last"`, `"first-except"`) into the caller's typed policy enum. Returning
+/// `None` from `map_fn` signals an unknown identifier.
+fn parse_policy_ident<'i, T>(
+    input: &mut Parser<'i, '_>,
+    map_fn: impl Fn(&str) -> Option<T>,
+) -> Result<T, ParseError<'i, ()>> {
     let ident = input.expect_ident()?.clone();
-    if ident.eq_ignore_ascii_case("start") {
-        Ok(StringPolicy::Start)
-    } else if ident.eq_ignore_ascii_case("last") {
-        Ok(StringPolicy::Last)
-    } else if ident.eq_ignore_ascii_case("first-except") {
-        Ok(StringPolicy::FirstExcept)
-    } else if ident.eq_ignore_ascii_case("first") {
+    let canonical: String = if ident.eq_ignore_ascii_case("first") {
         // Try to consume a trailing `-except` (cssparser may split the hyphenated ident).
         let has_except = input
             .try_parse(|input| {
@@ -522,47 +522,40 @@ fn parse_string_policy<'i>(input: &mut Parser<'i, '_>) -> Result<StringPolicy, P
                 }
             })
             .is_ok();
-        Ok(if has_except {
-            StringPolicy::FirstExcept
+        if has_except {
+            "first-except".to_string()
         } else {
-            StringPolicy::First
-        })
+            "first".to_string()
+        }
     } else {
-        Err(input.new_error(BasicParseErrorKind::QualifiedRuleInvalid))
-    }
+        ident.to_ascii_lowercase()
+    };
+
+    map_fn(&canonical).ok_or_else(|| input.new_error(BasicParseErrorKind::QualifiedRuleInvalid))
+}
+
+/// Parse the policy argument of `string(name, <policy>)`.
+fn parse_string_policy<'i>(input: &mut Parser<'i, '_>) -> Result<StringPolicy, ParseError<'i, ()>> {
+    parse_policy_ident(input, |s| match s {
+        "first" => Some(StringPolicy::First),
+        "start" => Some(StringPolicy::Start),
+        "last" => Some(StringPolicy::Last),
+        "first-except" => Some(StringPolicy::FirstExcept),
+        _ => None,
+    })
 }
 
 /// Parse the policy argument of `element(name, <policy>)`.
 fn parse_element_policy<'i>(
     input: &mut Parser<'i, '_>,
 ) -> Result<ElementPolicy, ParseError<'i, ()>> {
-    let ident = input.expect_ident()?.clone();
-    if ident.eq_ignore_ascii_case("start") {
-        Ok(ElementPolicy::Start)
-    } else if ident.eq_ignore_ascii_case("last") {
-        Ok(ElementPolicy::Last)
-    } else if ident.eq_ignore_ascii_case("first-except") {
-        Ok(ElementPolicy::FirstExcept)
-    } else if ident.eq_ignore_ascii_case("first") {
-        let has_except = input
-            .try_parse(|input| {
-                input.expect_delim('-')?;
-                let next = input.expect_ident()?.clone();
-                if next.eq_ignore_ascii_case("except") {
-                    Ok(())
-                } else {
-                    Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid))
-                }
-            })
-            .is_ok();
-        Ok(if has_except {
-            ElementPolicy::FirstExcept
-        } else {
-            ElementPolicy::First
-        })
-    } else {
-        Err(input.new_error(BasicParseErrorKind::QualifiedRuleInvalid))
-    }
+    parse_policy_ident(input, |s| match s {
+        "first" => Some(ElementPolicy::First),
+        "start" => Some(ElementPolicy::Start),
+        "last" => Some(ElementPolicy::Last),
+        "first-except" => Some(ElementPolicy::FirstExcept),
+        _ => None,
+    })
 }
 
 /// Parse a `content` property value into a list of `ContentItem`s using cssparser.

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -583,6 +583,14 @@ fn parse_content_value(input: &mut Parser<'_, '_>) -> Vec<ContentItem> {
                             // Optional second argument: policy identifier.
                             // If a comma is present but the policy is invalid,
                             // drop the item entirely.
+                            //
+                            // Note: this is asymmetric with `string(name, <policy>)`
+                            // below, which silently falls back to `StringPolicy::First`
+                            // on invalid policy via `unwrap_or`. `element()` is stricter
+                            // because a mistyped running-element policy (e.g. `last`
+                            // typoed as `lsat`) should surface as a missing margin box
+                            // rather than silently defaulting to `first` — the running
+                            // element concept is newer and we prefer fail-loud here.
                             let had_comma = input.try_parse(|input| input.expect_comma()).is_ok();
                             if had_comma {
                                 if let Ok(policy) = parse_element_policy(input) {

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -5,8 +5,8 @@ use cssparser::{
 
 use super::margin_box::MarginBoxPosition;
 use super::{
-    ContentItem, CounterType, GcpmContext, MarginBoxRule, ParsedSelector, RunningMapping,
-    StringPolicy, StringSetMapping, StringSetValue,
+    ContentItem, CounterType, ElementPolicy, GcpmContext, MarginBoxRule, ParsedSelector,
+    RunningMapping, StringPolicy, StringSetMapping, StringSetValue,
 };
 
 // ---------------------------------------------------------------------------
@@ -532,8 +532,41 @@ fn parse_string_policy<'i>(input: &mut Parser<'i, '_>) -> Result<StringPolicy, P
     }
 }
 
+/// Parse the policy argument of `element(name, <policy>)`.
+fn parse_element_policy<'i>(
+    input: &mut Parser<'i, '_>,
+) -> Result<ElementPolicy, ParseError<'i, ()>> {
+    let ident = input.expect_ident()?.clone();
+    if ident.eq_ignore_ascii_case("start") {
+        Ok(ElementPolicy::Start)
+    } else if ident.eq_ignore_ascii_case("last") {
+        Ok(ElementPolicy::Last)
+    } else if ident.eq_ignore_ascii_case("first-except") {
+        Ok(ElementPolicy::FirstExcept)
+    } else if ident.eq_ignore_ascii_case("first") {
+        let has_except = input
+            .try_parse(|input| {
+                input.expect_delim('-')?;
+                let next = input.expect_ident()?.clone();
+                if next.eq_ignore_ascii_case("except") {
+                    Ok(())
+                } else {
+                    Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid))
+                }
+            })
+            .is_ok();
+        Ok(if has_except {
+            ElementPolicy::FirstExcept
+        } else {
+            ElementPolicy::First
+        })
+    } else {
+        Err(input.new_error(BasicParseErrorKind::QualifiedRuleInvalid))
+    }
+}
+
 /// Parse a `content` property value into a list of `ContentItem`s using cssparser.
-/// Handles: `element(<name>)`, `counter(page)`, `counter(pages)`, `string(<name>, <policy>)`, `"string"`.
+/// Handles: `element(<name>, <policy>)`, `counter(page)`, `counter(pages)`, `string(<name>, <policy>)`, `"string"`.
 fn parse_content_value(input: &mut Parser<'_, '_>) -> Vec<ContentItem> {
     let mut items = Vec::new();
 
@@ -553,7 +586,22 @@ fn parse_content_value(input: &mut Parser<'_, '_>) -> Vec<ContentItem> {
                     input.parse_nested_block(|input| {
                         let arg = input.expect_ident()?.clone();
                         if fn_name.eq_ignore_ascii_case("element") {
-                            items.push(ContentItem::Element(arg.to_string()));
+                            let name = arg.to_string();
+                            // Optional second argument: policy identifier.
+                            // If a comma is present but the policy is invalid,
+                            // drop the item entirely.
+                            let had_comma = input.try_parse(|input| input.expect_comma()).is_ok();
+                            if had_comma {
+                                if let Ok(policy) = parse_element_policy(input) {
+                                    items.push(ContentItem::Element { name, policy });
+                                }
+                                // Invalid policy — reject this call.
+                            } else {
+                                items.push(ContentItem::Element {
+                                    name,
+                                    policy: ElementPolicy::First,
+                                });
+                            }
                         } else if fn_name.eq_ignore_ascii_case("counter") {
                             match &*arg {
                                 "page" => items.push(ContentItem::Counter(CounterType::Page)),
@@ -733,7 +781,10 @@ mod tests {
         assert_eq!(mb.page_selector, None);
         assert_eq!(
             mb.content,
-            vec![ContentItem::Element("pageHeader".to_string())]
+            vec![ContentItem::Element {
+                name: "pageHeader".to_string(),
+                policy: ElementPolicy::First,
+            }]
         );
         // @page block should be removed from cleaned_css
         assert!(!ctx.cleaned_css.contains("@page"));
@@ -788,7 +839,10 @@ mod tests {
         assert_eq!(mb.position, MarginBoxPosition::TopCenter);
         assert_eq!(
             mb.content,
-            vec![ContentItem::Element("firstHeader".to_string())]
+            vec![ContentItem::Element {
+                name: "firstHeader".to_string(),
+                policy: ElementPolicy::First,
+            }]
         );
     }
 
@@ -851,7 +905,13 @@ mod tests {
         let ctx = parse_gcpm(css);
         assert_eq!(ctx.margin_boxes.len(), 1);
         let mb = &ctx.margin_boxes[0];
-        assert_eq!(mb.content, vec![ContentItem::Element("hdr".to_string())]);
+        assert_eq!(
+            mb.content,
+            vec![ContentItem::Element {
+                name: "hdr".to_string(),
+                policy: ElementPolicy::First,
+            }]
+        );
         assert!(mb.declarations.contains("font-size"));
         assert!(mb.declarations.contains("color"));
     }
@@ -1018,6 +1078,55 @@ mod tests {
                 policy_str
             );
         }
+    }
+
+    #[test]
+    fn test_parse_element_function_default_policy() {
+        let css = "@page { @top-center { content: element(hdr); } }";
+        let ctx = parse_gcpm(css);
+        let rule = ctx.margin_boxes.first().unwrap();
+        assert_eq!(
+            rule.content,
+            vec![ContentItem::Element {
+                name: "hdr".into(),
+                policy: ElementPolicy::First,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_parse_element_function_all_policies() {
+        for (policy_str, policy) in [
+            ("first", ElementPolicy::First),
+            ("start", ElementPolicy::Start),
+            ("last", ElementPolicy::Last),
+            ("first-except", ElementPolicy::FirstExcept),
+        ] {
+            let css = format!(
+                "@page {{ @top-center {{ content: element(hdr, {}); }} }}",
+                policy_str
+            );
+            let ctx = parse_gcpm(&css);
+            let rule = ctx.margin_boxes.first().unwrap();
+            assert_eq!(
+                rule.content,
+                vec![ContentItem::Element {
+                    name: "hdr".into(),
+                    policy,
+                }],
+                "Failed for policy: {}",
+                policy_str
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_element_function_invalid_policy() {
+        // Unknown policy identifier — the whole element() call should be dropped.
+        let css = "@page { @top-center { content: element(hdr, bogus); } }";
+        let ctx = parse_gcpm(css);
+        let rule = ctx.margin_boxes.first().unwrap();
+        assert!(rule.content.is_empty());
     }
 
     #[test]

--- a/crates/fulgur/src/gcpm/running.rs
+++ b/crates/fulgur/src/gcpm/running.rs
@@ -7,9 +7,9 @@ use std::collections::BTreeMap;
 
 /// A single running element assignment, identified by a numeric instance id.
 #[derive(Debug, Clone)]
-pub struct RunningInstance {
-    pub name: String,
-    pub html: String,
+struct RunningInstance {
+    name: String,
+    html: String,
 }
 
 /// Stores running element instances in source order, keyed by a sequential id.
@@ -37,12 +37,11 @@ impl RunningElementStore {
     }
 
     /// Register a running element instance. Returns the assigned instance_id.
+    ///
+    /// Invariant: each `node_id` is registered at most once, guaranteed by
+    /// `RunningElementPass::walk_tree` not recursing into running element
+    /// subtrees.
     pub fn register(&mut self, node_id: usize, name: String, html: String) -> usize {
-        debug_assert!(
-            !self.node_to_instance.contains_key(&node_id),
-            "RunningElementStore: node_id {} registered twice",
-            node_id
-        );
         let id = self.instances.len();
         self.instances.push(RunningInstance { name, html });
         self.node_to_instance.insert(node_id, id);

--- a/crates/fulgur/src/gcpm/running.rs
+++ b/crates/fulgur/src/gcpm/running.rs
@@ -5,39 +5,59 @@
 
 use std::collections::HashMap;
 
-/// Stores running elements keyed by name.
+/// A single running element assignment, identified by a numeric instance id.
+#[derive(Debug, Clone)]
+pub struct RunningInstance {
+    pub id: usize,
+    pub name: String,
+    pub html: String,
+}
+
+/// Stores running element instances in source order, keyed by a sequential id.
 ///
-/// Running elements are DOM subtrees that have been extracted from the normal
-/// document flow (via `position: running(...)`) and serialized to HTML strings.
-/// They are later injected into margin boxes via `content: element(name)`.
+/// Multiple assignments to the same running name are preserved as separate
+/// instances so per-page policy resolution (first/start/last/first-except)
+/// can pick the correct one. The DOM `node_id` → `instance_id` map lets the
+/// convert stage emit zero-size markers at the source position of each
+/// running element.
 pub struct RunningElementStore {
-    elements: HashMap<String, String>,
+    instances: Vec<RunningInstance>,
+    node_to_instance: HashMap<usize, usize>,
 }
 
 impl RunningElementStore {
-    /// Create an empty store.
     pub fn new() -> Self {
         Self {
-            elements: HashMap::new(),
+            instances: Vec::new(),
+            node_to_instance: HashMap::new(),
         }
     }
 
-    /// Register a running element by name with its serialized HTML.
-    pub fn register(&mut self, name: String, html: String) {
-        self.elements.insert(name, html);
+    /// Register a running element instance. Returns the assigned instance_id.
+    pub fn register(&mut self, node_id: usize, name: String, html: String) -> usize {
+        let id = self.instances.len();
+        self.instances.push(RunningInstance {
+            id,
+            name,
+            html,
+        });
+        self.node_to_instance.insert(node_id, id);
+        id
     }
 
-    /// Look up a running element by name.
-    pub fn get(&self, name: &str) -> Option<&str> {
-        self.elements.get(name).map(|s| s.as_str())
+    /// Look up the instance_id assigned to a DOM node, if any.
+    pub fn instance_for_node(&self, node_id: usize) -> Option<usize> {
+        self.node_to_instance.get(&node_id).copied()
     }
 
-    /// Convert to pairs for counter resolution or other consumers.
-    pub fn to_pairs(&self) -> Vec<(String, String)> {
-        self.elements
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect()
+    /// Get the serialized HTML for a given instance_id.
+    pub fn get_html(&self, instance_id: usize) -> Option<&str> {
+        self.instances.get(instance_id).map(|i| i.html.as_str())
+    }
+
+    /// Get the running name for a given instance_id.
+    pub fn name_of(&self, instance_id: usize) -> Option<&str> {
+        self.instances.get(instance_id).map(|i| i.name.as_str())
     }
 }
 
@@ -120,41 +140,23 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_running_element_store_and_lookup() {
+    fn test_running_store_instance_registration() {
         let mut store = RunningElementStore::new();
+        let id_a = store.register(10, "header".to_string(), "<h1>A</h1>".to_string());
+        let id_b = store.register(20, "header".to_string(), "<h1>B</h1>".to_string());
 
-        // Initially empty
-        assert!(store.get("header").is_none());
-
-        // Register and retrieve
-        store.register("header".to_string(), "<h1>Title</h1>".to_string());
-        assert_eq!(store.get("header"), Some("<h1>Title</h1>"));
-
-        // Nonexistent key
-        assert!(store.get("footer").is_none());
-
-        // Overwrite
-        store.register("header".to_string(), "<h1>New Title</h1>".to_string());
-        assert_eq!(store.get("header"), Some("<h1>New Title</h1>"));
+        assert_ne!(id_a, id_b);
+        assert_eq!(store.get_html(id_a), Some("<h1>A</h1>"));
+        assert_eq!(store.get_html(id_b), Some("<h1>B</h1>"));
+        assert_eq!(store.instance_for_node(10), Some(id_a));
+        assert_eq!(store.instance_for_node(20), Some(id_b));
+        assert_eq!(store.instance_for_node(99), None);
     }
 
     #[test]
-    fn test_to_pairs() {
+    fn test_running_store_name_lookup() {
         let mut store = RunningElementStore::new();
-        store.register("header".to_string(), "<h1>Title</h1>".to_string());
-        store.register("footer".to_string(), "<footer>F</footer>".to_string());
-
-        let mut pairs = store.to_pairs();
-        pairs.sort_by(|a, b| a.0.cmp(&b.0));
-
-        assert_eq!(pairs.len(), 2);
-        assert_eq!(
-            pairs[0],
-            ("footer".to_string(), "<footer>F</footer>".to_string())
-        );
-        assert_eq!(
-            pairs[1],
-            ("header".to_string(), "<h1>Title</h1>".to_string())
-        );
+        let id = store.register(5, "footer".to_string(), "<p>F</p>".to_string());
+        assert_eq!(store.name_of(id), Some("footer"));
     }
 }

--- a/crates/fulgur/src/gcpm/running.rs
+++ b/crates/fulgur/src/gcpm/running.rs
@@ -71,6 +71,13 @@ impl Default for RunningElementStore {
     }
 }
 
+#[cfg(test)]
+impl RunningElementStore {
+    pub fn instance_count(&self) -> usize {
+        self.instances.len()
+    }
+}
+
 /// Serialize a Blitz DOM node subtree back to an HTML string.
 ///
 /// Used to extract running elements for re-layout in margin boxes.

--- a/crates/fulgur/src/gcpm/running.rs
+++ b/crates/fulgur/src/gcpm/running.rs
@@ -3,12 +3,11 @@
 //! Manages running elements extracted from the DOM via `position: running(name)`.
 //! These elements are serialized to HTML and stored for later re-layout in margin boxes.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 /// A single running element assignment, identified by a numeric instance id.
 #[derive(Debug, Clone)]
 pub struct RunningInstance {
-    pub id: usize,
     pub name: String,
     pub html: String,
 }
@@ -20,27 +19,32 @@ pub struct RunningInstance {
 /// can pick the correct one. The DOM `node_id` → `instance_id` map lets the
 /// convert stage emit zero-size markers at the source position of each
 /// running element.
+///
+/// Instances are append-only — once registered, they remain in the store for
+/// the lifetime of the pass. This is what allows `instance_id` to be a stable
+/// index into `instances`.
 pub struct RunningElementStore {
     instances: Vec<RunningInstance>,
-    node_to_instance: HashMap<usize, usize>,
+    node_to_instance: BTreeMap<usize, usize>,
 }
 
 impl RunningElementStore {
     pub fn new() -> Self {
         Self {
             instances: Vec::new(),
-            node_to_instance: HashMap::new(),
+            node_to_instance: BTreeMap::new(),
         }
     }
 
     /// Register a running element instance. Returns the assigned instance_id.
     pub fn register(&mut self, node_id: usize, name: String, html: String) -> usize {
+        debug_assert!(
+            !self.node_to_instance.contains_key(&node_id),
+            "RunningElementStore: node_id {} registered twice",
+            node_id
+        );
         let id = self.instances.len();
-        self.instances.push(RunningInstance {
-            id,
-            name,
-            html,
-        });
+        self.instances.push(RunningInstance { name, html });
         self.node_to_instance.insert(node_id, id);
         id
     }
@@ -158,5 +162,12 @@ mod tests {
         let mut store = RunningElementStore::new();
         let id = store.register(5, "footer".to_string(), "<p>F</p>".to_string());
         assert_eq!(store.name_of(id), Some("footer"));
+    }
+
+    #[test]
+    fn test_running_store_invalid_instance_id_returns_none() {
+        let store = RunningElementStore::new();
+        assert!(store.get_html(999).is_none());
+        assert!(store.name_of(999).is_none());
     }
 }

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -1183,6 +1183,20 @@ impl Pageable for StringSetPageable {
 /// which running element instances fall on which page. The actual HTML of
 /// the running element lives in `RunningElementStore`, keyed by
 /// `instance_id`.
+///
+/// Parallels `StringSetPageable` but carries an `instance_id` instead of
+/// a value — running elements are full DOM subtrees that can be large, so
+/// the marker stays zero-cost and the HTML is looked up by id at render
+/// time via `resolve_element_policy`.
+///
+/// **Known limitation:** When a running element marker is followed by an
+/// unsplittable Pageable that overflows the current page, the content is
+/// pushed to the next page but the zero-size marker stays behind. For the
+/// typical "chapter title immediately before a large block" layout this
+/// causes the marker to land one page earlier than the content it
+/// conceptually belongs to. A `RunningElementWrapperPageable` analogous
+/// to `StringSetWrapperPageable` would fix this; deferred until a real
+/// use case surfaces the issue.
 #[derive(Clone)]
 pub struct RunningElementMarkerPageable {
     pub name: String,

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -1189,14 +1189,9 @@ impl Pageable for StringSetPageable {
 /// the marker stays zero-cost and the HTML is looked up by id at render
 /// time via `resolve_element_policy`.
 ///
-/// **Known limitation:** When a running element marker is followed by an
-/// unsplittable Pageable that overflows the current page, the content is
-/// pushed to the next page but the zero-size marker stays behind. For the
-/// typical "chapter title immediately before a large block" layout this
-/// causes the marker to land one page earlier than the content it
-/// conceptually belongs to. A `RunningElementWrapperPageable` analogous
-/// to `StringSetWrapperPageable` would fix this; deferred until a real
-/// use case surfaces the issue.
+/// During convert, markers are attached to the following real child via
+/// `RunningElementWrapperPageable` so that when the child moves to the
+/// next page due to an unsplittable overflow, the marker travels with it.
 #[derive(Clone)]
 pub struct RunningElementMarkerPageable {
     pub name: String,
@@ -1278,6 +1273,73 @@ impl Pageable for StringSetWrapperPageable {
     ) -> Option<(Box<dyn Pageable>, Box<dyn Pageable>)> {
         let (first, second) = self.child.split(avail_width, avail_height)?;
         let first_wrapped = StringSetWrapperPageable {
+            markers: self.markers.clone(),
+            child: first,
+        };
+        Some((Box::new(first_wrapped), second))
+    }
+
+    fn draw(&self, canvas: &mut Canvas<'_, '_>, x: Pt, y: Pt, avail_width: Pt, avail_height: Pt) {
+        self.child.draw(canvas, x, y, avail_width, avail_height);
+    }
+
+    fn clone_box(&self) -> Box<dyn Pageable> {
+        Box::new(self.clone())
+    }
+
+    fn height(&self) -> Pt {
+        self.child.height()
+    }
+
+    fn pagination(&self) -> Pagination {
+        self.child.pagination()
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+// ─── RunningElementWrapperPageable ──────────────────────────
+
+/// Wraps a Pageable together with `RunningElementMarkerPageable` markers that
+/// must stay attached to it during pagination.
+///
+/// Running elements are rewritten to `display: none`, so their markers have
+/// no layout of their own. Without this wrapper, a plain marker emitted as
+/// a sibling could be stranded on the previous page when the following
+/// unsplittable child overflows — the marker's zero-size position would
+/// land before the split point while the content conceptually belonging
+/// with it is pushed to the next page. Chapter heading + large figure is
+/// the canonical case.
+///
+/// The wrapper delegates `split()` to the inner child: if the child splits,
+/// markers travel with the first fragment; if the child cannot split, the
+/// wrapper is atomic and the whole thing moves to the next page together.
+#[derive(Clone)]
+pub struct RunningElementWrapperPageable {
+    pub markers: Vec<RunningElementMarkerPageable>,
+    pub child: Box<dyn Pageable>,
+}
+
+impl RunningElementWrapperPageable {
+    pub fn new(markers: Vec<RunningElementMarkerPageable>, child: Box<dyn Pageable>) -> Self {
+        Self { markers, child }
+    }
+}
+
+impl Pageable for RunningElementWrapperPageable {
+    fn wrap(&mut self, avail_width: Pt, avail_height: Pt) -> Size {
+        self.child.wrap(avail_width, avail_height)
+    }
+
+    fn split(
+        &self,
+        avail_width: Pt,
+        avail_height: Pt,
+    ) -> Option<(Box<dyn Pageable>, Box<dyn Pageable>)> {
+        let (first, second) = self.child.split(avail_width, avail_height)?;
+        let first_wrapped = RunningElementWrapperPageable {
             markers: self.markers.clone(),
             child: first,
         };

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -1174,6 +1174,58 @@ impl Pageable for StringSetPageable {
     }
 }
 
+// ─── RunningElementMarkerPageable ────────────────────────
+
+/// Zero-size marker for a running element instance.
+///
+/// Inserted into the Pageable tree at the source position where
+/// `position: running(name)` was declared, so that pagination can track
+/// which running element instances fall on which page. The actual HTML of
+/// the running element lives in `RunningElementStore`, keyed by
+/// `instance_id`.
+#[derive(Clone)]
+pub struct RunningElementMarkerPageable {
+    pub name: String,
+    pub instance_id: usize,
+}
+
+impl RunningElementMarkerPageable {
+    pub fn new(name: String, instance_id: usize) -> Self {
+        Self { name, instance_id }
+    }
+}
+
+impl Pageable for RunningElementMarkerPageable {
+    fn wrap(&mut self, _avail_width: Pt, _avail_height: Pt) -> Size {
+        Size {
+            width: 0.0,
+            height: 0.0,
+        }
+    }
+
+    fn split(
+        &self,
+        _avail_width: Pt,
+        _avail_height: Pt,
+    ) -> Option<(Box<dyn Pageable>, Box<dyn Pageable>)> {
+        None
+    }
+
+    fn draw(&self, _canvas: &mut Canvas, _x: Pt, _y: Pt, _avail_width: Pt, _avail_height: Pt) {}
+
+    fn clone_box(&self) -> Box<dyn Pageable> {
+        Box::new(self.clone())
+    }
+
+    fn height(&self) -> Pt {
+        0.0
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
 // ─── StringSetWrapperPageable ──────────────────────────────
 
 /// Wraps a Pageable together with `StringSetPageable` markers that must stay
@@ -1801,6 +1853,18 @@ mod tests {
         let p = StringSetPageable::new("title".to_string(), "Chapter 1".to_string());
         assert_eq!(p.name, "title");
         assert_eq!(p.value, "Chapter 1");
+    }
+
+    #[test]
+    fn test_running_element_marker_is_zero_size_noop() {
+        let mut m = RunningElementMarkerPageable::new("header".to_string(), 42);
+        let size = m.wrap(100.0, 100.0);
+        assert_eq!(size.width, 0.0);
+        assert_eq!(size.height, 0.0);
+        assert_eq!(m.height(), 0.0);
+        assert_eq!(m.name, "header");
+        assert_eq!(m.instance_id, 42);
+        assert!(m.split(100.0, 100.0).is_none());
     }
 }
 

--- a/crates/fulgur/src/paginate.rs
+++ b/crates/fulgur/src/paginate.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 
 use crate::pageable::{
-    BlockPageable, ListItemPageable, Pageable, Pt, StringSetPageable, StringSetWrapperPageable,
-    TablePageable,
+    BlockPageable, ListItemPageable, Pageable, Pt, RunningElementMarkerPageable,
+    StringSetPageable, StringSetWrapperPageable, TablePageable,
 };
 
 /// Per-page state for a named string.
@@ -107,6 +107,68 @@ fn collect_markers(pageable: &dyn Pageable, markers: &mut Vec<(String, String)>)
         }
     } else if let Some(list_item) = any.downcast_ref::<ListItemPageable>() {
         collect_markers(list_item.body.as_ref(), markers);
+    }
+}
+
+/// Per-page state for running element instances of a given name.
+#[derive(Debug, Clone, Default)]
+pub struct PageRunningState {
+    /// Instance IDs of running elements whose source position falls on this
+    /// page, in source order.
+    pub instance_ids: Vec<usize>,
+}
+
+/// Walk paginated pages and collect `RunningElementMarkerPageable` markers
+/// per page, keyed by running element name.
+///
+/// Used by the render stage together with `resolve_element_policy` to
+/// determine which running element instance should be shown in each
+/// margin box on each page.
+pub fn collect_running_element_states(
+    pages: &[Box<dyn Pageable>],
+) -> Vec<BTreeMap<String, PageRunningState>> {
+    let mut result: Vec<BTreeMap<String, PageRunningState>> = Vec::with_capacity(pages.len());
+
+    for page in pages {
+        let mut page_state: BTreeMap<String, PageRunningState> = BTreeMap::new();
+        let mut markers = Vec::new();
+        collect_running_markers(page.as_ref(), &mut markers);
+        for (name, instance_id) in markers {
+            page_state
+                .entry(name)
+                .or_default()
+                .instance_ids
+                .push(instance_id);
+        }
+        result.push(page_state);
+    }
+
+    result
+}
+
+/// Recursively find all running element markers in a Pageable tree.
+///
+/// Mirrors `collect_markers` (for string-set) but looks for
+/// `RunningElementMarkerPageable` instances.
+fn collect_running_markers(pageable: &dyn Pageable, markers: &mut Vec<(String, usize)>) {
+    let any = pageable.as_any();
+    if let Some(m) = any.downcast_ref::<RunningElementMarkerPageable>() {
+        markers.push((m.name.clone(), m.instance_id));
+    } else if let Some(wrapper) = any.downcast_ref::<StringSetWrapperPageable>() {
+        collect_running_markers(wrapper.child.as_ref(), markers);
+    } else if let Some(block) = any.downcast_ref::<BlockPageable>() {
+        for child in &block.children {
+            collect_running_markers(child.child.as_ref(), markers);
+        }
+    } else if let Some(table) = any.downcast_ref::<TablePageable>() {
+        for child in &table.header_cells {
+            collect_running_markers(child.child.as_ref(), markers);
+        }
+        for child in &table.body_cells {
+            collect_running_markers(child.child.as_ref(), markers);
+        }
+    } else if let Some(list_item) = any.downcast_ref::<ListItemPageable>() {
+        collect_running_markers(list_item.body.as_ref(), markers);
     }
 }
 
@@ -263,5 +325,61 @@ mod tests {
             Some("Ch2".to_string()),
             "marker must be on page 2 with its content"
         );
+    }
+
+    // ─── Running element collection tests ────────────────────
+
+    #[test]
+    fn test_collect_running_element_states_single_page() {
+        use crate::pageable::RunningElementMarkerPageable;
+
+        let marker_a: Box<dyn Pageable> =
+            Box::new(RunningElementMarkerPageable::new("hdr".into(), 0));
+        let marker_b: Box<dyn Pageable> =
+            Box::new(RunningElementMarkerPageable::new("hdr".into(), 1));
+        let block = BlockPageable::with_positioned_children(vec![
+            pos(marker_a),
+            pos(make_spacer(50.0)),
+            pos(marker_b),
+            pos(make_spacer(50.0)),
+        ]);
+        let pages = paginate(Box::new(block), 200.0, 500.0);
+        assert_eq!(pages.len(), 1);
+        let states = collect_running_element_states(&pages);
+        assert_eq!(states[0].get("hdr").unwrap().instance_ids, vec![0, 1]);
+    }
+
+    #[test]
+    fn test_collect_running_element_states_splits_across_pages() {
+        use crate::pageable::RunningElementMarkerPageable;
+
+        let marker_a: Box<dyn Pageable> =
+            Box::new(RunningElementMarkerPageable::new("hdr".into(), 0));
+        let marker_b: Box<dyn Pageable> =
+            Box::new(RunningElementMarkerPageable::new("hdr".into(), 1));
+        let block = BlockPageable::with_positioned_children(vec![
+            pos(marker_a),
+            pos(make_spacer(100.0)),
+            pos(make_spacer(100.0)),
+            pos(marker_b),
+            pos(make_spacer(100.0)),
+        ]);
+        let pages = paginate(Box::new(block), 200.0, 200.0);
+        assert!(pages.len() >= 2);
+        let states = collect_running_element_states(&pages);
+        // marker_a is before any spacers — on page 1
+        assert_eq!(states[0].get("hdr").unwrap().instance_ids, vec![0]);
+        // marker_b is between spacer 2 and 3 — should be on page 2
+        assert_eq!(states[1].get("hdr").unwrap().instance_ids, vec![1]);
+    }
+
+    #[test]
+    fn test_collect_running_element_states_empty() {
+        // No markers — result is Vec of empty BTreeMaps.
+        let block = BlockPageable::with_positioned_children(vec![pos(make_spacer(100.0))]);
+        let pages = paginate(Box::new(block), 200.0, 500.0);
+        let states = collect_running_element_states(&pages);
+        assert_eq!(states.len(), 1);
+        assert!(states[0].is_empty());
     }
 }

--- a/crates/fulgur/src/paginate.rs
+++ b/crates/fulgur/src/paginate.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 
 use crate::pageable::{
-    BlockPageable, ListItemPageable, Pageable, Pt, RunningElementMarkerPageable,
-    StringSetPageable, StringSetWrapperPageable, TablePageable,
+    BlockPageable, ListItemPageable, Pageable, Pt, RunningElementMarkerPageable, StringSetPageable,
+    StringSetWrapperPageable, TablePageable,
 };
 
 /// Per-page state for a named string.
@@ -353,23 +353,41 @@ mod tests {
     fn test_collect_running_element_states_splits_across_pages() {
         use crate::pageable::RunningElementMarkerPageable;
 
+        // Need total_height > page_height for paginate() to split.
+        // Use positioned y coordinates so children stack vertically rather
+        // than overlapping at y=0 (which defeats wrap()'s max(y+h) total).
         let marker_a: Box<dyn Pageable> =
             Box::new(RunningElementMarkerPageable::new("hdr".into(), 0));
         let marker_b: Box<dyn Pageable> =
             Box::new(RunningElementMarkerPageable::new("hdr".into(), 1));
         let block = BlockPageable::with_positioned_children(vec![
-            pos(marker_a),
-            pos(make_spacer(100.0)),
-            pos(make_spacer(100.0)),
-            pos(marker_b),
-            pos(make_spacer(100.0)),
+            PositionedChild {
+                child: marker_a,
+                x: 0.0,
+                y: 0.0,
+            },
+            PositionedChild {
+                child: make_spacer(80.0),
+                x: 0.0,
+                y: 0.0,
+            },
+            PositionedChild {
+                child: marker_b,
+                x: 0.0,
+                y: 120.0,
+            },
+            PositionedChild {
+                child: make_spacer(80.0),
+                x: 0.0,
+                y: 120.0,
+            },
         ]);
-        let pages = paginate(Box::new(block), 200.0, 200.0);
+        let pages = paginate(Box::new(block), 200.0, 100.0);
         assert!(pages.len() >= 2);
         let states = collect_running_element_states(&pages);
-        // marker_a is before any spacers — on page 1
+        // marker_a sits before the first spacer on page 1.
         assert_eq!(states[0].get("hdr").unwrap().instance_ids, vec![0]);
-        // marker_b is between spacer 2 and 3 — should be on page 2
+        // marker_b sits with the second spacer, which overflows to page 2.
         assert_eq!(states[1].get("hdr").unwrap().instance_ids, vec![1]);
     }
 

--- a/crates/fulgur/src/paginate.rs
+++ b/crates/fulgur/src/paginate.rs
@@ -1,8 +1,8 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::pageable::{
-    BlockPageable, ListItemPageable, Pageable, Pt, RunningElementMarkerPageable, StringSetPageable,
-    StringSetWrapperPageable, TablePageable,
+    BlockPageable, ListItemPageable, Pageable, Pt, RunningElementMarkerPageable,
+    RunningElementWrapperPageable, StringSetPageable, StringSetWrapperPageable, TablePageable,
 };
 
 /// Per-page state for a named string.
@@ -91,6 +91,8 @@ fn collect_markers(pageable: &dyn Pageable, markers: &mut Vec<(String, String)>)
             markers.push((m.name.clone(), m.value.clone()));
         }
         collect_markers(wrapper.child.as_ref(), markers);
+    } else if let Some(wrapper) = any.downcast_ref::<RunningElementWrapperPageable>() {
+        collect_markers(wrapper.child.as_ref(), markers);
     } else if let Some(marker) = any.downcast_ref::<StringSetPageable>() {
         // Used by unit tests that construct markers directly.
         markers.push((marker.name.clone(), marker.value.clone()));
@@ -121,6 +123,13 @@ pub struct PageRunningState {
 /// Walk paginated pages and collect `RunningElementMarkerPageable` markers
 /// per page, keyed by running element name.
 ///
+/// Each `instance_id` is adopted only on the first page where it appears.
+/// This is necessary because some containers (e.g. `TablePageable`
+/// `header_cells`) are replicated on every page that shows the table; without
+/// deduplication, a running element declared inside a `<thead>` would be
+/// counted as a fresh assignment on every subsequent page and break
+/// `first` / `last` / `first-except` semantics.
+///
 /// Used by the render stage together with `resolve_element_policy` to
 /// determine which running element instance should be shown in each
 /// margin box on each page.
@@ -128,12 +137,16 @@ pub fn collect_running_element_states(
     pages: &[Box<dyn Pageable>],
 ) -> Vec<BTreeMap<String, PageRunningState>> {
     let mut result: Vec<BTreeMap<String, PageRunningState>> = Vec::with_capacity(pages.len());
+    let mut adopted: BTreeSet<usize> = BTreeSet::new();
 
     for page in pages {
         let mut page_state: BTreeMap<String, PageRunningState> = BTreeMap::new();
         let mut markers = Vec::new();
         collect_running_markers(page.as_ref(), &mut markers);
         for (name, instance_id) in markers {
+            if !adopted.insert(instance_id) {
+                continue; // already adopted on an earlier page
+            }
             page_state
                 .entry(name)
                 .or_default()
@@ -149,11 +162,18 @@ pub fn collect_running_element_states(
 /// Recursively find all running element markers in a Pageable tree.
 ///
 /// Mirrors `collect_markers` (for string-set) but looks for
-/// `RunningElementMarkerPageable` instances.
+/// `RunningElementMarkerPageable` instances. Descends into both
+/// `StringSetWrapperPageable` and `RunningElementWrapperPageable` so markers
+/// wrapped by either mechanism are still discovered.
 fn collect_running_markers(pageable: &dyn Pageable, markers: &mut Vec<(String, usize)>) {
     let any = pageable.as_any();
     if let Some(m) = any.downcast_ref::<RunningElementMarkerPageable>() {
         markers.push((m.name.clone(), m.instance_id));
+    } else if let Some(wrapper) = any.downcast_ref::<RunningElementWrapperPageable>() {
+        for m in &wrapper.markers {
+            markers.push((m.name.clone(), m.instance_id));
+        }
+        collect_running_markers(wrapper.child.as_ref(), markers);
     } else if let Some(wrapper) = any.downcast_ref::<StringSetWrapperPageable>() {
         collect_running_markers(wrapper.child.as_ref(), markers);
     } else if let Some(block) = any.downcast_ref::<BlockPageable>() {
@@ -399,5 +419,46 @@ mod tests {
         let states = collect_running_element_states(&pages);
         assert_eq!(states.len(), 1);
         assert!(states[0].is_empty());
+    }
+
+    #[test]
+    fn test_collect_running_element_states_deduplicates_instance_ids() {
+        // Simulates a marker that appears on multiple pages — e.g. inside a
+        // repeated table header. The same instance_id must only count once,
+        // adopted on the first page it appears.
+        use crate::pageable::RunningElementMarkerPageable;
+
+        let marker = || -> Box<dyn Pageable> {
+            Box::new(RunningElementMarkerPageable::new("hdr".into(), 7))
+        };
+
+        let page1 = BlockPageable::with_positioned_children(vec![pos(marker())]);
+        let page2 = BlockPageable::with_positioned_children(vec![pos(marker())]);
+        let pages: Vec<Box<dyn Pageable>> = vec![Box::new(page1), Box::new(page2)];
+
+        let states = collect_running_element_states(&pages);
+        assert_eq!(states.len(), 2);
+        assert_eq!(states[0].get("hdr").unwrap().instance_ids, vec![7]);
+        assert!(
+            states[1].get("hdr").is_none(),
+            "instance_id 7 must not be re-counted on the second page"
+        );
+    }
+
+    #[test]
+    fn test_collect_running_markers_descends_into_wrapper() {
+        // Markers attached via RunningElementWrapperPageable must still be
+        // discovered by collect_running_element_states.
+        use crate::pageable::{RunningElementMarkerPageable, RunningElementWrapperPageable};
+
+        let marker = RunningElementMarkerPageable::new("hdr".into(), 3);
+        let child: Box<dyn Pageable> = make_spacer(50.0);
+        let wrapper = RunningElementWrapperPageable::new(vec![marker], child);
+        let block = BlockPageable::with_positioned_children(vec![pos(Box::new(wrapper))]);
+        let pages = paginate(Box::new(block), 200.0, 500.0);
+
+        let states = collect_running_element_states(&pages);
+        assert_eq!(states.len(), 1);
+        assert_eq!(states[0].get("hdr").unwrap().instance_ids, vec![3]);
     }
 }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -187,7 +187,11 @@ pub fn render_to_pdf_with_gcpm(
     } else {
         crate::paginate::collect_string_set_states(&pages)
     };
-    let running_states = crate::paginate::collect_running_element_states(&pages);
+    let running_states = if gcpm.running_mappings.is_empty() {
+        vec![BTreeMap::new(); pages.len()]
+    } else {
+        crate::paginate::collect_running_element_states(&pages)
+    };
 
     let page_size = if config.landscape {
         config.page_size.landscape()

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -376,9 +376,9 @@ pub fn render_to_pdf_with_gcpm(
                     rect.height,
                     font_data,
                 );
-                let mut dummy_store = RunningElementStore::new();
+                let dummy_store = RunningElementStore::new();
                 let mut dummy_ctx = crate::convert::ConvertContext {
-                    running_store: &mut dummy_store,
+                    running_store: &dummy_store,
                     assets: None,
                     font_cache: HashMap::new(),
                     string_set_by_node: HashMap::new(),

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -187,14 +187,13 @@ pub fn render_to_pdf_with_gcpm(
     } else {
         crate::paginate::collect_string_set_states(&pages)
     };
+    let running_states = crate::paginate::collect_running_element_states(&pages);
 
     let page_size = if config.landscape {
         config.page_size.landscape()
     } else {
         config.page_size
     };
-
-    let running_pairs = running_store.to_pairs();
 
     // Build margin-box CSS: strip display:none rules that the parser
     // injected for running elements (they need to be visible in margin boxes).
@@ -256,10 +255,12 @@ pub fn render_to_pdf_with_gcpm(
         for (&pos, rule) in &effective_boxes {
             let content_html = resolve_content_to_html(
                 &rule.content,
-                &running_pairs,
+                running_store,
+                &running_states,
                 &string_set_states[page_idx],
                 page_num,
                 total_pages,
+                page_idx,
             );
             if !content_html.is_empty() {
                 let html = if rule.declarations.is_empty() {

--- a/crates/fulgur/tests/gcpm_integration.rs
+++ b/crates/fulgur/tests/gcpm_integration.rs
@@ -468,3 +468,117 @@ fn test_gcpm_string_set_with_policies() {
     assert!(!pdf.is_empty());
     assert!(pdf.starts_with(b"%PDF-"));
 }
+
+#[test]
+fn test_element_policy_multiple_chapters_last() {
+    let css = r#"
+        @page {
+            size: 400pt 300pt;
+            margin: 40pt;
+            @top-center { content: element(title, last); }
+        }
+        .title { position: running(title); }
+        .big { height: 250pt; border: 1px solid black; }
+    "#;
+
+    let html = r#"<!DOCTYPE html>
+<html>
+<head></head>
+<body>
+  <h1 class="title">Chapter 1</h1>
+  <div class="big">Chapter 1 body</div>
+  <h1 class="title">Chapter 2</h1>
+  <div class="big">Chapter 2 body</div>
+</body>
+</html>"#;
+
+    let mut assets = AssetBundle::new();
+    assets.add_css(css);
+
+    let engine = Engine::builder().assets(assets).build();
+    let pdf = engine
+        .render_html(html)
+        .expect("render should succeed with element(title, last) across multiple chapters");
+
+    assert!(
+        pdf.len() > 1000,
+        "PDF seems empty or too small: {} bytes",
+        pdf.len()
+    );
+    assert!(pdf.starts_with(b"%PDF-"));
+}
+
+#[test]
+fn test_element_policy_first_except() {
+    let css = r#"
+        @page {
+            size: 400pt 300pt;
+            margin: 40pt;
+            @top-center { content: element(title, first-except); }
+        }
+        .title { position: running(title); }
+        .big { height: 250pt; border: 1px solid black; }
+    "#;
+
+    let html = r#"<!DOCTYPE html>
+<html>
+<head></head>
+<body>
+  <h1 class="title">Chapter 1</h1>
+  <div class="big">Chapter 1 body</div>
+</body>
+</html>"#;
+
+    let mut assets = AssetBundle::new();
+    assets.add_css(css);
+
+    let engine = Engine::builder().assets(assets).build();
+    let pdf = engine
+        .render_html(html)
+        .expect("render should succeed with element(title, first-except)");
+
+    assert!(
+        pdf.len() > 1000,
+        "PDF seems empty or too small: {} bytes",
+        pdf.len()
+    );
+    assert!(pdf.starts_with(b"%PDF-"));
+}
+
+#[test]
+fn test_element_default_policy_still_works() {
+    // Baseline: element(title) without an explicit policy must still render
+    // (default = first), matching pre-policy behavior.
+    let css = r#"
+        @page {
+            size: 400pt 300pt;
+            margin: 40pt;
+            @top-center { content: element(title); }
+        }
+        .title { position: running(title); }
+    "#;
+
+    let html = r#"<!DOCTYPE html>
+<html>
+<head></head>
+<body>
+  <h1 class="title">My Title</h1>
+  <p>Body content.</p>
+</body>
+</html>"#;
+
+    let mut assets = AssetBundle::new();
+    assets.add_css(css);
+
+    let engine = Engine::builder().assets(assets).build();
+    let pdf = engine
+        .render_html(html)
+        .expect("render should succeed with default element() policy");
+
+    assert!(
+        pdf.len() > 1000,
+        "PDF seems empty or too small: {} bytes",
+        pdf.len()
+    );
+    assert!(pdf.starts_with(b"%PDF-"));
+}

--- a/docs/plans/2026-04-06-gcpm-element-policy-implementation.md
+++ b/docs/plans/2026-04-06-gcpm-element-policy-implementation.md
@@ -1,0 +1,1196 @@
+# GCPM element() 4ポリシー対応 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** `content: element(name, <policy>)` の第2引数 (first/start/last/first-except) をWeasyPrint互換の意味論で実装する。
+
+**Architecture:** string-set 実装と同じマーカー方式。`RunningElementPass` で DOM walk 時に node_id → instance_id マップを構築。`convert.rs` の zero-size 分岐で `RunningElementMarkerPageable` (zero-size no-op) を発行。`paginate.rs` で per-page instance リストを収集。`resolve_element_policy` でポリシーに応じて instance_id を選び、`RunningElementStore` から HTML を引く。フォールバックは「直近の先行ページの最後の instance」に統一。
+
+**Tech Stack:** Rust, cssparser, Blitz DOM, 既存 GCPM infrastructure
+
+**Related issue:** `fulgur-94h`
+
+---
+
+## Task 1: データ型 — ElementPolicy と ContentItem::Element の再構造化
+
+**Files:**
+
+- Modify: `crates/fulgur/src/gcpm/mod.rs`
+
+**Step 1: ElementPolicy enum を追加**
+
+`StringPolicy` 定義の直後に:
+
+```rust
+/// Policy for `element(name, <policy>)` — determines which running element
+/// instance to show on a given page. WeasyPrint-compatible semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ElementPolicy {
+    /// First instance assigned on the current page (default).
+    First,
+    /// Element in effect at start of page. Implemented identically to `First`
+    /// with fallback (WeasyPrint has the same effective behavior).
+    Start,
+    /// Last instance assigned on the current page.
+    Last,
+    /// Like `First`, but empty on pages where the element is assigned.
+    FirstExcept,
+}
+```
+
+**Step 2: ContentItem::Element を構造体バリアントに変更**
+
+```rust
+// 変更前
+Element(String),
+
+// 変更後
+Element {
+    name: String,
+    policy: ElementPolicy,
+},
+```
+
+**Step 3: `cargo check -p fulgur` でビルドエラー箇所を洗い出し**
+
+Expected: `ContentItem::Element(...)` の呼び出し箇所すべてがエラー化する (parser.rs, counter.rs)。次タスクで順次修正。
+
+**Step 4: コミット**
+
+```bash
+git add crates/fulgur/src/gcpm/mod.rs
+git commit -m "feat(gcpm): add ElementPolicy enum and restructure ContentItem::Element"
+```
+
+---
+
+## Task 2: パーサー — element() の第2引数パース
+
+**Files:**
+
+- Modify: `crates/fulgur/src/gcpm/parser.rs`
+
+**Step 1: 失敗テストを追加**
+
+`parser.rs` の `tests` モジュール末尾に:
+
+```rust
+#[test]
+fn test_parse_element_function_default_policy() {
+    let css = "@page { @top-center { content: element(hdr); } }";
+    let ctx = parse_gcpm_css(css);
+    let rule = ctx.margin_boxes.first().unwrap();
+    assert_eq!(
+        rule.content,
+        vec![ContentItem::Element {
+            name: "hdr".into(),
+            policy: ElementPolicy::First,
+        }]
+    );
+}
+
+#[test]
+fn test_parse_element_function_all_policies() {
+    for (policy_str, policy) in [
+        ("first", ElementPolicy::First),
+        ("start", ElementPolicy::Start),
+        ("last", ElementPolicy::Last),
+        ("first-except", ElementPolicy::FirstExcept),
+    ] {
+        let css = format!(
+            "@page {{ @top-center {{ content: element(hdr, {}); }} }}",
+            policy_str
+        );
+        let ctx = parse_gcpm_css(&css);
+        let rule = ctx.margin_boxes.first().unwrap();
+        assert_eq!(
+            rule.content,
+            vec![ContentItem::Element {
+                name: "hdr".into(),
+                policy,
+            }],
+            "Failed for policy: {}",
+            policy_str
+        );
+    }
+}
+
+#[test]
+fn test_parse_element_function_invalid_policy() {
+    // Unknown policy identifier — the whole element() call should be dropped.
+    let css = "@page { @top-center { content: element(hdr, bogus); } }";
+    let ctx = parse_gcpm_css(css);
+    let rule = ctx.margin_boxes.first().unwrap();
+    assert!(rule.content.is_empty());
+}
+```
+
+**Step 2: テスト実行して失敗を確認**
+
+```bash
+cargo test -p fulgur --lib gcpm::parser::tests::test_parse_element_function
+```
+
+Expected: コンパイルエラーまたは FAIL (ElementPolicy未使用import または ContentItem形不一致)。
+
+**Step 3: パーサーに `parse_element_policy` と呼び出しを追加**
+
+`parse_string_policy` の直後に共通ヘルパを追加 (ほぼ同一構造):
+
+```rust
+/// Parse the policy argument of `element(name, <policy>)`.
+fn parse_element_policy<'i>(
+    input: &mut Parser<'i, '_>,
+) -> Result<ElementPolicy, ParseError<'i, ()>> {
+    let ident = input.expect_ident()?.clone();
+    if ident.eq_ignore_ascii_case("start") {
+        Ok(ElementPolicy::Start)
+    } else if ident.eq_ignore_ascii_case("last") {
+        Ok(ElementPolicy::Last)
+    } else if ident.eq_ignore_ascii_case("first-except") {
+        Ok(ElementPolicy::FirstExcept)
+    } else if ident.eq_ignore_ascii_case("first") {
+        let has_except = input
+            .try_parse(|input| {
+                input.expect_delim('-')?;
+                let next = input.expect_ident()?.clone();
+                if next.eq_ignore_ascii_case("except") {
+                    Ok(())
+                } else {
+                    Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid))
+                }
+            })
+            .is_ok();
+        Ok(if has_except {
+            ElementPolicy::FirstExcept
+        } else {
+            ElementPolicy::First
+        })
+    } else {
+        Err(input.new_error(BasicParseErrorKind::QualifiedRuleInvalid))
+    }
+}
+```
+
+`parse_content_value` の `element` 分岐を置き換え:
+
+```rust
+if fn_name.eq_ignore_ascii_case("element") {
+    let name = arg.to_string();
+    // Optional second argument: policy identifier.
+    let policy_result = input.try_parse(|input| {
+        input.expect_comma()?;
+        parse_element_policy(input)
+    });
+    // If a comma is present but the policy is invalid, drop the item entirely.
+    match policy_result {
+        Ok(policy) => {
+            items.push(ContentItem::Element { name, policy });
+        }
+        Err(_) if input.is_exhausted() => {
+            // No second argument — default to First.
+            items.push(ContentItem::Element {
+                name,
+                policy: ElementPolicy::First,
+            });
+        }
+        Err(_) => {
+            // Second argument present but invalid — reject this call.
+        }
+    }
+}
+```
+
+`use` 行に `ElementPolicy` を追加。
+
+**Step 4: テスト実行**
+
+```bash
+cargo test -p fulgur --lib gcpm::parser
+```
+
+Expected: 全パーサーテスト PASS。
+
+**Step 5: コミット**
+
+```bash
+git add crates/fulgur/src/gcpm/parser.rs
+git commit -m "feat(gcpm): parse element() policy second argument"
+```
+
+---
+
+## Task 3: RunningElementStore を instance-list 方式に書き換え
+
+**Files:**
+
+- Modify: `crates/fulgur/src/gcpm/running.rs`
+
+**Step 1: 失敗テストを追加**
+
+既存テストを置き換える形で:
+
+```rust
+#[test]
+fn test_running_store_instance_registration() {
+    let mut store = RunningElementStore::new();
+    let id_a = store.register(10, "header".to_string(), "<h1>A</h1>".to_string());
+    let id_b = store.register(20, "header".to_string(), "<h1>B</h1>".to_string());
+
+    assert_ne!(id_a, id_b);
+    assert_eq!(store.get_html(id_a), Some("<h1>A</h1>"));
+    assert_eq!(store.get_html(id_b), Some("<h1>B</h1>"));
+    assert_eq!(store.instance_for_node(10), Some(id_a));
+    assert_eq!(store.instance_for_node(20), Some(id_b));
+    assert_eq!(store.instance_for_node(99), None);
+}
+
+#[test]
+fn test_running_store_name_lookup() {
+    let mut store = RunningElementStore::new();
+    let id = store.register(5, "footer".to_string(), "<p>F</p>".to_string());
+    assert_eq!(store.name_of(id), Some("footer"));
+}
+```
+
+**Step 2: テスト実行 — コンパイル失敗を確認**
+
+```bash
+cargo test -p fulgur --lib gcpm::running
+```
+
+Expected: `register` シグネチャ不一致、`get_html` / `instance_for_node` / `name_of` 未定義でエラー。
+
+**Step 3: `RunningElementStore` を書き換え**
+
+既存の `HashMap<String, String>` ベース実装を削除し、以下に置換:
+
+```rust
+#[derive(Debug, Clone)]
+pub struct RunningInstance {
+    pub id: usize,
+    pub name: String,
+    pub html: String,
+}
+
+pub struct RunningElementStore {
+    instances: Vec<RunningInstance>,
+    /// Maps DOM node_id → index into `instances`.
+    node_to_instance: HashMap<usize, usize>,
+}
+
+impl RunningElementStore {
+    pub fn new() -> Self {
+        Self {
+            instances: Vec::new(),
+            node_to_instance: HashMap::new(),
+        }
+    }
+
+    /// Register a running element instance. Returns the assigned instance_id.
+    pub fn register(&mut self, node_id: usize, name: String, html: String) -> usize {
+        let id = self.instances.len();
+        self.instances.push(RunningInstance { id, name, html });
+        self.node_to_instance.insert(node_id, id);
+        id
+    }
+
+    /// Look up the instance_id assigned to a DOM node, if any.
+    pub fn instance_for_node(&self, node_id: usize) -> Option<usize> {
+        self.node_to_instance.get(&node_id).copied()
+    }
+
+    /// Get the serialized HTML for a given instance_id.
+    pub fn get_html(&self, instance_id: usize) -> Option<&str> {
+        self.instances.get(instance_id).map(|i| i.html.as_str())
+    }
+
+    /// Get the running name for a given instance_id.
+    pub fn name_of(&self, instance_id: usize) -> Option<&str> {
+        self.instances.get(instance_id).map(|i| i.name.as_str())
+    }
+}
+
+impl Default for RunningElementStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+```
+
+既存の `get(&str)` や `to_pairs()` は削除 (呼び出し元も後続タスクで更新)。
+
+**Step 4: 残りのコンパイルエラーを洗い出し**
+
+```bash
+cargo check -p fulgur 2>&1 | tail -30
+```
+
+Expected: `blitz_adapter.rs` と `render.rs` に `to_pairs` / `get` / `register(name, html)` の呼び出しがあり、それぞれタスク4と8で修正する。
+
+**Step 5: `gcpm::running` モジュールのテストのみ通す**
+
+```bash
+cargo test -p fulgur --lib gcpm::running
+```
+
+Expected: PASS (他モジュールはまだ壊れているが、このモジュール単体は通る)。
+
+**Step 6: コミット**
+
+この時点でトップレベルビルドは壊れているが、コミット境界を小さく保つため進める。
+
+```bash
+git add crates/fulgur/src/gcpm/running.rs
+git commit -m "feat(gcpm): rewrite RunningElementStore with instance-list storage"
+```
+
+---
+
+## Task 4: RunningElementPass — node_id を登録
+
+**Files:**
+
+- Modify: `crates/fulgur/src/blitz_adapter.rs`
+
+**Step 1: `RunningElementPass::walk_tree` を修正**
+
+既存の呼び出し:
+
+```rust
+self.store.borrow_mut().register(running_name, html);
+```
+
+を以下に置換:
+
+```rust
+self.store.borrow_mut().register(node_id, running_name, html);
+```
+
+**Step 2: 既存の `test_running_element_pass_extracts_by_class` テストを確認して更新**
+
+テストは `store.get(name)` を呼んでいるはず。新APIに合わせて `instance_for_node` + `get_html` の組み合わせ、または新しいアサーションに書き換える。
+
+```bash
+grep -n "test_running_element_pass" crates/fulgur/src/blitz_adapter.rs
+```
+
+該当テストの中で:
+
+```rust
+// 変更前の想定
+let store = pass.into_running_store();
+assert_eq!(store.get("header"), Some("<h1>Title</h1>"));
+
+// 変更後
+let store = pass.into_running_store();
+// Walk instances to find the one with name "header".
+let header_id = (0..).find(|&i| store.name_of(i) == Some("header")).unwrap();
+assert!(store.get_html(header_id).unwrap().contains("Title"));
+```
+
+(実際のテスト箇所を読んで文面を合わせる)
+
+**Step 3: ビルド確認**
+
+```bash
+cargo check -p fulgur 2>&1 | tail -20
+```
+
+Expected: blitz_adapter.rs のエラーは解消。残りは render.rs のみ (後続タスク)。
+
+**Step 4: `blitz_adapter` のテストを実行**
+
+```bash
+cargo test -p fulgur --lib blitz_adapter
+```
+
+Expected: PASS。
+
+**Step 5: コミット**
+
+```bash
+git add crates/fulgur/src/blitz_adapter.rs
+git commit -m "feat(gcpm): record node_id when registering running element instances"
+```
+
+---
+
+## Task 5: RunningElementMarkerPageable — zero-size marker
+
+**Files:**
+
+- Modify: `crates/fulgur/src/pageable.rs`
+
+**Step 1: 失敗テストを追加**
+
+`pageable.rs` の tests モジュール末尾に:
+
+```rust
+#[test]
+fn test_running_element_marker_is_zero_size_noop() {
+    let mut m = RunningElementMarkerPageable::new("header".to_string(), 42);
+    let size = m.wrap(100.0, 100.0);
+    assert_eq!(size.width, 0.0);
+    assert_eq!(size.height, 0.0);
+    assert_eq!(m.height(), 0.0);
+    assert_eq!(m.name, "header");
+    assert_eq!(m.instance_id, 42);
+    assert!(m.split(100.0, 100.0).is_none());
+}
+```
+
+**Step 2: テスト実行して失敗確認**
+
+```bash
+cargo test -p fulgur --lib pageable::tests::test_running_element_marker
+```
+
+Expected: FAIL (型未定義)。
+
+**Step 3: `RunningElementMarkerPageable` を実装**
+
+`StringSetPageable` 定義の直後に:
+
+```rust
+// ─── RunningElementMarkerPageable ────────────────────────
+
+/// Zero-size marker for running element instances.
+/// Inserted into the Pageable tree at the source position where
+/// `position: running(name)` was declared, so that pagination can track
+/// which running element instance is in effect on each page.
+#[derive(Clone)]
+pub struct RunningElementMarkerPageable {
+    pub name: String,
+    pub instance_id: usize,
+}
+
+impl RunningElementMarkerPageable {
+    pub fn new(name: String, instance_id: usize) -> Self {
+        Self { name, instance_id }
+    }
+}
+
+impl Pageable for RunningElementMarkerPageable {
+    fn wrap(&mut self, _avail_width: Pt, _avail_height: Pt) -> Size {
+        Size { width: 0.0, height: 0.0 }
+    }
+
+    fn split(
+        &self,
+        _avail_width: Pt,
+        _avail_height: Pt,
+    ) -> Option<(Box<dyn Pageable>, Box<dyn Pageable>)> {
+        None
+    }
+
+    fn draw(&self, _canvas: &mut Canvas, _x: Pt, _y: Pt, _avail_width: Pt, _avail_height: Pt) {}
+
+    fn clone_box(&self) -> Box<dyn Pageable> {
+        Box::new(self.clone())
+    }
+
+    fn height(&self) -> Pt {
+        0.0
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+```
+
+`pub use` / `mod` の再エクスポートがあれば追加。
+
+**Step 4: テスト PASS 確認**
+
+```bash
+cargo test -p fulgur --lib pageable::tests::test_running_element_marker
+```
+
+Expected: PASS。
+
+**Step 5: コミット**
+
+```bash
+git add crates/fulgur/src/pageable.rs
+git commit -m "feat(pageable): add RunningElementMarkerPageable zero-size marker"
+```
+
+---
+
+## Task 6: Convert — running要素ノードの位置にマーカーを発行
+
+**Files:**
+
+- Modify: `crates/fulgur/src/convert.rs`
+
+**Step 1: `ConvertContext` のフィールドを調整**
+
+現状 `pub running_store: &'a mut RunningElementStore` を読み取り専用に変更:
+
+```rust
+pub running_store: &'a RunningElementStore,
+```
+
+(もはや convert 時点では register しない — RunningElementPass が済んでいる)
+
+**Step 2: `emit_orphan_running_markers` ヘルパを追加**
+
+`emit_orphan_string_set_markers` の直後に:
+
+```rust
+/// Emit a `RunningElementMarkerPageable` when a zero-size node corresponds to
+/// a running element instance. Running elements are rewritten to `display: none`
+/// by the GCPM parser, so they land in the zero-size branches of
+/// `collect_positioned_children`. This preserves their source position in the
+/// Pageable tree as a zero-size marker so pagination can determine which
+/// running element instances fall on which page.
+fn emit_orphan_running_marker(
+    node_id: usize,
+    x: f32,
+    y: f32,
+    ctx: &ConvertContext<'_>,
+    out: &mut Vec<PositionedChild>,
+) {
+    if let Some(instance_id) = ctx.running_store.instance_for_node(node_id) {
+        if let Some(name) = ctx.running_store.name_of(instance_id) {
+            out.push(PositionedChild {
+                child: Box::new(RunningElementMarkerPageable::new(
+                    name.to_string(),
+                    instance_id,
+                )),
+                x,
+                y,
+            });
+        }
+    }
+}
+```
+
+`use` に `RunningElementMarkerPageable` を追加。
+
+**Step 3: `collect_positioned_children` の zero-size 分岐で marker を emit**
+
+既存の 2 箇所 (zero-size leaf, zero-size container) に、`emit_orphan_string_set_markers` 呼び出しの直後で:
+
+```rust
+emit_orphan_running_marker(
+    child_id,
+    child_layout.location.x,
+    child_layout.location.y,
+    ctx,
+    &mut result,
+);
+```
+
+**Step 4: 単体テスト追加**
+
+`convert.rs` の tests モジュール (なければ作る) に統合テスト相当は不要だが、意図を表すテストを後続タスク 11 の統合テストで担保するため、ここでは `cargo check` で成立確認のみ。
+
+**Step 5: ビルド確認**
+
+```bash
+cargo check -p fulgur 2>&1 | tail -20
+```
+
+Expected: convert.rs 由来のエラーなし。
+
+**Step 6: コミット**
+
+```bash
+git add crates/fulgur/src/convert.rs
+git commit -m "feat(convert): emit RunningElementMarkerPageable at running element source positions"
+```
+
+---
+
+## Task 7: Paginate — ページごとの running instance 収集
+
+**Files:**
+
+- Modify: `crates/fulgur/src/paginate.rs`
+
+**Step 1: 失敗テストを追加**
+
+`paginate.rs` の tests モジュールに:
+
+```rust
+#[test]
+fn test_collect_running_element_states_single_page() {
+    use crate::pageable::RunningElementMarkerPageable;
+
+    let marker_a: Box<dyn Pageable> =
+        Box::new(RunningElementMarkerPageable::new("hdr".into(), 0));
+    let marker_b: Box<dyn Pageable> =
+        Box::new(RunningElementMarkerPageable::new("hdr".into(), 1));
+    let block = BlockPageable::with_positioned_children(vec![
+        pos(marker_a),
+        pos(make_spacer(50.0)),
+        pos(marker_b),
+        pos(make_spacer(50.0)),
+    ]);
+    let pages = paginate(Box::new(block), 200.0, 500.0);
+    assert_eq!(pages.len(), 1);
+    let states = collect_running_element_states(&pages);
+    assert_eq!(states[0].get("hdr").unwrap().instance_ids, vec![0, 1]);
+}
+
+#[test]
+fn test_collect_running_element_states_splits_across_pages() {
+    use crate::pageable::RunningElementMarkerPageable;
+
+    let marker_a: Box<dyn Pageable> =
+        Box::new(RunningElementMarkerPageable::new("hdr".into(), 0));
+    let marker_b: Box<dyn Pageable> =
+        Box::new(RunningElementMarkerPageable::new("hdr".into(), 1));
+    let block = BlockPageable::with_positioned_children(vec![
+        pos(marker_a),
+        pos(make_spacer(100.0)),
+        pos(make_spacer(100.0)), // forces split around here
+        pos(marker_b),
+        pos(make_spacer(100.0)),
+    ]);
+    let pages = paginate(Box::new(block), 200.0, 200.0);
+    assert!(pages.len() >= 2);
+    let states = collect_running_element_states(&pages);
+    assert_eq!(states[0].get("hdr").unwrap().instance_ids, vec![0]);
+    assert_eq!(states[1].get("hdr").unwrap().instance_ids, vec![1]);
+}
+```
+
+**Step 2: 実行して失敗確認**
+
+```bash
+cargo test -p fulgur --lib paginate::tests::test_collect_running_element_states
+```
+
+Expected: FAIL (`PageRunningState`, `collect_running_element_states` 未定義)。
+
+**Step 3: 実装を追加**
+
+`paginate.rs` の string-set 関数群の直後に:
+
+```rust
+use crate::pageable::RunningElementMarkerPageable;
+
+/// Per-page state for running elements of a given name.
+#[derive(Debug, Clone, Default)]
+pub struct PageRunningState {
+    /// Instance IDs of running elements whose source position lies on this page,
+    /// in source order.
+    pub instance_ids: Vec<usize>,
+}
+
+/// Walk paginated pages and collect `RunningElementMarkerPageable` markers
+/// per page, keyed by running element name.
+pub fn collect_running_element_states(
+    pages: &[Box<dyn Pageable>],
+) -> Vec<BTreeMap<String, PageRunningState>> {
+    let mut result: Vec<BTreeMap<String, PageRunningState>> = Vec::with_capacity(pages.len());
+
+    for page in pages {
+        let mut page_state: BTreeMap<String, PageRunningState> = BTreeMap::new();
+        let mut markers = Vec::new();
+        collect_running_markers(page.as_ref(), &mut markers);
+        for (name, instance_id) in markers {
+            page_state
+                .entry(name)
+                .or_default()
+                .instance_ids
+                .push(instance_id);
+        }
+        result.push(page_state);
+    }
+
+    result
+}
+
+fn collect_running_markers(pageable: &dyn Pageable, markers: &mut Vec<(String, usize)>) {
+    let any = pageable.as_any();
+    if let Some(m) = any.downcast_ref::<RunningElementMarkerPageable>() {
+        markers.push((m.name.clone(), m.instance_id));
+    } else if let Some(wrapper) = any.downcast_ref::<StringSetWrapperPageable>() {
+        collect_running_markers(wrapper.child.as_ref(), markers);
+    } else if let Some(block) = any.downcast_ref::<BlockPageable>() {
+        for child in &block.children {
+            collect_running_markers(child.child.as_ref(), markers);
+        }
+    } else if let Some(table) = any.downcast_ref::<TablePageable>() {
+        for child in &table.header_cells {
+            collect_running_markers(child.child.as_ref(), markers);
+        }
+        for child in &table.body_cells {
+            collect_running_markers(child.child.as_ref(), markers);
+        }
+    } else if let Some(list_item) = any.downcast_ref::<ListItemPageable>() {
+        collect_running_markers(list_item.body.as_ref(), markers);
+    }
+}
+```
+
+(`StringSetWrapperPageable`, `BlockPageable`, `TablePageable`, `ListItemPageable` のimportを追加)
+
+**Step 4: テスト PASS 確認**
+
+```bash
+cargo test -p fulgur --lib paginate
+```
+
+Expected: PASS。
+
+**Step 5: コミット**
+
+```bash
+git add crates/fulgur/src/paginate.rs
+git commit -m "feat(paginate): add collect_running_element_states for per-page instance tracking"
+```
+
+---
+
+## Task 8: Resolver — ポリシーに基づく instance 選択
+
+**Files:**
+
+- Modify: `crates/fulgur/src/gcpm/counter.rs`
+
+**Step 1: 失敗テストを追加**
+
+`counter.rs` の tests モジュールに:
+
+```rust
+#[test]
+fn test_resolve_element_policy_scenarios() {
+    use crate::gcpm::running::RunningElementStore;
+    use crate::paginate::PageRunningState;
+
+    let mut store = RunningElementStore::new();
+    let id_a = store.register(1, "hdr".into(), "<h1>A</h1>".into()); // 0
+    let id_b = store.register(2, "hdr".into(), "<h1>B</h1>".into()); // 1
+    let id_c = store.register(3, "hdr".into(), "<h1>C</h1>".into()); // 2
+
+    // P0 = [A, B], P1 = [C], P2 = []
+    let mut p0 = BTreeMap::new();
+    p0.insert(
+        "hdr".to_string(),
+        PageRunningState { instance_ids: vec![id_a, id_b] },
+    );
+    let mut p1 = BTreeMap::new();
+    p1.insert(
+        "hdr".to_string(),
+        PageRunningState { instance_ids: vec![id_c] },
+    );
+    let p2 = BTreeMap::new();
+    let states = vec![p0, p1, p2];
+
+    // first: A, C, C (P2 falls back to P1.last = C)
+    assert_eq!(resolve_element_policy("hdr", ElementPolicy::First, 0, &states, &store), Some("<h1>A</h1>"));
+    assert_eq!(resolve_element_policy("hdr", ElementPolicy::First, 1, &states, &store), Some("<h1>C</h1>"));
+    assert_eq!(resolve_element_policy("hdr", ElementPolicy::First, 2, &states, &store), Some("<h1>C</h1>"));
+
+    // last: B, C, C
+    assert_eq!(resolve_element_policy("hdr", ElementPolicy::Last, 0, &states, &store), Some("<h1>B</h1>"));
+    assert_eq!(resolve_element_policy("hdr", ElementPolicy::Last, 1, &states, &store), Some("<h1>C</h1>"));
+    assert_eq!(resolve_element_policy("hdr", ElementPolicy::Last, 2, &states, &store), Some("<h1>C</h1>"));
+
+    // first-except: A, empty (has assignment), C (fallback)
+    assert_eq!(resolve_element_policy("hdr", ElementPolicy::FirstExcept, 0, &states, &store), None);
+    assert_eq!(resolve_element_policy("hdr", ElementPolicy::FirstExcept, 1, &states, &store), None);
+    assert_eq!(resolve_element_policy("hdr", ElementPolicy::FirstExcept, 2, &states, &store), Some("<h1>C</h1>"));
+}
+
+#[test]
+fn test_resolve_element_policy_no_assignments_anywhere() {
+    use crate::gcpm::running::RunningElementStore;
+    use crate::paginate::PageRunningState;
+
+    let store = RunningElementStore::new();
+    let states: Vec<BTreeMap<String, PageRunningState>> = vec![BTreeMap::new(); 3];
+
+    for policy in [ElementPolicy::First, ElementPolicy::Start, ElementPolicy::Last, ElementPolicy::FirstExcept] {
+        for page in 0..3 {
+            assert_eq!(
+                resolve_element_policy("hdr", policy, page, &states, &store),
+                None,
+            );
+        }
+    }
+}
+```
+
+Note: `FirstExcept` on P0 returns `None` (assignment exists), fallback scan finds nothing earlier → `None`. Test reflects this.
+
+**Step 2: 実行して失敗確認**
+
+```bash
+cargo test -p fulgur --lib gcpm::counter::tests::test_resolve_element_policy
+```
+
+Expected: FAIL (関数未定義)。
+
+**Step 3: `resolve_element_policy` を実装**
+
+`counter.rs` に:
+
+```rust
+use crate::gcpm::ElementPolicy;
+use crate::gcpm::running::RunningElementStore;
+use crate::paginate::PageRunningState;
+
+/// Resolve an `element(name, policy)` reference to the HTML of the chosen
+/// running element instance for the given page.
+///
+/// WeasyPrint-compatible semantics:
+/// - `first` / `start`: first instance assigned on the current page.
+/// - `last`: last instance assigned on the current page.
+/// - `first-except`: returns `None` if the current page has any assignment.
+/// - Fallback (any policy, no resolution on current page): the last instance
+///   of the most recent preceding page that had an assignment.
+pub fn resolve_element_policy<'a>(
+    name: &str,
+    policy: ElementPolicy,
+    page_idx: usize,
+    page_states: &[BTreeMap<String, PageRunningState>],
+    store: &'a RunningElementStore,
+) -> Option<&'a str> {
+    let current = page_states.get(page_idx).and_then(|s| s.get(name));
+
+    let chosen_id: Option<usize> = match policy {
+        ElementPolicy::First | ElementPolicy::Start => {
+            current.and_then(|s| s.instance_ids.first().copied())
+        }
+        ElementPolicy::Last => current.and_then(|s| s.instance_ids.last().copied()),
+        ElementPolicy::FirstExcept => {
+            if current.map(|s| !s.instance_ids.is_empty()).unwrap_or(false) {
+                return None;
+            }
+            None
+        }
+    };
+
+    if let Some(id) = chosen_id {
+        return store.get_html(id);
+    }
+
+    // Fallback: scan preceding pages for the most recent assignment.
+    for prev in (0..page_idx).rev() {
+        if let Some(state) = page_states.get(prev).and_then(|s| s.get(name)) {
+            if let Some(&last_id) = state.instance_ids.last() {
+                return store.get_html(last_id);
+            }
+        }
+    }
+
+    None
+}
+```
+
+**Step 4: `resolve_content_to_html` のシグネチャと実装を更新**
+
+既存:
+
+```rust
+pub fn resolve_content_to_html(
+    items: &[ContentItem],
+    running_elements: &[(String, String)],
+    string_set_states: &BTreeMap<String, StringSetPageState>,
+    page: usize,
+    total_pages: usize,
+) -> String
+```
+
+新規:
+
+```rust
+pub fn resolve_content_to_html(
+    items: &[ContentItem],
+    store: &RunningElementStore,
+    running_states: &[BTreeMap<String, PageRunningState>],
+    string_set_states: &BTreeMap<String, StringSetPageState>,
+    page_idx: usize,
+    total_pages: usize,
+) -> String
+```
+
+`ContentItem::Element` 分岐:
+
+```rust
+// 変更前
+ContentItem::Element(name) => {
+    if let Some((_, html)) = running_elements.iter().find(|(n, _)| n == name) {
+        out.push_str(html);
+    }
+}
+
+// 変更後
+ContentItem::Element { name, policy } => {
+    if let Some(html) = resolve_element_policy(name, *policy, page_idx, running_states, store) {
+        out.push_str(html);
+    }
+}
+```
+
+`resolve_content_to_string` の `ContentItem::Element(_)` 分岐を `ContentItem::Element { .. }` に更新 (string モードでは相変わらず空)。
+
+**Step 5: 既存テスト (`test_element_becomes_empty`, `test_resolve_html_with_running_element` 等) を新API に合わせて更新**
+
+```bash
+grep -n "resolve_content_to_html\|resolve_content_to_string\|ContentItem::Element" crates/fulgur/src/gcpm/counter.rs
+```
+
+呼び出し箇所を置換し、`running_elements: &[(String, String)]` を組み立てていた箇所は `store` と `running_states` に置換。
+
+**Step 6: テスト実行**
+
+```bash
+cargo test -p fulgur --lib gcpm::counter
+```
+
+Expected: PASS。
+
+**Step 7: コミット**
+
+```bash
+git add crates/fulgur/src/gcpm/counter.rs
+git commit -m "feat(gcpm): add resolve_element_policy and wire into resolve_content_to_html"
+```
+
+---
+
+## Task 9: Render と Engine — running_states をパイプライン経由で渡す
+
+**Files:**
+
+- Modify: `crates/fulgur/src/render.rs`
+- Modify: `crates/fulgur/src/engine.rs`
+
+**Step 1: `render_to_pdf_with_gcpm` の改修**
+
+`running_store` は既に `&RunningElementStore` を受け取っている。追加で `running_states` を内部で計算:
+
+```rust
+let running_states = crate::paginate::collect_running_element_states(&pages);
+```
+
+(string_set_states の直後に配置)
+
+既存の `running_pairs` 行:
+
+```rust
+let running_pairs = running_store.to_pairs();
+```
+
+を **削除** (もう使わない)。
+
+`resolve_content_to_html` の呼び出しを更新:
+
+```rust
+let content_html = resolve_content_to_html(
+    &rule.content,
+    running_store,
+    &running_states,
+    &string_set_states[page_idx],
+    page_num,
+    total_pages,
+);
+```
+
+note: `page_num` (1-based) と `page_idx` (0-based) の扱いを確認。現状の resolver は `page_idx` 引数を 0-based として実装したので、ここでは `page_idx` (つまり `page_num - 1`) を渡すこと。
+
+**Step 2: 修正点 — resolver シグネチャの確認**
+
+`resolve_element_policy` は 0-based `page_idx` を期待している。`resolve_content_to_html` は caller の page 番号をそのまま使っていた (counter resolution では 1-based)。これは分離する:
+
+```rust
+pub fn resolve_content_to_html(
+    items: &[ContentItem],
+    store: &RunningElementStore,
+    running_states: &[BTreeMap<String, PageRunningState>],
+    string_set_states: &BTreeMap<String, StringSetPageState>,
+    page_num: usize,       // 1-based, for counter(page)
+    total_pages: usize,
+    page_idx: usize,       // 0-based, for running element resolution
+) -> String
+```
+
+Task 8 の Step 4 のシグネチャをこれに修正 (plan 側の記述と一致させる)。
+
+**Step 3: `render.rs` の dummy_store 初期化箇所**
+
+margin-box 内部レンダリング用の `dummy_store`:
+
+```rust
+let mut dummy_store = RunningElementStore::new();
+let mut dummy_ctx = crate::convert::ConvertContext {
+    running_store: &mut dummy_store,
+    ...
+};
+```
+
+`ConvertContext::running_store` が `&RunningElementStore` (immutable) に変わったので、`&dummy_store` に変更。`mut` を外す。
+
+**Step 4: `engine.rs` の `running_store: &mut running_store` を `&running_store` に変更**
+
+convert に渡す時点では既に register 完了しているので immutable で OK。
+
+**Step 5: ビルド + テスト**
+
+```bash
+cargo build -p fulgur 2>&1 | tail -20
+cargo test -p fulgur --lib 2>&1 | tail -5
+```
+
+Expected: ビルドPASS、全 lib テスト PASS。
+
+**Step 6: コミット**
+
+```bash
+git add crates/fulgur/src/render.rs crates/fulgur/src/engine.rs crates/fulgur/src/convert.rs crates/fulgur/src/gcpm/counter.rs
+git commit -m "feat(render): wire per-page running element states through rendering pipeline"
+```
+
+---
+
+## Task 10: 統合テスト — 複数chapter の running element 切替
+
+**Files:**
+
+- Create: `crates/fulgur/tests/gcpm_element_policy.rs` (または既存 `gcpm_integration.rs` に追加)
+
+**Step 1: 既存の統合テストファイルを確認**
+
+```bash
+ls crates/fulgur/tests/
+grep -l "running\|element(" crates/fulgur/tests/*.rs
+```
+
+既存 `gcpm_integration.rs` があればそこに test function を追加、なければ新規ファイルを作る。
+
+**Step 2: 統合テストを追加**
+
+```rust
+#[test]
+fn test_element_policy_multiple_chapters_last() {
+    // Two chapters across multiple pages; last policy should show the current chapter title.
+    let html = r#"
+<html>
+<head>
+<style>
+  @page { size: 400pt 300pt; margin: 40pt; @top-center { content: element(title, last); } }
+  .title { position: running(title); }
+  .big { height: 600pt; }
+</style>
+</head>
+<body>
+  <h1 class="title">Chapter 1</h1>
+  <div class="big">Chapter 1 body</div>
+  <h1 class="title">Chapter 2</h1>
+  <div class="big">Chapter 2 body</div>
+</body>
+</html>
+"#;
+    let pdf = Engine::new().render_html(html).unwrap();
+    // At minimum assert PDF was produced; exact content assertion requires
+    // PDF text extraction which the project handles elsewhere.
+    assert!(pdf.len() > 1000);
+    // If pdf text extraction helper exists:
+    // let pages = extract_text_per_page(&pdf);
+    // assert!(pages[0].contains("Chapter 1"));
+    // assert!(pages[pages.len() - 1].contains("Chapter 2"));
+}
+
+#[test]
+fn test_element_policy_first_except_default() {
+    // first-except: chapter title hidden on the page where chapter starts.
+    let html = r#"
+<html>
+<head>
+<style>
+  @page { size: 400pt 300pt; margin: 40pt; @top-center { content: element(title, first-except); } }
+  .title { position: running(title); }
+  .big { height: 600pt; }
+</style>
+</head>
+<body>
+  <h1 class="title">Chapter 1</h1>
+  <div class="big">Chapter 1 body</div>
+</body>
+</html>
+"#;
+    let pdf = Engine::new().render_html(html).unwrap();
+    assert!(pdf.len() > 1000);
+}
+```
+
+**Step 3: テスト実行**
+
+```bash
+cargo test -p fulgur --test gcpm_element_policy -- --test-threads=1
+```
+
+(または `gcpm_integration` に統合した場合はそちら)
+
+Expected: PASS。
+
+**Step 4: コミット**
+
+```bash
+git add crates/fulgur/tests/
+git commit -m "test(gcpm): integration tests for element() policy across multiple pages"
+```
+
+---
+
+## Task 11: 最終検証
+
+**Step 1: 全lib + 全統合テスト**
+
+```bash
+cargo test --lib -p fulgur
+cargo test -p fulgur --test gcpm_integration -- --test-threads=1
+cargo test -p fulgur --test gcpm_element_policy -- --test-threads=1 2>/dev/null || true
+```
+
+Expected: 全 PASS、ベースラインから後退なし。
+
+**Step 2: fmt + clippy**
+
+```bash
+cargo fmt --check
+cargo clippy -p fulgur -- -D warnings
+```
+
+Expected: 出力なし (違反なし)。
+
+**Step 3: markdown lint (plan document のため)**
+
+```bash
+npx markdownlint-cli2 'docs/plans/2026-04-06-gcpm-element-policy-implementation.md'
+```
+
+Expected: 問題なし、またはあれば修正。
+
+**Step 4: bd update — 実装完了記録**
+
+```bash
+bd update fulgur-94h --notes "Implementation complete on branch feature/gcpm-element-policy. All 4 policies (first/start/last/first-except) supported with WeasyPrint-compatible fallback semantics."
+```
+
+**Step 5: 最終コミット (必要なら)**
+
+fmt/clippy 修正があれば:
+
+```bash
+git add -u
+git commit -m "chore: fmt and clippy cleanup"
+```
+
+---
+
+## 注意点
+
+- `ContentItem::Element` は破壊的変更 — 該当バリアントのパターンマッチを全箇所更新する必要がある。`cargo check` のエラーメッセージを手がかりに網羅する。
+- `RunningElementStore` も API 総入れ替え。`get`/`to_pairs` 使用箇所は全滅するので、やはり `cargo check` で追い込む。
+- `page_num` (1-based) と `page_idx` (0-based) を混同しないこと。counter() は 1-based、running policy resolution は 0-based でpage_statesへのindex。
+- 既存の `display: none` 経由の running要素除外は依然として機能する。マーカーは zero-size node の分岐で emit されるので、CSS rewrite を変更する必要はない。


### PR DESCRIPTION
## Summary

CSS GCPM `element(name, <policy>)` の第2引数対応。WeasyPrint 互換セマンティクスで `first` / `start` / `last` / `first-except` の 4 ポリシーをサポートし、複数章を跨ぐ running element のページごと切替を正しく解決します。

Closes `fulgur-94h`.

## Approach

string-set パイプラインと対称なマーカー + per-page state 方式:

1. `RunningElementStore` を instance-list 方式に書き換え、`node_id → instance_id` を記録
2. `RunningElementMarkerPageable` (zero-size Pageable) を source 位置に発行
3. `collect_running_element_states` でページごとの instance_id リストを収集
4. `resolve_element_policy` が policy に応じた instance を選択、見つからなければ直近の先行ページへ fallback
5. `resolve_content_to_html` を新 API に再配線

## Policy semantics (WeasyPrint-compatible)

| Policy | 解決ルール |
|---|---|
| `first` (default) | 当該ページの最初の instance。なければ直近の先行ページの最後の instance へ fallback |
| `start` | 実装上 `first` と等価 (典型的 running element ユースケースでは同一挙動)。doc で明示 |
| `last` | 当該ページの最後の instance。なければ同様 fallback |
| `first-except` | 代入のあるページでは空。なければ fallback |

無効 policy (e.g. ` element(title, bogus)`) は item 丸ごと drop (fail-loud)。`string()` とは非対称だが意図的で、コメントに記録済み。

## Key changes

- `crates/fulgur/src/gcpm/mod.rs` — `ElementPolicy` enum 追加、`ContentItem::Element` を struct variant 化
- `crates/fulgur/src/gcpm/parser.rs` — `parse_policy_ident` を共通ヘルパ化、`element(name, policy)` パース
- `crates/fulgur/src/gcpm/running.rs` — `RunningElementStore` を append-only instance-list に書き換え
- `crates/fulgur/src/pageable.rs` — `RunningElementMarkerPageable` (zero-size marker)
- `crates/fulgur/src/convert.rs` — zero-size 分岐で `emit_orphan_markers` ヘルパ経由で marker 発行
- `crates/fulgur/src/paginate.rs` — `PageRunningState` + `collect_running_element_states`
- `crates/fulgur/src/gcpm/counter.rs` — `resolve_element_policy` + 新 `resolve_content_to_html` シグネチャ
- `crates/fulgur/src/render.rs` — per-page running states をパイプラインに配線

## Breaking changes

- `ContentItem::Element(String)` → `ContentItem::Element { name: String, policy: ElementPolicy }` (内部 API)
- `RunningElementStore::register` / `get` / `to_pairs` を置換 (内部 API)
- `resolve_content_to_html` シグネチャ変更 (7 引数)

fulgur はまだ 0.x なので破壊的変更は許容。

## Known limitations (documented in code)

- `ElementPolicy::Start` は `First` と等価実装。章題の典型配置では区別不要
- Running marker 直後に unsplittable オーバーフロー要素があると marker が前ページに残る
- `element()` と `string()` の無効 policy ハンドリングが非対称 (strict vs lenient)

## Follow-up issues

simplify レビューで見送った改善項目を beads に積み済み:

- `fulgur-18k` (P4) — resolve_content_to_html を PageRenderContext で置き換え
- `fulgur-7ig` (P4) — PageRunningState に start carry フィールドを追加して fallback loop 削除
- `fulgur-9gw` (P4) — paginate.rs テストヘルパ pos() に y 引数追加

## Test plan

- [x] `cargo test -p fulgur --lib` — 176 passed (baseline 165, +11 new)
- [x] `cargo test -p fulgur --test gcpm_integration -- --test-threads=1` — 18 passed (baseline 15, +3 new)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p fulgur --lib -- -D warnings` — clean
- [x] `npx markdownlint-cli2 'docs/plans/2026-04-06-gcpm-element-policy-implementation.md'` — clean
- [x] `resolve_element_policy` 4 ポリシー × 3 ページ状態の網羅テスト
- [x] Multi-chapter integration tests (last / first-except / default policy)

詳細な実装計画: `docs/plans/2026-04-06-gcpm-element-policy-implementation.md`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ランニング要素に選択ポリシー(first/start/last/first-except)を追加し、ページごとに適切なインスタンスを表示するように改善。
  * ソース位置を示すゼロサイズのマーカーと、分割後もマーカーを保持するラッパーを導入。ページ収集でインスタンスを追跡。

* **Refactor**
  * ランニング要素の登録・参照をインスタンス化して順序を保持する方式に移行し、読み取り専用経路を導入。

* **Tests**
  * ポリシー別・複数ページ統合テストと関連ユニットテストを追加。

* **Documentation**
  * 実装計画ドキュメントを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->