### PR TITLE
Update fulgur to newer blitz/stylo stack

### DIFF
--- a/crates/fulgur/Cargo.toml
+++ b/crates/fulgur/Cargo.toml
@@ -12,16 +12,17 @@ keywords = ["pdf", "html", "css", "converter"]
 categories = ["text-processing", "command-line-utilities"]
 
 [dependencies]
-cssparser = "0.35"
+cssparser = "0.36"
 krilla = "0.7.0"
 krilla-svg = "0.7.0"
 usvg = "0.45"
-blitz-html = "0.2"
-blitz-dom = "0.2"
-blitz-traits = "0.2"
-parley = "0.6"
-skrifa = "0.37"
-stylo = "0.8.0"
+blitz-usvg = { package = "usvg", version = "0.46" }
+blitz-html = { git = "https://github.com/dioxuslabs/blitz", branch = "main", default-features = false }
+blitz-dom = { git = "https://github.com/dioxuslabs/blitz", branch = "main", default-features = false, features = ["svg", "woff-rust"] }
+blitz-traits = { git = "https://github.com/dioxuslabs/blitz", branch = "main", default-features = false }
+parley = { git = "https://github.com/linebender/parley", rev = "5660d0b1acec4a3118f0301c2d35508b33dfe785", default-features = false, features = ["std"] }
+skrifa = { version = "0.40", default-features = false, features = ["std"] }
+stylo = "0.16.0"
 woff2-patched = "0.4"
 thiserror = "2"
 minijinja = { version = "=2.19.0", features = ["unstable_machinery"] }

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -255,7 +255,7 @@ fn draw_background_layer(
                 canvas.surface.push_transform(&transform);
                 if canvas
                     .surface
-                    .draw_svg(tree, size, SvgSettings::default())
+                    .draw_svg(tree.as_ref(), size, SvgSettings::default())
                     .is_none()
                 {
                     log::warn!("failed to draw SVG background tile");

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -21,7 +21,6 @@
 //! for the full investigation and rationale.
 
 use blitz_dom::DocumentConfig;
-use blitz_dom::net::Resource;
 use blitz_html::HtmlDocument;
 use blitz_traits::net::{NetProvider, Url};
 use blitz_traits::shell::{ColorScheme, Viewport};
@@ -103,12 +102,10 @@ pub fn parse_html_with_local_resources(
     font_data: &[Arc<Vec<u8>>],
     base_path: Option<&Path>,
 ) -> (HtmlDocument, crate::gcpm::GcpmContext) {
-    use std::collections::HashSet;
-
     let net_provider = Arc::new(crate::net::FulgurNetProvider::new(
         base_path.map(|p| p.to_path_buf()),
     ));
-    let provider: Arc<dyn NetProvider<Resource>> = net_provider.clone();
+    let provider: Arc<dyn NetProvider> = net_provider.clone();
     let base_url = base_path
         .and_then(|p| p.canonicalize().ok())
         .and_then(|p| Url::from_directory_path(&p).ok())
@@ -116,36 +113,15 @@ pub fn parse_html_with_local_resources(
 
     let mut doc = parse_inner(html, viewport_width, font_data, Some(provider), base_url);
 
-    // Identify <link rel=stylesheet media=X> nodes *before* mutating so
-    // their attributes are stable, and before loading so we can filter
-    // out the (wrong-media) resources that blitz's parser already
-    // triggered for them.
+    // Identify <link rel=stylesheet media=X> nodes before mutating so
+    // their attributes are stable.
     let rewrites = collect_link_media_rewrites(&doc);
-    let rewrite_node_ids: HashSet<usize> = rewrites.iter().map(|r| r.link_node_id).collect();
-
-    // First drain: load resources that correspond to <link> elements
-    // WITHOUT a media rewrite. Discard resources for nodes we are about
-    // to rewrite — their @import replacements will re-fetch with the
-    // correct MediaList.
-    for resource in net_provider.drain_pending_resources() {
-        if let Resource::Css(node_id, _) = &resource {
-            if rewrite_node_ids.contains(node_id) {
-                continue;
-            }
-        }
-        doc.load_resource(resource);
-    }
 
     // Apply the DOM rewrite. Mutator's `drop` synchronously triggers
     // `process_style_element` for each new <style>, which parses the
     // @import, calls StylesheetLoader → NetProvider::fetch → CssHandler
-    // with `MediaList` properly propagated, and pushes new Resources.
+    // with `MediaList` properly propagated.
     apply_link_media_rewrites(&mut doc, &rewrites);
-
-    // Second drain: load the correctly-fetched stylesheets.
-    for resource in net_provider.drain_pending_resources() {
-        doc.load_resource(resource);
-    }
 
     // Fold the per-stylesheet GCPM contexts into one. The caller still
     // has to merge this with its own AssetBundle-derived context.
@@ -162,7 +138,7 @@ fn parse_inner(
     html: &str,
     viewport_width: f32,
     font_data: &[Arc<Vec<u8>>],
-    net_provider: Option<Arc<dyn NetProvider<Resource>>>,
+    net_provider: Option<Arc<dyn NetProvider>>,
     base_url: Option<String>,
 ) -> HtmlDocument {
     let viewport = Viewport::new(viewport_width as u32, 10000, 1.0, ColorScheme::Light);
@@ -273,7 +249,12 @@ pub fn extract_inline_svg_tree(
 ) -> Option<std::sync::Arc<usvg::Tree>> {
     use blitz_dom::node::ImageData;
     match elem.image_data()? {
-        ImageData::Svg(tree) => Some(std::sync::Arc::new((**tree).clone())),
+        ImageData::Svg(tree) => {
+            let svg = tree.to_string(&blitz_usvg::WriteOptions::default());
+            usvg::Tree::from_str(&svg, &usvg::Options::default())
+                .ok()
+                .map(std::sync::Arc::new)
+        }
         _ => None,
     }
 }
@@ -345,34 +326,39 @@ fn extract_url_from_stylo_image(image: &style::values::computed::image::Image) -
 /// map it to fulgur's `VerticalAlign` enum.
 pub fn extract_vertical_align(node: &blitz_dom::Node) -> crate::paragraph::VerticalAlign {
     use crate::paragraph::VerticalAlign;
+    use style::Zero;
+
     let Some(styles) = node.primary_styles() else {
         return VerticalAlign::Baseline;
     };
-    let va = styles.clone_vertical_align();
-    match va {
-        style::values::generics::box_::VerticalAlign::Keyword(kw) => {
-            use style::values::generics::box_::VerticalAlignKeyword;
+
+    match styles.clone_baseline_shift() {
+        style::values::generics::box_::BaselineShift::Keyword(kw) => {
+            use style::values::generics::box_::BaselineShiftKeyword;
             match kw {
-                VerticalAlignKeyword::Baseline => VerticalAlign::Baseline,
-                VerticalAlignKeyword::Middle => VerticalAlign::Middle,
-                VerticalAlignKeyword::Top => VerticalAlign::Top,
-                VerticalAlignKeyword::Bottom => VerticalAlign::Bottom,
-                VerticalAlignKeyword::Sub => VerticalAlign::Sub,
-                VerticalAlignKeyword::Super => VerticalAlign::Super,
-                VerticalAlignKeyword::TextTop => VerticalAlign::TextTop,
-                VerticalAlignKeyword::TextBottom => VerticalAlign::TextBottom,
-                #[allow(unreachable_patterns)]
-                _ => VerticalAlign::Baseline,
+                BaselineShiftKeyword::Sub => VerticalAlign::Sub,
+                BaselineShiftKeyword::Super => VerticalAlign::Super,
+                BaselineShiftKeyword::Top => VerticalAlign::Top,
+                BaselineShiftKeyword::Center => VerticalAlign::Middle,
+                BaselineShiftKeyword::Bottom => VerticalAlign::Bottom,
             }
         }
-        style::values::generics::box_::VerticalAlign::Length(lp) => {
+        style::values::generics::box_::BaselineShift::Length(lp) => {
+            if lp.is_zero() {
+                return match styles.clone_alignment_baseline() {
+                    style::values::computed::AlignmentBaseline::Baseline => VerticalAlign::Baseline,
+                    style::values::computed::AlignmentBaseline::Middle => VerticalAlign::Middle,
+                    style::values::computed::AlignmentBaseline::TextTop => VerticalAlign::TextTop,
+                    style::values::computed::AlignmentBaseline::TextBottom => {
+                        VerticalAlign::TextBottom
+                    }
+                    _ => VerticalAlign::Baseline,
+                };
+            }
+
             if let Some(pct) = lp.to_percentage() {
                 VerticalAlign::Percent(pct.0)
             } else {
-                // Note: for calc() mixed values like `calc(10px + 50%)`,
-                // to_percentage() returns None and we resolve with basis=0,
-                // which drops the percentage component. This is a known
-                // limitation — calc() in vertical-align is extremely rare.
                 VerticalAlign::Length(lp.resolve(style::values::computed::Length::new(0.0)).px())
             }
         }

--- a/crates/fulgur/src/net.rs
+++ b/crates/fulgur/src/net.rs
@@ -30,8 +30,7 @@
 
 use crate::gcpm::GcpmContext;
 use crate::gcpm::parser::parse_gcpm;
-use blitz_dom::net::Resource;
-use blitz_traits::net::{BoxedHandler, Bytes, NetProvider, Request, SharedCallback};
+use blitz_traits::net::{Bytes, NetHandler, NetProvider, Request};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
@@ -54,7 +53,6 @@ pub struct FulgurNetProvider {
 #[derive(Default)]
 struct Inner {
     gcpm_contexts: Vec<GcpmContext>,
-    pending_resources: Vec<Resource>,
 }
 
 impl FulgurNetProvider {
@@ -66,14 +64,6 @@ impl FulgurNetProvider {
             canonical_base,
             inner: Arc::new(Mutex::new(Inner::default())),
         }
-    }
-
-    /// Take the queued [`Resource`] objects loaded so far. The caller
-    /// is expected to apply each one to the document via
-    /// `BaseDocument::load_resource`.
-    pub fn drain_pending_resources(&self) -> Vec<Resource> {
-        let mut inner = self.inner.lock().unwrap();
-        std::mem::take(&mut inner.pending_resources)
     }
 
     /// Take the GCPM contexts extracted from CSS payloads. The caller
@@ -112,8 +102,8 @@ impl FulgurNetProvider {
     }
 }
 
-impl NetProvider<Resource> for FulgurNetProvider {
-    fn fetch(&self, doc_id: usize, request: Request, handler: BoxedHandler<Resource>) {
+impl NetProvider for FulgurNetProvider {
+    fn fetch(&self, _doc_id: usize, request: Request, handler: Box<dyn NetHandler>) {
         let Some(canonical_path) = self.resolve_local_path(&request) else {
             return;
         };
@@ -137,20 +127,12 @@ impl NetProvider<Resource> for FulgurNetProvider {
             (Bytes::from(raw_bytes), None)
         };
 
-        let inner = self.inner.clone();
-        let callback: SharedCallback<Resource> = Arc::new(
-            move |_doc_id: usize, result: Result<Resource, Option<String>>| {
-                if let Ok(res) = result {
-                    inner.lock().unwrap().pending_resources.push(res);
-                }
-            },
-        );
-
         // `handler.bytes` parses the CSS via stylo, which synchronously
         // triggers `fetch()` again for every `@import` before returning.
         // When it does return, every imported child stylesheet has
         // already pushed its own `GcpmContext`.
-        handler.bytes(doc_id, bytes_for_blitz, callback);
+        let resolved_url = request.url.to_string();
+        handler.bytes(resolved_url, bytes_for_blitz);
 
         // Post-order push: the parent context goes into the buffer
         // *after* its children, so the eventual `cleaned_css`
@@ -183,13 +165,8 @@ mod tests {
         bytes: Arc<Mutex<Option<Vec<u8>>>>,
     }
 
-    impl NetHandler<Resource> for RecordingHandler {
-        fn bytes(
-            self: Box<Self>,
-            _doc_id: usize,
-            bytes: blitz_traits::net::Bytes,
-            _callback: blitz_traits::net::SharedCallback<Resource>,
-        ) {
+    impl NetHandler for RecordingHandler {
+        fn bytes(self: Box<Self>, _resolved_url: String, bytes: blitz_traits::net::Bytes) {
             *self.bytes.lock().unwrap() = Some(bytes.to_vec());
         }
     }

--- a/crates/fulgur/src/svg.rs
+++ b/crates/fulgur/src/svg.rs
@@ -69,7 +69,7 @@ impl Pageable for SvgPageable {
             // when krilla::image::Image::from_* returns Err.
             let _ = canvas
                 .surface
-                .draw_svg(&self.tree, size, SvgSettings::default());
+                .draw_svg(self.tree.as_ref(), size, SvgSettings::default());
             canvas.surface.pop();
         });
     }


### PR DESCRIPTION
## Summary\n- update  to the newer  mainline stack\n- move from  to the newer  series\n- keep the library building on the newer dependency set used by downstream consumers\n\n## Notes\n- this is the base PR for the two follow-up rendering fixes\n- the follow-up PRs were split out to keep the dependency bump reviewable\n