### PR TITLE
feat(gcpm): apply @page size/margin declarations

### DIFF
--- a/crates/fulgur-cli/src/main.rs
+++ b/crates/fulgur-cli/src/main.rs
@@ -144,8 +144,8 @@ fn parse_page_size(s: &str) -> PageSize {
         "A3" => PageSize::A3,
         "LETTER" => PageSize::LETTER,
         _ => {
-            eprintln!("Unknown page size '{}', defaulting to A4", s);
-            PageSize::A4
+            eprintln!("Error: unknown page size '{}'. Supported: A4, A3, Letter", s);
+            std::process::exit(1);
         }
     }
 }

--- a/crates/fulgur-cli/src/main.rs
+++ b/crates/fulgur-cli/src/main.rs
@@ -51,11 +51,11 @@ enum Commands {
         output: PathBuf,
 
         /// Page size (A4, Letter, A3)
-        #[arg(short, long, default_value = "A4")]
-        size: String,
+        #[arg(short, long)]
+        size: Option<String>,
 
         /// Landscape orientation
-        #[arg(short, long, default_value_t = false)]
+        #[arg(short, long)]
         landscape: bool,
 
         /// PDF title
@@ -279,9 +279,13 @@ fn main() {
                 None
             };
 
-            let mut builder = Engine::builder()
-                .page_size(parse_page_size(&size))
-                .landscape(landscape);
+            let mut builder = Engine::builder();
+            if let Some(ref s) = size {
+                builder = builder.page_size(parse_page_size(s));
+            }
+            if landscape {
+                builder = builder.landscape(landscape);
+            }
 
             if let Some(ref m) = margin {
                 builder = builder.margin(parse_margin(m));

--- a/crates/fulgur-cli/src/main.rs
+++ b/crates/fulgur-cli/src/main.rs
@@ -144,7 +144,10 @@ fn parse_page_size(s: &str) -> PageSize {
         "A3" => PageSize::A3,
         "LETTER" => PageSize::LETTER,
         _ => {
-            eprintln!("Error: unknown page size '{}'. Supported: A4, A3, Letter", s);
+            eprintln!(
+                "Error: unknown page size '{}'. Supported: A4, A3, Letter",
+                s
+            );
             std::process::exit(1);
         }
     }

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -558,6 +558,7 @@ mod tests {
                 running_name: "pageHeader".to_string(),
             }],
             string_set_mappings: vec![],
+            page_settings: vec![],
             cleaned_css: String::new(),
         };
 
@@ -598,6 +599,7 @@ mod tests {
                 running_name: "pageTitle".to_string(),
             }],
             string_set_mappings: vec![],
+            page_settings: vec![],
             cleaned_css: String::new(),
         };
 
@@ -624,6 +626,7 @@ mod tests {
             margin_boxes: vec![],
             running_mappings: vec![],
             string_set_mappings: vec![],
+            page_settings: vec![],
             cleaned_css: String::new(),
         };
 
@@ -653,6 +656,7 @@ mod tests {
                 running_name: "shouldNotMatch".to_string(),
             }],
             string_set_mappings: vec![],
+            page_settings: vec![],
             cleaned_css: String::new(),
         };
 

--- a/crates/fulgur/src/config.rs
+++ b/crates/fulgur/src/config.rs
@@ -73,12 +73,22 @@ impl Default for Margin {
     }
 }
 
+/// Tracks which Config fields were explicitly set by the caller (CLI/API).
+/// When true, the field takes precedence over CSS @page declarations.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ConfigOverrides {
+    pub page_size: bool,
+    pub margin: bool,
+    pub landscape: bool,
+}
+
 /// PDF generation configuration
 #[derive(Debug, Clone)]
 pub struct Config {
     pub page_size: PageSize,
     pub margin: Margin,
     pub landscape: bool,
+    pub overrides: ConfigOverrides,
     pub title: Option<String>,
     pub authors: Vec<String>,
     pub description: Option<String>,
@@ -95,6 +105,7 @@ impl Default for Config {
             page_size: PageSize::A4,
             margin: Margin::default(),
             landscape: false,
+            overrides: ConfigOverrides::default(),
             title: None,
             authors: vec![],
             description: None,
@@ -141,16 +152,19 @@ pub struct ConfigBuilder {
 impl ConfigBuilder {
     pub fn page_size(mut self, size: PageSize) -> Self {
         self.config.page_size = size;
+        self.config.overrides.page_size = true;
         self
     }
 
     pub fn margin(mut self, margin: Margin) -> Self {
         self.config.margin = margin;
+        self.config.overrides.margin = true;
         self
     }
 
     pub fn landscape(mut self, landscape: bool) -> Self {
         self.config.landscape = landscape;
+        self.config.overrides.landscape = true;
         self
     }
 
@@ -245,6 +259,25 @@ mod tests {
             .build();
         assert!((config.content_width() - (841.89 - 144.0)).abs() < 0.01);
         assert!((config.content_height() - (595.28 - 144.0)).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_config_overrides_default() {
+        let config = Config::default();
+        assert!(!config.overrides.page_size);
+        assert!(!config.overrides.margin);
+        assert!(!config.overrides.landscape);
+    }
+
+    #[test]
+    fn test_config_builder_tracks_overrides() {
+        let config = Config::builder()
+            .page_size(PageSize::LETTER)
+            .margin(Margin::uniform_mm(10.0))
+            .build();
+        assert!(config.overrides.page_size);
+        assert!(config.overrides.margin);
+        assert!(!config.overrides.landscape);
     }
 
     #[test]

--- a/crates/fulgur/src/config.rs
+++ b/crates/fulgur/src/config.rs
@@ -35,7 +35,7 @@ impl PageSize {
 }
 
 /// Margin in points
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Margin {
     pub top: f32,
     pub right: f32,

--- a/crates/fulgur/src/gcpm/mod.rs
+++ b/crates/fulgur/src/gcpm/mod.rs
@@ -1,5 +1,6 @@
 pub mod counter;
 pub mod margin_box;
+pub mod page_settings;
 pub mod parser;
 pub mod running;
 pub mod string_set;

--- a/crates/fulgur/src/gcpm/mod.rs
+++ b/crates/fulgur/src/gcpm/mod.rs
@@ -94,6 +94,39 @@ pub struct StringSetMapping {
     pub values: Vec<StringSetValue>,
 }
 
+/// Parsed `size` declaration from `@page`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PageSizeDecl {
+    /// A named page size, e.g. `A4`, `letter`.
+    Keyword(String),
+    /// A named page size with orientation, e.g. `A4 landscape`.
+    KeywordWithOrientation(String, bool),
+    /// Explicit width × height, e.g. `210mm 297mm`. Values in points.
+    Custom(f32, f32),
+    /// `auto` — use Config default.
+    Auto,
+}
+
+/// Parsed `margin` declaration from `@page`. All values in points.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PageMarginDecl {
+    pub top: f32,
+    pub right: f32,
+    pub bottom: f32,
+    pub left: f32,
+}
+
+/// A parsed `@page { size: ...; margin: ...; }` settings rule.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PageSettingsRule {
+    /// Optional page selector (e.g. `:first`, `:left`). `None` means all pages.
+    pub page_selector: Option<String>,
+    /// Parsed `size` declaration, if present.
+    pub size: Option<PageSizeDecl>,
+    /// Parsed `margin` declaration, if present.
+    pub margin: Option<PageMarginDecl>,
+}
+
 /// A single content item inside a margin box rule's `content` property.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ContentItem {
@@ -148,6 +181,8 @@ pub struct GcpmContext {
     pub running_mappings: Vec<RunningMapping>,
     /// Mappings from CSS selectors to named strings via `string-set`.
     pub string_set_mappings: Vec<StringSetMapping>,
+    /// Page settings rules parsed from `@page { size: ...; margin: ...; }`.
+    pub page_settings: Vec<PageSettingsRule>,
     /// The CSS with GCPM constructs stripped, suitable for normal rendering.
     pub cleaned_css: String,
 }
@@ -158,6 +193,7 @@ impl GcpmContext {
         self.margin_boxes.is_empty()
             && self.running_mappings.is_empty()
             && self.string_set_mappings.is_empty()
+            && self.page_settings.is_empty()
     }
 }
 
@@ -171,6 +207,7 @@ mod tests {
             margin_boxes: vec![],
             running_mappings: vec![],
             string_set_mappings: vec![],
+            page_settings: vec![],
             cleaned_css: String::new(),
         };
         assert!(ctx.is_empty());
@@ -187,6 +224,7 @@ mod tests {
             }],
             running_mappings: vec![],
             string_set_mappings: vec![],
+            page_settings: vec![],
             cleaned_css: String::new(),
         };
         assert!(!ctx.is_empty());
@@ -201,6 +239,23 @@ mod tests {
                 running_name: "header".to_string(),
             }],
             string_set_mappings: vec![],
+            page_settings: vec![],
+            cleaned_css: String::new(),
+        };
+        assert!(!ctx.is_empty());
+    }
+
+    #[test]
+    fn test_gcpm_context_not_empty_with_page_settings() {
+        let ctx = GcpmContext {
+            margin_boxes: vec![],
+            running_mappings: vec![],
+            string_set_mappings: vec![],
+            page_settings: vec![PageSettingsRule {
+                page_selector: None,
+                size: Some(PageSizeDecl::Keyword("A4".into())),
+                margin: None,
+            }],
             cleaned_css: String::new(),
         };
         assert!(!ctx.is_empty());

--- a/crates/fulgur/src/gcpm/mod.rs
+++ b/crates/fulgur/src/gcpm/mod.rs
@@ -108,15 +108,6 @@ pub enum PageSizeDecl {
     Auto,
 }
 
-/// Parsed `margin` declaration from `@page`. All values in points.
-#[derive(Debug, Clone, PartialEq)]
-pub struct PageMarginDecl {
-    pub top: f32,
-    pub right: f32,
-    pub bottom: f32,
-    pub left: f32,
-}
-
 /// A parsed `@page { size: ...; margin: ...; }` settings rule.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PageSettingsRule {
@@ -124,8 +115,8 @@ pub struct PageSettingsRule {
     pub page_selector: Option<String>,
     /// Parsed `size` declaration, if present.
     pub size: Option<PageSizeDecl>,
-    /// Parsed `margin` declaration, if present.
-    pub margin: Option<PageMarginDecl>,
+    /// Parsed `margin` declaration, if present. Values in points.
+    pub margin: Option<crate::config::Margin>,
 }
 
 /// A single content item inside a margin box rule's `content` property.

--- a/crates/fulgur/src/gcpm/page_settings.rs
+++ b/crates/fulgur/src/gcpm/page_settings.rs
@@ -1,0 +1,276 @@
+use crate::config::{Config, Margin, PageSize};
+use crate::gcpm::{PageMarginDecl, PageSettingsRule, PageSizeDecl};
+
+/// Map a CSS page-size keyword (case-insensitive) to a [`PageSize`].
+/// Falls back to A4 for unrecognised keywords.
+fn keyword_to_page_size(name: &str) -> PageSize {
+    match name.to_uppercase().as_str() {
+        "A4" => PageSize::A4,
+        "A3" => PageSize::A3,
+        "LETTER" => PageSize::LETTER,
+        _ => PageSize::A4,
+    }
+}
+
+/// Returns `true` when `selector` matches the given page number.
+///
+/// Supported pseudo-selectors:
+/// - `:first` — matches page 1 only
+/// - `:left`  — matches even page numbers (verso in LTR)
+/// - `:right` — matches odd page numbers (recto in LTR)
+fn selector_matches(selector: &str, page_num: usize) -> bool {
+    match selector {
+        ":first" => page_num == 1,
+        ":left" => page_num % 2 == 0,
+        ":right" => page_num % 2 == 1,
+        _ => false,
+    }
+}
+
+/// Resolve effective page size, margin, and landscape for a given page number.
+///
+/// Priority model (highest wins):
+///
+/// ```text
+/// CLI override (config.overrides) > CSS @page selector match > CSS @page default > Config defaults
+/// ```
+pub fn resolve_page_settings(
+    rules: &[PageSettingsRule],
+    page_num: usize,
+    _total_pages: usize,
+    config: &Config,
+) -> (PageSize, Margin, bool) {
+    // --- Collect CSS declarations, separating default from selector-matched ---
+    let mut default_size: Option<&PageSizeDecl> = None;
+    let mut default_margin: Option<&PageMarginDecl> = None;
+    let mut matched_size: Option<&PageSizeDecl> = None;
+    let mut matched_margin: Option<&PageMarginDecl> = None;
+
+    for rule in rules {
+        match &rule.page_selector {
+            None => {
+                // Default (no selector) — later rules override earlier ones.
+                if rule.size.is_some() {
+                    default_size = rule.size.as_ref();
+                }
+                if rule.margin.is_some() {
+                    default_margin = rule.margin.as_ref();
+                }
+            }
+            Some(sel) => {
+                if selector_matches(sel, page_num) {
+                    if rule.size.is_some() {
+                        matched_size = rule.size.as_ref();
+                    }
+                    if rule.margin.is_some() {
+                        matched_margin = rule.margin.as_ref();
+                    }
+                }
+            }
+        }
+    }
+
+    // Selector match overrides default for each property independently.
+    let css_size = matched_size.or(default_size);
+    let css_margin = matched_margin.or(default_margin);
+
+    // --- Resolve page size and landscape ---
+    let (size, landscape) = if config.overrides.page_size {
+        // CLI override for size — also respect CLI landscape override separately.
+        let ls = if config.overrides.landscape {
+            config.landscape
+        } else {
+            resolve_landscape_from_css(css_size, config.landscape)
+        };
+        (config.page_size, ls)
+    } else {
+        match css_size {
+            Some(PageSizeDecl::Keyword(name)) => {
+                // Keyword without orientation carries no landscape signal;
+                // use config.landscape regardless of override flag.
+                (keyword_to_page_size(name), config.landscape)
+            }
+            Some(PageSizeDecl::KeywordWithOrientation(name, is_landscape)) => {
+                let ls = if config.overrides.landscape {
+                    config.landscape
+                } else {
+                    *is_landscape
+                };
+                (keyword_to_page_size(name), ls)
+            }
+            Some(PageSizeDecl::Custom(w, h)) => {
+                let ls = if config.overrides.landscape {
+                    config.landscape
+                } else {
+                    false
+                };
+                (
+                    PageSize {
+                        width: *w,
+                        height: *h,
+                    },
+                    ls,
+                )
+            }
+            Some(PageSizeDecl::Auto) | None => {
+                // No CSS size — fall back entirely to config defaults.
+                (config.page_size, config.landscape)
+            }
+        }
+    };
+
+    // --- Resolve margin ---
+    let margin = if config.overrides.margin {
+        config.margin
+    } else {
+        match css_margin {
+            Some(decl) => Margin {
+                top: decl.top,
+                right: decl.right,
+                bottom: decl.bottom,
+                left: decl.left,
+            },
+            None => config.margin,
+        }
+    };
+
+    (size, margin, landscape)
+}
+
+/// Extract landscape flag from a CSS size declaration.
+fn resolve_landscape_from_css(css_size: Option<&PageSizeDecl>, fallback: bool) -> bool {
+    match css_size {
+        Some(PageSizeDecl::KeywordWithOrientation(_, is_landscape)) => *is_landscape,
+        Some(PageSizeDecl::Custom(_, _)) => false,
+        _ => fallback,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Config, PageSize};
+    use crate::gcpm::{PageMarginDecl, PageSettingsRule, PageSizeDecl};
+
+    #[test]
+    fn test_no_page_settings_uses_config() {
+        let config = Config::default();
+        let (size, margin, landscape) = resolve_page_settings(&[], 1, 10, &config);
+        assert!((size.width - PageSize::A4.width).abs() < 0.01);
+        assert!((margin.top - config.margin.top).abs() < 0.01);
+        assert!(!landscape);
+    }
+
+    #[test]
+    fn test_css_size_overrides_default_config() {
+        let config = Config::default(); // overrides all false
+        let rules = vec![PageSettingsRule {
+            page_selector: None,
+            size: Some(PageSizeDecl::Keyword("letter".into())),
+            margin: None,
+        }];
+        let (size, _, _) = resolve_page_settings(&rules, 1, 10, &config);
+        assert!((size.width - PageSize::LETTER.width).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_cli_override_beats_css() {
+        let config = Config::builder().page_size(PageSize::A3).build();
+        // config.overrides.page_size is true
+        let rules = vec![PageSettingsRule {
+            page_selector: None,
+            size: Some(PageSizeDecl::Keyword("letter".into())),
+            margin: None,
+        }];
+        let (size, _, _) = resolve_page_settings(&rules, 1, 10, &config);
+        assert!((size.width - PageSize::A3.width).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_selector_first_matches_page_1() {
+        let config = Config::default();
+        let rules = vec![
+            PageSettingsRule {
+                page_selector: None,
+                size: None,
+                margin: Some(PageMarginDecl {
+                    top: 20.0,
+                    right: 20.0,
+                    bottom: 20.0,
+                    left: 20.0,
+                }),
+            },
+            PageSettingsRule {
+                page_selector: Some(":first".into()),
+                size: None,
+                margin: Some(PageMarginDecl {
+                    top: 50.0,
+                    right: 50.0,
+                    bottom: 50.0,
+                    left: 50.0,
+                }),
+            },
+        ];
+        let (_, margin_p1, _) = resolve_page_settings(&rules, 1, 10, &config);
+        assert!((margin_p1.top - 50.0).abs() < 0.01);
+        let (_, margin_p2, _) = resolve_page_settings(&rules, 2, 10, &config);
+        assert!((margin_p2.top - 20.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_left_right_selectors() {
+        let config = Config::default();
+        let rules = vec![
+            PageSettingsRule {
+                page_selector: Some(":left".into()),
+                size: None,
+                margin: Some(PageMarginDecl {
+                    top: 20.0,
+                    right: 30.0,
+                    bottom: 20.0,
+                    left: 10.0,
+                }),
+            },
+            PageSettingsRule {
+                page_selector: Some(":right".into()),
+                size: None,
+                margin: Some(PageMarginDecl {
+                    top: 20.0,
+                    right: 10.0,
+                    bottom: 20.0,
+                    left: 30.0,
+                }),
+            },
+        ];
+        let (_, m2, _) = resolve_page_settings(&rules, 2, 10, &config);
+        assert!((m2.left - 10.0).abs() < 0.01);
+        let (_, m3, _) = resolve_page_settings(&rules, 3, 10, &config);
+        assert!((m3.left - 30.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_page_size_landscape_from_css() {
+        let config = Config::default();
+        let rules = vec![PageSettingsRule {
+            page_selector: None,
+            size: Some(PageSizeDecl::KeywordWithOrientation("A4".into(), true)),
+            margin: None,
+        }];
+        let (_, _, landscape) = resolve_page_settings(&rules, 1, 10, &config);
+        assert!(landscape);
+    }
+
+    #[test]
+    fn test_custom_page_size() {
+        let config = Config::default();
+        let rules = vec![PageSettingsRule {
+            page_selector: None,
+            size: Some(PageSizeDecl::Custom(400.0, 600.0)),
+            margin: None,
+        }];
+        let (size, _, landscape) = resolve_page_settings(&rules, 1, 10, &config);
+        assert!((size.width - 400.0).abs() < 0.01);
+        assert!((size.height - 600.0).abs() < 0.01);
+        assert!(!landscape);
+    }
+}

--- a/crates/fulgur/src/gcpm/page_settings.rs
+++ b/crates/fulgur/src/gcpm/page_settings.rs
@@ -1,5 +1,5 @@
 use crate::config::{Config, Margin, PageSize};
-use crate::gcpm::{PageMarginDecl, PageSettingsRule, PageSizeDecl};
+use crate::gcpm::{PageSettingsRule, PageSizeDecl};
 
 /// Map a CSS page-size keyword (case-insensitive) to a [`PageSize`].
 /// Falls back to A4 for unrecognised keywords.
@@ -42,9 +42,9 @@ pub fn resolve_page_settings(
 ) -> (PageSize, Margin, bool) {
     // --- Collect CSS declarations, separating default from selector-matched ---
     let mut default_size: Option<&PageSizeDecl> = None;
-    let mut default_margin: Option<&PageMarginDecl> = None;
+    let mut default_margin: Option<&Margin> = None;
     let mut matched_size: Option<&PageSizeDecl> = None;
-    let mut matched_margin: Option<&PageMarginDecl> = None;
+    let mut matched_margin: Option<&Margin> = None;
 
     for rule in rules {
         match &rule.page_selector {
@@ -124,12 +124,7 @@ pub fn resolve_page_settings(
         config.margin
     } else {
         match css_margin {
-            Some(decl) => Margin {
-                top: decl.top,
-                right: decl.right,
-                bottom: decl.bottom,
-                left: decl.left,
-            },
+            Some(decl) => *decl,
             None => config.margin,
         }
     };
@@ -149,8 +144,8 @@ fn resolve_landscape_from_css(css_size: Option<&PageSizeDecl>, fallback: bool) -
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{Config, PageSize};
-    use crate::gcpm::{PageMarginDecl, PageSettingsRule, PageSizeDecl};
+    use crate::config::{Config, Margin, PageSize};
+    use crate::gcpm::{PageSettingsRule, PageSizeDecl};
 
     #[test]
     fn test_no_page_settings_uses_config() {
@@ -193,7 +188,7 @@ mod tests {
             PageSettingsRule {
                 page_selector: None,
                 size: None,
-                margin: Some(PageMarginDecl {
+                margin: Some(Margin {
                     top: 20.0,
                     right: 20.0,
                     bottom: 20.0,
@@ -203,7 +198,7 @@ mod tests {
             PageSettingsRule {
                 page_selector: Some(":first".into()),
                 size: None,
-                margin: Some(PageMarginDecl {
+                margin: Some(Margin {
                     top: 50.0,
                     right: 50.0,
                     bottom: 50.0,
@@ -224,7 +219,7 @@ mod tests {
             PageSettingsRule {
                 page_selector: Some(":left".into()),
                 size: None,
-                margin: Some(PageMarginDecl {
+                margin: Some(Margin {
                     top: 20.0,
                     right: 30.0,
                     bottom: 20.0,
@@ -234,7 +229,7 @@ mod tests {
             PageSettingsRule {
                 page_selector: Some(":right".into()),
                 size: None,
-                margin: Some(PageMarginDecl {
+                margin: Some(Margin {
                     top: 20.0,
                     right: 10.0,
                     bottom: 20.0,

--- a/crates/fulgur/src/gcpm/page_settings.rs
+++ b/crates/fulgur/src/gcpm/page_settings.rs
@@ -96,7 +96,12 @@ pub fn resolve_page_settings(
                 } else {
                     *is_landscape
                 };
-                (keyword_to_page_size(name), ls)
+                let size = if name == "auto" {
+                    config.page_size
+                } else {
+                    keyword_to_page_size(name)
+                };
+                (size, ls)
             }
             Some(PageSizeDecl::Custom(w, h)) => {
                 let ls = if config.overrides.landscape {

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -5,8 +5,9 @@ use cssparser::{
 
 use super::margin_box::MarginBoxPosition;
 use super::{
-    ContentItem, CounterType, ElementPolicy, GcpmContext, MarginBoxRule, ParsedSelector,
-    RunningMapping, StringPolicy, StringSetMapping, StringSetValue,
+    ContentItem, CounterType, ElementPolicy, GcpmContext, MarginBoxRule, PageMarginDecl,
+    PageSettingsRule, PageSizeDecl, ParsedSelector, RunningMapping, StringPolicy, StringSetMapping,
+    StringSetValue,
 };
 
 // ---------------------------------------------------------------------------
@@ -34,6 +35,7 @@ struct GcpmSheetParser<'a> {
     margin_boxes: &'a mut Vec<MarginBoxRule>,
     running_mappings: &'a mut Vec<RunningMapping>,
     string_set_mappings: &'a mut Vec<StringSetMapping>,
+    page_settings: &'a mut Vec<PageSettingsRule>,
 }
 
 /// Describes a region in the original CSS to edit when building `cleaned_css`.
@@ -81,7 +83,9 @@ impl<'i, 'a> AtRuleParser<'i> for GcpmSheetParser<'a> {
         input: &mut Parser<'i, 't>,
     ) -> Result<Self::AtRule, ParseError<'i, ()>> {
         let mut boxes = Vec::new();
-        parse_page_block(input, &page_selector, &mut boxes);
+        let mut size = None;
+        let mut margin = None;
+        parse_page_block(input, &page_selector, &mut boxes, &mut size, &mut margin);
 
         // Record the full @page rule span for removal.
         let start_offset = start.position().byte_index();
@@ -92,6 +96,15 @@ impl<'i, 'a> AtRuleParser<'i> for GcpmSheetParser<'a> {
         });
 
         self.margin_boxes.extend(boxes);
+
+        if size.is_some() || margin.is_some() {
+            self.page_settings.push(PageSettingsRule {
+                page_selector,
+                size,
+                margin,
+            });
+        }
+
         Ok(TopLevelItem::PageRule)
     }
 }
@@ -209,6 +222,127 @@ fn parse_css_length(s: &str) -> Option<f32> {
 }
 
 // ---------------------------------------------------------------------------
+// @page size/margin value parsers
+// ---------------------------------------------------------------------------
+
+/// Convert a CSS dimension value+unit to PDF points.
+fn css_unit_to_pt(value: f32, unit: &str) -> Option<f32> {
+    let factor = match unit.to_ascii_lowercase().as_str() {
+        "mm" => 72.0 / 25.4,
+        "cm" => 72.0 / 2.54,
+        "in" => 72.0,
+        "pt" => 1.0,
+        "px" => 72.0 / 96.0,
+        _ => return None,
+    };
+    Some(value * factor)
+}
+
+/// Parse the value of an `@page { size: ... }` declaration.
+fn parse_page_size_value(input: &mut Parser<'_, '_>) -> Option<PageSizeDecl> {
+    let token = input.next().ok()?.clone();
+    match token {
+        Token::Ident(ref name) => {
+            if name.eq_ignore_ascii_case("auto") {
+                return Some(PageSizeDecl::Auto);
+            }
+            let keyword = name.to_string();
+            // Try to read a second ident for orientation
+            let orientation = input.try_parse(|input| {
+                let tok = input.next()?.clone();
+                match tok {
+                    Token::Ident(ref orient) => {
+                        if orient.eq_ignore_ascii_case("landscape") {
+                            Ok(true)
+                        } else if orient.eq_ignore_ascii_case("portrait") {
+                            Ok(false)
+                        } else {
+                            Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid))
+                        }
+                    }
+                    _ => Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)),
+                }
+            });
+            match orientation {
+                Ok(landscape) => Some(PageSizeDecl::KeywordWithOrientation(keyword, landscape)),
+                Err(_) => Some(PageSizeDecl::Keyword(keyword)),
+            }
+        }
+        Token::Dimension { value, unit, .. } => {
+            let w = css_unit_to_pt(value, &unit)?;
+            // Try to read a second dimension for height
+            let h = input
+                .try_parse(|input| {
+                    let tok = input.next()?.clone();
+                    match tok {
+                        Token::Dimension { value, unit, .. } => css_unit_to_pt(value, &unit)
+                            .ok_or_else(|| {
+                                input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)
+                            }),
+                        _ => Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)),
+                    }
+                })
+                .unwrap_or(w);
+            Some(PageSizeDecl::Custom(w, h))
+        }
+        _ => None,
+    }
+}
+
+/// Parse the value of an `@page { margin: ... }` declaration (CSS shorthand).
+fn parse_page_margin_value(input: &mut Parser<'_, '_>) -> Option<PageMarginDecl> {
+    let mut values = Vec::new();
+    loop {
+        let result = input.try_parse(|input| {
+            let tok = input.next()?.clone();
+            match tok {
+                Token::Dimension { value, unit, .. } => {
+                    css_unit_to_pt(value, &unit).ok_or_else(|| {
+                        input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)
+                    })
+                }
+                _ => Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)),
+            }
+        });
+        match result {
+            Ok(v) => values.push(v),
+            Err(_) => break,
+        }
+        if values.len() >= 4 {
+            break;
+        }
+    }
+
+    match values.len() {
+        1 => Some(PageMarginDecl {
+            top: values[0],
+            right: values[0],
+            bottom: values[0],
+            left: values[0],
+        }),
+        2 => Some(PageMarginDecl {
+            top: values[0],
+            right: values[1],
+            bottom: values[0],
+            left: values[1],
+        }),
+        3 => Some(PageMarginDecl {
+            top: values[0],
+            right: values[1],
+            bottom: values[2],
+            left: values[1],
+        }),
+        4 => Some(PageMarginDecl {
+            top: values[0],
+            right: values[1],
+            bottom: values[2],
+            left: values[3],
+        }),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
 // 2. @page block parser (PageRuleParser) — uses RuleBodyParser
 // ---------------------------------------------------------------------------
 
@@ -216,10 +350,14 @@ fn parse_page_block(
     input: &mut Parser<'_, '_>,
     page_selector: &Option<String>,
     boxes: &mut Vec<MarginBoxRule>,
+    size: &mut Option<PageSizeDecl>,
+    margin: &mut Option<PageMarginDecl>,
 ) {
     let mut parser = PageRuleParser {
         page_selector,
         boxes,
+        size,
+        margin,
     };
     let iter = RuleBodyParser::new(input, &mut parser);
     for item in iter {
@@ -230,6 +368,8 @@ fn parse_page_block(
 struct PageRuleParser<'a> {
     page_selector: &'a Option<String>,
     boxes: &'a mut Vec<MarginBoxRule>,
+    size: &'a mut Option<PageSizeDecl>,
+    margin: &'a mut Option<PageMarginDecl>,
 }
 
 impl<'i, 'a> AtRuleParser<'i> for PageRuleParser<'a> {
@@ -285,9 +425,14 @@ impl<'i, 'a> DeclarationParser<'i> for PageRuleParser<'a> {
         input: &mut Parser<'i, 't>,
         _start: &cssparser::ParserState,
     ) -> Result<(), ParseError<'i, ()>> {
-        // Skip declarations directly inside @page (not inside margin boxes)
-        let _ = name;
-        while input.next().is_ok() {}
+        if name.eq_ignore_ascii_case("size") {
+            *self.size = parse_page_size_value(input);
+        } else if name.eq_ignore_ascii_case("margin") {
+            *self.margin = parse_page_margin_value(input);
+        } else {
+            // Skip unknown declarations
+            while input.next().is_ok() {}
+        }
         Ok(())
     }
 }
@@ -674,6 +819,7 @@ pub fn parse_gcpm(css: &str) -> GcpmContext {
     let mut margin_boxes = Vec::new();
     let mut running_mappings = Vec::new();
     let mut string_set_mappings = Vec::new();
+    let mut page_settings = Vec::new();
     let mut edits: Vec<CssEdit> = Vec::new();
 
     // Run the cssparser-based parse to collect GCPM data and edit spans.
@@ -686,6 +832,7 @@ pub fn parse_gcpm(css: &str) -> GcpmContext {
             margin_boxes: &mut margin_boxes,
             running_mappings: &mut running_mappings,
             string_set_mappings: &mut string_set_mappings,
+            page_settings: &mut page_settings,
         };
 
         let iter = StyleSheetParser::new(&mut input, &mut parser);
@@ -701,7 +848,7 @@ pub fn parse_gcpm(css: &str) -> GcpmContext {
         margin_boxes,
         running_mappings,
         string_set_mappings,
-        page_settings: vec![],
+        page_settings,
         cleaned_css,
     }
 }
@@ -1217,5 +1364,122 @@ mod tests {
     fn test_parse_css_length_invalid() {
         assert!(parse_css_length("20em").is_none());
         assert!(parse_css_length("abc").is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // @page size/margin parsing tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_page_size_keyword() {
+        let css = "@page { size: A4; }";
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.page_settings.len(), 1);
+        assert_eq!(
+            ctx.page_settings[0].size,
+            Some(PageSizeDecl::Keyword("A4".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_page_size_keyword_landscape() {
+        let css = "@page { size: A4 landscape; }";
+        let ctx = parse_gcpm(css);
+        assert_eq!(
+            ctx.page_settings[0].size,
+            Some(PageSizeDecl::KeywordWithOrientation("A4".to_string(), true))
+        );
+    }
+
+    #[test]
+    fn test_page_size_custom_dimensions() {
+        let css = "@page { size: 210mm 297mm; }";
+        let ctx = parse_gcpm(css);
+        match &ctx.page_settings[0].size {
+            Some(PageSizeDecl::Custom(w, h)) => {
+                assert!((w - 595.28).abs() < 0.2);
+                assert!((h - 841.89).abs() < 0.2);
+            }
+            other => panic!("Expected Custom, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_page_size_auto() {
+        let css = "@page { size: auto; }";
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.page_settings[0].size, Some(PageSizeDecl::Auto));
+    }
+
+    #[test]
+    fn test_page_margin_uniform() {
+        let css = "@page { margin: 20mm; }";
+        let ctx = parse_gcpm(css);
+        let m = ctx.page_settings[0].margin.as_ref().unwrap();
+        let expected = 20.0 * 72.0 / 25.4;
+        assert!((m.top - expected).abs() < 0.01);
+        assert!((m.right - expected).abs() < 0.01);
+        assert!((m.bottom - expected).abs() < 0.01);
+        assert!((m.left - expected).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_page_margin_shorthand_two() {
+        let css = "@page { margin: 10mm 20mm; }";
+        let ctx = parse_gcpm(css);
+        let m = ctx.page_settings[0].margin.as_ref().unwrap();
+        let v = 10.0 * 72.0 / 25.4;
+        let h = 20.0 * 72.0 / 25.4;
+        assert!((m.top - v).abs() < 0.01);
+        assert!((m.right - h).abs() < 0.01);
+        assert!((m.bottom - v).abs() < 0.01);
+        assert!((m.left - h).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_page_margin_shorthand_three() {
+        let css = "@page { margin: 10mm 20mm 30mm; }";
+        let ctx = parse_gcpm(css);
+        let m = ctx.page_settings[0].margin.as_ref().unwrap();
+        assert!((m.top - 10.0 * 72.0 / 25.4).abs() < 0.01);
+        assert!((m.right - 20.0 * 72.0 / 25.4).abs() < 0.01);
+        assert!((m.bottom - 30.0 * 72.0 / 25.4).abs() < 0.01);
+        assert!((m.left - 20.0 * 72.0 / 25.4).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_page_margin_shorthand_four() {
+        let css = "@page { margin: 10mm 20mm 30mm 40mm; }";
+        let ctx = parse_gcpm(css);
+        let m = ctx.page_settings[0].margin.as_ref().unwrap();
+        assert!((m.top - 10.0 * 72.0 / 25.4).abs() < 0.01);
+        assert!((m.right - 20.0 * 72.0 / 25.4).abs() < 0.01);
+        assert!((m.bottom - 30.0 * 72.0 / 25.4).abs() < 0.01);
+        assert!((m.left - 40.0 * 72.0 / 25.4).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_page_size_with_selector() {
+        let css = "@page :first { size: letter; margin: 1in; }";
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.page_settings.len(), 1);
+        assert_eq!(
+            ctx.page_settings[0].page_selector,
+            Some(":first".to_string())
+        );
+        assert_eq!(
+            ctx.page_settings[0].size,
+            Some(PageSizeDecl::Keyword("letter".to_string()))
+        );
+        let m = ctx.page_settings[0].margin.as_ref().unwrap();
+        assert!((m.top - 72.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_page_size_and_margin_boxes_coexist() {
+        let css = r#"@page { size: A4; margin: 20mm; @top-center { content: counter(page); } }"#;
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.page_settings.len(), 1);
+        assert_eq!(ctx.margin_boxes.len(), 1);
     }
 }

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -225,10 +225,16 @@ fn parse_page_size_value(input: &mut Parser<'_, '_>) -> Option<PageSizeDecl> {
                 return Some(PageSizeDecl::Auto);
             }
             if name.eq_ignore_ascii_case("landscape") {
-                return Some(PageSizeDecl::KeywordWithOrientation("auto".to_string(), true));
+                return Some(PageSizeDecl::KeywordWithOrientation(
+                    "auto".to_string(),
+                    true,
+                ));
             }
             if name.eq_ignore_ascii_case("portrait") {
-                return Some(PageSizeDecl::KeywordWithOrientation("auto".to_string(), false));
+                return Some(PageSizeDecl::KeywordWithOrientation(
+                    "auto".to_string(),
+                    false,
+                ));
             }
             let keyword = name.to_string();
             // Try to read a second ident for orientation
@@ -286,7 +292,7 @@ fn parse_page_margin_value(input: &mut Parser<'_, '_>) -> Option<Margin> {
                         input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)
                     })
                 }
-                Token::Number { value, .. } if value == 0.0 => Ok(0.0_f32),
+                Token::Number { value: 0.0, .. } => Ok(0.0_f32),
                 _ => Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)),
             }
         });

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -205,57 +205,60 @@ impl<'i, 'a> QualifiedRuleParser<'i> for GcpmSheetParser<'a> {
 
 /// Convert a CSS dimension value+unit to PDF points.
 fn css_unit_to_pt(value: f32, unit: &str) -> Option<f32> {
-    let factor = match unit {
-        "mm" => 72.0 / 25.4,
-        "cm" => 72.0 / 2.54,
-        "in" => 72.0,
-        "pt" => 1.0,
-        "px" => 72.0 / 96.0,
+    let factor = match () {
+        _ if unit.eq_ignore_ascii_case("mm") => 72.0 / 25.4,
+        _ if unit.eq_ignore_ascii_case("cm") => 72.0 / 2.54,
+        _ if unit.eq_ignore_ascii_case("in") => 72.0,
+        _ if unit.eq_ignore_ascii_case("pt") => 1.0,
+        _ if unit.eq_ignore_ascii_case("px") => 72.0 / 96.0,
         _ => return None,
     };
     Some(value * factor)
 }
 
 /// Parse the value of an `@page { size: ... }` declaration.
+///
+/// Returns `None` if the value is invalid or has trailing tokens
+/// (CSS requires invalid declarations to be ignored entirely).
 fn parse_page_size_value(input: &mut Parser<'_, '_>) -> Option<PageSizeDecl> {
     let token = input.next().ok()?.clone();
-    match token {
+    let result = match token {
         Token::Ident(ref name) => {
             if name.eq_ignore_ascii_case("auto") {
-                return Some(PageSizeDecl::Auto);
-            }
-            if name.eq_ignore_ascii_case("landscape") {
-                return Some(PageSizeDecl::KeywordWithOrientation(
+                Some(PageSizeDecl::Auto)
+            } else if name.eq_ignore_ascii_case("landscape") {
+                Some(PageSizeDecl::KeywordWithOrientation(
                     "auto".to_string(),
                     true,
-                ));
-            }
-            if name.eq_ignore_ascii_case("portrait") {
-                return Some(PageSizeDecl::KeywordWithOrientation(
+                ))
+            } else if name.eq_ignore_ascii_case("portrait") {
+                Some(PageSizeDecl::KeywordWithOrientation(
                     "auto".to_string(),
                     false,
-                ));
-            }
-            let keyword = name.to_string();
-            // Try to read a second ident for orientation
-            let orientation = input.try_parse(|input| {
-                let tok = input.next()?.clone();
-                match tok {
-                    Token::Ident(ref orient) => {
-                        if orient.eq_ignore_ascii_case("landscape") {
-                            Ok(true)
-                        } else if orient.eq_ignore_ascii_case("portrait") {
-                            Ok(false)
-                        } else {
-                            Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid))
+                ))
+            } else {
+                let keyword = name.to_string();
+                // Try to read a second ident for orientation
+                let orientation = input.try_parse(|input| {
+                    let tok = input.next()?.clone();
+                    match tok {
+                        Token::Ident(ref orient) => {
+                            if orient.eq_ignore_ascii_case("landscape") {
+                                Ok(true)
+                            } else if orient.eq_ignore_ascii_case("portrait") {
+                                Ok(false)
+                            } else {
+                                Err(input
+                                    .new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid))
+                            }
                         }
+                        _ => Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)),
                     }
-                    _ => Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)),
+                });
+                match orientation {
+                    Ok(landscape) => Some(PageSizeDecl::KeywordWithOrientation(keyword, landscape)),
+                    Err(_) => Some(PageSizeDecl::Keyword(keyword)),
                 }
-            });
-            match orientation {
-                Ok(landscape) => Some(PageSizeDecl::KeywordWithOrientation(keyword, landscape)),
-                Err(_) => Some(PageSizeDecl::Keyword(keyword)),
             }
         }
         Token::Dimension { value, unit, .. } => {
@@ -277,10 +280,18 @@ fn parse_page_size_value(input: &mut Parser<'_, '_>) -> Option<PageSizeDecl> {
             Some(PageSizeDecl::Custom(w, h))
         }
         _ => None,
+    };
+    // Reject if trailing tokens remain (CSS: invalid declaration → ignore entirely)
+    if result.is_some() && input.next().is_ok() {
+        return None;
     }
+    result
 }
 
 /// Parse the value of an `@page { margin: ... }` declaration (CSS shorthand).
+///
+/// Returns `None` if the value is invalid or has trailing tokens
+/// (CSS requires invalid declarations to be ignored entirely).
 fn parse_page_margin_value(input: &mut Parser<'_, '_>) -> Option<Margin> {
     let mut values = Vec::new();
     loop {
@@ -303,6 +314,11 @@ fn parse_page_margin_value(input: &mut Parser<'_, '_>) -> Option<Margin> {
         if values.len() >= 4 {
             break;
         }
+    }
+
+    // Reject if trailing tokens remain (CSS: invalid declaration → ignore entirely)
+    if input.next().is_ok() {
+        return None;
     }
 
     match values.len() {
@@ -1462,5 +1478,40 @@ mod tests {
         let css = "@page { size: -10mm 297mm; }";
         let ctx = parse_gcpm(css);
         assert!(ctx.page_settings.is_empty() || ctx.page_settings[0].size.is_none());
+    }
+
+    #[test]
+    fn test_page_size_trailing_tokens_rejected() {
+        let css = "@page { size: A4 bogus; }";
+        let ctx = parse_gcpm(css);
+        assert!(ctx.page_settings.is_empty() || ctx.page_settings[0].size.is_none());
+    }
+
+    #[test]
+    fn test_page_margin_trailing_tokens_rejected() {
+        let css = "@page { margin: 10mm 20mm bad; }";
+        let ctx = parse_gcpm(css);
+        assert!(ctx.page_settings.is_empty() || ctx.page_settings[0].margin.is_none());
+    }
+
+    #[test]
+    fn test_page_margin_five_values_rejected() {
+        let css = "@page { margin: 1mm 2mm 3mm 4mm 5mm; }";
+        let ctx = parse_gcpm(css);
+        assert!(ctx.page_settings.is_empty() || ctx.page_settings[0].margin.is_none());
+    }
+
+    #[test]
+    fn test_css_unit_case_insensitive() {
+        let css = "@page { size: 210MM 297MM; }";
+        let ctx = parse_gcpm(css);
+        let size = ctx.page_settings[0].size.as_ref().unwrap();
+        match size {
+            PageSizeDecl::Custom(w, h) => {
+                assert!((*w - 210.0 * 72.0 / 25.4).abs() < 0.01);
+                assert!((*h - 297.0 * 72.0 / 25.4).abs() < 0.01);
+            }
+            _ => panic!("expected Custom size"),
+        }
     }
 }

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -183,6 +183,32 @@ impl<'i, 'a> QualifiedRuleParser<'i> for GcpmSheetParser<'a> {
 }
 
 // ---------------------------------------------------------------------------
+// CSS length unit → points converter
+// ---------------------------------------------------------------------------
+
+/// Parses a CSS length string (e.g. "20mm", "1in") and returns the equivalent
+/// value in PDF points (1 pt = 1/72 inch).
+#[allow(dead_code)] // will be used by @page size/margin parser (Task 3)
+fn parse_css_length(s: &str) -> Option<f32> {
+    let s = s.trim();
+    // Find where the numeric part ends and the unit begins.
+    let unit_start = s
+        .find(|c: char| c.is_ascii_alphabetic())
+        .filter(|&i| i > 0)?;
+    let (num_str, unit) = s.split_at(unit_start);
+    let value: f32 = num_str.parse().ok()?;
+    let factor = match unit {
+        "mm" => 72.0 / 25.4,
+        "cm" => 72.0 / 2.54,
+        "in" => 72.0,
+        "pt" => 1.0,
+        "px" => 72.0 / 96.0,
+        _ => return None,
+    };
+    Some(value * factor)
+}
+
+// ---------------------------------------------------------------------------
 // 2. @page block parser (PageRuleParser) — uses RuleBodyParser
 // ---------------------------------------------------------------------------
 
@@ -1159,5 +1185,36 @@ mod tests {
             "string-set declaration should be removed: {:?}",
             ctx.cleaned_css
         );
+    }
+
+    #[test]
+    fn test_parse_css_length_mm() {
+        assert!((parse_css_length("20mm").unwrap() - 56.6929).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_parse_css_length_cm() {
+        assert!((parse_css_length("2cm").unwrap() - 56.6929).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_parse_css_length_in() {
+        assert!((parse_css_length("1in").unwrap() - 72.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_parse_css_length_pt() {
+        assert!((parse_css_length("72pt").unwrap() - 72.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_parse_css_length_px() {
+        assert!((parse_css_length("96px").unwrap() - 72.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_parse_css_length_invalid() {
+        assert!(parse_css_length("20em").is_none());
+        assert!(parse_css_length("abc").is_none());
     }
 }

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -224,6 +224,12 @@ fn parse_page_size_value(input: &mut Parser<'_, '_>) -> Option<PageSizeDecl> {
             if name.eq_ignore_ascii_case("auto") {
                 return Some(PageSizeDecl::Auto);
             }
+            if name.eq_ignore_ascii_case("landscape") {
+                return Some(PageSizeDecl::KeywordWithOrientation("auto".to_string(), true));
+            }
+            if name.eq_ignore_ascii_case("portrait") {
+                return Some(PageSizeDecl::KeywordWithOrientation("auto".to_string(), false));
+            }
             let keyword = name.to_string();
             // Try to read a second ident for orientation
             let orientation = input.try_parse(|input| {
@@ -406,9 +412,13 @@ impl<'i, 'a> DeclarationParser<'i> for PageRuleParser<'a> {
         _start: &cssparser::ParserState,
     ) -> Result<(), ParseError<'i, ()>> {
         if name.eq_ignore_ascii_case("size") {
-            *self.size = parse_page_size_value(input);
+            if let Some(v) = parse_page_size_value(input) {
+                *self.size = Some(v);
+            }
         } else if name.eq_ignore_ascii_case("margin") {
-            *self.margin = parse_page_margin_value(input);
+            if let Some(v) = parse_page_margin_value(input) {
+                *self.margin = Some(v);
+            }
         } else {
             // Skip unknown declarations
             while input.next().is_ok() {}

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -286,7 +286,7 @@ fn parse_page_margin_value(input: &mut Parser<'_, '_>) -> Option<Margin> {
                         input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)
                     })
                 }
-                Token::Number { value: 0.0, .. } => Ok(0.0_f32),
+                Token::Number { value, .. } if value == 0.0 => Ok(0.0_f32),
                 _ => Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)),
             }
         });

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -199,35 +199,13 @@ impl<'i, 'a> QualifiedRuleParser<'i> for GcpmSheetParser<'a> {
 // CSS length unit → points converter
 // ---------------------------------------------------------------------------
 
-/// Parses a CSS length string (e.g. "20mm", "1in") and returns the equivalent
-/// value in PDF points (1 pt = 1/72 inch).
-#[allow(dead_code)] // will be used by @page size/margin parser (Task 3)
-fn parse_css_length(s: &str) -> Option<f32> {
-    let s = s.trim();
-    // Find where the numeric part ends and the unit begins.
-    let unit_start = s
-        .find(|c: char| c.is_ascii_alphabetic())
-        .filter(|&i| i > 0)?;
-    let (num_str, unit) = s.split_at(unit_start);
-    let value: f32 = num_str.parse().ok()?;
-    let factor = match unit {
-        "mm" => 72.0 / 25.4,
-        "cm" => 72.0 / 2.54,
-        "in" => 72.0,
-        "pt" => 1.0,
-        "px" => 72.0 / 96.0,
-        _ => return None,
-    };
-    Some(value * factor)
-}
-
 // ---------------------------------------------------------------------------
 // @page size/margin value parsers
 // ---------------------------------------------------------------------------
 
 /// Convert a CSS dimension value+unit to PDF points.
 fn css_unit_to_pt(value: f32, unit: &str) -> Option<f32> {
-    let factor = match unit.to_ascii_lowercase().as_str() {
+    let factor = match unit {
         "mm" => 72.0 / 25.4,
         "cm" => 72.0 / 2.54,
         "in" => 72.0,
@@ -269,13 +247,14 @@ fn parse_page_size_value(input: &mut Parser<'_, '_>) -> Option<PageSizeDecl> {
             }
         }
         Token::Dimension { value, unit, .. } => {
-            let w = css_unit_to_pt(value, &unit)?;
+            let w = css_unit_to_pt(value, &unit).filter(|v| *v > 0.0)?;
             // Try to read a second dimension for height
             let h = input
                 .try_parse(|input| {
                     let tok = input.next()?.clone();
                     match tok {
                         Token::Dimension { value, unit, .. } => css_unit_to_pt(value, &unit)
+                            .filter(|v| *v > 0.0)
                             .ok_or_else(|| {
                                 input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)
                             }),
@@ -301,6 +280,7 @@ fn parse_page_margin_value(input: &mut Parser<'_, '_>) -> Option<PageMarginDecl>
                         input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)
                     })
                 }
+                Token::Number { value: 0.0, .. } => Ok(0.0_f32),
                 _ => Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)),
             }
         });
@@ -1335,37 +1315,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_parse_css_length_mm() {
-        assert!((parse_css_length("20mm").unwrap() - 56.6929).abs() < 0.01);
-    }
-
-    #[test]
-    fn test_parse_css_length_cm() {
-        assert!((parse_css_length("2cm").unwrap() - 56.6929).abs() < 0.01);
-    }
-
-    #[test]
-    fn test_parse_css_length_in() {
-        assert!((parse_css_length("1in").unwrap() - 72.0).abs() < 0.01);
-    }
-
-    #[test]
-    fn test_parse_css_length_pt() {
-        assert!((parse_css_length("72pt").unwrap() - 72.0).abs() < 0.01);
-    }
-
-    #[test]
-    fn test_parse_css_length_px() {
-        assert!((parse_css_length("96px").unwrap() - 72.0).abs() < 0.01);
-    }
-
-    #[test]
-    fn test_parse_css_length_invalid() {
-        assert!(parse_css_length("20em").is_none());
-        assert!(parse_css_length("abc").is_none());
-    }
-
     // -----------------------------------------------------------------------
     // @page size/margin parsing tests
     // -----------------------------------------------------------------------
@@ -1481,5 +1430,21 @@ mod tests {
         let ctx = parse_gcpm(css);
         assert_eq!(ctx.page_settings.len(), 1);
         assert_eq!(ctx.margin_boxes.len(), 1);
+    }
+
+    #[test]
+    fn test_page_margin_zero() {
+        let css = "@page { margin: 0; }";
+        let ctx = parse_gcpm(css);
+        let m = ctx.page_settings[0].margin.as_ref().unwrap();
+        assert!((m.top).abs() < 0.01);
+        assert!((m.right).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_page_size_negative_rejected() {
+        let css = "@page { size: -10mm 297mm; }";
+        let ctx = parse_gcpm(css);
+        assert!(ctx.page_settings.is_empty() || ctx.page_settings[0].size.is_none());
     }
 }

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -5,10 +5,10 @@ use cssparser::{
 
 use super::margin_box::MarginBoxPosition;
 use super::{
-    ContentItem, CounterType, ElementPolicy, GcpmContext, MarginBoxRule, PageMarginDecl,
-    PageSettingsRule, PageSizeDecl, ParsedSelector, RunningMapping, StringPolicy, StringSetMapping,
-    StringSetValue,
+    ContentItem, CounterType, ElementPolicy, GcpmContext, MarginBoxRule, PageSettingsRule,
+    PageSizeDecl, ParsedSelector, RunningMapping, StringPolicy, StringSetMapping, StringSetValue,
 };
+use crate::config::Margin;
 
 // ---------------------------------------------------------------------------
 // Top-level result types
@@ -269,7 +269,7 @@ fn parse_page_size_value(input: &mut Parser<'_, '_>) -> Option<PageSizeDecl> {
 }
 
 /// Parse the value of an `@page { margin: ... }` declaration (CSS shorthand).
-fn parse_page_margin_value(input: &mut Parser<'_, '_>) -> Option<PageMarginDecl> {
+fn parse_page_margin_value(input: &mut Parser<'_, '_>) -> Option<Margin> {
     let mut values = Vec::new();
     loop {
         let result = input.try_parse(|input| {
@@ -294,25 +294,25 @@ fn parse_page_margin_value(input: &mut Parser<'_, '_>) -> Option<PageMarginDecl>
     }
 
     match values.len() {
-        1 => Some(PageMarginDecl {
+        1 => Some(Margin {
             top: values[0],
             right: values[0],
             bottom: values[0],
             left: values[0],
         }),
-        2 => Some(PageMarginDecl {
+        2 => Some(Margin {
             top: values[0],
             right: values[1],
             bottom: values[0],
             left: values[1],
         }),
-        3 => Some(PageMarginDecl {
+        3 => Some(Margin {
             top: values[0],
             right: values[1],
             bottom: values[2],
             left: values[1],
         }),
-        4 => Some(PageMarginDecl {
+        4 => Some(Margin {
             top: values[0],
             right: values[1],
             bottom: values[2],
@@ -331,7 +331,7 @@ fn parse_page_block(
     page_selector: &Option<String>,
     boxes: &mut Vec<MarginBoxRule>,
     size: &mut Option<PageSizeDecl>,
-    margin: &mut Option<PageMarginDecl>,
+    margin: &mut Option<Margin>,
 ) {
     let mut parser = PageRuleParser {
         page_selector,
@@ -349,7 +349,7 @@ struct PageRuleParser<'a> {
     page_selector: &'a Option<String>,
     boxes: &'a mut Vec<MarginBoxRule>,
     size: &'a mut Option<PageSizeDecl>,
-    margin: &'a mut Option<PageMarginDecl>,
+    margin: &'a mut Option<Margin>,
 }
 
 impl<'i, 'a> AtRuleParser<'i> for PageRuleParser<'a> {

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -701,6 +701,7 @@ pub fn parse_gcpm(css: &str) -> GcpmContext {
         margin_boxes,
         running_mappings,
         string_set_mappings,
+        page_settings: vec![],
         cleaned_css,
     }
 }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -124,9 +124,9 @@ fn parse_datetime(s: &str) -> Option<krilla::metadata::DateTime> {
 }
 
 /// Cached max-content width and render Pageable for margin boxes.
-/// Measure cache: html → max-content width (measured once at content_width).
+/// Measure cache: (html, page_height as bits) → max-content width.
 /// Render cache: (html, final_width as bits, final_height as bits) → Pageable.
-type MeasureCache = HashMap<String, f32>;
+type MeasureCache = HashMap<(String, u32), f32>;
 type RenderCache = HashMap<(String, u32, u32), Box<dyn Pageable>>;
 
 fn width_key(w: f32) -> u32 {
@@ -294,7 +294,8 @@ pub fn render_to_pdf_with_gcpm(
             if !pos.edge().is_some_and(|e| e.is_horizontal()) {
                 continue;
             }
-            if !measure_cache.contains_key(html) {
+            let measure_key = (html.clone(), width_key(page_size.height));
+            measure_cache.entry(measure_key).or_insert_with(|| {
                 let measure_html = format!(
                     "<html><head><style>{}</style></head><body style=\"margin:0;padding:0;\"><div style=\"display:inline-block\">{}</div></body></html>",
                     margin_css, html
@@ -305,9 +306,8 @@ pub fn render_to_pdf_with_gcpm(
                     page_size.height,
                     font_data,
                 );
-                let max_content_width = get_body_child_dimension(&measure_doc, true);
-                measure_cache.insert(html.clone(), max_content_width);
-            }
+                get_body_child_dimension(&measure_doc, true)
+            });
         }
 
         // Stage 1b: Measure max-content height for left/right boxes.
@@ -343,7 +343,9 @@ pub fn render_to_pdf_with_gcpm(
                 None => continue, // corners
             };
             let size = if edge.is_horizontal() {
-                measure_cache.get(html).copied()
+                measure_cache
+                    .get(&(html.clone(), width_key(page_size.height)))
+                    .copied()
             } else {
                 let fixed_width = if edge == Edge::Left {
                     resolved_margin.left

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -193,12 +193,6 @@ pub fn render_to_pdf_with_gcpm(
         crate::paginate::collect_running_element_states(&pages)
     };
 
-    let page_size = if config.landscape {
-        config.page_size.landscape()
-    } else {
-        config.page_size
-    };
-
     // Build margin-box CSS: strip display:none rules that the parser
     // injected for running elements (they need to be visible in margin boxes).
     let margin_css = strip_display_none(&gcpm.cleaned_css);
@@ -214,6 +208,20 @@ pub fn render_to_pdf_with_gcpm(
     // Pass 2: render each page with margin boxes
     for (page_idx, page_content) in pages.iter().enumerate() {
         let page_num = page_idx + 1;
+
+        // Resolve per-page size, margin, and landscape from @page rules + CLI overrides
+        let (resolved_size, resolved_margin, resolved_landscape) =
+            crate::gcpm::page_settings::resolve_page_settings(
+                &gcpm.page_settings,
+                page_num,
+                total_pages,
+                config,
+            );
+        let page_size = if resolved_landscape {
+            resolved_size.landscape()
+        } else {
+            resolved_size
+        };
 
         let settings = krilla::page::PageSettings::from_wh(page_size.width, page_size.height)
             .ok_or_else(|| Error::PdfGeneration("Invalid page dimensions".into()))?;
@@ -306,8 +314,8 @@ pub fn render_to_pdf_with_gcpm(
         // Layout at fixed margin width, then read the resulting height.
         for (&pos, html) in &resolved_htmls {
             let fixed_width = match pos.edge() {
-                Some(Edge::Left) => config.margin.left,
-                Some(Edge::Right) => config.margin.right,
+                Some(Edge::Left) => resolved_margin.left,
+                Some(Edge::Right) => resolved_margin.right,
                 _ => continue,
             };
             let hc_key = (html.clone(), width_key(fixed_width));
@@ -338,9 +346,9 @@ pub fn render_to_pdf_with_gcpm(
                 measure_cache.get(html).copied()
             } else {
                 let fixed_width = if edge == Edge::Left {
-                    config.margin.left
+                    resolved_margin.left
                 } else {
-                    config.margin.right
+                    resolved_margin.right
                 };
                 height_cache
                     .get(&(html.clone(), width_key(fixed_width)))
@@ -357,7 +365,7 @@ pub fn render_to_pdf_with_gcpm(
                 *edge,
                 defined,
                 page_size,
-                config.margin,
+                resolved_margin,
             ));
         }
 
@@ -367,7 +375,7 @@ pub fn render_to_pdf_with_gcpm(
             let rect = all_rects
                 .get(&pos)
                 .copied()
-                .unwrap_or_else(|| pos.bounding_rect(page_size, config.margin));
+                .unwrap_or_else(|| pos.bounding_rect(page_size, resolved_margin));
 
             let cache_key = (html.clone(), width_key(rect.width), width_key(rect.height));
             if !render_cache.contains_key(&cache_key) {
@@ -397,13 +405,15 @@ pub fn render_to_pdf_with_gcpm(
             }
         }
 
-        // Draw body content
+        // Draw body content with resolved per-page margin
+        let page_content_width = page_size.width - resolved_margin.left - resolved_margin.right;
+        let page_content_height = page_size.height - resolved_margin.top - resolved_margin.bottom;
         page_content.draw(
             &mut canvas,
-            config.margin.left,
-            config.margin.top,
-            content_width,
-            content_height,
+            resolved_margin.left,
+            resolved_margin.top,
+            page_content_width,
+            page_content_height,
         );
     }
 

--- a/crates/fulgur/tests/gcpm_integration.rs
+++ b/crates/fulgur/tests/gcpm_integration.rs
@@ -1,4 +1,5 @@
 use fulgur::asset::AssetBundle;
+use fulgur::config::PageSize;
 use fulgur::engine::Engine;
 
 #[test]
@@ -581,4 +582,72 @@ fn test_element_default_policy_still_works() {
         pdf.len()
     );
     assert!(pdf.starts_with(b"%PDF-"));
+}
+
+#[test]
+fn test_gcpm_page_size_from_css() {
+    let html = "<html><body><p>Hello World</p></body></html>";
+    let css = "@page { size: letter; margin: 1in; }";
+    let mut assets = AssetBundle::new();
+    assets.add_css(css);
+    let engine = Engine::builder().assets(assets).build();
+    let result = engine.render_html(html);
+    assert!(result.is_ok(), "Failed: {:?}", result.err());
+}
+
+#[test]
+fn test_gcpm_page_size_cli_overrides_css() {
+    let html = "<html><body><p>Hello World</p></body></html>";
+    let css = "@page { size: letter; }";
+    let mut assets = AssetBundle::new();
+    assets.add_css(css);
+    let engine = Engine::builder()
+        .page_size(PageSize::A3)
+        .assets(assets)
+        .build();
+    let result = engine.render_html(html);
+    assert!(result.is_ok(), "Failed: {:?}", result.err());
+}
+
+#[test]
+fn test_gcpm_page_margin_from_css() {
+    let html = "<html><body><p>Hello World</p></body></html>";
+    let css = "@page { margin: 10mm; }";
+    let mut assets = AssetBundle::new();
+    assets.add_css(css);
+    let engine = Engine::builder().assets(assets).build();
+    let result = engine.render_html(html);
+    assert!(result.is_ok(), "Failed: {:?}", result.err());
+}
+
+#[test]
+fn test_gcpm_page_size_custom_dimensions() {
+    let html = "<html><body><p>Hello World</p></body></html>";
+    let css = "@page { size: 100mm 200mm; margin: 10mm; }";
+    let mut assets = AssetBundle::new();
+    assets.add_css(css);
+    let engine = Engine::builder().assets(assets).build();
+    let result = engine.render_html(html);
+    assert!(result.is_ok(), "Failed: {:?}", result.err());
+}
+
+#[test]
+fn test_gcpm_page_size_with_margin_boxes() {
+    let html = r#"<html><body>
+        <div class="header">Header</div>
+        <p>Content</p>
+    </body></html>"#;
+    let css = r#"
+        .header { position: running(pageHeader); }
+        @page {
+            size: A4 landscape;
+            margin: 20mm;
+            @top-center { content: element(pageHeader); }
+        }
+    "#;
+    let mut assets = AssetBundle::new();
+    assets.add_css(css);
+    let engine = Engine::builder().assets(assets).build();
+    let result = engine.render_html(html);
+    assert!(result.is_ok(), "Failed: {:?}", result.err());
 }


### PR DESCRIPTION
## Summary

- CSS `@page` ルール内の `size` / `margin` 宣言をパースし、PDFページ寸法に反映
- 優先順位: **CLI明示指定 > CSS @page セレクタ > CSS @page デフォルト > Config デフォルト**
- ページセレクタ (`:first`, `:left`, `:right`) ごとに異なるサイズ・マージンを指定可能
- 対応単位: `mm`, `cm`, `in`, `pt`, `px`
- `size` 構文: `auto`, キーワード (`A4`, `letter`), キーワード+向き (`A4 landscape`), カスタム寸法 (`210mm 297mm`)
- `margin` 構文: CSS shorthand (1〜4値)

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `gcpm/parser.rs` | `@page` 内 `size`/`margin` 宣言のパース、`css_unit_to_pt` |
| `gcpm/mod.rs` | `PageSizeDecl`, `PageMarginDecl`, `PageSettingsRule` 型定義 |
| `gcpm/page_settings.rs` | `resolve_page_settings` — per-page 寸法解決ロジック |
| `config.rs` | `ConfigOverrides` — CLI明示指定のトラッキング |
| `render.rs` | GCPM パイプラインでページごとに解決された寸法を適用 |
| `blitz_adapter.rs` | `GcpmContext` フィールド追加対応 |
| `gcpm_integration.rs` | 統合テスト5件追加 |

## Test plan

- [x] ユニットテスト: 201件パス (`cargo test -p fulgur --lib`)
- [x] 統合テスト: 23件パス (`cargo test -p fulgur --test gcpm_integration -- --test-threads=1`)
- [x] `cargo clippy` 警告なし
- [x] `cargo fmt --check` クリーン

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * CSS の @page を解釈し、ページごとに異なるサイズ・マージン・向きを反映してレンダリング可能に
* **描画/計測**
  * ページごとの解決済みサイズ・マージンを描画に適用。内部の計測キャッシュキーをページ依存に調整
* **CLI**
  * ページサイズ/向きは明示指定時のみ適用。未知のサイズ指定はエラーで終了し、サポート値を案内
* **設定**
  * どの設定項目が明示指定されたかを保持する仕組みを追加
* **テスト**
  * @page のキーワード/カスタム寸法/マージン/選択子挙動を検証する単体・統合テストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/58" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
