### PR TITLE
fix(cli): restore main build and flush stdout buffer in StdoutIsolator::Drop

### DIFF
--- a/crates/fulgur-cli/src/main.rs
+++ b/crates/fulgur-cli/src/main.rs
@@ -91,6 +91,16 @@ impl StdoutIsolator {
 #[cfg(unix)]
 impl Drop for StdoutIsolator {
     fn drop(&mut self) {
+        // Flush any bytes still sitting in Rust's `io::Stdout` buffer while
+        // fd 1 is still pointing at stderr. `io::Stdout` is a LineWriter that
+        // flushes on newline, so the common case of `println!("ERROR: ...")`
+        // from dependencies is already flushed inline. This flush is
+        // defense-in-depth for writes without a trailing newline (e.g. a
+        // future dependency using `print!`, or blitz changing its error
+        // sink), and keeps the Drop symmetric with `install()` which also
+        // flushes before manipulating fd 1.
+        use std::io::Write;
+        let _ = std::io::stdout().flush();
         // Restore fd 1 to the real stdout so any final messages the process
         // prints (e.g. panic output on failure paths) land in the right place.
         unsafe {

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -116,7 +116,7 @@ impl Engine {
                     gcpm.counter_mappings.clone(),
                     gcpm.content_counter_mappings.clone(),
                 );
-                pass.apply(&mut doc, &ctx);
+                crate::blitz_adapter::apply_single_pass(&pass, &mut doc, &ctx);
                 pass.into_parts()
             } else {
                 (Vec::new(), String::new())
@@ -125,7 +125,7 @@ impl Engine {
         // Inject counter-resolved CSS for ::before/::after
         if !counter_css.is_empty() {
             let inject_pass = crate::blitz_adapter::InjectCssPass { css: counter_css };
-            inject_pass.apply(&mut doc, &ctx);
+            crate::blitz_adapter::apply_single_pass(&inject_pass, &mut doc, &ctx);
         }
 
         crate::blitz_adapter::resolve(&mut doc);


### PR DESCRIPTION
## 概要

2 つの修正を含みます：

1. **broken main の復旧** — PR #62 と PR #59 の並行マージで \`cargo build\` が壊れていた状態を \`apply_single_pass\` 経由で統一的に修正
2. **`StdoutIsolator::Drop` の flush 追加** — PR #62 マージ後に Devin が指摘した defensive improvement を新 PR で対応

## 問題 1: main の compile error

PR #62 (d119b65) で \`engine.rs\` から \`use crate::blitz_adapter::DomPass\` を削除し、\`RunningElementPass\` / \`StringSetPass\` の呼び出しを \`apply_single_pass\` 経由に統一しました。その直後、PR #59 (807ab6f) がマージされ、新たに追加された \`CounterPass\` と counter-CSS \`InjectCssPass\` が直接 \`pass.apply(&mut doc, &ctx)\` を呼んでいました。

各 PR は個別の CI でそれぞれの pre-merge base に対して通っていましたが、両方マージされた後の main では次のエラーで build が壊れています：

\`\`\`text
error[E0599]: no method named \`apply\` found for struct \`CounterPass\`
error[E0599]: no method named \`apply\` found for struct \`InjectCssPass\`
\`\`\`

### 修正

\`CounterPass\` と \`InjectCssPass\` の呼び出しを \`crate::blitz_adapter::apply_single_pass(&pass, &mut doc, &ctx)\` 経由に差し替え、PR #62 の統一パターンに合わせます。\`engine.rs\` に \`DomPass\` trait を再導入する選択肢もありますが、それは CLAUDE.md の **"Adapter isolation: Blitz API surface is contained in blitz_adapter.rs"** の原則に反するので避けました（coderabbit が PR #62 で同じ原則を指摘しています）。

## 問題 2: `StdoutIsolator::Drop` の stdout flush

PR #62 マージ後に Devin Review から以下の finding が来ていました：

> The `StdoutIsolator::Drop` restores fd 1 to the real stdout without first flushing Rust's internal `stdout()` buffer. [...] buffered blitz output would be flushed to the real stdout **after** the PDF bytes, corrupting the output.

既にマージ済みだったので、本 PR で対応します。

### 調査結果

一時的な再現テストクレートで Rust stdlib の挙動を実測した結果：

- **Rust の `io::Stdout` は LineWriter ベース**で、改行ごとにフラッシュされます
- \`blitz-html\` の現在のエラー出力 \`println!("ERROR: {e}")\` は **\`\\n\` 付きなので inline flush** され、現状では Devin の指摘する mechanism では corruption は起きません
- しかし、**\`print!\`（改行なし）だと LineWriter の buffer に残る**ことも実測で確認（\`print!("X"); dup2(2, 1); println!("Y")\` の最小再現で検証）。これは将来依存が変われば顕在化するリスク

### 修正

\`Drop::drop\` の先頭で \`std::io::stdout().flush()\` を呼び、fd 1 が stderr を指している間に Rust の buffer を flush します。これにより：

- 改行なし write が buffer に残っていても、\`dup2\` 復帰前に stderr に流れる
- **\`install()\` 側の flush との対称性**が取れる（\`install()\` は \`main.rs:40\` で flush してから dup2 する形、\`Drop\` も同じ順序に）
- 通常ケースでは buffer が既に空なのでコストゼロ

## Test plan

- [x] \`cargo build --release\` clean（壊れていた main がこの PR で直る）
- [x] \`cargo test -p fulgur --release\` default parallelism: **297/297 pass**（PR #59 の counter-reset テスト 12 件 + gcpm_integration 2 件増を含む）
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --release\` clean
- [x] smoke test: \`fulgur render bad.html -o - > out.pdf\` → 15191 バイトの valid \`%PDF-1.7\` ファイル、stderr に blitz エラー分離
- [x] smoke test: \`fulgur render bad.html -o out.pdf\` → stdout 0 バイト、stderr に errors + "PDF written to"、out.pdf は valid

## 関連

- Fix 1 は PR #62 と PR #59 のマージ順序の副作用で、両 PR 個別の責任ではありません。Adapter isolation の原則で合流する形で修正します
- Fix 2 は [PR #62 の Devin review コメント](https://github.com/mitsuru/fulgur/pull/62#discussion_r3066072789) への対応
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/63" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改善内容

* **バグ修正**
  * 出力バッファリング処理の信頼性を向上させました。

* **リファクタリング**
  * 内部処理の一貫性と保守性を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->