### PR TITLE
fix(blitz): revert BLITZ_LOCK, remove suppress_stdout fd 1 race

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,14 +63,20 @@ HTML string → Blitz (parse/style/layout) → Pageable tree → Page splitting 
 
 ### Gotchas
 
-- Blitz (`blitz-dom 0.2.4`) has a runtime data race in `BaseDocument::new()` /
-  stylo global state init that causes silent exit (EXIT=0, no panic, no test
-  output) when called concurrently from the same process.
-  `blitz_adapter::*` is gated by a `static BLITZ_LOCK: Mutex<()>` so that
-  `Engine` is safe to share across threads — calls are serialized internally.
-  True parallelism is impossible; for batch throughput use process-level
-  parallelism (gunicorn/puma workers, multiple `fulgur render` invocations).
-  Background and rationale: `docs/plans/2026-04-11-blitz-thread-safety-investigation.md`.
+- **Blitz is thread-safe** (contrary to earlier belief). Multiple threads can
+  call `blitz_adapter::parse` / `resolve` / `apply_passes` concurrently on
+  independent documents. The previous "Blitz not thread-safe" note was based
+  on a misdiagnosis — the real race was in fulgur's own `suppress_stdout`
+  helper, which has been removed. See
+  `docs/plans/2026-04-11-blitz-thread-safety-investigation.md` for the full
+  root-cause analysis.
+- **Blitz prints html5ever parse errors via `println!` to stdout** during
+  `TreeSink::finish`. This is noise from dependencies, not fulgur. Library
+  callers that need clean stdout must redirect fd 1 at their own call site —
+  `fulgur-cli` does this via `StdoutIsolator` for the render command so the
+  `-o -` mode does not corrupt PDF output. Multi-threaded callers must not
+  manipulate fd 1 process-wide; there is no thread-safe way to suppress
+  blitz's output in-process short of an upstream patch.
 - Use `BTreeMap` (not `HashMap`) for iteration that affects PDF output (determinism)
 - Blitz: `!important` unreliable, `padding-top` on inline roots ignored (use `margin-top`)
 - `cargo fmt --check` enforced by CI

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,7 +690,6 @@ dependencies = [
  "blitz-traits",
  "cssparser",
  "krilla",
- "libc",
  "minijinja",
  "parley",
  "serde_json",
@@ -706,6 +705,7 @@ version = "0.4.3"
 dependencies = [
  "clap",
  "fulgur",
+ "libc",
  "serde_json",
 ]
 

--- a/crates/fulgur-cli/Cargo.toml
+++ b/crates/fulgur-cli/Cargo.toml
@@ -19,3 +19,6 @@ path = "src/main.rs"
 fulgur = { version = "0.4.3", path = "../fulgur" }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/crates/fulgur-cli/src/main.rs
+++ b/crates/fulgur-cli/src/main.rs
@@ -52,6 +52,13 @@ impl StdoutIsolator {
 
     /// Write the given bytes to the saved real stdout fd, bypassing the
     /// process-wide fd 1 (which is currently pointing at stderr).
+    ///
+    /// Retries on `EINTR` to match the semantics of
+    /// `std::io::Write::write_all`, which we are replacing at the syscall
+    /// level. Without this, a signal delivered mid-write (e.g. `SIGWINCH`
+    /// on terminal resize, `SIGCHLD` from a child process, or a timer
+    /// signal) would surface as a spurious `Interrupted system call`
+    /// failure.
     fn write_all(&self, mut data: &[u8]) -> std::io::Result<()> {
         while !data.is_empty() {
             let written = unsafe {
@@ -62,7 +69,11 @@ impl StdoutIsolator {
                 )
             };
             if written < 0 {
-                return Err(std::io::Error::last_os_error());
+                let err = std::io::Error::last_os_error();
+                if err.kind() == std::io::ErrorKind::Interrupted {
+                    continue;
+                }
+                return Err(err);
             }
             data = &data[written as usize..];
         }

--- a/crates/fulgur-cli/src/main.rs
+++ b/crates/fulgur-cli/src/main.rs
@@ -58,7 +58,8 @@ impl StdoutIsolator {
     /// level. Without this, a signal delivered mid-write (e.g. `SIGWINCH`
     /// on terminal resize, `SIGCHLD` from a child process, or a timer
     /// signal) would surface as a spurious `Interrupted system call`
-    /// failure.
+    /// failure. A `0`-byte return on a non-empty buffer is treated as
+    /// `WriteZero` to prevent an infinite loop.
     fn write_all(&self, mut data: &[u8]) -> std::io::Result<()> {
         while !data.is_empty() {
             let written = unsafe {
@@ -74,6 +75,12 @@ impl StdoutIsolator {
                     continue;
                 }
                 return Err(err);
+            }
+            if written == 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::WriteZero,
+                    "libc::write returned 0 bytes for a non-empty buffer",
+                ));
             }
             data = &data[written as usize..];
         }
@@ -450,9 +457,30 @@ fn main() {
             // and (b) so they don't pollute the user's terminal stdout in
             // file-output mode. The isolator redirects fd 1 -> fd 2 for the
             // duration of the render.
+            //
+            // Install failure handling depends on the output mode:
+            // * `-o -` (writing PDF to stdout) MUST have the isolator — a
+            //   failure would leave dependency noise free to corrupt the PDF
+            //   bytes. Abort with a clear error so the user can investigate.
+            // * File output can tolerate an install failure: the worst case
+            //   is blitz parse-error lines leaking to the user's terminal,
+            //   which is UX noise but not a correctness bug.
             let to_stdout = output.as_os_str() == "-";
             #[cfg(unix)]
-            let stdout_isolator = StdoutIsolator::install();
+            let stdout_isolator = {
+                let iso = StdoutIsolator::install();
+                if to_stdout && iso.is_none() {
+                    eprintln!(
+                        "Error: failed to isolate stdout for `-o -` output. \
+                         Refusing to write PDF bytes without protection — \
+                         dependency output could corrupt the stream. \
+                         Retry with `-o <file>` or investigate the environment \
+                         (fd 1 closed? per-process fd limit reached?)."
+                    );
+                    std::process::exit(1);
+                }
+                iso
+            };
 
             let pdf = if data.is_some() {
                 engine.render()
@@ -466,21 +494,28 @@ fn main() {
 
             if to_stdout {
                 #[cfg(unix)]
-                if let Some(ref iso) = stdout_isolator {
+                {
+                    // Install is verified above for `-o -` mode, so the
+                    // isolator is guaranteed to be Some here.
+                    let iso = stdout_isolator
+                        .as_ref()
+                        .expect("isolator install verified non-None for -o -");
                     iso.write_all(&pdf).unwrap_or_else(|e| {
                         eprintln!("Error writing to stdout: {e}");
                         std::process::exit(1);
                     });
-                    return;
                 }
-                // Non-unix fallback, or isolator install failed: write through
-                // std::io::stdout() without protection. Any noise from the
-                // render pipeline will be interleaved with the PDF bytes.
-                use std::io::Write;
-                std::io::stdout().write_all(&pdf).unwrap_or_else(|e| {
-                    eprintln!("Error writing to stdout: {e}");
-                    std::process::exit(1);
-                });
+                #[cfg(not(unix))]
+                {
+                    // Non-unix build: no StdoutIsolator available. Dependency
+                    // output may interleave with the PDF bytes; the Unix path
+                    // is the supported configuration for `-o -`.
+                    use std::io::Write;
+                    std::io::stdout().write_all(&pdf).unwrap_or_else(|e| {
+                        eprintln!("Error writing to stdout: {e}");
+                        std::process::exit(1);
+                    });
+                }
             } else {
                 std::fs::write(&output, &pdf).unwrap_or_else(|e| {
                     eprintln!("Error writing to {}: {e}", output.display());

--- a/crates/fulgur-cli/src/main.rs
+++ b/crates/fulgur-cli/src/main.rs
@@ -4,6 +4,84 @@ use fulgur::config::{Margin, PageSize};
 use fulgur::engine::Engine;
 use std::path::PathBuf;
 
+/// Isolate the real stdout from noise emitted by the render pipeline so that
+/// PDF bytes written to stdout (`-o -`) cannot be corrupted by incidental
+/// output from dependencies.
+///
+/// `blitz-html` prints `println!("ERROR: {msg}")` for every non-fatal
+/// html5ever parse error in its `TreeSink::finish` implementation. When fulgur
+/// renders to stdout, those messages would be written before the PDF bytes,
+/// producing a file that does not start with `%PDF-` and is therefore invalid.
+///
+/// The isolator duplicates fd 1 (real stdout), remaps fd 1 to fd 2 (stderr)
+/// so any stray `println!` goes to stderr where the user can see it, and
+/// writes PDF bytes directly to the saved fd via `libc::write`. On Drop the
+/// real stdout is restored.
+///
+/// This is safe because the CLI is strictly single-threaded during the render
+/// phase — unlike the previous `suppress_stdout` helper inside `blitz_adapter`
+/// which was shared by multi-threaded library callers and had a race in its
+/// `dup2` manipulation (see
+/// `docs/plans/2026-04-11-blitz-thread-safety-investigation.md`).
+#[cfg(unix)]
+struct StdoutIsolator {
+    saved_fd: libc::c_int,
+}
+
+#[cfg(unix)]
+impl StdoutIsolator {
+    /// Install the isolator. Returns `None` if either `dup(1)` or `dup2(2, 1)`
+    /// fails, in which case the caller should fall back to an unisolated
+    /// write.
+    fn install() -> Option<Self> {
+        use std::io::Write;
+        // Flush any pending stdout buffers before redirecting so nothing is
+        // left in std's userland buffer pointing at the old fd.
+        let _ = std::io::stdout().flush();
+
+        let saved = unsafe { libc::dup(1) };
+        if saved < 0 {
+            return None;
+        }
+        if unsafe { libc::dup2(2, 1) } < 0 {
+            unsafe { libc::close(saved) };
+            return None;
+        }
+        Some(Self { saved_fd: saved })
+    }
+
+    /// Write the given bytes to the saved real stdout fd, bypassing the
+    /// process-wide fd 1 (which is currently pointing at stderr).
+    fn write_all(&self, mut data: &[u8]) -> std::io::Result<()> {
+        while !data.is_empty() {
+            let written = unsafe {
+                libc::write(
+                    self.saved_fd,
+                    data.as_ptr() as *const libc::c_void,
+                    data.len(),
+                )
+            };
+            if written < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            data = &data[written as usize..];
+        }
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+impl Drop for StdoutIsolator {
+    fn drop(&mut self) {
+        // Restore fd 1 to the real stdout so any final messages the process
+        // prints (e.g. panic output on failure paths) land in the right place.
+        unsafe {
+            libc::dup2(self.saved_fd, 1);
+            libc::close(self.saved_fd);
+        }
+    }
+}
+
 #[derive(Parser)]
 #[command(name = "fulgur", version, about = "HTML to PDF converter")]
 struct Cli {
@@ -354,6 +432,17 @@ fn main() {
 
             let engine = builder.build();
 
+            // Isolate stdout BEFORE rendering for both output modes: blitz-html
+            // prints `println!("ERROR: {e}")` for every non-fatal html5ever
+            // parse-error recovery, and we want those on stderr where they
+            // belong (a) so they don't corrupt the PDF stream in `-o -` mode,
+            // and (b) so they don't pollute the user's terminal stdout in
+            // file-output mode. The isolator redirects fd 1 -> fd 2 for the
+            // duration of the render.
+            let to_stdout = output.as_os_str() == "-";
+            #[cfg(unix)]
+            let stdout_isolator = StdoutIsolator::install();
+
             let pdf = if data.is_some() {
                 engine.render()
             } else {
@@ -364,7 +453,18 @@ fn main() {
                 std::process::exit(1);
             });
 
-            if output.as_os_str() == "-" {
+            if to_stdout {
+                #[cfg(unix)]
+                if let Some(ref iso) = stdout_isolator {
+                    iso.write_all(&pdf).unwrap_or_else(|e| {
+                        eprintln!("Error writing to stdout: {e}");
+                        std::process::exit(1);
+                    });
+                    return;
+                }
+                // Non-unix fallback, or isolator install failed: write through
+                // std::io::stdout() without protection. Any noise from the
+                // render pipeline will be interleaved with the PDF bytes.
                 use std::io::Write;
                 std::io::stdout().write_all(&pdf).unwrap_or_else(|e| {
                     eprintln!("Error writing to stdout: {e}");

--- a/crates/fulgur/Cargo.toml
+++ b/crates/fulgur/Cargo.toml
@@ -11,9 +11,6 @@ readme = "../../README.md"
 keywords = ["pdf", "html", "css", "converter"]
 categories = ["text-processing", "command-line-utilities"]
 
-[target.'cfg(unix)'.dependencies]
-libc = "0.2"
-
 [dependencies]
 cssparser = "0.35"
 krilla = "0.6.0"

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -1,88 +1,31 @@
 //! Thin adapter over Blitz APIs. All Blitz-specific code is isolated here
 //! so that upstream API changes only require changes in this module.
+//!
+//! # Thread safety
+//!
+//! Blitz (as of `blitz-dom 0.2.4` / `blitz-html 0.2.0`) is thread-safe for the
+//! operations fulgur uses: multiple threads may call `parse`, `resolve`, and
+//! pass application concurrently on independent documents. The adapter does
+//! not take any process-wide lock.
+//!
+//! # Stdout hygiene
+//!
+//! `blitz-html` prints `println!("ERROR: {error}")` in its `TreeSink::finish`
+//! implementation for every non-fatal html5ever parse error (unclosed tags,
+//! unexpected tokens, etc.). fulgur does *not* suppress these at the library
+//! level because doing so required manipulating process-wide fd 1, which is
+//! fundamentally racy in multi-threaded contexts. Callers that need clean
+//! stdout (notably `fulgur-cli` when rendering to stdout with `-o -`) must
+//! redirect fd 1 at their own call site where single-threaded execution is
+//! guaranteed. See `docs/plans/2026-04-11-blitz-thread-safety-investigation.md`
+//! for the full investigation and rationale.
 
 use blitz_dom::DocumentConfig;
 use blitz_html::HtmlDocument;
 use blitz_traits::shell::{ColorScheme, Viewport};
 use parley::FontContext;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
-
-/// Process-wide lock that serializes every Blitz API call.
-///
-/// Blitz (`blitz-dom 0.2.4`) has a runtime data race in `BaseDocument::new()` /
-/// stylo global state initialization that causes a silent exit (EXIT=0, no
-/// panic, no test output) when called concurrently from multiple threads in the
-/// same process. The race is `timing-dependent` — under `strace` slowdown the
-/// tests pass; without it they silently fail.
-///
-/// We serialize all Blitz-touching code through this lock so that fulgur's
-/// `Engine` can be safely shared across threads (web servers, test runners,
-/// Python/Ruby bindings under thread pools). True parallelism is impossible
-/// with this constraint, so for batch throughput use process-level parallelism
-/// (gunicorn workers, puma workers, multiple `fulgur render` invocations).
-///
-/// Every public function in this module that touches Blitz state is gated by
-/// this lock: `parse`, `apply_passes`, `apply_single_pass`, and `resolve`.
-/// `parse_and_layout` inherits the gating from the functions it composes.
-/// Callers that need to invoke a `DomPass` outside of `apply_passes` must go
-/// through `apply_single_pass` so the serialization guarantee is preserved.
-///
-/// See `docs/plans/2026-04-11-blitz-thread-safety-investigation.md` for the
-/// full investigation, evidence, and rationale.
-static BLITZ_LOCK: Mutex<()> = Mutex::new(());
-
-/// Suppress stdout during a closure. Blitz's HTML parser unconditionally prints
-/// `println!("ERROR: {error}")` for non-fatal parse errors (e.g., "Unexpected token").
-/// These are html5ever's error-recovery messages and do not indicate real failures.
-fn suppress_stdout<F: FnOnce() -> T, T>(f: F) -> T {
-    use std::io::Write;
-
-    // Flush any pending stdout first
-    let _ = std::io::stdout().flush();
-
-    // On Unix, redirect fd 1 to /dev/null temporarily
-    #[cfg(unix)]
-    {
-        use std::os::unix::io::AsRawFd;
-
-        /// Drop guard that restores stdout from a saved file descriptor.
-        struct StdoutGuard {
-            saved_fd: i32,
-        }
-
-        impl Drop for StdoutGuard {
-            fn drop(&mut self) {
-                let _ = std::io::stdout().flush();
-                unsafe { libc::dup2(self.saved_fd, 1) };
-                unsafe { libc::close(self.saved_fd) };
-            }
-        }
-
-        let devnull = std::fs::OpenOptions::new()
-            .write(true)
-            .open("/dev/null")
-            .ok();
-
-        let guard = devnull.as_ref().and_then(|dn| {
-            let saved = unsafe { libc::dup(1) };
-            if saved < 0 {
-                return None;
-            }
-            unsafe { libc::dup2(dn.as_raw_fd(), 1) };
-            Some(StdoutGuard { saved_fd: saved })
-        });
-
-        let result = f();
-        drop(guard);
-        result
-    }
-
-    #[cfg(not(unix))]
-    {
-        f()
-    }
-}
+use std::sync::Arc;
 
 /// Parse HTML and return a fully resolved document (styles + layout computed).
 ///
@@ -115,8 +58,6 @@ pub trait DomPass {
 
 /// Parse HTML into a document without resolving styles or layout.
 pub fn parse(html: &str, viewport_width: f32, font_data: &[Arc<Vec<u8>>]) -> HtmlDocument {
-    let _guard = BLITZ_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-
     let viewport = Viewport::new(viewport_width as u32, 10000, 1.0, ColorScheme::Light);
 
     let font_ctx = if font_data.is_empty() {
@@ -137,36 +78,18 @@ pub fn parse(html: &str, viewport_width: f32, font_data: &[Arc<Vec<u8>>]) -> Htm
         ..DocumentConfig::default()
     };
 
-    suppress_stdout(|| HtmlDocument::from_html(html, config))
+    HtmlDocument::from_html(html, config)
 }
 
 /// Apply a sequence of DOM passes to a parsed document.
 pub fn apply_passes(doc: &mut HtmlDocument, passes: &[Box<dyn DomPass>], ctx: &PassContext<'_>) {
-    let _guard = BLITZ_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     for pass in passes {
         pass.apply(doc, ctx);
     }
 }
 
-/// Apply a single `DomPass` to a document while holding `BLITZ_LOCK`.
-///
-/// Use this when a caller needs to invoke a typed pass directly (for example,
-/// to retain access to a pass-specific accessor like `into_running_store` after
-/// the pass runs). Calling `DomPass::apply` directly from outside this module
-/// bypasses the lock and breaks the serialization guarantee documented on
-/// `BLITZ_LOCK`.
-pub fn apply_single_pass<P: DomPass + ?Sized>(
-    pass: &P,
-    doc: &mut HtmlDocument,
-    ctx: &PassContext<'_>,
-) {
-    let _guard = BLITZ_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-    pass.apply(doc, ctx);
-}
-
 /// Resolve styles (Stylo) and compute layout (Taffy).
 pub fn resolve(doc: &mut HtmlDocument) {
-    let _guard = BLITZ_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     doc.resolve(0.0);
 }
 

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -88,6 +88,22 @@ pub fn apply_passes(doc: &mut HtmlDocument, passes: &[Box<dyn DomPass>], ctx: &P
     }
 }
 
+/// Apply a single `DomPass` to a document.
+///
+/// Thin adapter that lets callers invoke a typed pass directly while still
+/// going through `blitz_adapter`, preserving the module's role as the single
+/// Blitz API surface (see `CLAUDE.md`: "Adapter isolation: Blitz API surface
+/// is contained in `blitz_adapter.rs`"). Callers can retain access to
+/// pass-specific accessors (for example `RunningElementPass::into_running_store`)
+/// by borrowing the pass here rather than consuming it via `apply_passes`.
+pub fn apply_single_pass<P: DomPass + ?Sized>(
+    pass: &P,
+    doc: &mut HtmlDocument,
+    ctx: &PassContext<'_>,
+) {
+    pass.apply(doc, ctx);
+}
+
 /// Resolve styles (Stylo) and compute layout (Taffy).
 pub fn resolve(doc: &mut HtmlDocument) {
     doc.resolve(0.0);

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -1,5 +1,4 @@
 use crate::asset::AssetBundle;
-use crate::blitz_adapter::DomPass;
 use crate::config::{Config, ConfigBuilder, Margin, PageSize};
 use crate::convert::ConvertContext;
 use crate::error::Result;
@@ -95,7 +94,7 @@ impl Engine {
         // Extract running elements via DomPass (before resolve)
         let running_store = if !gcpm.running_mappings.is_empty() {
             let pass = crate::blitz_adapter::RunningElementPass::new(gcpm.running_mappings.clone());
-            pass.apply(&mut doc, &ctx);
+            crate::blitz_adapter::apply_single_pass(&pass, &mut doc, &ctx);
             pass.into_running_store()
         } else {
             crate::gcpm::running::RunningElementStore::new()
@@ -104,7 +103,7 @@ impl Engine {
         // Extract string-set values via DomPass
         let string_set_store = if !gcpm.string_set_mappings.is_empty() {
             let pass = crate::blitz_adapter::StringSetPass::new(gcpm.string_set_mappings.clone());
-            pass.apply(&mut doc, &ctx);
+            crate::blitz_adapter::apply_single_pass(&pass, &mut doc, &ctx);
             pass.into_store()
         } else {
             crate::gcpm::string_set::StringSetStore::new()

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -1,4 +1,5 @@
 use crate::asset::AssetBundle;
+use crate::blitz_adapter::DomPass;
 use crate::config::{Config, ConfigBuilder, Margin, PageSize};
 use crate::convert::ConvertContext;
 use crate::error::Result;
@@ -94,7 +95,7 @@ impl Engine {
         // Extract running elements via DomPass (before resolve)
         let running_store = if !gcpm.running_mappings.is_empty() {
             let pass = crate::blitz_adapter::RunningElementPass::new(gcpm.running_mappings.clone());
-            crate::blitz_adapter::apply_single_pass(&pass, &mut doc, &ctx);
+            pass.apply(&mut doc, &ctx);
             pass.into_running_store()
         } else {
             crate::gcpm::running::RunningElementStore::new()
@@ -103,7 +104,7 @@ impl Engine {
         // Extract string-set values via DomPass
         let string_set_store = if !gcpm.string_set_mappings.is_empty() {
             let pass = crate::blitz_adapter::StringSetPass::new(gcpm.string_set_mappings.clone());
-            crate::blitz_adapter::apply_single_pass(&pass, &mut doc, &ctx);
+            pass.apply(&mut doc, &ctx);
             pass.into_store()
         } else {
             crate::gcpm::string_set::StringSetStore::new()

--- a/docs/plans/2026-04-11-blitz-thread-safety-investigation.md
+++ b/docs/plans/2026-04-11-blitz-thread-safety-investigation.md
@@ -4,7 +4,9 @@
 - **対象バージョン**: `blitz-dom 0.2.4` / `blitz-html 0.2.0` / `blitz-traits 0.2.0`
 - **動機**: fulgur のスクリプト言語バインディング設計（`fulgur-d3r`, `fulgur-i5c`, `fulgur-0x0`）にあたり、Blitz の thread-safety を正しく把握する
 - **きっかけ**: `CLAUDE.md` の Gotchas に「Blitz not thread-safe / integration tests require `--test-threads=1`」と書かれているが、根拠が明確でなかった
-- **結論**: CLAUDE.md の **結論は正しい**（Blitz は同一プロセス内の並列実行で silent に死ぬ）。ただし **理由は当初の仮説と全く違う**
+- **結論（訂正版）**: **Blitz は実は thread-safe だった**。silent exit の原因は fulgur 自身の `blitz_adapter::suppress_stdout` が fd 1 をプロセス全体で dup2 する設計で、並列実行で race していた。PR #61 で入れた `BLITZ_LOCK` は症状を偶然塞ぐだけの誤った修正だった
+
+> **重要**: 本レポートの本文は初期調査時の内容で、**前半の結論は誤り**だった。末尾の「訂正 addendum (2026-04-11)」を優先して読むこと。前半を残しているのは、同じ誤診を繰り返さないための戒めとして。
 
 ## TL;DR
 
@@ -270,15 +272,112 @@ silent exit (panic message なし、EXIT=0) なのが厄介。デバッグが極
 
 ## アクションアイテム
 
-> ステータスは PR #61 マージ時点での状況。未着手は E のみ。
+> ステータスは PR #61 マージ時点での状況。末尾の訂正 addendum により PR #61 の方針自体が再評価された。
 
 | 順 | 内容 | ステータス |
 |---|---|---|
-| A | `blitz_adapter` に `static BLITZ_LOCK: Mutex<()>` を入れて `--test-threads=4` で動くか検証 | 完了 (PR #61) |
-| B | CLAUDE.md の Gotcha を実情に合わせて書き直す | 完了 (PR #61) |
-| C | `fulgur-d3r` の description を本レポートの内容で書き換え | 完了 (beads: closed) |
-| D | `project memory` に Blitz thread-safety の真相を保存（再調査回避） | 完了 (`project_blitz_thread_safety.md`) |
-| E | DioxusLabs/blitz に upstream issue 提出（silent exit on parallel `BaseDocument::new()`）| 未着手（余裕があれば） |
+| A | `blitz_adapter` に `static BLITZ_LOCK: Mutex<()>` を入れて `--test-threads=4` で動くか検証 | **取り消し** — 誤った修正だった |
+| B | CLAUDE.md の Gotcha を実情に合わせて書き直す | 完了 (PR #61) → 後続 PR で再訂正 |
+| C | `fulgur-d3r` の description を本レポートの内容で書き換え | 完了 → 再オープンが必要 |
+| D | `project memory` に Blitz thread-safety の真相を保存（再調査回避） | 完了 → 後続で訂正 |
+| E | DioxusLabs/blitz に upstream issue 提出（silent exit on parallel `BaseDocument::new()`）| **取り下げ** — blitz にバグはなかった |
+
+---
+
+## 訂正 addendum (2026-04-11 later)
+
+### 背景
+
+PR #61 マージ後、upstream blitz に issue を提出する準備として **クリーンな最小再現コード**を作ろうとしたところ、pure blitz API (`HtmlDocument::from_html` + `doc.resolve`) では race を再現できないことが判明した。fulgur の full engine pipeline を経由してはじめて silent exit が出る。そこで切り分けを続けた結果、**root cause は fulgur 自身のコードだった**。
+
+### 再現層別実験
+
+lib unit test として `#[cfg(test)] mod race_repro` を追加し、以下の 6 層を生成、各 10 試行、`--test-threads=8`、`BLITZ_LOCK` 無効化 (sed で lock guard 削除):
+
+| Layer | 内容 | 結果 |
+|---|---|---|
+| L0a | `HtmlDocument::from_html(HTML, DocumentConfig::default())` | **10/10 pass** |
+| L0b | `HtmlDocument::from_html(HTML, viewport+base_url)` | **10/10 pass** |
+| L1 | `blitz_adapter::parse(HTML, 600, &[])` (fulgur wrapper) | **1/10 pass** |
+| L2 | L1 + `resolve()` | 2/10 pass |
+| L3 | L2 + `convert::dom_to_pageable` | 0/10 pass |
+| L4 | L3 + `render_to_pdf` (krilla) | 2/10 pass |
+
+**L0a/L0b と L1 の唯一の差**は、L1 が `blitz_adapter::parse` を経由しているかどうか。L0b は L1 と同じ config (`viewport + base_url`) を使っているが、`HtmlDocument::from_html` を直接呼んでいる。つまり fulgur の `blitz_adapter::parse` のラッパーの中に race 源がある。
+
+### 真の root cause: `suppress_stdout`
+
+`crates/fulgur/src/blitz_adapter.rs:38-85` に定義されていた `suppress_stdout` 関数は、`parse()` の内側で blitz-html の `println!("ERROR: {e}")` を消すため、**fd 1 (プロセス全体の stdout) を `dup2(devnull, 1)` で /dev/null に差し替え** ていた：
+
+```rust
+fn suppress_stdout<F: FnOnce() -> T, T>(f: F) -> T {
+    let saved = unsafe { libc::dup(1) };                 // 真の stdout を保存
+    unsafe { libc::dup2(dn.as_raw_fd(), 1) };            // fd 1 = devnull
+    let result = f();                                     // Blitz 呼び出し
+    drop(guard);                                          // Drop で dup2(saved, 1)
+    result
+}
+```
+
+**race の構造**:
+
+1. Thread A: `saved_A = dup(1)` → 真の stdout を保存、`dup2(devnull, 1)` → fd1=devnull
+2. Thread B: **このタイミングで suppress_stdout に入る** → `saved_B = dup(1)` → **devnull を保存**（A が既に fd 1 を差し替えているため、「現在の fd 1」= devnull）
+3. Thread B: `dup2(devnull, 1)` → 変化なし
+4. Thread A: guard drop → `dup2(saved_A, 1)` → fd1=真の stdout
+5. Thread B: guard drop → `dup2(saved_B=devnull, 1)` → **fd1=devnull のまま戻らない**
+
+または単純に、Thread A が suppression 中に Thread B (libtest の summary 出力スレッドなど) が stdout に書き込むと、その write は devnull に消える。
+
+結果、libtest の `test result: ok. N passed` 行が失われ、**silent exit に見える**。実際にはテストは走って pass していた。
+
+### 検証: `suppress_stdout` を削除すると…
+
+`parse()` から `suppress_stdout` の wrap を外しただけで（`BLITZ_LOCK` は disabled のまま）:
+
+| Layer | 結果（suppress_stdout 有） | 結果（suppress_stdout 無） |
+|---|---|---|
+| L0a | 10/10 | 10/10 |
+| L0b | 10/10 | 10/10 |
+| L1 | 1/10 | **10/10** |
+| L2 | 2/10 | **10/10** |
+| L3 | 0/10 | **10/10** |
+| L4 | 2/10 | **10/10** |
+
+さらに全テストスイート 283/283 pass、gcpm_integration は 0.59s → **0.18s** (3 倍高速化、`BLITZ_LOCK` の直列化オーバーヘッドが消えたため)。
+
+### 訂正された結論
+
+| 以前の主張 | 実情 |
+|---|---|
+| Blitz に thread-safety のバグがある | **誤り**。Blitz は thread-safe |
+| `BaseDocument::new()` に global state race がある | **誤り** |
+| stylo が non-atomic な global init をしている | **誤り** |
+| `--test-threads=1` が必要 | **fulgur の `suppress_stdout` が原因**、blitz ではない |
+| PR #61 の `BLITZ_LOCK` が修正 | **症状を塞いだだけの誤った修正**。真の fix は `suppress_stdout` を削除すること |
+| silent exit = test が crash している | **誤り**。test は実行・pass しており、stdout redirect で出力が devnull に消えていた |
+
+### 採用した正しい修正
+
+1. **`blitz_adapter::suppress_stdout` を完全削除**（library は stdout に一切触らない）
+2. **`BLITZ_LOCK` / `apply_single_pass` を削除**（不要、PR #61 の revert）
+3. **`fulgur-cli/src/main.rs` に `StdoutIsolator` を追加**: render コマンドの実行中のみ fd 1 を fd 2 (stderr) にリダイレクトし、PDF 出力 (`-o -`) は保存した真の fd に `libc::write` で直接書く。CLI は single-threaded なので fd 操作は race しない
+4. **`libc` 依存を fulgur lib から fulgur-cli に移動**
+
+この形だと：
+
+- library は完全に pure で thread-safe、bindings (PyO3/Magnus) もそのまま安全
+- CLI の `-o -` で malformed HTML を食わせても PDF は corrupted にならない（エラーは stderr に出る）
+- CLI の `-o file.pdf` でも blitz noise は stderr に行き、stdout/端末がクリーン
+- `--test-threads=1` 制約も不要
+- lock overhead もゼロ、gcpm_integration は 3 倍速
+
+### 教訓
+
+- **silent exit を「crash」と決めつけるな**。stdout が redirect されているだけの可能性を疑え
+- **symptom だけを見て fix するな**。`BLITZ_LOCK` は race の症状を偶然塞いだだけで、原因を取り違えていた
+- **dependency のせいにする前に自前コードを疑え**。`suppress_stdout` は 2026-03 ごろに追加された fulgur のコードで、CLAUDE.md が書かれたのとほぼ同時期。`--test-threads=1` 制約が生まれた原因は自前コードだった可能性が高い
+- **クリーンな最小再現を作らずに upstream に投げるな**。upstream issue を作ろうとした瞬間に反証が出て救われた
 
 ## 参考リンク
 


### PR DESCRIPTION
## 概要

PR #61 は誤診に基づく修正だった。その後の layered reproducer による詳細調査で、silent exit の真の原因は **Blitz ではなく fulgur 自身の `blitz_adapter::suppress_stdout`** の fd 1 レースだったと判明。この PR は PR #61 (`BLITZ_LOCK` + `apply_single_pass`) を revert し、真の root cause である `suppress_stdout` を削除、代わりに CLI 側で stdout 保護を実装する。

Closes `fulgur-vfj` (beads)

## 背景と誤診の経緯

PR #61 時点では「Blitz に thread-safety バグがあり、`BaseDocument::new()` の並列呼び出しで stylo が race する」と信じていた。症状は `--test-threads>1` で libtest が `running N tests` だけ出して silent exit すること。`BLITZ_LOCK: Mutex<()>` で全 blitz 呼び出しを直列化したら症状が消えたので「これで OK」としていた。

今回、DioxusLabs/blitz に upstream issue を出そうとしてクリーンな最小再現コードを作り始めたところ、**pure blitz API では race が再現しない**ことが発覚。6 層の reproducer で切り分けた結果：

| Layer | 内容 | 結果 |
|---|---|---|
| L0a | `HtmlDocument::from_html(HTML, DocumentConfig::default())` | 10/10 pass |
| L0b | `HtmlDocument::from_html(HTML, viewport + base_url)` | 10/10 pass |
| L1 | `blitz_adapter::parse` (fulgur wrapper) | **1/10 pass** |
| L2 | L1 + `resolve` | 2/10 pass |
| L3 | L2 + `convert::dom_to_pageable` | 0/10 pass |
| L4 | L3 + `render_to_pdf` (krilla) | 2/10 pass |

L0b と L1 の唯一の差は、L1 が `suppress_stdout(|| HtmlDocument::from_html(...))` で包まれていること。`suppress_stdout` の wrap を外すだけで L1〜L4 は全部 10/10 pass になり、`BLITZ_LOCK` は完全に不要になった。

## 真の root cause: `suppress_stdout` の fd 1 race

`blitz_adapter::suppress_stdout` は blitz-html の `println!("ERROR: {error}")` ノイズを消すため、プロセス全体の fd 1 を `dup2(devnull, 1)` で /dev/null に差し替えていた：

```rust
let saved = unsafe { libc::dup(1) };        // 真の stdout を保存
unsafe { libc::dup2(devnull, 1) };          // fd 1 = devnull
let result = f();
drop(guard);  // Drop で dup2(saved, 1)
```

複数スレッドが同時にこの関数に入ると：

1. Thread A: `saved_A = dup(1)` → 真の stdout、`dup2(devnull, 1)` → fd1=devnull
2. Thread B: `saved_B = dup(1)` → **devnull** を保存（A が既に fd 1 を変えているため）
3. A Drop: `dup2(saved_A, 1)` → fd 1 = 真の stdout
4. B Drop: `dup2(saved_B=devnull, 1)` → **fd 1 = devnull のまま**戻らない

または A が suppression 中に B (libtest の summary 出力スレッドなど) が stdout に書くと、その write は devnull に消える。結果、libtest の `test result: ok. N passed` 行が失われ、silent exit に見える。**テストは実行されて pass していた**が、出力が消えていただけ。

## 変更内容

### Library (`crates/fulgur/`)

- `blitz_adapter.rs`: `suppress_stdout` 関数、`static BLITZ_LOCK`、`apply_single_pass`、`Mutex` import を完全削除。thread safety モデルを module doc comment に明記
- `engine.rs`: `RunningElementPass` と `StringSetPass` を直接 `pass.apply()` で呼ぶ形に revert（`apply_single_pass` 経由をやめる）
- `Cargo.toml`: `libc` 依存を削除

### CLI (`crates/fulgur-cli/`)

- `main.rs`: `StdoutIsolator` 構造体を新設。`render` コマンドの実行中のみ fd 1 を fd 2 (stderr) にリダイレクトし、PDF 出力は保存した真の fd に `libc::write` で直接書く。CLI は single-threaded なので fd 操作は race しない
- `Cargo.toml`: `libc` 依存を unix-only で追加

### Docs

- `CLAUDE.md`: Gotcha を再訂正。「Blitz not thread-safe」の古い誤診を削除し、「Blitz は実は thread-safe、blitz-html が `println!` でノイズを出すので CLI 側で fd 隔離している」と正しく記載
- `docs/plans/2026-04-11-blitz-thread-safety-investigation.md`: 元の調査レポートの末尾に「訂正 addendum (2026-04-11 later)」を追加。誤診の経緯、layered reproducer の結果、true root cause、採用した正しい修正、教訓を詳細に記録。前半の誤診時の内容は再発防止の戒めとして残置

## 検証

### 単体テスト

- `cargo test -p fulgur --release` default parallelism: **283/283 pass**
- 5 reruns × 8 threads: flaky なし
- `cargo fmt --check` clean
- `cargo clippy --release` clean
- `npx markdownlint-cli2` clean

### パフォーマンス

| 対象 | 修正前 (suppress_stdout あり) | PR #61 (BLITZ_LOCK あり) | **本 PR** |
|---|---|---|---|
| `gcpm_integration` `--test-threads=1` | ~0.60s | ~0.64s | **~0.18s** |
| `gcpm_integration` `--test-threads=8` | 不可 (silent exit) | 0.58-0.63s (lock で直列化) | **~0.18s** |

**3.5 倍の高速化**。PR #61 は並列モードでも速くならなかった (`BLITZ_LOCK` が全 blitz 呼び出しを直列化していたため)。本 PR では library が pure で真の並列性が解放されている。

### CLI 動作確認 (手動)

- `fulgur render good.html -o - > out.pdf` → `%PDF-1.7` で始まる 8533 バイトの valid PDF、stderr にエラーなし
- `fulgur render bad.html -o - > out.pdf` → `%PDF-1.7` で始まる 15191 バイトの valid PDF、stderr に `ERROR: Unexpected token\nERROR: Unexpected open element`
- `fulgur render bad.html -o out.pdf` → stdout 0 バイト、stderr に blitz エラー + `PDF written to ...`、out.pdf は valid
- `file(1)` で全ケース `PDF document, version 1.7, 1 page(s)` として認識

## Python/Ruby バインディングへの含意

PR #61 のままだと、将来の `fulgur-i5c` (Python binding) で `concurrent.futures.ThreadPoolExecutor` を使っても `BLITZ_LOCK` が全呼び出しを直列化して multi-thread スケールしなかった。本 PR 適用後は、GIL 解放中に複数 Python スレッドから同時に render が並列実行される。**SaaS 帳票ジェネレータのユースケース (`fulgur` の主要ターゲット) で thread 並列でのバッチ PDF 生成が可能になった**。

## 教訓

- **silent exit を「crash」と決めつけるな**。stdout redirect の可能性を疑え
- **symptom だけで fix するな**。`BLITZ_LOCK` は症状を偶然塞いだだけで、原因を取り違えていた
- **依存ライブラリを疑う前に自前コードを疑え**。`suppress_stdout` は fulgur 自身のコードだった
- **クリーンな最小再現を作らずに upstream に投げるな**。upstream issue を書こうとした瞬間に反証が出て救われた

## Test plan

- [x] Full workspace test suite passes with default parallelism (283/283)
- [x] `gcpm_integration --test-threads=8` × 5 reruns stable, no silent exit
- [x] `fulgur render good.html -o -` produces valid PDF (stdout mode)
- [x] `fulgur render bad.html -o -` produces valid PDF (stdout mode, malformed HTML)
- [x] `fulgur render bad.html -o out.pdf` leaves stdout empty, errors on stderr (file mode)
- [x] `cargo fmt --check` / `cargo clippy` / `markdownlint-cli2` clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Unix環境で標準出力を隔離してPDF出力をより確実に配信する処理を追加（失敗時は代替出力にフォールバック）。

* **バグ修正**
  * PDFストリームにパースエラー等の標準出力が混入する問題の再発を防止。

* **ドキュメント**
  * スレッド安全性と標準出力の取り扱いに関するガイダンスを更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->