### PR TITLE
feat: support list-style-position: inside

### DIFF
--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -493,7 +493,7 @@ fn convert_node_inner(
         && styles.get_box().display.is_list_item()
         && node
             .element_data()
-            .map_or(true, |e| e.list_item_data.is_none())
+            .is_none_or(|e| e.list_item_data.is_none())
     {
         let style = extract_block_style(node, ctx.assets);
         let (opacity, visible) = extract_opacity_visible(node);

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -422,10 +422,12 @@ fn convert_node_inner(
     // Inside-positioned markers are already injected into Parley's inline layout by Blitz,
     // so they fall through to the normal paragraph path below.
     if let Some(elem_data) = node.element_data()
-        && elem_data
-            .list_item_data
-            .as_ref()
-            .is_some_and(|d| matches!(d.position, blitz_dom::node::ListItemLayoutPosition::Outside(_)))
+        && elem_data.list_item_data.as_ref().is_some_and(|d| {
+            matches!(
+                d.position,
+                blitz_dom::node::ListItemLayoutPosition::Outside(_)
+            )
+        })
     {
         let (marker_lines, marker_width, marker_line_height) = extract_marker_lines(doc, node, ctx);
         let style = extract_block_style(node, ctx.assets);
@@ -583,8 +585,7 @@ fn convert_node_inner(
                         .items
                         .insert(0, LineItem::Image(inline_img));
                     recalculate_paragraph_line_boxes(&mut paragraph.lines);
-                    paragraph.cached_height =
-                        paragraph.lines.iter().map(|l| l.height).sum();
+                    paragraph.cached_height = paragraph.lines.iter().map(|l| l.height).sum();
                 }
             }
 

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -581,6 +581,13 @@ fn convert_node_inner(
                 if let Some(inline_img) =
                     resolve_inside_image_marker(node, first_line_height, ctx.assets)
                 {
+                    let shift = inline_img.width;
+                    for item in &mut paragraph.lines[0].items {
+                        match item {
+                            LineItem::Text(run) => run.x_offset += shift,
+                            LineItem::Image(i) => i.x_offset += shift,
+                        }
+                    }
                     paragraph.lines[0]
                         .items
                         .insert(0, LineItem::Image(inline_img));

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -13,7 +13,7 @@ use crate::pageable::{
 };
 use crate::paragraph::{
     InlineImage, LineFontMetrics, LineItem, ParagraphPageable, ShapedGlyph, ShapedGlyphRun,
-    ShapedLine, TextDecoration, TextDecorationLine, TextDecorationStyle,
+    ShapedLine, TextDecoration, TextDecorationLine, TextDecorationStyle, VerticalAlign,
 };
 use crate::svg::SvgPageable;
 use blitz_dom::{Node, NodeData};
@@ -573,6 +573,21 @@ fn convert_node_inner(
             });
 
         if let Some(mut paragraph) = paragraph_opt {
+            // Inject inside list-style-image as inline image at start of first line
+            if !paragraph.lines.is_empty() {
+                let first_line_height = paragraph.lines[0].height;
+                if let Some(inline_img) =
+                    resolve_inside_image_marker(node, first_line_height, ctx.assets)
+                {
+                    paragraph.lines[0]
+                        .items
+                        .insert(0, LineItem::Image(inline_img));
+                    recalculate_paragraph_line_boxes(&mut paragraph.lines);
+                    paragraph.cached_height =
+                        paragraph.lines.iter().map(|l| l.height).sum();
+                }
+            }
+
             // Existing path: inject inline pseudo images into real paragraph
             if before_inline.is_some() || after_inline.is_some() {
                 inject_inline_pseudo_images(&mut paragraph.lines, before_inline, after_inline);
@@ -2021,6 +2036,69 @@ fn resolve_list_marker(
             })
         }
         AssetKind::Unknown => None,
+    }
+}
+
+/// For `list-style-position: inside` with `list-style-image`, resolve
+/// the image and return it as an `InlineImage` sized to match the
+/// paragraph's first line height. Only supports raster images (PNG/JPEG/GIF).
+/// Returns `None` when the node is not an inside list item, the image URL
+/// cannot be resolved, or the image is SVG.
+fn resolve_inside_image_marker(
+    node: &Node,
+    first_line_height: f32,
+    assets: Option<&AssetBundle>,
+) -> Option<InlineImage> {
+    use crate::image::AssetKind;
+    use style::values::computed::image::Image;
+
+    let elem_data = node.element_data()?;
+    let list_data = elem_data.list_item_data.as_ref()?;
+    if !matches!(
+        list_data.position,
+        blitz_dom::node::ListItemLayoutPosition::Inside
+    ) {
+        return None;
+    }
+    if first_line_height <= 0.0 {
+        return None;
+    }
+
+    let styles = node.primary_styles()?;
+    let image = styles.clone_list_style_image();
+    let url = match image {
+        Image::Url(u) => u,
+        _ => return None,
+    };
+    let raw_src = match &url {
+        style::servo::url::ComputedUrl::Valid(u) => u.as_str(),
+        style::servo::url::ComputedUrl::Invalid(s) => s.as_str(),
+    };
+    let src = extract_asset_name(raw_src);
+    let bundle = assets?;
+    let data = bundle.get_image(src)?;
+
+    match AssetKind::detect(data) {
+        AssetKind::Raster(format) => {
+            let (iw, ih) = ImagePageable::decode_dimensions(data, format)?;
+            let intrinsic_w = iw as f32 * 0.75;
+            let intrinsic_h = ih as f32 * 0.75;
+            let (width, height) =
+                crate::pageable::clamp_marker_size(intrinsic_w, intrinsic_h, first_line_height);
+            Some(InlineImage {
+                data: Arc::clone(data),
+                format,
+                width,
+                height,
+                x_offset: 0.0,
+                vertical_align: VerticalAlign::Baseline,
+                opacity: 1.0,
+                visible: true,
+                computed_y: 0.0,
+            })
+        }
+        // SVG inline images are not yet supported in LineItem::Image
+        AssetKind::Svg | AssetKind::Unknown => None,
     }
 }
 

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -419,8 +419,13 @@ fn convert_node_inner(
     let width = layout.size.width;
 
     // Check if this is a list item with an outside marker (must be before inline root check)
+    // Inside-positioned markers are already injected into Parley's inline layout by Blitz,
+    // so they fall through to the normal paragraph path below.
     if let Some(elem_data) = node.element_data()
-        && elem_data.list_item_data.is_some()
+        && elem_data
+            .list_item_data
+            .as_ref()
+            .is_some_and(|d| matches!(d.position, blitz_dom::node::ListItemLayoutPosition::Outside(_)))
     {
         let (marker_lines, marker_width, marker_line_height) = extract_marker_lines(doc, node, ctx);
         let style = extract_block_style(node, ctx.assets);

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -483,10 +483,17 @@ fn convert_node_inner(
 
     // Fallback: display: list-item with list-style-image but no list_item_data
     // (Blitz 0.2.4 skips list_item_data when list-style-type: none).
-    // The primary path's guard already consumed `list_item_data.is_some()`,
-    // so reaching here means list_item_data is None — only check display.
+    //
+    // The primary guard above now only matches Outside-positioned items, so we
+    // must additionally require `list_item_data.is_none()` here to avoid
+    // intercepting inside-positioned items that DO have list_item_data — those
+    // should fall through to the inline-root path so `resolve_inside_image_marker`
+    // can inject the marker inline.
     if let Some(styles) = node.primary_styles()
         && styles.get_box().display.is_list_item()
+        && node
+            .element_data()
+            .map_or(true, |e| e.list_item_data.is_none())
     {
         let style = extract_block_style(node, ctx.assets);
         let (opacity, visible) = extract_opacity_visible(node);

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -418,9 +418,19 @@ fn convert_node_inner(
     let height = layout.size.height;
     let width = layout.size.width;
 
-    // Check if this is a list item with an outside marker (must be before inline root check)
-    // Inside-positioned markers are already injected into Parley's inline layout by Blitz,
-    // so they fall through to the normal paragraph path below.
+    // Check if this is a list item with an outside marker (must be before inline root check).
+    //
+    // Inside-positioned markers are injected into Parley's inline layout by Blitz
+    // (blitz-dom/src/layout/construct.rs in `build_inline_layout`), so when the
+    // `<li>` IS an inline root they fall through to the normal paragraph path below
+    // and render correctly. For `list-style-image` + inside, `resolve_inside_image_marker`
+    // injects the image at the start of the paragraph's first line.
+    //
+    // Known limitation: when `<li>` is NOT an inline root (contains only block
+    // children, e.g. `<li><p>...</p></li>`) or is empty, neither Blitz nor
+    // fulgur injects the marker, and the marker is not rendered. This matches
+    // upstream Blitz behavior — Blitz's inline-layout injection only fires for
+    // inline-root elements.
     if let Some(elem_data) = node.element_data()
         && elem_data.list_item_data.as_ref().is_some_and(|d| {
             matches!(

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -585,7 +585,21 @@ fn convert_node_inner(
             });
 
         if let Some(mut paragraph) = paragraph_opt {
-            // Inject inside list-style-image as inline image at start of first line
+            // Inject pseudo images BEFORE the list marker so the marker stays
+            // at index 0 of the first line after both injections. CSS order
+            // for list-style-position: inside is: marker → ::before → content.
+            // Blitz already pushes text markers to the inline layout before
+            // ::before, so when list-style-image triggers marker injection we
+            // must put it at index 0 last.
+            if before_inline.is_some() || after_inline.is_some() {
+                inject_inline_pseudo_images(&mut paragraph.lines, before_inline, after_inline);
+                recalculate_paragraph_line_boxes(&mut paragraph.lines);
+                paragraph.cached_height = paragraph.lines.iter().map(|l| l.height).sum();
+            }
+
+            // Inject inside list-style-image as inline image at start of first line.
+            // Runs AFTER pseudo image injection so the marker ends up at index 0
+            // and pushes existing items (including ::before) to index 1+.
             if !paragraph.lines.is_empty() {
                 let first_line_height = paragraph.lines[0].height;
                 if let Some(inline_img) =
@@ -604,13 +618,6 @@ fn convert_node_inner(
                     recalculate_paragraph_line_boxes(&mut paragraph.lines);
                     paragraph.cached_height = paragraph.lines.iter().map(|l| l.height).sum();
                 }
-            }
-
-            // Existing path: inject inline pseudo images into real paragraph
-            if before_inline.is_some() || after_inline.is_some() {
-                inject_inline_pseudo_images(&mut paragraph.lines, before_inline, after_inline);
-                recalculate_paragraph_line_boxes(&mut paragraph.lines);
-                paragraph.cached_height = paragraph.lines.iter().map(|l| l.height).sum();
             }
 
             // Then existing block pseudo check
@@ -1989,6 +1996,49 @@ fn is_non_visual_element(node: &Node) -> bool {
     }
 }
 
+/// Resolve a node's computed `list-style-image` to bundled asset bytes and
+/// detected asset kind. Returns `None` when there is no `list-style-image`,
+/// the computed value is not a plain `url(...)`, no asset bundle is set, or
+/// the asset is not registered in the bundle.
+fn resolve_list_style_image_asset<'a>(
+    node: &Node,
+    assets: Option<&'a AssetBundle>,
+) -> Option<(&'a Arc<Vec<u8>>, crate::image::AssetKind)> {
+    use style::values::computed::image::Image;
+    let assets = assets?;
+    let styles = node.primary_styles()?;
+    let image = styles.clone_list_style_image();
+    let url = match image {
+        Image::Url(u) => u,
+        _ => return None,
+    };
+    let raw_src = match &url {
+        style::servo::url::ComputedUrl::Valid(u) => u.as_str(),
+        style::servo::url::ComputedUrl::Invalid(s) => s.as_str(),
+    };
+    let src = extract_asset_name(raw_src);
+    let data = assets.get_image(src)?;
+    let kind = crate::image::AssetKind::detect(data);
+    Some((data, kind))
+}
+
+/// Clamp a raster image's intrinsic dimensions (in CSS px) to a marker size
+/// bounded by `line_height`. Returns `(width_pt, height_pt)`.
+fn size_raster_marker(
+    data: &Arc<Vec<u8>>,
+    format: crate::image::ImageFormat,
+    line_height: f32,
+) -> Option<(f32, f32)> {
+    let (iw, ih) = ImagePageable::decode_dimensions(data, format)?;
+    let intrinsic_w = iw as f32 * PX_TO_PT;
+    let intrinsic_h = ih as f32 * PX_TO_PT;
+    Some(crate::pageable::clamp_marker_size(
+        intrinsic_w,
+        intrinsic_h,
+        line_height,
+    ))
+}
+
 /// Resolve a list-style-image marker from the node's computed styles.
 ///
 /// Returns `Some(ListItemMarker::Image { ... })` when the node's
@@ -2003,7 +2053,6 @@ fn resolve_list_marker(
     assets: Option<&AssetBundle>,
 ) -> Option<ListItemMarker> {
     use crate::image::AssetKind;
-    use style::values::computed::image::Image;
 
     // Zero or negative line-height (e.g. list-style-position: inside where
     // extract_marker_lines returns 0.0) would clamp image size to 0x0.
@@ -2012,26 +2061,10 @@ fn resolve_list_marker(
     if line_height <= 0.0 {
         return None;
     }
-    let assets = assets?;
-    let styles = node.primary_styles()?;
-    let image = styles.clone_list_style_image();
-    let url = match image {
-        Image::Url(u) => u,
-        _ => return None,
-    };
-    let raw_src = match &url {
-        style::servo::url::ComputedUrl::Valid(u) => u.as_str(),
-        style::servo::url::ComputedUrl::Invalid(s) => s.as_str(),
-    };
-    let src = extract_asset_name(raw_src);
-    let data = assets.get_image(src)?;
-    match AssetKind::detect(data) {
+    let (data, kind) = resolve_list_style_image_asset(node, assets)?;
+    match kind {
         AssetKind::Raster(format) => {
-            let (iw, ih) = ImagePageable::decode_dimensions(data, format)?;
-            let intrinsic_w = iw as f32 * PX_TO_PT;
-            let intrinsic_h = ih as f32 * PX_TO_PT;
-            let (width, height) =
-                crate::pageable::clamp_marker_size(intrinsic_w, intrinsic_h, line_height);
+            let (width, height) = size_raster_marker(data, format, line_height)?;
             let img = ImagePageable::new(Arc::clone(data), format, width, height);
             Some(ListItemMarker::Image {
                 marker: ImageMarker::Raster(img),
@@ -2068,7 +2101,6 @@ fn resolve_inside_image_marker(
     assets: Option<&AssetBundle>,
 ) -> Option<InlineImage> {
     use crate::image::AssetKind;
-    use style::values::computed::image::Image;
 
     let elem_data = node.element_data()?;
     let list_data = elem_data.list_item_data.as_ref()?;
@@ -2082,27 +2114,10 @@ fn resolve_inside_image_marker(
         return None;
     }
 
-    let styles = node.primary_styles()?;
-    let image = styles.clone_list_style_image();
-    let url = match image {
-        Image::Url(u) => u,
-        _ => return None,
-    };
-    let raw_src = match &url {
-        style::servo::url::ComputedUrl::Valid(u) => u.as_str(),
-        style::servo::url::ComputedUrl::Invalid(s) => s.as_str(),
-    };
-    let src = extract_asset_name(raw_src);
-    let bundle = assets?;
-    let data = bundle.get_image(src)?;
-
-    match AssetKind::detect(data) {
+    let (data, kind) = resolve_list_style_image_asset(node, assets)?;
+    match kind {
         AssetKind::Raster(format) => {
-            let (iw, ih) = ImagePageable::decode_dimensions(data, format)?;
-            let intrinsic_w = iw as f32 * 0.75;
-            let intrinsic_h = ih as f32 * 0.75;
-            let (width, height) =
-                crate::pageable::clamp_marker_size(intrinsic_w, intrinsic_h, first_line_height);
+            let (width, height) = size_raster_marker(data, format, first_line_height)?;
             Some(InlineImage {
                 data: Arc::clone(data),
                 format,

--- a/crates/fulgur/tests/list_style_inside_test.rs
+++ b/crates/fulgur/tests/list_style_inside_test.rs
@@ -34,7 +34,11 @@ fn test_list_style_position_inside_text_marker_renders() {
     </body></html>"#;
     let pdf = engine.render_html(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
-    assert!(pdf.len() > 500, "PDF should have non-trivial content, got {} bytes", pdf.len());
+    assert!(
+        pdf.len() > 500,
+        "PDF should have non-trivial content, got {} bytes",
+        pdf.len()
+    );
 }
 
 #[test]
@@ -49,7 +53,11 @@ fn test_list_style_position_inside_ordered_list() {
     </body></html>"#;
     let pdf = engine.render_html(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
-    assert!(pdf.len() > 500, "PDF should have non-trivial content, got {} bytes", pdf.len());
+    assert!(
+        pdf.len() > 500,
+        "PDF should have non-trivial content, got {} bytes",
+        pdf.len()
+    );
 }
 
 #[test]
@@ -71,5 +79,46 @@ fn test_list_style_position_inside_image_marker() {
     assert!(
         pdf_contains(&pdf, b"/Subtype /Image") || pdf_contains(&pdf, b"/Subtype/Image"),
         "PDF should embed an Image XObject for the inside-position image marker"
+    );
+}
+
+#[test]
+fn test_outside_markers_still_work_after_inside_changes() {
+    let engine = build_engine();
+    let html = r#"<html><body>
+        <ul style="list-style-position: outside">
+            <li>Outside one</li>
+            <li>Outside two</li>
+            <li>Outside three</li>
+        </ul>
+    </body></html>"#;
+    let pdf = engine.render_html(html).unwrap();
+    assert!(pdf.starts_with(b"%PDF"));
+    assert!(
+        pdf.len() > 500,
+        "PDF should have non-trivial content, got {} bytes",
+        pdf.len()
+    );
+}
+
+#[test]
+fn test_inside_and_outside_in_same_document() {
+    let engine = build_engine();
+    let html = r#"<html><body>
+        <ul style="list-style-position: outside">
+            <li>Outside item A</li>
+            <li>Outside item B</li>
+        </ul>
+        <ul style="list-style-position: inside">
+            <li>Inside item A</li>
+            <li>Inside item B</li>
+        </ul>
+    </body></html>"#;
+    let pdf = engine.render_html(html).unwrap();
+    assert!(pdf.starts_with(b"%PDF"));
+    assert!(
+        pdf.len() > 500,
+        "PDF should have non-trivial content, got {} bytes",
+        pdf.len()
     );
 }

--- a/crates/fulgur/tests/list_style_inside_test.rs
+++ b/crates/fulgur/tests/list_style_inside_test.rs
@@ -101,6 +101,42 @@ fn test_outside_markers_still_work_after_inside_changes() {
     );
 }
 
+// Known limitation: when <li> contains only block children (not an inline
+// root) or is empty, Blitz does not inject the marker into any inline
+// layout, so the marker is not rendered. This matches upstream Blitz
+// behavior — Blitz's own layout construction in
+// blitz-dom/src/layout/construct.rs only injects inside markers in
+// `build_inline_layout`, which is not called for non-inline-root elements.
+//
+// Tracked as a follow-up: see CHANGELOG and the `list-style-inside`
+// limitations note. These tests guard that fulgur still produces a valid
+// PDF in these edge cases (no panic, no crash) even though the marker
+// is absent.
+#[test]
+fn test_inside_marker_with_block_child_does_not_crash() {
+    let engine = build_engine();
+    let html = r#"<html><body>
+        <ul style="list-style-position: inside">
+            <li><p>Nested paragraph</p></li>
+        </ul>
+    </body></html>"#;
+    let pdf = engine.render_html(html).unwrap();
+    assert!(pdf.starts_with(b"%PDF"));
+}
+
+#[test]
+fn test_inside_empty_li_does_not_crash() {
+    let engine = build_engine();
+    let html = r#"<html><body>
+        <ul style="list-style-position: inside">
+            <li></li>
+            <li>Not empty</li>
+        </ul>
+    </body></html>"#;
+    let pdf = engine.render_html(html).unwrap();
+    assert!(pdf.starts_with(b"%PDF"));
+}
+
 #[test]
 fn test_inside_and_outside_in_same_document() {
     let engine = build_engine();

--- a/crates/fulgur/tests/list_style_inside_test.rs
+++ b/crates/fulgur/tests/list_style_inside_test.rs
@@ -1,11 +1,25 @@
+use fulgur::asset::AssetBundle;
 use fulgur::config::{Margin, PageSize};
 use fulgur::engine::Engine;
+
+// Minimal 1x1 red PNG (69 bytes) — copied from list_style_image_test.rs.
+const MINIMAL_PNG: &[u8] = &[
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+    0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0x00,
+    0x00, 0x03, 0x01, 0x01, 0x00, 0xC9, 0xFE, 0x92, 0xEF, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E,
+    0x44, 0xAE, 0x42, 0x60, 0x82,
+];
 
 fn build_engine() -> Engine {
     Engine::builder()
         .page_size(PageSize::A4)
         .margin(Margin::uniform(72.0))
         .build()
+}
+
+fn pdf_contains(pdf: &[u8], needle: &[u8]) -> bool {
+    pdf.windows(needle.len()).any(|w| w == needle)
 }
 
 #[test]
@@ -36,4 +50,26 @@ fn test_list_style_position_inside_ordered_list() {
     let pdf = engine.render_html(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     assert!(pdf.len() > 500, "PDF should have non-trivial content, got {} bytes", pdf.len());
+}
+
+#[test]
+fn test_list_style_position_inside_image_marker() {
+    let mut assets = AssetBundle::new();
+    assets.add_image("bullet.png", MINIMAL_PNG.to_vec());
+    let engine = Engine::builder()
+        .page_size(PageSize::A4)
+        .margin(Margin::uniform(72.0))
+        .assets(assets)
+        .build();
+    let html = r#"<html><body>
+        <ul style="list-style-position: inside; list-style-image: url(bullet.png)">
+            <li>Image inside</li>
+        </ul>
+    </body></html>"#;
+    let pdf = engine.render_html(html).unwrap();
+    assert!(pdf.starts_with(b"%PDF"), "output should be a valid PDF");
+    assert!(
+        pdf_contains(&pdf, b"/Subtype /Image") || pdf_contains(&pdf, b"/Subtype/Image"),
+        "PDF should embed an Image XObject for the inside-position image marker"
+    );
 }

--- a/crates/fulgur/tests/list_style_inside_test.rs
+++ b/crates/fulgur/tests/list_style_inside_test.rs
@@ -1,0 +1,39 @@
+use fulgur::config::{Margin, PageSize};
+use fulgur::engine::Engine;
+
+fn build_engine() -> Engine {
+    Engine::builder()
+        .page_size(PageSize::A4)
+        .margin(Margin::uniform(72.0))
+        .build()
+}
+
+#[test]
+fn test_list_style_position_inside_text_marker_renders() {
+    let engine = build_engine();
+    let html = r#"<html><body>
+        <ul style="list-style-position: inside">
+            <li>Item one</li>
+            <li>Item two</li>
+            <li>Item three</li>
+        </ul>
+    </body></html>"#;
+    let pdf = engine.render_html(html).unwrap();
+    assert!(pdf.starts_with(b"%PDF"));
+    assert!(pdf.len() > 500, "PDF should have non-trivial content, got {} bytes", pdf.len());
+}
+
+#[test]
+fn test_list_style_position_inside_ordered_list() {
+    let engine = build_engine();
+    let html = r#"<html><body>
+        <ol style="list-style-position: inside">
+            <li>First item</li>
+            <li>Second item</li>
+            <li>Third item</li>
+        </ol>
+    </body></html>"#;
+    let pdf = engine.render_html(html).unwrap();
+    assert!(pdf.starts_with(b"%PDF"));
+    assert!(pdf.len() > 500, "PDF should have non-trivial content, got {} bytes", pdf.len());
+}

--- a/crates/fulgur/tests/list_style_inside_test.rs
+++ b/crates/fulgur/tests/list_style_inside_test.rs
@@ -137,6 +137,37 @@ fn test_inside_empty_li_does_not_crash() {
     assert!(pdf.starts_with(b"%PDF"));
 }
 
+// Regression: when list-style-position: inside + list-style-image is combined
+// with li::before (also an image pseudo), the marker must appear before
+// ::before in the inline flow (order: marker → ::before → content).
+// The injection code must run pseudo images first so the marker ends up at
+// index 0 after both injections.
+#[test]
+fn test_inside_image_marker_with_before_pseudo_does_not_crash() {
+    let mut assets = AssetBundle::new();
+    assets.add_image("bullet.png", MINIMAL_PNG.to_vec());
+    assets.add_image("pseudo.png", MINIMAL_PNG.to_vec());
+    let engine = Engine::builder()
+        .page_size(PageSize::A4)
+        .margin(Margin::uniform(72.0))
+        .assets(assets)
+        .build();
+    let html = r#"<html><head><style>
+        li::before { content: url(pseudo.png); }
+    </style></head><body>
+        <ul style="list-style-position: inside; list-style-image: url(bullet.png)">
+            <li>Item with pseudo</li>
+        </ul>
+    </body></html>"#;
+    let pdf = engine.render_html(html).unwrap();
+    assert!(pdf.starts_with(b"%PDF"));
+    // Both the marker image and the ::before image should be embedded.
+    assert!(
+        pdf_contains(&pdf, b"/Subtype /Image") || pdf_contains(&pdf, b"/Subtype/Image"),
+        "PDF should embed an Image XObject"
+    );
+}
+
 #[test]
 fn test_inside_and_outside_in_same_document() {
     let engine = build_engine();


### PR DESCRIPTION
## 概要

- Inside位置のリストアイテムが空マーカーの `ListItemPageable` にラップされる代わりに、通常のパラグラフパスにフォールスルーするように修正。Blitzは inside の場合マーカーテキストを `inline_layout_data` に既に含めているため、`extract_paragraph` が自然に拾う。
- `list-style-image` + inside の場合、ラスター画像マーカーをパラグラフ先頭行のインライン画像として注入。既存アイテムの x_offset シフトにより重なりを防止。
- inside テキストマーカー、inside 画像マーカー、outside リグレッション、同一ドキュメント内の inside/outside 混在をカバーする統合テスト5件を追加。

Closes fulgur-146

## テスト計画

- [x] `cargo test -p fulgur --lib` — 316テストパス
- [x] `cargo test -p fulgur --test list_style_inside_test` — 5テストパス
- [x] `cargo test -p fulgur --test list_style_image_test` — 3テストパス（outside画像リグレッション）
- [x] `cargo test -p fulgur --test opacity_visibility_test` — 9テストパス（visibilityリグレッション）
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 内側配置（inside）のみを正しく判定するよう条件を厳密化し、誤って内部の項目を別経路で処理していたことで発生するレイアウト崩れを修正。画像マーカー挿入時の行頭オフセットと段落高さの再計算も改善しました。

* **新機能**
  * 内側配置のリスト項目へ行高に合わせた画像マーカーを挿入して表示する処理を追加。ラスター画像のサイズ算出と制限を行い、埋め込み画像出力をサポートします。

* **テスト**
  * inside/outside、画像マーカー、空項目や入れ子ブロックのみの項目などを確認する回帰テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->