### PR TITLE
docs(claude): note Engine builder API, pdftocairo helper, and fulgur --lib split

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,8 @@ cargo build
 cargo build --release
 
 # Test
-cargo test --lib
+cargo test --lib                   # note: in the workspace root this runs only fulgur-vrt
+cargo test -p fulgur --lib         # fulgur unit tests (~340)
 cargo test -p fulgur
 cargo test -p fulgur --test gcpm_integration
 
@@ -95,3 +96,5 @@ callers don't get this guarantee by default — see the tracking issue
 - Use `BTreeMap` (not `HashMap`) for iteration that affects PDF output (determinism)
 - Blitz: `!important` unreliable, `padding-top` on inline roots ignored (use `margin-top`)
 - `cargo fmt --check` enforced by CI
+- **`Engine` is a builder**: `Engine::builder().page_size(PageSize::A4).base_path(root).build()` + single-arg `render_html(html)`. There is no `Engine::new().with_*()`.
+- **PDF → PNG for visual tests**: `pdftocairo -png -r 100 -f 1 -l 1 <pdf> <prefix>` (poppler-utils). Installed in CI; gate with skip-if-missing for local dev. `fulgur-vrt::pdf_render::render_html_to_rgba` wraps this but does not accept `base_path`, so integration tests that load local CSS must inline the call.


### PR DESCRIPTION
## 概要

fulgur-2ai 実装セッション (#86) で `Engine::new()` と誤認しやすい API ミスや `cargo test --lib` の罠、視覚テストでの `pdftocairo` 利用を繰り返し遭遇したため、CLAUDE.md に短く固定します。

## 変更内容

- `Common Commands` の `cargo test --lib` に「workspace root では fulgur-vrt のみ走る」注記、および `cargo test -p fulgur --lib` を追加
- `Gotchas` に 2 行追加:
  - Engine は builder パターン (`Engine::builder().page_size().base_path().build()` + 1引数 `render_html`)
  - PDF → PNG 視覚テストは `pdftocairo -png -r 100 -f 1 -l 1 <pdf> <prefix>`、CI には poppler-utils 済み

## Test plan

- [x] `npx markdownlint-cli2 CLAUDE.md` — clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/87" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
