### PR TITLE
fix: inject inside marker for non-inline-root <li> elements

### DIFF
--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -2730,9 +2730,10 @@ fn shape_marker_with_skrifa(
         skrifa::instance::LocationRef::default(),
     );
 
-    let text_len = text.len();
     let mut glyphs = Vec::new();
+    let mut byte_offset = 0usize;
     for ch in text.chars() {
+        let ch_len = ch.len_utf8();
         let gid = charmap.map(ch).unwrap_or(skrifa::GlyphId::new(0));
         let advance = glyph_metrics.advance_width(gid).unwrap_or(0.0);
         glyphs.push(ShapedGlyph {
@@ -2740,8 +2741,9 @@ fn shape_marker_with_skrifa(
             x_advance: advance / font_size,
             x_offset: 0.0,
             y_offset: 0.0,
-            text_range: 0..text_len,
+            text_range: byte_offset..byte_offset + ch_len,
         });
+        byte_offset += ch_len;
     }
 
     Some(ShapedGlyphRun {

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -693,7 +693,25 @@ fn convert_node_inner(
                 if let Some(marker_run) =
                     shape_marker_with_skrifa(marker, &font_data, font_index, font_size_pt, color)
                 {
-                    inject_inside_marker_into_children(&mut positioned_children, marker_run);
+                    if !inject_inside_marker_into_children(
+                        &mut positioned_children,
+                        marker_run.clone(),
+                    ) {
+                        // No paragraph descendant found — insert a standalone marker paragraph.
+                        let paragraph = ParagraphPageable::new(vec![ShapedLine {
+                            height: line_height,
+                            baseline: line_height / DEFAULT_LINE_HEIGHT_RATIO,
+                            items: vec![LineItem::Text(marker_run)],
+                        }]);
+                        positioned_children.insert(
+                            0,
+                            PositionedChild {
+                                child: Box::new(paragraph),
+                                x: 0.0,
+                                y: 0.0,
+                            },
+                        );
+                    }
                 }
             }
 
@@ -2767,7 +2785,17 @@ fn inject_inside_marker_into_children(
     // Direct ParagraphPageable child
     if let Some(para) = pc.child.as_any().downcast_ref::<ParagraphPageable>() {
         let mut para_clone = para.clone();
-        if !para_clone.lines.is_empty() {
+        if para_clone.lines.is_empty() {
+            // Empty paragraph — create a line with just the marker.
+            let font_size = marker_run.font_size;
+            let line_height = font_size * DEFAULT_LINE_HEIGHT_RATIO;
+            let baseline = line_height / DEFAULT_LINE_HEIGHT_RATIO;
+            para_clone.lines.push(ShapedLine {
+                height: line_height,
+                baseline,
+                items: vec![LineItem::Text(marker_run)],
+            });
+        } else {
             for item in &mut para_clone.lines[0].items {
                 match item {
                     LineItem::Text(run) => run.x_offset += marker_width,
@@ -2778,8 +2806,8 @@ fn inject_inside_marker_into_children(
                 .items
                 .insert(0, LineItem::Text(marker_run));
             recalculate_paragraph_line_boxes(&mut para_clone.lines);
-            para_clone.cached_height = para_clone.lines.iter().map(|l| l.height).sum();
         }
+        para_clone.cached_height = para_clone.lines.iter().map(|l| l.height).sum();
         pc.child = Box::new(para_clone);
         return true;
     }

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -645,73 +645,80 @@ fn convert_node_inner(
         let children: &[usize] = &node.children;
         if children.is_empty() {
             // Empty <li>: create a standalone paragraph with just the marker.
-            if let Some((font_data, font_index)) = find_marker_font(marker, ctx.assets, &[]) {
-                if let Some(marker_run) =
-                    shape_marker_with_skrifa(marker, &font_data, font_index, font_size_pt, color)
-                {
-                    let paragraph = ParagraphPageable::new(vec![ShapedLine {
-                        height: line_height,
-                        baseline: line_height / DEFAULT_LINE_HEIGHT_RATIO,
-                        items: vec![LineItem::Text(marker_run)],
-                    }]);
-                    let (before_pseudo, after_pseudo) =
-                        build_block_pseudo_images(doc, node, content_box, ctx.assets);
-                    let paragraph_children = vec![PositionedChild {
-                        child: Box::new(paragraph),
-                        x: 0.0,
-                        y: 0.0,
-                    }];
-                    let positioned_children = wrap_with_block_pseudo_images(
-                        before_pseudo,
-                        after_pseudo,
-                        content_box,
-                        paragraph_children,
-                    );
-                    let needs_wrapper = style.needs_block_wrapper();
-                    let mut block = BlockPageable::with_positioned_children(positioned_children)
-                        .with_style(style)
-                        .with_opacity(opacity)
-                        .with_visible(visible)
-                        .with_id(extract_block_id(node));
-                    block.wrap(width, 10000.0);
-                    if needs_wrapper {
-                        block.layout_size = Some(Size { width, height });
-                    }
-                    return Box::new(block);
+            // Try image marker first (list-style-image), then text fallback.
+            let marker_item: Option<LineItem> =
+                resolve_inside_image_marker(node, line_height, ctx.assets)
+                    .map(LineItem::Image)
+                    .or_else(|| {
+                        let (fd, fi) = find_marker_font(marker, ctx.assets, &[])?;
+                        let run = shape_marker_with_skrifa(marker, &fd, fi, font_size_pt, color)?;
+                        Some(LineItem::Text(run))
+                    });
+            if let Some(item) = marker_item {
+                let paragraph = ParagraphPageable::new(vec![ShapedLine {
+                    height: line_height,
+                    baseline: line_height / DEFAULT_LINE_HEIGHT_RATIO,
+                    items: vec![item],
+                }]);
+                let (before_pseudo, after_pseudo) =
+                    build_block_pseudo_images(doc, node, content_box, ctx.assets);
+                let (child_x, child_y) = style.content_inset();
+                let paragraph_children = vec![PositionedChild {
+                    child: Box::new(paragraph),
+                    x: child_x,
+                    y: child_y,
+                }];
+                let positioned_children = wrap_with_block_pseudo_images(
+                    before_pseudo,
+                    after_pseudo,
+                    content_box,
+                    paragraph_children,
+                );
+                let needs_wrapper = style.needs_block_wrapper();
+                let mut block = BlockPageable::with_positioned_children(positioned_children)
+                    .with_style(style)
+                    .with_opacity(opacity)
+                    .with_visible(visible)
+                    .with_id(extract_block_id(node));
+                block.wrap(width, 10000.0);
+                if needs_wrapper {
+                    block.layout_size = Some(Size { width, height });
                 }
+                return Box::new(block);
             }
-            // No font available — fall through to normal empty-element handling
+            // No marker resolved — fall through to normal empty-element handling
         } else {
             // Non-empty <li> with block children: convert children, then inject
             // marker into the first ParagraphPageable found in the tree.
+            // Try image marker first (list-style-image), then text fallback.
             let mut positioned_children = collect_positioned_children(doc, children, ctx, depth);
 
-            // Find font: first from AssetBundle, then from child paragraph runs.
-            let font_info = find_marker_font(marker, ctx.assets, &positioned_children);
+            let marker_item: Option<LineItem> =
+                resolve_inside_image_marker(node, line_height, ctx.assets)
+                    .map(LineItem::Image)
+                    .or_else(|| {
+                        let (fd, fi) = find_marker_font(marker, ctx.assets, &positioned_children)?;
+                        let run = shape_marker_with_skrifa(marker, &fd, fi, font_size_pt, color)?;
+                        Some(LineItem::Text(run))
+                    });
 
-            if let Some((font_data, font_index)) = font_info {
-                if let Some(marker_run) =
-                    shape_marker_with_skrifa(marker, &font_data, font_index, font_size_pt, color)
+            if let Some(item) = marker_item {
+                if !inject_inside_marker_item_into_children(&mut positioned_children, item.clone())
                 {
-                    if !inject_inside_marker_into_children(
-                        &mut positioned_children,
-                        marker_run.clone(),
-                    ) {
-                        // No paragraph descendant found — insert a standalone marker paragraph.
-                        let paragraph = ParagraphPageable::new(vec![ShapedLine {
-                            height: line_height,
-                            baseline: line_height / DEFAULT_LINE_HEIGHT_RATIO,
-                            items: vec![LineItem::Text(marker_run)],
-                        }]);
-                        positioned_children.insert(
-                            0,
-                            PositionedChild {
-                                child: Box::new(paragraph),
-                                x: 0.0,
-                                y: 0.0,
-                            },
-                        );
-                    }
+                    // No paragraph descendant found — insert a standalone marker paragraph.
+                    let paragraph = ParagraphPageable::new(vec![ShapedLine {
+                        height: line_height,
+                        baseline: line_height / DEFAULT_LINE_HEIGHT_RATIO,
+                        items: vec![item],
+                    }]);
+                    positioned_children.insert(
+                        0,
+                        PositionedChild {
+                            child: Box::new(paragraph),
+                            x: 0.0,
+                            y: 0.0,
+                        },
+                    );
                 }
             }
 
@@ -2759,16 +2766,14 @@ fn shape_marker_with_skrifa(
     })
 }
 
-/// Inject a shaped marker run into the first `ParagraphPageable` found in the
-/// `positioned_children` tree. Handles both direct `ParagraphPageable` children
-/// and paragraphs nested inside `BlockPageable` wrappers (e.g. `<p>` with
-/// border/background). Returns `true` if injection succeeded.
-fn inject_inside_marker_into_children(
+/// Inject a marker `LineItem` (text or image) into the first `ParagraphPageable`
+/// found in the `positioned_children` tree. Handles both direct children and
+/// paragraphs nested inside `BlockPageable` wrappers. Returns `true` if
+/// injection succeeded.
+fn inject_inside_marker_item_into_children(
     children: &mut [PositionedChild],
-    marker_run: ShapedGlyphRun,
+    marker_item: LineItem,
 ) -> bool {
-    // First pass: check which child contains the target paragraph, so we
-    // don't move the marker_run into a dead end.
     let target_idx = children
         .iter()
         .position(|pc| has_paragraph_descendant(pc.child.as_ref()));
@@ -2778,24 +2783,24 @@ fn inject_inside_marker_into_children(
     };
 
     let pc = &mut children[idx];
-    let marker_width: f32 = marker_run
-        .glyphs
-        .iter()
-        .map(|g| g.x_advance * marker_run.font_size)
-        .sum();
+    let marker_width: f32 = match &marker_item {
+        LineItem::Text(run) => run.glyphs.iter().map(|g| g.x_advance * run.font_size).sum(),
+        LineItem::Image(img) => img.width,
+    };
 
     // Direct ParagraphPageable child
     if let Some(para) = pc.child.as_any().downcast_ref::<ParagraphPageable>() {
         let mut para_clone = para.clone();
         if para_clone.lines.is_empty() {
             // Empty paragraph — create a line with just the marker.
-            let font_size = marker_run.font_size;
-            let line_height = font_size * DEFAULT_LINE_HEIGHT_RATIO;
-            let baseline = line_height / DEFAULT_LINE_HEIGHT_RATIO;
+            let line_height = match &marker_item {
+                LineItem::Text(run) => run.font_size * DEFAULT_LINE_HEIGHT_RATIO,
+                LineItem::Image(img) => img.height,
+            };
             para_clone.lines.push(ShapedLine {
                 height: line_height,
-                baseline,
-                items: vec![LineItem::Text(marker_run)],
+                baseline: line_height / DEFAULT_LINE_HEIGHT_RATIO,
+                items: vec![marker_item],
             });
         } else {
             for item in &mut para_clone.lines[0].items {
@@ -2804,9 +2809,7 @@ fn inject_inside_marker_into_children(
                     LineItem::Image(i) => i.x_offset += marker_width,
                 }
             }
-            para_clone.lines[0]
-                .items
-                .insert(0, LineItem::Text(marker_run));
+            para_clone.lines[0].items.insert(0, marker_item);
             recalculate_paragraph_line_boxes(&mut para_clone.lines);
         }
         para_clone.cached_height = para_clone.lines.iter().map(|l| l.height).sum();
@@ -2817,8 +2820,7 @@ fn inject_inside_marker_into_children(
     // ParagraphPageable nested inside a BlockPageable (e.g. <p> with styles)
     if let Some(block) = pc.child.as_any().downcast_ref::<BlockPageable>() {
         let mut block_clone = block.clone();
-        if inject_inside_marker_into_children(&mut block_clone.children, marker_run) {
-            // Re-wrap with the original layout width if available.
+        if inject_inside_marker_item_into_children(&mut block_clone.children, marker_item) {
             let wrap_w = block_clone.layout_size.map(|s| s.width).unwrap_or(10000.0);
             block_clone.wrap(wrap_w, 10000.0);
             pc.child = Box::new(block_clone);

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -607,6 +607,118 @@ fn convert_node_inner(
         }
     }
 
+    // Inside-positioned marker on non-inline-root <li> (e.g. `<li><p>text</p></li>`
+    // or empty `<li>`). Blitz only injects inside markers via `build_inline_layout`,
+    // which doesn't run for non-inline-root elements. We shape the marker with
+    // skrifa and inject it into the first child ParagraphPageable.
+    if let Some(elem_data) = node.element_data()
+        && let Some(list_data) = &elem_data.list_item_data
+        && matches!(
+            list_data.position,
+            blitz_dom::node::ListItemLayoutPosition::Inside
+        )
+        && !node.flags.is_inline_root()
+    {
+        let marker = &list_data.marker;
+        let style = extract_block_style(node, ctx.assets);
+        let (opacity, visible) = extract_opacity_visible(node);
+        let content_box = compute_content_box(node, &style);
+
+        // Derive font_size and line_height from computed styles.
+        let (font_size_pt, line_height) = if let Some(styles) = node.primary_styles() {
+            let fs = styles.clone_font_size().used_size().px() * PX_TO_PT;
+            let lh = {
+                use style::values::computed::font::LineHeight;
+                match styles.clone_line_height() {
+                    LineHeight::Normal => fs * DEFAULT_LINE_HEIGHT_RATIO,
+                    LineHeight::Number(num) => fs * num.0,
+                    LineHeight::Length(value) => value.0.px() * PX_TO_PT,
+                }
+            };
+            (fs, lh)
+        } else {
+            (12.0 * PX_TO_PT, 12.0 * PX_TO_PT * DEFAULT_LINE_HEIGHT_RATIO)
+        };
+
+        let color = get_text_color(doc, node_id);
+
+        let children: &[usize] = &node.children;
+        if children.is_empty() {
+            // Empty <li>: create a standalone paragraph with just the marker.
+            if let Some((font_data, font_index)) = find_marker_font(marker, ctx.assets, &[]) {
+                if let Some(marker_run) =
+                    shape_marker_with_skrifa(marker, &font_data, font_index, font_size_pt, color)
+                {
+                    let paragraph = ParagraphPageable::new(vec![ShapedLine {
+                        height: line_height,
+                        baseline: line_height / DEFAULT_LINE_HEIGHT_RATIO,
+                        items: vec![LineItem::Text(marker_run)],
+                    }]);
+                    let (before_pseudo, after_pseudo) =
+                        build_block_pseudo_images(doc, node, content_box, ctx.assets);
+                    let paragraph_children = vec![PositionedChild {
+                        child: Box::new(paragraph),
+                        x: 0.0,
+                        y: 0.0,
+                    }];
+                    let positioned_children = wrap_with_block_pseudo_images(
+                        before_pseudo,
+                        after_pseudo,
+                        content_box,
+                        paragraph_children,
+                    );
+                    let needs_wrapper = style.needs_block_wrapper();
+                    let mut block = BlockPageable::with_positioned_children(positioned_children)
+                        .with_style(style)
+                        .with_opacity(opacity)
+                        .with_visible(visible)
+                        .with_id(extract_block_id(node));
+                    block.wrap(width, 10000.0);
+                    if needs_wrapper {
+                        block.layout_size = Some(Size { width, height });
+                    }
+                    return Box::new(block);
+                }
+            }
+            // No font available — fall through to normal empty-element handling
+        } else {
+            // Non-empty <li> with block children: convert children, then inject
+            // marker into the first ParagraphPageable found in the tree.
+            let mut positioned_children = collect_positioned_children(doc, children, ctx, depth);
+
+            // Find font: first from AssetBundle, then from child paragraph runs.
+            let font_info = find_marker_font(marker, ctx.assets, &positioned_children);
+
+            if let Some((font_data, font_index)) = font_info {
+                if let Some(marker_run) =
+                    shape_marker_with_skrifa(marker, &font_data, font_index, font_size_pt, color)
+                {
+                    inject_inside_marker_into_children(&mut positioned_children, marker_run);
+                }
+            }
+
+            let (before_pseudo, after_pseudo) =
+                build_block_pseudo_images(doc, node, content_box, ctx.assets);
+            let positioned_children = wrap_with_block_pseudo_images(
+                before_pseudo,
+                after_pseudo,
+                content_box,
+                positioned_children,
+            );
+            let has_style = style.needs_block_wrapper();
+            let mut block = BlockPageable::with_positioned_children(positioned_children)
+                .with_style(style)
+                .with_opacity(opacity)
+                .with_visible(visible)
+                .with_id(extract_block_id(node));
+            block.wrap(width, 10000.0);
+            if has_style {
+                block.layout_size = Some(Size { width, height });
+            }
+            return Box::new(block);
+        }
+    }
+
     // Check if this is a table element
     if let Some(elem_data) = node.element_data() {
         let tag = elem_data.name.local.as_ref();
@@ -2491,6 +2603,209 @@ fn extract_marker_lines(
     (shaped_lines, max_width, line_height_pt)
 }
 
+/// Search for a font that covers the marker's non-whitespace characters.
+///
+/// First checks `AssetBundle.fonts` for a font whose skrifa charmap covers all
+/// non-whitespace characters in the marker text. If no asset fonts match (or no
+/// bundle is provided), falls back to borrowing `font_data` + `font_index` from
+/// the first `ShapedGlyphRun` found in the already-converted `children`.
+///
+/// Returns `None` only when no font source is available at all (empty `<li>`
+/// without asset fonts).
+fn find_marker_font(
+    marker: &blitz_dom::node::Marker,
+    assets: Option<&AssetBundle>,
+    children: &[PositionedChild],
+) -> Option<(Arc<Vec<u8>>, u32)> {
+    let marker_text = match marker {
+        blitz_dom::node::Marker::Char(c) => {
+            let mut s = String::new();
+            s.push(*c);
+            s
+        }
+        blitz_dom::node::Marker::String(s) => s.clone(),
+    };
+    let check_chars: Vec<char> = marker_text.chars().filter(|c| !c.is_whitespace()).collect();
+
+    // Try AssetBundle fonts first — check charmap coverage.
+    if let Some(bundle) = assets {
+        for font_arc in &bundle.fonts {
+            for idx in 0u32..16 {
+                if let Ok(font_ref) = skrifa::FontRef::from_index(font_arc, idx) {
+                    let charmap = font_ref.charmap();
+                    if check_chars.iter().all(|&c| charmap.map(c).is_some()) {
+                        return Some((Arc::clone(font_arc), idx));
+                    }
+                } else {
+                    break; // No more sub-fonts
+                }
+            }
+        }
+    }
+
+    // Fallback: find the first ShapedGlyphRun in children's ParagraphPageables.
+    fn find_run_font_in_children(children: &[PositionedChild]) -> Option<(Arc<Vec<u8>>, u32)> {
+        for pc in children {
+            if let Some(para) = pc.child.as_any().downcast_ref::<ParagraphPageable>() {
+                for line in &para.lines {
+                    for item in &line.items {
+                        if let LineItem::Text(run) = item {
+                            return Some((Arc::clone(&run.font_data), run.font_index));
+                        }
+                    }
+                }
+            }
+            if let Some(block) = pc.child.as_any().downcast_ref::<BlockPageable>() {
+                if let Some(result) = find_run_font_in_children(&block.children) {
+                    return Some(result);
+                }
+            }
+        }
+        None
+    }
+
+    find_run_font_in_children(children)
+}
+
+/// Shape a list marker string into a `ShapedGlyphRun` using skrifa.
+///
+/// For `Marker::Char`, appends a trailing space (matching Blitz's
+/// `build_inline_layout` which does `format!("{char} ")`).
+/// For `Marker::String`, uses the string as-is (Blitz already includes
+/// trailing content like `"1. "`).
+///
+/// `x_advance` values are normalized by `font_size` following fulgur convention
+/// (see `extract_marker_lines`).
+fn shape_marker_with_skrifa(
+    marker: &blitz_dom::node::Marker,
+    font_data: &Arc<Vec<u8>>,
+    font_index: u32,
+    font_size: f32,
+    color: [u8; 4],
+) -> Option<ShapedGlyphRun> {
+    let text = match marker {
+        blitz_dom::node::Marker::Char(c) => format!("{c} "),
+        blitz_dom::node::Marker::String(s) => s.clone(),
+    };
+
+    let font_ref = skrifa::FontRef::from_index(font_data, font_index).ok()?;
+    let charmap = font_ref.charmap();
+    let glyph_metrics = font_ref.glyph_metrics(
+        skrifa::instance::Size::new(font_size),
+        skrifa::instance::LocationRef::default(),
+    );
+
+    let text_len = text.len();
+    let mut glyphs = Vec::new();
+    for ch in text.chars() {
+        let gid = charmap.map(ch).unwrap_or(skrifa::GlyphId::new(0));
+        let advance = glyph_metrics.advance_width(gid).unwrap_or(0.0);
+        glyphs.push(ShapedGlyph {
+            id: gid.to_u32(),
+            x_advance: advance / font_size,
+            x_offset: 0.0,
+            y_offset: 0.0,
+            text_range: 0..text_len,
+        });
+    }
+
+    Some(ShapedGlyphRun {
+        font_data: Arc::clone(font_data),
+        font_index,
+        font_size,
+        color,
+        decoration: TextDecoration::default(),
+        glyphs,
+        text,
+        x_offset: 0.0,
+        link: None,
+    })
+}
+
+/// Inject a shaped marker run into the first `ParagraphPageable` found in the
+/// `positioned_children` tree. Handles both direct `ParagraphPageable` children
+/// and paragraphs nested inside `BlockPageable` wrappers (e.g. `<p>` with
+/// border/background). Returns `true` if injection succeeded.
+fn inject_inside_marker_into_children(
+    children: &mut [PositionedChild],
+    marker_run: ShapedGlyphRun,
+) -> bool {
+    // First pass: check which child contains the target paragraph, so we
+    // don't move the marker_run into a dead end.
+    let target_idx = children
+        .iter()
+        .position(|pc| has_paragraph_descendant(pc.child.as_ref()));
+
+    let Some(idx) = target_idx else {
+        return false;
+    };
+
+    let pc = &mut children[idx];
+    let marker_width: f32 = marker_run
+        .glyphs
+        .iter()
+        .map(|g| g.x_advance * marker_run.font_size)
+        .sum();
+
+    // Direct ParagraphPageable child
+    if pc
+        .child
+        .as_any()
+        .downcast_ref::<ParagraphPageable>()
+        .is_some()
+    {
+        let para = pc
+            .child
+            .as_any()
+            .downcast_ref::<ParagraphPageable>()
+            .unwrap();
+        let mut para_clone = para.clone();
+        if !para_clone.lines.is_empty() {
+            for item in &mut para_clone.lines[0].items {
+                match item {
+                    LineItem::Text(run) => run.x_offset += marker_width,
+                    LineItem::Image(i) => i.x_offset += marker_width,
+                }
+            }
+            para_clone.lines[0]
+                .items
+                .insert(0, LineItem::Text(marker_run));
+            recalculate_paragraph_line_boxes(&mut para_clone.lines);
+            para_clone.cached_height = para_clone.lines.iter().map(|l| l.height).sum();
+        }
+        pc.child = Box::new(para_clone);
+        return true;
+    }
+
+    // ParagraphPageable nested inside a BlockPageable (e.g. <p> with styles)
+    if let Some(block) = pc.child.as_any().downcast_ref::<BlockPageable>() {
+        let mut block_clone = block.clone();
+        if inject_inside_marker_into_children(&mut block_clone.children, marker_run) {
+            // Re-wrap with the original layout width if available.
+            let wrap_w = block_clone.layout_size.map(|s| s.width).unwrap_or(10000.0);
+            block_clone.wrap(wrap_w, 10000.0);
+            pc.child = Box::new(block_clone);
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Check whether a Pageable contains a ParagraphPageable (directly or nested).
+fn has_paragraph_descendant(p: &dyn Pageable) -> bool {
+    if p.as_any().downcast_ref::<ParagraphPageable>().is_some() {
+        return true;
+    }
+    if let Some(block) = p.as_any().downcast_ref::<BlockPageable>() {
+        return block
+            .children
+            .iter()
+            .any(|c| has_paragraph_descendant(c.child.as_ref()));
+    }
+    false
+}
+
 /// Get text color from a DOM node's computed styles.
 fn get_text_color(doc: &blitz_dom::BaseDocument, node_id: usize) -> [u8; 4] {
     if let Some(node) = doc.get_node(node_id)
@@ -3765,5 +4080,101 @@ mod tests {
             }
         }
         assert_eq!(alt.as_deref(), Some("hello world"));
+    }
+
+    // ---- inside marker tests ----
+
+    /// Walk a Pageable tree and check whether any ParagraphPageable's first line
+    /// has a Text item whose text starts with the given marker string.
+    fn find_marker_text_in_tree(p: &dyn Pageable, marker: &str) -> bool {
+        if let Some(para) = p.as_any().downcast_ref::<ParagraphPageable>() {
+            if let Some(first_line) = para.lines.first() {
+                for item in &first_line.items {
+                    if let LineItem::Text(run) = item {
+                        if run.text.starts_with(marker) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        if let Some(block) = p.as_any().downcast_ref::<BlockPageable>() {
+            for c in &block.children {
+                if find_marker_text_in_tree(c.child.as_ref(), marker) {
+                    return true;
+                }
+            }
+        }
+        if let Some(item) = p.as_any().downcast_ref::<ListItemPageable>() {
+            if find_marker_text_in_tree(item.body.as_ref(), marker) {
+                return true;
+            }
+        }
+        false
+    }
+
+    #[test]
+    fn inside_marker_on_block_child_li() {
+        let html = r#"<html><body><ul style="list-style-position:inside"><li><p>hello</p></li></ul></body></html>"#;
+        let mut doc = crate::blitz_adapter::parse(html, 800.0, &[]);
+        crate::blitz_adapter::resolve(&mut doc);
+        let running_store = crate::gcpm::running::RunningElementStore::new();
+        let mut ctx = ConvertContext {
+            running_store: &running_store,
+            assets: None,
+            font_cache: HashMap::new(),
+            string_set_by_node: HashMap::new(),
+            counter_ops_by_node: HashMap::new(),
+            bookmark_by_node: HashMap::new(),
+        };
+        let tree = super::dom_to_pageable(&doc, &mut ctx);
+        assert!(
+            find_marker_text_in_tree(&*tree, "\u{2022}"),
+            "inside marker bullet should be injected into <li><p>hello</p></li>"
+        );
+    }
+
+    #[test]
+    fn inside_marker_on_empty_li() {
+        let html =
+            r#"<html><body><ul style="list-style-position:inside"><li></li></ul></body></html>"#;
+        let mut doc = crate::blitz_adapter::parse(html, 800.0, &[]);
+        crate::blitz_adapter::resolve(&mut doc);
+        let running_store = crate::gcpm::running::RunningElementStore::new();
+        let mut ctx = ConvertContext {
+            running_store: &running_store,
+            assets: None,
+            font_cache: HashMap::new(),
+            string_set_by_node: HashMap::new(),
+            counter_ops_by_node: HashMap::new(),
+            bookmark_by_node: HashMap::new(),
+        };
+        let tree = super::dom_to_pageable(&doc, &mut ctx);
+        // Empty <li> with no AssetBundle fonts: marker may not render if no
+        // system font covers the bullet. We still verify no panic occurs.
+        // When a system font IS available, the marker should be present.
+        let _found = find_marker_text_in_tree(&*tree, "\u{2022}");
+        // Not asserting found==true because system font availability varies.
+    }
+
+    #[test]
+    fn inside_marker_on_block_child_ol() {
+        let html = r#"<html><body><ol style="list-style-position:inside"><li><p>hello</p></li></ol></body></html>"#;
+        let mut doc = crate::blitz_adapter::parse(html, 800.0, &[]);
+        crate::blitz_adapter::resolve(&mut doc);
+        let running_store = crate::gcpm::running::RunningElementStore::new();
+        let mut ctx = ConvertContext {
+            running_store: &running_store,
+            assets: None,
+            font_cache: HashMap::new(),
+            string_set_by_node: HashMap::new(),
+            counter_ops_by_node: HashMap::new(),
+            bookmark_by_node: HashMap::new(),
+        };
+        let tree = super::dom_to_pageable(&doc, &mut ctx);
+        assert!(
+            find_marker_text_in_tree(&*tree, "1."),
+            "inside marker '1.' should be injected into <li><p>hello</p></li> in <ol>"
+        );
     }
 }

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -2630,7 +2630,8 @@ fn find_marker_font(
     // Try AssetBundle fonts first — check charmap coverage.
     if let Some(bundle) = assets {
         for font_arc in &bundle.fonts {
-            for idx in 0u32..16 {
+            // Try sub-fonts in a TTC collection; break on first Err (no more faces).
+            for idx in 0u32.. {
                 if let Ok(font_ref) = skrifa::FontRef::from_index(font_arc, idx) {
                     let charmap = font_ref.charmap();
                     if check_chars.iter().all(|&c| charmap.map(c).is_some()) {
@@ -2643,20 +2644,31 @@ fn find_marker_font(
         }
     }
 
-    // Fallback: find the first ShapedGlyphRun in children's ParagraphPageables.
-    fn find_run_font_in_children(children: &[PositionedChild]) -> Option<(Arc<Vec<u8>>, u32)> {
+    // Fallback: find the first ShapedGlyphRun in children's ParagraphPageables
+    // whose font covers all marker characters.
+    fn find_run_font_in_children(
+        children: &[PositionedChild],
+        check_chars: &[char],
+    ) -> Option<(Arc<Vec<u8>>, u32)> {
         for pc in children {
             if let Some(para) = pc.child.as_any().downcast_ref::<ParagraphPageable>() {
                 for line in &para.lines {
                     for item in &line.items {
                         if let LineItem::Text(run) = item {
-                            return Some((Arc::clone(&run.font_data), run.font_index));
+                            if let Ok(font_ref) =
+                                skrifa::FontRef::from_index(&run.font_data, run.font_index)
+                            {
+                                let charmap = font_ref.charmap();
+                                if check_chars.iter().all(|c| charmap.map(*c).is_some()) {
+                                    return Some((Arc::clone(&run.font_data), run.font_index));
+                                }
+                            }
                         }
                     }
                 }
             }
             if let Some(block) = pc.child.as_any().downcast_ref::<BlockPageable>() {
-                if let Some(result) = find_run_font_in_children(&block.children) {
+                if let Some(result) = find_run_font_in_children(&block.children, check_chars) {
                     return Some(result);
                 }
             }
@@ -2664,10 +2676,15 @@ fn find_marker_font(
         None
     }
 
-    find_run_font_in_children(children)
+    find_run_font_in_children(children, &check_chars)
 }
 
 /// Shape a list marker string into a `ShapedGlyphRun` using skrifa.
+///
+/// Performs simplified character-by-character glyph mapping (no complex
+/// OpenType shaping, kerning, or ligatures). This is sufficient for
+/// bullet characters (U+2022) and ordered markers ("1. ") which don't
+/// require advanced text layout.
 ///
 /// For `Marker::Char`, appends a trailing space (matching Blitz's
 /// `build_inline_layout` which does `format!("{char} ")`).
@@ -2748,17 +2765,7 @@ fn inject_inside_marker_into_children(
         .sum();
 
     // Direct ParagraphPageable child
-    if pc
-        .child
-        .as_any()
-        .downcast_ref::<ParagraphPageable>()
-        .is_some()
-    {
-        let para = pc
-            .child
-            .as_any()
-            .downcast_ref::<ParagraphPageable>()
-            .unwrap();
+    if let Some(para) = pc.child.as_any().downcast_ref::<ParagraphPageable>() {
         let mut para_clone = para.clone();
         if !para_clone.lines.is_empty() {
             for item in &mut para_clone.lines[0].items {


### PR DESCRIPTION
## Summary

- `list-style-position: inside` のマーカーが、`<li>` がブロック子のみを持つ場合（例: `<li><p>text</p></li>`）や空の `<li>` で描画されないバグを修正
- skrifa の charmap + glyph_metrics を使ってマーカーテキストを直接シェイプし、最初の子 `ParagraphPageable` の先頭行にインライン注入する方式で実装
- Blitz の `build_inline_layout` が inline root でない要素では呼ばれないことが根本原因（Blitz 側パッチ不要）

## Changes

- `shape_marker_with_skrifa`: skrifa で文字→グリフID→アドバンス幅を取得し `ShapedGlyphRun` を構築
- `find_marker_font`: AssetBundle フォント → 子パラグラフのフォントの順で charmap カバレッジを確認
- `inject_inside_marker_into_children`: 最初の `ParagraphPageable` を探し、clone+修正+置換でマーカーを注入
- `convert_node_inner` に Inside + 非 inline root の検出ブランチを追加

## Test plan

- [x] `inside_marker_on_block_child_li` — `<ul>` + `<li><p>hello</p></li>` でバレット `•` が注入される
- [x] `inside_marker_on_empty_li` — 空 `<li>` でパニックしない
- [x] `inside_marker_on_block_child_ol` — `<ol>` + `<li><p>hello</p></li>` で `1.` が注入される
- [x] 既存テスト 424 件全パス、regression なし
- [x] `cargo clippy` / `cargo fmt --check` クリーン

Closes fulgur-pno
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * リスト項目のマーカー表示を改善しました。`list-style-position: inside` CSS プロパティを使用する場合、マーカーがリスト項目内に正しく配置されるようになりました。
  * 順序なしリスト（`<ul>`）および順序付きリスト（`<ol>`）の両方のマーカー表示に対応しました。
  * ネストされたコンテンツを含むリスト項目での適切なレイアウト処理を実装しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->