### PR TITLE
feat(link): PDF link annotations for <a href> (fulgur-d5k)

### DIFF
--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -257,6 +257,28 @@ pub fn get_attr<'a>(elem: &'a blitz_dom::node::ElementData, name: &str) -> Optio
         .map(|a| a.value.as_ref())
 }
 
+/// Concatenate all descendant text under `node_id` into a single String (DFS).
+///
+/// Used to build a PDF link's `alt_text` (tooltip / accessibility label) from
+/// the visible text of an `<a>` element. Returns an empty string if the node
+/// has no text descendants or does not exist.
+pub fn element_text(doc: &blitz_dom::BaseDocument, node_id: usize) -> String {
+    fn walk(doc: &blitz_dom::BaseDocument, id: usize, out: &mut String) {
+        let Some(node) = doc.get_node(id) else {
+            return;
+        };
+        if let blitz_dom::node::NodeData::Text(t) = &node.data {
+            out.push_str(&t.content);
+        }
+        for &child_id in &node.children {
+            walk(doc, child_id, out);
+        }
+    }
+    let mut out = String::new();
+    walk(doc, node_id, &mut out);
+    out
+}
+
 /// Extract the parsed `usvg::Tree` from an inline `<svg>` element, if present.
 ///
 /// Blitz parses inline `<svg>` elements during DOM construction (default `svg`

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -263,7 +263,10 @@ pub fn get_attr<'a>(elem: &'a blitz_dom::node::ElementData, name: &str) -> Optio
 /// the visible text of an `<a>` element. Returns an empty string if the node
 /// has no text descendants or does not exist.
 pub fn element_text(doc: &blitz_dom::BaseDocument, node_id: usize) -> String {
-    fn walk(doc: &blitz_dom::BaseDocument, id: usize, out: &mut String) {
+    fn walk(doc: &blitz_dom::BaseDocument, id: usize, depth: usize, out: &mut String) {
+        if depth >= MAX_DOM_DEPTH {
+            return;
+        }
         let Some(node) = doc.get_node(id) else {
             return;
         };
@@ -271,11 +274,11 @@ pub fn element_text(doc: &blitz_dom::BaseDocument, node_id: usize) -> String {
             out.push_str(&t.content);
         }
         for &child_id in &node.children {
-            walk(doc, child_id, out);
+            walk(doc, child_id, depth + 1, out);
         }
     }
     let mut out = String::new();
-    walk(doc, node_id, &mut out);
+    walk(doc, node_id, 0, &mut out);
     out
 }
 
@@ -1883,6 +1886,29 @@ mod tests {
         assert!(b_css_link_found, "<link href=b.css> must be preserved");
         let text = style_text_found.expect("<style> with @import must exist");
         assert_eq!(text, r#"@import url("a.css") print;"#);
+    }
+
+    #[test]
+    fn element_text_does_not_stack_overflow_on_deep_nesting() {
+        // Regression guard: element_text used to recurse without a depth
+        // bound, so attacker-controlled HTML with thousands of nested
+        // elements could overflow the thread stack. MAX_DOM_DEPTH now caps
+        // the recursion — building ~2000 nested divs must return (possibly
+        // truncated) rather than panic.
+        let mut html = String::from("<html><body>");
+        for _ in 0..2000 {
+            html.push_str("<div>");
+        }
+        html.push_str("leaf");
+        for _ in 0..2000 {
+            html.push_str("</div>");
+        }
+        html.push_str("</body></html>");
+
+        let (doc, _gcpm) = parse_html_with_local_resources(&html, 400.0, &[], None);
+        use std::ops::Deref;
+        let root = doc.root_element();
+        let _ = element_text(doc.deref(), root.id);
     }
 }
 

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -262,7 +262,51 @@ pub fn get_attr<'a>(elem: &'a blitz_dom::node::ElementData, name: &str) -> Optio
 /// Used to build a PDF link's `alt_text` (tooltip / accessibility label) from
 /// the visible text of an `<a>` element. Returns an empty string if the node
 /// has no text descendants or does not exist.
+///
+/// Word-boundary preservation: a single space is inserted before descending
+/// into a child element when that child is `<br>` or a block-level element
+/// (block boundaries act as implicit whitespace in the visual rendering).
+/// Without this, `<a><div>foo</div><div>bar</div></a>` would collapse to
+/// `"foobar"` — meaningless for screen readers. Spaces are deduped by
+/// checking the accumulator's trailing char before pushing.
 pub fn element_text(doc: &blitz_dom::BaseDocument, node_id: usize) -> String {
+    fn is_block_boundary_tag(tag: &str) -> bool {
+        matches!(
+            tag,
+            "br" | "div"
+                | "p"
+                | "li"
+                | "ul"
+                | "ol"
+                | "blockquote"
+                | "section"
+                | "article"
+                | "header"
+                | "footer"
+                | "nav"
+                | "aside"
+                | "h1"
+                | "h2"
+                | "h3"
+                | "h4"
+                | "h5"
+                | "h6"
+                | "table"
+                | "tr"
+                | "td"
+                | "th"
+                | "pre"
+                | "figure"
+                | "hr"
+        )
+    }
+
+    fn push_separator(out: &mut String) {
+        if !out.is_empty() && !out.ends_with(|c: char| c.is_whitespace()) {
+            out.push(' ');
+        }
+    }
+
     fn walk(doc: &blitz_dom::BaseDocument, id: usize, depth: usize, out: &mut String) {
         if depth >= MAX_DOM_DEPTH {
             return;
@@ -274,6 +318,13 @@ pub fn element_text(doc: &blitz_dom::BaseDocument, node_id: usize) -> String {
             out.push_str(&t.content);
         }
         for &child_id in &node.children {
+            if let Some(child) = doc.get_node(child_id) {
+                if let blitz_dom::node::NodeData::Element(el) = &child.data {
+                    if is_block_boundary_tag(el.name.local.as_ref()) {
+                        push_separator(out);
+                    }
+                }
+            }
             walk(doc, child_id, depth + 1, out);
         }
     }
@@ -1909,6 +1960,69 @@ mod tests {
         use std::ops::Deref;
         let root = doc.root_element();
         let _ = element_text(doc.deref(), root.id);
+    }
+
+    /// Walk the DOM to find the first element whose `id` attribute equals `id_value`.
+    fn find_element_by_attr_id(doc: &blitz_dom::BaseDocument, id_value: &str) -> usize {
+        fn walk(
+            doc: &blitz_dom::BaseDocument,
+            node_id: usize,
+            want: &str,
+            depth: usize,
+        ) -> Option<usize> {
+            if depth >= MAX_DOM_DEPTH {
+                return None;
+            }
+            let node = doc.get_node(node_id)?;
+            if let Some(el) = node.element_data() {
+                if get_attr(el, "id") == Some(want) {
+                    return Some(node_id);
+                }
+            }
+            for &child_id in &node.children {
+                if let Some(found) = walk(doc, child_id, want, depth + 1) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        let root_id = doc.root_element().id;
+        walk(doc, root_id, id_value, 0)
+            .unwrap_or_else(|| panic!("element with id={id_value:?} not found"))
+    }
+
+    #[test]
+    fn element_text_inserts_space_between_block_children() {
+        let html = "<html><body><a id='x'><div>foo</div><div>bar</div></a></body></html>";
+        let (doc, _gcpm) = parse_html_with_local_resources(html, 400.0, &[], None);
+        use std::ops::Deref;
+        let a_id = find_element_by_attr_id(doc.deref(), "x");
+        let text = element_text(doc.deref(), a_id);
+        assert_eq!(text.trim(), "foo bar", "got {text:?}");
+    }
+
+    #[test]
+    fn element_text_inserts_space_for_br() {
+        let html = "<html><body><a id='x'>foo<br>bar</a></body></html>";
+        let (doc, _gcpm) = parse_html_with_local_resources(html, 400.0, &[], None);
+        use std::ops::Deref;
+        let a_id = find_element_by_attr_id(doc.deref(), "x");
+        let text = element_text(doc.deref(), a_id);
+        assert_eq!(text.trim(), "foo bar");
+    }
+
+    #[test]
+    fn element_text_does_not_double_whitespace() {
+        // If the text already ends in whitespace, a block boundary should
+        // not add another space.
+        let html = "<html><body><a id='x'>foo <div>bar</div></a></body></html>";
+        let (doc, _gcpm) = parse_html_with_local_resources(html, 400.0, &[], None);
+        use std::ops::Deref;
+        let a_id = find_element_by_attr_id(doc.deref(), "x");
+        let text = element_text(doc.deref(), a_id);
+        // Should be "foo bar" (single space), not "foo  bar".
+        assert_eq!(text.trim(), "foo bar");
+        assert!(!text.contains("  "));
     }
 }
 

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -1718,7 +1718,14 @@ fn resolve_enclosing_anchor(
     start_id: usize,
 ) -> Option<(usize, LinkSpan)> {
     let mut cur = Some(start_id);
+    let mut depth: usize = 0;
     while let Some(id) = cur {
+        // Defense-in-depth against pathological / malformed parent chains,
+        // matching the bounds applied in `debug_print_tree`,
+        // `collect_positioned_children`, and `blitz_adapter::element_text`.
+        if depth >= MAX_DOM_DEPTH {
+            return None;
+        }
         let node = doc.get_node(id)?;
         if let NodeData::Element(el) = &node.data {
             if el.name.local.as_ref() == "a" {
@@ -1737,6 +1744,7 @@ fn resolve_enclosing_anchor(
             }
         }
         cur = node.parent;
+        depth += 1;
     }
     None
 }

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -1856,7 +1856,11 @@ fn extract_paragraph(
         return None;
     }
 
-    Some(ParagraphPageable::new(shaped_lines))
+    // Propagate the inline-root `id` so headings like `<h1 id="top">` that
+    // end up as plain `ParagraphPageable` (no block wrapper triggered by the
+    // default style) still register with `DestinationRegistry` for
+    // `href="#top"` resolution.
+    Some(ParagraphPageable::new(shaped_lines).with_id(extract_block_id(node)))
 }
 
 /// Extract visual style (background, borders, padding, background-image) from a node.

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -12,8 +12,9 @@ use crate::pageable::{
     StringSetPageable, StringSetWrapperPageable, TablePageable, TransformWrapperPageable,
 };
 use crate::paragraph::{
-    InlineImage, LineFontMetrics, LineItem, ParagraphPageable, ShapedGlyph, ShapedGlyphRun,
-    ShapedLine, TextDecoration, TextDecorationLine, TextDecorationStyle, VerticalAlign,
+    InlineImage, LineFontMetrics, LineItem, LinkSpan, LinkTarget, ParagraphPageable, ShapedGlyph,
+    ShapedGlyphRun, ShapedLine, TextDecoration, TextDecorationLine, TextDecorationStyle,
+    VerticalAlign,
 };
 use crate::svg::SvgPageable;
 use blitz_dom::{Node, NodeData};
@@ -319,6 +320,10 @@ fn build_list_item_body(
             .filter(|p| !is_block_pseudo(p))
             .and_then(|p| {
                 build_inline_pseudo_image(p, content_box.width, content_box.height, ctx.assets)
+            })
+            .map(|mut img| {
+                attach_link_to_inline_image(&mut img, doc, node.id);
+                img
             });
         let after_inline = node
             .after
@@ -326,6 +331,10 @@ fn build_list_item_body(
             .filter(|p| !is_block_pseudo(p))
             .and_then(|p| {
                 build_inline_pseudo_image(p, content_box.width, content_box.height, ctx.assets)
+            })
+            .map(|mut img| {
+                attach_link_to_inline_image(&mut img, doc, node.id);
+                img
             });
 
         if let Some(mut paragraph) = paragraph_opt {
@@ -619,6 +628,10 @@ fn convert_node_inner(
             .filter(|p| !is_block_pseudo(p))
             .and_then(|p| {
                 build_inline_pseudo_image(p, content_box.width, content_box.height, ctx.assets)
+            })
+            .map(|mut img| {
+                attach_link_to_inline_image(&mut img, doc, node.id);
+                img
             });
         let after_inline = node
             .after
@@ -626,6 +639,10 @@ fn convert_node_inner(
             .filter(|p| !is_block_pseudo(p))
             .and_then(|p| {
                 build_inline_pseudo_image(p, content_box.width, content_box.height, ctx.assets)
+            })
+            .map(|mut img| {
+                attach_link_to_inline_image(&mut img, doc, node.id);
+                img
             });
 
         if let Some(mut paragraph) = paragraph_opt {
@@ -1285,6 +1302,28 @@ fn build_inline_pseudo_image(
     })
 }
 
+/// Populate the `link` field on an `InlineImage` built for a pseudo-element
+/// whose real originating node is `origin_node_id` (typically the pseudo's
+/// parent — the element that owns `::before` / `::after`). If that node is
+/// enclosed by an `<a href>` ancestor, attach a fresh `LinkSpan`.
+///
+/// We build a fresh `LinkSpan` here rather than sharing through the
+/// `extract_paragraph` cache because pseudo images are injected into the
+/// paragraph's line vector by callers, not emitted from within the glyph-run
+/// loop — they live on a separate control-flow path. Rect-dedup in a later
+/// task will be keyed on the LinkTarget+alt_text payload for pseudo images,
+/// not on Arc identity, and this is fine because most anchors contain at
+/// most one pseudo image.
+fn attach_link_to_inline_image(
+    img: &mut InlineImage,
+    doc: &blitz_dom::BaseDocument,
+    origin_node_id: usize,
+) {
+    if let Some((_, span)) = resolve_enclosing_anchor(doc, origin_node_id) {
+        img.link = Some(Arc::new(span));
+    }
+}
+
 /// Inject an inline pseudo image at the start (::before) and/or end (::after)
 /// of the shaped lines. The ::before image is prepended to the first line and
 /// all existing items are shifted right by its width. The ::after image is
@@ -1643,6 +1682,81 @@ fn collect_table_cells(
     }
 }
 
+/// Walk up from `start_id` to find the closest `<a href>` ancestor and build
+/// a `LinkSpan` describing its target. Returns `None` if no ancestor is an
+/// anchor with a non-empty `href`.
+///
+/// Caller should memoize results per anchor node ID so multiple glyph runs
+/// descended from the same `<a>` share one `Arc<LinkSpan>` (pointer identity,
+/// required for later rect-dedup in PDF emission).
+fn resolve_enclosing_anchor(
+    doc: &blitz_dom::BaseDocument,
+    start_id: usize,
+) -> Option<(usize, LinkSpan)> {
+    let mut cur = Some(start_id);
+    while let Some(id) = cur {
+        let node = doc.get_node(id)?;
+        if let NodeData::Element(el) = &node.data {
+            if el.name.local.as_ref() == "a" {
+                let href = crate::blitz_adapter::get_attr(el, "href")?.trim();
+                if href.is_empty() {
+                    return None;
+                }
+                let target = if let Some(frag) = href.strip_prefix('#') {
+                    LinkTarget::Internal(Arc::new(frag.to_string()))
+                } else {
+                    LinkTarget::External(Arc::new(href.to_string()))
+                };
+                let alt = crate::blitz_adapter::element_text(doc, id);
+                let alt_text = if alt.is_empty() { None } else { Some(alt) };
+                return Some((id, LinkSpan { target, alt_text }));
+            }
+        }
+        cur = node.parent;
+    }
+    None
+}
+
+/// Memoized lookup of the enclosing `<a href>` for a node.
+///
+/// Two-level cache to ensure pointer identity per anchor:
+/// - `by_start` maps the starting node ID (e.g. a glyph run's brush.id) to
+///   the resolved anchor's node ID (or `None` if no anchor ancestor).
+/// - `by_anchor` maps the anchor's node ID to the canonical `Arc<LinkSpan>`.
+///
+/// This guarantees that two glyph runs under the same `<a>` receive the
+/// SAME `Arc<LinkSpan>` (verified via `Arc::ptr_eq`), which is required for
+/// correct quad_points deduplication during PDF /Link emission.
+#[derive(Default)]
+struct LinkCache {
+    by_start: HashMap<usize, Option<usize>>,
+    by_anchor: HashMap<usize, Arc<LinkSpan>>,
+}
+
+impl LinkCache {
+    fn lookup(&mut self, doc: &blitz_dom::BaseDocument, start_id: usize) -> Option<Arc<LinkSpan>> {
+        if let Some(cached) = self.by_start.get(&start_id) {
+            let anchor_id = (*cached)?;
+            return self.by_anchor.get(&anchor_id).cloned();
+        }
+        match resolve_enclosing_anchor(doc, start_id) {
+            Some((anchor_id, span)) => {
+                self.by_start.insert(start_id, Some(anchor_id));
+                let arc = self
+                    .by_anchor
+                    .entry(anchor_id)
+                    .or_insert_with(|| Arc::new(span))
+                    .clone();
+                Some(arc)
+            }
+            None => {
+                self.by_start.insert(start_id, None);
+                None
+            }
+        }
+    }
+}
+
 /// Extract a ParagraphPageable from an inline root node.
 fn extract_paragraph(
     doc: &blitz_dom::BaseDocument,
@@ -1656,6 +1770,7 @@ fn extract_paragraph(
     let text = &text_layout.text;
 
     let mut shaped_lines = Vec::new();
+    let mut link_cache = LinkCache::default();
 
     for line in parley_layout.lines() {
         let metrics = line.metrics();
@@ -1673,6 +1788,7 @@ fn extract_paragraph(
                 let brush = &glyph_run.style().brush;
                 let color = get_text_color(doc, brush.id);
                 let decoration = get_text_decoration(doc, brush.id);
+                let link = link_cache.lookup(doc, brush.id);
 
                 // Extract raw glyphs (relative offsets, not absolute positions)
                 let text_len = text.len();
@@ -1699,7 +1815,7 @@ fn extract_paragraph(
                         glyphs,
                         text: run_text,
                         x_offset: glyph_run.offset(),
-                        link: None,
+                        link,
                     }));
                 }
             }
@@ -3240,5 +3356,212 @@ mod tests {
             None
         }
         assert_eq!(find(root.as_ref()), Some((3u8, "Subsection".to_string())));
+    }
+
+    /// Locate the first element with the given tag by DFS from the document root.
+    fn find_tag(doc: &blitz_html::HtmlDocument, tag: &str) -> Option<usize> {
+        fn walk(doc: &blitz_dom::BaseDocument, id: usize, tag: &str) -> Option<usize> {
+            let node = doc.get_node(id)?;
+            if let Some(ed) = node.element_data() {
+                if ed.name.local.as_ref() == tag {
+                    return Some(id);
+                }
+            }
+            for &c in &node.children {
+                if let Some(v) = walk(doc, c, tag) {
+                    return Some(v);
+                }
+            }
+            None
+        }
+        walk(doc.deref(), doc.root_element().id, tag)
+    }
+
+    macro_rules! make_ctx {
+        ($store:ident) => {{
+            ConvertContext {
+                running_store: &$store,
+                assets: None,
+                font_cache: HashMap::new(),
+                string_set_by_node: HashMap::new(),
+                counter_ops_by_node: HashMap::new(),
+            }
+        }};
+    }
+
+    #[test]
+    fn paragraph_attaches_external_link_to_glyph_run_inside_anchor() {
+        let html =
+            r#"<html><body><p>Go to <a href="https://example.com">example</a>.</p></body></html>"#;
+        let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
+        crate::blitz_adapter::resolve(&mut doc);
+
+        let store = crate::gcpm::running::RunningElementStore::new();
+        let mut ctx = make_ctx!(store);
+        let p_id = find_tag(&doc, "p").expect("p exists");
+        let p_node = doc.get_node(p_id).expect("p node");
+        let para = extract_paragraph(doc.deref(), p_node, &mut ctx).expect("paragraph");
+
+        let mut found_external = false;
+        for line in &para.lines {
+            for item in &line.items {
+                if let LineItem::Text(run) = item {
+                    if let Some(ls) = &run.link {
+                        if let LinkTarget::External(u) = &ls.target {
+                            if u.as_str() == "https://example.com" {
+                                found_external = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        assert!(
+            found_external,
+            "expected at least one glyph run under <a> to carry an External link"
+        );
+    }
+
+    #[test]
+    fn paragraph_attaches_internal_link_for_fragment_href() {
+        let html = r##"<html><body><p>See <a href="#intro">intro</a></p></body></html>"##;
+        let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
+        crate::blitz_adapter::resolve(&mut doc);
+
+        let store = crate::gcpm::running::RunningElementStore::new();
+        let mut ctx = make_ctx!(store);
+        let p_id = find_tag(&doc, "p").expect("p exists");
+        let p_node = doc.get_node(p_id).expect("p node");
+        let para = extract_paragraph(doc.deref(), p_node, &mut ctx).expect("paragraph");
+
+        let mut found = false;
+        for line in &para.lines {
+            for item in &line.items {
+                if let LineItem::Text(run) = item {
+                    if let Some(ls) = &run.link {
+                        if let LinkTarget::Internal(frag) = &ls.target {
+                            if frag.as_str() == "intro" {
+                                found = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        assert!(
+            found,
+            "expected fragment link to produce LinkTarget::Internal(\"intro\")"
+        );
+    }
+
+    #[test]
+    fn paragraph_shares_arc_linkspan_across_glyph_runs_under_same_anchor() {
+        // <em> forces two separate glyph runs (different style) under one <a>.
+        let html =
+            r#"<html><body><p><a href="https://x.test"><em>foo</em> bar</a></p></body></html>"#;
+        let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
+        crate::blitz_adapter::resolve(&mut doc);
+
+        let store = crate::gcpm::running::RunningElementStore::new();
+        let mut ctx = make_ctx!(store);
+        let p_id = find_tag(&doc, "p").expect("p exists");
+        let p_node = doc.get_node(p_id).expect("p node");
+        let para = extract_paragraph(doc.deref(), p_node, &mut ctx).expect("paragraph");
+
+        let mut links: Vec<Arc<LinkSpan>> = Vec::new();
+        for line in &para.lines {
+            for item in &line.items {
+                if let LineItem::Text(run) = item {
+                    if let Some(ls) = &run.link {
+                        links.push(Arc::clone(ls));
+                    }
+                }
+            }
+        }
+        assert!(
+            links.len() >= 2,
+            "expected at least two linked glyph runs (got {})",
+            links.len()
+        );
+        let first = &links[0];
+        for other in &links[1..] {
+            assert!(
+                Arc::ptr_eq(first, other),
+                "all glyph runs inside the same <a> must share one Arc<LinkSpan>"
+            );
+        }
+    }
+
+    #[test]
+    fn paragraph_leaves_link_none_for_anchor_without_href() {
+        let html = r#"<html><body><p>Text <a>no href</a> here.</p></body></html>"#;
+        let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
+        crate::blitz_adapter::resolve(&mut doc);
+
+        let store = crate::gcpm::running::RunningElementStore::new();
+        let mut ctx = make_ctx!(store);
+        let p_id = find_tag(&doc, "p").expect("p exists");
+        let p_node = doc.get_node(p_id).expect("p node");
+        let para = extract_paragraph(doc.deref(), p_node, &mut ctx).expect("paragraph");
+
+        for line in &para.lines {
+            for item in &line.items {
+                if let LineItem::Text(run) = item {
+                    assert!(
+                        run.link.is_none(),
+                        "glyph runs under <a> without href must have link: None"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn paragraph_leaves_link_none_for_anchor_with_empty_href() {
+        let html = r#"<html><body><p><a href="">empty</a></p></body></html>"#;
+        let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
+        crate::blitz_adapter::resolve(&mut doc);
+
+        let store = crate::gcpm::running::RunningElementStore::new();
+        let mut ctx = make_ctx!(store);
+        let p_id = find_tag(&doc, "p").expect("p exists");
+        let p_node = doc.get_node(p_id).expect("p node");
+        let para = extract_paragraph(doc.deref(), p_node, &mut ctx).expect("paragraph");
+
+        for line in &para.lines {
+            for item in &line.items {
+                if let LineItem::Text(run) = item {
+                    assert!(
+                        run.link.is_none(),
+                        "glyph runs under <a href=\"\"> must have link: None"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn paragraph_linkspan_alt_text_uses_anchor_text_content() {
+        let html = r#"<html><body><p><a href="https://x.test">hello world</a></p></body></html>"#;
+        let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
+        crate::blitz_adapter::resolve(&mut doc);
+
+        let store = crate::gcpm::running::RunningElementStore::new();
+        let mut ctx = make_ctx!(store);
+        let p_id = find_tag(&doc, "p").expect("p exists");
+        let p_node = doc.get_node(p_id).expect("p node");
+        let para = extract_paragraph(doc.deref(), p_node, &mut ctx).expect("paragraph");
+
+        let mut alt: Option<String> = None;
+        for line in &para.lines {
+            for item in &line.items {
+                if let LineItem::Text(run) = item {
+                    if let Some(ls) = &run.link {
+                        alt = ls.alt_text.clone();
+                    }
+                }
+            }
+        }
+        assert_eq!(alt.as_deref(), Some("hello world"));
     }
 }

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -1281,6 +1281,7 @@ fn build_inline_pseudo_image(
         opacity,
         visible,
         computed_y: 0.0,
+        link: None,
     })
 }
 
@@ -1698,6 +1699,7 @@ fn extract_paragraph(
                         glyphs,
                         text: run_text,
                         x_offset: glyph_run.offset(),
+                        link: None,
                     }));
                 }
             }
@@ -2205,6 +2207,7 @@ fn resolve_inside_image_marker(
                 opacity: 1.0,
                 visible: true,
                 computed_y: 0.0,
+                link: None,
             })
         }
         // SVG inline images are not yet supported in LineItem::Image
@@ -2285,6 +2288,7 @@ fn extract_marker_lines(
                         glyphs,
                         text: marker_text.clone(),
                         x_offset: glyph_run.offset(),
+                        link: None,
                     }));
                 }
             }
@@ -2879,6 +2883,7 @@ mod tests {
             opacity: 1.0,
             visible: true,
             computed_y: 0.0,
+            link: None,
         }
     }
 
@@ -2898,6 +2903,7 @@ mod tests {
             }],
             text: "A".to_string(),
             x_offset,
+            link: None,
         }
     }
 

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -1613,6 +1613,7 @@ fn convert_table(
         cached_height: height,
         opacity,
         visible,
+        id: extract_block_id(node),
     };
     Box::new(table)
 }

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -364,7 +364,8 @@ fn build_list_item_body(
                 );
                 let mut block = BlockPageable::with_positioned_children(children)
                     .with_style(style)
-                    .with_visible(visible);
+                    .with_visible(visible)
+                    .with_id(extract_block_id(node));
                 block.wrap(width, height);
                 block.layout_size = Some(Size { width, height });
                 Box::new(block)
@@ -408,7 +409,8 @@ fn build_list_item_body(
                 );
                 let mut block = BlockPageable::with_positioned_children(children)
                     .with_style(style)
-                    .with_visible(visible);
+                    .with_visible(visible)
+                    .with_id(extract_block_id(node));
                 block.wrap(width, height);
                 block.layout_size = Some(Size { width, height });
                 Box::new(block)
@@ -430,7 +432,8 @@ fn build_list_item_body(
             );
             let mut block = BlockPageable::with_positioned_children(positioned_children)
                 .with_style(style)
-                .with_visible(visible);
+                .with_visible(visible)
+                .with_id(extract_block_id(node));
             block.wrap(width, 10000.0);
             Box::new(block)
         }
@@ -447,7 +450,8 @@ fn build_list_item_body(
         );
         let mut block = BlockPageable::with_positioned_children(positioned_children)
             .with_style(style)
-            .with_visible(visible);
+            .with_visible(visible)
+            .with_id(extract_block_id(node));
         block.wrap(width, 10000.0);
         Box::new(block)
     }
@@ -706,7 +710,8 @@ fn convert_node_inner(
                 let mut block = BlockPageable::with_positioned_children(children)
                     .with_style(style)
                     .with_opacity(opacity)
-                    .with_visible(visible);
+                    .with_visible(visible)
+                    .with_id(extract_block_id(node));
                 block.wrap(width, height);
                 // Use Taffy's computed height (includes padding + border) instead of children-only height
                 block.layout_size = Some(Size { width, height });
@@ -755,7 +760,8 @@ fn convert_node_inner(
                 let mut block = BlockPageable::with_positioned_children(children)
                     .with_style(style)
                     .with_opacity(opacity)
-                    .with_visible(visible);
+                    .with_visible(visible)
+                    .with_id(extract_block_id(node));
                 block.wrap(width, height);
                 block.layout_size = Some(Size { width, height });
                 return Box::new(block);
@@ -783,7 +789,8 @@ fn convert_node_inner(
             let mut block = BlockPageable::with_positioned_children(positioned_children)
                 .with_style(style)
                 .with_opacity(opacity)
-                .with_visible(visible);
+                .with_visible(visible)
+                .with_id(extract_block_id(node));
             block.wrap(width, height);
             block.layout_size = Some(Size { width, height });
             return Box::new(block);
@@ -812,7 +819,8 @@ fn convert_node_inner(
     let mut block = BlockPageable::with_positioned_children(positioned_children)
         .with_style(style)
         .with_opacity(opacity)
-        .with_visible(visible);
+        .with_visible(visible)
+        .with_id(extract_block_id(node));
     block.wrap(width, 10000.0);
     if has_style {
         block.layout_size = Some(Size { width, height });
@@ -964,6 +972,21 @@ fn collect_positioned_children(
 
 use crate::blitz_adapter::{extract_inline_svg_tree, get_attr};
 
+/// Extract a trimmed, non-empty HTML `id` attribute from `node` and wrap it
+/// in an `Arc<String>` so split fragments can share without cloning the string.
+///
+/// Returns `None` if the node has no element data, no `id` attribute, or an
+/// empty/whitespace-only value.
+fn extract_block_id(node: &Node) -> Option<Arc<String>> {
+    let el = node.element_data()?;
+    let raw = get_attr(el, "id")?.trim();
+    if raw.is_empty() {
+        None
+    } else {
+        Some(Arc::new(raw.to_string()))
+    }
+}
+
 /// Wrap an atomic replaced element (image, svg) in a styled `BlockPageable`
 /// when the node has visual styling, or return the inner Pageable directly.
 ///
@@ -1006,7 +1029,8 @@ where
         let mut block = BlockPageable::with_positioned_children(vec![child])
             .with_style(style)
             .with_opacity(opacity)
-            .with_visible(visible);
+            .with_visible(visible)
+            .with_id(extract_block_id(node));
         block.wrap(width, height);
         block.layout_size = Some(Size { width, height });
         Box::new(block)

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -11,6 +11,7 @@ pub mod engine;
 pub mod error;
 pub mod gcpm;
 pub mod image;
+pub(crate) mod link;
 pub(crate) mod net;
 pub mod outline;
 pub mod pageable;

--- a/crates/fulgur/src/link.rs
+++ b/crates/fulgur/src/link.rs
@@ -1,0 +1,74 @@
+//! PDF link annotation emission.
+//!
+//! Bridges fulgur's in-memory `LinkOccurrence` records (captured per-page by
+//! `LinkCollector` during `draw`) to krilla's `LinkAnnotation` API. One
+//! annotation is emitted per occurrence; multiple rects on the same
+//! occurrence (a link broken across lines) become a single annotation with
+//! multiple `quad_points`.
+//!
+//! Internal anchors (`href="#foo"`) are resolved against a
+//! `DestinationRegistry` built from the paginated page tree. Unresolved
+//! anchors are logged to stderr and skipped — they are a content error, not
+//! a rendering error.
+
+use krilla::action::{Action, LinkAction};
+use krilla::annotation::{Annotation, LinkAnnotation, Target};
+use krilla::destination::{Destination, XyzDestination};
+use krilla::geom::{Point, Quadrilateral, Rect as KRect};
+use krilla::page::Page;
+
+use crate::pageable::{DestinationRegistry, LinkOccurrence, Rect as FRect};
+use crate::paragraph::LinkTarget;
+
+/// Emit PDF link annotations for every occurrence on the given page.
+///
+/// `occurrences` must already be filtered to the page represented by `page`.
+/// Internal anchors that cannot be resolved in `registry` are logged via
+/// `eprintln!` and skipped; rendering continues.
+pub(crate) fn emit_link_annotations(
+    page: &mut Page,
+    occurrences: &[LinkOccurrence],
+    registry: &DestinationRegistry,
+) {
+    for occ in occurrences {
+        let target = match &occ.target {
+            LinkTarget::External(uri) => {
+                Target::Action(Action::Link(LinkAction::new(uri.as_str().to_string())))
+            }
+            LinkTarget::Internal(id) => match registry.get(id.as_str()) {
+                Some((page_idx, y_pt)) => {
+                    // Use x=0 so that viewers scroll so the anchor sits at the
+                    // top-left of the viewport. y is in page-local (top-down)
+                    // coordinates; krilla flips to PDF bottom-up during
+                    // serialization.
+                    let dest = XyzDestination::new(page_idx, Point::from_xy(0.0, y_pt));
+                    Target::Destination(Destination::Xyz(dest))
+                }
+                None => {
+                    eprintln!("fulgur: unresolved internal anchor #{id}");
+                    continue;
+                }
+            },
+        };
+
+        let quads: Vec<Quadrilateral> = occ.rects.iter().filter_map(rect_to_quad).collect();
+        if quads.is_empty() {
+            continue;
+        }
+
+        let link_ann = LinkAnnotation::new_with_quad_points(quads, target);
+        let annotation = Annotation::new_link(link_ann, occ.alt_text.clone());
+        page.add_annotation(annotation);
+    }
+}
+
+/// Convert a fulgur `Rect` (page-local, top-down, pt units) to a krilla
+/// `Quadrilateral` with the point order documented by krilla:
+/// bottom-left → bottom-right → top-right → top-left, Y-down.
+///
+/// Returns `None` for degenerate rects (non-positive width or height) since
+/// `krilla::geom::Rect::from_xywh` rejects them.
+fn rect_to_quad(r: &FRect) -> Option<Quadrilateral> {
+    let krect = KRect::from_xywh(r.x, r.y, r.width, r.height)?;
+    Some(Quadrilateral::from(krect))
+}

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -3064,6 +3064,51 @@ mod tests {
     }
 
     #[test]
+    fn destination_registry_captures_paragraph_id_for_headings() {
+        // Headings like `<h1 id="top">` are inline roots that typically
+        // become `ParagraphPageable`, not `BlockPageable`. Ensure their ids
+        // are still captured so `href="#top"` links resolve.
+        use crate::convert::{self, ConvertContext};
+        use crate::gcpm::running::RunningElementStore;
+        use std::collections::HashMap;
+
+        let html = r##"<html><body>
+            <h1 id="top">Top</h1>
+            <div style="height:2000px"></div>
+            <h2 id="next">Next</h2>
+        </body></html>"##;
+        let doc = crate::blitz_adapter::parse_and_layout(html, 400.0, 600.0, &[]);
+        let dummy_store = RunningElementStore::new();
+        let mut ctx = ConvertContext {
+            running_store: &dummy_store,
+            assets: None,
+            font_cache: HashMap::new(),
+            string_set_by_node: HashMap::new(),
+            counter_ops_by_node: HashMap::new(),
+        };
+        let pageable = convert::dom_to_pageable(&doc, &mut ctx);
+        let pages = crate::paginate::paginate(pageable, 400.0, 600.0);
+        let mut registry = DestinationRegistry::default();
+        for (idx, p) in pages.iter().enumerate() {
+            registry.set_current_page(idx);
+            p.collect_ids(0.0, 0.0, 400.0, 600.0, &mut registry);
+        }
+        assert!(
+            registry.get("top").is_some(),
+            "expected <h1 id=top> to be captured"
+        );
+        assert!(
+            registry.get("next").is_some(),
+            "expected <h2 id=next> to be captured"
+        );
+        assert_ne!(
+            registry.get("top"),
+            registry.get("next"),
+            "headings separated by 2000px spacer should not share location"
+        );
+    }
+
+    #[test]
     fn destination_registry_first_write_wins_for_duplicate_ids() {
         let mut reg = DestinationRegistry::default();
         reg.set_current_page(0);

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -259,16 +259,21 @@ pub struct LinkOccurrence {
 /// with multiple rects. Distinct `<a href="...">` elements — even pointing
 /// at the same URL — land in separate occurrences.
 ///
-/// `occurrences` iteration order is *insertion* order, which is the draw
-/// order for a given page; this is deterministic, which is what matters
-/// for reproducible PDFs. The internal `HashMap` is a dedup-only index
-/// (keyed by `(page_idx, Arc pointer)`) and is never iterated for output,
-/// so it does not violate CLAUDE.md's BTreeMap-for-output rule.
+/// Occurrences are bucketed by `page_idx` so emission is O(L) per page
+/// instead of O(P×L). Within a bucket, ordering is insertion order (the
+/// draw order for that page), which is deterministic — what matters for
+/// reproducible PDFs. The internal `HashMap` dedup index (keyed by
+/// `(page_idx, Arc pointer)`) is never iterated for output, so it does
+/// not violate CLAUDE.md's BTreeMap-for-output rule.
 #[derive(Debug, Default)]
 pub struct LinkCollector {
     current_page_idx: usize,
+    /// Dedup index: `(page_idx, Arc pointer)` → index into the per-page
+    /// Vec in `pages`. Stale entries for already-taken pages are harmless.
     index: std::collections::HashMap<(usize, usize), usize>,
-    occurrences: Vec<LinkOccurrence>,
+    /// Occurrences grouped by `page_idx`. `BTreeMap` for deterministic
+    /// iteration (CLAUDE.md rule) and cheap page-keyed removal.
+    pages: BTreeMap<usize, Vec<LinkOccurrence>>,
 }
 
 impl LinkCollector {
@@ -285,27 +290,47 @@ impl LinkCollector {
     /// `LinkOccurrence`; on different pages they produce separate
     /// occurrences.
     pub fn push_rect(&mut self, link: &std::sync::Arc<crate::paragraph::LinkSpan>, rect: Rect) {
-        let key = (self.current_page_idx, std::sync::Arc::as_ptr(link) as usize);
+        let page_idx = self.current_page_idx;
+        let key = (page_idx, std::sync::Arc::as_ptr(link) as usize);
+        let bucket = self.pages.entry(page_idx).or_default();
         if let Some(&i) = self.index.get(&key) {
-            self.occurrences[i].rects.push(rect);
-        } else {
-            let i = self.occurrences.len();
-            self.index.insert(key, i);
-            self.occurrences.push(LinkOccurrence {
-                page_idx: self.current_page_idx,
-                target: link.target.clone(),
-                alt_text: link.alt_text.clone(),
-                rects: vec![rect],
-            });
+            // Defensive check: if the index is stale (e.g. the page was
+            // already drained via `take_page`), `i` may be out of range.
+            if let Some(occ) = bucket.get_mut(i) {
+                occ.rects.push(rect);
+                return;
+            }
         }
+        let i = bucket.len();
+        self.index.insert(key, i);
+        bucket.push(LinkOccurrence {
+            page_idx,
+            target: link.target.clone(),
+            alt_text: link.alt_text.clone(),
+            rects: vec![rect],
+        });
     }
 
+    /// Remove and return all occurrences recorded for `page_idx`.
+    ///
+    /// Pages are emitted in order during rendering, so after calling
+    /// `take_page(n)` no further `push_rect` calls should target page `n`.
+    /// Returns an empty `Vec` if the page had no link occurrences.
+    pub fn take_page(&mut self, page_idx: usize) -> Vec<LinkOccurrence> {
+        self.pages.remove(&page_idx).unwrap_or_default()
+    }
+
+    /// Consume the collector and return every occurrence across all pages,
+    /// flattened in page-index order. Retained for testing.
     pub fn into_occurrences(self) -> Vec<LinkOccurrence> {
-        self.occurrences
+        self.pages.into_values().flatten().collect()
     }
 
-    pub fn occurrences(&self) -> &[LinkOccurrence] {
-        &self.occurrences
+    /// Return every occurrence across all pages as an owned Vec, in
+    /// page-index order. Retained for testing — production callers should
+    /// prefer `take_page` for O(L) per-page emission.
+    pub fn occurrences(&self) -> Vec<LinkOccurrence> {
+        self.pages.values().flatten().cloned().collect()
     }
 }
 

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -1,7 +1,51 @@
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use crate::gcpm::CounterOp;
 use crate::image::ImageFormat;
+
+/// Registry of block-level anchor destinations discovered during a pre-pass
+/// walk of the paginated page tree.
+///
+/// Maps `id` → `(page_idx, y_pt)`. Later stages (link annotation emission)
+/// consult this to resolve `href="#foo"` into a `GoToXYZ` action.
+///
+/// # Semantics
+///
+/// - **First-write-wins**: duplicate IDs in a document are invalid HTML, but
+///   rather than crashing we keep the first occurrence and ignore subsequent
+///   ones. This matches browser behavior for `getElementById`.
+/// - **BTreeMap** for deterministic iteration ordering — see CLAUDE.md.
+/// - **Pre-pass**: callers must `set_current_page(idx)` before each page's
+///   `collect_ids` walk.
+#[derive(Debug, Default)]
+pub struct DestinationRegistry {
+    current_page_idx: usize,
+    entries: BTreeMap<String, (usize, Pt)>,
+}
+
+impl DestinationRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the page index to attach subsequent `record` calls to.
+    pub fn set_current_page(&mut self, idx: usize) {
+        self.current_page_idx = idx;
+    }
+
+    /// Record an anchor destination. First-write-wins: later duplicates are ignored.
+    pub fn record(&mut self, id: &str, y: Pt) {
+        self.entries
+            .entry(id.to_string())
+            .or_insert((self.current_page_idx, y));
+    }
+
+    /// Look up a recorded anchor.
+    pub fn get(&self, id: &str) -> Option<(usize, Pt)> {
+        self.entries.get(id).copied()
+    }
+}
 
 /// Point unit (1/72 inch)
 pub type Pt = f32;
@@ -252,6 +296,27 @@ pub trait Pageable: Send + Sync {
 
     /// Downcast support for tests.
     fn as_any(&self) -> &dyn std::any::Any;
+
+    /// Walk this Pageable and record any block-level `id` anchors into
+    /// `registry`, in page-local coordinates.
+    ///
+    /// `(x, y)` is the top-left of this element in the current page's
+    /// content area. Containers must recurse into their children using the
+    /// same positional arithmetic that `draw()` uses so anchor positions
+    /// match the rendered output.
+    ///
+    /// Default: no-op. Overridden on block-like Pageables (`BlockPageable`)
+    /// and containers that hold children (pagination wrappers, `ListItemPageable`,
+    /// `TablePageable`, etc.).
+    fn collect_ids(
+        &self,
+        _x: Pt,
+        _y: Pt,
+        _avail_width: Pt,
+        _avail_height: Pt,
+        _registry: &mut DestinationRegistry,
+    ) {
+    }
 }
 
 impl Clone for Box<dyn Pageable> {
@@ -497,6 +562,10 @@ pub struct BlockPageable {
     pub style: BlockStyle,
     pub opacity: f32,
     pub visible: bool,
+    /// HTML `id` attribute (trimmed, non-empty). Used as an anchor target
+    /// for internal `href="#..."` links. `Arc<String>` so split fragments
+    /// can share without cloning the string.
+    pub id: Option<Arc<String>>,
 }
 
 impl BlockPageable {
@@ -523,6 +592,7 @@ impl BlockPageable {
             style: BlockStyle::default(),
             opacity: 1.0,
             visible: true,
+            id: None,
         }
     }
 
@@ -535,6 +605,7 @@ impl BlockPageable {
             style: BlockStyle::default(),
             opacity: 1.0,
             visible: true,
+            id: None,
         }
     }
 
@@ -555,6 +626,11 @@ impl BlockPageable {
 
     pub fn with_visible(mut self, visible: bool) -> Self {
         self.visible = visible;
+        self
+    }
+
+    pub fn with_id(mut self, id: Option<Arc<String>>) -> Self {
+        self.id = id;
         self
     }
 
@@ -1198,14 +1274,16 @@ impl Pageable for BlockPageable {
                             .with_pagination(self.pagination)
                             .with_style(self.style.clone())
                             .with_opacity(self.opacity)
-                            .with_visible(self.visible),
+                            .with_visible(self.visible)
+                            .with_id(self.id.clone()),
                     ),
                     Box::new(
                         BlockPageable::with_positioned_children(second)
                             .with_pagination(self.pagination)
                             .with_style(self.style.clone())
                             .with_opacity(self.opacity)
-                            .with_visible(self.visible),
+                            .with_visible(self.visible)
+                            .with_id(self.id.clone()),
                     ),
                 ))
             }
@@ -1225,14 +1303,16 @@ impl Pageable for BlockPageable {
                             .with_pagination(self.pagination)
                             .with_style(self.style.clone())
                             .with_opacity(self.opacity)
-                            .with_visible(self.visible),
+                            .with_visible(self.visible)
+                            .with_id(self.id.clone()),
                     ),
                     Box::new(
                         BlockPageable::with_positioned_children(second)
                             .with_pagination(self.pagination)
                             .with_style(self.style.clone())
                             .with_opacity(self.opacity)
-                            .with_visible(self.visible),
+                            .with_visible(self.visible)
+                            .with_id(self.id.clone()),
                     ),
                 ))
             }
@@ -1276,14 +1356,16 @@ impl Pageable for BlockPageable {
                             .with_pagination(me.pagination)
                             .with_style(me.style.clone())
                             .with_opacity(me.opacity)
-                            .with_visible(me.visible),
+                            .with_visible(me.visible)
+                            .with_id(me.id.clone()),
                     ),
                     Box::new(
                         BlockPageable::with_positioned_children(second)
                             .with_pagination(me.pagination)
                             .with_style(me.style)
                             .with_opacity(me.opacity)
-                            .with_visible(me.visible),
+                            .with_visible(me.visible)
+                            .with_id(me.id),
                     ),
                 ))
             }
@@ -1310,14 +1392,16 @@ impl Pageable for BlockPageable {
                             .with_pagination(me.pagination)
                             .with_style(me.style.clone())
                             .with_opacity(me.opacity)
-                            .with_visible(me.visible),
+                            .with_visible(me.visible)
+                            .with_id(me.id.clone()),
                     ),
                     Box::new(
                         BlockPageable::with_positioned_children(second_children)
                             .with_pagination(me.pagination)
                             .with_style(me.style)
                             .with_opacity(me.opacity)
-                            .with_visible(me.visible),
+                            .with_visible(me.visible)
+                            .with_id(me.id),
                     ),
                 ))
             }
@@ -1401,6 +1485,30 @@ impl Pageable for BlockPageable {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn collect_ids(
+        &self,
+        x: Pt,
+        y: Pt,
+        avail_width: Pt,
+        _avail_height: Pt,
+        registry: &mut DestinationRegistry,
+    ) {
+        // Record this block's own id at its top-left in page-local coords.
+        if let Some(id) = &self.id
+            && !id.is_empty()
+        {
+            registry.record(id, y);
+        }
+        // Recurse into children using the same positional arithmetic
+        // `draw()` uses (see the loop at the end of `draw`). We do NOT
+        // need to replicate clipping / opacity / background paths —
+        // anchor registration only cares about block-top coordinates.
+        for pc in &self.children {
+            pc.child
+                .collect_ids(x + pc.x, y + pc.y, avail_width, pc.child.height(), registry);
+        }
     }
 }
 
@@ -1606,6 +1714,18 @@ impl Pageable for HeadingMarkerWrapperPageable {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn collect_ids(
+        &self,
+        x: Pt,
+        y: Pt,
+        avail_width: Pt,
+        avail_height: Pt,
+        registry: &mut DestinationRegistry,
+    ) {
+        self.child
+            .collect_ids(x, y, avail_width, avail_height, registry);
     }
 }
 
@@ -1830,6 +1950,18 @@ impl Pageable for CounterOpWrapperPageable {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
+
+    fn collect_ids(
+        &self,
+        x: Pt,
+        y: Pt,
+        avail_width: Pt,
+        avail_height: Pt,
+        registry: &mut DestinationRegistry,
+    ) {
+        self.child
+            .collect_ids(x, y, avail_width, avail_height, registry);
+    }
 }
 
 // ─── TransformWrapperPageable ──────────────────────────────
@@ -1920,6 +2052,20 @@ impl Pageable for TransformWrapperPageable {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
+
+    fn collect_ids(
+        &self,
+        x: Pt,
+        y: Pt,
+        avail_width: Pt,
+        avail_height: Pt,
+        registry: &mut DestinationRegistry,
+    ) {
+        // Transform is a visual effect; the anchor position is the pre-transform
+        // block-top, matching where the destination "logically" lives.
+        self.inner
+            .collect_ids(x, y, avail_width, avail_height, registry);
+    }
 }
 
 // ─── StringSetWrapperPageable ──────────────────────────────
@@ -1984,6 +2130,18 @@ impl Pageable for StringSetWrapperPageable {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn collect_ids(
+        &self,
+        x: Pt,
+        y: Pt,
+        avail_width: Pt,
+        avail_height: Pt,
+        registry: &mut DestinationRegistry,
+    ) {
+        self.child
+            .collect_ids(x, y, avail_width, avail_height, registry);
     }
 }
 
@@ -2051,6 +2209,18 @@ impl Pageable for RunningElementWrapperPageable {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn collect_ids(
+        &self,
+        x: Pt,
+        y: Pt,
+        avail_width: Pt,
+        avail_height: Pt,
+        registry: &mut DestinationRegistry,
+    ) {
+        self.child
+            .collect_ids(x, y, avail_width, avail_height, registry);
     }
 }
 
@@ -2248,6 +2418,21 @@ impl Pageable for ListItemPageable {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn collect_ids(
+        &self,
+        x: Pt,
+        y: Pt,
+        avail_width: Pt,
+        avail_height: Pt,
+        registry: &mut DestinationRegistry,
+    ) {
+        // `draw` calls `self.body.draw(canvas, x, y, ...)` (markers drawn
+        // at negative x); the body is the positional root for any nested
+        // block ids, so walk it at the same (x, y).
+        self.body
+            .collect_ids(x, y, avail_width, avail_height, registry);
     }
 }
 
@@ -2496,6 +2681,22 @@ impl Pageable for TablePageable {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn collect_ids(
+        &self,
+        x: Pt,
+        y: Pt,
+        _avail_width: Pt,
+        _avail_height: Pt,
+        registry: &mut DestinationRegistry,
+    ) {
+        // Mirror TablePageable::draw child iteration — header + body cells.
+        let total_width = self.width;
+        for pc in self.header_cells.iter().chain(self.body_cells.iter()) {
+            pc.child
+                .collect_ids(x + pc.x, y + pc.y, total_width, pc.child.height(), registry);
+        }
     }
 }
 
@@ -2809,6 +3010,67 @@ mod tests {
         assert_eq!(m.name, "header");
         assert_eq!(m.instance_id, 42);
         assert!(m.split(100.0, 100.0).is_none());
+    }
+
+    // ─── DestinationRegistry tests ───────────────────────────
+
+    #[test]
+    fn destination_registry_collects_block_ids_from_paginated_pages() {
+        use crate::convert::{self, ConvertContext};
+        use crate::gcpm::running::RunningElementStore;
+        use std::collections::HashMap;
+
+        // Use `<div>` wrappers (container nodes, always BlockPageable) so
+        // the test does not depend on whether headings gain a block wrapper
+        // via default CSS — `<h1>` is an inline root that only becomes a
+        // BlockPageable when `needs_block_wrapper()` triggers on its style.
+        let html = r##"<html><body>
+            <div id="top" style="border:1px solid red">Top</div>
+            <div style="height:2000px"></div>
+            <div id="next" style="border:1px solid red">Next</div>
+        </body></html>"##;
+        let doc = crate::blitz_adapter::parse_and_layout(html, 400.0, 600.0, &[]);
+        let dummy_store = RunningElementStore::new();
+        let mut ctx = ConvertContext {
+            running_store: &dummy_store,
+            assets: None,
+            font_cache: HashMap::new(),
+            string_set_by_node: HashMap::new(),
+            counter_ops_by_node: HashMap::new(),
+        };
+        let pageable = convert::dom_to_pageable(&doc, &mut ctx);
+        let pages = crate::paginate::paginate(pageable, 400.0, 600.0);
+        let mut registry = DestinationRegistry::default();
+        for (idx, p) in pages.iter().enumerate() {
+            registry.set_current_page(idx);
+            p.collect_ids(0.0, 0.0, 400.0, 600.0, &mut registry);
+        }
+        assert!(registry.get("top").is_some(), "missing top");
+        assert!(registry.get("next").is_some(), "missing next");
+        // `top` and `next` should be on different pages (or different y) since
+        // the spacer between them is 2000px tall.
+        assert_ne!(registry.get("top"), registry.get("next"));
+    }
+
+    #[test]
+    fn destination_registry_ignores_blocks_without_id() {
+        // A BlockPageable with `id: None` should not register anything.
+        let mut block = BlockPageable::with_positioned_children(vec![]);
+        block.wrap(100.0, 100.0);
+        let mut registry = DestinationRegistry::default();
+        registry.set_current_page(0);
+        block.collect_ids(0.0, 0.0, 100.0, 100.0, &mut registry);
+        assert!(registry.get("anything").is_none());
+    }
+
+    #[test]
+    fn destination_registry_first_write_wins_for_duplicate_ids() {
+        let mut reg = DestinationRegistry::default();
+        reg.set_current_page(0);
+        reg.record("dup", 10.0);
+        reg.set_current_page(2);
+        reg.record("dup", 99.0);
+        assert_eq!(reg.get("dup"), Some((0, 10.0)));
     }
 }
 

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -2545,6 +2545,10 @@ pub struct TablePageable {
     pub cached_height: Pt,
     pub opacity: f32,
     pub visible: bool,
+    /// HTML `id` attribute (trimmed, non-empty). Used as an anchor target
+    /// for internal `href="#..."` links. `Arc<String>` so split fragments
+    /// can share without cloning the string. Mirrors `BlockPageable::id`.
+    pub id: Option<Arc<String>>,
 }
 
 impl Pageable for TablePageable {
@@ -2620,6 +2624,7 @@ impl Pageable for TablePageable {
                 cached_height: 0.0,
                 opacity: self.opacity,
                 visible: self.visible,
+                id: self.id.clone(),
             }),
             Box::new(TablePageable {
                 header_cells: second_header,
@@ -2631,6 +2636,7 @@ impl Pageable for TablePageable {
                 cached_height: 0.0,
                 opacity: self.opacity,
                 visible: self.visible,
+                id: self.id.clone(),
             }),
         ))
     }
@@ -2685,6 +2691,7 @@ impl Pageable for TablePageable {
                 cached_height: 0.0,
                 opacity: me.opacity,
                 visible: me.visible,
+                id: me.id.clone(),
             }),
             Box::new(TablePageable {
                 header_cells: me.header_cells,
@@ -2696,6 +2703,7 @@ impl Pageable for TablePageable {
                 cached_height: 0.0,
                 opacity: me.opacity,
                 visible: me.visible,
+                id: me.id,
             }),
         ))
     }
@@ -2779,6 +2787,12 @@ impl Pageable for TablePageable {
         _avail_height: Pt,
         registry: &mut DestinationRegistry,
     ) {
+        // Record this table's own id at its top-left (mirrors BlockPageable).
+        if let Some(id) = &self.id
+            && !id.is_empty()
+        {
+            registry.record(id, y);
+        }
         // Mirror TablePageable::draw child iteration — header + body cells.
         let total_width = self.width;
         for pc in self.header_cells.iter().chain(self.body_cells.iter()) {
@@ -3025,6 +3039,7 @@ mod tests {
             cached_height: 0.0,
             opacity: 1.0,
             visible: true,
+            id: None,
         };
         table.wrap(200.0, 1000.0);
 
@@ -3193,6 +3208,40 @@ mod tests {
             registry.get("top"),
             registry.get("next"),
             "headings separated by 2000px spacer should not share location"
+        );
+    }
+
+    #[test]
+    fn destination_registry_captures_table_id() {
+        // Regression: `<table id=...>` previously skipped BlockPageable
+        // wrapping, so TablePageable never registered its own id.
+        use crate::convert::{self, ConvertContext};
+        use crate::gcpm::running::RunningElementStore;
+        use std::collections::HashMap;
+
+        let html = r##"<html><body>
+            <table id="data"><tr><td>x</td></tr></table>
+        </body></html>"##;
+        let doc = crate::blitz_adapter::parse_and_layout(html, 400.0, 600.0, &[]);
+        let dummy_store = RunningElementStore::new();
+        let mut ctx = ConvertContext {
+            running_store: &dummy_store,
+            assets: None,
+            font_cache: HashMap::new(),
+            string_set_by_node: HashMap::new(),
+            counter_ops_by_node: HashMap::new(),
+        };
+        let pageable = convert::dom_to_pageable(&doc, &mut ctx);
+        let pages = crate::paginate::paginate(pageable, 400.0, 600.0);
+        let mut registry = DestinationRegistry::default();
+        for (idx, p) in pages.iter().enumerate() {
+            registry.set_current_page(idx);
+            p.collect_ids(0.0, 0.0, 400.0, 600.0, &mut registry);
+        }
+        assert!(
+            registry.get("data").is_some(),
+            "table id was not captured (entries: {:?})",
+            registry
         );
     }
 

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -222,11 +222,99 @@ impl Default for Pagination {
     }
 }
 
+/// Axis-aligned rectangle used to describe PDF link activation areas.
+///
+/// Coordinates are in PDF points in the Krilla surface coordinate space
+/// (origin at top-left, y growing downward) — i.e. the same space the
+/// `draw()` methods use when talking to `Surface`. `x`, `y` mark the
+/// top-left corner.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Rect {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+}
+
+/// One clickable link area captured by `LinkCollector` during draw.
+///
+/// A single `<a>` element may produce multiple rects when its glyphs wrap
+/// across lines (or when nested inlines split shaping into multiple runs);
+/// in that case `rects` holds one entry per fragment and `target`/`alt_text`
+/// are the shared anchor metadata.
+#[derive(Debug, Clone)]
+pub struct LinkOccurrence {
+    pub page_idx: usize,
+    pub target: crate::paragraph::LinkTarget,
+    pub alt_text: Option<String>,
+    pub rects: Vec<Rect>,
+}
+
+/// Per-page collector of link activation rects, grouped by `<a>` identity.
+///
+/// Identity is the pointer value of `Arc<LinkSpan>`. `convert.rs` guarantees
+/// that every glyph run / inline image extracted from the same `<a>`
+/// shares the *same* `Arc<LinkSpan>` clone, so runs that were split by
+/// `<em>`/`<strong>` inside an anchor merge into a single `LinkOccurrence`
+/// with multiple rects. Distinct `<a href="...">` elements — even pointing
+/// at the same URL — land in separate occurrences.
+///
+/// `occurrences` iteration order is *insertion* order, which is the draw
+/// order for a given page; this is deterministic, which is what matters
+/// for reproducible PDFs. The internal `HashMap` is a dedup-only index
+/// (keyed by `(page_idx, Arc pointer)`) and is never iterated for output,
+/// so it does not violate CLAUDE.md's BTreeMap-for-output rule.
+#[derive(Debug, Default)]
+pub struct LinkCollector {
+    current_page_idx: usize,
+    index: std::collections::HashMap<(usize, usize), usize>,
+    occurrences: Vec<LinkOccurrence>,
+}
+
+impl LinkCollector {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn set_current_page(&mut self, idx: usize) {
+        self.current_page_idx = idx;
+    }
+
+    /// Record a rect for the given `<a>`. Rects pointing at the same
+    /// `Arc<LinkSpan>` *on the same page* are merged into a single
+    /// `LinkOccurrence`; on different pages they produce separate
+    /// occurrences.
+    pub fn push_rect(&mut self, link: &std::sync::Arc<crate::paragraph::LinkSpan>, rect: Rect) {
+        let key = (self.current_page_idx, std::sync::Arc::as_ptr(link) as usize);
+        if let Some(&i) = self.index.get(&key) {
+            self.occurrences[i].rects.push(rect);
+        } else {
+            let i = self.occurrences.len();
+            self.index.insert(key, i);
+            self.occurrences.push(LinkOccurrence {
+                page_idx: self.current_page_idx,
+                target: link.target.clone(),
+                alt_text: link.alt_text.clone(),
+                rects: vec![rect],
+            });
+        }
+    }
+
+    pub fn into_occurrences(self) -> Vec<LinkOccurrence> {
+        self.occurrences
+    }
+
+    pub fn occurrences(&self) -> &[LinkOccurrence] {
+        &self.occurrences
+    }
+}
+
 /// Wrapper around Krilla Surface for drawing commands.
 /// This decouples Pageable types from Krilla's concrete Surface type.
 pub struct Canvas<'a, 'b> {
     pub surface: &'a mut krilla::surface::Surface<'b>,
     pub heading_collector: Option<&'a mut HeadingCollector>,
+    pub link_collector: Option<&'a mut LinkCollector>,
 }
 
 /// Run a draw closure wrapped in opacity guards.

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -153,6 +153,11 @@ pub struct ParagraphPageable {
     pub cached_height: f32,
     pub opacity: f32,
     pub visible: bool,
+    /// HTML `id` attribute of the inline-root element this paragraph was
+    /// extracted from. Used by `DestinationRegistry` to resolve `#anchor`
+    /// links targeting headings (`<h1 id=..>`) and similar inline-root
+    /// elements that do not gain a `BlockPageable` wrapper.
+    pub id: Option<Arc<String>>,
 }
 
 impl ParagraphPageable {
@@ -164,7 +169,14 @@ impl ParagraphPageable {
             cached_height,
             opacity: 1.0,
             visible: true,
+            id: None,
         }
+    }
+
+    /// Attach an `id` anchor to this paragraph. Chain after `new()`.
+    pub fn with_id(mut self, id: Option<Arc<String>>) -> Self {
+        self.id = id;
+        self
     }
 }
 
@@ -708,6 +720,7 @@ impl Pageable for ParagraphPageable {
         let mut first = ParagraphPageable::new(self.lines[..split_at].to_vec());
         first.opacity = self.opacity;
         first.visible = self.visible;
+        first.id = self.id.clone();
 
         // Rebase second fragment: baseline is absolute from paragraph top,
         // so subtract the consumed height to make it relative to the new fragment.
@@ -730,6 +743,11 @@ impl Pageable for ParagraphPageable {
         let mut second = ParagraphPageable::new(second_lines);
         second.opacity = self.opacity;
         second.visible = self.visible;
+        // Both fragments inherit the id. `DestinationRegistry::record` is
+        // first-write-wins, so the second fragment's entry is a no-op when
+        // it lands on a later page — we just carry the id so ordering quirks
+        // don't drop anchors.
+        second.id = self.id.clone();
 
         Some((Box::new(first), Box::new(second)))
     }
@@ -757,6 +775,22 @@ impl Pageable for ParagraphPageable {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn collect_ids(
+        &self,
+        _x: Pt,
+        y: Pt,
+        _avail_width: Pt,
+        _avail_height: Pt,
+        registry: &mut crate::pageable::DestinationRegistry,
+    ) {
+        if let Some(id) = &self.id
+            && !id.is_empty()
+        {
+            registry.record(id, y);
+        }
+        // No child recursion: paragraph lines are glyph data, not Pageables.
     }
 }
 
@@ -1129,6 +1163,62 @@ mod tests {
         } else {
             panic!("expected image item");
         }
+    }
+
+    // ---------- Id propagation ----------
+
+    #[test]
+    fn paragraph_default_has_no_id() {
+        let p = ParagraphPageable::new(Vec::new());
+        assert!(p.id.is_none());
+    }
+
+    #[test]
+    fn paragraph_with_id_stores_value() {
+        let p = ParagraphPageable::new(Vec::new()).with_id(Some(Arc::new("section-1".to_string())));
+        assert_eq!(p.id.as_deref().map(String::as_str), Some("section-1"));
+    }
+
+    #[test]
+    fn collect_ids_records_paragraph_id() {
+        use crate::pageable::DestinationRegistry;
+        let p = ParagraphPageable::new(Vec::new()).with_id(Some(Arc::new("anchor".to_string())));
+        let mut reg = DestinationRegistry::default();
+        reg.set_current_page(3);
+        p.collect_ids(10.0, 42.0, 400.0, 600.0, &mut reg);
+        assert_eq!(reg.get("anchor"), Some((3, 42.0)));
+    }
+
+    #[test]
+    fn collect_ids_is_noop_without_id() {
+        use crate::pageable::DestinationRegistry;
+        let p = ParagraphPageable::new(Vec::new());
+        let mut reg = DestinationRegistry::default();
+        p.collect_ids(0.0, 0.0, 400.0, 600.0, &mut reg);
+        assert!(reg.get("anything").is_none());
+    }
+
+    #[test]
+    fn split_propagates_id_to_both_fragments() {
+        // Four lines so orphans/widows (default=2) allow splitting at line 2.
+        let line1 = text_line(16.0, 12.0);
+        let line2 = text_line(16.0, 28.0);
+        let line3 = text_line(16.0, 44.0);
+        let line4 = text_line(16.0, 60.0);
+        let para = ParagraphPageable::new(vec![line1, line2, line3, line4])
+            .with_id(Some(Arc::new("heading".to_string())));
+
+        let (first, second) = para.split(100.0, 32.0).expect("should split");
+        let first_para = first.as_any().downcast_ref::<ParagraphPageable>().unwrap();
+        let second_para = second.as_any().downcast_ref::<ParagraphPageable>().unwrap();
+        assert_eq!(
+            first_para.id.as_deref().map(String::as_str),
+            Some("heading")
+        );
+        assert_eq!(
+            second_para.id.as_deref().map(String::as_str),
+            Some("heading")
+        );
     }
 }
 

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -488,7 +488,15 @@ fn draw_line_decorations(canvas: &mut Canvas<'_, '_>, items: &[LineItem], x: Pt,
 
 /// Draw pre-shaped text lines at the given position.
 pub fn draw_shaped_lines(canvas: &mut Canvas<'_, '_>, lines: &[ShapedLine], x: Pt, y: Pt) {
+    // Track the top edge of each line within the paragraph (paragraph y=0 at
+    // `y`). Lines pack tightly by `line.height`. We use the full line box for
+    // link activation rects (matches WeasyPrint behavior), so tracking the
+    // top via cumulative height is both simpler and more robust than trying
+    // to derive it from `line.baseline` (which is an absolute baseline offset
+    // and does not carry per-line ascent).
+    let mut line_top: f32 = 0.0;
     for line in lines {
+        let line_top_abs = y + line_top;
         let baseline_y = y + line.baseline;
 
         for item in &line.items {
@@ -543,6 +551,25 @@ pub fn draw_shaped_lines(canvas: &mut Canvas<'_, '_>, lines: &[ShapedLine], x: P
                         run.font_size,
                         false,
                     );
+
+                    // After the glyphs are drawn, record a link rect if this
+                    // run was emitted under an <a href>. Width mirrors the
+                    // decoration-span computation in `draw_line_decorations`
+                    // (same glyph advance accumulator); height uses the full
+                    // line box so the hit area is stable across lines.
+                    if let Some(link_span) = run.link.as_ref() {
+                        let run_width: f32 =
+                            run.glyphs.iter().map(|g| g.x_advance * run.font_size).sum();
+                        let rect = crate::pageable::Rect {
+                            x: x + run.x_offset,
+                            y: line_top_abs,
+                            width: run_width.max(0.0),
+                            height: line.height,
+                        };
+                        if let Some(collector) = canvas.link_collector.as_deref_mut() {
+                            collector.push_rect(link_span, rect);
+                        }
+                    }
                 }
                 LineItem::Image(img) => {
                     if !img.visible {
@@ -563,12 +590,29 @@ pub fn draw_shaped_lines(canvas: &mut Canvas<'_, '_>, lines: &[ShapedLine], x: P
                         canvas.surface.draw_image(image, size);
                         canvas.surface.pop();
                     });
+
+                    // Record a rect for this image if it sits under an <a>.
+                    // Matches the image's drawn coordinates exactly:
+                    // (x + x_offset, y + computed_y, width, height).
+                    if let Some(link_span) = img.link.as_ref() {
+                        let rect = crate::pageable::Rect {
+                            x: x + img.x_offset,
+                            y: y + img.computed_y,
+                            width: img.width.max(0.0),
+                            height: img.height.max(0.0),
+                        };
+                        if let Some(collector) = canvas.link_collector.as_deref_mut() {
+                            collector.push_rect(link_span, rect);
+                        }
+                    }
                 }
             }
         }
 
         // Draw decorations after all glyphs so lines appear on top
         draw_line_decorations(canvas, &line.items, x, baseline_y);
+
+        line_top += line.height;
     }
 }
 
@@ -1250,5 +1294,119 @@ mod link_span_tests {
             link: None,
         };
         assert!(run.link.is_none());
+    }
+}
+
+#[cfg(test)]
+mod link_collect_tests {
+    use super::*;
+    use crate::pageable::{Canvas, LinkCollector};
+    use std::collections::HashMap;
+
+    fn render_pages_into_collector(html: &str, collector: &mut LinkCollector) -> usize {
+        use crate::convert::{self, ConvertContext};
+        use crate::gcpm::running::RunningElementStore;
+
+        let doc = crate::blitz_adapter::parse_and_layout(html, 400.0, 600.0, &[]);
+        let dummy_store = RunningElementStore::new();
+        let mut ctx = ConvertContext {
+            running_store: &dummy_store,
+            assets: None,
+            font_cache: HashMap::new(),
+            string_set_by_node: HashMap::new(),
+            counter_ops_by_node: HashMap::new(),
+        };
+        let pageable = convert::dom_to_pageable(&doc, &mut ctx);
+        let pages = crate::paginate::paginate(pageable, 400.0, 600.0);
+        let page_count = pages.len();
+
+        let mut krilla_doc = krilla::Document::new();
+        for (idx, p) in pages.iter().enumerate() {
+            let settings =
+                krilla::page::PageSettings::from_wh(400.0, 600.0).expect("valid page dimensions");
+            let mut page = krilla_doc.start_page_with(settings);
+            let mut surface = page.surface();
+            collector.set_current_page(idx);
+            {
+                let mut canvas = Canvas {
+                    surface: &mut surface,
+                    heading_collector: None,
+                    link_collector: Some(collector),
+                };
+                p.draw(&mut canvas, 0.0, 0.0, 400.0, 600.0);
+            }
+        }
+        // Drop the document — we only care about the collector side effect.
+        let _ = krilla_doc.finish();
+        page_count
+    }
+
+    #[test]
+    fn draw_pushes_link_rect_for_glyph_run_inside_anchor() {
+        let html = r#"<html><body><p><a href="https://x.test">hello world</a></p></body></html>"#;
+        let mut collector = LinkCollector::new();
+        render_pages_into_collector(html, &mut collector);
+
+        let occs = collector.into_occurrences();
+        assert!(!occs.is_empty(), "expected at least one link occurrence");
+        let first = &occs[0];
+        assert_eq!(first.page_idx, 0, "link should land on page 0");
+        assert!(
+            matches!(&first.target, LinkTarget::External(u) if u.as_str() == "https://x.test"),
+            "unexpected target: {:?}",
+            first.target,
+        );
+        assert!(!first.rects.is_empty());
+        assert!(
+            first.rects[0].width > 0.0,
+            "expected positive rect width, got {}",
+            first.rects[0].width,
+        );
+        assert!(
+            first.rects[0].height > 0.0,
+            "expected positive rect height, got {}",
+            first.rects[0].height,
+        );
+    }
+
+    #[test]
+    fn draw_merges_multiple_glyph_runs_under_same_anchor_into_one_occurrence() {
+        // <em> inside <a> forces shaping to split into multiple glyph runs,
+        // but convert.rs clones the same Arc<LinkSpan> onto every run — so
+        // LinkCollector's Arc-pointer dedup should merge them into one
+        // occurrence with multiple rects.
+        let html =
+            r#"<html><body><p><a href="https://x.test"><em>foo</em>bar</a></p></body></html>"#;
+        let mut collector = LinkCollector::new();
+        render_pages_into_collector(html, &mut collector);
+
+        let occs = collector.into_occurrences();
+        assert_eq!(
+            occs.len(),
+            1,
+            "expected one occurrence even with multiple glyph runs, got {:?}",
+            occs.iter().map(|o| &o.target).collect::<Vec<_>>(),
+        );
+        assert!(
+            occs[0].rects.len() >= 2,
+            "expected at least two rects merged under one occurrence, got {}",
+            occs[0].rects.len(),
+        );
+    }
+
+    #[test]
+    fn distinct_anchors_with_same_href_stay_separate() {
+        // Two separate <a> elements pointing at the same URL must produce
+        // two occurrences — Arc identity is what distinguishes them.
+        let html = r#"<html><body><p><a href="https://x.test">one</a> <a href="https://x.test">two</a></p></body></html>"#;
+        let mut collector = LinkCollector::new();
+        render_pages_into_collector(html, &mut collector);
+
+        let occs = collector.into_occurrences();
+        assert_eq!(
+            occs.len(),
+            2,
+            "expected two occurrences for two distinct <a> elements",
+        );
     }
 }

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -69,6 +69,20 @@ pub struct ShapedGlyph {
     pub text_range: std::ops::Range<usize>,
 }
 
+/// Target for a clickable link in PDF output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LinkTarget {
+    External(Arc<String>),
+    Internal(Arc<String>),
+}
+
+/// Link association attached to a glyph run or inline image.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkSpan {
+    pub target: LinkTarget,
+    pub alt_text: Option<String>,
+}
+
 /// A pre-extracted glyph run (single font + style).
 #[derive(Clone, Debug)]
 pub struct ShapedGlyphRun {
@@ -80,6 +94,7 @@ pub struct ShapedGlyphRun {
     pub glyphs: Vec<ShapedGlyph>,
     pub text: String,
     pub x_offset: f32,
+    pub link: Option<Arc<LinkSpan>>,
 }
 
 /// Vertical alignment for inline replaced elements (images).
@@ -111,6 +126,7 @@ pub struct InlineImage {
     pub visible: bool,
     /// Y position relative to line top, computed by recalculate_line_box.
     pub computed_y: f32,
+    pub link: Option<Arc<LinkSpan>>,
 }
 
 /// A single item in a shaped line: either a text glyph run or an inline image.
@@ -769,6 +785,7 @@ mod tests {
             opacity: 1.0,
             visible: true,
             computed_y: 0.0,
+            link: None,
         }
     }
 
@@ -1112,5 +1129,36 @@ mod tests {
         } else {
             panic!("expected image item");
         }
+    }
+}
+
+#[cfg(test)]
+mod link_span_tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn link_target_equality_is_by_value() {
+        let a = LinkTarget::External(Arc::new("https://example.com".into()));
+        let b = LinkTarget::External(Arc::new("https://example.com".into()));
+        assert_eq!(a, b);
+        let c = LinkTarget::Internal(Arc::new("section".into()));
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn shaped_glyph_run_default_has_no_link() {
+        let run = ShapedGlyphRun {
+            font_data: Arc::new(Vec::new()),
+            font_index: 0,
+            font_size: 12.0,
+            color: [0, 0, 0, 255],
+            decoration: TextDecoration::default(),
+            glyphs: Vec::new(),
+            text: String::new(),
+            x_offset: 0.0,
+            link: None,
+        };
+        assert!(run.link.is_none());
     }
 }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -80,13 +80,9 @@ pub fn render_to_pdf(root: Box<dyn Pageable>, config: &Config) -> Result<Vec<u8>
         }
 
         // Emit link annotations for this page now that `page` is exclusively
-        // ours again. Filter the collector's occurrences to this page.
-        let per_page: Vec<_> = link_collector
-            .occurrences()
-            .iter()
-            .filter(|o| o.page_idx == page_idx)
-            .cloned()
-            .collect();
+        // ours again. `take_page` drains just this page's occurrences in
+        // O(L_page) instead of scanning the entire occurrence list.
+        let per_page = link_collector.take_page(page_idx);
         crate::link::emit_link_annotations(&mut page, &per_page, &dest_registry);
     }
 
@@ -551,12 +547,7 @@ pub fn render_to_pdf_with_gcpm(
         // wrapper around `&mut surface`, so dropping `surface` is enough.
         drop(surface);
 
-        let per_page: Vec<_> = link_collector
-            .occurrences()
-            .iter()
-            .filter(|o| o.page_idx == page_idx)
-            .cloned()
-            .collect();
+        let per_page = link_collector.take_page(page_idx);
         crate::link::emit_link_annotations(&mut page, &per_page, &dest_registry);
     }
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -47,6 +47,7 @@ pub fn render_to_pdf(root: Box<dyn Pageable>, config: &Config) -> Result<Vec<u8>
         let mut canvas = Canvas {
             surface: &mut surface,
             heading_collector: collector.as_mut(),
+            link_collector: None,
         };
         page_content.draw(
             &mut canvas,
@@ -270,6 +271,7 @@ pub fn render_to_pdf_with_gcpm(
         let mut canvas = Canvas {
             surface: &mut surface,
             heading_collector: None,
+            link_collector: None,
         };
 
         // Resolve margin boxes: for each position, pick the most specific
@@ -458,6 +460,7 @@ pub fn render_to_pdf_with_gcpm(
         canvas = Canvas {
             surface: &mut surface,
             heading_collector: collector.as_mut(),
+            link_collector: None,
         };
         let page_content_width = page_size.width - resolved_margin.left - resolved_margin.right;
         let page_content_height = page_size.height - resolved_margin.top - resolved_margin.bottom;

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -267,18 +267,36 @@ pub fn render_to_pdf_with_gcpm(
         None
     };
 
-    // Pre-pass: collect block-level anchor destinations. Margins differ
-    // per-page under GCPM, but the destination y-coordinate only needs to
-    // land the viewer near the anchor; using `config.margin` here is a
-    // reasonable approximation and matches the non-GCPM path's accuracy.
+    // Pre-pass: collect block-level anchor destinations. Under GCPM,
+    // `@page :first` / `@page :left` / etc. can override the size or
+    // margins of individual pages, so we must replay the same
+    // `resolve_page_settings` logic the render loop uses below — using the
+    // global `config.margin` here would produce stale destination
+    // coordinates on pages whose size or margins differ from the default.
     let mut dest_registry = crate::pageable::DestinationRegistry::new();
     for (idx, p) in pages.iter().enumerate() {
+        let page_num = idx + 1;
+        let (resolved_size, resolved_margin, resolved_landscape) =
+            crate::gcpm::page_settings::resolve_page_settings(
+                &gcpm.page_settings,
+                page_num,
+                total_pages,
+                config,
+            );
+        let page_size = if resolved_landscape {
+            resolved_size.landscape()
+        } else {
+            resolved_size
+        };
+        let page_content_width = page_size.width - resolved_margin.left - resolved_margin.right;
+        let page_content_height = page_size.height - resolved_margin.top - resolved_margin.bottom;
+
         dest_registry.set_current_page(idx);
         p.collect_ids(
-            config.margin.left,
-            config.margin.top,
-            content_width,
-            content_height,
+            resolved_margin.left,
+            resolved_margin.top,
+            page_content_width,
+            page_content_height,
             &mut dest_registry,
         );
     }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -32,31 +32,62 @@ pub fn render_to_pdf(root: Box<dyn Pageable>, config: &Config) -> Result<Vec<u8>
         None
     };
 
+    // Pre-pass: collect block-level anchor destinations so `href="#id"`
+    // links can resolve to `(page_idx, y)` during annotation emission.
+    let mut dest_registry = crate::pageable::DestinationRegistry::new();
+    for (idx, p) in pages.iter().enumerate() {
+        dest_registry.set_current_page(idx);
+        p.collect_ids(
+            config.margin.left,
+            config.margin.top,
+            content_width,
+            content_height,
+            &mut dest_registry,
+        );
+    }
+
+    let mut link_collector = crate::pageable::LinkCollector::new();
+
     for (page_idx, page_content) in pages.iter().enumerate() {
         let settings = krilla::page::PageSettings::from_wh(page_size.width, page_size.height)
             .ok_or_else(|| Error::PdfGeneration("Invalid page dimensions".into()))?;
 
         let mut page = document.start_page_with(settings);
-        let mut surface = page.surface();
 
         if let Some(c) = collector.as_mut() {
             c.set_current_page(page_idx);
         }
+        link_collector.set_current_page(page_idx);
 
-        // Pass margin offsets as x/y origin to draw
-        let mut canvas = Canvas {
-            surface: &mut surface,
-            heading_collector: collector.as_mut(),
-            link_collector: None,
-        };
-        page_content.draw(
-            &mut canvas,
-            config.margin.left,
-            config.margin.top,
-            content_width,
-            content_height,
-        );
-        // Surface::finish is handled by Drop
+        // Scope the surface borrow so we can mutate `page` (add_annotation)
+        // afterwards: `page.surface()` returns a `Surface<'_>` that exclusively
+        // borrows `page` until dropped.
+        {
+            let mut surface = page.surface();
+            let mut canvas = Canvas {
+                surface: &mut surface,
+                heading_collector: collector.as_mut(),
+                link_collector: Some(&mut link_collector),
+            };
+            page_content.draw(
+                &mut canvas,
+                config.margin.left,
+                config.margin.top,
+                content_width,
+                content_height,
+            );
+            // Surface drops here, releasing the borrow on `page`.
+        }
+
+        // Emit link annotations for this page now that `page` is exclusively
+        // ours again. Filter the collector's occurrences to this page.
+        let per_page: Vec<_> = link_collector
+            .occurrences()
+            .iter()
+            .filter(|o| o.page_idx == page_idx)
+            .cloned()
+            .collect();
+        crate::link::emit_link_annotations(&mut page, &per_page, &dest_registry);
     }
 
     if let Some(c) = collector {
@@ -236,6 +267,24 @@ pub fn render_to_pdf_with_gcpm(
         None
     };
 
+    // Pre-pass: collect block-level anchor destinations. Margins differ
+    // per-page under GCPM, but the destination y-coordinate only needs to
+    // land the viewer near the anchor; using `config.margin` here is a
+    // reasonable approximation and matches the non-GCPM path's accuracy.
+    let mut dest_registry = crate::pageable::DestinationRegistry::new();
+    for (idx, p) in pages.iter().enumerate() {
+        dest_registry.set_current_page(idx);
+        p.collect_ids(
+            config.margin.left,
+            config.margin.top,
+            content_width,
+            content_height,
+            &mut dest_registry,
+        );
+    }
+
+    let mut link_collector = crate::pageable::LinkCollector::new();
+
     // Pass 2: render each page with margin boxes
     for (page_idx, page_content) in pages.iter().enumerate() {
         let page_num = page_idx + 1;
@@ -257,17 +306,23 @@ pub fn render_to_pdf_with_gcpm(
         let settings = krilla::page::PageSettings::from_wh(page_size.width, page_size.height)
             .ok_or_else(|| Error::PdfGeneration("Invalid page dimensions".into()))?;
         let mut page = document.start_page_with(settings);
-        let mut surface = page.surface();
 
         if let Some(c) = collector.as_mut() {
             c.set_current_page(page_idx);
         }
+        link_collector.set_current_page(page_idx);
+
+        let mut surface = page.surface();
 
         // Margin boxes use a Canvas with no heading collector — running
         // elements promoted into margin boxes may contain h1-h6, but their
         // bookmark entry must come from the source position in the body,
         // not from each margin-box repetition. The body Canvas (created
         // after this scope) carries the collector instead.
+        //
+        // Margin-box links are out of scope for this task — only the body
+        // canvas wires the link collector below. Clickable `<a>` inside
+        // header/footer content is a follow-up.
         let mut canvas = Canvas {
             surface: &mut surface,
             heading_collector: None,
@@ -455,12 +510,13 @@ pub fn render_to_pdf_with_gcpm(
         // Draw body content with resolved per-page margin. Reuse `canvas`
         // by overwriting it so the previous (collector-less) Canvas's
         // borrow on `surface` is released, then reborrow with the heading
-        // collector so h1-h6 markers in body content can record their
-        // (page_idx, y) for the PDF outline.
+        // and link collectors so h1-h6 markers can record their
+        // (page_idx, y) for the PDF outline and `<a>` rects for link
+        // annotations.
         canvas = Canvas {
             surface: &mut surface,
             heading_collector: collector.as_mut(),
-            link_collector: None,
+            link_collector: Some(&mut link_collector),
         };
         let page_content_width = page_size.width - resolved_margin.left - resolved_margin.right;
         let page_content_height = page_size.height - resolved_margin.top - resolved_margin.bottom;
@@ -471,6 +527,19 @@ pub fn render_to_pdf_with_gcpm(
             page_content_width,
             page_content_height,
         );
+        // Release the surface borrow before mutating `page` to add
+        // annotations. `Surface` has a `Drop` impl that flushes the content
+        // stream and releases its borrow on `page`. `Canvas` is a no-drop
+        // wrapper around `&mut surface`, so dropping `surface` is enough.
+        drop(surface);
+
+        let per_page: Vec<_> = link_collector
+            .occurrences()
+            .iter()
+            .filter(|o| o.page_idx == page_idx)
+            .cloned()
+            .collect();
+        crate::link::emit_link_annotations(&mut page, &per_page, &dest_registry);
     }
 
     if let Some(c) = collector {

--- a/crates/fulgur/tests/link_integration.rs
+++ b/crates/fulgur/tests/link_integration.rs
@@ -1,9 +1,25 @@
 //! Integration tests: `<a href>` is emitted as PDF `/Link` annotation.
 
 use fulgur::Engine;
+use fulgur::asset::AssetBundle;
+
+// Minimal 1x1 red PNG (69 bytes) — shared with background_test.rs.
+const MINIMAL_PNG: &[u8] = &[
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+    0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0x00,
+    0x00, 0x03, 0x01, 0x01, 0x00, 0xC9, 0xFE, 0x92, 0xEF, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E,
+    0x44, 0xAE, 0x42, 0x60, 0x82,
+];
 
 fn engine() -> Engine {
     Engine::builder().build()
+}
+
+fn engine_with_png(name: &str) -> Engine {
+    let mut assets = AssetBundle::new();
+    assets.add_image(name, MINIMAL_PNG.to_vec());
+    Engine::builder().assets(assets).build()
 }
 
 #[test]
@@ -92,5 +108,65 @@ fn link_spanning_page_break_emits_annotation_on_each_page() {
     assert!(
         uri_count >= 2,
         "expected URI on both pages, got {uri_count}"
+    );
+}
+
+#[test]
+fn link_works_through_gcpm_render_path() {
+    // @page rule forces render_to_pdf_with_gcpm rather than render_to_pdf.
+    let html = r##"<html>
+        <head><style>@page { margin: 2cm; @top-center { content: "Header"; } }</style></head>
+        <body><p><a href="https://gcpm.test">click</a></p></body>
+    </html>"##;
+    let bytes = engine().render_html(html).unwrap();
+    let text = String::from_utf8_lossy(&bytes);
+    assert!(text.contains("/Link"), "GCPM path missing /Link");
+    assert!(text.contains("https://gcpm.test"), "GCPM path missing URI");
+}
+
+// TODO(fulgur-pdf-links): wire link emission for `<a><img/></a>` when the
+// anchor and `<img>` live inside an inline-root paragraph.
+//
+// Investigation (2026-04-16) showed that when `<img>` is a default-display
+// (inline) child of a paragraph — e.g. `<p><a><img/></a></p>` — the image
+// itself never reaches the PDF at all:
+//
+//   1. Blitz marks `<p>` as an inline root and positions the `<img>` as a
+//      Parley `InlineBox` inside the paragraph's layout.
+//   2. `convert::extract_paragraph` walks `parley_layout.lines()` but only
+//      matches `PositionedLayoutItem::GlyphRun`; `InlineBox` items are
+//      silently dropped. No `LineItem::Image` is produced, no image data is
+//      embedded, the content stream is empty — `/Link` annotations are moot
+//      because there is nothing to click through to.
+//   3. The ImagePageable path in `convert::convert_image` only fires when
+//      `<img>` is visited as its own node (i.e. block-level, such as
+//      `<div><img style="display:block"/></div>` in `image_test.rs`), and
+//      that path currently has no link support either.
+//
+// So the "anchor-wrapping image" feature has two gaps stacked on top of
+// each other: (a) InlineBox-aware paragraph extraction that materialises
+// `<img>` as `InlineImage`, and (b) link attachment to those `InlineImage`
+// entries. Inline pseudo-element images (`::before { content: url(...) }`)
+// already use `attach_link_to_inline_image`, so the link wiring will be
+// trivial once (a) lands — `<img>` inside `<a>` will go through the same
+// `LineItem::Image` draw path that already records link rects at
+// `paragraph.rs` line ~597.
+//
+// Scope for this test file is link emission only, so the gap is captured
+// as an ignored test. Unignoring this test is the acceptance criterion for
+// closing both gaps together.
+#[test]
+#[ignore = "blocked on InlineBox → InlineImage materialisation in extract_paragraph; see TODO above"]
+fn anchor_wrapping_inline_image_is_clickable() {
+    let html = r##"<html><body><p><a href="https://img.test"><img src="pixel.png" width="100" height="50"/></a></p></body></html>"##;
+    let bytes = engine_with_png("pixel.png").render_html(html).unwrap();
+    let text = String::from_utf8_lossy(&bytes);
+    assert!(
+        text.contains("/Link"),
+        "anchor-wrapping image missing /Link"
+    );
+    assert!(
+        text.contains("https://img.test"),
+        "URI missing — anchor-wrapping image not clickable"
     );
 }

--- a/crates/fulgur/tests/link_integration.rs
+++ b/crates/fulgur/tests/link_integration.rs
@@ -46,3 +46,51 @@ fn unresolved_internal_anchor_is_ignored_not_error() {
     let bytes = engine().render_html(html).expect("render should not fail");
     assert!(bytes.starts_with(b"%PDF"));
 }
+
+#[test]
+fn multiline_link_merges_into_single_annotation_with_multiple_quads() {
+    // Force line-wrapping of a single <a> via narrow container.
+    // 200 "word " repetitions inside a 200px-wide container guarantees many lines.
+    let long: String = "word ".repeat(200);
+    let html = format!(
+        r##"<html><body><div style="width:200px"><p><a href="https://multiline.test">{}</a></p></div></body></html>"##,
+        long
+    );
+    let bytes = engine().render_html(&html).unwrap();
+    let text = String::from_utf8_lossy(&bytes);
+    // Single <a> with text broken across multiple lines → one LinkAnnotation
+    // that carries multiple QuadPoints. PDF writer emits /QuadPoints array
+    // only when the annotation has more than one rectangle.
+    assert!(
+        text.contains("/QuadPoints"),
+        "expected /QuadPoints in multi-line link"
+    );
+    // URI should appear once (one occurrence, not one per line)
+    let uri_count = text.matches("https://multiline.test").count();
+    assert!(uri_count >= 1, "URI missing");
+}
+
+#[test]
+fn link_spanning_page_break_emits_annotation_on_each_page() {
+    // Push a long <a> near the end of page 1 so it wraps onto page 2.
+    // A spacer slightly larger than one A4 content page (≈730pt) leaves a
+    // shallow strip on the next page; a tall-font, narrow-column link
+    // placed after the spacer is guaranteed to overflow across the page
+    // boundary so its rects land on two different pages.
+    let link_text = "link ".repeat(60);
+    let html = format!(
+        r##"<html><body>
+        <div style="height:900pt"></div>
+        <div style="width:120pt;font-size:40pt;line-height:1.2"><a href="https://cross.test">{link_text}</a></div>
+    </body></html>"##
+    );
+    let bytes = engine().render_html(&html).unwrap();
+    let text = String::from_utf8_lossy(&bytes);
+    // Page-crossing links must produce ONE annotation per page (can't share across pages).
+    // Expect the URI to appear at least twice in the PDF byte stream (once per /URI entry).
+    let uri_count = text.matches("https://cross.test").count();
+    assert!(
+        uri_count >= 2,
+        "expected URI on both pages, got {uri_count}"
+    );
+}

--- a/crates/fulgur/tests/link_integration.rs
+++ b/crates/fulgur/tests/link_integration.rs
@@ -1,0 +1,48 @@
+//! Integration tests: `<a href>` is emitted as PDF `/Link` annotation.
+
+use fulgur::Engine;
+
+fn engine() -> Engine {
+    Engine::builder().build()
+}
+
+#[test]
+fn external_link_produces_uri_action_in_pdf() {
+    let html = r#"<html><body><p><a href="https://example.com">click</a></p></body></html>"#;
+    let bytes = engine().render_html(html).expect("render");
+    assert!(bytes.starts_with(b"%PDF"));
+    let text = String::from_utf8_lossy(&bytes);
+    assert!(text.contains("/Link"), "missing /Link annotation subtype");
+    assert!(text.contains("/URI"), "missing /URI action type");
+    assert!(
+        text.contains("https://example.com"),
+        "missing URI string in PDF body"
+    );
+}
+
+#[test]
+fn internal_anchor_produces_destination() {
+    let html = r##"<html><body>
+        <p><a href="#section">jump</a></p>
+        <div style="height:1500px"></div>
+        <h2 id="section">Target</h2>
+    </body></html>"##;
+    let bytes = engine().render_html(html).expect("render");
+    assert!(bytes.starts_with(b"%PDF"));
+    let text = String::from_utf8_lossy(&bytes);
+    assert!(text.contains("/Link"), "missing /Link annotation");
+    // krilla serializes XYZ destinations; the annotation dict references
+    // it via /Dest (indirect object reference) and the destination itself
+    // carries /XYZ.
+    assert!(
+        text.contains("/XYZ") || text.contains("/Dest"),
+        "missing internal destination marker (/XYZ or /Dest)"
+    );
+}
+
+#[test]
+fn unresolved_internal_anchor_is_ignored_not_error() {
+    let html = r##"<html><body><p><a href="#nope">dangling</a></p></body></html>"##;
+    let bytes = engine().render_html(html).expect("render should not fail");
+    assert!(bytes.starts_with(b"%PDF"));
+}

--- a/docs/plans/2026-04-16-pdf-links.md
+++ b/docs/plans/2026-04-16-pdf-links.md
@@ -1,0 +1,610 @@
+# PDF Links (fulgur-d5k) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** `<a href>` タグを PDF のクリッカブルリンク (外部URI + 内部アンカー) として出力する。
+
+**Architecture:**
+
+- convert.rs で `<a href>` をインラインの祖先として検出し、配下の `ShapedGlyphRun` / `InlineImage` に `LinkSpan` を添付。
+- BlockPageable 系に `id: Option<Arc<String>>` を持たせ、ページ分割後に `(id → (page_idx, y_pt))` の `DestinationRegistry` を事前収集。
+- draw パスで `LinkCollector` を介して per-page の link rect を集約し、ページスコープを抜ける前に `page.add_annotation(LinkAnnotation)` を発行する。複数行は `quad_points` で 1 annotation にまとめる。
+
+**Tech Stack:** Rust, blitz-dom 0.2.4, parley, krilla 0.6 (`krilla::interactive::annotation::{Annotation, LinkAnnotation}`, `Action::Uri`, `XyzDestination`).
+
+---
+
+## Global Notes
+
+- ブランチ: `feature/pdf-links`、worktree `/home/ubuntu/fulgur/.worktrees/pdf-links`。
+- 全編 TDD。各タスクで「失敗するテストを先に書く → 実装 → テスト通過 → commit」。
+- テスト用 PDF バイト検査は `pdf-writer` 依存を足さず、`pdf` crate や既存テストと同じ `Vec<u8>` 内の文字列/バイトパターン比較で十分。具体的には `/Link`, `/URI`, `/Dest` などの PDF キーワードを grep する。
+- `cargo fmt` と `cargo clippy -- -D warnings` を各 commit 前に必ず実行。
+- 視覚回帰は examples フォルダには触らない想定。影響した場合のみ別途扱う。
+
+---
+
+## Task 1: `LinkTarget` / `LinkSpan` 型定義
+
+**Files:**
+- Modify: `crates/fulgur/src/paragraph.rs` — 先頭部 (既存の `ShapedGlyph` 定義前) に型を追加し、`ShapedGlyphRun` と `InlineImage` に `link: Option<Arc<LinkSpan>>` フィールドを追加。
+- Test: `crates/fulgur/src/paragraph.rs` 内 `#[cfg(test)]` モジュール (既存があれば末尾、なければ新規)。
+
+**Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod link_span_tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn link_target_equality_is_by_value() {
+        let a = LinkTarget::External(Arc::new("https://example.com".into()));
+        let b = LinkTarget::External(Arc::new("https://example.com".into()));
+        assert_eq!(a, b);
+        let c = LinkTarget::Internal(Arc::new("section".into()));
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn shaped_glyph_run_default_has_no_link() {
+        let run = ShapedGlyphRun {
+            font_data: Arc::new(Vec::new()),
+            font_index: 0,
+            font_size: 12.0,
+            color: [0, 0, 0, 255],
+            decoration: TextDecoration::default(),
+            glyphs: Vec::new(),
+            text: String::new(),
+            x_offset: 0.0,
+            link: None,
+        };
+        assert!(run.link.is_none());
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cargo test -p fulgur --lib paragraph::link_span_tests 2>&1 | tail -20
+```
+
+Expected: コンパイルエラー (`LinkTarget`, `LinkSpan`, `link` フィールド未定義)。
+
+**Step 3: Add the types and fields**
+
+```rust
+/// Target for a clickable link in PDF output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LinkTarget {
+    External(Arc<String>),
+    Internal(Arc<String>),
+}
+
+/// Link association attached to a glyph run or inline image.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkSpan {
+    pub target: LinkTarget,
+    pub alt_text: Option<String>,
+}
+```
+
+`ShapedGlyphRun` と `InlineImage` に `pub link: Option<Arc<LinkSpan>>` を追加。既存コンストラクション箇所 (`convert.rs` の `extract_paragraph` や `InlineImage` の新規生成、テスト) は `link: None` で補う。
+
+**Step 4: Run tests**
+
+```bash
+cargo test -p fulgur --lib 2>&1 | tail -10
+```
+
+Expected: 全通過 (既存 + 新規)。
+
+**Step 5: Commit**
+
+```bash
+git add crates/fulgur/src/paragraph.rs crates/fulgur/src/convert.rs
+git commit -m "feat(link): add LinkTarget/LinkSpan types and link field on text items"
+```
+
+---
+
+## Task 2: convert.rs で `<a href>` を検出して LinkSpan を付与
+
+**Files:**
+- Modify: `crates/fulgur/src/convert.rs:1645-1720` (`extract_paragraph`)
+- Modify: `crates/fulgur/src/blitz_adapter.rs` (必要に応じて `find_enclosing_link(doc, node_id) -> Option<(String, Option<String>)>` ヘルパーを公開 — `href` と `<a>` 内テキスト(alt) を返す。既存 `get_attr` は再利用)
+- Test: `crates/fulgur/src/convert.rs` の末尾 `#[cfg(test)]`
+
+**Step 1: Write the failing test**
+
+convert.rs のテストモジュールに以下を追加:
+
+```rust
+#[test]
+fn paragraph_attaches_link_to_glyph_run_inside_anchor() {
+    let html = r#"<html><body><p>Go to <a href="https://example.com">example</a>.</p></body></html>"#;
+    let doc = crate::blitz_adapter::parse_and_layout(html, 400.0, 600.0, &[]);
+    let dummy_store = crate::gcpm::running::RunningElementStore::new();
+    let mut ctx = ConvertContext {
+        running_store: &dummy_store,
+        assets: None,
+        font_cache: Default::default(),
+        string_set_by_node: Default::default(),
+        counter_ops_by_node: Default::default(),
+    };
+    let pageable = crate::convert::dom_to_pageable(&doc, &mut ctx);
+    let paragraphs = collect_paragraphs(&*pageable);
+    let all_links: Vec<_> = paragraphs
+        .iter()
+        .flat_map(|p| p.lines.iter())
+        .flat_map(|l| l.items.iter())
+        .filter_map(|item| match item {
+            LineItem::Text(r) => r.link.clone(),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        all_links.iter().any(|ls| matches!(&ls.target, LinkTarget::External(u) if u.as_str() == "https://example.com")),
+        "expected at least one glyph run with External(https://example.com) link, got {all_links:?}"
+    );
+}
+```
+
+`collect_paragraphs` は既存ヘルパーがなければ小さな visitor を書く (テストフォルダ内)。
+
+**Step 2: Run test to verify failing**
+
+```bash
+cargo test -p fulgur --lib convert::tests::paragraph_attaches_link 2>&1 | tail -20
+```
+
+Expected: FAIL (link is None everywhere)。
+
+**Step 3: Implement link detection**
+
+`extract_paragraph` 内の glyph_run ループで、`brush.id` から `doc.get_node(brush.id)` を引き、親を辿って最初に見つかった `<a>` 要素 (`el.name.local.as_ref() == "a"`) の `href` を取得する。空文字列は無視。
+
+```rust
+fn enclosing_link(doc: &blitz_dom::BaseDocument, start_id: usize) -> Option<Arc<LinkSpan>> {
+    let mut cur = Some(start_id);
+    while let Some(id) = cur {
+        let node = doc.get_node(id)?;
+        if let blitz_dom::NodeData::Element(el) = &node.data {
+            if el.name.local.as_ref() == "a" {
+                let href = crate::blitz_adapter::get_attr(el, "href")?.trim();
+                if href.is_empty() { return None; }
+                let target = if let Some(frag) = href.strip_prefix('#') {
+                    LinkTarget::Internal(Arc::new(frag.to_string()))
+                } else {
+                    LinkTarget::External(Arc::new(href.to_string()))
+                };
+                // alt = <a> 内テキスト (単純結合で十分)
+                let alt_text = crate::blitz_adapter::element_text(doc, id);
+                return Some(Arc::new(LinkSpan { target, alt_text: Some(alt_text).filter(|s| !s.is_empty()) }));
+            }
+        }
+        cur = node.parent;
+    }
+    None
+}
+```
+
+`blitz_adapter::element_text(doc, node_id) -> String` は subtree の text を結合して返す新ヘルパー (既存に類似関数があれば再利用)。
+
+glyph_run 処理で `link: enclosing_link(doc, brush.id)` を `ShapedGlyphRun` に渡す。inline image 側も同様に最近親を辿って付与。
+
+**Step 4: Run test to verify passing**
+
+```bash
+cargo test -p fulgur --lib convert::tests::paragraph_attaches_link 2>&1 | tail -10
+cargo test -p fulgur --lib 2>&1 | tail -10
+```
+
+**Step 5: Commit**
+
+```bash
+git add crates/fulgur/src/convert.rs crates/fulgur/src/blitz_adapter.rs
+git commit -m "feat(link): attach LinkSpan to glyph runs inside <a href>"
+```
+
+---
+
+## Task 3: Block-level id を保持し DestinationRegistry を事前収集
+
+**Files:**
+- Modify: `crates/fulgur/src/pageable.rs` — `BlockPageable` (および id を持てる主要 Pageable) に `pub id: Option<Arc<String>>` を追加。
+- Modify: `crates/fulgur/src/pageable.rs` — `Pageable` trait に `fn collect_ids(&self, x: f32, y: f32, width: f32, height: f32, registry: &mut DestinationRegistry) { /* default: noop */ }` を追加。BlockPageable がオーバーライドして自身の id を記録し、子を再帰。
+- Modify: `crates/fulgur/src/convert.rs` — BlockPageable 生成箇所で id 属性を `get_attr(el, "id")` から取得してセット。
+- New: `crates/fulgur/src/pageable.rs` — `DestinationRegistry` 型 (BTreeMap<String, (usize, Pt)>、決定性のため BTreeMap)。
+- Test: `crates/fulgur/src/pageable.rs` 末尾 `#[cfg(test)]`。
+
+**Step 1: Write the failing test**
+
+```rust
+#[test]
+fn destination_registry_collects_block_ids_from_paginated_pages() {
+    let html = r#"<html><body>
+        <h1 id="top">Top</h1>
+        <div style="height:2000px"></div>
+        <h2 id="next">Next</h2>
+    </body></html>"#;
+    let bytes = crate::engine::Engine::new().render_html(html).unwrap();
+    // smoke: PDF generated
+    assert!(bytes.starts_with(b"%PDF"));
+    // unit-level test instead:
+    let doc = crate::blitz_adapter::parse_and_layout(html, 400.0, 600.0, &[]);
+    let dummy_store = crate::gcpm::running::RunningElementStore::new();
+    let mut ctx = crate::convert::ConvertContext {
+        running_store: &dummy_store,
+        assets: None,
+        font_cache: Default::default(),
+        string_set_by_node: Default::default(),
+        counter_ops_by_node: Default::default(),
+    };
+    let pageable = crate::convert::dom_to_pageable(&doc, &mut ctx);
+    let pages = crate::paginate::paginate(pageable, 400.0, 600.0);
+    let mut registry = DestinationRegistry::default();
+    for (idx, p) in pages.iter().enumerate() {
+        registry.set_current_page(idx);
+        p.collect_ids(0.0, 0.0, 400.0, 600.0, &mut registry);
+    }
+    assert!(registry.get("top").is_some());
+    assert!(registry.get("next").is_some());
+    assert_ne!(registry.get("top"), registry.get("next"));
+}
+```
+
+**Step 2: Run test**
+
+Expected: FAIL (DestinationRegistry 未定義)。
+
+**Step 3: Implement**
+
+- `DestinationRegistry` を新設 (`HeadingCollector` と同じパターン、`current_page_idx` を持つ)。
+- `Pageable::collect_ids` の default impl は no-op。
+- `BlockPageable::collect_ids` で自身の `id` を `registry.record(id.clone(), y)` して children を再帰。
+- convert.rs で BlockPageable 生成箇所に `id: get_attr(el, "id").map(|s| Arc::new(s.to_string()))` を追加。
+
+**Step 4: Pass**
+
+```bash
+cargo test -p fulgur --lib pageable::tests::destination_registry 2>&1 | tail -10
+```
+
+**Step 5: Commit**
+
+```bash
+git add crates/fulgur/src/pageable.rs crates/fulgur/src/convert.rs
+git commit -m "feat(link): collect block id→(page,y) registry for destinations"
+```
+
+---
+
+## Task 4: LinkCollector と per-page rect 集約
+
+**Files:**
+- Modify: `crates/fulgur/src/pageable.rs` — `Canvas` に `pub link_collector: Option<&'a mut LinkCollector>` を追加。
+- New: `crates/fulgur/src/pageable.rs` — `LinkCollector` 型: `current_page_idx`, `Vec<LinkOccurrence>` を保持。`LinkOccurrence { page_idx, target, alt_text, rects: Vec<Rect> }` で、同一 LinkSpan Arc は同じ occurrence にまとめる (HashMap キー `(page_idx, Arc::as_ptr as usize)` で dedup)。
+- Modify: `crates/fulgur/src/paragraph.rs` — `ParagraphPageable::draw` で glyph run ごとに `link` が `Some` なら rect を計算して collector に push。`InlineImage::draw` 相当も同様。
+- Test: `crates/fulgur/src/paragraph.rs` の `#[cfg(test)]`。
+
+**Step 1: Write the failing test**
+
+```rust
+#[test]
+fn draw_pushes_link_rect_for_anchor_glyph_run() {
+    // Build a minimal ShapedLine with one glyph run carrying a LinkSpan,
+    // draw via a mock Canvas that has a LinkCollector but no Surface (use
+    // a new TestCanvas helper). Assert 1 occurrence with rect width>0.
+    // (Uses a krilla Page + surface from a throwaway Document; see existing
+    //  tests like `heading_collector_records_entry_on_draw` for pattern.)
+    let span = Arc::new(LinkSpan {
+        target: LinkTarget::External(Arc::new("https://x.test".into())),
+        alt_text: None,
+    });
+    let run = make_test_glyph_run_with_link(span.clone());
+    let line = ShapedLine { height: 14.0, baseline: 11.0, items: vec![LineItem::Text(run)] };
+    let paragraph = ParagraphPageable::new(vec![line]);
+
+    let mut doc = krilla::Document::new();
+    let settings = krilla::page::PageSettings::from_wh(200.0, 200.0).unwrap();
+    let mut page = doc.start_page_with(settings);
+    let mut surface = page.surface();
+    let mut link_collector = LinkCollector::new();
+    link_collector.set_current_page(0);
+    {
+        let mut canvas = Canvas {
+            surface: &mut surface,
+            heading_collector: None,
+            link_collector: Some(&mut link_collector),
+        };
+        paragraph.draw(&mut canvas, 10.0, 20.0, 180.0, 100.0);
+    }
+    let occurrences = link_collector.into_occurrences();
+    assert_eq!(occurrences.len(), 1);
+    assert_eq!(occurrences[0].page_idx, 0);
+    assert!(matches!(&occurrences[0].target, LinkTarget::External(u) if u.as_str() == "https://x.test"));
+    assert_eq!(occurrences[0].rects.len(), 1);
+    assert!(occurrences[0].rects[0].width > 0.0);
+}
+```
+
+`make_test_glyph_run_with_link` はテストヘルパー (既存テスト用 fixtures を流用)。
+
+**Step 2: Run — FAIL** (LinkCollector 未定義)。
+
+**Step 3: Implement**
+
+- `LinkCollector` に occurrence 蓄積。同一 page + 同一 Arc ポインタの LinkSpan はマージ。
+- `Canvas` 構造体を拡張。既存の `Canvas { surface, heading_collector }` 初期化箇所 (render.rs 内 4 箇所) に `link_collector: None` or `Some(&mut ...)` を追加。
+- paragraph draw: 各 glyph run の link が Some のとき、rect = `(canvas_x + run.x_offset, line_top, run_advance_total, line.height)` を記録。`run_advance_total` はグリフの advance 合算から計算 (単位変換済み)。
+- InlineImage の link は後続 (scope 内だが同パターン)。
+
+**Step 4: Pass**
+
+```bash
+cargo test -p fulgur --lib paragraph::link_span_tests 2>&1 | tail -10
+cargo test -p fulgur --lib 2>&1 | tail -10
+```
+
+**Step 5: Commit**
+
+```bash
+git add crates/fulgur/src/pageable.rs crates/fulgur/src/paragraph.rs crates/fulgur/src/render.rs
+git commit -m "feat(link): LinkCollector collects per-page link rects during draw"
+```
+
+---
+
+## Task 5: render.rs で annotation を発行
+
+**Files:**
+- Modify: `crates/fulgur/src/render.rs` — `render_to_pdf` / `render_to_pdf_with_gcpm` を修正。
+- New module: `crates/fulgur/src/link.rs` — `emit_link_annotations(page: &mut krilla::page::Page, occurrences_for_page: &[LinkOccurrence], registry: &DestinationRegistry)` ヘルパー。未解決アンカーは `eprintln!` で警告。
+- Modify: `crates/fulgur/src/lib.rs` — `pub mod link;` を追加 (crate 内用途なら `pub(crate)` で十分)。
+- Test: `crates/fulgur/tests/link_integration.rs` (新規 integration test)
+
+**Step 1: Write failing integration test**
+
+```rust
+// crates/fulgur/tests/link_integration.rs
+use fulgur::Engine;
+
+#[test]
+fn external_link_produces_uri_action_in_pdf() {
+    let html = r#"<html><body><p><a href="https://example.com">click</a></p></body></html>"#;
+    let bytes = Engine::new().render_html(html).unwrap();
+    let text = String::from_utf8_lossy(&bytes).to_string();
+    assert!(text.contains("/Link"), "missing /Link annotation in PDF: {}", &text[..text.len().min(500)]);
+    assert!(text.contains("https://example.com"), "missing URI");
+    assert!(text.contains("/URI"), "missing URI action");
+}
+
+#[test]
+fn internal_anchor_produces_destination() {
+    let html = r#"<html><body>
+        <p><a href="#section">jump</a></p>
+        <div style="height:1000px"></div>
+        <h2 id="section">Target</h2>
+    </body></html>"#;
+    let bytes = Engine::new().render_html(html).unwrap();
+    let text = String::from_utf8_lossy(&bytes).to_string();
+    assert!(text.contains("/Link"));
+    // krilla が XyzDestination を埋める PDF キー
+    assert!(text.contains("/XYZ") || text.contains("/Dest"), "missing internal destination");
+}
+
+#[test]
+fn unresolved_internal_anchor_is_ignored_not_error() {
+    let html = r#"<html><body><p><a href="#nope">dangling</a></p></body></html>"#;
+    let bytes = Engine::new().render_html(html).unwrap();
+    assert!(bytes.starts_with(b"%PDF"));
+}
+```
+
+**Step 2: Run — FAIL**
+
+```bash
+cargo test -p fulgur --test link_integration 2>&1 | tail -20
+```
+
+**Step 3: Implement**
+
+`render_to_pdf` 改造:
+
+```rust
+// After paginate, before the page loop:
+let mut dest_registry = DestinationRegistry::default();
+for (idx, p) in pages.iter().enumerate() {
+    dest_registry.set_current_page(idx);
+    p.collect_ids(config.margin.left, config.margin.top, content_width, content_height, &mut dest_registry);
+}
+
+let mut link_collector = LinkCollector::new();
+
+for (page_idx, page_content) in pages.iter().enumerate() {
+    // ... existing setup ...
+    link_collector.set_current_page(page_idx);
+    let mut canvas = Canvas {
+        surface: &mut surface,
+        heading_collector: collector.as_mut(),
+        link_collector: Some(&mut link_collector),
+    };
+    page_content.draw(...);
+    drop(canvas);
+    // Emit annotations for this page before the Page drops.
+    let per_page = link_collector.take_page(page_idx);
+    crate::link::emit_link_annotations(&mut page, &per_page, &dest_registry);
+}
+```
+
+`emit_link_annotations`:
+
+```rust
+pub(crate) fn emit_link_annotations(
+    page: &mut krilla::page::Page,
+    occurrences: &[LinkOccurrence],
+    registry: &DestinationRegistry,
+) {
+    use krilla::interactive::action::{Action, LinkAction};
+    use krilla::interactive::annotation::{Annotation, LinkAnnotation, Target};
+    use krilla::interactive::destination::XyzDestination;
+    use krilla::geom::{Point, Quadrilateral};
+
+    for occ in occurrences {
+        let target = match &occ.target {
+            LinkTarget::External(uri) => {
+                Target::Action(Action::Link(LinkAction::new(uri.to_string())))
+            }
+            LinkTarget::Internal(id) => {
+                match registry.get(id.as_str()) {
+                    Some((page_idx, y_pt)) => {
+                        let dest = XyzDestination::new(*page_idx, Point::from_xy(0.0, y_pt.0));
+                        Target::Destination(krilla::interactive::destination::Destination::Xyz(dest))
+                    }
+                    None => {
+                        eprintln!("fulgur: unresolved internal anchor #{id}");
+                        continue;
+                    }
+                }
+            }
+        };
+
+        let quads: Vec<Quadrilateral> = occ.rects.iter().map(rect_to_quad).collect();
+        let ann = LinkAnnotation::new_with_quad_points(quads, target);
+        let annotation = Annotation::new_link(ann, occ.alt_text.clone());
+        page.add_annotation(annotation);
+    }
+}
+```
+
+`rect_to_quad` は 4 コーナーの `Point` を詰める小関数 (テスト済み座標順 左下→右下→右上→左上 を krilla の規約に合わせる。krilla annotation.rs の `page_root_transform` との整合を検証)。
+
+GCPM 側 (`render_to_pdf_with_gcpm`) にも同じ wiring を追加 (両方で動く設計)。
+
+**Step 4: Pass**
+
+```bash
+cargo test -p fulgur 2>&1 | tail -20
+```
+
+**Step 5: Commit**
+
+```bash
+git add crates/fulgur/src/link.rs crates/fulgur/src/lib.rs crates/fulgur/src/render.rs crates/fulgur/tests/link_integration.rs
+git commit -m "feat(link): emit URI actions and XYZ destinations as PDF link annotations"
+```
+
+---
+
+## Task 6: 複数行リンクの quad_points 集約を検証
+
+**Files:**
+- Modify: `crates/fulgur/tests/link_integration.rs` — テスト追加。
+
+**Step 1: Test**
+
+```rust
+#[test]
+fn multiline_link_merges_into_single_annotation_with_multiple_quads() {
+    // 強制的に折り返しが起きる長文リンク
+    let long = "word ".repeat(200);
+    let html = format!(
+        r#"<html><body style="width:100px"><p><a href="https://x.test">{}</a></p></body></html>"#,
+        long
+    );
+    let bytes = Engine::new().render_html(&html).unwrap();
+    let text = String::from_utf8_lossy(&bytes).to_string();
+    // /QuadPoints が出ていること = 単一 annotation に複数行の矩形が入った
+    assert!(text.contains("/QuadPoints"), "expected /QuadPoints in multi-line link");
+    // /URI は 1 件 (同じ href は重複しない想定)
+    let uri_count = text.matches("https://x.test").count();
+    assert!(uri_count >= 1);
+}
+```
+
+**Step 2: Run** — 行ごとに rect が追加されていれば既に通るはず。FAIL するなら LinkCollector の dedup 実装を見直す。
+
+**Step 3: Fix if needed**
+
+LinkCollector の occurrence マージ条件を `(page_idx, Arc::as_ptr(link_span))` で行う。同一 LinkSpan Arc を共有するグリフ run が複数行に散らばっても 1 occurrence に統合。
+
+**Step 4: Commit**
+
+```bash
+git add crates/fulgur/tests/link_integration.rs crates/fulgur/src/pageable.rs
+git commit -m "test(link): multi-line <a> merges into one annotation via quad_points"
+```
+
+---
+
+## Task 7: ページ跨ぎリンクのテスト
+
+**Files:**
+- Modify: `crates/fulgur/tests/link_integration.rs`。
+
+**Step 1: Test**
+
+```rust
+#[test]
+fn link_spanning_page_break_emits_annotation_on_each_page() {
+    // 1 ページ目の下部から 2 ページ目の上部までリンクがまたがる
+    let html = r#"<html><body>
+        <div style="height:1700px"></div>
+        <p><a href="https://cross.test">really long long long long long long long long link text that spans pages</a></p>
+    </body></html>"#;
+    let bytes = Engine::new().render_html(html).unwrap();
+    let text = String::from_utf8_lossy(&bytes).to_string();
+    // 同じ URI が 2 つのページに対して登場する = /URI 出現回数 >= 2
+    let uri_count = text.matches("https://cross.test").count();
+    assert!(uri_count >= 2, "expected URI on both pages, got {uri_count}");
+}
+```
+
+**Step 2: Run** — 1 occurrence per page を page_idx キーで分けている設計なので通るはず。
+
+**Step 3: Commit**
+
+```bash
+git add crates/fulgur/tests/link_integration.rs
+git commit -m "test(link): page-crossing anchor emits annotation on each page"
+```
+
+---
+
+## Task 8: clippy・fmt・全体 regression
+
+**Step 1:**
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test --workspace
+```
+
+エラーを都度修正して再実行。
+
+**Step 2: Final commit (if fix-ups)**
+
+```bash
+git commit -am "chore(link): fmt + clippy pass"
+```
+
+---
+
+## 検証 (verification)
+
+- `cargo test --workspace` 全通過
+- `cargo clippy -- -D warnings` エラーなし
+- `cargo fmt --check` 差分なし
+- `cargo run --bin fulgur -- render docs/examples/<something>.html -o /tmp/out.pdf` で生成した PDF を Acrobat/Preview で開いて `<a>` が実際にクリックできること (可能なら手動確認)
+
+## Follow-ups (not in scope)
+
+- inline 要素 (span 等) の id ターゲット対応
+- link annotation の `with_border` サポート
+- `target` 属性 (`_blank` 等) は PDF では無視される (仕様) ので何もしない
+- `mailto:`、`tel:`、相対URL の挙動テスト
+- GCPM bookmark (fulgur-yqi, fulgur-7r9)


### PR DESCRIPTION
## Summary

- `<a href="https://...">` → PDF `/Link` with `/URI` action
- `<a href="#id">` → `/Link` with `/XYZ` destination (任意の id 要素がターゲット)
- 複数行にまたがるリンクは `quad_points` で1アノテーションに集約
- ページ跨ぎのリンクはページごとに別アノテーション
- GCPM (@page rules) レンダリングパスでも動作
- 未解決の内部アンカーは警告のみで生成成功

Closes fulgur-d5k.

## Architecture

1. **convert.rs**: `extract_paragraph` で `<a href>` 祖先を検出し `ShapedGlyphRun` / `InlineImage` に `Arc<LinkSpan>` を付与(同一 `<a>` 配下は Arc を共有)。
2. **pageable.rs**: `BlockPageable` / `ParagraphPageable` に `id` フィールド。`Pageable::collect_ids` trait メソッド。`DestinationRegistry` (BTreeMap, first-write-wins)。`LinkCollector` (per-page rect 集約、Arc-ptr 同一性で dedup)。
3. **render.rs**: pre-pass で `collect_ids` を実行して `DestinationRegistry` を構築、draw 中に `LinkCollector` が rect を収集、ページ drop 前に `emit_link_annotations` でアノテーション発行。
4. **link.rs** (新規): `LinkOccurrence → krilla::LinkAnnotation` の変換ヘルパー。

## Test Plan

- [x] `cargo test -p fulgur --lib` (392 pass)
- [x] `cargo test -p fulgur --test link_integration` (6 pass + 1 ignored)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] 外部URL / 内部アンカー / 未解決アンカー / 複数行 / ページ跨ぎ / GCPMパス — すべて integration test あり
- [ ] 実PDFをAcrobat/Preview等で開いてクリック可能であることの手動確認

## Known Limitations

- `<p><a><img/></a></p>` (パラグラフ内インライン画像) はリンクにならない。Pre-existing な inline-image 非対応が根本原因 (`extract_paragraph` が `PositionedLayoutItem::InlineBox` を無視)。`#[ignore]` でテスト記録、TODO コメント付き。

## CodeRabbit レビュー指摘対応

- **Critical**: `element_text` の再帰に `MAX_DOM_DEPTH` ガード追加 + 深ネストのregression test
- **Important**: GCPM pre-pass で `resolve_page_settings` を呼び per-page margin を反映

## v0.4.5 関連 issue

- fulgur-yqi (GCPM `bookmark-*` CSS プロパティ対応)
- fulgur-7r9 (UA stylesheet で h1-h6 を bookmark-* 駆動に移行)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/92" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * PDFドキュメント内でHTML `<a href>` 要素がクリック可能なリンクとして機能するようになりました。外部URL（HTTP/HTTPS）と内部フラグメント（#アンカー）の両方に対応します。
  * テキストと画像の両方にリンクを適用可能です。

* **テスト**
  * リンク機能の包括的な統合テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->