### PR TITLE
chore: add placeholder packages for PyPI (pyfulgur) and RubyGems (fulgur)

### DIFF
--- a/crates/fulgur-ruby/LICENSE-MIT
+++ b/crates/fulgur-ruby/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mitsuru Takigahira
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/fulgur-ruby/README.md
+++ b/crates/fulgur-ruby/README.md
@@ -1,0 +1,31 @@
+# fulgur
+
+Ruby bindings for [fulgur](https://github.com/mitsuru/fulgur) — an offline, deterministic HTML/CSS to PDF conversion library written in Rust.
+
+## Status
+
+**This gem is a name reservation.** The implementation is under active development.
+
+## Planned API
+
+```ruby
+require "fulgur"
+
+bundle = Fulgur::AssetBundle.new
+bundle.add_css("body { font-family: sans-serif; }")
+bundle.add_font_file("fonts/NotoSans-Regular.ttf")
+
+engine = Fulgur::Engine.builder.page_size("A4").assets(bundle).build
+pdf_bytes = engine.render_html("<h1>Hello, world!</h1>")
+
+File.binwrite("output.pdf", pdf_bytes)
+```
+
+## Links
+
+- [fulgur on GitHub](https://github.com/mitsuru/fulgur)
+- [fulgur on crates.io](https://crates.io/crates/fulgur)
+
+## License
+
+Licensed under either of Apache License, Version 2.0 or MIT license at your option.

--- a/crates/fulgur-ruby/README.md
+++ b/crates/fulgur-ruby/README.md
@@ -8,6 +8,8 @@ Ruby bindings for [fulgur](https://github.com/mitsuru/fulgur) — an offline, de
 
 ## Planned API
 
+> **Not available in v0.0.1.** The current release is a placeholder for name reservation.
+
 ```ruby
 require "fulgur"
 

--- a/crates/fulgur-ruby/fulgur.gemspec
+++ b/crates/fulgur-ruby/fulgur.gemspec
@@ -1,0 +1,22 @@
+Gem::Specification.new do |s|
+  s.name        = "fulgur"
+  s.version     = "0.0.1"
+  s.summary     = "Ruby bindings for fulgur — offline HTML/CSS to PDF conversion"
+  s.description = <<~DESC
+    Ruby bindings for fulgur, an offline, deterministic HTML/CSS to PDF
+    conversion library written in Rust. This is a name reservation;
+    the implementation is under active development.
+  DESC
+  s.authors     = ["Mitsuru Hayasaka"]
+  s.email       = "hayasaka.mitsuru@gmail.com"
+  s.homepage    = "https://github.com/mitsuru/fulgur"
+  s.license     = "MIT"
+  s.metadata    = {
+    "source_code_uri"   => "https://github.com/mitsuru/fulgur",
+    "changelog_uri"     => "https://github.com/mitsuru/fulgur/blob/main/CHANGELOG.md",
+    "bug_tracker_uri"   => "https://github.com/mitsuru/fulgur/issues",
+  }
+
+  s.required_ruby_version = ">= 3.1"
+  s.files = ["lib/fulgur.rb", "README.md", "LICENSE-MIT"]
+end

--- a/crates/fulgur-ruby/fulgur.gemspec
+++ b/crates/fulgur-ruby/fulgur.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.authors     = ["Mitsuru Hayasaka"]
   s.email       = "hayasaka.mitsuru@gmail.com"
   s.homepage    = "https://github.com/mitsuru/fulgur"
-  s.license     = "MIT"
+  s.licenses    = ["MIT", "Apache-2.0"]
   s.metadata    = {
     "source_code_uri"   => "https://github.com/mitsuru/fulgur",
     "changelog_uri"     => "https://github.com/mitsuru/fulgur/blob/main/CHANGELOG.md",

--- a/crates/fulgur-ruby/lib/fulgur.rb
+++ b/crates/fulgur-ruby/lib/fulgur.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Fulgur — Ruby bindings for fulgur (HTML/CSS to PDF).
+#
+# This is a placeholder gem. The implementation is under active development.
+# See https://github.com/mitsuru/fulgur for details.
+module Fulgur
+  VERSION = "0.0.1"
+
+  def self.placeholder
+    raise NotImplementedError,
+      "fulgur gem is not yet implemented. " \
+      "See https://github.com/mitsuru/fulgur for progress."
+  end
+end

--- a/crates/pyfulgur/.gitignore
+++ b/crates/pyfulgur/.gitignore
@@ -1,0 +1,6 @@
+
+# Build artifacts
+build/
+dist/
+*.egg-info/
+

--- a/crates/pyfulgur/README.md
+++ b/crates/pyfulgur/README.md
@@ -1,0 +1,32 @@
+# pyfulgur
+
+Python bindings for [fulgur](https://github.com/mitsuru/fulgur) — an offline, deterministic HTML/CSS to PDF conversion library written in Rust.
+
+## Status
+
+**This package is a name reservation.** The implementation is under active development.
+
+## Planned API
+
+```python
+from pyfulgur import Engine, AssetBundle
+
+bundle = AssetBundle()
+bundle.add_css("body { font-family: sans-serif; }")
+bundle.add_font_file("fonts/NotoSans-Regular.ttf")
+
+engine = Engine.builder().page_size("A4").assets(bundle).build()
+pdf_bytes = engine.render_html("<h1>Hello, world!</h1>")
+
+with open("output.pdf", "wb") as f:
+    f.write(pdf_bytes)
+```
+
+## Links
+
+- [fulgur on GitHub](https://github.com/mitsuru/fulgur)
+- [fulgur on crates.io](https://crates.io/crates/fulgur)
+
+## License
+
+Licensed under either of Apache License, Version 2.0 or MIT license at your option.

--- a/crates/pyfulgur/README.md
+++ b/crates/pyfulgur/README.md
@@ -8,6 +8,8 @@ Python bindings for [fulgur](https://github.com/mitsuru/fulgur) — an offline, 
 
 ## Planned API
 
+> **Not available in v0.0.1.** The current release is a placeholder for name reservation.
+
 ```python
 from pyfulgur import Engine, AssetBundle
 

--- a/crates/pyfulgur/pyfulgur/__init__.py
+++ b/crates/pyfulgur/pyfulgur/__init__.py
@@ -1,0 +1,14 @@
+"""pyfulgur — Python bindings for fulgur (HTML/CSS to PDF).
+
+This is a placeholder package. The implementation is under active development.
+See https://github.com/mitsuru/fulgur for details.
+"""
+
+__version__ = "0.0.1"
+
+
+def _placeholder() -> None:
+    raise NotImplementedError(
+        "pyfulgur is not yet implemented. "
+        "See https://github.com/mitsuru/fulgur for progress."
+    )

--- a/crates/pyfulgur/pyfulgur/__init__.py
+++ b/crates/pyfulgur/pyfulgur/__init__.py
@@ -7,7 +7,7 @@ See https://github.com/mitsuru/fulgur for details.
 __version__ = "0.0.1"
 
 
-def _placeholder() -> None:
+def placeholder() -> None:
     raise NotImplementedError(
         "pyfulgur is not yet implemented. "
         "See https://github.com/mitsuru/fulgur for progress."

--- a/crates/pyfulgur/pyproject.toml
+++ b/crates/pyfulgur/pyproject.toml
@@ -1,0 +1,31 @@
+# NOTE: placeholder build uses setuptools. Real builds will use maturin.
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pyfulgur"
+version = "0.0.1"
+description = "Python bindings for fulgur — offline HTML/CSS to PDF conversion"
+readme = "README.md"
+license = "MIT OR Apache-2.0"
+requires-python = ">=3.9"
+authors = [
+    { name = "Mitsuru Hayasaka", email = "hayasaka.mitsuru@gmail.com" },
+]
+keywords = ["pdf", "html", "css", "conversion", "typesetting"]
+classifiers = [
+    "Development Status :: 1 - Planning",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Rust",
+    "Topic :: Text Processing :: Markup :: HTML",
+]
+
+[project.urls]
+Repository = "https://github.com/mitsuru/fulgur"
+Documentation = "https://github.com/mitsuru/fulgur"
+
+[tool.setuptools.packages.find]
+where = ["."]

--- a/crates/pyfulgur/pyproject.toml
+++ b/crates/pyfulgur/pyproject.toml
@@ -8,7 +8,7 @@ name = "pyfulgur"
 version = "0.0.1"
 description = "Python bindings for fulgur — offline HTML/CSS to PDF conversion"
 readme = "README.md"
-license = "MIT OR Apache-2.0"
+license = {text = "MIT OR Apache-2.0"}
 requires-python = ">=3.9"
 authors = [
     { name = "Mitsuru Hayasaka", email = "hayasaka.mitsuru@gmail.com" },

--- a/crates/pyfulgur/src/lib.rs
+++ b/crates/pyfulgur/src/lib.rs
@@ -1,0 +1,2 @@
+// Placeholder for pyfulgur — Python bindings for fulgur.
+// This crate is not yet functional. See https://github.com/mitsuru/fulgur


### PR DESCRIPTION
## Summary

- Python/Ruby バインディングのパッケージ名を予約するための placeholder パッケージを追加
- **pyfulgur 0.0.1** — PyPI に publish 済み (`pip install pyfulgur`)
- **fulgur 0.0.1** (gem) — RubyGems への publish は別環境から実施予定

## Contents

- `crates/pyfulgur/` — pyproject.toml + stub module + README with planned API
- `crates/fulgur-ruby/` — gemspec + stub lib + README with planned API

## Test plan

- [x] `pip install pyfulgur` → import 成功、バージョン表示、placeholder エラー確認
- [x] `gem build fulgur.gemspec` → gem ビルド確認 (Ruby 環境で実施)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/98" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **ドキュメンテーション**
  * Ruby と Python 用 Fulgur バインディングのプロジェクトドキュメントを追加
  * ライセンスファイル（MIT）を含む

* **設定**
  * Ruby gem（v0.0.1）の gemspec 設定ファイルを追加
  * Python パッケージの pyproject.toml とビルド設定を追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->