### PR TITLE
feat: support ::marker { content: url() } for image list markers

### DIFF
--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -1859,4 +1859,16 @@ li::marker { content: url("star.png"); }
             "should handle parentheses inside quoted URL"
         );
     }
+
+    #[test]
+    fn test_rewrite_marker_content_url_in_html_uppercase_style_with_attrs() {
+        let html = r#"<html><head><STYLE type="text/css">
+li::marker { content: url("star.png"); }
+</STYLE></head><body></body></html>"#;
+        let result = rewrite_marker_content_url_in_html(html);
+        assert!(
+            result.contains("list-style-image"),
+            "should handle uppercase STYLE with attributes, got: {result}"
+        );
+    }
 }

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -930,7 +930,7 @@ pub fn rewrite_marker_content_url(css: &str) -> String {
 
     // We'll collect "rewrites" — each is (insert_position, extra_css_text).
     // After scanning we splice them in (back-to-front so offsets stay valid).
-    let mut rewrites: Vec<(usize, String)> = Vec::new();
+    let mut rewrites: Vec<String> = Vec::new();
 
     // Track at-rule wrappers (e.g. @media print) so we can re-wrap the
     // generated rule in the same at-rule context.
@@ -1064,7 +1064,7 @@ pub fn rewrite_marker_content_url(css: &str) -> String {
                 format!("\n{at_header}{{{stripped}{{list-style-image:url({url})}}}}")
             };
 
-            rewrites.push((i, new_rule));
+            rewrites.push(new_rule);
         }
     }
 
@@ -1072,13 +1072,11 @@ pub fn rewrite_marker_content_url(css: &str) -> String {
         return css.to_string();
     }
 
-    // Build the result by inserting rewrites (they're in forward order).
+    // Append all generated rules at the end of the CSS text so they are
+    // never accidentally nested inside an existing at-rule block.
     let mut result = css.to_string();
-    // Insert back-to-front so byte offsets remain valid.
-    // But our positions are char-based; convert to byte positions.
-    for (char_pos, extra) in rewrites.into_iter().rev() {
-        let byte_pos: usize = chars[..char_pos].iter().map(|c| c.len_utf8()).sum();
-        result.insert_str(byte_pos, &extra);
+    for extra in rewrites {
+        result.push_str(&extra);
     }
 
     result
@@ -1676,7 +1674,32 @@ mod marker_rewrite_tests {
     fn test_rewrite_marker_content_url_at_media() {
         let css = r#"@media print { li::marker { content: url("print-bullet.png"); } }"#;
         let result = rewrite_marker_content_url(css);
-        assert!(result.contains("@media print") && result.contains("list-style-image"));
+
+        // The original @media block must remain intact.
+        assert!(
+            result.starts_with(css),
+            "original CSS must be preserved at the start, got:\n{result}"
+        );
+
+        // The generated list-style-image rule must appear AFTER the
+        // original @media block, wrapped in its own @media print { }.
+        let suffix = &result[css.len()..];
+        assert!(
+            suffix.contains("@media print"),
+            "generated rule must be wrapped in @media print, suffix:\n{suffix}"
+        );
+        assert!(
+            suffix.contains("li{list-style-image:url("),
+            "generated rule must contain li{{list-style-image:...}}, suffix:\n{suffix}"
+        );
+
+        // There must be exactly two @media print occurrences — the original
+        // and the generated one — proving there is no double-wrapping.
+        let count = result.matches("@media print").count();
+        assert_eq!(
+            count, 2,
+            "expected exactly 2 @media print occurrences (original + generated), got {count}\nresult:\n{result}"
+        );
     }
 
     #[test]

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -1099,6 +1099,62 @@ pub fn rewrite_marker_content_url(css: &str) -> String {
     result
 }
 
+/// Rewrite `::marker { content: url(...) }` inside `<style>` blocks in HTML.
+///
+/// Finds all `<style>...</style>` regions in the HTML string and applies
+/// [`rewrite_marker_content_url`] to each one's contents. Non-style
+/// content is passed through unchanged.
+pub fn rewrite_marker_content_url_in_html(html: &str) -> String {
+    let lower = html.to_ascii_lowercase();
+    // Quick check: bail early if no <style tag at all.
+    if !lower.contains("<style") {
+        return html.to_string();
+    }
+
+    let mut result = String::with_capacity(html.len());
+    let mut cursor = 0;
+
+    loop {
+        // Find <style (case-insensitive) from cursor.
+        let search = lower[cursor..].find("<style");
+        let Some(rel_start) = search else {
+            // No more <style tags; copy remainder.
+            result.push_str(&html[cursor..]);
+            break;
+        };
+        let tag_start = cursor + rel_start;
+
+        // Find the end of the opening tag `>`.
+        let Some(rel_gt) = html[tag_start..].find('>') else {
+            // Malformed — no closing `>`; copy remainder as-is.
+            result.push_str(&html[cursor..]);
+            break;
+        };
+        let content_start = tag_start + rel_gt + 1;
+
+        // Find </style (case-insensitive).
+        let Some(rel_end) = lower[content_start..].find("</style") else {
+            // No closing tag; copy remainder as-is.
+            result.push_str(&html[cursor..]);
+            break;
+        };
+        let content_end = content_start + rel_end;
+
+        // Copy everything before the CSS content (including the <style> tag).
+        result.push_str(&html[cursor..content_start]);
+
+        // Rewrite the CSS content.
+        let css_content = &html[content_start..content_end];
+        let rewritten = rewrite_marker_content_url(css_content);
+        result.push_str(&rewritten);
+
+        // Advance cursor past the CSS content.
+        cursor = content_end;
+    }
+
+    result
+}
+
 /// Extract the URL from a `content: url(...)` declaration, if present.
 /// Returns the inner URL string (without the `url()` wrapper).
 fn extract_content_url(declarations: &str) -> Option<String> {
@@ -1755,6 +1811,42 @@ mod marker_rewrite_tests {
         assert!(
             result.contains("list-style-image"),
             "should work with @import prefix, got: {result}"
+        );
+    }
+
+    #[test]
+    fn test_rewrite_marker_content_url_in_html_rewrites_style() {
+        let html = r#"<html><head><style>
+li::marker { content: url("star.png"); }
+</style></head><body><ul><li>x</li></ul></body></html>"#;
+        let result = rewrite_marker_content_url_in_html(html);
+        assert!(
+            result.contains("list-style-image"),
+            "should rewrite inside <style>, got: {result}"
+        );
+    }
+
+    #[test]
+    fn test_rewrite_marker_content_url_in_html_no_style_passthrough() {
+        let html = "<html><body><p>Hello</p></body></html>";
+        let result = rewrite_marker_content_url_in_html(html);
+        assert_eq!(result, html);
+    }
+
+    #[test]
+    fn test_rewrite_marker_content_url_in_html_multiple_style_blocks() {
+        let html = r#"<html><head>
+<style>p { color: red; }</style>
+<style>li::marker { content: url("a.png"); }</style>
+</head><body><ul><li>x</li></ul></body></html>"#;
+        let result = rewrite_marker_content_url_in_html(html);
+        assert!(
+            result.contains("list-style-image"),
+            "second style block rewritten"
+        );
+        assert!(
+            result.contains("p { color: red; }"),
+            "first style block preserved"
         );
     }
 

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -916,6 +916,209 @@ fn op_to_matrix(
     }
 }
 
+/// Rewrite `::marker { content: url(...) }` rules into `list-style-image` equivalents.
+///
+/// Blitz 0.2.4 does not expose `::marker` pseudo-element computed styles, so we
+/// rewrite the CSS text to convert `::marker { content: url(...) }` into
+/// `list-style-image: url(...)` on the parent selector, which Blitz already supports.
+///
+/// The original rule is preserved verbatim (for forward-compat); the rewritten rule
+/// is appended immediately after it.
+pub fn rewrite_marker_content_url(css: &str) -> String {
+    let chars: Vec<char> = css.chars().collect();
+    let len = chars.len();
+
+    // We'll collect "rewrites" — each is (insert_position, extra_css_text).
+    // After scanning we splice them in (back-to-front so offsets stay valid).
+    let mut rewrites: Vec<(usize, String)> = Vec::new();
+
+    // Track at-rule wrappers (e.g. @media print) so we can re-wrap the
+    // generated rule in the same at-rule context.
+    // Stack entries: the text of the at-rule header (e.g. "@media print ").
+    let mut at_stack: Vec<String> = Vec::new();
+
+    let mut i = 0;
+    while i < len {
+        let ch = chars[i];
+
+        // Skip string literals so we don't match ::marker inside them.
+        if ch == '"' || ch == '\'' {
+            let quote = ch;
+            i += 1;
+            while i < len && chars[i] != quote {
+                if chars[i] == '\\' {
+                    i += 1; // skip escaped char
+                }
+                i += 1;
+            }
+            i += 1; // skip closing quote
+            continue;
+        }
+
+        // Skip CSS comments.
+        if ch == '/' && i + 1 < len && chars[i + 1] == '*' {
+            i += 2;
+            while i + 1 < len && !(chars[i] == '*' && chars[i + 1] == '/') {
+                i += 1;
+            }
+            i += 2; // skip */
+            continue;
+        }
+
+        // Detect at-rule start: @something ... {
+        if ch == '@' {
+            let at_start = i;
+            // Scan to the opening brace.
+            while i < len && chars[i] != '{' {
+                i += 1;
+            }
+            if i < len {
+                let header: String = chars[at_start..i].iter().collect();
+                at_stack.push(header.trim_end().to_string());
+                i += 1; // skip {
+            }
+            continue;
+        }
+
+        // Detect closing brace — could close an at-rule or a rule block.
+        if ch == '}' {
+            // If we're inside an at-rule wrapper (at_stack non-empty) and
+            // there's no rule block open, this closes the at-rule.
+            // We handle rule block closing below; at-rule closing happens
+            // when we see } at the at-rule depth.
+            // For simplicity: we'll handle rule blocks inline and pop
+            // at-rule on bare }.
+            if !at_stack.is_empty() {
+                at_stack.pop();
+            }
+            i += 1;
+            continue;
+        }
+
+        // Anything else might be the start of a selector.
+        // Scan the selector up to '{'.
+        let selector_start = i;
+        let mut found_brace = false;
+        while i < len {
+            if chars[i] == '{' {
+                found_brace = true;
+                break;
+            }
+            // If we hit } or ; outside a block, this isn't a rule.
+            if chars[i] == '}' || chars[i] == ';' {
+                break;
+            }
+            i += 1;
+        }
+        if !found_brace {
+            i += 1;
+            continue;
+        }
+
+        let selector: String = chars[selector_start..i].iter().collect();
+        let selector = selector.trim();
+        i += 1; // skip {
+
+        // Now scan the declaration block to the matching }.
+        let block_start = i;
+        let mut depth = 1u32;
+        while i < len && depth > 0 {
+            match chars[i] {
+                '{' => depth += 1,
+                '}' => depth -= 1,
+                '"' | '\'' => {
+                    let q = chars[i];
+                    i += 1;
+                    while i < len && chars[i] != q {
+                        if chars[i] == '\\' {
+                            i += 1;
+                        }
+                        i += 1;
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        // i now points just past the closing }
+        let block_end = i - 1; // index of the closing }
+        let declarations: String = chars[block_start..block_end].iter().collect();
+
+        // Check if selector contains ::marker
+        if !selector.contains("::marker") {
+            continue;
+        }
+
+        // Extract content: url(...) from declarations
+        let url_value = extract_content_url(&declarations);
+        if let Some(url) = url_value {
+            // Build the stripped selector (remove ::marker)
+            let stripped = selector.replace("::marker", "");
+            let stripped = stripped.trim();
+
+            // Build the new rule
+            let new_rule = if at_stack.is_empty() {
+                format!("\n{stripped}{{list-style-image:url({url})}}")
+            } else {
+                let at_header = at_stack.last().unwrap();
+                format!("\n{at_header}{{{stripped}{{list-style-image:url({url})}}}}")
+            };
+
+            rewrites.push((i, new_rule));
+        }
+    }
+
+    if rewrites.is_empty() {
+        return css.to_string();
+    }
+
+    // Build the result by inserting rewrites (they're in forward order).
+    let mut result = css.to_string();
+    // Insert back-to-front so byte offsets remain valid.
+    // But our positions are char-based; convert to byte positions.
+    for (char_pos, extra) in rewrites.into_iter().rev() {
+        let byte_pos: usize = chars[..char_pos].iter().map(|c| c.len_utf8()).sum();
+        result.insert_str(byte_pos, &extra);
+    }
+
+    result
+}
+
+/// Extract the URL from a `content: url(...)` declaration, if present.
+/// Returns the inner URL string (without the `url()` wrapper).
+fn extract_content_url(declarations: &str) -> Option<String> {
+    // Find `content` property followed by `:` and then `url(`
+    let decls = declarations.trim();
+    for decl in decls.split(';') {
+        let decl = decl.trim();
+        if let Some(value) = decl.strip_prefix("content") {
+            let value = value.trim();
+            if let Some(value) = value.strip_prefix(':') {
+                let value = value.trim();
+                if let Some(rest) = value.strip_prefix("url(") {
+                    // Find the matching closing paren
+                    let rest = rest.trim();
+                    // The URL might be quoted or unquoted
+                    let url_end = rest.find(')')?;
+                    let url_inner = rest[..url_end].trim();
+                    // Strip quotes if present
+                    let url_inner = url_inner
+                        .strip_prefix('"')
+                        .and_then(|s| s.strip_suffix('"'))
+                        .or_else(|| {
+                            url_inner
+                                .strip_prefix('\'')
+                                .and_then(|s| s.strip_suffix('\''))
+                        })
+                        .unwrap_or(url_inner);
+                    return Some(format!("\"{}\"", url_inner));
+                }
+            }
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1432,5 +1635,57 @@ mod transform_tests {
         let y = m.b * 1.0 + m.d * 0.0 + m.f;
         assert!(approx(x, 0.0), "x expected 0.0, got {x}");
         assert!(approx(y, 1.0), "y expected 1.0, got {y}");
+    }
+}
+
+#[cfg(test)]
+mod marker_rewrite_tests {
+    use super::*;
+
+    #[test]
+    fn test_rewrite_marker_content_url_simple() {
+        let css = r#"li::marker { content: url("star.png"); }"#;
+        let result = rewrite_marker_content_url(css);
+        assert!(result.contains("::marker"), "original rule preserved");
+        assert!(result.contains("list-style-image"), "new rule appended");
+        assert!(result.contains("star.png"), "URL preserved");
+    }
+
+    #[test]
+    fn test_rewrite_marker_content_url_compound_selector() {
+        let css = r#".list li.custom::marker { content: url("check.svg"); }"#;
+        let result = rewrite_marker_content_url(css);
+        assert!(result.contains(".list li.custom") && result.contains("list-style-image"));
+    }
+
+    #[test]
+    fn test_rewrite_marker_content_url_no_marker_passthrough() {
+        let css = "p { color: red; }";
+        let result = rewrite_marker_content_url(css);
+        assert_eq!(result, css);
+    }
+
+    #[test]
+    fn test_rewrite_marker_content_url_non_url_content_ignored() {
+        let css = r#"li::marker { content: "→ "; }"#;
+        let result = rewrite_marker_content_url(css);
+        assert!(!result.contains("list-style-image"));
+    }
+
+    #[test]
+    fn test_rewrite_marker_content_url_at_media() {
+        let css = r#"@media print { li::marker { content: url("print-bullet.png"); } }"#;
+        let result = rewrite_marker_content_url(css);
+        assert!(result.contains("@media print") && result.contains("list-style-image"));
+    }
+
+    #[test]
+    fn test_rewrite_marker_content_url_preserves_other_rules() {
+        let css =
+            "h1 { font-size: 2em; }\nli::marker { content: url(\"icon.png\"); }\np { margin: 0; }";
+        let result = rewrite_marker_content_url(css);
+        assert!(result.contains("h1 { font-size: 2em; }"));
+        assert!(result.contains("p { margin: 0; }"));
+        assert!(result.contains("list-style-image"));
     }
 }

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -928,14 +928,18 @@ pub fn rewrite_marker_content_url(css: &str) -> String {
     let chars: Vec<char> = css.chars().collect();
     let len = chars.len();
 
-    // We'll collect "rewrites" — each is (insert_position, extra_css_text).
-    // After scanning we splice them in (back-to-front so offsets stay valid).
+    // We'll collect "rewrites" — each is an extra CSS text string.
+    // After scanning we append them all at the end of the CSS text.
     let mut rewrites: Vec<String> = Vec::new();
 
     // Track at-rule wrappers (e.g. @media print) so we can re-wrap the
     // generated rule in the same at-rule context.
-    // Stack entries: the text of the at-rule header (e.g. "@media print ").
-    let mut at_stack: Vec<String> = Vec::new();
+    // Stack entries: (brace_depth_when_opened, header_text).
+    let mut at_stack: Vec<(u32, String)> = Vec::new();
+
+    // Unified brace-depth counter — incremented on every `{`, decremented
+    // on every `}` (including those inside rule blocks we scan over).
+    let mut brace_depth: u32 = 0;
 
     let mut i = 0;
     while i < len {
@@ -965,31 +969,37 @@ pub fn rewrite_marker_content_url(css: &str) -> String {
             continue;
         }
 
-        // Detect at-rule start: @something ... {
+        // Detect at-rule start: @something ... { OR @charset/import ... ;
         if ch == '@' {
             let at_start = i;
-            // Scan to the opening brace.
-            while i < len && chars[i] != '{' {
+            // Scan to the first `{` or `;` — whichever comes first.
+            while i < len && chars[i] != '{' && chars[i] != ';' {
                 i += 1;
             }
             if i < len {
-                let header: String = chars[at_start..i].iter().collect();
-                at_stack.push(header.trim_end().to_string());
-                i += 1; // skip {
+                if chars[i] == ';' {
+                    // Statement at-rule (@charset, @import, etc.) — skip it
+                    // without pushing onto at_stack.
+                    i += 1; // skip ;
+                } else {
+                    // Block at-rule — push header and open brace.
+                    let header: String = chars[at_start..i].iter().collect();
+                    at_stack.push((brace_depth, header.trim_end().to_string()));
+                    brace_depth += 1;
+                    i += 1; // skip {
+                }
             }
             continue;
         }
 
         // Detect closing brace — could close an at-rule or a rule block.
         if ch == '}' {
-            // If we're inside an at-rule wrapper (at_stack non-empty) and
-            // there's no rule block open, this closes the at-rule.
-            // We handle rule block closing below; at-rule closing happens
-            // when we see } at the at-rule depth.
-            // For simplicity: we'll handle rule blocks inline and pop
-            // at-rule on bare }.
-            if !at_stack.is_empty() {
-                at_stack.pop();
+            brace_depth = brace_depth.saturating_sub(1);
+            // If the top at-rule was opened at the current depth, pop it.
+            if let Some(&(depth, _)) = at_stack.last() {
+                if depth == brace_depth {
+                    at_stack.pop();
+                }
             }
             i += 1;
             continue;
@@ -1017,6 +1027,7 @@ pub fn rewrite_marker_content_url(css: &str) -> String {
 
         let selector: String = chars[selector_start..i].iter().collect();
         let selector = selector.trim();
+        brace_depth += 1;
         i += 1; // skip {
 
         // Now scan the declaration block to the matching }.
@@ -1024,8 +1035,14 @@ pub fn rewrite_marker_content_url(css: &str) -> String {
         let mut depth = 1u32;
         while i < len && depth > 0 {
             match chars[i] {
-                '{' => depth += 1,
-                '}' => depth -= 1,
+                '{' => {
+                    depth += 1;
+                    brace_depth += 1;
+                }
+                '}' => {
+                    depth -= 1;
+                    brace_depth = brace_depth.saturating_sub(1);
+                }
                 '"' | '\'' => {
                     let q = chars[i];
                     i += 1;
@@ -1060,7 +1077,7 @@ pub fn rewrite_marker_content_url(css: &str) -> String {
             let new_rule = if at_stack.is_empty() {
                 format!("\n{stripped}{{list-style-image:url({url})}}")
             } else {
-                let at_header = at_stack.last().unwrap();
+                let (_, at_header) = at_stack.last().unwrap();
                 format!("\n{at_header}{{{stripped}{{list-style-image:url({url})}}}}")
             };
 
@@ -1094,21 +1111,26 @@ fn extract_content_url(declarations: &str) -> Option<String> {
             if let Some(value) = value.strip_prefix(':') {
                 let value = value.trim();
                 if let Some(rest) = value.strip_prefix("url(") {
-                    // Find the matching closing paren
+                    // Find the matching closing paren, respecting quotes.
                     let rest = rest.trim();
                     // The URL might be quoted or unquoted
-                    let url_end = rest.find(')')?;
-                    let url_inner = rest[..url_end].trim();
-                    // Strip quotes if present
-                    let url_inner = url_inner
-                        .strip_prefix('"')
-                        .and_then(|s| s.strip_suffix('"'))
-                        .or_else(|| {
-                            url_inner
-                                .strip_prefix('\'')
-                                .and_then(|s| s.strip_suffix('\''))
-                        })
-                        .unwrap_or(url_inner);
+                    let (url_inner, _) = if let Some(after_quote) = rest.strip_prefix('"') {
+                        // Quoted with double quotes — find closing quote,
+                        // then verify `)` follows. This handles parens
+                        // inside the URL like `url("image(1).png")`.
+                        let close_quote = after_quote.find('"')?;
+                        let inner = &after_quote[..close_quote];
+                        (inner, close_quote + 2) // +2 for both quotes
+                    } else if let Some(after_quote) = rest.strip_prefix('\'') {
+                        let close_quote = after_quote.find('\'')?;
+                        let inner = &after_quote[..close_quote];
+                        (inner, close_quote + 2)
+                    } else {
+                        // Unquoted — find the closing paren
+                        let url_end = rest.find(')')?;
+                        let inner = rest[..url_end].trim();
+                        (inner, url_end)
+                    };
                     return Some(format!("\"{}\"", url_inner));
                 }
             }
@@ -1710,5 +1732,39 @@ mod marker_rewrite_tests {
         assert!(result.contains("h1 { font-size: 2em; }"));
         assert!(result.contains("p { margin: 0; }"));
         assert!(result.contains("list-style-image"));
+    }
+
+    #[test]
+    fn test_rewrite_marker_content_url_with_charset() {
+        let css = r#"@charset "UTF-8"; li::marker { content: url("star.png"); }"#;
+        let result = rewrite_marker_content_url(css);
+        assert!(
+            result.contains("list-style-image"),
+            "should work with @charset prefix, got: {result}"
+        );
+        assert!(
+            result.contains(r#"@charset "UTF-8";"#),
+            "charset rule preserved"
+        );
+    }
+
+    #[test]
+    fn test_rewrite_marker_content_url_with_import() {
+        let css = r#"@import url("base.css"); li::marker { content: url("icon.png"); }"#;
+        let result = rewrite_marker_content_url(css);
+        assert!(
+            result.contains("list-style-image"),
+            "should work with @import prefix, got: {result}"
+        );
+    }
+
+    #[test]
+    fn test_extract_content_url_quoted_parens() {
+        let url = extract_content_url(r#"content: url("image(1).png")"#);
+        assert_eq!(
+            url.as_deref(),
+            Some("\"image(1).png\""),
+            "should handle parentheses inside quoted URL"
+        );
     }
 }

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -1073,6 +1073,11 @@ pub fn rewrite_marker_content_url(css: &str) -> String {
             let stripped = selector.replace("::marker", "");
             let stripped = stripped.trim();
 
+            // Skip if selector becomes empty (e.g., bare `::marker` without element)
+            if stripped.is_empty() {
+                continue;
+            }
+
             // Build the new rule
             let new_rule = if at_stack.is_empty() {
                 format!("\n{stripped}{{list-style-image:url({url})}}")
@@ -1857,6 +1862,18 @@ li::marker { content: url("star.png"); }
             url.as_deref(),
             Some("\"image(1).png\""),
             "should handle parentheses inside quoted URL"
+        );
+    }
+
+    #[test]
+    fn test_rewrite_marker_content_url_bare_marker_selector() {
+        // A bare `::marker` selector (no element) should not produce an
+        // empty-selector rule like `{list-style-image:...}`.
+        let css = r#"::marker { content: url("star.png"); }"#;
+        let result = rewrite_marker_content_url(css);
+        assert!(
+            !result.contains("\n{"),
+            "bare ::marker should not produce empty-selector rule, got: {result}"
         );
     }
 

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -532,4 +532,29 @@ li::marker { content: url("bullet.png"); }
         let pdf = engine.render_html(html).expect("render should not panic");
         assert!(!pdf.is_empty());
     }
+
+    #[test]
+    fn test_render_html_marker_content_url_with_image() {
+        // 1x1 red PNG (valid, generated with correct CRC checksums)
+        let png_data: Vec<u8> = vec![
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48,
+            0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00,
+            0x00, 0x90, 0x77, 0x53, 0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41, 0x54, 0x78,
+            0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00, 0xC9, 0xFE, 0x92,
+            0xEF, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+        ];
+
+        let mut bundle = AssetBundle::default();
+        bundle.add_css(r#"li::marker { content: url("bullet.png"); }"#);
+        bundle.add_image("bullet.png", png_data);
+
+        let html = r#"<!doctype html>
+<html><body><ul><li>Item 1</li><li>Item 2</li></ul></body></html>"#;
+
+        let engine = Engine::builder().assets(bundle).build();
+        let pdf = engine
+            .render_html(html)
+            .expect("render should succeed with marker image");
+        assert!(!pdf.is_empty(), "PDF should be non-empty");
+    }
 }

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -50,11 +50,14 @@ impl Engine {
     /// a 2-pass rendering pipeline is used: pass 1 paginates body content, pass 2
     /// renders each page with resolved margin boxes.
     pub fn render_html(&self, html: &str) -> Result<Vec<u8>> {
+        let html = crate::blitz_adapter::rewrite_marker_content_url_in_html(html);
+
         let combined_css = self
             .assets
             .as_ref()
             .map(|a| a.combined_css())
             .unwrap_or_default();
+        let combined_css = crate::blitz_adapter::rewrite_marker_content_url(&combined_css);
 
         let mut gcpm = crate::gcpm::parser::parse_gcpm(&combined_css);
         let css_to_inject = gcpm.cleaned_css.clone();
@@ -80,7 +83,7 @@ impl Engine {
         // default browser styles even though their content resolved
         // correctly.
         let (mut doc, link_gcpm) = crate::blitz_adapter::parse_html_with_local_resources(
-            html,
+            &html,
             self.config.content_width(),
             fonts,
             self.base_path.as_deref(),
@@ -515,6 +518,18 @@ mod tests {
 
         let engine = Engine::builder().base_path(&base).build();
         let pdf = engine.render_html(html).expect("render");
+        assert!(!pdf.is_empty());
+    }
+
+    #[test]
+    fn test_render_html_marker_content_url_does_not_panic() {
+        let html = r#"<!doctype html>
+<html><head><style>
+li::marker { content: url("bullet.png"); }
+</style></head>
+<body><ul><li>Item</li></ul></body></html>"#;
+        let engine = Engine::builder().build();
+        let pdf = engine.render_html(html).expect("render should not panic");
         assert!(!pdf.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- `::marker { content: url(...) }` を `list-style-image: url(...)` にCSS事前変換することで、Blitz 0.2.4が::marker pseudo stylesを公開しない制約を回避
- `rewrite_marker_content_url` (CSSテキスト変換) と `rewrite_marker_content_url_in_html` (HTMLインライン`<style>`変換) の2関数を`blitz_adapter.rs`に追加
- `engine.rs`の`render_html`パイプラインに統合（Blitzパース前に適用）

## Details

- 文字単位CSSスキャナーで`::marker`セレクタを検出、`content: url()`を抽出
- `@media`等のat-ruleラッピング、`@charset`/`@import`等のstatement at-rule、複合セレクタに対応
- 元の`::marker`ルールは保持（forward-compat）、変換後ルールをCSS末尾に追記
- 既存の`resolve_list_marker` → `list-style-image`パスにそのまま乗る設計

## Test plan

- [ ] 12 unit tests for `rewrite_marker_content_url` (simple, compound selector, @media, @charset, @import, non-URL content, passthrough, preserves other rules, quoted URL parens, HTML style blocks x3, uppercase STYLE)
- [ ] 2 integration tests in engine.rs (smoke test + image asset render)
- [ ] `cargo test -p fulgur --lib` — 331 passed
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] `cargo fmt --check` — clean

Closes fulgur-9l5
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * マーカーコンテンツURLの処理機能を追加しました。
  * CSSの`::marker`セレクタを使用したスタイルのレンダリング互換性が向上しました。

* **テスト**
  * マーカーCSS変換とHTMLスタイルブロック処理の包括的なテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->