### PR TITLE
feat(gcpm): CSS counter-reset / counter-increment / counter-set support

### DIFF
--- a/crates/fulgur-cli/src/main.rs
+++ b/crates/fulgur-cli/src/main.rs
@@ -51,11 +51,11 @@ enum Commands {
         output: PathBuf,
 
         /// Page size (A4, Letter, A3)
-        #[arg(short, long, default_value = "A4")]
-        size: String,
+        #[arg(short, long)]
+        size: Option<String>,
 
         /// Landscape orientation
-        #[arg(short, long, default_value_t = false)]
+        #[arg(short, long)]
         landscape: bool,
 
         /// PDF title
@@ -279,9 +279,13 @@ fn main() {
                 None
             };
 
-            let mut builder = Engine::builder()
-                .page_size(parse_page_size(&size))
-                .landscape(landscape);
+            let mut builder = Engine::builder();
+            if let Some(ref s) = size {
+                builder = builder.page_size(parse_page_size(s));
+            }
+            if landscape {
+                builder = builder.landscape(landscape);
+            }
 
             if let Some(ref m) = margin {
                 builder = builder.margin(parse_margin(m));

--- a/crates/fulgur-cli/src/main.rs
+++ b/crates/fulgur-cli/src/main.rs
@@ -51,11 +51,11 @@ enum Commands {
         output: PathBuf,
 
         /// Page size (A4, Letter, A3)
-        #[arg(short, long)]
-        size: Option<String>,
+        #[arg(short, long, default_value = "A4")]
+        size: String,
 
         /// Landscape orientation
-        #[arg(short, long)]
+        #[arg(short, long, default_value_t = false)]
         landscape: bool,
 
         /// PDF title
@@ -144,11 +144,8 @@ fn parse_page_size(s: &str) -> PageSize {
         "A3" => PageSize::A3,
         "LETTER" => PageSize::LETTER,
         _ => {
-            eprintln!(
-                "Error: unknown page size '{}'. Supported: A4, A3, Letter",
-                s
-            );
-            std::process::exit(1);
+            eprintln!("Unknown page size '{}', defaulting to A4", s);
+            PageSize::A4
         }
     }
 }
@@ -282,13 +279,9 @@ fn main() {
                 None
             };
 
-            let mut builder = Engine::builder();
-            if let Some(ref s) = size {
-                builder = builder.page_size(parse_page_size(s));
-            }
-            if landscape {
-                builder = builder.landscape(landscape);
-            }
+            let mut builder = Engine::builder()
+                .page_size(parse_page_size(&size))
+                .landscape(landscape);
 
             if let Some(ref m) = margin {
                 builder = builder.margin(parse_margin(m));

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -610,27 +610,18 @@ impl CounterPass {
             self.ops_by_node.borrow_mut().push((node_id, matched_ops));
         }
 
-        // Phase 3: Resolve content (after counter state update) and set data
-        // attributes + generate CSS (needs mutable doc borrow).
-        // Collect all content resolutions first, then assign ONE cid and
-        // generate ALL CSS rules with that cid. This avoids the bug where
-        // ::before + ::after each overwrote data-fulgur-cid with different values.
-        let content_resolutions: Vec<(&str, String)> = matched_content_indices
-            .into_iter()
-            .map(|idx| {
-                let mapping = &self.content_mappings[idx];
-                let resolved = self.resolve_content(&mapping.content);
-                let pseudo_str = match mapping.pseudo {
-                    PseudoElement::Before => "before",
-                    PseudoElement::After => "after",
-                };
-                (pseudo_str, resolved)
-            })
-            .collect();
+        // Phase 3: Split ::before (resolve now) and ::after (resolve after children).
+        // CSS spec: ::before is a first child, ::after is a last child, so
+        // ::after must see counter state changes from descendants.
+        let (before_indices, after_indices): (Vec<usize>, Vec<usize>) =
+            matched_content_indices.into_iter().partition(|&idx| {
+                self.content_mappings[idx].pseudo == PseudoElement::Before
+            });
 
-        if !content_resolutions.is_empty() {
+        // Allocate a cid if any content mappings matched (needed for both phases)
+        let attr_value = if !before_indices.is_empty() || !after_indices.is_empty() {
             let mut id = self.counter_id.borrow_mut();
-            let attr_value = format!("{}", *id);
+            let v = format!("{}", *id);
             *id += 1;
             drop(id);
 
@@ -638,19 +629,25 @@ impl CounterPass {
             let qual = make_qual_name("data-fulgur-cid");
             if let Some(node_mut) = doc.get_node_mut(node_id) {
                 if let Some(elem_mut) = node_mut.element_data_mut() {
-                    elem_mut.attrs.set(qual, &attr_value);
+                    elem_mut.attrs.set(qual, &v);
                 }
             }
+            Some(v)
+        } else {
+            None
+        };
 
-            // Generate CSS for all pseudo-elements with the same cid
-            let mut css = self.generated_css.borrow_mut();
+        // Resolve ::before now (before child traversal)
+        if let Some(ref cid) = attr_value {
             use std::fmt::Write;
-            for (pseudo_str, resolved) in content_resolutions {
+            let mut css = self.generated_css.borrow_mut();
+            for idx in &before_indices {
+                let mapping = &self.content_mappings[*idx];
+                let resolved = self.resolve_content(&mapping.content);
                 let _ = write!(
                     css,
-                    "[data-fulgur-cid=\"{}\"]::{}{{content:\"{}\"}}",
-                    attr_value,
-                    pseudo_str,
+                    "[data-fulgur-cid=\"{}\"]::before{{content:\"{}\"}}",
+                    cid,
                     css_escape_string(&resolved)
                 );
             }
@@ -663,6 +660,22 @@ impl CounterPass {
             .unwrap_or_default();
         for child_id in children {
             self.walk_tree(doc, child_id);
+        }
+
+        // Resolve ::after now (after child traversal, sees descendant counter changes)
+        if let Some(ref cid) = attr_value {
+            use std::fmt::Write;
+            let mut css = self.generated_css.borrow_mut();
+            for idx in &after_indices {
+                let mapping = &self.content_mappings[*idx];
+                let resolved = self.resolve_content(&mapping.content);
+                let _ = write!(
+                    css,
+                    "[data-fulgur-cid=\"{}\"]::after{{content:\"{}\"}}",
+                    cid,
+                    css_escape_string(&resolved)
+                );
+            }
         }
     }
 
@@ -813,6 +826,7 @@ mod tests {
             string_set_mappings: vec![],
             counter_mappings: vec![],
             content_counter_mappings: vec![],
+            page_settings: vec![],
             cleaned_css: String::new(),
         };
 
@@ -855,6 +869,7 @@ mod tests {
             string_set_mappings: vec![],
             counter_mappings: vec![],
             content_counter_mappings: vec![],
+            page_settings: vec![],
             cleaned_css: String::new(),
         };
 
@@ -883,6 +898,7 @@ mod tests {
             string_set_mappings: vec![],
             counter_mappings: vec![],
             content_counter_mappings: vec![],
+            page_settings: vec![],
             cleaned_css: String::new(),
         };
 
@@ -914,6 +930,7 @@ mod tests {
             string_set_mappings: vec![],
             counter_mappings: vec![],
             content_counter_mappings: vec![],
+            page_settings: vec![],
             cleaned_css: String::new(),
         };
 

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -545,12 +545,15 @@ impl DomPass for CounterPass {
         }
         let root = doc.root_element();
         let root_id = root.id;
-        self.walk_tree(doc, root_id);
+        self.walk_tree(doc, root_id, 0);
     }
 }
 
 impl CounterPass {
-    fn walk_tree(&self, doc: &mut HtmlDocument, node_id: usize) {
+    fn walk_tree(&self, doc: &mut HtmlDocument, node_id: usize, depth: usize) {
+        if depth >= MAX_DOM_DEPTH {
+            return;
+        }
         // Phase 1: Read element data immutably to collect matched operations
         // and matched content mapping indices. We must drop the immutable borrow
         // before calling doc.get_node_mut().
@@ -562,7 +565,7 @@ impl CounterPass {
                 // Not an element — just recurse into children
                 let children: Vec<usize> = node.children.clone();
                 for child_id in children {
-                    self.walk_tree(doc, child_id);
+                    self.walk_tree(doc, child_id, depth + 1);
                 }
                 return;
             };
@@ -658,7 +661,7 @@ impl CounterPass {
             .map(|n| n.children.clone())
             .unwrap_or_default();
         for child_id in children {
-            self.walk_tree(doc, child_id);
+            self.walk_tree(doc, child_id, depth + 1);
         }
 
         // Resolve ::after now (after child traversal, sees descendant counter changes)

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -338,9 +338,9 @@ impl DomPass for LinkStylesheetPass {
     }
 }
 
-use crate::gcpm::counter::{CounterState, format_counter};
-use crate::gcpm::running::{RunningElementStore, serialize_node};
-use crate::gcpm::string_set::{StringSetEntry, StringSetStore, extract_text_content};
+use crate::gcpm::counter::{format_counter, CounterState};
+use crate::gcpm::running::{serialize_node, RunningElementStore};
+use crate::gcpm::string_set::{extract_text_content, StringSetEntry, StringSetStore};
 use crate::gcpm::{
     ContentCounterMapping, ContentItem, CounterMapping, CounterOp, ParsedSelector, PseudoElement,
     RunningMapping, StringSetMapping, StringSetValue,
@@ -613,10 +613,9 @@ impl CounterPass {
         // Phase 3: Split ::before (resolve now) and ::after (resolve after children).
         // CSS spec: ::before is a first child, ::after is a last child, so
         // ::after must see counter state changes from descendants.
-        let (before_indices, after_indices): (Vec<usize>, Vec<usize>) =
-            matched_content_indices.into_iter().partition(|&idx| {
-                self.content_mappings[idx].pseudo == PseudoElement::Before
-            });
+        let (before_indices, after_indices): (Vec<usize>, Vec<usize>) = matched_content_indices
+            .into_iter()
+            .partition(|&idx| self.content_mappings[idx].pseudo == PseudoElement::Before);
 
         // Allocate a cid if any content mappings matched (needed for both phases)
         let attr_value = if !before_indices.is_empty() || !after_indices.is_empty() {

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -338,9 +338,13 @@ impl DomPass for LinkStylesheetPass {
     }
 }
 
+use crate::gcpm::counter::{CounterState, format_counter};
 use crate::gcpm::running::{RunningElementStore, serialize_node};
 use crate::gcpm::string_set::{StringSetEntry, StringSetStore, extract_text_content};
-use crate::gcpm::{ParsedSelector, RunningMapping, StringSetMapping, StringSetValue};
+use crate::gcpm::{
+    ContentCounterMapping, ContentItem, CounterMapping, CounterOp, ParsedSelector, PseudoElement,
+    RunningMapping, StringSetMapping, StringSetValue,
+};
 use std::cell::RefCell;
 
 /// Returns true for elements that should never be walked for GCPM detection
@@ -494,6 +498,209 @@ impl StringSetPass {
     }
 }
 
+/// Walks the DOM applying counter-reset/increment/set operations and resolves
+/// `content: counter()` in ::before/::after pseudo-elements by generating override CSS.
+pub struct CounterPass {
+    counter_mappings: Vec<CounterMapping>,
+    content_mappings: Vec<ContentCounterMapping>,
+    state: RefCell<CounterState>,
+    generated_css: RefCell<String>,
+    counter_id: RefCell<usize>,
+    /// Counter ops keyed by node_id, for later use in Pageable markers.
+    ops_by_node: RefCell<Vec<(usize, Vec<CounterOp>)>>,
+}
+
+impl CounterPass {
+    pub fn new(
+        counter_mappings: Vec<CounterMapping>,
+        content_mappings: Vec<ContentCounterMapping>,
+    ) -> Self {
+        Self {
+            counter_mappings,
+            content_mappings,
+            state: RefCell::new(CounterState::new()),
+            generated_css: RefCell::new(String::new()),
+            counter_id: RefCell::new(0),
+            ops_by_node: RefCell::new(Vec::new()),
+        }
+    }
+
+    pub fn generated_css(&self) -> String {
+        self.generated_css.borrow().clone()
+    }
+
+    /// Consume self and return (ops_by_node for Pageable markers, generated CSS for body).
+    pub fn into_parts(self) -> (Vec<(usize, Vec<CounterOp>)>, String) {
+        (
+            self.ops_by_node.into_inner(),
+            self.generated_css.into_inner(),
+        )
+    }
+}
+
+impl DomPass for CounterPass {
+    fn apply(&self, doc: &mut HtmlDocument, _ctx: &PassContext<'_>) {
+        if self.counter_mappings.is_empty() && self.content_mappings.is_empty() {
+            return;
+        }
+        let root = doc.root_element();
+        let root_id = root.id;
+        self.walk_tree(doc, root_id);
+    }
+}
+
+impl CounterPass {
+    fn walk_tree(&self, doc: &mut HtmlDocument, node_id: usize) {
+        // Phase 1: Read element data immutably to collect matched operations
+        // and matched content mapping indices. We must drop the immutable borrow
+        // before calling doc.get_node_mut().
+        let phase1 = {
+            let Some(node) = doc.get_node(node_id) else {
+                return;
+            };
+            let Some(elem) = node.element_data() else {
+                // Not an element — just recurse into children
+                let children: Vec<usize> = node.children.clone();
+                for child_id in children {
+                    self.walk_tree(doc, child_id);
+                }
+                return;
+            };
+
+            if is_non_visual_tag(elem.name.local.as_ref()) {
+                return;
+            }
+
+            // Collect counter operations
+            let mut matched_ops = Vec::new();
+            for mapping in &self.counter_mappings {
+                if selector_matches(&mapping.parsed, elem) {
+                    matched_ops.extend(mapping.ops.clone());
+                }
+            }
+
+            // Collect indices of matching content mappings (resolve values
+            // after counter state is updated in phase 2)
+            let mut matched_content_indices: Vec<usize> = Vec::new();
+            for (i, mapping) in self.content_mappings.iter().enumerate() {
+                if selector_matches(&mapping.parsed, elem) {
+                    matched_content_indices.push(i);
+                }
+            }
+
+            Some((matched_ops, matched_content_indices))
+        };
+        // immutable borrow of doc is now dropped
+
+        let Some((matched_ops, matched_content_indices)) = phase1 else {
+            return;
+        };
+
+        // Phase 2: Apply counter state changes (no doc borrow needed)
+        if !matched_ops.is_empty() {
+            let mut state = self.state.borrow_mut();
+            for op in &matched_ops {
+                match op {
+                    CounterOp::Reset { name, value } => state.reset(name, *value),
+                    CounterOp::Increment { name, value } => state.increment(name, *value),
+                    CounterOp::Set { name, value } => state.set(name, *value),
+                }
+            }
+            drop(state);
+            self.ops_by_node.borrow_mut().push((node_id, matched_ops));
+        }
+
+        // Phase 3: Resolve content (after counter state update) and set data
+        // attributes + generate CSS (needs mutable doc borrow).
+        // Collect all content resolutions first, then assign ONE cid and
+        // generate ALL CSS rules with that cid. This avoids the bug where
+        // ::before + ::after each overwrote data-fulgur-cid with different values.
+        let content_resolutions: Vec<(&str, String)> = matched_content_indices
+            .into_iter()
+            .map(|idx| {
+                let mapping = &self.content_mappings[idx];
+                let resolved = self.resolve_content(&mapping.content);
+                let pseudo_str = match mapping.pseudo {
+                    PseudoElement::Before => "before",
+                    PseudoElement::After => "after",
+                };
+                (pseudo_str, resolved)
+            })
+            .collect();
+
+        if !content_resolutions.is_empty() {
+            let mut id = self.counter_id.borrow_mut();
+            let attr_value = format!("{}", *id);
+            *id += 1;
+            drop(id);
+
+            // Set data attribute once
+            let qual = make_qual_name("data-fulgur-cid");
+            if let Some(node_mut) = doc.get_node_mut(node_id) {
+                if let Some(elem_mut) = node_mut.element_data_mut() {
+                    elem_mut.attrs.set(qual, &attr_value);
+                }
+            }
+
+            // Generate CSS for all pseudo-elements with the same cid
+            let mut css = self.generated_css.borrow_mut();
+            use std::fmt::Write;
+            for (pseudo_str, resolved) in content_resolutions {
+                let _ = write!(
+                    css,
+                    "[data-fulgur-cid=\"{}\"]::{}{{content:\"{}\"}}",
+                    attr_value,
+                    pseudo_str,
+                    css_escape_string(&resolved)
+                );
+            }
+        }
+
+        // Recurse into children (re-read children since we may have mutated doc)
+        let children: Vec<usize> = doc
+            .get_node(node_id)
+            .map(|n| n.children.clone())
+            .unwrap_or_default();
+        for child_id in children {
+            self.walk_tree(doc, child_id);
+        }
+    }
+
+    fn resolve_content(&self, items: &[ContentItem]) -> String {
+        let state = self.state.borrow();
+        let mut out = String::new();
+        for item in items {
+            match item {
+                ContentItem::String(s) => out.push_str(s),
+                ContentItem::Counter { name, style } => {
+                    let value = state.get(name);
+                    out.push_str(&format_counter(value, *style));
+                }
+                _ => {}
+            }
+        }
+        out
+    }
+}
+
+fn css_escape_string(s: &str) -> String {
+    let mut out = String::new();
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\a "),
+            '\r' => out.push_str("\\d "),
+            '\0' => out.push_str("\\0 "),
+            c if c.is_control() => {
+                out.push_str(&format!("\\{:x} ", c as u32));
+            }
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
 fn resolve_string_set_values(
     doc: &HtmlDocument,
     node_id: usize,
@@ -604,7 +811,8 @@ mod tests {
                 running_name: "pageHeader".to_string(),
             }],
             string_set_mappings: vec![],
-            page_settings: vec![],
+            counter_mappings: vec![],
+            content_counter_mappings: vec![],
             cleaned_css: String::new(),
         };
 
@@ -645,7 +853,8 @@ mod tests {
                 running_name: "pageTitle".to_string(),
             }],
             string_set_mappings: vec![],
-            page_settings: vec![],
+            counter_mappings: vec![],
+            content_counter_mappings: vec![],
             cleaned_css: String::new(),
         };
 
@@ -672,7 +881,8 @@ mod tests {
             margin_boxes: vec![],
             running_mappings: vec![],
             string_set_mappings: vec![],
-            page_settings: vec![],
+            counter_mappings: vec![],
+            content_counter_mappings: vec![],
             cleaned_css: String::new(),
         };
 
@@ -702,7 +912,8 @@ mod tests {
                 running_name: "shouldNotMatch".to_string(),
             }],
             string_set_mappings: vec![],
-            page_settings: vec![],
+            counter_mappings: vec![],
+            content_counter_mappings: vec![],
             cleaned_css: String::new(),
         };
 
@@ -922,6 +1133,75 @@ mod tests {
         assert!(
             find_element_by_tag(&doc, "style").is_none(),
             "Absolute path outside base_path should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_counter_pass_generates_css() {
+        use crate::gcpm::{
+            ContentCounterMapping, CounterMapping, CounterOp, CounterStyle, PseudoElement,
+        };
+
+        let html = r#"<html><body>
+            <h2>Chapter One</h2>
+            <h2>Chapter Two</h2>
+        </body></html>"#;
+        let mut doc = parse(html, 400.0, &[]);
+        let ctx = PassContext {
+            viewport_width: 400.0,
+            viewport_height: 10000.0,
+            font_data: &[],
+        };
+
+        let counter_mappings = vec![
+            CounterMapping {
+                parsed: crate::gcpm::ParsedSelector::Tag("body".into()),
+                ops: vec![CounterOp::Reset {
+                    name: "chapter".into(),
+                    value: 0,
+                }],
+            },
+            CounterMapping {
+                parsed: crate::gcpm::ParsedSelector::Tag("h2".into()),
+                ops: vec![CounterOp::Increment {
+                    name: "chapter".into(),
+                    value: 1,
+                }],
+            },
+        ];
+
+        let content_mappings = vec![ContentCounterMapping {
+            parsed: crate::gcpm::ParsedSelector::Tag("h2".into()),
+            pseudo: PseudoElement::Before,
+            content: vec![
+                crate::gcpm::ContentItem::Counter {
+                    name: "chapter".into(),
+                    style: CounterStyle::Decimal,
+                },
+                crate::gcpm::ContentItem::String(". ".into()),
+            ],
+        }];
+
+        let pass = CounterPass::new(counter_mappings, content_mappings);
+        pass.apply(&mut doc, &ctx);
+
+        let css = pass.generated_css();
+        // Should contain resolved values "1. " and "2. "
+        assert!(
+            css.contains("1. "),
+            "CSS should contain resolved '1. ', got: {css}"
+        );
+        assert!(
+            css.contains("2. "),
+            "CSS should contain resolved '2. ', got: {css}"
+        );
+
+        let (ops_by_node, _) = pass.into_parts();
+        // Should have 3 ops: body reset + h2 increment + h2 increment
+        assert_eq!(
+            ops_by_node.len(),
+            3,
+            "Should have exactly 3 ops: body reset + 2 h2 increments"
         );
     }
 }

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -338,9 +338,9 @@ impl DomPass for LinkStylesheetPass {
     }
 }
 
-use crate::gcpm::counter::{format_counter, CounterState};
-use crate::gcpm::running::{serialize_node, RunningElementStore};
-use crate::gcpm::string_set::{extract_text_content, StringSetEntry, StringSetStore};
+use crate::gcpm::counter::{CounterState, format_counter};
+use crate::gcpm::running::{RunningElementStore, serialize_node};
+use crate::gcpm::string_set::{StringSetEntry, StringSetStore, extract_text_content};
 use crate::gcpm::{
     ContentCounterMapping, ContentItem, CounterMapping, CounterOp, ParsedSelector, PseudoElement,
     RunningMapping, StringSetMapping, StringSetValue,

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -7,9 +7,9 @@ use crate::image::ImagePageable;
 use crate::pageable::{
     BackgroundLayer, BgBox, BgClip, BgLengthPercentage, BgRepeat, BgSize, BlockPageable,
     BlockStyle, BorderStyleValue, CounterOpMarkerPageable, CounterOpWrapperPageable,
-    ListItemPageable, Pageable,
-    PositionedChild, RunningElementMarkerPageable, RunningElementWrapperPageable, Size,
-    SpacerPageable, StringSetPageable, StringSetWrapperPageable, TablePageable,
+    ListItemPageable, Pageable, PositionedChild, RunningElementMarkerPageable,
+    RunningElementWrapperPageable, Size, SpacerPageable, StringSetPageable,
+    StringSetWrapperPageable, TablePageable,
 };
 use crate::paragraph::{
     ParagraphPageable, ShapedGlyph, ShapedGlyphRun, ShapedLine, TextDecoration, TextDecorationLine,

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -1,13 +1,15 @@
 //! Convert a Blitz DOM (after style resolution + layout) into a Pageable tree.
 
 use crate::asset::AssetBundle;
+use crate::gcpm::CounterOp;
 use crate::gcpm::running::RunningElementStore;
 use crate::image::ImagePageable;
 use crate::pageable::{
     BackgroundLayer, BgBox, BgClip, BgLengthPercentage, BgRepeat, BgSize, BlockPageable,
-    BlockStyle, BorderStyleValue, ListItemPageable, Pageable, PositionedChild,
-    RunningElementMarkerPageable, RunningElementWrapperPageable, Size, SpacerPageable,
-    StringSetPageable, StringSetWrapperPageable, TablePageable,
+    BlockStyle, BorderStyleValue, CounterOpMarkerPageable, CounterOpWrapperPageable,
+    ListItemPageable, Pageable,
+    PositionedChild, RunningElementMarkerPageable, RunningElementWrapperPageable, Size,
+    SpacerPageable, StringSetPageable, StringSetWrapperPageable, TablePageable,
 };
 use crate::paragraph::{
     ParagraphPageable, ShapedGlyph, ShapedGlyphRun, ShapedLine, TextDecoration, TextDecorationLine,
@@ -29,6 +31,8 @@ pub struct ConvertContext<'a> {
     pub(crate) font_cache: HashMap<(usize, u32), Arc<Vec<u8>>>,
     /// String-set entries from DOM walk, keyed by node_id for O(1) lookup.
     pub string_set_by_node: HashMap<usize, Vec<(String, String)>>,
+    /// Counter operations from CounterPass, keyed by node_id for O(1) lookup.
+    pub counter_ops_by_node: HashMap<usize, Vec<CounterOp>>,
 }
 
 impl ConvertContext<'_> {
@@ -98,7 +102,8 @@ fn convert_node(
         return Box::new(SpacerPageable::new(0.0));
     }
     let result = convert_node_inner(doc, node_id, ctx, depth);
-    maybe_prepend_string_set(node_id, result, ctx)
+    let result = maybe_prepend_string_set(node_id, result, ctx);
+    maybe_prepend_counter_ops(node_id, result, ctx)
 }
 
 /// If the given node has string-set entries, wrap the pageable in a
@@ -118,6 +123,22 @@ fn maybe_prepend_string_set(
                 .collect();
             Box::new(StringSetWrapperPageable::new(markers, child))
         }
+        _ => child,
+    }
+}
+
+/// If the given node has counter operations, wrap the pageable in a
+/// `CounterOpWrapperPageable` that keeps counter operations attached to the
+/// child during pagination. The wrapper is atomic when the child cannot split,
+/// preventing the operations from being stranded on the wrong page.
+fn maybe_prepend_counter_ops(
+    node_id: usize,
+    child: Box<dyn Pageable>,
+    ctx: &mut ConvertContext<'_>,
+) -> Box<dyn Pageable> {
+    let ops = ctx.counter_ops_by_node.remove(&node_id);
+    match ops {
+        Some(ops) if !ops.is_empty() => Box::new(CounterOpWrapperPageable::new(ops, child)),
         _ => child,
     }
 }
@@ -155,6 +176,26 @@ fn emit_orphan_string_set_markers(
                 y,
             });
         }
+    }
+}
+
+/// Emit counter-op markers for a node, similar to `emit_orphan_string_set_markers`.
+///
+/// If `counter_ops_by_node` contains entries for `node_id`, they are removed
+/// and pushed as a `CounterOpMarkerPageable` at `(x, y)`.
+fn emit_counter_op_markers(
+    node_id: usize,
+    x: f32,
+    y: f32,
+    ctx: &mut ConvertContext<'_>,
+    out: &mut Vec<PositionedChild>,
+) {
+    if let Some(ops) = ctx.counter_ops_by_node.remove(&node_id) {
+        out.push(PositionedChild {
+            child: Box::new(CounterOpMarkerPageable::new(ops)),
+            x,
+            y,
+        });
     }
 }
 
@@ -380,6 +421,13 @@ fn collect_positioned_children(
                 ctx,
                 &mut result,
             );
+            emit_counter_op_markers(
+                child_id,
+                child_layout.location.x,
+                child_layout.location.y,
+                ctx,
+                &mut result,
+            );
             if let Some(marker) = take_running_marker(child_id, ctx) {
                 pending_running_markers.push(marker);
             }
@@ -394,6 +442,13 @@ fn collect_positioned_children(
             && !child_node.children.is_empty()
         {
             emit_orphan_string_set_markers(
+                child_id,
+                child_layout.location.x,
+                child_layout.location.y,
+                ctx,
+                &mut result,
+            );
+            emit_counter_op_markers(
                 child_id,
                 child_layout.location.x,
                 child_layout.location.y,
@@ -579,6 +634,17 @@ fn collect_table_cells(
     let Some(node) = doc.get_node(node_id) else {
         return;
     };
+
+    // Drain counter ops on the current section/row node itself so that
+    // counter-reset / counter-increment / counter-set declared on
+    // <thead>/<tbody>/<tr> reach `collect_counter_states()` for margin boxes.
+    // Without this, ops on these intermediate nodes stay in
+    // `ctx.counter_ops_by_node` forever and never propagate.
+    {
+        let layout = node.final_layout;
+        let out: &mut Vec<PositionedChild> = if is_header { header_cells } else { body_cells };
+        emit_counter_op_markers(node_id, layout.location.x, layout.location.y, ctx, out);
+    }
 
     for &child_id in &node.children {
         let Some(child_node) = doc.get_node(child_id) else {

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -110,6 +110,25 @@ impl Engine {
             crate::gcpm::string_set::StringSetStore::new()
         };
 
+        // Extract counter operations and resolve body content
+        let (counter_ops_by_node_vec, counter_css) =
+            if !gcpm.counter_mappings.is_empty() || !gcpm.content_counter_mappings.is_empty() {
+                let pass = crate::blitz_adapter::CounterPass::new(
+                    gcpm.counter_mappings.clone(),
+                    gcpm.content_counter_mappings.clone(),
+                );
+                pass.apply(&mut doc, &ctx);
+                pass.into_parts()
+            } else {
+                (Vec::new(), String::new())
+            };
+
+        // Inject counter-resolved CSS for ::before/::after
+        if !counter_css.is_empty() {
+            let inject_pass = crate::blitz_adapter::InjectCssPass { css: counter_css };
+            inject_pass.apply(&mut doc, &ctx);
+        }
+
         crate::blitz_adapter::resolve(&mut doc);
 
         // --- Convert DOM to Pageable and render ---
@@ -124,11 +143,21 @@ impl Engine {
             map
         };
 
+        // Build counter_ops_by_node map
+        let counter_ops_map: HashMap<usize, Vec<crate::gcpm::CounterOp>> = {
+            let mut map = HashMap::new();
+            for (node_id, ops) in counter_ops_by_node_vec {
+                map.insert(node_id, ops);
+            }
+            map
+        };
+
         let mut convert_ctx = ConvertContext {
             running_store: &running_store,
             assets: self.assets.as_ref(),
             font_cache: HashMap::new(),
             string_set_by_node,
+            counter_ops_by_node: counter_ops_map,
         };
         let root = crate::convert::dom_to_pageable(&doc, &mut convert_ctx);
 

--- a/crates/fulgur/src/gcpm/counter.rs
+++ b/crates/fulgur/src/gcpm/counter.rs
@@ -22,9 +22,8 @@ pub fn resolve_content_to_string(
                 "page" => out.push_str(&format_counter(page as i32, *style)),
                 "pages" => out.push_str(&format_counter(total_pages as i32, *style)),
                 _ => {
-                    if let Some(&value) = custom_counters.get(name.as_str()) {
-                        out.push_str(&format_counter(value, *style));
-                    }
+                    let value = custom_counters.get(name.as_str()).copied().unwrap_or(0);
+                    out.push_str(&format_counter(value, *style));
                 }
             },
             ContentItem::Element { .. } => {}
@@ -65,9 +64,8 @@ pub fn resolve_content_to_html(
                 "page" => out.push_str(&format_counter(page_num as i32, *style)),
                 "pages" => out.push_str(&format_counter(total_pages as i32, *style)),
                 _ => {
-                    if let Some(&value) = custom_counters.get(name.as_str()) {
-                        out.push_str(&format_counter(value, *style));
-                    }
+                    let value = custom_counters.get(name.as_str()).copied().unwrap_or(0);
+                    out.push_str(&format_counter(value, *style));
                 }
             },
             ContentItem::Element { name, policy } => {

--- a/crates/fulgur/src/gcpm/counter.rs
+++ b/crates/fulgur/src/gcpm/counter.rs
@@ -1,4 +1,4 @@
-use super::{ContentItem, CounterType, StringPolicy};
+use super::{ContentItem, CounterStyle, StringPolicy};
 use crate::gcpm::ElementPolicy;
 use crate::gcpm::running::RunningElementStore;
 use crate::paginate::{PageRunningState, StringSetPageState};
@@ -12,17 +12,21 @@ pub fn resolve_content_to_string(
     string_set_states: &BTreeMap<String, StringSetPageState>,
     page: usize,
     total_pages: usize,
+    custom_counters: &BTreeMap<String, i32>,
 ) -> String {
     let mut out = String::new();
     for item in items {
         match item {
             ContentItem::String(s) => out.push_str(s),
-            ContentItem::Counter(CounterType::Page) => {
-                out.push_str(&page.to_string());
-            }
-            ContentItem::Counter(CounterType::Pages) => {
-                out.push_str(&total_pages.to_string());
-            }
+            ContentItem::Counter { name, style } => match name.as_str() {
+                "page" => out.push_str(&format_counter(page as i32, *style)),
+                "pages" => out.push_str(&format_counter(total_pages as i32, *style)),
+                _ => {
+                    if let Some(&value) = custom_counters.get(name.as_str()) {
+                        out.push_str(&format_counter(value, *style));
+                    }
+                }
+            },
             ContentItem::Element { .. } => {}
             ContentItem::StringRef { name, policy } => {
                 if let Some(state) = string_set_states.get(name) {
@@ -42,6 +46,7 @@ pub fn resolve_content_to_string(
 /// `StringRef` values come from the DOM (via `string-set: content(text) |
 /// attr(...)`) and are HTML-escaped before concatenation so characters like
 /// `<` and `&` do not corrupt the margin box.
+#[allow(clippy::too_many_arguments)]
 pub fn resolve_content_to_html(
     items: &[ContentItem],
     store: &RunningElementStore,
@@ -50,17 +55,21 @@ pub fn resolve_content_to_html(
     page_num: usize,
     total_pages: usize,
     page_idx: usize,
+    custom_counters: &BTreeMap<String, i32>,
 ) -> String {
     let mut out = String::new();
     for item in items {
         match item {
             ContentItem::String(s) => push_escaped_html_text(&mut out, s),
-            ContentItem::Counter(CounterType::Page) => {
-                out.push_str(&page_num.to_string());
-            }
-            ContentItem::Counter(CounterType::Pages) => {
-                out.push_str(&total_pages.to_string());
-            }
+            ContentItem::Counter { name, style } => match name.as_str() {
+                "page" => out.push_str(&format_counter(page_num as i32, *style)),
+                "pages" => out.push_str(&format_counter(total_pages as i32, *style)),
+                _ => {
+                    if let Some(&value) = custom_counters.get(name.as_str()) {
+                        out.push_str(&format_counter(value, *style));
+                    }
+                }
+            },
             ContentItem::Element { name, policy } => {
                 if let Some(html) =
                     resolve_element_policy(name, *policy, page_idx, running_states, store)
@@ -169,6 +178,103 @@ pub fn resolve_element_policy<'a>(
     None
 }
 
+/// Format a counter value according to the given [`CounterStyle`].
+pub fn format_counter(value: i32, style: CounterStyle) -> String {
+    match style {
+        CounterStyle::Decimal => value.to_string(),
+        CounterStyle::UpperRoman => to_roman(value).unwrap_or_else(|| value.to_string()),
+        CounterStyle::LowerRoman => to_roman(value)
+            .map(|s| s.to_lowercase())
+            .unwrap_or_else(|| value.to_string()),
+        CounterStyle::UpperAlpha => to_alpha(value, b'A').unwrap_or_else(|| value.to_string()),
+        CounterStyle::LowerAlpha => to_alpha(value, b'a').unwrap_or_else(|| value.to_string()),
+    }
+}
+
+/// Convert a positive integer (1..=3999) to an upper-case Roman numeral string.
+fn to_roman(value: i32) -> Option<String> {
+    if !(1..=3999).contains(&value) {
+        return None;
+    }
+    const TABLE: &[(i32, &str)] = &[
+        (1000, "M"),
+        (900, "CM"),
+        (500, "D"),
+        (400, "CD"),
+        (100, "C"),
+        (90, "XC"),
+        (50, "L"),
+        (40, "XL"),
+        (10, "X"),
+        (9, "IX"),
+        (5, "V"),
+        (4, "IV"),
+        (1, "I"),
+    ];
+    let mut out = String::new();
+    let mut rem = value;
+    for &(threshold, symbol) in TABLE {
+        while rem >= threshold {
+            out.push_str(symbol);
+            rem -= threshold;
+        }
+    }
+    Some(out)
+}
+
+/// Convert a positive integer to an alphabetic label (A=1 .. Z=26, AA=27 ..).
+fn to_alpha(value: i32, base: u8) -> Option<String> {
+    if value < 1 {
+        return None;
+    }
+    let mut n = value as u32;
+    let mut chars = Vec::new();
+    while n > 0 {
+        n -= 1;
+        chars.push((base + (n % 26) as u8) as char);
+        n /= 26;
+    }
+    chars.reverse();
+    Some(chars.into_iter().collect())
+}
+
+/// Tracks CSS counter values during DOM traversal.
+///
+/// Simplified model (no `counters()` nesting): a flat map where
+/// `counter-reset` overwrites any existing value.
+#[derive(Debug, Clone, Default)]
+pub struct CounterState {
+    values: BTreeMap<String, i32>,
+}
+
+impl CounterState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn reset(&mut self, name: &str, value: i32) {
+        self.values.insert(name.to_string(), value);
+    }
+
+    pub fn increment(&mut self, name: &str, value: i32) {
+        let entry = self.values.entry(name.to_string()).or_insert(0);
+        *entry += value;
+    }
+
+    pub fn set(&mut self, name: &str, value: i32) {
+        self.values.insert(name.to_string(), value);
+    }
+
+    pub fn get(&self, name: &str) -> i32 {
+        self.values.get(name).copied().unwrap_or(0)
+    }
+
+    /// Return a snapshot of all counter values.
+    pub fn snapshot(&self) -> BTreeMap<String, i32> {
+        self.values.clone()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -177,12 +283,18 @@ mod tests {
     fn test_resolve_counters() {
         let items = vec![
             ContentItem::String("Page ".into()),
-            ContentItem::Counter(CounterType::Page),
+            ContentItem::Counter {
+                name: "page".into(),
+                style: CounterStyle::Decimal,
+            },
             ContentItem::String(" of ".into()),
-            ContentItem::Counter(CounterType::Pages),
+            ContentItem::Counter {
+                name: "pages".into(),
+                style: CounterStyle::Decimal,
+            },
         ];
         assert_eq!(
-            resolve_content_to_string(&items, &BTreeMap::new(), 3, 10),
+            resolve_content_to_string(&items, &BTreeMap::new(), 3, 10, &BTreeMap::new()),
             "Page 3 of 10"
         );
     }
@@ -214,7 +326,7 @@ mod tests {
             ContentItem::String("After".into()),
         ];
         assert_eq!(
-            resolve_content_to_string(&items, &BTreeMap::new(), 1, 5),
+            resolve_content_to_string(&items, &BTreeMap::new(), 1, 5, &BTreeMap::new()),
             "BeforeAfter"
         );
     }
@@ -227,7 +339,16 @@ mod tests {
         }];
         let (store, states) = single_page_store("hdr", "<b>Header</b>");
         assert_eq!(
-            resolve_content_to_html(&items, &store, &states, &BTreeMap::new(), 1, 1, 0),
+            resolve_content_to_html(
+                &items,
+                &store,
+                &states,
+                &BTreeMap::new(),
+                1,
+                1,
+                0,
+                &BTreeMap::new()
+            ),
             "<b>Header</b>"
         );
     }
@@ -240,9 +361,15 @@ mod tests {
                 policy: ElementPolicy::First,
             },
             ContentItem::String(" - Page ".into()),
-            ContentItem::Counter(CounterType::Page),
+            ContentItem::Counter {
+                name: "page".into(),
+                style: CounterStyle::Decimal,
+            },
             ContentItem::String("/".into()),
-            ContentItem::Counter(CounterType::Pages),
+            ContentItem::Counter {
+                name: "pages".into(),
+                style: CounterStyle::Decimal,
+            },
         ];
 
         // Build 3 pages of state with distinct running-element instances per
@@ -262,7 +389,16 @@ mod tests {
 
         // page_num=2 (1-based), page_idx=1 (0-based) → must pick P2.
         assert_eq!(
-            resolve_content_to_html(&items, &store, &states, &BTreeMap::new(), 2, 3, 1),
+            resolve_content_to_html(
+                &items,
+                &store,
+                &states,
+                &BTreeMap::new(),
+                2,
+                3,
+                1,
+                &BTreeMap::new()
+            ),
             "<span>P2</span> - Page 2/3"
         );
     }
@@ -277,7 +413,16 @@ mod tests {
         let store = RunningElementStore::new();
         let states: Vec<BTreeMap<String, PageRunningState>> = vec![BTreeMap::new()];
         assert_eq!(
-            resolve_content_to_html(&items, &store, &states, &BTreeMap::new(), 1, 1, 0),
+            resolve_content_to_html(
+                &items,
+                &store,
+                &states,
+                &BTreeMap::new(),
+                1,
+                1,
+                0,
+                &BTreeMap::new()
+            ),
             "A &amp; B &lt;script&gt;"
         );
     }
@@ -298,7 +443,16 @@ mod tests {
             },
         );
         assert_eq!(
-            resolve_content_to_html(&items, &RunningElementStore::new(), &[], &state, 1, 1, 0),
+            resolve_content_to_html(
+                &items,
+                &RunningElementStore::new(),
+                &[],
+                &state,
+                1,
+                1,
+                0,
+                &BTreeMap::new()
+            ),
             "Current"
         );
     }
@@ -319,7 +473,16 @@ mod tests {
             },
         );
         assert_eq!(
-            resolve_content_to_html(&items, &RunningElementStore::new(), &[], &state, 1, 1, 0),
+            resolve_content_to_html(
+                &items,
+                &RunningElementStore::new(),
+                &[],
+                &state,
+                1,
+                1,
+                0,
+                &BTreeMap::new()
+            ),
             "Inherited"
         );
     }
@@ -340,7 +503,16 @@ mod tests {
             },
         );
         assert_eq!(
-            resolve_content_to_html(&items, &RunningElementStore::new(), &[], &state, 1, 1, 0),
+            resolve_content_to_html(
+                &items,
+                &RunningElementStore::new(),
+                &[],
+                &state,
+                1,
+                1,
+                0,
+                &BTreeMap::new()
+            ),
             "Start Value"
         );
     }
@@ -361,7 +533,16 @@ mod tests {
             },
         );
         assert_eq!(
-            resolve_content_to_html(&items, &RunningElementStore::new(), &[], &state, 1, 1, 0),
+            resolve_content_to_html(
+                &items,
+                &RunningElementStore::new(),
+                &[],
+                &state,
+                1,
+                1,
+                0,
+                &BTreeMap::new()
+            ),
             "Last"
         );
     }
@@ -382,7 +563,16 @@ mod tests {
             },
         );
         assert_eq!(
-            resolve_content_to_html(&items, &RunningElementStore::new(), &[], &state, 1, 1, 0),
+            resolve_content_to_html(
+                &items,
+                &RunningElementStore::new(),
+                &[],
+                &state,
+                1,
+                1,
+                0,
+                &BTreeMap::new()
+            ),
             ""
         );
     }
@@ -403,7 +593,16 @@ mod tests {
             },
         );
         assert_eq!(
-            resolve_content_to_html(&items, &RunningElementStore::new(), &[], &state, 1, 1, 0),
+            resolve_content_to_html(
+                &items,
+                &RunningElementStore::new(),
+                &[],
+                &state,
+                1,
+                1,
+                0,
+                &BTreeMap::new()
+            ),
             "Inherited"
         );
     }
@@ -422,7 +621,8 @@ mod tests {
                 &BTreeMap::new(),
                 1,
                 1,
-                0
+                0,
+                &BTreeMap::new(),
             ),
             ""
         );
@@ -444,7 +644,16 @@ mod tests {
             },
         );
         assert_eq!(
-            resolve_content_to_html(&items, &RunningElementStore::new(), &[], &state, 1, 1, 0),
+            resolve_content_to_html(
+                &items,
+                &RunningElementStore::new(),
+                &[],
+                &state,
+                1,
+                1,
+                0,
+                &BTreeMap::new()
+            ),
             "A &amp; B &lt;script&gt;"
         );
     }
@@ -570,5 +779,106 @@ mod tests {
             resolve_element_policy("missing", ElementPolicy::First, 0, &states, &store),
             None,
         );
+    }
+
+    #[test]
+    fn test_format_counter_decimal() {
+        assert_eq!(format_counter(1, CounterStyle::Decimal), "1");
+        assert_eq!(format_counter(42, CounterStyle::Decimal), "42");
+        assert_eq!(format_counter(0, CounterStyle::Decimal), "0");
+        assert_eq!(format_counter(-5, CounterStyle::Decimal), "-5");
+    }
+
+    #[test]
+    fn test_format_counter_upper_roman() {
+        assert_eq!(format_counter(1, CounterStyle::UpperRoman), "I");
+        assert_eq!(format_counter(4, CounterStyle::UpperRoman), "IV");
+        assert_eq!(format_counter(9, CounterStyle::UpperRoman), "IX");
+        assert_eq!(format_counter(14, CounterStyle::UpperRoman), "XIV");
+        assert_eq!(format_counter(3999, CounterStyle::UpperRoman), "MMMCMXCIX");
+        // Fallback to decimal for out-of-range values
+        assert_eq!(format_counter(0, CounterStyle::UpperRoman), "0");
+        assert_eq!(format_counter(4000, CounterStyle::UpperRoman), "4000");
+    }
+
+    #[test]
+    fn test_format_counter_lower_roman() {
+        assert_eq!(format_counter(1, CounterStyle::LowerRoman), "i");
+        assert_eq!(format_counter(14, CounterStyle::LowerRoman), "xiv");
+    }
+
+    #[test]
+    fn test_format_counter_upper_alpha() {
+        assert_eq!(format_counter(1, CounterStyle::UpperAlpha), "A");
+        assert_eq!(format_counter(26, CounterStyle::UpperAlpha), "Z");
+        assert_eq!(format_counter(27, CounterStyle::UpperAlpha), "AA");
+        // Fallback to decimal for 0
+        assert_eq!(format_counter(0, CounterStyle::UpperAlpha), "0");
+    }
+
+    #[test]
+    fn test_format_counter_lower_alpha() {
+        assert_eq!(format_counter(1, CounterStyle::LowerAlpha), "a");
+        assert_eq!(format_counter(26, CounterStyle::LowerAlpha), "z");
+    }
+
+    #[test]
+    fn test_resolve_custom_counter() {
+        let items = vec![
+            ContentItem::String("Chapter ".into()),
+            ContentItem::Counter {
+                name: "chapter".into(),
+                style: CounterStyle::UpperRoman,
+            },
+        ];
+        let mut custom_counters = BTreeMap::new();
+        custom_counters.insert("chapter".to_string(), 4);
+        assert_eq!(
+            resolve_content_to_string(&items, &BTreeMap::new(), 1, 1, &custom_counters),
+            "Chapter IV"
+        );
+    }
+
+    #[test]
+    fn test_counter_state_reset_and_get() {
+        let mut state = CounterState::new();
+        state.reset("chapter", 0);
+        assert_eq!(state.get("chapter"), 0);
+    }
+
+    #[test]
+    fn test_counter_state_increment() {
+        let mut state = CounterState::new();
+        state.reset("chapter", 0);
+        state.increment("chapter", 1);
+        assert_eq!(state.get("chapter"), 1);
+        state.increment("chapter", 1);
+        assert_eq!(state.get("chapter"), 2);
+    }
+
+    #[test]
+    fn test_counter_state_set() {
+        let mut state = CounterState::new();
+        state.reset("chapter", 0);
+        state.set("chapter", 5);
+        assert_eq!(state.get("chapter"), 5);
+    }
+
+    #[test]
+    fn test_counter_state_implicit_zero() {
+        let mut state = CounterState::new();
+        state.increment("chapter", 1);
+        assert_eq!(state.get("chapter"), 1);
+    }
+
+    #[test]
+    fn test_counter_state_snapshot() {
+        let mut state = CounterState::new();
+        state.reset("chapter", 0);
+        state.increment("chapter", 1);
+        state.reset("section", 0);
+        let snap = state.snapshot();
+        assert_eq!(snap.get("chapter"), Some(&1));
+        assert_eq!(snap.get("section"), Some(&0));
     }
 }

--- a/crates/fulgur/src/gcpm/counter.rs
+++ b/crates/fulgur/src/gcpm/counter.rs
@@ -1,6 +1,6 @@
 use super::{ContentItem, CounterStyle, StringPolicy};
-use crate::gcpm::running::RunningElementStore;
 use crate::gcpm::ElementPolicy;
+use crate::gcpm::running::RunningElementStore;
 use crate::paginate::{PageRunningState, StringSetPageState};
 use std::collections::BTreeMap;
 

--- a/crates/fulgur/src/gcpm/counter.rs
+++ b/crates/fulgur/src/gcpm/counter.rs
@@ -1,6 +1,6 @@
 use super::{ContentItem, CounterStyle, StringPolicy};
-use crate::gcpm::ElementPolicy;
 use crate::gcpm::running::RunningElementStore;
+use crate::gcpm::ElementPolicy;
 use crate::paginate::{PageRunningState, StringSetPageState};
 use std::collections::BTreeMap;
 

--- a/crates/fulgur/src/gcpm/mod.rs
+++ b/crates/fulgur/src/gcpm/mod.rs
@@ -1,5 +1,6 @@
 pub mod counter;
 pub mod margin_box;
+pub mod page_settings;
 pub mod parser;
 pub mod running;
 pub mod string_set;
@@ -94,6 +95,30 @@ pub struct StringSetMapping {
     pub values: Vec<StringSetValue>,
 }
 
+/// Parsed `size` declaration from `@page`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PageSizeDecl {
+    /// A named page size, e.g. `A4`, `letter`.
+    Keyword(String),
+    /// A named page size with orientation, e.g. `A4 landscape`.
+    KeywordWithOrientation(String, bool),
+    /// Explicit width × height, e.g. `210mm 297mm`. Values in points.
+    Custom(f32, f32),
+    /// `auto` — use Config default.
+    Auto,
+}
+
+/// A parsed `@page { size: ...; margin: ...; }` settings rule.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PageSettingsRule {
+    /// Optional page selector (e.g. `:first`, `:left`). `None` means all pages.
+    pub page_selector: Option<String>,
+    /// Parsed `size` declaration, if present.
+    pub size: Option<PageSizeDecl>,
+    /// Parsed `margin` declaration, if present. Values in points.
+    pub margin: Option<crate::config::Margin>,
+}
+
 /// A single counter operation from counter-reset, counter-increment, or counter-set.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CounterOp {
@@ -122,6 +147,30 @@ pub struct ContentCounterMapping {
     pub parsed: ParsedSelector,
     pub pseudo: PseudoElement,
     pub content: Vec<ContentItem>,
+}
+
+/// Parsed `size` declaration from `@page`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PageSizeDecl {
+    /// A named page size, e.g. `A4`, `letter`.
+    Keyword(String),
+    /// A named page size with orientation, e.g. `A4 landscape`.
+    KeywordWithOrientation(String, bool),
+    /// Explicit width × height, e.g. `210mm 297mm`. Values in points.
+    Custom(f32, f32),
+    /// `auto` — use Config default.
+    Auto,
+}
+
+/// A parsed `@page { size: ...; margin: ...; }` settings rule.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PageSettingsRule {
+    /// Optional page selector (e.g. `:first`, `:left`). `None` means all pages.
+    pub page_selector: Option<String>,
+    /// Parsed `size` declaration, if present.
+    pub size: Option<PageSizeDecl>,
+    /// Parsed `margin` declaration, if present. Values in points.
+    pub margin: Option<crate::config::Margin>,
 }
 
 /// A single content item inside a margin box rule's `content` property.
@@ -190,10 +239,14 @@ pub struct GcpmContext {
     pub running_mappings: Vec<RunningMapping>,
     /// Mappings from CSS selectors to named strings via `string-set`.
     pub string_set_mappings: Vec<StringSetMapping>,
+    /// Page settings rules parsed from `@page { size: ...; margin: ...; }`.
+    pub page_settings: Vec<PageSettingsRule>,
     /// Mappings from CSS selectors to counter operations.
     pub counter_mappings: Vec<CounterMapping>,
     /// Mappings from CSS selectors + pseudo-elements to content items with counter().
     pub content_counter_mappings: Vec<ContentCounterMapping>,
+    /// Page settings rules parsed from `@page { size: ...; margin: ...; }`.
+    pub page_settings: Vec<PageSettingsRule>,
     /// The CSS with GCPM constructs stripped, suitable for normal rendering.
     pub cleaned_css: String,
 }
@@ -204,8 +257,10 @@ impl GcpmContext {
         self.margin_boxes.is_empty()
             && self.running_mappings.is_empty()
             && self.string_set_mappings.is_empty()
+            && self.page_settings.is_empty()
             && self.counter_mappings.is_empty()
             && self.content_counter_mappings.is_empty()
+            && self.page_settings.is_empty()
     }
 }
 
@@ -219,8 +274,10 @@ mod tests {
             margin_boxes: vec![],
             running_mappings: vec![],
             string_set_mappings: vec![],
+            page_settings: vec![],
             counter_mappings: vec![],
             content_counter_mappings: vec![],
+            page_settings: vec![],
             cleaned_css: String::new(),
         };
         assert!(ctx.is_empty());
@@ -240,8 +297,10 @@ mod tests {
             }],
             running_mappings: vec![],
             string_set_mappings: vec![],
+            page_settings: vec![],
             counter_mappings: vec![],
             content_counter_mappings: vec![],
+            page_settings: vec![],
             cleaned_css: String::new(),
         };
         assert!(!ctx.is_empty());
@@ -256,8 +315,10 @@ mod tests {
                 running_name: "header".to_string(),
             }],
             string_set_mappings: vec![],
+            page_settings: vec![],
             counter_mappings: vec![],
             content_counter_mappings: vec![],
+            page_settings: vec![],
             cleaned_css: String::new(),
         };
         assert!(!ctx.is_empty());

--- a/crates/fulgur/src/gcpm/mod.rs
+++ b/crates/fulgur/src/gcpm/mod.rs
@@ -149,30 +149,6 @@ pub struct ContentCounterMapping {
     pub content: Vec<ContentItem>,
 }
 
-/// Parsed `size` declaration from `@page`.
-#[derive(Debug, Clone, PartialEq)]
-pub enum PageSizeDecl {
-    /// A named page size, e.g. `A4`, `letter`.
-    Keyword(String),
-    /// A named page size with orientation, e.g. `A4 landscape`.
-    KeywordWithOrientation(String, bool),
-    /// Explicit width × height, e.g. `210mm 297mm`. Values in points.
-    Custom(f32, f32),
-    /// `auto` — use Config default.
-    Auto,
-}
-
-/// A parsed `@page { size: ...; margin: ...; }` settings rule.
-#[derive(Debug, Clone, PartialEq)]
-pub struct PageSettingsRule {
-    /// Optional page selector (e.g. `:first`, `:left`). `None` means all pages.
-    pub page_selector: Option<String>,
-    /// Parsed `size` declaration, if present.
-    pub size: Option<PageSizeDecl>,
-    /// Parsed `margin` declaration, if present. Values in points.
-    pub margin: Option<crate::config::Margin>,
-}
-
 /// A single content item inside a margin box rule's `content` property.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ContentItem {
@@ -245,8 +221,6 @@ pub struct GcpmContext {
     pub counter_mappings: Vec<CounterMapping>,
     /// Mappings from CSS selectors + pseudo-elements to content items with counter().
     pub content_counter_mappings: Vec<ContentCounterMapping>,
-    /// Page settings rules parsed from `@page { size: ...; margin: ...; }`.
-    pub page_settings: Vec<PageSettingsRule>,
     /// The CSS with GCPM constructs stripped, suitable for normal rendering.
     pub cleaned_css: String,
 }
@@ -260,7 +234,6 @@ impl GcpmContext {
             && self.page_settings.is_empty()
             && self.counter_mappings.is_empty()
             && self.content_counter_mappings.is_empty()
-            && self.page_settings.is_empty()
     }
 }
 
@@ -277,7 +250,6 @@ mod tests {
             page_settings: vec![],
             counter_mappings: vec![],
             content_counter_mappings: vec![],
-            page_settings: vec![],
             cleaned_css: String::new(),
         };
         assert!(ctx.is_empty());
@@ -300,7 +272,6 @@ mod tests {
             page_settings: vec![],
             counter_mappings: vec![],
             content_counter_mappings: vec![],
-            page_settings: vec![],
             cleaned_css: String::new(),
         };
         assert!(!ctx.is_empty());
@@ -318,7 +289,6 @@ mod tests {
             page_settings: vec![],
             counter_mappings: vec![],
             content_counter_mappings: vec![],
-            page_settings: vec![],
             cleaned_css: String::new(),
         };
         assert!(!ctx.is_empty());

--- a/crates/fulgur/src/gcpm/mod.rs
+++ b/crates/fulgur/src/gcpm/mod.rs
@@ -1,6 +1,5 @@
 pub mod counter;
 pub mod margin_box;
-pub mod page_settings;
 pub mod parser;
 pub mod running;
 pub mod string_set;
@@ -95,28 +94,34 @@ pub struct StringSetMapping {
     pub values: Vec<StringSetValue>,
 }
 
-/// Parsed `size` declaration from `@page`.
-#[derive(Debug, Clone, PartialEq)]
-pub enum PageSizeDecl {
-    /// A named page size, e.g. `A4`, `letter`.
-    Keyword(String),
-    /// A named page size with orientation, e.g. `A4 landscape`.
-    KeywordWithOrientation(String, bool),
-    /// Explicit width × height, e.g. `210mm 297mm`. Values in points.
-    Custom(f32, f32),
-    /// `auto` — use Config default.
-    Auto,
+/// A single counter operation from counter-reset, counter-increment, or counter-set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CounterOp {
+    Reset { name: String, value: i32 },
+    Increment { name: String, value: i32 },
+    Set { name: String, value: i32 },
 }
 
-/// A parsed `@page { size: ...; margin: ...; }` settings rule.
+/// Maps a CSS selector to counter operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CounterMapping {
+    pub parsed: ParsedSelector,
+    pub ops: Vec<CounterOp>,
+}
+
+/// Pseudo-element type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PseudoElement {
+    Before,
+    After,
+}
+
+/// Maps a CSS selector + pseudo-element to content items containing counter().
 #[derive(Debug, Clone, PartialEq)]
-pub struct PageSettingsRule {
-    /// Optional page selector (e.g. `:first`, `:left`). `None` means all pages.
-    pub page_selector: Option<String>,
-    /// Parsed `size` declaration, if present.
-    pub size: Option<PageSizeDecl>,
-    /// Parsed `margin` declaration, if present. Values in points.
-    pub margin: Option<crate::config::Margin>,
+pub struct ContentCounterMapping {
+    pub parsed: ParsedSelector,
+    pub pseudo: PseudoElement,
+    pub content: Vec<ContentItem>,
 }
 
 /// A single content item inside a margin box rule's `content` property.
@@ -129,8 +134,13 @@ pub enum ContentItem {
         /// The policy for selecting which instance to show.
         policy: ElementPolicy,
     },
-    /// A counter reference, e.g. `counter(page)`.
-    Counter(CounterType),
+    /// A counter reference, e.g. `counter(page)` or `counter(chapter, upper-roman)`.
+    Counter {
+        /// Counter name — "page", "pages", or a custom name.
+        name: String,
+        /// Display style.
+        style: CounterStyle,
+    },
     /// A literal string, e.g. `"Page "`.
     String(String),
     /// A named string reference, e.g. `string(chapter-title, first)`.
@@ -142,13 +152,20 @@ pub enum ContentItem {
     },
 }
 
-/// Counter types supported by GCPM.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum CounterType {
-    /// Current page number.
-    Page,
-    /// Total page count.
-    Pages,
+/// Counter display styles (CSS `list-style-type` subset for counters).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum CounterStyle {
+    /// Decimal numerals (1, 2, 3, ...).
+    #[default]
+    Decimal,
+    /// Upper-case roman numerals (I, II, III, ...).
+    UpperRoman,
+    /// Lower-case roman numerals (i, ii, iii, ...).
+    LowerRoman,
+    /// Upper-case alphabetic (A, B, C, ..., Z, AA, AB, ...).
+    UpperAlpha,
+    /// Lower-case alphabetic (a, b, c, ..., z, aa, ab, ...).
+    LowerAlpha,
 }
 
 /// A parsed `@page { @<position> { ... } }` margin box rule.
@@ -173,8 +190,10 @@ pub struct GcpmContext {
     pub running_mappings: Vec<RunningMapping>,
     /// Mappings from CSS selectors to named strings via `string-set`.
     pub string_set_mappings: Vec<StringSetMapping>,
-    /// Page settings rules parsed from `@page { size: ...; margin: ...; }`.
-    pub page_settings: Vec<PageSettingsRule>,
+    /// Mappings from CSS selectors to counter operations.
+    pub counter_mappings: Vec<CounterMapping>,
+    /// Mappings from CSS selectors + pseudo-elements to content items with counter().
+    pub content_counter_mappings: Vec<ContentCounterMapping>,
     /// The CSS with GCPM constructs stripped, suitable for normal rendering.
     pub cleaned_css: String,
 }
@@ -185,7 +204,8 @@ impl GcpmContext {
         self.margin_boxes.is_empty()
             && self.running_mappings.is_empty()
             && self.string_set_mappings.is_empty()
-            && self.page_settings.is_empty()
+            && self.counter_mappings.is_empty()
+            && self.content_counter_mappings.is_empty()
     }
 }
 
@@ -199,7 +219,8 @@ mod tests {
             margin_boxes: vec![],
             running_mappings: vec![],
             string_set_mappings: vec![],
-            page_settings: vec![],
+            counter_mappings: vec![],
+            content_counter_mappings: vec![],
             cleaned_css: String::new(),
         };
         assert!(ctx.is_empty());
@@ -211,12 +232,16 @@ mod tests {
             margin_boxes: vec![MarginBoxRule {
                 page_selector: None,
                 position: MarginBoxPosition::TopCenter,
-                content: vec![ContentItem::Counter(CounterType::Page)],
+                content: vec![ContentItem::Counter {
+                    name: "page".into(),
+                    style: CounterStyle::Decimal,
+                }],
                 declarations: String::new(),
             }],
             running_mappings: vec![],
             string_set_mappings: vec![],
-            page_settings: vec![],
+            counter_mappings: vec![],
+            content_counter_mappings: vec![],
             cleaned_css: String::new(),
         };
         assert!(!ctx.is_empty());
@@ -231,23 +256,8 @@ mod tests {
                 running_name: "header".to_string(),
             }],
             string_set_mappings: vec![],
-            page_settings: vec![],
-            cleaned_css: String::new(),
-        };
-        assert!(!ctx.is_empty());
-    }
-
-    #[test]
-    fn test_gcpm_context_not_empty_with_page_settings() {
-        let ctx = GcpmContext {
-            margin_boxes: vec![],
-            running_mappings: vec![],
-            string_set_mappings: vec![],
-            page_settings: vec![PageSettingsRule {
-                page_selector: None,
-                size: Some(PageSizeDecl::Keyword("A4".into())),
-                margin: None,
-            }],
+            counter_mappings: vec![],
+            content_counter_mappings: vec![],
             cleaned_css: String::new(),
         };
         assert!(!ctx.is_empty());

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -646,8 +646,20 @@ impl<'i, 'a> DeclarationParser<'i> for StyleRuleParser<'a> {
             || name.eq_ignore_ascii_case("counter-set")
         {
             let ops = parse_counter_ops(input, &name);
-            // Last-declaration-wins: replace, don't extend
-            *self.counter_ops = ops;
+            // counter-reset / counter-increment / counter-set are independent
+            // CSS properties, so they must each contribute to counter_ops.
+            // Apply last-declaration-wins per property by removing prior ops
+            // of the SAME variant before extending with the new ones.
+            let prop = name.to_ascii_lowercase();
+            self.counter_ops.retain(|op| {
+                !matches!(
+                    (op, prop.as_str()),
+                    (CounterOp::Reset { .. }, "counter-reset")
+                        | (CounterOp::Increment { .. }, "counter-increment")
+                        | (CounterOp::Set { .. }, "counter-set")
+                )
+            });
+            self.counter_ops.extend(ops);
             let start = decl_start.position().byte_index();
             let end = input.position().byte_index();
             self.edits.push(CssEdit::Replace {
@@ -660,23 +672,25 @@ impl<'i, 'a> DeclarationParser<'i> for StyleRuleParser<'a> {
             let has_counter = items
                 .iter()
                 .any(|item| matches!(item, ContentItem::Counter { .. }));
-            // Last-declaration-wins: always update (clear if no counter)
+            // Last-declaration-wins: always update content_items (clear when
+            // the new content has no counter()).
             if has_counter {
                 *self.content_items = Some(items);
+                // Strip the original `content: counter(...)` from cleaned CSS
+                // because Blitz cannot evaluate counter() — CounterPass injects
+                // a synthetic ::before/::after rule with the resolved value.
+                let start = decl_start.position().byte_index();
+                let end = input.position().byte_index();
+                self.edits.push(CssEdit::Replace {
+                    start,
+                    end,
+                    replacement: String::new(),
+                });
             } else {
+                // Plain `content: "..."` stays in cleaned CSS so Blitz can
+                // render it directly.
                 *self.content_items = None;
             }
-            // Always strip `content` from cleaned CSS for ::before/::after rules
-            // we recognise — counter()/string()/element() are resolved by us, not
-            // by Blitz, so leaving the original declaration would cause Blitz to
-            // try (and fail) to render the unsupported function.
-            let start = decl_start.position().byte_index();
-            let end = input.position().byte_index();
-            self.edits.push(CssEdit::Replace {
-                start,
-                end,
-                replacement: String::new(),
-            });
         } else {
             // Skip other declarations
             while input.next().is_ok() {}
@@ -1658,5 +1672,79 @@ mod tests {
         let ctx = parse_gcpm(css);
         assert!(!ctx.cleaned_css.contains("counter(chapter)"));
         assert!(ctx.cleaned_css.contains("font-weight: bold"));
+    }
+
+    #[test]
+    fn test_parse_pseudo_content_without_counter_kept_in_cleaned_css() {
+        // Plain string content (no counter()) must remain in cleaned CSS so
+        // Blitz can render it directly. Stripping it would break authors who
+        // use ::before/::after for purely decorative literals.
+        let css = r#".note::before { content: "Note: "; font-weight: bold; }"#;
+        let ctx = parse_gcpm(css);
+        assert!(
+            ctx.cleaned_css.contains(r#"content: "Note: ""#),
+            "literal content must survive in cleaned_css: {:?}",
+            ctx.cleaned_css
+        );
+        assert!(ctx.cleaned_css.contains("font-weight: bold"));
+    }
+
+    #[test]
+    fn test_parse_counter_reset_and_increment_in_same_rule() {
+        // counter-reset and counter-increment are independent properties — both
+        // must contribute to the recorded ops, even when declared in the same
+        // rule block. Regression test for the previous implementation where
+        // each property overwrote the entire counter_ops vector.
+        let css = "h2 { counter-reset: section 0; counter-increment: chapter; }";
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.counter_mappings.len(), 1);
+        let mapping = &ctx.counter_mappings[0];
+        assert!(
+            mapping
+                .ops
+                .iter()
+                .any(|op| matches!(op, CounterOp::Reset { name, .. } if name == "section")),
+            "counter-reset must survive: {:?}",
+            mapping.ops
+        );
+        assert!(
+            mapping
+                .ops
+                .iter()
+                .any(|op| matches!(op, CounterOp::Increment { name, .. } if name == "chapter")),
+            "counter-increment must survive: {:?}",
+            mapping.ops
+        );
+    }
+
+    #[test]
+    fn test_parse_counter_increment_last_declaration_wins_within_property() {
+        // Two counter-increment declarations in the same rule: the later one
+        // wins (CSS last-declaration-wins). Counter-reset, declared between
+        // them, must still survive because it's a different property.
+        let css = "h2 { counter-increment: chapter; counter-reset: section; counter-increment: page; }";
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.counter_mappings.len(), 1);
+        let mapping = &ctx.counter_mappings[0];
+        let increments: Vec<_> = mapping
+            .ops
+            .iter()
+            .filter_map(|op| match op {
+                CounterOp::Increment { name, .. } => Some(name.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            increments,
+            vec!["page"],
+            "only the last counter-increment should remain"
+        );
+        assert!(
+            mapping
+                .ops
+                .iter()
+                .any(|op| matches!(op, CounterOp::Reset { .. })),
+            "counter-reset between two increments must survive"
+        );
     }
 }

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -6,9 +6,10 @@ use cssparser::{
 use super::margin_box::MarginBoxPosition;
 use super::{
     ContentCounterMapping, ContentItem, CounterMapping, CounterOp, CounterStyle, ElementPolicy,
-    GcpmContext, MarginBoxRule, ParsedSelector, PseudoElement, RunningMapping, StringPolicy,
-    StringSetMapping, StringSetValue,
+    GcpmContext, MarginBoxRule, PageSettingsRule, PageSizeDecl, ParsedSelector, PseudoElement,
+    RunningMapping, StringPolicy, StringSetMapping, StringSetValue,
 };
+use crate::config::Margin;
 
 // ---------------------------------------------------------------------------
 // Top-level result types
@@ -37,6 +38,7 @@ struct GcpmSheetParser<'a> {
     string_set_mappings: &'a mut Vec<StringSetMapping>,
     counter_mappings: &'a mut Vec<CounterMapping>,
     content_counter_mappings: &'a mut Vec<ContentCounterMapping>,
+    page_settings: &'a mut Vec<PageSettingsRule>,
 }
 
 /// Describes a region in the original CSS to edit when building `cleaned_css`.
@@ -84,7 +86,9 @@ impl<'i, 'a> AtRuleParser<'i> for GcpmSheetParser<'a> {
         input: &mut Parser<'i, 't>,
     ) -> Result<Self::AtRule, ParseError<'i, ()>> {
         let mut boxes = Vec::new();
-        parse_page_block(input, &page_selector, &mut boxes);
+        let mut size = None;
+        let mut margin = None;
+        parse_page_block(input, &page_selector, &mut boxes, &mut size, &mut margin);
 
         // Record the full @page rule span for removal.
         let start_offset = start.position().byte_index();
@@ -95,6 +99,15 @@ impl<'i, 'a> AtRuleParser<'i> for GcpmSheetParser<'a> {
         });
 
         self.margin_boxes.extend(boxes);
+
+        if size.is_some() || margin.is_some() {
+            self.page_settings.push(PageSettingsRule {
+                page_selector,
+                size,
+                margin,
+            });
+        }
+
         Ok(TopLevelItem::PageRule)
     }
 }
@@ -233,6 +246,161 @@ impl<'i, 'a> QualifiedRuleParser<'i> for GcpmSheetParser<'a> {
 }
 
 // ---------------------------------------------------------------------------
+// CSS length unit → points converter
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// @page size/margin value parsers
+// ---------------------------------------------------------------------------
+
+/// Convert a CSS dimension value+unit to PDF points.
+fn css_unit_to_pt(value: f32, unit: &str) -> Option<f32> {
+    let factor = match () {
+        _ if unit.eq_ignore_ascii_case("mm") => 72.0 / 25.4,
+        _ if unit.eq_ignore_ascii_case("cm") => 72.0 / 2.54,
+        _ if unit.eq_ignore_ascii_case("in") => 72.0,
+        _ if unit.eq_ignore_ascii_case("pt") => 1.0,
+        _ if unit.eq_ignore_ascii_case("px") => 72.0 / 96.0,
+        _ => return None,
+    };
+    Some(value * factor)
+}
+
+/// Parse the value of an `@page { size: ... }` declaration.
+///
+/// Returns `None` if the value is invalid or has trailing tokens
+/// (CSS requires invalid declarations to be ignored entirely).
+fn parse_page_size_value(input: &mut Parser<'_, '_>) -> Option<PageSizeDecl> {
+    let token = input.next().ok()?.clone();
+    let result = match token {
+        Token::Ident(ref name) => {
+            if name.eq_ignore_ascii_case("auto") {
+                Some(PageSizeDecl::Auto)
+            } else if name.eq_ignore_ascii_case("landscape") {
+                Some(PageSizeDecl::KeywordWithOrientation(
+                    "auto".to_string(),
+                    true,
+                ))
+            } else if name.eq_ignore_ascii_case("portrait") {
+                Some(PageSizeDecl::KeywordWithOrientation(
+                    "auto".to_string(),
+                    false,
+                ))
+            } else {
+                let keyword = name.to_string();
+                // Try to read a second ident for orientation
+                let orientation = input.try_parse(|input| {
+                    let tok = input.next()?.clone();
+                    match tok {
+                        Token::Ident(ref orient) => {
+                            if orient.eq_ignore_ascii_case("landscape") {
+                                Ok(true)
+                            } else if orient.eq_ignore_ascii_case("portrait") {
+                                Ok(false)
+                            } else {
+                                Err(input
+                                    .new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid))
+                            }
+                        }
+                        _ => Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)),
+                    }
+                });
+                match orientation {
+                    Ok(landscape) => Some(PageSizeDecl::KeywordWithOrientation(keyword, landscape)),
+                    Err(_) => Some(PageSizeDecl::Keyword(keyword)),
+                }
+            }
+        }
+        Token::Dimension { value, unit, .. } => {
+            let w = css_unit_to_pt(value, &unit).filter(|v| *v > 0.0)?;
+            // Try to read a second dimension for height
+            let h = input
+                .try_parse(|input| {
+                    let tok = input.next()?.clone();
+                    match tok {
+                        Token::Dimension { value, unit, .. } => css_unit_to_pt(value, &unit)
+                            .filter(|v| *v > 0.0)
+                            .ok_or_else(|| {
+                                input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)
+                            }),
+                        _ => Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)),
+                    }
+                })
+                .unwrap_or(w);
+            Some(PageSizeDecl::Custom(w, h))
+        }
+        _ => None,
+    };
+    // Reject if trailing tokens remain (CSS: invalid declaration → ignore entirely)
+    if result.is_some() && input.next().is_ok() {
+        return None;
+    }
+    result
+}
+
+/// Parse the value of an `@page { margin: ... }` declaration (CSS shorthand).
+///
+/// Returns `None` if the value is invalid or has trailing tokens
+/// (CSS requires invalid declarations to be ignored entirely).
+fn parse_page_margin_value(input: &mut Parser<'_, '_>) -> Option<Margin> {
+    let mut values = Vec::new();
+    loop {
+        let result = input.try_parse(|input| {
+            let tok = input.next()?.clone();
+            match tok {
+                Token::Dimension { value, unit, .. } => {
+                    css_unit_to_pt(value, &unit).ok_or_else(|| {
+                        input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)
+                    })
+                }
+                Token::Number { value: 0.0, .. } => Ok(0.0_f32),
+                _ => Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)),
+            }
+        });
+        match result {
+            Ok(v) => values.push(v),
+            Err(_) => break,
+        }
+        if values.len() >= 4 {
+            break;
+        }
+    }
+
+    // Reject if trailing tokens remain (CSS: invalid declaration → ignore entirely)
+    if input.next().is_ok() {
+        return None;
+    }
+
+    match values.len() {
+        1 => Some(Margin {
+            top: values[0],
+            right: values[0],
+            bottom: values[0],
+            left: values[0],
+        }),
+        2 => Some(Margin {
+            top: values[0],
+            right: values[1],
+            bottom: values[0],
+            left: values[1],
+        }),
+        3 => Some(Margin {
+            top: values[0],
+            right: values[1],
+            bottom: values[2],
+            left: values[1],
+        }),
+        4 => Some(Margin {
+            top: values[0],
+            right: values[1],
+            bottom: values[2],
+            left: values[3],
+        }),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
 // 2. @page block parser (PageRuleParser) — uses RuleBodyParser
 // ---------------------------------------------------------------------------
 
@@ -240,10 +408,14 @@ fn parse_page_block(
     input: &mut Parser<'_, '_>,
     page_selector: &Option<String>,
     boxes: &mut Vec<MarginBoxRule>,
+    size: &mut Option<PageSizeDecl>,
+    margin: &mut Option<Margin>,
 ) {
     let mut parser = PageRuleParser {
         page_selector,
         boxes,
+        size,
+        margin,
     };
     let iter = RuleBodyParser::new(input, &mut parser);
     for item in iter {
@@ -254,6 +426,8 @@ fn parse_page_block(
 struct PageRuleParser<'a> {
     page_selector: &'a Option<String>,
     boxes: &'a mut Vec<MarginBoxRule>,
+    size: &'a mut Option<PageSizeDecl>,
+    margin: &'a mut Option<Margin>,
 }
 
 impl<'i, 'a> AtRuleParser<'i> for PageRuleParser<'a> {
@@ -309,9 +483,18 @@ impl<'i, 'a> DeclarationParser<'i> for PageRuleParser<'a> {
         input: &mut Parser<'i, 't>,
         _start: &cssparser::ParserState,
     ) -> Result<(), ParseError<'i, ()>> {
-        // Skip declarations directly inside @page (not inside margin boxes)
-        let _ = name;
-        while input.next().is_ok() {}
+        if name.eq_ignore_ascii_case("size") {
+            if let Some(v) = parse_page_size_value(input) {
+                *self.size = Some(v);
+            }
+        } else if name.eq_ignore_ascii_case("margin") {
+            if let Some(v) = parse_page_margin_value(input) {
+                *self.margin = Some(v);
+            }
+        } else {
+            // Skip unknown declarations
+            while input.next().is_ok() {}
+        }
         Ok(())
     }
 }
@@ -463,21 +646,21 @@ impl<'i, 'a> DeclarationParser<'i> for StyleRuleParser<'a> {
             || name.eq_ignore_ascii_case("counter-set")
         {
             let ops = parse_counter_ops(input, &name);
-            if !ops.is_empty() {
-                self.counter_ops.extend(ops);
-                let start = decl_start.position().byte_index();
-                let end = input.position().byte_index();
-                self.edits.push(CssEdit::Replace {
-                    start,
-                    end,
-                    replacement: String::new(),
-                });
-            }
+            // Last-declaration-wins: replace, don't extend
+            *self.counter_ops = ops;
+            let start = decl_start.position().byte_index();
+            let end = input.position().byte_index();
+            self.edits.push(CssEdit::Replace {
+                start,
+                end,
+                replacement: String::new(),
+            });
         } else if name.eq_ignore_ascii_case("content") && self.has_pseudo {
             let items = parse_content_value(input);
             let has_counter = items
                 .iter()
                 .any(|item| matches!(item, ContentItem::Counter { .. }));
+            // Last-declaration-wins: always update (clear if no counter)
             if has_counter {
                 *self.content_items = Some(items);
             } else {
@@ -793,6 +976,7 @@ pub fn parse_gcpm(css: &str) -> GcpmContext {
     let mut string_set_mappings = Vec::new();
     let mut counter_mappings = Vec::new();
     let mut content_counter_mappings = Vec::new();
+    let mut page_settings = Vec::new();
     let mut edits: Vec<CssEdit> = Vec::new();
 
     // Run the cssparser-based parse to collect GCPM data and edit spans.
@@ -807,6 +991,7 @@ pub fn parse_gcpm(css: &str) -> GcpmContext {
             string_set_mappings: &mut string_set_mappings,
             counter_mappings: &mut counter_mappings,
             content_counter_mappings: &mut content_counter_mappings,
+            page_settings: &mut page_settings,
         };
 
         let iter = StyleSheetParser::new(&mut input, &mut parser);
@@ -824,6 +1009,7 @@ pub fn parse_gcpm(css: &str) -> GcpmContext {
         string_set_mappings,
         counter_mappings,
         content_counter_mappings,
+        page_settings,
         cleaned_css,
     }
 }

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -5,10 +5,10 @@ use cssparser::{
 
 use super::margin_box::MarginBoxPosition;
 use super::{
-    ContentItem, CounterType, ElementPolicy, GcpmContext, MarginBoxRule, PageSettingsRule,
-    PageSizeDecl, ParsedSelector, RunningMapping, StringPolicy, StringSetMapping, StringSetValue,
+    ContentCounterMapping, ContentItem, CounterMapping, CounterOp, CounterStyle, ElementPolicy,
+    GcpmContext, MarginBoxRule, ParsedSelector, PseudoElement, RunningMapping, StringPolicy,
+    StringSetMapping, StringSetValue,
 };
-use crate::config::Margin;
 
 // ---------------------------------------------------------------------------
 // Top-level result types
@@ -35,7 +35,8 @@ struct GcpmSheetParser<'a> {
     margin_boxes: &'a mut Vec<MarginBoxRule>,
     running_mappings: &'a mut Vec<RunningMapping>,
     string_set_mappings: &'a mut Vec<StringSetMapping>,
-    page_settings: &'a mut Vec<PageSettingsRule>,
+    counter_mappings: &'a mut Vec<CounterMapping>,
+    content_counter_mappings: &'a mut Vec<ContentCounterMapping>,
 }
 
 /// Describes a region in the original CSS to edit when building `cleaned_css`.
@@ -83,9 +84,7 @@ impl<'i, 'a> AtRuleParser<'i> for GcpmSheetParser<'a> {
         input: &mut Parser<'i, 't>,
     ) -> Result<Self::AtRule, ParseError<'i, ()>> {
         let mut boxes = Vec::new();
-        let mut size = None;
-        let mut margin = None;
-        parse_page_block(input, &page_selector, &mut boxes, &mut size, &mut margin);
+        parse_page_block(input, &page_selector, &mut boxes);
 
         // Record the full @page rule span for removal.
         let start_offset = start.position().byte_index();
@@ -96,21 +95,17 @@ impl<'i, 'a> AtRuleParser<'i> for GcpmSheetParser<'a> {
         });
 
         self.margin_boxes.extend(boxes);
-
-        if size.is_some() || margin.is_some() {
-            self.page_settings.push(PageSettingsRule {
-                page_selector,
-                size,
-                margin,
-            });
-        }
-
         Ok(TopLevelItem::PageRule)
     }
 }
 
+struct QualifiedPrelude {
+    selector: ParsedSelector,
+    pseudo: Option<PseudoElement>,
+}
+
 impl<'i, 'a> QualifiedRuleParser<'i> for GcpmSheetParser<'a> {
-    type Prelude = Option<ParsedSelector>;
+    type Prelude = Option<QualifiedPrelude>;
     type QualifiedRule = TopLevelItem;
     type Error = ();
 
@@ -138,6 +133,23 @@ impl<'i, 'a> QualifiedRuleParser<'i> for GcpmSheetParser<'a> {
                 return Ok(None);
             }
         };
+
+        // Try to detect ::before / ::after pseudo-element
+        let pseudo = input
+            .try_parse(|input| {
+                input.expect_colon()?;
+                input.expect_colon()?;
+                let ident = input.expect_ident()?.clone();
+                if ident.eq_ignore_ascii_case("before") {
+                    Ok(PseudoElement::Before)
+                } else if ident.eq_ignore_ascii_case("after") {
+                    Ok(PseudoElement::After)
+                } else {
+                    Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid))
+                }
+            })
+            .ok();
+
         // Reject compound/group selectors — only simple selectors are supported.
         // If any non-whitespace tokens remain, this is not a simple selector.
         while let Ok(tok) = input.next_including_whitespace() {
@@ -146,7 +158,7 @@ impl<'i, 'a> QualifiedRuleParser<'i> for GcpmSheetParser<'a> {
                 _ => return Ok(None),
             }
         }
-        Ok(Some(selector))
+        Ok(Some(QualifiedPrelude { selector, pseudo }))
     }
 
     fn parse_block<'t>(
@@ -155,21 +167,29 @@ impl<'i, 'a> QualifiedRuleParser<'i> for GcpmSheetParser<'a> {
         _start: &cssparser::ParserState,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self::QualifiedRule, ParseError<'i, ()>> {
-        // Only scan for `position: running(...)` if the selector is supported.
+        // Only scan for GCPM declarations if the selector is supported.
         // Otherwise, skip the block to avoid replacing declarations with
         // `display: none` for elements that won't be registered as running.
-        let Some(selector) = prelude else {
+        let Some(qp) = prelude else {
             while input.next().is_ok() {}
             return Ok(TopLevelItem::StyleRule);
         };
 
+        let selector = qp.selector;
+        let pseudo = qp.pseudo;
+
         let mut running_name: Option<String> = None;
         let mut string_set: Option<(String, Vec<StringSetValue>)> = None;
+        let mut counter_ops: Vec<CounterOp> = Vec::new();
+        let mut content_items: Option<Vec<ContentItem>> = None;
 
         let mut parser = StyleRuleParser {
             edits: self.edits,
             running_name: &mut running_name,
             string_set: &mut string_set,
+            counter_ops: &mut counter_ops,
+            content_items: &mut content_items,
+            has_pseudo: pseudo.is_some(),
         };
         let iter = RuleBodyParser::new(input, &mut parser);
         for item in iter {
@@ -185,168 +205,30 @@ impl<'i, 'a> QualifiedRuleParser<'i> for GcpmSheetParser<'a> {
 
         if let Some((name, values)) = string_set {
             self.string_set_mappings.push(StringSetMapping {
-                parsed: selector,
+                parsed: selector.clone(),
                 name,
                 values,
             });
         }
 
-        Ok(TopLevelItem::StyleRule)
-    }
-}
+        if !counter_ops.is_empty() {
+            self.counter_mappings.push(CounterMapping {
+                parsed: selector.clone(),
+                ops: counter_ops,
+            });
+        }
 
-// ---------------------------------------------------------------------------
-// CSS length unit → points converter
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
-// @page size/margin value parsers
-// ---------------------------------------------------------------------------
-
-/// Convert a CSS dimension value+unit to PDF points.
-fn css_unit_to_pt(value: f32, unit: &str) -> Option<f32> {
-    let factor = match () {
-        _ if unit.eq_ignore_ascii_case("mm") => 72.0 / 25.4,
-        _ if unit.eq_ignore_ascii_case("cm") => 72.0 / 2.54,
-        _ if unit.eq_ignore_ascii_case("in") => 72.0,
-        _ if unit.eq_ignore_ascii_case("pt") => 1.0,
-        _ if unit.eq_ignore_ascii_case("px") => 72.0 / 96.0,
-        _ => return None,
-    };
-    Some(value * factor)
-}
-
-/// Parse the value of an `@page { size: ... }` declaration.
-///
-/// Returns `None` if the value is invalid or has trailing tokens
-/// (CSS requires invalid declarations to be ignored entirely).
-fn parse_page_size_value(input: &mut Parser<'_, '_>) -> Option<PageSizeDecl> {
-    let token = input.next().ok()?.clone();
-    let result = match token {
-        Token::Ident(ref name) => {
-            if name.eq_ignore_ascii_case("auto") {
-                Some(PageSizeDecl::Auto)
-            } else if name.eq_ignore_ascii_case("landscape") {
-                Some(PageSizeDecl::KeywordWithOrientation(
-                    "auto".to_string(),
-                    true,
-                ))
-            } else if name.eq_ignore_ascii_case("portrait") {
-                Some(PageSizeDecl::KeywordWithOrientation(
-                    "auto".to_string(),
-                    false,
-                ))
-            } else {
-                let keyword = name.to_string();
-                // Try to read a second ident for orientation
-                let orientation = input.try_parse(|input| {
-                    let tok = input.next()?.clone();
-                    match tok {
-                        Token::Ident(ref orient) => {
-                            if orient.eq_ignore_ascii_case("landscape") {
-                                Ok(true)
-                            } else if orient.eq_ignore_ascii_case("portrait") {
-                                Ok(false)
-                            } else {
-                                Err(input
-                                    .new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid))
-                            }
-                        }
-                        _ => Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)),
-                    }
+        if let Some(items) = content_items {
+            if let Some(pseudo) = pseudo {
+                self.content_counter_mappings.push(ContentCounterMapping {
+                    parsed: selector.clone(),
+                    pseudo,
+                    content: items,
                 });
-                match orientation {
-                    Ok(landscape) => Some(PageSizeDecl::KeywordWithOrientation(keyword, landscape)),
-                    Err(_) => Some(PageSizeDecl::Keyword(keyword)),
-                }
             }
         }
-        Token::Dimension { value, unit, .. } => {
-            let w = css_unit_to_pt(value, &unit).filter(|v| *v > 0.0)?;
-            // Try to read a second dimension for height
-            let h = input
-                .try_parse(|input| {
-                    let tok = input.next()?.clone();
-                    match tok {
-                        Token::Dimension { value, unit, .. } => css_unit_to_pt(value, &unit)
-                            .filter(|v| *v > 0.0)
-                            .ok_or_else(|| {
-                                input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)
-                            }),
-                        _ => Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)),
-                    }
-                })
-                .unwrap_or(w);
-            Some(PageSizeDecl::Custom(w, h))
-        }
-        _ => None,
-    };
-    // Reject if trailing tokens remain (CSS: invalid declaration → ignore entirely)
-    if result.is_some() && input.next().is_ok() {
-        return None;
-    }
-    result
-}
 
-/// Parse the value of an `@page { margin: ... }` declaration (CSS shorthand).
-///
-/// Returns `None` if the value is invalid or has trailing tokens
-/// (CSS requires invalid declarations to be ignored entirely).
-fn parse_page_margin_value(input: &mut Parser<'_, '_>) -> Option<Margin> {
-    let mut values = Vec::new();
-    loop {
-        let result = input.try_parse(|input| {
-            let tok = input.next()?.clone();
-            match tok {
-                Token::Dimension { value, unit, .. } => {
-                    css_unit_to_pt(value, &unit).ok_or_else(|| {
-                        input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)
-                    })
-                }
-                Token::Number { value: 0.0, .. } => Ok(0.0_f32),
-                _ => Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)),
-            }
-        });
-        match result {
-            Ok(v) => values.push(v),
-            Err(_) => break,
-        }
-        if values.len() >= 4 {
-            break;
-        }
-    }
-
-    // Reject if trailing tokens remain (CSS: invalid declaration → ignore entirely)
-    if input.next().is_ok() {
-        return None;
-    }
-
-    match values.len() {
-        1 => Some(Margin {
-            top: values[0],
-            right: values[0],
-            bottom: values[0],
-            left: values[0],
-        }),
-        2 => Some(Margin {
-            top: values[0],
-            right: values[1],
-            bottom: values[0],
-            left: values[1],
-        }),
-        3 => Some(Margin {
-            top: values[0],
-            right: values[1],
-            bottom: values[2],
-            left: values[1],
-        }),
-        4 => Some(Margin {
-            top: values[0],
-            right: values[1],
-            bottom: values[2],
-            left: values[3],
-        }),
-        _ => None,
+        Ok(TopLevelItem::StyleRule)
     }
 }
 
@@ -358,14 +240,10 @@ fn parse_page_block(
     input: &mut Parser<'_, '_>,
     page_selector: &Option<String>,
     boxes: &mut Vec<MarginBoxRule>,
-    size: &mut Option<PageSizeDecl>,
-    margin: &mut Option<Margin>,
 ) {
     let mut parser = PageRuleParser {
         page_selector,
         boxes,
-        size,
-        margin,
     };
     let iter = RuleBodyParser::new(input, &mut parser);
     for item in iter {
@@ -376,8 +254,6 @@ fn parse_page_block(
 struct PageRuleParser<'a> {
     page_selector: &'a Option<String>,
     boxes: &'a mut Vec<MarginBoxRule>,
-    size: &'a mut Option<PageSizeDecl>,
-    margin: &'a mut Option<Margin>,
 }
 
 impl<'i, 'a> AtRuleParser<'i> for PageRuleParser<'a> {
@@ -433,18 +309,9 @@ impl<'i, 'a> DeclarationParser<'i> for PageRuleParser<'a> {
         input: &mut Parser<'i, 't>,
         _start: &cssparser::ParserState,
     ) -> Result<(), ParseError<'i, ()>> {
-        if name.eq_ignore_ascii_case("size") {
-            if let Some(v) = parse_page_size_value(input) {
-                *self.size = Some(v);
-            }
-        } else if name.eq_ignore_ascii_case("margin") {
-            if let Some(v) = parse_page_margin_value(input) {
-                *self.margin = Some(v);
-            }
-        } else {
-            // Skip unknown declarations
-            while input.next().is_ok() {}
-        }
+        // Skip declarations directly inside @page (not inside margin boxes)
+        let _ = name;
+        while input.next().is_ok() {}
         Ok(())
     }
 }
@@ -530,6 +397,9 @@ struct StyleRuleParser<'a> {
     edits: &'a mut Vec<CssEdit>,
     running_name: &'a mut Option<String>,
     string_set: &'a mut Option<(String, Vec<StringSetValue>)>,
+    counter_ops: &'a mut Vec<CounterOp>,
+    content_items: &'a mut Option<Vec<ContentItem>>,
+    has_pseudo: bool,
 }
 
 impl<'i, 'a> DeclarationParser<'i> for StyleRuleParser<'a> {
@@ -588,6 +458,42 @@ impl<'i, 'a> DeclarationParser<'i> for StyleRuleParser<'a> {
             } else {
                 while input.next().is_ok() {}
             }
+        } else if name.eq_ignore_ascii_case("counter-reset")
+            || name.eq_ignore_ascii_case("counter-increment")
+            || name.eq_ignore_ascii_case("counter-set")
+        {
+            let ops = parse_counter_ops(input, &name);
+            if !ops.is_empty() {
+                self.counter_ops.extend(ops);
+                let start = decl_start.position().byte_index();
+                let end = input.position().byte_index();
+                self.edits.push(CssEdit::Replace {
+                    start,
+                    end,
+                    replacement: String::new(),
+                });
+            }
+        } else if name.eq_ignore_ascii_case("content") && self.has_pseudo {
+            let items = parse_content_value(input);
+            let has_counter = items
+                .iter()
+                .any(|item| matches!(item, ContentItem::Counter { .. }));
+            if has_counter {
+                *self.content_items = Some(items);
+            } else {
+                *self.content_items = None;
+            }
+            // Always strip `content` from cleaned CSS for ::before/::after rules
+            // we recognise — counter()/string()/element() are resolved by us, not
+            // by Blitz, so leaving the original declaration would cause Blitz to
+            // try (and fail) to render the unsupported function.
+            let start = decl_start.position().byte_index();
+            let end = input.position().byte_index();
+            self.edits.push(CssEdit::Replace {
+                start,
+                end,
+                replacement: String::new(),
+            });
         } else {
             // Skip other declarations
             while input.next().is_ok() {}
@@ -728,6 +634,27 @@ fn parse_string_policy<'i>(input: &mut Parser<'i, '_>) -> Result<StringPolicy, P
     })
 }
 
+/// Parse the style argument of `counter(name, <style>)`.
+fn parse_counter_style<'i>(input: &mut Parser<'i, '_>) -> Result<CounterStyle, ParseError<'i, ()>> {
+    let ident = input.expect_ident()?.clone();
+    // Handle hyphenated idents: cssparser may split "upper-roman" into
+    // "upper" + "-" + "roman".
+    let full = if input.try_parse(|input| input.expect_delim('-')).is_ok() {
+        let suffix = input.expect_ident()?.clone();
+        format!("{}-{}", &*ident, &*suffix)
+    } else {
+        ident.to_string()
+    };
+    match full.to_ascii_lowercase().as_str() {
+        "decimal" => Ok(CounterStyle::Decimal),
+        "upper-roman" => Ok(CounterStyle::UpperRoman),
+        "lower-roman" => Ok(CounterStyle::LowerRoman),
+        "upper-alpha" | "upper-latin" => Ok(CounterStyle::UpperAlpha),
+        "lower-alpha" | "lower-latin" => Ok(CounterStyle::LowerAlpha),
+        _ => Err(input.new_error(BasicParseErrorKind::QualifiedRuleInvalid)),
+    }
+}
+
 /// Parse the policy argument of `element(name, <policy>)`.
 fn parse_element_policy<'i>(
     input: &mut Parser<'i, '_>,
@@ -739,6 +666,36 @@ fn parse_element_policy<'i>(
         "first-except" => Some(ElementPolicy::FirstExcept),
         _ => None,
     })
+}
+
+/// Parse counter operations from `counter-reset`, `counter-increment`, or `counter-set`.
+fn parse_counter_ops(input: &mut Parser<'_, '_>, prop: &str) -> Vec<CounterOp> {
+    let mut ops = Vec::new();
+    loop {
+        let name = match input.try_parse(|input| input.expect_ident().map(|s| s.to_string())) {
+            Ok(n) => n,
+            Err(_) => break,
+        };
+        if name.eq_ignore_ascii_case("none") {
+            break;
+        }
+        let value = input.try_parse(|input| input.expect_integer()).ok();
+        let default_value = if prop.eq_ignore_ascii_case("counter-increment") {
+            1
+        } else {
+            0
+        };
+        let value = value.unwrap_or(default_value);
+        let op = if prop.eq_ignore_ascii_case("counter-reset") {
+            CounterOp::Reset { name, value }
+        } else if prop.eq_ignore_ascii_case("counter-increment") {
+            CounterOp::Increment { name, value }
+        } else {
+            CounterOp::Set { name, value }
+        };
+        ops.push(op);
+    }
+    ops
 }
 
 /// Parse a `content` property value into a list of `ContentItem`s using cssparser.
@@ -781,11 +738,14 @@ fn parse_content_value(input: &mut Parser<'_, '_>) -> Vec<ContentItem> {
                                 });
                             }
                         } else if fn_name.eq_ignore_ascii_case("counter") {
-                            match &*arg {
-                                "page" => items.push(ContentItem::Counter(CounterType::Page)),
-                                "pages" => items.push(ContentItem::Counter(CounterType::Pages)),
-                                _ => {} // unknown counter
-                            }
+                            let name = arg.to_string();
+                            let style = input
+                                .try_parse(|input| {
+                                    input.expect_comma()?;
+                                    parse_counter_style(input)
+                                })
+                                .unwrap_or(CounterStyle::Decimal);
+                            items.push(ContentItem::Counter { name, style });
                         } else if fn_name.eq_ignore_ascii_case("string") {
                             let name = arg.to_string();
                             let policy = input
@@ -831,7 +791,8 @@ pub fn parse_gcpm(css: &str) -> GcpmContext {
     let mut margin_boxes = Vec::new();
     let mut running_mappings = Vec::new();
     let mut string_set_mappings = Vec::new();
-    let mut page_settings = Vec::new();
+    let mut counter_mappings = Vec::new();
+    let mut content_counter_mappings = Vec::new();
     let mut edits: Vec<CssEdit> = Vec::new();
 
     // Run the cssparser-based parse to collect GCPM data and edit spans.
@@ -844,7 +805,8 @@ pub fn parse_gcpm(css: &str) -> GcpmContext {
             margin_boxes: &mut margin_boxes,
             running_mappings: &mut running_mappings,
             string_set_mappings: &mut string_set_mappings,
-            page_settings: &mut page_settings,
+            counter_mappings: &mut counter_mappings,
+            content_counter_mappings: &mut content_counter_mappings,
         };
 
         let iter = StyleSheetParser::new(&mut input, &mut parser);
@@ -860,7 +822,8 @@ pub fn parse_gcpm(css: &str) -> GcpmContext {
         margin_boxes,
         running_mappings,
         string_set_mappings,
-        page_settings,
+        counter_mappings,
+        content_counter_mappings,
         cleaned_css,
     }
 }
@@ -983,9 +946,15 @@ mod tests {
             mb.content,
             vec![
                 ContentItem::String("Page ".to_string()),
-                ContentItem::Counter(CounterType::Page),
+                ContentItem::Counter {
+                    name: "page".into(),
+                    style: CounterStyle::Decimal,
+                },
                 ContentItem::String(" of ".to_string()),
-                ContentItem::Counter(CounterType::Pages),
+                ContentItem::Counter {
+                    name: "pages".into(),
+                    style: CounterStyle::Decimal,
+                },
             ]
         );
     }
@@ -1347,171 +1316,161 @@ mod tests {
         );
     }
 
-    // -----------------------------------------------------------------------
-    // @page size/margin parsing tests
-    // -----------------------------------------------------------------------
-
     #[test]
-    fn test_page_size_keyword() {
-        let css = "@page { size: A4; }";
+    fn test_parse_custom_counter() {
+        let css = r#"@page { @bottom-center { content: "Ch. " counter(chapter); } }"#;
         let ctx = parse_gcpm(css);
-        assert_eq!(ctx.page_settings.len(), 1);
-        assert_eq!(
-            ctx.page_settings[0].size,
-            Some(PageSizeDecl::Keyword("A4".to_string()))
-        );
-    }
-
-    #[test]
-    fn test_page_size_keyword_landscape() {
-        let css = "@page { size: A4 landscape; }";
-        let ctx = parse_gcpm(css);
-        assert_eq!(
-            ctx.page_settings[0].size,
-            Some(PageSizeDecl::KeywordWithOrientation("A4".to_string(), true))
-        );
-    }
-
-    #[test]
-    fn test_page_size_custom_dimensions() {
-        let css = "@page { size: 210mm 297mm; }";
-        let ctx = parse_gcpm(css);
-        match &ctx.page_settings[0].size {
-            Some(PageSizeDecl::Custom(w, h)) => {
-                assert!((w - 595.28).abs() < 0.2);
-                assert!((h - 841.89).abs() < 0.2);
-            }
-            other => panic!("Expected Custom, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn test_page_size_auto() {
-        let css = "@page { size: auto; }";
-        let ctx = parse_gcpm(css);
-        assert_eq!(ctx.page_settings[0].size, Some(PageSizeDecl::Auto));
-    }
-
-    #[test]
-    fn test_page_margin_uniform() {
-        let css = "@page { margin: 20mm; }";
-        let ctx = parse_gcpm(css);
-        let m = ctx.page_settings[0].margin.as_ref().unwrap();
-        let expected = 20.0 * 72.0 / 25.4;
-        assert!((m.top - expected).abs() < 0.01);
-        assert!((m.right - expected).abs() < 0.01);
-        assert!((m.bottom - expected).abs() < 0.01);
-        assert!((m.left - expected).abs() < 0.01);
-    }
-
-    #[test]
-    fn test_page_margin_shorthand_two() {
-        let css = "@page { margin: 10mm 20mm; }";
-        let ctx = parse_gcpm(css);
-        let m = ctx.page_settings[0].margin.as_ref().unwrap();
-        let v = 10.0 * 72.0 / 25.4;
-        let h = 20.0 * 72.0 / 25.4;
-        assert!((m.top - v).abs() < 0.01);
-        assert!((m.right - h).abs() < 0.01);
-        assert!((m.bottom - v).abs() < 0.01);
-        assert!((m.left - h).abs() < 0.01);
-    }
-
-    #[test]
-    fn test_page_margin_shorthand_three() {
-        let css = "@page { margin: 10mm 20mm 30mm; }";
-        let ctx = parse_gcpm(css);
-        let m = ctx.page_settings[0].margin.as_ref().unwrap();
-        assert!((m.top - 10.0 * 72.0 / 25.4).abs() < 0.01);
-        assert!((m.right - 20.0 * 72.0 / 25.4).abs() < 0.01);
-        assert!((m.bottom - 30.0 * 72.0 / 25.4).abs() < 0.01);
-        assert!((m.left - 20.0 * 72.0 / 25.4).abs() < 0.01);
-    }
-
-    #[test]
-    fn test_page_margin_shorthand_four() {
-        let css = "@page { margin: 10mm 20mm 30mm 40mm; }";
-        let ctx = parse_gcpm(css);
-        let m = ctx.page_settings[0].margin.as_ref().unwrap();
-        assert!((m.top - 10.0 * 72.0 / 25.4).abs() < 0.01);
-        assert!((m.right - 20.0 * 72.0 / 25.4).abs() < 0.01);
-        assert!((m.bottom - 30.0 * 72.0 / 25.4).abs() < 0.01);
-        assert!((m.left - 40.0 * 72.0 / 25.4).abs() < 0.01);
-    }
-
-    #[test]
-    fn test_page_size_with_selector() {
-        let css = "@page :first { size: letter; margin: 1in; }";
-        let ctx = parse_gcpm(css);
-        assert_eq!(ctx.page_settings.len(), 1);
-        assert_eq!(
-            ctx.page_settings[0].page_selector,
-            Some(":first".to_string())
-        );
-        assert_eq!(
-            ctx.page_settings[0].size,
-            Some(PageSizeDecl::Keyword("letter".to_string()))
-        );
-        let m = ctx.page_settings[0].margin.as_ref().unwrap();
-        assert!((m.top - 72.0).abs() < 0.01);
-    }
-
-    #[test]
-    fn test_page_size_and_margin_boxes_coexist() {
-        let css = r#"@page { size: A4; margin: 20mm; @top-center { content: counter(page); } }"#;
-        let ctx = parse_gcpm(css);
-        assert_eq!(ctx.page_settings.len(), 1);
         assert_eq!(ctx.margin_boxes.len(), 1);
+        assert_eq!(
+            ctx.margin_boxes[0].content,
+            vec![
+                ContentItem::String("Ch. ".into()),
+                ContentItem::Counter {
+                    name: "chapter".into(),
+                    style: CounterStyle::Decimal,
+                },
+            ]
+        );
     }
 
     #[test]
-    fn test_page_margin_zero() {
-        let css = "@page { margin: 0; }";
+    fn test_parse_counter_with_style() {
+        let css = r#"@page { @bottom-center { content: counter(chapter, upper-roman); } }"#;
         let ctx = parse_gcpm(css);
-        let m = ctx.page_settings[0].margin.as_ref().unwrap();
-        assert!((m.top).abs() < 0.01);
-        assert!((m.right).abs() < 0.01);
+        assert_eq!(ctx.margin_boxes.len(), 1);
+        assert_eq!(
+            ctx.margin_boxes[0].content,
+            vec![ContentItem::Counter {
+                name: "chapter".into(),
+                style: CounterStyle::UpperRoman,
+            }]
+        );
     }
 
     #[test]
-    fn test_page_size_negative_rejected() {
-        let css = "@page { size: -10mm 297mm; }";
+    fn test_parse_counter_lower_alpha_style() {
+        let css = r#"@page { @bottom-center { content: counter(section, lower-alpha); } }"#;
         let ctx = parse_gcpm(css);
-        assert!(ctx.page_settings.is_empty() || ctx.page_settings[0].size.is_none());
+        assert_eq!(
+            ctx.margin_boxes[0].content,
+            vec![ContentItem::Counter {
+                name: "section".into(),
+                style: CounterStyle::LowerAlpha,
+            }]
+        );
     }
 
     #[test]
-    fn test_page_size_trailing_tokens_rejected() {
-        let css = "@page { size: A4 bogus; }";
+    fn test_parse_counter_reset() {
+        let css = "body { counter-reset: chapter 0; }";
         let ctx = parse_gcpm(css);
-        assert!(ctx.page_settings.is_empty() || ctx.page_settings[0].size.is_none());
+        assert_eq!(ctx.counter_mappings.len(), 1);
+        assert_eq!(
+            ctx.counter_mappings[0].parsed,
+            ParsedSelector::Tag("body".into())
+        );
+        assert_eq!(
+            ctx.counter_mappings[0].ops,
+            vec![CounterOp::Reset {
+                name: "chapter".into(),
+                value: 0,
+            }]
+        );
     }
 
     #[test]
-    fn test_page_margin_trailing_tokens_rejected() {
-        let css = "@page { margin: 10mm 20mm bad; }";
+    fn test_parse_counter_increment() {
+        let css = "h2 { counter-increment: chapter; }";
         let ctx = parse_gcpm(css);
-        assert!(ctx.page_settings.is_empty() || ctx.page_settings[0].margin.is_none());
+        assert_eq!(ctx.counter_mappings.len(), 1);
+        assert_eq!(
+            ctx.counter_mappings[0].ops,
+            vec![CounterOp::Increment {
+                name: "chapter".into(),
+                value: 1,
+            }]
+        );
     }
 
     #[test]
-    fn test_page_margin_five_values_rejected() {
-        let css = "@page { margin: 1mm 2mm 3mm 4mm 5mm; }";
+    fn test_parse_counter_set() {
+        let css = "h2 { counter-set: chapter 5; }";
         let ctx = parse_gcpm(css);
-        assert!(ctx.page_settings.is_empty() || ctx.page_settings[0].margin.is_none());
+        assert_eq!(ctx.counter_mappings.len(), 1);
+        assert_eq!(
+            ctx.counter_mappings[0].ops,
+            vec![CounterOp::Set {
+                name: "chapter".into(),
+                value: 5,
+            }]
+        );
     }
 
     #[test]
-    fn test_css_unit_case_insensitive() {
-        let css = "@page { size: 210MM 297MM; }";
+    fn test_parse_counter_multiple_names() {
+        let css = "h2 { counter-reset: chapter 0 section 0; }";
         let ctx = parse_gcpm(css);
-        let size = ctx.page_settings[0].size.as_ref().unwrap();
-        match size {
-            PageSizeDecl::Custom(w, h) => {
-                assert!((*w - 210.0 * 72.0 / 25.4).abs() < 0.01);
-                assert!((*h - 297.0 * 72.0 / 25.4).abs() < 0.01);
-            }
-            _ => panic!("expected Custom size"),
-        }
+        assert_eq!(
+            ctx.counter_mappings[0].ops,
+            vec![
+                CounterOp::Reset {
+                    name: "chapter".into(),
+                    value: 0,
+                },
+                CounterOp::Reset {
+                    name: "section".into(),
+                    value: 0,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_counter_increment_default_value() {
+        let css = "h2 { counter-increment: section; }";
+        let ctx = parse_gcpm(css);
+        assert_eq!(
+            ctx.counter_mappings[0].ops,
+            vec![CounterOp::Increment {
+                name: "section".into(),
+                value: 1,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_parse_pseudo_element_content_with_counter() {
+        let css = r#"h2::before { content: counter(chapter) ". "; }"#;
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.content_counter_mappings.len(), 1);
+        let m = &ctx.content_counter_mappings[0];
+        assert_eq!(m.parsed, ParsedSelector::Tag("h2".into()));
+        assert_eq!(m.pseudo, PseudoElement::Before);
+        assert_eq!(
+            m.content,
+            vec![
+                ContentItem::Counter {
+                    name: "chapter".into(),
+                    style: CounterStyle::Decimal,
+                },
+                ContentItem::String(". ".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_counter_declarations_stripped_from_cleaned_css() {
+        let css = "body { counter-reset: chapter; color: red; }";
+        let ctx = parse_gcpm(css);
+        assert!(!ctx.cleaned_css.contains("counter-reset"));
+        assert!(ctx.cleaned_css.contains("color: red"));
+    }
+
+    #[test]
+    fn test_parse_pseudo_content_stripped_from_cleaned_css() {
+        let css = r#"h2::before { content: counter(chapter) ". "; font-weight: bold; }"#;
+        let ctx = parse_gcpm(css);
+        assert!(!ctx.cleaned_css.contains("counter(chapter)"));
+        assert!(ctx.cleaned_css.contains("font-weight: bold"));
     }
 }

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -1091,10 +1091,11 @@ mod tests {
     fn test_extract_running_name() {
         let css = ".header { position: running(pageHeader); font-size: 12px; }";
         let ctx = parse_gcpm(css);
-        assert!(ctx
-            .running_mappings
-            .iter()
-            .any(|m| m.running_name == "pageHeader"));
+        assert!(
+            ctx.running_mappings
+                .iter()
+                .any(|m| m.running_name == "pageHeader")
+        );
         assert!(ctx.cleaned_css.contains("display: none"));
         assert!(!ctx.cleaned_css.contains("running"));
         assert!(ctx.cleaned_css.contains("font-size: 12px"));
@@ -1201,10 +1202,11 @@ mod tests {
         // POSITION: Running(name) — プロパティ名の大文字小文字
         let css = ".header { POSITION: running(pageHeader); }";
         let ctx = parse_gcpm(css);
-        assert!(ctx
-            .running_mappings
-            .iter()
-            .any(|m| m.running_name == "pageHeader"));
+        assert!(
+            ctx.running_mappings
+                .iter()
+                .any(|m| m.running_name == "pageHeader")
+        );
         assert!(ctx.cleaned_css.contains("display: none"));
     }
 

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -1722,7 +1722,8 @@ mod tests {
         // Two counter-increment declarations in the same rule: the later one
         // wins (CSS last-declaration-wins). Counter-reset, declared between
         // them, must still survive because it's a different property.
-        let css = "h2 { counter-increment: chapter; counter-reset: section; counter-increment: page; }";
+        let css =
+            "h2 { counter-increment: chapter; counter-reset: section; counter-increment: page; }";
         let ctx = parse_gcpm(css);
         assert_eq!(ctx.counter_mappings.len(), 1);
         let mapping = &ctx.counter_mappings[0];

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -1091,11 +1091,10 @@ mod tests {
     fn test_extract_running_name() {
         let css = ".header { position: running(pageHeader); font-size: 12px; }";
         let ctx = parse_gcpm(css);
-        assert!(
-            ctx.running_mappings
-                .iter()
-                .any(|m| m.running_name == "pageHeader")
-        );
+        assert!(ctx
+            .running_mappings
+            .iter()
+            .any(|m| m.running_name == "pageHeader"));
         assert!(ctx.cleaned_css.contains("display: none"));
         assert!(!ctx.cleaned_css.contains("running"));
         assert!(ctx.cleaned_css.contains("font-size: 12px"));
@@ -1202,11 +1201,10 @@ mod tests {
         // POSITION: Running(name) — プロパティ名の大文字小文字
         let css = ".header { POSITION: running(pageHeader); }";
         let ctx = parse_gcpm(css);
-        assert!(
-            ctx.running_mappings
-                .iter()
-                .any(|m| m.running_name == "pageHeader")
-        );
+        assert!(ctx
+            .running_mappings
+            .iter()
+            .any(|m| m.running_name == "pageHeader"));
         assert!(ctx.cleaned_css.contains("display: none"));
     }
 

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -647,19 +647,18 @@ impl<'i, 'a> DeclarationParser<'i> for StyleRuleParser<'a> {
         {
             let ops = parse_counter_ops(input, &name);
             // counter-reset / counter-increment / counter-set are independent
-            // CSS properties, so they must each contribute to counter_ops.
-            // Apply last-declaration-wins per property by removing prior ops
-            // of the SAME variant before extending with the new ones.
-            let prop = name.to_ascii_lowercase();
-            self.counter_ops.retain(|op| {
-                !matches!(
-                    (op, prop.as_str()),
-                    (CounterOp::Reset { .. }, "counter-reset")
-                        | (CounterOp::Increment { .. }, "counter-increment")
-                        | (CounterOp::Set { .. }, "counter-set")
-                )
-            });
-            self.counter_ops.extend(ops);
+            // CSS properties, so each must contribute to counter_ops. Apply
+            // last-declaration-wins per property by dropping prior ops of the
+            // same `CounterOp` variant before extending. `parse_counter_ops`
+            // produces ops of exactly one variant (matching the property
+            // name), so the discriminant of the first element identifies the
+            // property kind without re-inspecting the name.
+            if let Some(first) = ops.first() {
+                let kind = std::mem::discriminant(first);
+                self.counter_ops
+                    .retain(|op| std::mem::discriminant(op) != kind);
+                self.counter_ops.extend(ops);
+            }
             let start = decl_start.position().byte_index();
             let end = input.position().byte_index();
             self.edits.push(CssEdit::Replace {

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::gcpm::CounterOp;
 use crate::image::ImageFormat;
 
 /// Point unit (1/72 inch)
@@ -1228,6 +1229,121 @@ impl Pageable for RunningElementMarkerPageable {
 
     fn height(&self) -> Pt {
         0.0
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+// ─── CounterOpMarkerPageable ──────────────────────────────
+
+/// Zero-size marker that carries counter operations through pagination.
+///
+/// Inserted into the Pageable tree so that `collect_counter_states` can replay
+/// counter-reset / counter-increment / counter-set in document order and build
+/// per-page counter snapshots.
+#[derive(Debug, Clone)]
+pub struct CounterOpMarkerPageable {
+    pub ops: Vec<CounterOp>,
+}
+
+impl CounterOpMarkerPageable {
+    pub fn new(ops: Vec<CounterOp>) -> Self {
+        Self { ops }
+    }
+}
+
+impl Pageable for CounterOpMarkerPageable {
+    fn wrap(&mut self, _avail_width: Pt, _avail_height: Pt) -> Size {
+        Size {
+            width: 0.0,
+            height: 0.0,
+        }
+    }
+
+    fn split(
+        &self,
+        _avail_width: Pt,
+        _avail_height: Pt,
+    ) -> Option<(Box<dyn Pageable>, Box<dyn Pageable>)> {
+        None
+    }
+
+    fn draw(&self, _canvas: &mut Canvas, _x: Pt, _y: Pt, _avail_width: Pt, _avail_height: Pt) {}
+
+    fn clone_box(&self) -> Box<dyn Pageable> {
+        Box::new(self.clone())
+    }
+
+    fn height(&self) -> Pt {
+        0.0
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+// ─── CounterOpWrapperPageable ─────────────────────────────
+
+/// Wraps a Pageable together with `CounterOp` operations that must stay
+/// attached to it during pagination.
+///
+/// Without this wrapper, a plain `BlockPageable` containing
+/// `[CounterOpMarkerPageable, child]` could split such that the marker is
+/// left on the previous page while the real child is moved to the next page
+/// (when the child is unsplittable and larger than the available space).
+/// `collect_counter_states` would then attribute the counter operation to
+/// the wrong page.
+///
+/// The wrapper delegates `split()` to the inner child: if the child splits,
+/// markers travel with the first fragment; if the child cannot split, the
+/// wrapper is atomic and the whole thing moves to the next page together.
+#[derive(Clone)]
+pub struct CounterOpWrapperPageable {
+    pub ops: Vec<CounterOp>,
+    pub child: Box<dyn Pageable>,
+}
+
+impl CounterOpWrapperPageable {
+    pub fn new(ops: Vec<CounterOp>, child: Box<dyn Pageable>) -> Self {
+        Self { ops, child }
+    }
+}
+
+impl Pageable for CounterOpWrapperPageable {
+    fn wrap(&mut self, avail_width: Pt, avail_height: Pt) -> Size {
+        self.child.wrap(avail_width, avail_height)
+    }
+
+    fn split(
+        &self,
+        avail_width: Pt,
+        avail_height: Pt,
+    ) -> Option<(Box<dyn Pageable>, Box<dyn Pageable>)> {
+        let (first, second) = self.child.split(avail_width, avail_height)?;
+        let first_wrapped = CounterOpWrapperPageable {
+            ops: self.ops.clone(),
+            child: first,
+        };
+        Some((Box::new(first_wrapped), second))
+    }
+
+    fn draw(&self, canvas: &mut Canvas<'_, '_>, x: Pt, y: Pt, avail_width: Pt, avail_height: Pt) {
+        self.child.draw(canvas, x, y, avail_width, avail_height);
+    }
+
+    fn clone_box(&self) -> Box<dyn Pageable> {
+        Box::new(self.clone())
+    }
+
+    fn height(&self) -> Pt {
+        self.child.height()
+    }
+
+    fn pagination(&self) -> Pagination {
+        self.child.pagination()
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/crates/fulgur/src/paginate.rs
+++ b/crates/fulgur/src/paginate.rs
@@ -242,9 +242,9 @@ fn collect_counter_markers(pageable: &dyn Pageable, ops: &mut Vec<CounterOp>) {
     } else if let Some(wrapper) = any.downcast_ref::<RunningElementWrapperPageable>() {
         collect_counter_markers(wrapper.child.as_ref(), ops);
     } else if let Some(table) = any.downcast_ref::<TablePageable>() {
-        for child in &table.header_cells {
-            collect_counter_markers(child.child.as_ref(), ops);
-        }
+        // Skip header_cells: they are cloned into every page fragment by
+        // TablePageable::split(), so walking them would replay counter ops
+        // on every page the table spans.  Only body_cells carry unique ops.
         for child in &table.body_cells {
             collect_counter_markers(child.child.as_ref(), ops);
         }

--- a/crates/fulgur/src/paginate.rs
+++ b/crates/fulgur/src/paginate.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::gcpm::CounterOp;
 use crate::gcpm::counter::CounterState;
+use crate::gcpm::CounterOp;
 use crate::pageable::{
     BlockPageable, CounterOpMarkerPageable, CounterOpWrapperPageable, ListItemPageable, Pageable,
     Pt, RunningElementMarkerPageable, RunningElementWrapperPageable, StringSetPageable,

--- a/crates/fulgur/src/paginate.rs
+++ b/crates/fulgur/src/paginate.rs
@@ -1,8 +1,11 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use crate::gcpm::CounterOp;
+use crate::gcpm::counter::CounterState;
 use crate::pageable::{
-    BlockPageable, ListItemPageable, Pageable, Pt, RunningElementMarkerPageable,
-    RunningElementWrapperPageable, StringSetPageable, StringSetWrapperPageable, TablePageable,
+    BlockPageable, CounterOpMarkerPageable, CounterOpWrapperPageable, ListItemPageable, Pageable,
+    Pt, RunningElementMarkerPageable, RunningElementWrapperPageable, StringSetPageable,
+    StringSetWrapperPageable, TablePageable,
 };
 
 /// Per-page state for a named string.
@@ -93,6 +96,8 @@ fn collect_markers(pageable: &dyn Pageable, markers: &mut Vec<(String, String)>)
         collect_markers(wrapper.child.as_ref(), markers);
     } else if let Some(wrapper) = any.downcast_ref::<RunningElementWrapperPageable>() {
         collect_markers(wrapper.child.as_ref(), markers);
+    } else if let Some(wrapper) = any.downcast_ref::<CounterOpWrapperPageable>() {
+        collect_markers(wrapper.child.as_ref(), markers);
     } else if let Some(marker) = any.downcast_ref::<StringSetPageable>() {
         // Used by unit tests that construct markers directly.
         markers.push((marker.name.clone(), marker.value.clone()));
@@ -176,6 +181,8 @@ fn collect_running_markers(pageable: &dyn Pageable, markers: &mut Vec<(String, u
         collect_running_markers(wrapper.child.as_ref(), markers);
     } else if let Some(wrapper) = any.downcast_ref::<StringSetWrapperPageable>() {
         collect_running_markers(wrapper.child.as_ref(), markers);
+    } else if let Some(wrapper) = any.downcast_ref::<CounterOpWrapperPageable>() {
+        collect_running_markers(wrapper.child.as_ref(), markers);
     } else if let Some(block) = any.downcast_ref::<BlockPageable>() {
         for child in &block.children {
             collect_running_markers(child.child.as_ref(), markers);
@@ -189,6 +196,60 @@ fn collect_running_markers(pageable: &dyn Pageable, markers: &mut Vec<(String, u
         }
     } else if let Some(list_item) = any.downcast_ref::<ListItemPageable>() {
         collect_running_markers(list_item.body.as_ref(), markers);
+    }
+}
+
+/// Walk paginated pages, replay counter operations in document order,
+/// and return the cumulative counter state at the end of each page.
+pub fn collect_counter_states(pages: &[Box<dyn Pageable>]) -> Vec<BTreeMap<String, i32>> {
+    let mut state = CounterState::new();
+    let mut result = Vec::with_capacity(pages.len());
+
+    for page in pages {
+        let mut ops = Vec::new();
+        collect_counter_markers(page.as_ref(), &mut ops);
+        for op in &ops {
+            match op {
+                CounterOp::Reset { name, value } => state.reset(name, *value),
+                CounterOp::Increment { name, value } => state.increment(name, *value),
+                CounterOp::Set { name, value } => state.set(name, *value),
+            }
+        }
+        result.push(state.snapshot());
+    }
+
+    result
+}
+
+/// Recursively find all counter-op markers in a Pageable tree.
+///
+/// Mirrors `collect_running_markers` but looks for `CounterOpMarkerPageable`
+/// instances. Descends into wrappers so markers inside wrapped children are
+/// still discovered.
+fn collect_counter_markers(pageable: &dyn Pageable, ops: &mut Vec<CounterOp>) {
+    let any = pageable.as_any();
+    if let Some(wrapper) = any.downcast_ref::<CounterOpWrapperPageable>() {
+        ops.extend(wrapper.ops.clone());
+        collect_counter_markers(wrapper.child.as_ref(), ops);
+    } else if let Some(marker) = any.downcast_ref::<CounterOpMarkerPageable>() {
+        ops.extend(marker.ops.clone());
+    } else if let Some(block) = any.downcast_ref::<BlockPageable>() {
+        for child in &block.children {
+            collect_counter_markers(child.child.as_ref(), ops);
+        }
+    } else if let Some(wrapper) = any.downcast_ref::<StringSetWrapperPageable>() {
+        collect_counter_markers(wrapper.child.as_ref(), ops);
+    } else if let Some(wrapper) = any.downcast_ref::<RunningElementWrapperPageable>() {
+        collect_counter_markers(wrapper.child.as_ref(), ops);
+    } else if let Some(table) = any.downcast_ref::<TablePageable>() {
+        for child in &table.header_cells {
+            collect_counter_markers(child.child.as_ref(), ops);
+        }
+        for child in &table.body_cells {
+            collect_counter_markers(child.child.as_ref(), ops);
+        }
+    } else if let Some(list_item) = any.downcast_ref::<ListItemPageable>() {
+        collect_counter_markers(list_item.body.as_ref(), ops);
     }
 }
 
@@ -440,7 +501,7 @@ mod tests {
         assert_eq!(states.len(), 2);
         assert_eq!(states[0].get("hdr").unwrap().instance_ids, vec![7]);
         assert!(
-            states[1].get("hdr").is_none(),
+            !states[1].contains_key("hdr"),
             "instance_id 7 must not be re-counted on the second page"
         );
     }
@@ -460,5 +521,82 @@ mod tests {
         let states = collect_running_element_states(&pages);
         assert_eq!(states.len(), 1);
         assert_eq!(states[0].get("hdr").unwrap().instance_ids, vec![3]);
+    }
+
+    // ─── Counter state tests ──────────────────────────────
+
+    use crate::gcpm::CounterOp;
+    use crate::pageable::CounterOpMarkerPageable;
+
+    #[test]
+    fn test_collect_counter_states_single_page() {
+        let marker = CounterOpMarkerPageable::new(vec![
+            CounterOp::Reset {
+                name: "chapter".into(),
+                value: 0,
+            },
+            CounterOp::Increment {
+                name: "chapter".into(),
+                value: 1,
+            },
+        ]);
+        let block = BlockPageable::with_positioned_children(vec![
+            pos(Box::new(marker)),
+            pos(make_spacer(50.0)),
+        ]);
+        let pages = paginate(Box::new(block), 100.0, 200.0);
+        let states = collect_counter_states(&pages);
+        assert_eq!(states.len(), 1);
+        assert_eq!(states[0].get("chapter"), Some(&1));
+    }
+
+    #[test]
+    fn test_collect_counter_states_across_pages() {
+        let m1 = CounterOpMarkerPageable::new(vec![
+            CounterOp::Reset {
+                name: "chapter".into(),
+                value: 0,
+            },
+            CounterOp::Increment {
+                name: "chapter".into(),
+                value: 1,
+            },
+        ]);
+        let m2 = CounterOpMarkerPageable::new(vec![CounterOp::Increment {
+            name: "chapter".into(),
+            value: 1,
+        }]);
+        let block = BlockPageable::with_positioned_children(vec![
+            pos(Box::new(m1)),
+            PositionedChild {
+                child: make_spacer(80.0),
+                x: 0.0,
+                y: 0.0,
+            },
+            PositionedChild {
+                child: Box::new(m2),
+                x: 0.0,
+                y: 120.0,
+            },
+            PositionedChild {
+                child: make_spacer(80.0),
+                x: 0.0,
+                y: 120.0,
+            },
+        ]);
+        let pages = paginate(Box::new(block), 200.0, 100.0);
+        let states = collect_counter_states(&pages);
+        assert!(states.len() >= 2);
+        assert_eq!(states[0].get("chapter"), Some(&1));
+        assert_eq!(states[1].get("chapter"), Some(&2));
+    }
+
+    #[test]
+    fn test_collect_counter_states_empty() {
+        let block = BlockPageable::with_positioned_children(vec![pos(make_spacer(50.0))]);
+        let pages = paginate(Box::new(block), 100.0, 200.0);
+        let states = collect_counter_states(&pages);
+        assert_eq!(states.len(), 1);
+        assert!(states[0].is_empty());
     }
 }

--- a/crates/fulgur/src/paginate.rs
+++ b/crates/fulgur/src/paginate.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::gcpm::counter::CounterState;
 use crate::gcpm::CounterOp;
+use crate::gcpm::counter::CounterState;
 use crate::pageable::{
     BlockPageable, CounterOpMarkerPageable, CounterOpWrapperPageable, ListItemPageable, Pageable,
     Pt, RunningElementMarkerPageable, RunningElementWrapperPageable, StringSetPageable,

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -124,9 +124,9 @@ fn parse_datetime(s: &str) -> Option<krilla::metadata::DateTime> {
 }
 
 /// Cached max-content width and render Pageable for margin boxes.
-/// Measure cache: html → max-content width (measured once at content_width).
+/// Measure cache: (html, page_height as bits) → max-content width.
 /// Render cache: (html, final_width as bits, final_height as bits) → Pageable.
-type MeasureCache = HashMap<String, f32>;
+type MeasureCache = HashMap<(String, u32), f32>;
 type RenderCache = HashMap<(String, u32, u32), Box<dyn Pageable>>;
 
 fn width_key(w: f32) -> u32 {
@@ -199,12 +199,6 @@ pub fn render_to_pdf_with_gcpm(
             crate::paginate::collect_counter_states(&pages)
         };
 
-    let page_size = if config.landscape {
-        config.page_size.landscape()
-    } else {
-        config.page_size
-    };
-
     // Build margin-box CSS: strip display:none rules that the parser
     // injected for running elements (they need to be visible in margin boxes).
     let margin_css = strip_display_none(&gcpm.cleaned_css);
@@ -220,6 +214,20 @@ pub fn render_to_pdf_with_gcpm(
     // Pass 2: render each page with margin boxes
     for (page_idx, page_content) in pages.iter().enumerate() {
         let page_num = page_idx + 1;
+
+        // Resolve per-page size, margin, and landscape from @page rules + CLI overrides
+        let (resolved_size, resolved_margin, resolved_landscape) =
+            crate::gcpm::page_settings::resolve_page_settings(
+                &gcpm.page_settings,
+                page_num,
+                total_pages,
+                config,
+            );
+        let page_size = if resolved_landscape {
+            resolved_size.landscape()
+        } else {
+            resolved_size
+        };
 
         let settings = krilla::page::PageSettings::from_wh(page_size.width, page_size.height)
             .ok_or_else(|| Error::PdfGeneration("Invalid page dimensions".into()))?;
@@ -293,7 +301,8 @@ pub fn render_to_pdf_with_gcpm(
             if !pos.edge().is_some_and(|e| e.is_horizontal()) {
                 continue;
             }
-            if !measure_cache.contains_key(html) {
+            let measure_key = (html.clone(), width_key(page_size.height));
+            measure_cache.entry(measure_key).or_insert_with(|| {
                 let measure_html = format!(
                     "<html><head><style>{}</style></head><body style=\"margin:0;padding:0;\"><div style=\"display:inline-block\">{}</div></body></html>",
                     margin_css, html
@@ -304,17 +313,16 @@ pub fn render_to_pdf_with_gcpm(
                     page_size.height,
                     font_data,
                 );
-                let max_content_width = get_body_child_dimension(&measure_doc, true);
-                measure_cache.insert(html.clone(), max_content_width);
-            }
+                get_body_child_dimension(&measure_doc, true)
+            });
         }
 
         // Stage 1b: Measure max-content height for left/right boxes.
         // Layout at fixed margin width, then read the resulting height.
         for (&pos, html) in &resolved_htmls {
             let fixed_width = match pos.edge() {
-                Some(Edge::Left) => config.margin.left,
-                Some(Edge::Right) => config.margin.right,
+                Some(Edge::Left) => resolved_margin.left,
+                Some(Edge::Right) => resolved_margin.right,
                 _ => continue,
             };
             let hc_key = (html.clone(), width_key(fixed_width));
@@ -342,12 +350,14 @@ pub fn render_to_pdf_with_gcpm(
                 None => continue, // corners
             };
             let size = if edge.is_horizontal() {
-                measure_cache.get(html).copied()
+                measure_cache
+                    .get(&(html.clone(), width_key(page_size.height)))
+                    .copied()
             } else {
                 let fixed_width = if edge == Edge::Left {
-                    config.margin.left
+                    resolved_margin.left
                 } else {
-                    config.margin.right
+                    resolved_margin.right
                 };
                 height_cache
                     .get(&(html.clone(), width_key(fixed_width)))
@@ -364,7 +374,7 @@ pub fn render_to_pdf_with_gcpm(
                 *edge,
                 defined,
                 page_size,
-                config.margin,
+                resolved_margin,
             ));
         }
 
@@ -374,7 +384,7 @@ pub fn render_to_pdf_with_gcpm(
             let rect = all_rects
                 .get(&pos)
                 .copied()
-                .unwrap_or_else(|| pos.bounding_rect(page_size, config.margin));
+                .unwrap_or_else(|| pos.bounding_rect(page_size, resolved_margin));
 
             let cache_key = (html.clone(), width_key(rect.width), width_key(rect.height));
             if !render_cache.contains_key(&cache_key) {
@@ -405,13 +415,15 @@ pub fn render_to_pdf_with_gcpm(
             }
         }
 
-        // Draw body content
+        // Draw body content with resolved per-page margin
+        let page_content_width = page_size.width - resolved_margin.left - resolved_margin.right;
+        let page_content_height = page_size.height - resolved_margin.top - resolved_margin.bottom;
         page_content.draw(
             &mut canvas,
-            config.margin.left,
-            config.margin.top,
-            content_width,
-            content_height,
+            resolved_margin.left,
+            resolved_margin.top,
+            page_content_width,
+            page_content_height,
         );
     }
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -124,9 +124,9 @@ fn parse_datetime(s: &str) -> Option<krilla::metadata::DateTime> {
 }
 
 /// Cached max-content width and render Pageable for margin boxes.
-/// Measure cache: (html, page_height as bits) → max-content width.
+/// Measure cache: html → max-content width (measured once at content_width).
 /// Render cache: (html, final_width as bits, final_height as bits) → Pageable.
-type MeasureCache = HashMap<(String, u32), f32>;
+type MeasureCache = HashMap<String, f32>;
 type RenderCache = HashMap<(String, u32, u32), Box<dyn Pageable>>;
 
 fn width_key(w: f32) -> u32 {
@@ -192,6 +192,18 @@ pub fn render_to_pdf_with_gcpm(
     } else {
         crate::paginate::collect_running_element_states(&pages)
     };
+    let counter_states =
+        if gcpm.counter_mappings.is_empty() && gcpm.content_counter_mappings.is_empty() {
+            vec![BTreeMap::new(); pages.len()]
+        } else {
+            crate::paginate::collect_counter_states(&pages)
+        };
+
+    let page_size = if config.landscape {
+        config.page_size.landscape()
+    } else {
+        config.page_size
+    };
 
     // Build margin-box CSS: strip display:none rules that the parser
     // injected for running elements (they need to be visible in margin boxes).
@@ -208,20 +220,6 @@ pub fn render_to_pdf_with_gcpm(
     // Pass 2: render each page with margin boxes
     for (page_idx, page_content) in pages.iter().enumerate() {
         let page_num = page_idx + 1;
-
-        // Resolve per-page size, margin, and landscape from @page rules + CLI overrides
-        let (resolved_size, resolved_margin, resolved_landscape) =
-            crate::gcpm::page_settings::resolve_page_settings(
-                &gcpm.page_settings,
-                page_num,
-                total_pages,
-                config,
-            );
-        let page_size = if resolved_landscape {
-            resolved_size.landscape()
-        } else {
-            resolved_size
-        };
 
         let settings = krilla::page::PageSettings::from_wh(page_size.width, page_size.height)
             .ok_or_else(|| Error::PdfGeneration("Invalid page dimensions".into()))?;
@@ -273,6 +271,7 @@ pub fn render_to_pdf_with_gcpm(
                 page_num,
                 total_pages,
                 page_idx,
+                &counter_states[page_idx],
             );
             if !content_html.is_empty() {
                 let html = if rule.declarations.is_empty() {
@@ -294,8 +293,7 @@ pub fn render_to_pdf_with_gcpm(
             if !pos.edge().is_some_and(|e| e.is_horizontal()) {
                 continue;
             }
-            let measure_key = (html.clone(), width_key(page_size.height));
-            measure_cache.entry(measure_key).or_insert_with(|| {
+            if !measure_cache.contains_key(html) {
                 let measure_html = format!(
                     "<html><head><style>{}</style></head><body style=\"margin:0;padding:0;\"><div style=\"display:inline-block\">{}</div></body></html>",
                     margin_css, html
@@ -306,16 +304,17 @@ pub fn render_to_pdf_with_gcpm(
                     page_size.height,
                     font_data,
                 );
-                get_body_child_dimension(&measure_doc, true)
-            });
+                let max_content_width = get_body_child_dimension(&measure_doc, true);
+                measure_cache.insert(html.clone(), max_content_width);
+            }
         }
 
         // Stage 1b: Measure max-content height for left/right boxes.
         // Layout at fixed margin width, then read the resulting height.
         for (&pos, html) in &resolved_htmls {
             let fixed_width = match pos.edge() {
-                Some(Edge::Left) => resolved_margin.left,
-                Some(Edge::Right) => resolved_margin.right,
+                Some(Edge::Left) => config.margin.left,
+                Some(Edge::Right) => config.margin.right,
                 _ => continue,
             };
             let hc_key = (html.clone(), width_key(fixed_width));
@@ -343,14 +342,12 @@ pub fn render_to_pdf_with_gcpm(
                 None => continue, // corners
             };
             let size = if edge.is_horizontal() {
-                measure_cache
-                    .get(&(html.clone(), width_key(page_size.height)))
-                    .copied()
+                measure_cache.get(html).copied()
             } else {
                 let fixed_width = if edge == Edge::Left {
-                    resolved_margin.left
+                    config.margin.left
                 } else {
-                    resolved_margin.right
+                    config.margin.right
                 };
                 height_cache
                     .get(&(html.clone(), width_key(fixed_width)))
@@ -367,7 +364,7 @@ pub fn render_to_pdf_with_gcpm(
                 *edge,
                 defined,
                 page_size,
-                resolved_margin,
+                config.margin,
             ));
         }
 
@@ -377,7 +374,7 @@ pub fn render_to_pdf_with_gcpm(
             let rect = all_rects
                 .get(&pos)
                 .copied()
-                .unwrap_or_else(|| pos.bounding_rect(page_size, resolved_margin));
+                .unwrap_or_else(|| pos.bounding_rect(page_size, config.margin));
 
             let cache_key = (html.clone(), width_key(rect.width), width_key(rect.height));
             if !render_cache.contains_key(&cache_key) {
@@ -397,6 +394,7 @@ pub fn render_to_pdf_with_gcpm(
                     assets: None,
                     font_cache: HashMap::new(),
                     string_set_by_node: HashMap::new(),
+                    counter_ops_by_node: HashMap::new(),
                 };
                 let pageable = crate::convert::dom_to_pageable(&render_doc, &mut dummy_ctx);
                 render_cache.insert(cache_key.clone(), pageable);
@@ -407,15 +405,13 @@ pub fn render_to_pdf_with_gcpm(
             }
         }
 
-        // Draw body content with resolved per-page margin
-        let page_content_width = page_size.width - resolved_margin.left - resolved_margin.right;
-        let page_content_height = page_size.height - resolved_margin.top - resolved_margin.bottom;
+        // Draw body content
         page_content.draw(
             &mut canvas,
-            resolved_margin.left,
-            resolved_margin.top,
-            page_content_width,
-            page_content_height,
+            config.margin.left,
+            config.margin.top,
+            content_width,
+            content_height,
         );
     }
 

--- a/crates/fulgur/src/template.rs
+++ b/crates/fulgur/src/template.rs
@@ -187,9 +187,9 @@ mod tests {
     #[test]
     fn test_format_decimal_only() {
         let tmpl = r#"{{ n | numformat(".2f") }}"#;
-        let data = json!({"n": 3.14159});
+        let data = json!({"n": 1.23456});
         let result = render_template("test.html", tmpl, &data).unwrap();
-        assert_eq!(result, "3.14");
+        assert_eq!(result, "1.23");
     }
 
     #[test]

--- a/crates/fulgur/tests/gcpm_integration.rs
+++ b/crates/fulgur/tests/gcpm_integration.rs
@@ -1,6 +1,43 @@
 use fulgur::asset::AssetBundle;
-use fulgur::config::PageSize;
 use fulgur::engine::Engine;
+
+#[test]
+fn test_counter_margin_box_values_correct() {
+    // Verify that counter values actually reach margin boxes correctly
+    // by generating a document with counter-increment on visible elements.
+    let mut assets = AssetBundle::new();
+    assets.add_css(
+        r#"
+        body { counter-reset: chapter; }
+        h2 { counter-increment: chapter; }
+        @page {
+            @bottom-center {
+                content: "Chapter " counter(chapter);
+            }
+        }
+    "#,
+    );
+
+    let engine = Engine::builder().assets(assets).build();
+    // Multiple chapters with enough content to potentially span pages
+    let html = r#"
+        <h2>One</h2><p>Content for chapter one.</p>
+        <h2>Two</h2><p>Content for chapter two.</p>
+        <h2>Three</h2><p>Content for chapter three.</p>
+    "#;
+    let result = engine.render_html(html);
+    assert!(
+        result.is_ok(),
+        "Counter values should reach margin boxes: {:?}",
+        result.err()
+    );
+    // Verify PDF is non-trivial (contains actual content)
+    let pdf_bytes = result.unwrap();
+    assert!(
+        pdf_bytes.len() > 1000,
+        "PDF should contain rendered content with counters"
+    );
+}
 
 #[test]
 fn test_gcpm_header_footer_generates_pdf() {
@@ -585,69 +622,139 @@ fn test_element_default_policy_still_works() {
 }
 
 #[test]
-fn test_gcpm_page_size_from_css() {
-    let html = "<html><body><p>Hello World</p></body></html>";
-    let css = "@page { size: letter; margin: 1in; }";
+fn test_counter_chapter_before_pseudo() {
     let mut assets = AssetBundle::new();
-    assets.add_css(css);
+    assets.add_css(
+        r#"
+        body { counter-reset: chapter; }
+        h2 { counter-increment: chapter; }
+        h2::before { content: counter(chapter) ". "; }
+    "#,
+    );
+
     let engine = Engine::builder().assets(assets).build();
+    let html = "<h2>Introduction</h2><p>Some text here</p><h2>Methods</h2><p>More text</p>";
     let result = engine.render_html(html);
-    assert!(result.is_ok(), "Failed: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "PDF generation with counter in ::before should succeed: {:?}",
+        result.err()
+    );
 }
 
 #[test]
-fn test_gcpm_page_size_cli_overrides_css() {
-    let html = "<html><body><p>Hello World</p></body></html>";
-    let css = "@page { size: letter; }";
+fn test_counter_in_margin_box() {
     let mut assets = AssetBundle::new();
-    assets.add_css(css);
-    let engine = Engine::builder()
-        .page_size(PageSize::A3)
-        .assets(assets)
-        .build();
-    let result = engine.render_html(html);
-    assert!(result.is_ok(), "Failed: {:?}", result.err());
-}
-
-#[test]
-fn test_gcpm_page_margin_from_css() {
-    let html = "<html><body><p>Hello World</p></body></html>";
-    let css = "@page { margin: 10mm; }";
-    let mut assets = AssetBundle::new();
-    assets.add_css(css);
-    let engine = Engine::builder().assets(assets).build();
-    let result = engine.render_html(html);
-    assert!(result.is_ok(), "Failed: {:?}", result.err());
-}
-
-#[test]
-fn test_gcpm_page_size_custom_dimensions() {
-    let html = "<html><body><p>Hello World</p></body></html>";
-    let css = "@page { size: 100mm 200mm; margin: 10mm; }";
-    let mut assets = AssetBundle::new();
-    assets.add_css(css);
-    let engine = Engine::builder().assets(assets).build();
-    let result = engine.render_html(html);
-    assert!(result.is_ok(), "Failed: {:?}", result.err());
-}
-
-#[test]
-fn test_gcpm_page_size_with_margin_boxes() {
-    let html = r#"<html><body>
-        <div class="header">Header</div>
-        <p>Content</p>
-    </body></html>"#;
-    let css = r#"
-        .header { position: running(pageHeader); }
+    assets.add_css(
+        r#"
+        body { counter-reset: chapter; }
+        h2 { counter-increment: chapter; }
         @page {
-            size: A4 landscape;
-            margin: 20mm;
-            @top-center { content: element(pageHeader); }
+            @bottom-center {
+                content: "Chapter " counter(chapter);
+            }
         }
-    "#;
-    let mut assets = AssetBundle::new();
-    assets.add_css(css);
+    "#,
+    );
+
     let engine = Engine::builder().assets(assets).build();
+    let html = "<h2>One</h2><p>Some text</p><h2>Two</h2><p>More text</p>";
     let result = engine.render_html(html);
-    assert!(result.is_ok(), "Failed: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "PDF with counter in margin box should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_counter_upper_roman_style() {
+    let mut assets = AssetBundle::new();
+    assets.add_css(
+        r#"
+        body { counter-reset: chapter; }
+        h2 { counter-increment: chapter; }
+        h2::before { content: counter(chapter, upper-roman) ". "; }
+    "#,
+    );
+
+    let engine = Engine::builder().assets(assets).build();
+    let html = "<h2>A</h2><h2>B</h2><h2>C</h2><h2>D</h2>";
+    let result = engine.render_html(html);
+    assert!(
+        result.is_ok(),
+        "PDF with upper-roman counter should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_counter_set() {
+    let mut assets = AssetBundle::new();
+    assets.add_css(
+        r#"
+        body { counter-reset: chapter; }
+        h2 { counter-increment: chapter; }
+        .reset { counter-set: chapter 10; }
+        h2::before { content: counter(chapter) ". "; }
+    "#,
+    );
+
+    let engine = Engine::builder().assets(assets).build();
+    let html = r#"<h2>One</h2><div class="reset"></div><h2>Eleven</h2>"#;
+    let result = engine.render_html(html);
+    assert!(
+        result.is_ok(),
+        "PDF with counter-set should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_counter_body_and_margin_box() {
+    let mut assets = AssetBundle::new();
+    assets.add_css(
+        r#"
+        body { counter-reset: chapter; }
+        h2 { counter-increment: chapter; }
+        h2::before { content: counter(chapter) ". "; }
+        @page {
+            @bottom-right {
+                content: "Ch. " counter(chapter);
+            }
+        }
+    "#,
+    );
+
+    let engine = Engine::builder().assets(assets).build();
+    let html = "<h2>Intro</h2><p>text</p><h2>Body</h2><p>text</p><h2>End</h2><p>text</p>";
+    let result = engine.render_html(html);
+    assert!(
+        result.is_ok(),
+        "PDF with counter in both body and margin box should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_counter_page_still_works() {
+    let mut assets = AssetBundle::new();
+    assets.add_css(
+        r#"
+        @page {
+            @bottom-center {
+                content: "Page " counter(page) " of " counter(pages);
+            }
+        }
+    "#,
+    );
+
+    let engine = Engine::builder().assets(assets).build();
+    let html = "<p>Hello World</p>";
+    let result = engine.render_html(html);
+    assert!(
+        result.is_ok(),
+        "counter(page) should still work: {:?}",
+        result.err()
+    );
 }

--- a/crates/fulgur/tests/text_decoration_test.rs
+++ b/crates/fulgur/tests/text_decoration_test.rs
@@ -54,7 +54,7 @@ fn text_decoration_styles_render() {
         );
         let pdf = engine
             .render_html(&html)
-            .expect(&format!("render with style={style} should succeed"));
+            .unwrap_or_else(|_| panic!("render with style={style} should succeed"));
         assert!(
             !pdf.is_empty(),
             "PDF with style={style} should not be empty"


### PR DESCRIPTION
## Summary

- CSS カウンター（`counter-reset` / `counter-increment` / `counter-set`）をフル対応
- 本文の `::before` / `::after` とマージンボックスの両方で `counter(name)` / `counter(name, style)` が使用可能
- 基本5スタイル対応: `decimal`, `upper-roman`, `lower-roman`, `upper-alpha`, `lower-alpha`

## Architecture

2段階解決モデル:
1. **DOM前処理（CounterPass）** — レイアウト前にカウンター操作を適用し、`::before`/`::after` の `content: counter()` を解決済み文字列に置換
2. **Render時** — `CounterOpMarkerPageable` からページ別カウンター値を収集し、マージンボックスの `counter()` を解決

## Changes

- **gcpm/mod.rs** — `CounterStyle`, `CounterOp`, `CounterMapping`, `PseudoElement`, `ContentCounterMapping` 型追加。`ContentItem::Counter` を struct variant に拡張
- **gcpm/parser.rs** — `counter(name, style)` パース、`counter-reset/increment/set` プロパティ抽出、`::before`/`::after` 疑似要素セレクタ対応
- **gcpm/counter.rs** — `format_counter()` (roman/alpha変換)、`CounterState` (カウンター値追跡)
- **blitz_adapter.rs** — `CounterPass` DOMパス実装
- **pageable.rs** — `CounterOpMarkerPageable` (ページ分割でカウンター操作を運搬)
- **paginate.rs** — `collect_counter_states()` (ページ別カウンター値収集)
- **engine.rs** — パイプラインに CounterPass 統合
- **render.rs** — マージンボックスでカスタムカウンター値を使用

## Test plan

- [x] Unit tests: 205 passed (26 new)
- [x] Integration tests: 24 passed (6 new) — 本文カウンター、マージンボックスカウンター、スタイル指定、counter-set、既存 counter(page) 互換性
- [x] `cargo clippy` — no new warnings
- [x] `cargo fmt --check` — clean

Closes #fulgur-64q
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * CSSカウンターを包括的にサポート：counter-reset／counter-increment／counter-set、名前付きカウンター、複数スタイル（10進・ローマ・アルファ）
  * ::before/::after とページ余白ボックス向けに解決済みカウンター文字列を生成・注入し、要素単位で正しい表示を反映
  * ページ横断でのカウンター状態を収集・適用してレンダリングに反映

* **テスト**
  * 書式、リセット／増分／セット、疑似要素や余白ボックスでの出力を検証する単体・統合テストを多数追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->