### PR TITLE
feat: follow transformed link rectangles and anchor coordinates via transform matrix

### DIFF
--- a/crates/fulgur/src/link.rs
+++ b/crates/fulgur/src/link.rs
@@ -36,12 +36,10 @@ pub(crate) fn emit_link_annotations(
                 Target::Action(Action::Link(LinkAction::new(uri.as_str().to_string())))
             }
             LinkTarget::Internal(id) => match registry.get(id.as_str()) {
-                Some((page_idx, y_pt)) => {
-                    // Use x=0 so that viewers scroll so the anchor sits at the
-                    // top-left of the viewport. y is in page-local (top-down)
-                    // coordinates; krilla flips to PDF bottom-up during
-                    // serialization.
-                    let dest = XyzDestination::new(page_idx, Point::from_xy(0.0, y_pt));
+                Some((page_idx, x_pt, y_pt)) => {
+                    // x and y are in page-local (top-down) coordinates;
+                    // krilla flips to PDF bottom-up during serialization.
+                    let dest = XyzDestination::new(page_idx, Point::from_xy(x_pt, y_pt));
                     Target::Destination(Destination::Xyz(dest))
                 }
                 None => {

--- a/crates/fulgur/src/link.rs
+++ b/crates/fulgur/src/link.rs
@@ -59,4 +59,3 @@ pub(crate) fn emit_link_annotations(
         page.add_annotation(annotation);
     }
 }
-

--- a/crates/fulgur/src/link.rs
+++ b/crates/fulgur/src/link.rs
@@ -14,10 +14,10 @@
 use krilla::action::{Action, LinkAction};
 use krilla::annotation::{Annotation, LinkAnnotation, Target};
 use krilla::destination::{Destination, XyzDestination};
-use krilla::geom::{Point, Quadrilateral, Rect as KRect};
+use krilla::geom::{Point, Quadrilateral};
 use krilla::page::Page;
 
-use crate::pageable::{DestinationRegistry, LinkOccurrence, Rect as FRect};
+use crate::pageable::{DestinationRegistry, LinkOccurrence};
 use crate::paragraph::LinkTarget;
 
 /// Emit PDF link annotations for every occurrence on the given page.
@@ -51,7 +51,7 @@ pub(crate) fn emit_link_annotations(
             },
         };
 
-        let quads: Vec<Quadrilateral> = occ.rects.iter().filter_map(rect_to_quad).collect();
+        let quads: Vec<Quadrilateral> = occ.quads.iter().map(|q| q.to_krilla()).collect();
         if quads.is_empty() {
             continue;
         }
@@ -62,13 +62,3 @@ pub(crate) fn emit_link_annotations(
     }
 }
 
-/// Convert a fulgur `Rect` (page-local, top-down, pt units) to a krilla
-/// `Quadrilateral` with the point order documented by krilla:
-/// bottom-left → bottom-right → top-right → top-left, Y-down.
-///
-/// Returns `None` for degenerate rects (non-positive width or height) since
-/// `krilla::geom::Rect::from_xywh` rejects them.
-fn rect_to_quad(r: &FRect) -> Option<Quadrilateral> {
-    let krect = KRect::from_xywh(r.x, r.y, r.width, r.height)?;
-    Some(Quadrilateral::from(krect))
-}

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -156,6 +156,25 @@ impl Affine2D {
             self.b * x + self.d * y + self.f,
         )
     }
+
+    /// Transform a `Rect` into a `Quad` by applying this matrix to each corner.
+    ///
+    /// The four corners of the input rect (in Y-down page coordinates) are
+    /// transformed individually, preserving the krilla quad-point order:
+    /// bottom-left → bottom-right → top-right → top-left.
+    pub fn transform_rect(&self, r: &Rect) -> Quad {
+        let x0 = r.x;
+        let y0 = r.y;
+        let x1 = r.x + r.width;
+        let y1 = r.y + r.height;
+        let bl = self.transform_point(x0, y1);
+        let br = self.transform_point(x1, y1);
+        let tr = self.transform_point(x1, y0);
+        let tl = self.transform_point(x0, y0);
+        Quad {
+            points: [[bl.0, bl.1], [br.0, br.1], [tr.0, tr.1], [tl.0, tl.1]],
+        }
+    }
 }
 
 /// Matrix product `self * rhs`. Applied to a point `p`, this yields
@@ -242,6 +261,27 @@ pub struct Rect {
     pub y: f32,
     pub width: f32,
     pub height: f32,
+}
+
+/// Four-point quadrilateral for transformed link areas.
+///
+/// Point order follows krilla convention:
+/// bottom-left → bottom-right → top-right → top-left (Y-down coordinates).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Quad {
+    pub points: [[f32; 2]; 4],
+}
+
+impl Quad {
+    /// Convert to krilla's `Quadrilateral` for PDF annotation emission.
+    pub fn to_krilla(&self) -> krilla::geom::Quadrilateral {
+        krilla::geom::Quadrilateral([
+            krilla::geom::Point::from_xy(self.points[0][0], self.points[0][1]),
+            krilla::geom::Point::from_xy(self.points[1][0], self.points[1][1]),
+            krilla::geom::Point::from_xy(self.points[2][0], self.points[2][1]),
+            krilla::geom::Point::from_xy(self.points[3][0], self.points[3][1]),
+        ])
+    }
 }
 
 /// One clickable link area captured by `LinkCollector` during draw.
@@ -3653,6 +3693,40 @@ mod affine_tests {
         let (x, y) = m.transform_point(1.0, 0.0);
         assert!((x - 0.0).abs() < 1e-4);
         assert!((y - 1.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn transform_rect_identity_produces_axis_aligned_quad() {
+        let r = Rect {
+            x: 10.0,
+            y: 20.0,
+            width: 30.0,
+            height: 40.0,
+        };
+        let q = Affine2D::IDENTITY.transform_rect(&r);
+        let expected = [
+            [10.0, 60.0],
+            [40.0, 60.0],
+            [40.0, 20.0],
+            [10.0, 20.0],
+        ];
+        for (i, (got, exp)) in q.points.iter().zip(expected.iter()).enumerate() {
+            assert!((got[0] - exp[0]).abs() < 1e-5, "quad[{i}].x");
+            assert!((got[1] - exp[1]).abs() < 1e-5, "quad[{i}].y");
+        }
+    }
+
+    #[test]
+    fn transform_rect_translate() {
+        let r = Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 10.0,
+            height: 10.0,
+        };
+        let q = Affine2D::translation(100.0, 200.0).transform_rect(&r);
+        assert!((q.points[0][0] - 100.0).abs() < 1e-5);
+        assert!((q.points[0][1] - 210.0).abs() < 1e-5);
     }
 }
 

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -301,6 +301,17 @@ pub struct Quad {
 }
 
 impl Quad {
+    /// Returns `true` when the quad has collapsed to zero (or near-zero) area,
+    /// e.g. after a `scaleX(0)` transform. Uses the cross product of two edge
+    /// vectors originating from the bottom-left corner.
+    pub fn is_degenerate(&self) -> bool {
+        let ax = self.points[1][0] - self.points[0][0];
+        let ay = self.points[1][1] - self.points[0][1];
+        let bx = self.points[3][0] - self.points[0][0];
+        let by = self.points[3][1] - self.points[0][1];
+        (ax * by - ay * bx).abs() <= f32::EPSILON
+    }
+
     /// Convert to krilla's `Quadrilateral` for PDF annotation emission.
     pub fn to_krilla(&self) -> krilla::geom::Quadrilateral {
         krilla::geom::Quadrilateral([
@@ -400,6 +411,12 @@ impl LinkCollector {
             return;
         }
         let quad = self.current_transform().transform_rect(&rect);
+        // Also reject quads that collapsed to zero area after transform
+        // (e.g. scaleX(0)). Cross product of two edge vectors gives
+        // twice the signed area of the parallelogram.
+        if quad.is_degenerate() {
+            return;
+        }
         let page_idx = self.current_page_idx;
         let key = (page_idx, std::sync::Arc::as_ptr(link) as usize);
         let bucket = self.pages.entry(page_idx).or_default();
@@ -3792,6 +3809,33 @@ mod affine_tests {
         assert!((q.points[0][0] - 100.0).abs() < 1e-5);
         assert!((q.points[0][1] - 210.0).abs() < 1e-5);
     }
+
+    #[test]
+    fn quad_is_degenerate_after_scale_zero() {
+        let r = Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 10.0,
+            height: 10.0,
+        };
+        let q = Affine2D::scale(0.0, 1.0).transform_rect(&r);
+        assert!(q.is_degenerate(), "scaleX(0) should produce degenerate quad");
+
+        let q2 = Affine2D::scale(1.0, 0.0).transform_rect(&r);
+        assert!(q2.is_degenerate(), "scaleY(0) should produce degenerate quad");
+    }
+
+    #[test]
+    fn quad_is_not_degenerate_for_normal_transform() {
+        let r = Rect {
+            x: 10.0,
+            y: 20.0,
+            width: 30.0,
+            height: 40.0,
+        };
+        let q = Affine2D::rotation(std::f32::consts::FRAC_PI_4).transform_rect(&r);
+        assert!(!q.is_degenerate(), "rotated rect should not be degenerate");
+    }
 }
 
 #[cfg(test)]
@@ -4120,6 +4164,26 @@ mod link_collector_transform_tests {
         // TL corner untransformed: (5, 10)
         assert!((q.points[3][0] - 5.0).abs() < 1e-5, "tl.x identity");
         assert!((q.points[3][1] - 10.0).abs() < 1e-5, "tl.y identity");
+    }
+
+    #[test]
+    fn scale_zero_x_produces_no_occurrence() {
+        let mut lc = LinkCollector::new();
+        lc.set_current_page(0);
+        lc.push_transform(Affine2D::scale(0.0, 1.0));
+        let link = make_link();
+        lc.push_rect(
+            &link,
+            Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 10.0,
+                height: 10.0,
+            },
+        );
+        lc.pop_transform();
+        let occs = lc.into_occurrences();
+        assert!(occs.is_empty(), "scaleX(0) should produce no link occurrence");
     }
 }
 

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -21,7 +21,9 @@ use crate::image::ImageFormat;
 #[derive(Debug, Default)]
 pub struct DestinationRegistry {
     current_page_idx: usize,
-    entries: BTreeMap<String, (usize, Pt)>,
+    entries: BTreeMap<String, (usize, Pt, Pt)>,
+    /// Stack of transforms applied to coordinates before storing.
+    transform_stack: Vec<Affine2D>,
 }
 
 impl DestinationRegistry {
@@ -34,15 +36,35 @@ impl DestinationRegistry {
         self.current_page_idx = idx;
     }
 
-    /// Record an anchor destination. First-write-wins: later duplicates are ignored.
-    pub fn record(&mut self, id: &str, y: Pt) {
-        self.entries
-            .entry(id.to_string())
-            .or_insert((self.current_page_idx, y));
+    /// Push a transform onto the stack; subsequent `record` calls will
+    /// transform coordinates through the composed stack before storing.
+    pub fn push_transform(&mut self, m: Affine2D) {
+        self.transform_stack.push(m);
     }
 
-    /// Look up a recorded anchor.
-    pub fn get(&self, id: &str) -> Option<(usize, Pt)> {
+    /// Pop the most recent transform off the stack.
+    pub fn pop_transform(&mut self) {
+        self.transform_stack.pop();
+    }
+
+    /// Compose all stacked transforms into a single matrix.
+    fn current_transform(&self) -> Affine2D {
+        self.transform_stack
+            .iter()
+            .copied()
+            .fold(Affine2D::IDENTITY, |acc, m| acc * m)
+    }
+
+    /// Record an anchor destination. First-write-wins: later duplicates are ignored.
+    pub fn record(&mut self, id: &str, x: Pt, y: Pt) {
+        let (tx, ty) = self.current_transform().transform_point(x, y);
+        self.entries
+            .entry(id.to_string())
+            .or_insert((self.current_page_idx, tx, ty));
+    }
+
+    /// Look up a recorded anchor. Returns `(page_idx, x, y)`.
+    pub fn get(&self, id: &str) -> Option<(usize, Pt, Pt)> {
         self.entries.get(id).copied()
     }
 }
@@ -1682,7 +1704,7 @@ impl Pageable for BlockPageable {
         if let Some(id) = &self.id
             && !id.is_empty()
         {
-            registry.record(id, y);
+            registry.record(id, x, y);
         }
         // Recurse into children using the same positional arithmetic
         // `draw()` uses (see the loop at the end of `draw`). We do NOT
@@ -2886,7 +2908,7 @@ impl Pageable for TablePageable {
         if let Some(id) = &self.id
             && !id.is_empty()
         {
-            registry.record(id, y);
+            registry.record(id, x, y);
         }
         // Mirror TablePageable::draw child iteration — header + body cells.
         let total_width = self.width;
@@ -3347,10 +3369,10 @@ mod tests {
     fn destination_registry_first_write_wins_for_duplicate_ids() {
         let mut reg = DestinationRegistry::default();
         reg.set_current_page(0);
-        reg.record("dup", 10.0);
+        reg.record("dup", 0.0, 10.0);
         reg.set_current_page(2);
-        reg.record("dup", 99.0);
-        assert_eq!(reg.get("dup"), Some((0, 10.0)));
+        reg.record("dup", 0.0, 99.0);
+        assert_eq!(reg.get("dup"), Some((0, 0.0, 10.0)));
     }
 }
 
@@ -4081,5 +4103,61 @@ mod link_collector_transform_tests {
         // TL corner untransformed: (5, 10)
         assert!((q.points[3][0] - 5.0).abs() < 1e-5, "tl.x identity");
         assert!((q.points[3][1] - 10.0).abs() < 1e-5, "tl.y identity");
+    }
+}
+
+#[cfg(test)]
+mod dest_registry_transform_tests {
+    use super::*;
+
+    #[test]
+    fn record_without_transform_stores_original_coords() {
+        let mut reg = DestinationRegistry::new();
+        reg.set_current_page(0);
+        reg.record("sec", 10.0, 50.0);
+        let (page, x, y) = reg.get("sec").unwrap();
+        assert_eq!(page, 0);
+        assert!((x - 10.0).abs() < 1e-5);
+        assert!((y - 50.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn record_with_translation_shifts_coords() {
+        let mut reg = DestinationRegistry::new();
+        reg.set_current_page(0);
+        reg.push_transform(Affine2D::translation(100.0, 200.0));
+        reg.record("sec", 10.0, 50.0);
+        reg.pop_transform();
+        let (page, x, y) = reg.get("sec").unwrap();
+        assert_eq!(page, 0);
+        assert!((x - 110.0).abs() < 1e-5);
+        assert!((y - 250.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn nested_transforms_compose_in_registry() {
+        let mut reg = DestinationRegistry::new();
+        reg.set_current_page(0);
+        reg.push_transform(Affine2D::translation(10.0, 0.0));
+        reg.push_transform(Affine2D::translation(0.0, 20.0));
+        reg.record("nested", 5.0, 5.0);
+        reg.pop_transform();
+        reg.pop_transform();
+        let (_, x, y) = reg.get("nested").unwrap();
+        assert!((x - 15.0).abs() < 1e-5);
+        assert!((y - 25.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn first_write_wins_even_with_transform() {
+        let mut reg = DestinationRegistry::new();
+        reg.set_current_page(0);
+        reg.record("dup", 0.0, 10.0);
+        reg.push_transform(Affine2D::translation(100.0, 100.0));
+        reg.record("dup", 0.0, 10.0);
+        reg.pop_transform();
+        let (_, x, y) = reg.get("dup").unwrap();
+        assert!((x - 0.0).abs() < 1e-5, "first write should win");
+        assert!((y - 10.0).abs() < 1e-5, "first write should win");
     }
 }

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -3819,10 +3819,16 @@ mod affine_tests {
             height: 10.0,
         };
         let q = Affine2D::scale(0.0, 1.0).transform_rect(&r);
-        assert!(q.is_degenerate(), "scaleX(0) should produce degenerate quad");
+        assert!(
+            q.is_degenerate(),
+            "scaleX(0) should produce degenerate quad"
+        );
 
         let q2 = Affine2D::scale(1.0, 0.0).transform_rect(&r);
-        assert!(q2.is_degenerate(), "scaleY(0) should produce degenerate quad");
+        assert!(
+            q2.is_degenerate(),
+            "scaleY(0) should produce degenerate quad"
+        );
     }
 
     #[test]
@@ -4183,7 +4189,10 @@ mod link_collector_transform_tests {
         );
         lc.pop_transform();
         let occs = lc.into_occurrences();
-        assert!(occs.is_empty(), "scaleX(0) should produce no link occurrence");
+        assert!(
+            occs.is_empty(),
+            "scaleX(0) should produce no link occurrence"
+        );
     }
 }
 

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -148,6 +148,14 @@ impl Affine2D {
     pub fn to_krilla(&self) -> krilla::geom::Transform {
         krilla::geom::Transform::from_row(self.a, self.b, self.c, self.d, self.e, self.f)
     }
+
+    /// Apply this affine transform to a 2D point.
+    pub fn transform_point(&self, x: f32, y: f32) -> (f32, f32) {
+        (
+            self.a * x + self.c * y + self.e,
+            self.b * x + self.d * y + self.f,
+        )
+    }
 }
 
 /// Matrix product `self * rhs`. Applied to a point `p`, this yields
@@ -3621,6 +3629,30 @@ mod affine_tests {
         assert!(approx(s.c, 0.0));
         assert!(approx(s.e, 0.0));
         assert!(approx(s.f, 0.0));
+    }
+
+    #[test]
+    fn transform_point_identity() {
+        let m = Affine2D::IDENTITY;
+        let (x, y) = m.transform_point(10.0, 20.0);
+        assert!((x - 10.0).abs() < 1e-5);
+        assert!((y - 20.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn transform_point_translation() {
+        let m = Affine2D::translation(5.0, -3.0);
+        let (x, y) = m.transform_point(10.0, 20.0);
+        assert!((x - 15.0).abs() < 1e-5);
+        assert!((y - 17.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn transform_point_rotation_90() {
+        let m = Affine2D::rotation(std::f32::consts::FRAC_PI_2);
+        let (x, y) = m.transform_point(1.0, 0.0);
+        assert!((x - 0.0).abs() < 1e-4);
+        assert!((y - 1.0).abs() < 1e-4);
     }
 }
 

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -2237,9 +2237,15 @@ impl Pageable for TransformWrapperPageable {
 
     fn draw(&self, canvas: &mut Canvas<'_, '_>, x: Pt, y: Pt, avail_width: Pt, avail_height: Pt) {
         let full = self.effective_matrix(x, y);
+        if let Some(lc) = canvas.link_collector.as_mut() {
+            lc.push_transform(full);
+        }
         canvas.surface.push_transform(&full.to_krilla());
         self.inner.draw(canvas, x, y, avail_width, avail_height);
         canvas.surface.pop();
+        if let Some(lc) = canvas.link_collector.as_mut() {
+            lc.pop_transform();
+        }
     }
 
     fn clone_box(&self) -> Box<dyn Pageable> {
@@ -2266,10 +2272,11 @@ impl Pageable for TransformWrapperPageable {
         avail_height: Pt,
         registry: &mut DestinationRegistry,
     ) {
-        // Transform is a visual effect; the anchor position is the pre-transform
-        // block-top, matching where the destination "logically" lives.
+        let full = self.effective_matrix(x, y);
+        registry.push_transform(full);
         self.inner
             .collect_ids(x, y, avail_width, avail_height, registry);
+        registry.pop_transform();
     }
 }
 
@@ -3748,12 +3755,7 @@ mod affine_tests {
             height: 40.0,
         };
         let q = Affine2D::IDENTITY.transform_rect(&r);
-        let expected = [
-            [10.0, 60.0],
-            [40.0, 60.0],
-            [40.0, 20.0],
-            [10.0, 20.0],
-        ];
+        let expected = [[10.0, 60.0], [40.0, 60.0], [40.0, 20.0], [10.0, 20.0]];
         for (i, (got, exp)) in q.points.iter().zip(expected.iter()).enumerate() {
             assert!((got[0] - exp[0]).abs() < 1e-5, "quad[{i}].x");
             assert!((got[1] - exp[1]).abs() < 1e-5, "quad[{i}].y");
@@ -4077,10 +4079,7 @@ mod link_collector_transform_tests {
         let q = &occs[0].quads[0];
         // After 90° rotation: (x,y) → (-y, x)
         // BL (0,5) → (-5, 0)
-        assert!(
-            (q.points[0][0] - (-5.0)).abs() < 1e-4,
-            "bl.x after rot90"
-        );
+        assert!((q.points[0][0] - (-5.0)).abs() < 1e-4, "bl.x after rot90");
         assert!((q.points[0][1] - 0.0).abs() < 1e-4, "bl.y after rot90");
     }
 

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -286,16 +286,16 @@ impl Quad {
 
 /// One clickable link area captured by `LinkCollector` during draw.
 ///
-/// A single `<a>` element may produce multiple rects when its glyphs wrap
+/// A single `<a>` element may produce multiple quads when its glyphs wrap
 /// across lines (or when nested inlines split shaping into multiple runs);
-/// in that case `rects` holds one entry per fragment and `target`/`alt_text`
+/// in that case `quads` holds one entry per fragment and `target`/`alt_text`
 /// are the shared anchor metadata.
 #[derive(Debug, Clone)]
 pub struct LinkOccurrence {
     pub page_idx: usize,
     pub target: crate::paragraph::LinkTarget,
     pub alt_text: Option<String>,
-    pub rects: Vec<Rect>,
+    pub quads: Vec<Quad>,
 }
 
 /// Per-page collector of link activation rects, grouped by `<a>` identity.
@@ -322,6 +322,8 @@ pub struct LinkCollector {
     /// Occurrences grouped by `page_idx`. `BTreeMap` for deterministic
     /// iteration (CLAUDE.md rule) and cheap page-keyed removal.
     pages: BTreeMap<usize, Vec<LinkOccurrence>>,
+    /// Stack of transforms applied to rects before storing as quads.
+    transform_stack: Vec<Affine2D>,
 }
 
 impl LinkCollector {
@@ -333,11 +335,31 @@ impl LinkCollector {
         self.current_page_idx = idx;
     }
 
+    /// Push a transform onto the stack; subsequent `push_rect` calls will
+    /// transform the rect through the composed stack before storing.
+    pub fn push_transform(&mut self, m: Affine2D) {
+        self.transform_stack.push(m);
+    }
+
+    /// Pop the most recent transform off the stack.
+    pub fn pop_transform(&mut self) {
+        self.transform_stack.pop();
+    }
+
+    /// Compose all stacked transforms into a single matrix.
+    fn current_transform(&self) -> Affine2D {
+        self.transform_stack
+            .iter()
+            .copied()
+            .fold(Affine2D::IDENTITY, |acc, m| acc * m)
+    }
+
     /// Record a rect for the given `<a>`. Rects pointing at the same
     /// `Arc<LinkSpan>` *on the same page* are merged into a single
     /// `LinkOccurrence`; on different pages they produce separate
     /// occurrences.
     pub fn push_rect(&mut self, link: &std::sync::Arc<crate::paragraph::LinkSpan>, rect: Rect) {
+        let quad = self.current_transform().transform_rect(&rect);
         let page_idx = self.current_page_idx;
         let key = (page_idx, std::sync::Arc::as_ptr(link) as usize);
         let bucket = self.pages.entry(page_idx).or_default();
@@ -345,7 +367,7 @@ impl LinkCollector {
             // Defensive check: if the index is stale (e.g. the page was
             // already drained via `take_page`), `i` may be out of range.
             if let Some(occ) = bucket.get_mut(i) {
-                occ.rects.push(rect);
+                occ.quads.push(quad);
                 return;
             }
         }
@@ -355,7 +377,7 @@ impl LinkCollector {
             page_idx,
             target: link.target.clone(),
             alt_text: link.alt_text.clone(),
-            rects: vec![rect],
+            quads: vec![quad],
         });
     }
 
@@ -3926,5 +3948,138 @@ mod transform_wrapper_tests {
         assert_eq!(entries[0].y_pt, 42.0);
         assert_eq!(entries[0].level, 2);
         assert_eq!(entries[0].label, "Section");
+    }
+}
+
+#[cfg(test)]
+mod link_collector_transform_tests {
+    use super::*;
+    use crate::paragraph::{LinkSpan, LinkTarget};
+    use std::sync::Arc;
+
+    fn make_link() -> Arc<LinkSpan> {
+        Arc::new(LinkSpan {
+            target: LinkTarget::External(Arc::new("https://test.example".to_string())),
+            alt_text: None,
+        })
+    }
+
+    #[test]
+    fn push_rect_without_transform_stores_axis_aligned_quad() {
+        let mut lc = LinkCollector::new();
+        lc.set_current_page(0);
+        let link = make_link();
+        lc.push_rect(
+            &link,
+            Rect {
+                x: 10.0,
+                y: 20.0,
+                width: 30.0,
+                height: 10.0,
+            },
+        );
+        let occs = lc.into_occurrences();
+        assert_eq!(occs.len(), 1);
+        assert_eq!(occs[0].quads.len(), 1);
+        let q = &occs[0].quads[0];
+        // Bottom-left of rect at (10, 20, w=30, h=10): (10, 30)
+        assert!((q.points[0][0] - 10.0).abs() < 1e-5, "bl.x");
+        assert!((q.points[0][1] - 30.0).abs() < 1e-5, "bl.y");
+    }
+
+    #[test]
+    fn push_rect_with_translation_shifts_quad() {
+        let mut lc = LinkCollector::new();
+        lc.set_current_page(0);
+        lc.push_transform(Affine2D::translation(100.0, 200.0));
+        let link = make_link();
+        lc.push_rect(
+            &link,
+            Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 10.0,
+                height: 10.0,
+            },
+        );
+        lc.pop_transform();
+        let occs = lc.into_occurrences();
+        let q = &occs[0].quads[0];
+        // BL: (0,10) + translate(100,200) = (100, 210)
+        assert!((q.points[0][0] - 100.0).abs() < 1e-5);
+        assert!((q.points[0][1] - 210.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn nested_transforms_compose() {
+        let mut lc = LinkCollector::new();
+        lc.set_current_page(0);
+        lc.push_transform(Affine2D::translation(10.0, 0.0));
+        lc.push_transform(Affine2D::translation(0.0, 20.0));
+        let link = make_link();
+        lc.push_rect(
+            &link,
+            Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 5.0,
+                height: 5.0,
+            },
+        );
+        lc.pop_transform();
+        lc.pop_transform();
+        let occs = lc.into_occurrences();
+        let q = &occs[0].quads[0];
+        // BL: (0,5) + translate(10,20) = (10, 25)
+        assert!((q.points[0][0] - 10.0).abs() < 1e-5);
+        assert!((q.points[0][1] - 25.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn rotation_produces_non_axis_aligned_quad() {
+        let mut lc = LinkCollector::new();
+        lc.set_current_page(0);
+        lc.push_transform(Affine2D::rotation(std::f32::consts::FRAC_PI_2));
+        let link = make_link();
+        lc.push_rect(
+            &link,
+            Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 10.0,
+                height: 5.0,
+            },
+        );
+        lc.pop_transform();
+        let occs = lc.into_occurrences();
+        let q = &occs[0].quads[0];
+        // After 90° rotation: (x,y) → (-y, x)
+        // BL (0,5) → (-5, 0)
+        assert!(
+            (q.points[0][0] - (-5.0)).abs() < 1e-4,
+            "bl.x after rot90"
+        );
+        assert!((q.points[0][1] - 0.0).abs() < 1e-4, "bl.y after rot90");
+    }
+
+    #[test]
+    fn empty_transform_stack_is_identity() {
+        let mut lc = LinkCollector::new();
+        lc.set_current_page(0);
+        let link = make_link();
+        lc.push_rect(
+            &link,
+            Rect {
+                x: 5.0,
+                y: 10.0,
+                width: 20.0,
+                height: 15.0,
+            },
+        );
+        let occs = lc.into_occurrences();
+        let q = &occs[0].quads[0];
+        // TL corner untransformed: (5, 10)
+        assert!((q.points[3][0] - 5.0).abs() < 1e-5, "tl.x identity");
+        assert!((q.points[3][1] - 10.0).abs() < 1e-5, "tl.y identity");
     }
 }

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -43,7 +43,13 @@ impl DestinationRegistry {
     }
 
     /// Pop the most recent transform off the stack.
+    ///
+    /// No-op if the stack is empty (debug builds will assert).
     pub fn pop_transform(&mut self) {
+        debug_assert!(
+            !self.transform_stack.is_empty(),
+            "DestinationRegistry::pop_transform called on empty stack"
+        );
         self.transform_stack.pop();
     }
 
@@ -364,7 +370,13 @@ impl LinkCollector {
     }
 
     /// Pop the most recent transform off the stack.
+    ///
+    /// No-op if the stack is empty (debug builds will assert).
     pub fn pop_transform(&mut self) {
+        debug_assert!(
+            !self.transform_stack.is_empty(),
+            "LinkCollector::pop_transform called on empty stack"
+        );
         self.transform_stack.pop();
     }
 
@@ -381,6 +393,12 @@ impl LinkCollector {
     /// `LinkOccurrence`; on different pages they produce separate
     /// occurrences.
     pub fn push_rect(&mut self, link: &std::sync::Arc<crate::paragraph::LinkSpan>, rect: Rect) {
+        // Skip degenerate rects (non-positive width or height) to match the
+        // filtering the old `rect_to_quad` helper performed via
+        // `KRect::from_xywh`, which rejects them.
+        if rect.width <= 0.0 || rect.height <= 0.0 {
+            return;
+        }
         let quad = self.current_transform().transform_rect(&rect);
         let page_idx = self.current_page_idx;
         let key = (page_idx, std::sync::Arc::as_ptr(link) as usize);
@@ -2237,13 +2255,13 @@ impl Pageable for TransformWrapperPageable {
 
     fn draw(&self, canvas: &mut Canvas<'_, '_>, x: Pt, y: Pt, avail_width: Pt, avail_height: Pt) {
         let full = self.effective_matrix(x, y);
-        if let Some(lc) = canvas.link_collector.as_mut() {
+        if let Some(lc) = canvas.link_collector.as_deref_mut() {
             lc.push_transform(full);
         }
         canvas.surface.push_transform(&full.to_krilla());
         self.inner.draw(canvas, x, y, avail_width, avail_height);
         canvas.surface.pop();
-        if let Some(lc) = canvas.link_collector.as_mut() {
+        if let Some(lc) = canvas.link_collector.as_deref_mut() {
             lc.pop_transform();
         }
     }

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -1362,11 +1362,7 @@ mod link_collect_tests {
         let q = &first.quads[0];
         let width = q.points[1][0] - q.points[0][0];
         let height = q.points[0][1] - q.points[3][1];
-        assert!(
-            width > 0.0,
-            "expected positive quad width, got {}",
-            width,
-        );
+        assert!(width > 0.0, "expected positive quad width, got {}", width,);
         assert!(
             height > 0.0,
             "expected positive quad height, got {}",

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -823,7 +823,7 @@ impl Pageable for ParagraphPageable {
 
     fn collect_ids(
         &self,
-        _x: Pt,
+        x: Pt,
         y: Pt,
         _avail_width: Pt,
         _avail_height: Pt,
@@ -832,7 +832,7 @@ impl Pageable for ParagraphPageable {
         if let Some(id) = &self.id
             && !id.is_empty()
         {
-            registry.record(id, y);
+            registry.record(id, x, y);
         }
         // No child recursion: paragraph lines are glyph data, not Pageables.
     }
@@ -1230,7 +1230,7 @@ mod tests {
         let mut reg = DestinationRegistry::default();
         reg.set_current_page(3);
         p.collect_ids(10.0, 42.0, 400.0, 600.0, &mut reg);
-        assert_eq!(reg.get("anchor"), Some((3, 42.0)));
+        assert_eq!(reg.get("anchor"), Some((3, 10.0, 42.0)));
     }
 
     #[test]

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -1357,16 +1357,20 @@ mod link_collect_tests {
             "unexpected target: {:?}",
             first.target,
         );
-        assert!(!first.rects.is_empty());
+        assert!(!first.quads.is_empty());
+        // Width: BR.x - BL.x; Height: BL.y - TL.y (axis-aligned, no transform)
+        let q = &first.quads[0];
+        let width = q.points[1][0] - q.points[0][0];
+        let height = q.points[0][1] - q.points[3][1];
         assert!(
-            first.rects[0].width > 0.0,
-            "expected positive rect width, got {}",
-            first.rects[0].width,
+            width > 0.0,
+            "expected positive quad width, got {}",
+            width,
         );
         assert!(
-            first.rects[0].height > 0.0,
-            "expected positive rect height, got {}",
-            first.rects[0].height,
+            height > 0.0,
+            "expected positive quad height, got {}",
+            height,
         );
     }
 
@@ -1389,9 +1393,9 @@ mod link_collect_tests {
             occs.iter().map(|o| &o.target).collect::<Vec<_>>(),
         );
         assert!(
-            occs[0].rects.len() >= 2,
-            "expected at least two rects merged under one occurrence, got {}",
-            occs[0].rects.len(),
+            occs[0].quads.len() >= 2,
+            "expected at least two quads merged under one occurrence, got {}",
+            occs[0].quads.len(),
         );
     }
 

--- a/crates/fulgur/src/schema.rs
+++ b/crates/fulgur/src/schema.rs
@@ -373,12 +373,12 @@ fn collect_from_expr(
                 collect_from_expr(fe, root, scope);
             }
         }
-        ast::Expr::GetAttr(a) => {
+        ast::Expr::GetAttr(a)
             // If resolve_expr_path returned None (e.g. filter/call base),
             // recurse into the base expression to collect its variables.
-            if resolve_expr_path(expr, scope).is_none() {
-                collect_from_expr(&a.expr, root, scope);
-            }
+            if resolve_expr_path(expr, scope).is_none() =>
+        {
+            collect_from_expr(&a.expr, root, scope);
         }
         ast::Expr::GetItem(gi) => {
             // Recurse into both base and subscript expressions


### PR DESCRIPTION
## Summary

- CSS transform配下の`<a>`リンクのPDFクリック矩形が変換後の視覚位置に正しく追従するようにした
- transform配下の`id`アンカーへの内部リンクジャンプ先が変換後座標を指すよう��した
- `LinkCollector`と`DestinationRegistry`にtransformスタックを導入し、`TransformWrapperPageable`のdraw/collect_idsでpush/popする設計

## Changes

- **`Affine2D::transform_point` / `transform_rect`**: 行列を点・矩形に適用するメソッド追加
- **`Quad`型**: 変換後の4頂点を保持する新型。`LinkOccurrence.rects: Vec<Rect>` → `quads: Vec<Quad>` に変更
- **`LinkCollector`**: transform stack追加。`push_rect`内部でRectをQuadに変換（callerは変更不要）
- **`DestinationRegistry`**: transform stack追加。entries型を`(page_idx, y)` → `(page_idx, x, y)`に拡張
- **`TransformWrapperPageable`**: `draw()`でLinkCollectorに、`collect_ids()`でDestinationRegistryにeffective matrixをpush/pop
- **`link.rs`**: `rect_to_quad`ヘルパー削除、`Quad::to_krilla()`直接使用。destination座標に格納済みxを使用

## Test plan

- [x] `Affine2D::transform_point` — identity / translation / rotation のユニットテスト
- [x] `Affine2D::transform_rect` — identity / translation のユニットテスト
- [x] `LinkCollector` transform stack — identity / translation / rotation / ネスト / 空スタック
- [x] `DestinationRegistry` transform stack — identity / translation / ネスト / first-write-wins
- [x] 既存テスト全pass（435 unit + integration tests）
- [x] clippy clean, fmt check pass

Closes fulgur-4hy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/95" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 内部リンクの目的地解決でX/Y座標の精度を向上させました（より正確なアンカー位置記録）。
  * リンク領域の表現を四点（クワッド）に変更し、変形（スケール/回転）されたコンテンツのサポートと退化判定を追加しました。
* **テスト**
  * 変換やリンク収集の振る舞いを検証するユニットテストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->