### PR TITLE
feat: support SVG in background-image: url()

### DIFF
--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -446,6 +446,30 @@ mod tests {
     }
 
     #[test]
+    fn test_svg_layer_resolve_size_contain() {
+        let svg_data = br#"<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100"><rect width="200" height="100" fill="blue"/></svg>"#;
+        let opts = usvg::Options::default();
+        let tree = usvg::Tree::from_data(svg_data, &opts).unwrap();
+        let layer = BackgroundLayer {
+            content: BgImageContent::Svg {
+                tree: std::sync::Arc::new(tree),
+            },
+            intrinsic_width: 200.0,
+            intrinsic_height: 100.0,
+            size: BgSize::Contain,
+            position_x: BgLengthPercentage::Percentage(0.0),
+            position_y: BgLengthPercentage::Percentage(0.0),
+            repeat_x: BgRepeat::NoRepeat,
+            repeat_y: BgRepeat::NoRepeat,
+            origin: BgBox::PaddingBox,
+            clip: BgClip::BorderBox,
+        };
+        let (w, h) = resolve_size(&layer, 300.0, 300.0);
+        assert_eq!(w, 300.0);
+        assert_eq!(h, 150.0);
+    }
+
+    #[test]
     fn test_repeat_alignment_with_offset_position() {
         // Tiles must align with position: tiles at position ± n*image_size.
         // position=25, clip_start=10, image_size=20 → tiles at 5, 25, 45, ...

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -3,7 +3,8 @@
 use std::sync::Arc;
 
 use crate::pageable::{
-    BackgroundLayer, BgBox, BgClip, BgLengthPercentage, BgRepeat, BgSize, BlockStyle, Canvas,
+    BackgroundLayer, BgBox, BgClip, BgImageContent, BgLengthPercentage, BgRepeat, BgSize,
+    BlockStyle, Canvas,
 };
 
 /// Draw all background layers for a block element.
@@ -111,20 +112,35 @@ fn draw_background_layer(
         .surface
         .push_clip_path(&clip_path, &krilla::paint::FillRule::default());
 
-    let data: krilla::Data = Arc::clone(&layer.image_data).into();
-    let Ok(image) = layer.format.to_krilla_image(data) else {
-        canvas.surface.pop();
-        return;
-    };
-
-    for (tx, ty, tw, th) in &tiles {
-        let Some(size) = krilla::geom::Size::from_wh(*tw, *th) else {
-            continue;
-        };
-        let transform = krilla::geom::Transform::from_translate(*tx, *ty);
-        canvas.surface.push_transform(&transform);
-        canvas.surface.draw_image(image.clone(), size);
-        canvas.surface.pop();
+    match &layer.content {
+        BgImageContent::Raster { data, format } => {
+            let data: krilla::Data = Arc::clone(data).into();
+            let Ok(image) = format.to_krilla_image(data) else {
+                canvas.surface.pop();
+                return;
+            };
+            for (tx, ty, tw, th) in &tiles {
+                let Some(size) = krilla::geom::Size::from_wh(*tw, *th) else {
+                    continue;
+                };
+                let transform = krilla::geom::Transform::from_translate(*tx, *ty);
+                canvas.surface.push_transform(&transform);
+                canvas.surface.draw_image(image.clone(), size);
+                canvas.surface.pop();
+            }
+        }
+        BgImageContent::Svg { tree } => {
+            use krilla_svg::{SurfaceExt, SvgSettings};
+            for (tx, ty, tw, th) in &tiles {
+                let Some(size) = krilla::geom::Size::from_wh(*tw, *th) else {
+                    continue;
+                };
+                let transform = krilla::geom::Transform::from_translate(*tx, *ty);
+                canvas.surface.push_transform(&transform);
+                let _ = canvas.surface.draw_svg(tree, size, SvgSettings::default());
+                canvas.surface.pop();
+            }
+        }
     }
 
     canvas.surface.pop();
@@ -359,8 +375,10 @@ mod tests {
 
     fn make_layer(iw: f32, ih: f32, size: BgSize) -> BackgroundLayer {
         BackgroundLayer {
-            image_data: Arc::new(vec![]),
-            format: ImageFormat::Png,
+            content: BgImageContent::Raster {
+                data: Arc::new(vec![]),
+                format: ImageFormat::Png,
+            },
             intrinsic_width: iw,
             intrinsic_height: ih,
             size,

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -137,7 +137,13 @@ fn draw_background_layer(
                 };
                 let transform = krilla::geom::Transform::from_translate(*tx, *ty);
                 canvas.surface.push_transform(&transform);
-                let _ = canvas.surface.draw_svg(tree, size, SvgSettings::default());
+                if canvas
+                    .surface
+                    .draw_svg(tree, size, SvgSettings::default())
+                    .is_none()
+                {
+                    log::warn!("failed to draw SVG background tile");
+                }
                 canvas.surface.pop();
             }
         }

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -6,11 +6,10 @@ use crate::gcpm::running::RunningElementStore;
 use crate::image::ImagePageable;
 use crate::pageable::{
     BackgroundLayer, BgBox, BgClip, BgImageContent, BgLengthPercentage, BgRepeat, BgSize,
-    BlockPageable,
-    BlockStyle, BorderStyleValue, CounterOpMarkerPageable, CounterOpWrapperPageable, ImageMarker,
-    ListItemMarker, ListItemPageable, Pageable, PositionedChild, RunningElementMarkerPageable,
-    RunningElementWrapperPageable, Size, SpacerPageable, StringSetPageable,
-    StringSetWrapperPageable, TablePageable, TransformWrapperPageable,
+    BlockPageable, BlockStyle, BorderStyleValue, CounterOpMarkerPageable, CounterOpWrapperPageable,
+    ImageMarker, ListItemMarker, ListItemPageable, Pageable, PositionedChild,
+    RunningElementMarkerPageable, RunningElementWrapperPageable, Size, SpacerPageable,
+    StringSetPageable, StringSetWrapperPageable, TablePageable, TransformWrapperPageable,
 };
 use crate::paragraph::{
     InlineImage, LineFontMetrics, LineItem, ParagraphPageable, ShapedGlyph, ShapedGlyphRun,
@@ -1642,8 +1641,8 @@ fn extract_block_style(node: &Node, assets: Option<&AssetBundle>) -> BlockStyle 
                         use crate::image::AssetKind;
                         match AssetKind::detect(data) {
                             AssetKind::Raster(format) => {
-                                let (iw, ih) =
-                                    ImagePageable::decode_dimensions(data, format).unwrap_or((1, 1));
+                                let (iw, ih) = ImagePageable::decode_dimensions(data, format)
+                                    .unwrap_or((1, 1));
                                 let size = convert_bg_size(&bg_sizes.0, i);
                                 let (px, py) = convert_bg_position(&bg_pos_x.0, &bg_pos_y.0, i);
                                 let (rx, ry) = convert_bg_repeat(&bg_repeats.0, i);
@@ -1671,8 +1670,7 @@ fn extract_block_style(node: &Node, assets: Option<&AssetBundle>) -> BlockStyle 
                                 if let Ok(tree) = usvg::Tree::from_data(data, &opts) {
                                     let svg_size = tree.size();
                                     let size = convert_bg_size(&bg_sizes.0, i);
-                                    let (px, py) =
-                                        convert_bg_position(&bg_pos_x.0, &bg_pos_y.0, i);
+                                    let (px, py) = convert_bg_position(&bg_pos_x.0, &bg_pos_y.0, i);
                                     let (rx, ry) = convert_bg_repeat(&bg_repeats.0, i);
                                     let origin = convert_bg_origin(&bg_origins.0, i);
                                     let clip = convert_bg_clip(&bg_clips.0, i);

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -1649,8 +1649,10 @@ fn extract_block_style(node: &Node, assets: Option<&AssetBundle>) -> BlockStyle 
                             let clip = convert_bg_clip(&bg_clips.0, i);
 
                             style.background_layers.push(BackgroundLayer {
-                                image_data: Arc::clone(data),
-                                format,
+                                content: crate::pageable::BgImageContent::Raster {
+                                    data: Arc::clone(data),
+                                    format,
+                                },
                                 intrinsic_width: iw as f32,
                                 intrinsic_height: ih as f32,
                                 size,

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -1639,67 +1639,65 @@ fn extract_block_style(node: &Node, assets: Option<&AssetBundle>) -> BlockStyle 
                     let src = extract_asset_name(raw_src);
                     if let Some(data) = assets.get_image(src) {
                         use crate::image::AssetKind;
-                        match AssetKind::detect(data) {
-                            AssetKind::Raster(format) => {
-                                let (iw, ih) = ImagePageable::decode_dimensions(data, format)
-                                    .unwrap_or((1, 1));
-                                let size = convert_bg_size(&bg_sizes.0, i);
-                                let (px, py) = convert_bg_position(&bg_pos_x.0, &bg_pos_y.0, i);
-                                let (rx, ry) = convert_bg_repeat(&bg_repeats.0, i);
-                                let origin = convert_bg_origin(&bg_origins.0, i);
-                                let clip = convert_bg_clip(&bg_clips.0, i);
 
-                                style.background_layers.push(BackgroundLayer {
-                                    content: BgImageContent::Raster {
-                                        data: Arc::clone(data),
-                                        format,
-                                    },
-                                    intrinsic_width: iw as f32,
-                                    intrinsic_height: ih as f32,
-                                    size,
-                                    position_x: px,
-                                    position_y: py,
-                                    repeat_x: rx,
-                                    repeat_y: ry,
-                                    origin,
-                                    clip,
-                                });
-                            }
-                            AssetKind::Svg => {
-                                let opts = usvg::Options::default();
-                                match usvg::Tree::from_data(data, &opts) {
-                                    Ok(tree) => {
-                                        let svg_size = tree.size();
-                                        let size = convert_bg_size(&bg_sizes.0, i);
-                                        let (px, py) =
-                                            convert_bg_position(&bg_pos_x.0, &bg_pos_y.0, i);
-                                        let (rx, ry) = convert_bg_repeat(&bg_repeats.0, i);
-                                        let origin = convert_bg_origin(&bg_origins.0, i);
-                                        let clip = convert_bg_clip(&bg_clips.0, i);
-
-                                        style.background_layers.push(BackgroundLayer {
-                                            content: BgImageContent::Svg {
-                                                tree: Arc::new(tree),
-                                            },
-                                            intrinsic_width: svg_size.width(),
-                                            intrinsic_height: svg_size.height(),
-                                            size,
-                                            position_x: px,
-                                            position_y: py,
-                                            repeat_x: rx,
-                                            repeat_y: ry,
-                                            origin,
-                                            clip,
-                                        });
-                                    }
-                                    Err(e) => {
-                                        log::warn!(
-                                            "failed to parse SVG background-image '{src}': {e}"
-                                        );
+                        // Resolve content + intrinsic size per asset kind.
+                        let resolved: Option<(BgImageContent, f32, f32)> =
+                            match AssetKind::detect(data) {
+                                AssetKind::Raster(format) => {
+                                    let (iw, ih) = ImagePageable::decode_dimensions(data, format)
+                                        .unwrap_or((1, 1));
+                                    Some((
+                                        BgImageContent::Raster {
+                                            data: Arc::clone(data),
+                                            format,
+                                        },
+                                        iw as f32,
+                                        ih as f32,
+                                    ))
+                                }
+                                AssetKind::Svg => {
+                                    let opts = usvg::Options::default();
+                                    match usvg::Tree::from_data(data, &opts) {
+                                        Ok(tree) => {
+                                            let svg_size = tree.size();
+                                            Some((
+                                                BgImageContent::Svg {
+                                                    tree: Arc::new(tree),
+                                                },
+                                                svg_size.width(),
+                                                svg_size.height(),
+                                            ))
+                                        }
+                                        Err(e) => {
+                                            log::warn!(
+                                                "failed to parse SVG background-image '{src}': {e}"
+                                            );
+                                            None
+                                        }
                                     }
                                 }
-                            }
-                            AssetKind::Unknown => {}
+                                AssetKind::Unknown => None,
+                            };
+
+                        if let Some((content, intrinsic_width, intrinsic_height)) = resolved {
+                            let size = convert_bg_size(&bg_sizes.0, i);
+                            let (px, py) = convert_bg_position(&bg_pos_x.0, &bg_pos_y.0, i);
+                            let (rx, ry) = convert_bg_repeat(&bg_repeats.0, i);
+                            let origin = convert_bg_origin(&bg_origins.0, i);
+                            let clip = convert_bg_clip(&bg_clips.0, i);
+
+                            style.background_layers.push(BackgroundLayer {
+                                content,
+                                intrinsic_width,
+                                intrinsic_height,
+                                size,
+                                position_x: px,
+                                position_y: py,
+                                repeat_x: rx,
+                                repeat_y: ry,
+                                origin,
+                                clip,
+                            });
                         }
                     }
                 }

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -1667,28 +1667,36 @@ fn extract_block_style(node: &Node, assets: Option<&AssetBundle>) -> BlockStyle 
                             }
                             AssetKind::Svg => {
                                 let opts = usvg::Options::default();
-                                if let Ok(tree) = usvg::Tree::from_data(data, &opts) {
-                                    let svg_size = tree.size();
-                                    let size = convert_bg_size(&bg_sizes.0, i);
-                                    let (px, py) = convert_bg_position(&bg_pos_x.0, &bg_pos_y.0, i);
-                                    let (rx, ry) = convert_bg_repeat(&bg_repeats.0, i);
-                                    let origin = convert_bg_origin(&bg_origins.0, i);
-                                    let clip = convert_bg_clip(&bg_clips.0, i);
+                                match usvg::Tree::from_data(data, &opts) {
+                                    Ok(tree) => {
+                                        let svg_size = tree.size();
+                                        let size = convert_bg_size(&bg_sizes.0, i);
+                                        let (px, py) =
+                                            convert_bg_position(&bg_pos_x.0, &bg_pos_y.0, i);
+                                        let (rx, ry) = convert_bg_repeat(&bg_repeats.0, i);
+                                        let origin = convert_bg_origin(&bg_origins.0, i);
+                                        let clip = convert_bg_clip(&bg_clips.0, i);
 
-                                    style.background_layers.push(BackgroundLayer {
-                                        content: BgImageContent::Svg {
-                                            tree: Arc::new(tree),
-                                        },
-                                        intrinsic_width: svg_size.width(),
-                                        intrinsic_height: svg_size.height(),
-                                        size,
-                                        position_x: px,
-                                        position_y: py,
-                                        repeat_x: rx,
-                                        repeat_y: ry,
-                                        origin,
-                                        clip,
-                                    });
+                                        style.background_layers.push(BackgroundLayer {
+                                            content: BgImageContent::Svg {
+                                                tree: Arc::new(tree),
+                                            },
+                                            intrinsic_width: svg_size.width(),
+                                            intrinsic_height: svg_size.height(),
+                                            size,
+                                            position_x: px,
+                                            position_y: py,
+                                            repeat_x: rx,
+                                            repeat_y: ry,
+                                            origin,
+                                            clip,
+                                        });
+                                    }
+                                    Err(e) => {
+                                        log::warn!(
+                                            "failed to parse SVG background-image '{src}': {e}"
+                                        );
+                                    }
                                 }
                             }
                             AssetKind::Unknown => {}

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -5,7 +5,8 @@ use crate::gcpm::CounterOp;
 use crate::gcpm::running::RunningElementStore;
 use crate::image::ImagePageable;
 use crate::pageable::{
-    BackgroundLayer, BgBox, BgClip, BgLengthPercentage, BgRepeat, BgSize, BlockPageable,
+    BackgroundLayer, BgBox, BgClip, BgImageContent, BgLengthPercentage, BgRepeat, BgSize,
+    BlockPageable,
     BlockStyle, BorderStyleValue, CounterOpMarkerPageable, CounterOpWrapperPageable, ImageMarker,
     ListItemMarker, ListItemPageable, Pageable, PositionedChild, RunningElementMarkerPageable,
     RunningElementWrapperPageable, Size, SpacerPageable, StringSetPageable,
@@ -1638,31 +1639,61 @@ fn extract_block_style(node: &Node, assets: Option<&AssetBundle>) -> BlockStyle 
                     // Extract the path/filename for AssetBundle lookup.
                     let src = extract_asset_name(raw_src);
                     if let Some(data) = assets.get_image(src) {
-                        if let Some(format) = ImagePageable::detect_format(data) {
-                            let (iw, ih) =
-                                ImagePageable::decode_dimensions(data, format).unwrap_or((1, 1));
+                        use crate::image::AssetKind;
+                        match AssetKind::detect(data) {
+                            AssetKind::Raster(format) => {
+                                let (iw, ih) =
+                                    ImagePageable::decode_dimensions(data, format).unwrap_or((1, 1));
+                                let size = convert_bg_size(&bg_sizes.0, i);
+                                let (px, py) = convert_bg_position(&bg_pos_x.0, &bg_pos_y.0, i);
+                                let (rx, ry) = convert_bg_repeat(&bg_repeats.0, i);
+                                let origin = convert_bg_origin(&bg_origins.0, i);
+                                let clip = convert_bg_clip(&bg_clips.0, i);
 
-                            let size = convert_bg_size(&bg_sizes.0, i);
-                            let (px, py) = convert_bg_position(&bg_pos_x.0, &bg_pos_y.0, i);
-                            let (rx, ry) = convert_bg_repeat(&bg_repeats.0, i);
-                            let origin = convert_bg_origin(&bg_origins.0, i);
-                            let clip = convert_bg_clip(&bg_clips.0, i);
+                                style.background_layers.push(BackgroundLayer {
+                                    content: BgImageContent::Raster {
+                                        data: Arc::clone(data),
+                                        format,
+                                    },
+                                    intrinsic_width: iw as f32,
+                                    intrinsic_height: ih as f32,
+                                    size,
+                                    position_x: px,
+                                    position_y: py,
+                                    repeat_x: rx,
+                                    repeat_y: ry,
+                                    origin,
+                                    clip,
+                                });
+                            }
+                            AssetKind::Svg => {
+                                let opts = usvg::Options::default();
+                                if let Ok(tree) = usvg::Tree::from_data(data, &opts) {
+                                    let svg_size = tree.size();
+                                    let size = convert_bg_size(&bg_sizes.0, i);
+                                    let (px, py) =
+                                        convert_bg_position(&bg_pos_x.0, &bg_pos_y.0, i);
+                                    let (rx, ry) = convert_bg_repeat(&bg_repeats.0, i);
+                                    let origin = convert_bg_origin(&bg_origins.0, i);
+                                    let clip = convert_bg_clip(&bg_clips.0, i);
 
-                            style.background_layers.push(BackgroundLayer {
-                                content: crate::pageable::BgImageContent::Raster {
-                                    data: Arc::clone(data),
-                                    format,
-                                },
-                                intrinsic_width: iw as f32,
-                                intrinsic_height: ih as f32,
-                                size,
-                                position_x: px,
-                                position_y: py,
-                                repeat_x: rx,
-                                repeat_y: ry,
-                                origin,
-                                clip,
-                            });
+                                    style.background_layers.push(BackgroundLayer {
+                                        content: BgImageContent::Svg {
+                                            tree: Arc::new(tree),
+                                        },
+                                        intrinsic_width: svg_size.width(),
+                                        intrinsic_height: svg_size.height(),
+                                        size,
+                                        position_x: px,
+                                        position_y: py,
+                                        repeat_x: rx,
+                                        repeat_y: ry,
+                                        origin,
+                                        clip,
+                                    });
+                                }
+                            }
+                            AssetKind::Unknown => {}
                         }
                     }
                 }

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -371,11 +371,22 @@ pub enum BgClip {
     Text,
 }
 
+/// Content payload for a background-image layer.
+#[derive(Clone, Debug)]
+pub enum BgImageContent {
+    /// Raster image (PNG/JPEG/GIF) — rendered via krilla Image API.
+    Raster {
+        data: Arc<Vec<u8>>,
+        format: ImageFormat,
+    },
+    /// SVG vector image — rendered via krilla-svg draw_svg.
+    Svg { tree: Arc<usvg::Tree> },
+}
+
 /// A single CSS background image layer with all associated properties.
 #[derive(Clone, Debug)]
 pub struct BackgroundLayer {
-    pub image_data: Arc<Vec<u8>>,
-    pub format: ImageFormat,
+    pub content: BgImageContent,
     pub intrinsic_width: f32,
     pub intrinsic_height: f32,
     pub size: BgSize,
@@ -2607,8 +2618,10 @@ mod background_tests {
         let mut style = BlockStyle::default();
         assert!(!style.has_visual_style());
         style.background_layers.push(BackgroundLayer {
-            image_data: Arc::new(vec![]),
-            format: ImageFormat::Png,
+            content: BgImageContent::Raster {
+                data: Arc::new(vec![]),
+                format: ImageFormat::Png,
+            },
             intrinsic_width: 100.0,
             intrinsic_height: 100.0,
             size: BgSize::Auto,

--- a/crates/fulgur/tests/background_test.rs
+++ b/crates/fulgur/tests/background_test.rs
@@ -126,9 +126,7 @@ fn test_background_image_svg_renders() {
         .page_size(PageSize::A4)
         .margin(Margin::uniform(72.0))
         .build()
-        .render_html(
-            r#"<html><body><div style="width:100px;height:100px"></div></body></html>"#,
-        )
+        .render_html(r#"<html><body><div style="width:100px;height:100px"></div></body></html>"#)
         .unwrap();
     assert!(
         pdf.len() > pdf_no_bg.len(),

--- a/crates/fulgur/tests/background_test.rs
+++ b/crates/fulgur/tests/background_test.rs
@@ -103,3 +103,37 @@ fn test_background_clip_padding_box() {
     let pdf = engine.render_html(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
 }
+
+#[test]
+fn test_background_image_svg_renders() {
+    let svg = br#"<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50"><circle cx="25" cy="25" r="20" fill="green"/></svg>"#;
+    let mut assets = AssetBundle::new();
+    assets.add_image("circle.svg", svg.to_vec());
+    let engine = Engine::builder()
+        .page_size(PageSize::A4)
+        .margin(Margin::uniform(72.0))
+        .assets(assets)
+        .build();
+
+    let html = r#"<html><body>
+        <div style="width:100px;height:100px;background-image:url(circle.svg);background-size:contain;background-repeat:no-repeat"></div>
+    </body></html>"#;
+    let pdf = engine.render_html(html).unwrap();
+    assert!(pdf.starts_with(b"%PDF"), "output should be a PDF");
+
+    // PDF with SVG background should be larger than without (verifies SVG is embedded)
+    let pdf_no_bg = Engine::builder()
+        .page_size(PageSize::A4)
+        .margin(Margin::uniform(72.0))
+        .build()
+        .render_html(
+            r#"<html><body><div style="width:100px;height:100px"></div></body></html>"#,
+        )
+        .unwrap();
+    assert!(
+        pdf.len() > pdf_no_bg.len(),
+        "PDF with SVG background-image ({} bytes) should be larger than without ({} bytes)",
+        pdf.len(),
+        pdf_no_bg.len()
+    );
+}


### PR DESCRIPTION
## Summary
- Introduce `BgImageContent` enum (Raster/Svg) to replace `BackgroundLayer`'s separate `image_data`+`format` fields
- Use `AssetKind::detect()` in `convert.rs` to classify background-image assets as raster or SVG
- Add SVG rendering path in `background.rs` via `krilla_svg::draw_svg`, matching existing `SvgPageable` approach

Closes fulgur-r07

## Test Plan
- [x] Unit test: `test_svg_layer_resolve_size_contain` verifies CSS background-size works with SVG layers
- [x] Integration test: `test_background_image_svg_renders` exercises full pipeline (HTML → SVG background → PDF)
- [x] All 316 lib tests + 10 integration tests pass (no regressions)
- [x] clippy clean, rustfmt clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/76" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 背景画像がラスターとSVGの両形式に対応しました。SVG背景の埋め込みが可能です。

* **改善**
  * タイル単位の配置とサイズ計算が強化され、背景画像の表示精度が向上しました。読み取りや描画に失敗した場合は警告を出しつつ処理を継続します。

* **テスト**
  * SVG背景のレンダリングとサイズ計算を検証するユニットテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->