### PR TITLE
feat: support list-style-image when list-style-type is none

### DIFF
--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -479,10 +479,20 @@ fn convert_node_inner(
         let style = extract_block_style(node, ctx.assets);
         let (opacity, visible) = extract_opacity_visible(node);
 
-        // Derive line_height from font-size since there is no Parley layout
+        // Derive line_height from computed styles since there is no Parley layout.
+        // Honour explicit line-height first; fall back to font-size * 1.2 for
+        // `normal`, matching the same heuristic Blitz uses internally.
         let line_height = node
             .primary_styles()
-            .map(|s| s.clone_font_size().used_size().px() * PX_TO_PT * DEFAULT_LINE_HEIGHT_RATIO)
+            .map(|s| {
+                use style::values::computed::font::LineHeight;
+                let font_size_pt = s.clone_font_size().used_size().px() * PX_TO_PT;
+                match s.clone_line_height() {
+                    LineHeight::Normal => font_size_pt * DEFAULT_LINE_HEIGHT_RATIO,
+                    LineHeight::Number(num) => font_size_pt * num.0,
+                    LineHeight::Length(value) => value.0.px() * PX_TO_PT,
+                }
+            })
             .unwrap_or(FALLBACK_LINE_HEIGHT_PT);
 
         if let Some(marker) = resolve_list_marker(node, line_height, ctx.assets) {

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -425,6 +425,79 @@ fn convert_node_inner(
         return Box::new(item);
     }
 
+    // Fallback: display: list-item with list-style-image but no list_item_data
+    // (Blitz 0.2.4 skips list_item_data when list-style-type: none)
+    if node
+        .element_data()
+        .is_some_and(|d| d.list_item_data.is_none())
+        && has_image_only_list_marker(node, ctx.assets)
+    {
+        let style = extract_block_style(node, ctx.assets);
+        let (opacity, visible) = extract_opacity_visible(node);
+
+        // Derive line_height from font-size since there is no Parley layout
+        let line_height = node
+            .primary_styles()
+            .map(|s| s.clone_font_size().used_size().px() * 0.75 * 1.2)
+            .unwrap_or(12.0);
+
+        if let Some(marker) = resolve_list_marker(node, line_height, ctx.assets) {
+            let content_box = compute_content_box(node, &style);
+            let body: Box<dyn Pageable> = if node.flags.is_inline_root() {
+                let paragraph_opt = extract_paragraph(doc, node, ctx);
+                if let Some(mut p) = paragraph_opt {
+                    p.visible = visible;
+                    Box::new(p)
+                } else {
+                    let children: &[usize] = &node.children;
+                    let positioned_children =
+                        collect_positioned_children(doc, children, ctx, depth);
+                    let (before_pseudo, after_pseudo) =
+                        build_block_pseudo_images(doc, node, content_box, ctx.assets);
+                    let positioned_children = wrap_with_block_pseudo_images(
+                        before_pseudo,
+                        after_pseudo,
+                        content_box,
+                        positioned_children,
+                    );
+                    let mut block = BlockPageable::with_positioned_children(positioned_children)
+                        .with_style(style.clone())
+                        .with_visible(visible);
+                    block.wrap(width, 10000.0);
+                    Box::new(block)
+                }
+            } else {
+                let children: &[usize] = &node.children;
+                let positioned_children = collect_positioned_children(doc, children, ctx, depth);
+                let (before_pseudo, after_pseudo) =
+                    build_block_pseudo_images(doc, node, content_box, ctx.assets);
+                let positioned_children = wrap_with_block_pseudo_images(
+                    before_pseudo,
+                    after_pseudo,
+                    content_box,
+                    positioned_children,
+                );
+                let mut block = BlockPageable::with_positioned_children(positioned_children)
+                    .with_style(style.clone())
+                    .with_visible(visible);
+                block.wrap(width, 10000.0);
+                Box::new(block)
+            };
+            let mut item = ListItemPageable {
+                marker,
+                marker_line_height: line_height,
+                body,
+                style: BlockStyle::default(),
+                width,
+                height: 0.0,
+                opacity,
+                visible,
+            };
+            item.wrap(width, 10000.0);
+            return Box::new(item);
+        }
+    }
+
     // Check if this is a table element
     if let Some(elem_data) = node.element_data() {
         let tag = elem_data.name.local.as_ref();
@@ -1825,6 +1898,34 @@ fn is_non_visual_element(node: &Node) -> bool {
     } else {
         false
     }
+}
+
+/// Returns `true` when the node has `display: list-item` and a non-`none`
+/// `list-style-image` value, regardless of whether Blitz populated
+/// `list_item_data` (which it skips when `list-style-type: none`).
+fn has_image_only_list_marker(node: &Node, assets: Option<&AssetBundle>) -> bool {
+    let styles = match node.primary_styles() {
+        Some(s) => s,
+        None => return false,
+    };
+    if !styles.get_box().display.is_list_item() {
+        return false;
+    }
+    let assets = match assets {
+        Some(a) => a,
+        None => return false,
+    };
+    use style::values::computed::image::Image;
+    let url = match styles.clone_list_style_image() {
+        Image::Url(u) => u,
+        _ => return false,
+    };
+    let raw_src = match &url {
+        style::servo::url::ComputedUrl::Valid(u) => u.as_str(),
+        style::servo::url::ComputedUrl::Invalid(s) => s.as_str(),
+    };
+    let src = extract_asset_name(raw_src);
+    assets.get_image(src).is_some()
 }
 
 /// Resolve a list-style-image marker from the node's computed styles.

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -32,9 +32,6 @@ const PX_TO_PT: f32 = 0.75;
 /// unavailable (CSS 2 §10.8.1 initial value for `line-height: normal`).
 const DEFAULT_LINE_HEIGHT_RATIO: f32 = 1.2;
 
-/// Fallback line-height in pt when no style information is available at all.
-const FALLBACK_LINE_HEIGHT_PT: f32 = 12.0;
-
 /// Context for DOM-to-Pageable conversion, bundling all shared state.
 pub struct ConvertContext<'a> {
     pub running_store: &'a RunningElementStore,
@@ -468,13 +465,11 @@ fn convert_node_inner(
     }
 
     // Fallback: display: list-item with list-style-image but no list_item_data
-    // (Blitz 0.2.4 skips list_item_data when list-style-type: none)
-    if node
-        .element_data()
-        .is_some_and(|d| d.list_item_data.is_none())
-        && node
-            .primary_styles()
-            .is_some_and(|s| s.get_box().display.is_list_item())
+    // (Blitz 0.2.4 skips list_item_data when list-style-type: none).
+    // The primary path's guard already consumed `list_item_data.is_some()`,
+    // so reaching here means list_item_data is None — only check display.
+    if let Some(styles) = node.primary_styles()
+        && styles.get_box().display.is_list_item()
     {
         let style = extract_block_style(node, ctx.assets);
         let (opacity, visible) = extract_opacity_visible(node);
@@ -482,18 +477,15 @@ fn convert_node_inner(
         // Derive line_height from computed styles since there is no Parley layout.
         // Honour explicit line-height first; fall back to font-size * 1.2 for
         // `normal`, matching the same heuristic Blitz uses internally.
-        let line_height = node
-            .primary_styles()
-            .map(|s| {
-                use style::values::computed::font::LineHeight;
-                let font_size_pt = s.clone_font_size().used_size().px() * PX_TO_PT;
-                match s.clone_line_height() {
-                    LineHeight::Normal => font_size_pt * DEFAULT_LINE_HEIGHT_RATIO,
-                    LineHeight::Number(num) => font_size_pt * num.0,
-                    LineHeight::Length(value) => value.0.px() * PX_TO_PT,
-                }
-            })
-            .unwrap_or(FALLBACK_LINE_HEIGHT_PT);
+        let line_height = {
+            use style::values::computed::font::LineHeight;
+            let font_size_pt = styles.clone_font_size().used_size().px() * PX_TO_PT;
+            match styles.clone_line_height() {
+                LineHeight::Normal => font_size_pt * DEFAULT_LINE_HEIGHT_RATIO,
+                LineHeight::Number(num) => font_size_pt * num.0,
+                LineHeight::Length(value) => value.0.px() * PX_TO_PT,
+            }
+        };
 
         if let Some(marker) = resolve_list_marker(node, line_height, ctx.assets) {
             let content_box = compute_content_box(node, &style);
@@ -1964,9 +1956,8 @@ fn resolve_list_marker(
     match AssetKind::detect(data) {
         AssetKind::Raster(format) => {
             let (iw, ih) = ImagePageable::decode_dimensions(data, format)?;
-            // px → pt (1px = 0.75pt)
-            let intrinsic_w = iw as f32 * 0.75;
-            let intrinsic_h = ih as f32 * 0.75;
+            let intrinsic_w = iw as f32 * PX_TO_PT;
+            let intrinsic_h = ih as f32 * PX_TO_PT;
             let (width, height) =
                 crate::pageable::clamp_marker_size(intrinsic_w, intrinsic_h, line_height);
             let img = ImagePageable::new(Arc::clone(data), format, width, height);
@@ -1979,9 +1970,8 @@ fn resolve_list_marker(
         AssetKind::Svg => {
             let tree = usvg::Tree::from_data(data, &usvg::Options::default()).ok()?;
             let size = tree.size();
-            // SVG user units = CSS px → PDF pt (1px = 0.75pt)
-            let intrinsic_w = size.width() * 0.75;
-            let intrinsic_h = size.height() * 0.75;
+            let intrinsic_w = size.width() * PX_TO_PT;
+            let intrinsic_h = size.height() * PX_TO_PT;
             let (width, height) =
                 crate::pageable::clamp_marker_size(intrinsic_w, intrinsic_h, line_height);
             let svg = SvgPageable::new(Arc::new(tree), width, height);

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -25,6 +25,16 @@ use std::sync::Arc;
 
 use crate::MAX_DOM_DEPTH;
 
+/// CSS px → PDF pt conversion factor (1 CSS px = 0.75 PDF pt).
+const PX_TO_PT: f32 = 0.75;
+
+/// Default CSS line-height multiplier when the actual computed value is
+/// unavailable (CSS 2 §10.8.1 initial value for `line-height: normal`).
+const DEFAULT_LINE_HEIGHT_RATIO: f32 = 1.2;
+
+/// Fallback line-height in pt when no style information is available at all.
+const FALLBACK_LINE_HEIGHT_PT: f32 = 12.0;
+
 /// Context for DOM-to-Pageable conversion, bundling all shared state.
 pub struct ConvertContext<'a> {
     pub running_store: &'a RunningElementStore,
@@ -246,6 +256,160 @@ fn take_running_marker(
     ))
 }
 
+/// Build the body pageable for a list-item node.
+///
+/// Both the primary list-item path (where Blitz populates `list_item_data`)
+/// and the fallback path (image-only markers with `list-style-type: none`)
+/// share this logic. It handles inline pseudo images, paragraph extraction,
+/// `needs_block_wrapper` + `layout_size`, synthesised paragraphs for
+/// pseudo-only items, and non-inline-root block child collection.
+#[allow(clippy::too_many_arguments)]
+fn build_list_item_body(
+    doc: &blitz_dom::BaseDocument,
+    node: &Node,
+    style: BlockStyle,
+    visible: bool,
+    width: f32,
+    height: f32,
+    content_box: ContentBox,
+    ctx: &mut ConvertContext<'_>,
+    depth: usize,
+) -> Box<dyn Pageable> {
+    if node.flags.is_inline_root() {
+        let paragraph_opt = extract_paragraph(doc, node, ctx);
+
+        // Inline pseudo images for list item body
+        let before_inline = node
+            .before
+            .and_then(|id| doc.get_node(id))
+            .filter(|p| !is_block_pseudo(p))
+            .and_then(|p| {
+                build_inline_pseudo_image(p, content_box.width, content_box.height, ctx.assets)
+            });
+        let after_inline = node
+            .after
+            .and_then(|id| doc.get_node(id))
+            .filter(|p| !is_block_pseudo(p))
+            .and_then(|p| {
+                build_inline_pseudo_image(p, content_box.width, content_box.height, ctx.assets)
+            });
+
+        if let Some(mut paragraph) = paragraph_opt {
+            if before_inline.is_some() || after_inline.is_some() {
+                inject_inline_pseudo_images(&mut paragraph.lines, before_inline, after_inline);
+                recalculate_paragraph_line_boxes(&mut paragraph.lines);
+                paragraph.cached_height = paragraph.lines.iter().map(|l| l.height).sum();
+            }
+
+            let (before_pseudo, after_pseudo) =
+                build_block_pseudo_images(doc, node, content_box, ctx.assets);
+            let has_pseudo = before_pseudo.is_some() || after_pseudo.is_some();
+            if style.needs_block_wrapper() || has_pseudo {
+                let (child_x, child_y) = style.content_inset();
+                let mut p = paragraph;
+                p.visible = visible;
+                let paragraph_children = vec![PositionedChild {
+                    child: Box::new(p),
+                    x: child_x,
+                    y: child_y,
+                }];
+                let children = wrap_with_block_pseudo_images(
+                    before_pseudo,
+                    after_pseudo,
+                    content_box,
+                    paragraph_children,
+                );
+                let mut block = BlockPageable::with_positioned_children(children)
+                    .with_style(style)
+                    .with_visible(visible);
+                block.wrap(width, height);
+                block.layout_size = Some(Size { width, height });
+                Box::new(block)
+            } else {
+                let mut p = paragraph;
+                p.visible = visible;
+                Box::new(p)
+            }
+        } else if before_inline.is_some() || after_inline.is_some() {
+            // Synthesize a minimal paragraph for pseudo-only list items
+            let mut line = ShapedLine {
+                height: 0.0,
+                baseline: 0.0,
+                items: vec![],
+            };
+            inject_inline_pseudo_images(
+                std::slice::from_mut(&mut line),
+                before_inline,
+                after_inline,
+            );
+            let font_metrics = metrics_from_line(&line);
+            crate::paragraph::recalculate_line_box(&mut line, &font_metrics);
+            let mut paragraph = ParagraphPageable::new(vec![line]);
+            paragraph.visible = visible;
+
+            let (before_pseudo, after_pseudo) =
+                build_block_pseudo_images(doc, node, content_box, ctx.assets);
+            let has_pseudo = before_pseudo.is_some() || after_pseudo.is_some();
+            if style.needs_block_wrapper() || has_pseudo {
+                let (child_x, child_y) = style.content_inset();
+                let paragraph_children = vec![PositionedChild {
+                    child: Box::new(paragraph),
+                    x: child_x,
+                    y: child_y,
+                }];
+                let children = wrap_with_block_pseudo_images(
+                    before_pseudo,
+                    after_pseudo,
+                    content_box,
+                    paragraph_children,
+                );
+                let mut block = BlockPageable::with_positioned_children(children)
+                    .with_style(style)
+                    .with_visible(visible);
+                block.wrap(width, height);
+                block.layout_size = Some(Size { width, height });
+                Box::new(block)
+            } else {
+                Box::new(paragraph)
+            }
+        } else {
+            // Inline root with no text and no inline pseudo images —
+            // fall through to the non-inline-root path below.
+            let children: &[usize] = &node.children;
+            let positioned_children = collect_positioned_children(doc, children, ctx, depth);
+            let (before_pseudo, after_pseudo) =
+                build_block_pseudo_images(doc, node, content_box, ctx.assets);
+            let positioned_children = wrap_with_block_pseudo_images(
+                before_pseudo,
+                after_pseudo,
+                content_box,
+                positioned_children,
+            );
+            let mut block = BlockPageable::with_positioned_children(positioned_children)
+                .with_style(style)
+                .with_visible(visible);
+            block.wrap(width, 10000.0);
+            Box::new(block)
+        }
+    } else {
+        let children: &[usize] = &node.children;
+        let positioned_children = collect_positioned_children(doc, children, ctx, depth);
+        let (before_pseudo, after_pseudo) =
+            build_block_pseudo_images(doc, node, content_box, ctx.assets);
+        let positioned_children = wrap_with_block_pseudo_images(
+            before_pseudo,
+            after_pseudo,
+            content_box,
+            positioned_children,
+        );
+        let mut block = BlockPageable::with_positioned_children(positioned_children)
+            .with_style(style)
+            .with_visible(visible);
+        block.wrap(width, 10000.0);
+        Box::new(block)
+    }
+}
+
 fn convert_node_inner(
     doc: &blitz_dom::BaseDocument,
     node_id: usize,
@@ -278,139 +442,17 @@ fn convert_node_inner(
         // own content (paragraph/image), since those are synthetic children
         // representing the node's own content, not real CSS children.
         let content_box = compute_content_box(node, &style);
-        let body: Box<dyn Pageable> = if node.flags.is_inline_root() {
-            let paragraph_opt = extract_paragraph(doc, node, ctx);
-
-            // Inline pseudo images for list item body
-            let before_inline = node
-                .before
-                .and_then(|id| doc.get_node(id))
-                .filter(|p| !is_block_pseudo(p))
-                .and_then(|p| {
-                    build_inline_pseudo_image(p, content_box.width, content_box.height, ctx.assets)
-                });
-            let after_inline = node
-                .after
-                .and_then(|id| doc.get_node(id))
-                .filter(|p| !is_block_pseudo(p))
-                .and_then(|p| {
-                    build_inline_pseudo_image(p, content_box.width, content_box.height, ctx.assets)
-                });
-
-            if let Some(mut paragraph) = paragraph_opt {
-                if before_inline.is_some() || after_inline.is_some() {
-                    inject_inline_pseudo_images(&mut paragraph.lines, before_inline, after_inline);
-                    recalculate_paragraph_line_boxes(&mut paragraph.lines);
-                    paragraph.cached_height = paragraph.lines.iter().map(|l| l.height).sum();
-                }
-
-                let (before_pseudo, after_pseudo) =
-                    build_block_pseudo_images(doc, node, content_box, ctx.assets);
-                let has_pseudo = before_pseudo.is_some() || after_pseudo.is_some();
-                if style.needs_block_wrapper() || has_pseudo {
-                    let (child_x, child_y) = style.content_inset();
-                    let mut p = paragraph;
-                    p.visible = visible;
-                    let paragraph_children = vec![PositionedChild {
-                        child: Box::new(p),
-                        x: child_x,
-                        y: child_y,
-                    }];
-                    let children = wrap_with_block_pseudo_images(
-                        before_pseudo,
-                        after_pseudo,
-                        content_box,
-                        paragraph_children,
-                    );
-                    let mut block = BlockPageable::with_positioned_children(children)
-                        .with_style(style)
-                        .with_visible(visible);
-                    block.wrap(width, height);
-                    block.layout_size = Some(Size { width, height });
-                    Box::new(block)
-                } else {
-                    let mut p = paragraph;
-                    p.visible = visible;
-                    Box::new(p)
-                }
-            } else if before_inline.is_some() || after_inline.is_some() {
-                // Synthesize a minimal paragraph for pseudo-only list items
-                let mut line = ShapedLine {
-                    height: 0.0,
-                    baseline: 0.0,
-                    items: vec![],
-                };
-                inject_inline_pseudo_images(
-                    std::slice::from_mut(&mut line),
-                    before_inline,
-                    after_inline,
-                );
-                let font_metrics = metrics_from_line(&line);
-                crate::paragraph::recalculate_line_box(&mut line, &font_metrics);
-                let mut paragraph = ParagraphPageable::new(vec![line]);
-                paragraph.visible = visible;
-
-                let (before_pseudo, after_pseudo) =
-                    build_block_pseudo_images(doc, node, content_box, ctx.assets);
-                let has_pseudo = before_pseudo.is_some() || after_pseudo.is_some();
-                if style.needs_block_wrapper() || has_pseudo {
-                    let (child_x, child_y) = style.content_inset();
-                    let paragraph_children = vec![PositionedChild {
-                        child: Box::new(paragraph),
-                        x: child_x,
-                        y: child_y,
-                    }];
-                    let children = wrap_with_block_pseudo_images(
-                        before_pseudo,
-                        after_pseudo,
-                        content_box,
-                        paragraph_children,
-                    );
-                    let mut block = BlockPageable::with_positioned_children(children)
-                        .with_style(style)
-                        .with_visible(visible);
-                    block.wrap(width, height);
-                    block.layout_size = Some(Size { width, height });
-                    Box::new(block)
-                } else {
-                    Box::new(paragraph)
-                }
-            } else {
-                // Inline root with no text and no inline pseudo images —
-                // fall through to the non-inline-root path below.
-                let children: &[usize] = &node.children;
-                let positioned_children = collect_positioned_children(doc, children, ctx, depth);
-                let (before_pseudo, after_pseudo) =
-                    build_block_pseudo_images(doc, node, content_box, ctx.assets);
-                let positioned_children = wrap_with_block_pseudo_images(
-                    before_pseudo,
-                    after_pseudo,
-                    content_box,
-                    positioned_children,
-                );
-                let mut block = BlockPageable::with_positioned_children(positioned_children)
-                    .with_style(style)
-                    .with_visible(visible);
-                block.wrap(width, 10000.0);
-                Box::new(block)
-            }
-        } else {
-            let children: &[usize] = &node.children;
-            let positioned_children = collect_positioned_children(doc, children, ctx, depth);
-            let (before_pseudo, after_pseudo) =
-                build_block_pseudo_images(doc, node, content_box, ctx.assets);
-            let positioned_children = wrap_with_block_pseudo_images(
-                before_pseudo,
-                after_pseudo,
-                content_box,
-                positioned_children,
-            );
-            let mut block = BlockPageable::with_positioned_children(positioned_children)
-                .with_style(style)
-                .with_visible(visible);
-            block.wrap(width, 10000.0);
-            Box::new(block)
-        };
+        let body = build_list_item_body(
+            doc,
+            node,
+            style,
+            visible,
+            width,
+            height,
+            content_box,
+            ctx,
+            depth,
+        );
         let mut item = ListItemPageable {
             marker,
             marker_line_height,
@@ -430,7 +472,9 @@ fn convert_node_inner(
     if node
         .element_data()
         .is_some_and(|d| d.list_item_data.is_none())
-        && has_image_only_list_marker(node, ctx.assets)
+        && node
+            .primary_styles()
+            .is_some_and(|s| s.get_box().display.is_list_item())
     {
         let style = extract_block_style(node, ctx.assets);
         let (opacity, visible) = extract_opacity_visible(node);
@@ -438,51 +482,22 @@ fn convert_node_inner(
         // Derive line_height from font-size since there is no Parley layout
         let line_height = node
             .primary_styles()
-            .map(|s| s.clone_font_size().used_size().px() * 0.75 * 1.2)
-            .unwrap_or(12.0);
+            .map(|s| s.clone_font_size().used_size().px() * PX_TO_PT * DEFAULT_LINE_HEIGHT_RATIO)
+            .unwrap_or(FALLBACK_LINE_HEIGHT_PT);
 
         if let Some(marker) = resolve_list_marker(node, line_height, ctx.assets) {
             let content_box = compute_content_box(node, &style);
-            let body: Box<dyn Pageable> = if node.flags.is_inline_root() {
-                let paragraph_opt = extract_paragraph(doc, node, ctx);
-                if let Some(mut p) = paragraph_opt {
-                    p.visible = visible;
-                    Box::new(p)
-                } else {
-                    let children: &[usize] = &node.children;
-                    let positioned_children =
-                        collect_positioned_children(doc, children, ctx, depth);
-                    let (before_pseudo, after_pseudo) =
-                        build_block_pseudo_images(doc, node, content_box, ctx.assets);
-                    let positioned_children = wrap_with_block_pseudo_images(
-                        before_pseudo,
-                        after_pseudo,
-                        content_box,
-                        positioned_children,
-                    );
-                    let mut block = BlockPageable::with_positioned_children(positioned_children)
-                        .with_style(style.clone())
-                        .with_visible(visible);
-                    block.wrap(width, 10000.0);
-                    Box::new(block)
-                }
-            } else {
-                let children: &[usize] = &node.children;
-                let positioned_children = collect_positioned_children(doc, children, ctx, depth);
-                let (before_pseudo, after_pseudo) =
-                    build_block_pseudo_images(doc, node, content_box, ctx.assets);
-                let positioned_children = wrap_with_block_pseudo_images(
-                    before_pseudo,
-                    after_pseudo,
-                    content_box,
-                    positioned_children,
-                );
-                let mut block = BlockPageable::with_positioned_children(positioned_children)
-                    .with_style(style.clone())
-                    .with_visible(visible);
-                block.wrap(width, 10000.0);
-                Box::new(block)
-            };
+            let body = build_list_item_body(
+                doc,
+                node,
+                style,
+                visible,
+                width,
+                height,
+                content_box,
+                ctx,
+                depth,
+            );
             let mut item = ListItemPageable {
                 marker,
                 marker_line_height: line_height,
@@ -1898,34 +1913,6 @@ fn is_non_visual_element(node: &Node) -> bool {
     } else {
         false
     }
-}
-
-/// Returns `true` when the node has `display: list-item` and a non-`none`
-/// `list-style-image` value, regardless of whether Blitz populated
-/// `list_item_data` (which it skips when `list-style-type: none`).
-fn has_image_only_list_marker(node: &Node, assets: Option<&AssetBundle>) -> bool {
-    let styles = match node.primary_styles() {
-        Some(s) => s,
-        None => return false,
-    };
-    if !styles.get_box().display.is_list_item() {
-        return false;
-    }
-    let assets = match assets {
-        Some(a) => a,
-        None => return false,
-    };
-    use style::values::computed::image::Image;
-    let url = match styles.clone_list_style_image() {
-        Image::Url(u) => u,
-        _ => return false,
-    };
-    let raw_src = match &url {
-        style::servo::url::ComputedUrl::Valid(u) => u.as_str(),
-        style::servo::url::ComputedUrl::Invalid(s) => s.as_str(),
-    };
-    let src = extract_asset_name(raw_src);
-    assets.get_image(src).is_some()
 }
 
 /// Resolve a list-style-image marker from the node's computed styles.

--- a/crates/fulgur/tests/list_style_image_test.rs
+++ b/crates/fulgur/tests/list_style_image_test.rs
@@ -68,6 +68,39 @@ fn test_list_style_image_unresolved_url_falls_back_to_text() {
     assert!(pdf.starts_with(b"%PDF"));
 }
 
+#[test]
+fn test_list_style_none_with_image_url_embeds_xobject() {
+    let engine = build_engine();
+    let html = r#"<html><body>
+        <ul style="list-style: none url(bullet.png)">
+            <li>Item one</li>
+            <li>Item two</li>
+        </ul>
+    </body></html>"#;
+    let pdf = engine.render_html(html).unwrap();
+    assert!(pdf.starts_with(b"%PDF"));
+    assert!(
+        pdf_contains(&pdf, b"/Subtype /Image") || pdf_contains(&pdf, b"/Subtype/Image"),
+        "PDF should embed an Image XObject when list-style: none url(bullet.png)"
+    );
+}
+
+#[test]
+fn test_list_style_image_only_embeds_xobject() {
+    let engine = build_engine();
+    let html = r#"<html><body>
+        <ul>
+            <li style="list-style-image: url(bullet.png)">Item</li>
+        </ul>
+    </body></html>"#;
+    let pdf = engine.render_html(html).unwrap();
+    assert!(pdf.starts_with(b"%PDF"));
+    assert!(
+        pdf_contains(&pdf, b"/Subtype /Image") || pdf_contains(&pdf, b"/Subtype/Image"),
+        "PDF should embed an Image XObject when list-style-image is set alone"
+    );
+}
+
 const MINIMAL_SVG: &[u8] = br#"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10" fill="red"/></svg>"#;
 
 #[test]


### PR DESCRIPTION
## Summary

- Blitz 0.2.4 sets `list_item_data = None` when `list-style-type: none`, causing fulgur to skip `ListItemPageable` creation even when `list-style-image` is set
- Added a fallback detection path in `convert_node` that checks `display: list-item` + `list-style-image` directly, deriving line-height from font-size
- Extracted shared `build_list_item_body` helper to deduplicate body-building logic between primary and fallback paths

Closes fulgur-bly

## Test Plan

- [x] `list-style: none url(bullet.png)` embeds Image XObject in PDF
- [x] `list-style-image: url(bullet.png)` alone embeds Image XObject
- [x] Existing list-style-image tests (PNG, SVG, unresolved fallback) pass without regression
- [x] All 316 lib tests pass
- [x] clippy clean, fmt clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * リスト項目の組み立てとサイズ計算を見直し、PDF出力時のリスト描画の一貫性と品質を向上しました。
  * リストマーカー（ビットマップ/SVG）のサイズ解釈を統一し、表示の精度を向上しました。

* **テスト**
  * リストスタイルイメージ（外部画像）に関する統合テストを追加し、PDFへの画像埋め込みを検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->