### PR TITLE
fix(security): path traversal defense, panic-safe fd handling, recursion limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /tmp
 .worktrees
 .beads/issues.jsonl
+.env
+.env.*

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 /tmp
 .worktrees
 .beads/issues.jsonl
-.env
-.env.*
+**/.env
+**/.env.*

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -21,32 +21,36 @@ fn suppress_stdout<F: FnOnce() -> T, T>(f: F) -> T {
     #[cfg(unix)]
     {
         use std::os::unix::io::AsRawFd;
+
+        /// Drop guard that restores stdout from a saved file descriptor.
+        struct StdoutGuard {
+            saved_fd: i32,
+        }
+
+        impl Drop for StdoutGuard {
+            fn drop(&mut self) {
+                let _ = std::io::stdout().flush();
+                unsafe { libc::dup2(self.saved_fd, 1) };
+                unsafe { libc::close(self.saved_fd) };
+            }
+        }
+
         let devnull = std::fs::OpenOptions::new()
             .write(true)
             .open("/dev/null")
             .ok();
-        let saved_fd = devnull.as_ref().map(|_| {
-            // dup(1) to save original stdout
+
+        let guard = devnull.as_ref().and_then(|dn| {
             let saved = unsafe { libc::dup(1) };
             if saved < 0 {
-                return -1;
+                return None;
             }
-            // dup2(devnull_fd, 1) to redirect stdout
-            if let Some(ref dn) = devnull {
-                unsafe { libc::dup2(dn.as_raw_fd(), 1) };
-            }
-            saved
+            unsafe { libc::dup2(dn.as_raw_fd(), 1) };
+            Some(StdoutGuard { saved_fd: saved })
         });
 
         let result = f();
-
-        // Restore original stdout
-        if let Some(Some(saved)) = saved_fd.map(|fd| if fd >= 0 { Some(fd) } else { None }) {
-            let _ = std::io::stdout().flush();
-            unsafe { libc::dup2(saved, 1) };
-            unsafe { libc::close(saved) };
-        }
-
+        drop(guard);
         result
     }
 
@@ -122,14 +126,24 @@ pub fn resolve(doc: &mut HtmlDocument) {
     doc.resolve(0.0);
 }
 
+use crate::MAX_DOM_DEPTH;
+
 /// Walk the DOM tree to find the first element with the given tag name.
 /// Returns the node id if found.
 fn find_element_by_tag(doc: &HtmlDocument, tag: &str) -> Option<usize> {
     let root = doc.root_element();
-    find_element_by_tag_recursive(doc, root.id, tag)
+    find_element_by_tag_recursive(doc, root.id, tag, 0)
 }
 
-fn find_element_by_tag_recursive(doc: &HtmlDocument, node_id: usize, tag: &str) -> Option<usize> {
+fn find_element_by_tag_recursive(
+    doc: &HtmlDocument,
+    node_id: usize,
+    tag: &str,
+    depth: usize,
+) -> Option<usize> {
+    if depth >= MAX_DOM_DEPTH {
+        return None;
+    }
     let node = doc.get_node(node_id)?;
     if let Some(el) = node.element_data() {
         if el.name.local.as_ref() == tag {
@@ -137,7 +151,7 @@ fn find_element_by_tag_recursive(doc: &HtmlDocument, node_id: usize, tag: &str) 
         }
     }
     for &child_id in &node.children {
-        if let Some(found) = find_element_by_tag_recursive(doc, child_id, tag) {
+        if let Some(found) = find_element_by_tag_recursive(doc, child_id, tag, depth + 1) {
             return Some(found);
         }
     }
@@ -237,6 +251,11 @@ impl DomPass for LinkStylesheetPass {
 
         let mut css_entries: Vec<(usize, String)> = Vec::new(); // (link_node_id, css_content)
 
+        let canonical_base = match self.base_path.canonicalize() {
+            Ok(p) => p,
+            Err(_) => return,
+        };
+
         let head_children: Vec<usize> = doc
             .get_node(head_id)
             .map(|n| n.children.clone())
@@ -271,15 +290,36 @@ impl DomPass for LinkStylesheetPass {
                 continue;
             }
 
-            // Resolve path
+            // Resolve path — restrict to base_path to prevent path traversal
             let path = if std::path::Path::new(&href).is_absolute() {
                 PathBuf::from(&href)
             } else {
                 self.base_path.join(&href)
             };
 
+            // Canonicalize both paths and verify the resolved path is within base_path.
+            // This prevents directory traversal attacks (e.g. href="../../etc/passwd").
+            let canonical_path = match path.canonicalize() {
+                Ok(p) => p,
+                Err(_) => {
+                    eprintln!(
+                        "Warning: could not resolve stylesheet '{}' (resolved to '{}')",
+                        href,
+                        path.display()
+                    );
+                    continue;
+                }
+            };
+            if !canonical_path.starts_with(&canonical_base) {
+                eprintln!(
+                    "Warning: stylesheet '{}' is outside base path, skipped",
+                    href
+                );
+                continue;
+            }
+
             // Read file (skip with warning if missing)
-            if let Ok(css) = std::fs::read_to_string(&path) {
+            if let Ok(css) = std::fs::read_to_string(&canonical_path) {
                 css_entries.push((child_id, css));
             } else {
                 eprintln!(
@@ -348,12 +388,15 @@ impl DomPass for RunningElementPass {
         }
         let root = doc.root_element();
         let root_id = root.id;
-        self.walk_tree(doc, root_id);
+        self.walk_tree(doc, root_id, 0);
     }
 }
 
 impl RunningElementPass {
-    fn walk_tree(&self, doc: &HtmlDocument, node_id: usize) {
+    fn walk_tree(&self, doc: &HtmlDocument, node_id: usize, depth: usize) {
+        if depth >= MAX_DOM_DEPTH {
+            return;
+        }
         let Some(node) = doc.get_node(node_id) else {
             return;
         };
@@ -373,7 +416,7 @@ impl RunningElementPass {
         }
 
         for &child_id in &node.children {
-            self.walk_tree(doc, child_id);
+            self.walk_tree(doc, child_id, depth + 1);
         }
     }
 
@@ -411,12 +454,15 @@ impl DomPass for StringSetPass {
         }
         let root = doc.root_element();
         let root_id = root.id;
-        self.walk_tree(doc, root_id);
+        self.walk_tree(doc, root_id, 0);
     }
 }
 
 impl StringSetPass {
-    fn walk_tree(&self, doc: &HtmlDocument, node_id: usize) {
+    fn walk_tree(&self, doc: &HtmlDocument, node_id: usize, depth: usize) {
+        if depth >= MAX_DOM_DEPTH {
+            return;
+        }
         let Some(node) = doc.get_node(node_id) else {
             return;
         };
@@ -437,7 +483,7 @@ impl StringSetPass {
 
         // string-set targets stay in document flow — always recurse into children.
         for &child_id in &node.children {
-            self.walk_tree(doc, child_id);
+            self.walk_tree(doc, child_id, depth + 1);
         }
     }
 
@@ -799,7 +845,7 @@ mod tests {
     }
 
     #[test]
-    fn test_link_stylesheet_pass_absolute_path() {
+    fn test_link_stylesheet_pass_absolute_path_within_base() {
         let dir = tempfile::tempdir().unwrap();
         let css_path = dir.path().join("abs.css");
         std::fs::write(&css_path, "body { margin: 0; }").unwrap();
@@ -809,8 +855,9 @@ mod tests {
             css_path.display()
         );
         let mut doc = parse(&html, 400.0, &[]);
+        // base_path is the same dir, so absolute path is allowed
         let pass = LinkStylesheetPass {
-            base_path: PathBuf::from("/nonexistent"),
+            base_path: dir.path().to_path_buf(),
         };
         let ctx = PassContext {
             viewport_width: 400.0,
@@ -821,7 +868,60 @@ mod tests {
         resolve(&mut doc);
         assert!(
             find_element_by_tag(&doc, "style").is_some(),
-            "Expected a <style> element when using absolute path in href"
+            "Expected a <style> element when using absolute path within base_path"
+        );
+    }
+
+    #[test]
+    fn test_link_stylesheet_pass_rejects_path_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        // Create a file outside the sub directory
+        std::fs::write(dir.path().join("secret.css"), "body { color: red; }").unwrap();
+
+        let html = r#"<html><head><link rel="stylesheet" href="../secret.css"></head><body><p>Hello</p></body></html>"#;
+        let mut doc = parse(html, 400.0, &[]);
+        let pass = LinkStylesheetPass {
+            base_path: sub.clone(),
+        };
+        let ctx = PassContext {
+            viewport_width: 400.0,
+            viewport_height: 10000.0,
+            font_data: &[],
+        };
+        apply_passes(&mut doc, &[Box::new(pass)], &ctx);
+        resolve(&mut doc);
+        assert!(
+            find_element_by_tag(&doc, "style").is_none(),
+            "Path traversal outside base_path should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_link_stylesheet_pass_rejects_absolute_outside_base() {
+        let dir = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+        std::fs::write(other.path().join("evil.css"), "body { color: red; }").unwrap();
+
+        let html = format!(
+            r#"<html><head><link rel="stylesheet" href="{}"></head><body><p>Hello</p></body></html>"#,
+            other.path().join("evil.css").display()
+        );
+        let mut doc = parse(&html, 400.0, &[]);
+        let pass = LinkStylesheetPass {
+            base_path: dir.path().to_path_buf(),
+        };
+        let ctx = PassContext {
+            viewport_width: 400.0,
+            viewport_height: 10000.0,
+            font_data: &[],
+        };
+        apply_passes(&mut doc, &[Box::new(pass)], &ctx);
+        resolve(&mut doc);
+        assert!(
+            find_element_by_tag(&doc, "style").is_none(),
+            "Absolute path outside base_path should be rejected"
         );
     }
 }

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -19,6 +19,8 @@ use std::collections::HashMap;
 use std::ops::Deref;
 use std::sync::Arc;
 
+use crate::MAX_DOM_DEPTH;
+
 /// Context for DOM-to-Pageable conversion, bundling all shared state.
 pub struct ConvertContext<'a> {
     pub running_store: &'a RunningElementStore,
@@ -53,10 +55,14 @@ pub fn dom_to_pageable(doc: &HtmlDocument, ctx: &mut ConvertContext<'_>) -> Box<
     if std::env::var("FULGUR_DEBUG").is_ok() {
         debug_print_tree(doc.deref(), root.id, 0);
     }
-    convert_node(doc.deref(), root.id, ctx)
+    convert_node(doc.deref(), root.id, ctx, 0)
 }
 
 fn debug_print_tree(doc: &blitz_dom::BaseDocument, node_id: usize, depth: usize) {
+    if depth >= MAX_DOM_DEPTH {
+        eprintln!("{}... (max depth reached)", "  ".repeat(depth));
+        return;
+    }
     let Some(node) = doc.get_node(node_id) else {
         return;
     };
@@ -86,8 +92,12 @@ fn convert_node(
     doc: &blitz_dom::BaseDocument,
     node_id: usize,
     ctx: &mut ConvertContext<'_>,
+    depth: usize,
 ) -> Box<dyn Pageable> {
-    let result = convert_node_inner(doc, node_id, ctx);
+    if depth >= MAX_DOM_DEPTH {
+        return Box::new(SpacerPageable::new(0.0));
+    }
+    let result = convert_node_inner(doc, node_id, ctx, depth);
     maybe_prepend_string_set(node_id, result, ctx)
 }
 
@@ -174,6 +184,7 @@ fn convert_node_inner(
     doc: &blitz_dom::BaseDocument,
     node_id: usize,
     ctx: &mut ConvertContext<'_>,
+    depth: usize,
 ) -> Box<dyn Pageable> {
     let node = doc.get_node(node_id).unwrap();
     let layout = node.final_layout;
@@ -217,7 +228,7 @@ fn convert_node_inner(
             }
         } else {
             let children: &[usize] = &node.children;
-            let positioned_children = collect_positioned_children(doc, children, ctx);
+            let positioned_children = collect_positioned_children(doc, children, ctx, depth);
             let mut block = BlockPageable::with_positioned_children(positioned_children)
                 .with_style(style)
                 .with_visible(visible);
@@ -242,7 +253,7 @@ fn convert_node_inner(
     if let Some(elem_data) = node.element_data() {
         let tag = elem_data.name.local.as_ref();
         if tag == "table" {
-            return convert_table(doc, node, ctx);
+            return convert_table(doc, node, ctx, depth);
         }
         if tag == "img" {
             if let Some(img) = convert_image(node, ctx.assets) {
@@ -306,7 +317,7 @@ fn convert_node_inner(
     }
 
     // Container node — collect children with Taffy-computed positions
-    let positioned_children = collect_positioned_children(doc, children, ctx);
+    let positioned_children = collect_positioned_children(doc, children, ctx, depth);
 
     let style = extract_block_style(node, ctx.assets);
     let has_style = style.has_visual_style() || style.has_radius();
@@ -333,6 +344,7 @@ fn collect_positioned_children(
     doc: &blitz_dom::BaseDocument,
     child_ids: &[usize],
     ctx: &mut ConvertContext<'_>,
+    depth: usize,
 ) -> Vec<PositionedChild> {
     let mut result = Vec::new();
     let mut pending_running_markers: Vec<RunningElementMarkerPageable> = Vec::new();
@@ -388,7 +400,7 @@ fn collect_positioned_children(
             if let Some(marker) = take_running_marker(child_id, ctx) {
                 pending_running_markers.push(marker);
             }
-            let mut nested = collect_positioned_children(doc, &child_node.children, ctx);
+            let mut nested = collect_positioned_children(doc, &child_node.children, ctx, depth + 1);
             // Flush pending running markers to the first real nested child so
             // they travel with the flattened content on page break. Without
             // this, the markers would skip over the container's children and
@@ -410,7 +422,7 @@ fn collect_positioned_children(
             continue;
         }
 
-        let mut child_pageable = convert_node(doc, child_id, ctx);
+        let mut child_pageable = convert_node(doc, child_id, ctx, depth + 1);
         if !pending_running_markers.is_empty() {
             child_pageable = Box::new(RunningElementWrapperPageable::new(
                 std::mem::take(&mut pending_running_markers),
@@ -491,6 +503,7 @@ fn convert_table(
     doc: &blitz_dom::BaseDocument,
     node: &Node,
     ctx: &mut ConvertContext<'_>,
+    depth: usize,
 ) -> Box<dyn Pageable> {
     let layout = node.final_layout;
     let width = layout.size.width;
@@ -514,6 +527,7 @@ fn convert_table(
             &mut header_cells,
             &mut body_cells,
             ctx,
+            depth,
         );
     }
 
@@ -554,7 +568,11 @@ fn collect_table_cells(
     header_cells: &mut Vec<PositionedChild>,
     body_cells: &mut Vec<PositionedChild>,
     ctx: &mut ConvertContext<'_>,
+    depth: usize,
 ) {
+    if depth >= MAX_DOM_DEPTH {
+        return;
+    }
     let Some(node) = doc.get_node(node_id) else {
         return;
     };
@@ -585,6 +603,7 @@ fn collect_table_cells(
                 header_cells,
                 body_cells,
                 ctx,
+                depth + 1,
             );
             continue;
         }
@@ -595,7 +614,7 @@ fn collect_table_cells(
         }
 
         // Actual cell (td/th) — convert and add to appropriate group
-        let cell_pageable = convert_node(doc, child_id, ctx);
+        let cell_pageable = convert_node(doc, child_id, ctx, depth + 1);
         let positioned = PositionedChild {
             child: cell_pageable,
             x: child_layout.location.x,

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -346,6 +346,9 @@ fn collect_positioned_children(
     ctx: &mut ConvertContext<'_>,
     depth: usize,
 ) -> Vec<PositionedChild> {
+    if depth >= MAX_DOM_DEPTH {
+        return Vec::new();
+    }
     let mut result = Vec::new();
     let mut pending_running_markers: Vec<RunningElementMarkerPageable> = Vec::new();
 

--- a/crates/fulgur/src/gcpm/running.rs
+++ b/crates/fulgur/src/gcpm/running.rs
@@ -84,13 +84,17 @@ impl RunningElementStore {
 /// handles styling in the re-layout pass.
 pub fn serialize_node(doc: &blitz_dom::BaseDocument, node_id: usize) -> String {
     let mut output = String::new();
-    write_node(doc, node_id, &mut output);
+    write_node(doc, node_id, &mut output, 0);
     output
 }
 
-fn write_node(doc: &blitz_dom::BaseDocument, node_id: usize, writer: &mut String) {
+fn write_node(doc: &blitz_dom::BaseDocument, node_id: usize, writer: &mut String, depth: usize) {
+    use crate::MAX_DOM_DEPTH;
     use blitz_dom::NodeData;
 
+    if depth >= MAX_DOM_DEPTH {
+        return;
+    }
     let Some(node) = doc.get_node(node_id) else {
         return;
     };
@@ -119,7 +123,7 @@ fn write_node(doc: &blitz_dom::BaseDocument, node_id: usize, writer: &mut String
             } else {
                 writer.push('>');
                 for &child_id in &node.children {
-                    write_node(doc, child_id, writer);
+                    write_node(doc, child_id, writer, depth + 1);
                 }
                 writer.push_str("</");
                 writer.push_str(tag);

--- a/crates/fulgur/src/gcpm/string_set.rs
+++ b/crates/fulgur/src/gcpm/string_set.rs
@@ -54,11 +54,16 @@ impl Default for StringSetStore {
 /// newlines and indentation.
 pub fn extract_text_content(doc: &blitz_dom::BaseDocument, node_id: usize) -> String {
     let mut raw = String::new();
-    collect_text(doc, node_id, &mut raw);
+    collect_text(doc, node_id, &mut raw, 0);
     normalize_whitespace(&raw)
 }
 
-fn collect_text(doc: &blitz_dom::BaseDocument, node_id: usize, out: &mut String) {
+fn collect_text(doc: &blitz_dom::BaseDocument, node_id: usize, out: &mut String, depth: usize) {
+    use crate::MAX_DOM_DEPTH;
+
+    if depth >= MAX_DOM_DEPTH {
+        return;
+    }
     let Some(node) = doc.get_node(node_id) else {
         return;
     };
@@ -77,7 +82,7 @@ fn collect_text(doc: &blitz_dom::BaseDocument, node_id: usize, out: &mut String)
         blitz_dom::NodeData::Text(text_data) => out.push_str(&text_data.content),
         _ => {
             for &child_id in &node.children {
-                collect_text(doc, child_id, out);
+                collect_text(doc, child_id, out, depth + 1);
             }
         }
     }

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -1,3 +1,7 @@
+/// Maximum DOM tree depth before recursion is cut off. Prevents stack overflow
+/// from pathologically deep HTML input.
+pub(crate) const MAX_DOM_DEPTH: usize = 512;
+
 pub mod asset;
 pub mod background;
 pub mod blitz_adapter;


### PR DESCRIPTION
## Summary

セキュリティレビューで発見された脆弱性を修正。

- **CRITICAL**: `.env`/`.env.*` を `.gitignore` に追加（APIキーの誤コミット防止）
- **HIGH**: `LinkStylesheetPass` にパストラバーサル防御を追加。`canonicalize()` + `starts_with(base_path)` で `href="../../etc/passwd"` 等の攻撃を阻止。テスト3件追加
- **HIGH**: `suppress_stdout` に Drop ガードパターンを導入。パニック時も stdout の fd が確実に復元される
- **MEDIUM**: 全再帰 DOM ウォーク関数に `MAX_DOM_DEPTH=512` 制限を追加。深くネストした HTML によるスタックオーバーフロー（DoS）を防止

## Test plan

- [x] `cargo test --lib -- --test-threads=1` — 全207テスト合格
- [x] `cargo fmt --check` — クリーン
- [x] `cargo clippy` — クリーン
- [x] 新規テスト: `test_link_stylesheet_pass_rejects_path_traversal`
- [x] 新規テスト: `test_link_stylesheet_pass_rejects_absolute_outside_base`
- [x] 新規テスト: `test_link_stylesheet_pass_absolute_path_within_base`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/60" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * DOMの深いネストに対する再帰深度制限を導入し、極端に深いHTMLでのクラッシュや無限再帰を防止しました。
  * スタイルシート読み込み時のパス検証を強化し、パストラバーサルや想定外の外部参照を防止しました。

* **Chores**
  * 環境ファイル（`.env` および `.env.*`）をバージョン管理から除外しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->