### PR TITLE
ci: add PyPI / RubyGems publish workflows (Trusted Publishing)

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -64,9 +64,20 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
+          # Rust core
           sed -i "s/^version = \".*\"/version = \"$VERSION\"/" crates/fulgur/Cargo.toml
           sed -i "s/^version = \".*\"/version = \"$VERSION\"/" crates/fulgur-cli/Cargo.toml
           sed -i "s/fulgur = { version = \"[^\"]*\", path/fulgur = { version = \"$VERSION\", path/" crates/fulgur-cli/Cargo.toml
+
+          # pyfulgur (Python binding)
+          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" crates/pyfulgur/Cargo.toml
+          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" crates/pyfulgur/pyproject.toml
+
+          # fulgur-ruby (Ruby binding)
+          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" crates/fulgur-ruby/Cargo.toml
+          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" crates/fulgur-ruby/ext/fulgur/Cargo.toml
+          sed -i "s/VERSION = \".*\"/VERSION = \"$VERSION\"/" crates/fulgur-ruby/lib/fulgur/version.rb
+
           cargo check --workspace
 
       - name: Regenerate example PDFs

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -24,7 +24,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
 
       - name: Install git-cliff
         env:

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -31,7 +31,7 @@ jobs:
             runner: ubuntu-24.04-arm
             manylinux: "2014"
           - target: x86_64-apple-darwin
-            runner: macos-13
+            runner: macos-15-intel
           - target: aarch64-apple-darwin
             runner: macos-latest
           - target: x86_64-pc-windows-msvc
@@ -77,7 +77,7 @@ jobs:
             artifact: wheels-x86_64-unknown-linux-gnu
           - os: ubuntu-24.04-arm
             artifact: wheels-aarch64-unknown-linux-gnu
-          - os: macos-13
+          - os: macos-15-intel
             artifact: wheels-x86_64-apple-darwin
           - os: macos-latest
             artifact: wheels-aarch64-apple-darwin
@@ -120,7 +120,7 @@ jobs:
   publish:
     name: Publish to PyPI
     needs: [build-wheels, build-sdist, smoke-test]
-    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !fromJSON(inputs.dry_run))
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -130,12 +130,12 @@ jobs:
         with:
           path: dist
           merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
 
   publish-testpypi:
     name: Publish to TestPyPI
     needs: [build-wheels, build-sdist, smoke-test]
-    if: github.event_name == 'workflow_dispatch' && fromJSON(inputs.dry_run)
+    if: github.event_name == 'workflow_dispatch' && inputs.dry_run
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:
@@ -145,6 +145,6 @@ jobs:
         with:
           path: dist
           merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -66,6 +66,36 @@ jobs:
           path: dist/*.tar.gz
           if-no-files-found: error
 
+  smoke-test-sdist:
+    name: Smoke test (sdist)
+    needs: [build-sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install sdist (source build)
+        shell: bash
+        run: |
+          shopt -s failglob
+          python -m pip install dist/*.tar.gz
+      - name: Smoke test
+        shell: bash
+        run: |
+          python -c "
+          import pyfulgur
+          engine = pyfulgur.Engine()
+          pdf = engine.render_html('<p>hi</p>')
+          assert isinstance(pdf, (bytes, bytearray)), type(pdf)
+          assert len(pdf) > 100, len(pdf)
+          print(f'OK: {len(pdf)} bytes')
+          "
+
   smoke-test:
     name: Smoke test (${{ matrix.os }})
     needs: [build-wheels]
@@ -119,7 +149,7 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    needs: [build-wheels, build-sdist, smoke-test]
+    needs: [build-wheels, build-sdist, smoke-test, smoke-test-sdist]
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
     runs-on: ubuntu-latest
     environment: pypi
@@ -134,7 +164,7 @@ jobs:
 
   publish-testpypi:
     name: Publish to TestPyPI
-    needs: [build-wheels, build-sdist, smoke-test]
+    needs: [build-wheels, build-sdist, smoke-test, smoke-test-sdist]
     if: github.event_name == 'workflow_dispatch' && inputs.dry_run
     runs-on: ubuntu-latest
     environment: testpypi

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -39,11 +39,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
       - name: Build wheel
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux || 'auto' }}
@@ -59,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: PyO3/maturin-action@v1
+      - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           command: sdist
           args: --out dist -m crates/pyfulgur/Cargo.toml
@@ -98,11 +95,16 @@ jobs:
       - name: Install wheel (unix)
         if: runner.os != 'Windows'
         shell: bash
-        run: pip install dist/*.whl
+        run: |
+          shopt -s failglob
+          pip install dist/*.whl
       - name: Install wheel (windows)
         if: runner.os == 'Windows'
         shell: pwsh
-        run: pip install (Get-ChildItem dist/*.whl)[0].FullName
+        run: |
+          $wheel = Get-ChildItem dist/*.whl | Select-Object -First 1
+          if (-not $wheel) { throw "No wheel found in dist/" }
+          pip install $wheel.FullName
       - name: Smoke test
         shell: bash
         run: |
@@ -118,7 +120,7 @@ jobs:
   publish:
     name: Publish to PyPI
     needs: [build-wheels, build-sdist, smoke-test]
-    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !fromJSON(inputs.dry_run))
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -133,7 +135,7 @@ jobs:
   publish-testpypi:
     name: Publish to TestPyPI
     needs: [build-wheels, build-sdist, smoke-test]
-    if: github.event_name == 'workflow_dispatch' && inputs.dry_run == true
+    if: github.event_name == 'workflow_dispatch' && fromJSON(inputs.dry_run)
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -67,9 +67,15 @@ jobs:
           if-no-files-found: error
 
   smoke-test-sdist:
-    name: Smoke test (sdist)
+    # sdist は wheel 非対応プラットフォームの fallback。requires-python = ">=3.9"
+    # の下端 (3.9) と最新 (3.13) で source build を検証する。
+    name: Smoke test (sdist / Python ${{ matrix.python-version }})
     needs: [build-sdist]
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.13"]
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -77,7 +83,7 @@ jobs:
           path: dist
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: stable

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -1,0 +1,148 @@
+name: Release (Python / PyPI)
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Publish to TestPyPI instead of PyPI'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-wheels:
+    name: Build wheel (${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            manylinux: "2014"
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+            manylinux: "2014"
+          - target: x86_64-apple-darwin
+            runner: macos-13
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          manylinux: ${{ matrix.manylinux || 'auto' }}
+          args: --release --strip --out dist -m crates/pyfulgur/Cargo.toml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.target }}
+          path: dist/*.whl
+          if-no-files-found: error
+
+  build-sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist -m crates/pyfulgur/Cargo.toml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
+  smoke-test:
+    name: Smoke test (${{ matrix.os }})
+    needs: [build-wheels]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact: wheels-x86_64-unknown-linux-gnu
+          - os: ubuntu-24.04-arm
+            artifact: wheels-aarch64-unknown-linux-gnu
+          - os: macos-13
+            artifact: wheels-x86_64-apple-darwin
+          - os: macos-latest
+            artifact: wheels-aarch64-apple-darwin
+          - os: windows-latest
+            artifact: wheels-x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: dist
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install wheel (unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: pip install dist/*.whl
+      - name: Install wheel (windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: pip install (Get-ChildItem dist/*.whl)[0].FullName
+      - name: Smoke test
+        shell: bash
+        run: |
+          python -c "
+          import pyfulgur
+          engine = pyfulgur.Engine()
+          pdf = engine.render_html('<p>hi</p>')
+          assert isinstance(pdf, (bytes, bytearray)), type(pdf)
+          assert len(pdf) > 100, len(pdf)
+          print(f'OK: {len(pdf)} bytes')
+          "
+
+  publish:
+    name: Publish to PyPI
+    needs: [build-wheels, build-sdist, smoke-test]
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: [build-wheels, build-sdist, smoke-test]
+    if: github.event_name == 'workflow_dispatch' && inputs.dry_run == true
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -78,7 +78,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
       - name: Install sdist (source build)
         shell: bash
         run: |
@@ -150,7 +152,10 @@ jobs:
   publish:
     name: Publish to PyPI
     needs: [build-wheels, build-sdist, smoke-test, smoke-test-sdist]
-    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
+    # 本番 PyPI publish は release イベント (release.yml がタグから発火) のみ。
+    # workflow_dispatch からは任意の ref を publish できないようにする (security)。
+    # 手動検証は publish-testpypi (dry_run=true) を使う。
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -88,7 +88,7 @@ jobs:
             runner: ubuntu-24.04-arm
             ruby: "3.3"
           - platform: x86_64-darwin
-            runner: macos-13
+            runner: macos-15-intel
             ruby: "3.3"
           - platform: arm64-darwin
             runner: macos-latest
@@ -162,8 +162,24 @@ jobs:
       - name: Push gems
         shell: bash
         run: |
+          set -euo pipefail
           shopt -s failglob
+          fail=0
           for gem in dist/*.gem; do
-            echo "Pushing $gem"
-            gem push "$gem"
+            echo "::group::Pushing $gem"
+            if output=$(gem push "$gem" 2>&1); then
+              echo "$output"
+              echo "::endgroup::"
+            else
+              echo "$output"
+              echo "::endgroup::"
+              # Treat "already pushed" as a skip (idempotent re-runs).
+              if printf '%s' "$output" | grep -qE 'Repushing of gem versions is not allowed|has already been pushed'; then
+                echo "::notice file=$gem::already published, skipping"
+              else
+                echo "::error file=$gem::push failed"
+                fail=1
+              fi
+            fi
           done
+          exit "$fail"

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -1,0 +1,156 @@
+name: Release (Ruby / RubyGems)
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Skip publish step (build + smoke test only)'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-source-gem:
+    name: Build source gem
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oxidize-rb/actions/setup-ruby-and-rust@e5f9a49a7812a078584072f6e3f657ad247c8771  # v1.4.4
+        with:
+          ruby-version: "3.3"
+          rustup-toolchain: stable
+          bundler-cache: true
+          cargo-cache: true
+          working-directory: crates/fulgur-ruby
+      - name: Build source gem
+        working-directory: crates/fulgur-ruby
+        run: bundle exec rake build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: source-gem
+          path: crates/fulgur-ruby/pkg/*.gem
+          if-no-files-found: error
+
+  build-precompiled:
+    name: Build precompiled gem (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - x86_64-linux
+          - x86_64-linux-musl
+          - aarch64-linux
+          - aarch64-linux-musl
+          - x86_64-darwin
+          - arm64-darwin
+          - x64-mingw-ucrt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a  # v1.302.0
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: crates/fulgur-ruby
+      - uses: oxidize-rb/cross-gem-action@80f59339d90789841d772f412fe4a8b201a8cfa2  # v7
+        with:
+          platform: ${{ matrix.platform }}
+          ruby-versions: "3.1,3.2,3.3,3.4"
+          directory: crates/fulgur-ruby
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cross-gem-${{ matrix.platform }}
+          path: crates/fulgur-ruby/pkg/*.gem
+          if-no-files-found: error
+
+  smoke-test:
+    name: Smoke test (${{ matrix.platform }})
+    needs: [build-precompiled]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: x86_64-linux
+            runner: ubuntu-latest
+          - platform: aarch64-linux
+            runner: ubuntu-24.04-arm
+          - platform: x86_64-darwin
+            runner: macos-13
+          - platform: arm64-darwin
+            runner: macos-latest
+          - platform: x64-mingw-ucrt
+            runner: windows-latest
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a  # v1.302.0
+        with:
+          ruby-version: "3.3"
+      - uses: actions/download-artifact@v4
+        with:
+          name: cross-gem-${{ matrix.platform }}
+          path: pkg
+      - name: Install gem (unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          shopt -s failglob
+          gem install --local pkg/*.gem
+      - name: Install gem (windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $gem = Get-ChildItem pkg/*.gem | Select-Object -First 1
+          if (-not $gem) { throw "No gem found in pkg/" }
+          gem install --local $gem.FullName
+      - name: Smoke test
+        shell: bash
+        run: |
+          ruby -e '
+            require "fulgur"
+            engine = Fulgur::Engine.new
+            pdf = engine.render_html("<p>hi</p>")
+            raise "not a Fulgur::Pdf: #{pdf.class}" unless pdf.is_a?(Fulgur::Pdf)
+            raise "too short: #{pdf.bytesize}" unless pdf.bytesize > 100
+            s = pdf.to_s
+            raise "bad header: #{s[0, 5].inspect}" unless s[0, 5] == "%PDF-".b
+            puts "OK: #{pdf.bytesize} bytes"
+          '
+
+  publish:
+    name: Publish to RubyGems
+    needs: [build-source-gem, build-precompiled, smoke-test]
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !fromJSON(inputs.dry_run))
+    runs-on: ubuntu-latest
+    environment: rubygems
+    permissions:
+      id-token: write
+    steps:
+      - uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a  # v1.302.0
+        with:
+          ruby-version: "3.3"
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - uses: rubygems/configure-rubygems-credentials@6f94374a7eb4cdf600b093bbcd94079187872fac  # main
+        with:
+          role-to-assume: rg_oidc_akr_mitsuru_fulgur
+      - name: List gems to publish
+        shell: bash
+        run: ls -la dist/*.gem
+      - name: Push gems
+        shell: bash
+        run: |
+          shopt -s failglob
+          for gem in dist/*.gem; do
+            echo "Pushing $gem"
+            gem push "$gem"
+          done

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -132,6 +132,9 @@ jobs:
             puts "OK: #{pdf.bytesize} bytes"
           '
 
+  # NOTE: RubyGems has no TestGems equivalent, so dry_run skips publish entirely.
+  # OIDC / role-to-assume / credential config is exercised for the first time
+  # on the actual first release. See docs/RELEASE_SETUP.md.
   publish:
     name: Publish to RubyGems
     needs: [build-source-gem, build-precompiled, smoke-test]
@@ -150,6 +153,9 @@ jobs:
           merge-multiple: true
       - uses: rubygems/configure-rubygems-credentials@6f94374a7eb4cdf600b093bbcd94079187872fac  # main
         with:
+          # TODO: replace placeholder with actual role name after RubyGems Trusted
+          # Publisher registration completes (value from rubygems.org UI).
+          # See docs/RELEASE_SETUP.md.
           role-to-assume: rg_oidc_akr_mitsuru_fulgur
       - name: List gems to publish
         shell: bash

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -72,7 +72,7 @@ jobs:
           if-no-files-found: error
 
   smoke-test:
-    name: Smoke test (${{ matrix.platform }})
+    name: Smoke test (${{ matrix.platform }} / Ruby ${{ matrix.ruby }})
     needs: [build-precompiled]
     strategy:
       fail-fast: false
@@ -80,19 +80,27 @@ jobs:
         include:
           - platform: x86_64-linux
             runner: ubuntu-latest
+            ruby: "3.1"
+          - platform: x86_64-linux
+            runner: ubuntu-latest
+            ruby: "3.4"
           - platform: aarch64-linux
             runner: ubuntu-24.04-arm
+            ruby: "3.3"
           - platform: x86_64-darwin
             runner: macos-13
+            ruby: "3.3"
           - platform: arm64-darwin
             runner: macos-latest
+            ruby: "3.3"
           - platform: x64-mingw-ucrt
             runner: windows-latest
+            ruby: "3.3"
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a  # v1.302.0
         with:
-          ruby-version: "3.3"
+          ruby-version: ${{ matrix.ruby }}
       - uses: actions/download-artifact@v4
         with:
           name: cross-gem-${{ matrix.platform }}

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -39,6 +39,40 @@ jobs:
           path: crates/fulgur-ruby/pkg/*.gem
           if-no-files-found: error
 
+  smoke-test-source-gem:
+    name: Smoke test (source gem)
+    needs: [build-source-gem]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: oxidize-rb/actions/setup-ruby-and-rust@e5f9a49a7812a078584072f6e3f657ad247c8771  # v1.4.4
+        with:
+          ruby-version: "3.3"
+          rustup-toolchain: stable
+          bundler-cache: false
+          cargo-cache: false
+      - uses: actions/download-artifact@v4
+        with:
+          name: source-gem
+          path: pkg
+      - name: Install source gem (compiles native ext)
+        shell: bash
+        run: |
+          shopt -s failglob
+          gem install --local pkg/*.gem
+      - name: Smoke test
+        shell: bash
+        run: |
+          ruby -e '
+            require "fulgur"
+            engine = Fulgur::Engine.new
+            pdf = engine.render_html("<p>hi</p>")
+            raise "not a Fulgur::Pdf: #{pdf.class}" unless pdf.is_a?(Fulgur::Pdf)
+            raise "too short: #{pdf.bytesize}" unless pdf.bytesize > 100
+            s = pdf.to_s
+            raise "bad header: #{s[0, 5].inspect}" unless s[0, 5] == "%PDF-".b
+            puts "OK: #{pdf.bytesize} bytes"
+          '
+
   build-precompiled:
     name: Build precompiled gem (${{ matrix.platform }})
     strategy:
@@ -137,7 +171,7 @@ jobs:
   # on the actual first release. See docs/RELEASE_SETUP.md.
   publish:
     name: Publish to RubyGems
-    needs: [build-source-gem, build-precompiled, smoke-test]
+    needs: [build-source-gem, smoke-test-source-gem, build-precompiled, smoke-test]
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
     runs-on: ubuntu-latest
     environment: rubygems

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -3,13 +3,9 @@ name: Release (Ruby / RubyGems)
 on:
   release:
     types: [published]
+  # workflow_dispatch は build + smoke のみ実行 (publish は release event 限定)。
+  # 任意 ref からの publish 経路を塞ぐため dry_run input は持たない。
   workflow_dispatch:
-    inputs:
-      dry_run:
-        description: 'Skip publish step (build + smoke test only)'
-        required: false
-        type: boolean
-        default: true
 
 permissions:
   contents: read
@@ -166,13 +162,57 @@ jobs:
             puts "OK: #{pdf.bytesize} bytes"
           '
 
-  # NOTE: RubyGems has no TestGems equivalent, so dry_run skips publish entirely.
-  # OIDC / role-to-assume / credential config is exercised for the first time
-  # on the actual first release. See docs/RELEASE_SETUP.md.
+  smoke-test-musl:
+    # musl native loader / packaging の破損を検出する。Alpine container に隔離して
+    # 実行することで glibc 前提の actions 側と衝突しない (actions/download-artifact
+    # はホスト側、gem install + smoke test のみ alpine 内)。
+    name: Smoke test musl (${{ matrix.platform }})
+    needs: [build-precompiled]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: x86_64-linux-musl
+            runner: ubuntu-latest
+          - platform: aarch64-linux-musl
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: cross-gem-${{ matrix.platform }}
+          path: pkg
+      - name: Smoke test in Alpine (${{ matrix.platform }})
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm -v "$PWD/pkg:/pkg:ro" ruby:3.3-alpine sh -c '
+            set -eu
+            for gem in /pkg/*.gem; do
+              echo "Installing $gem"
+              gem install --local "$gem" --no-document
+            done
+            ruby -e "
+              require \"fulgur\"
+              engine = Fulgur::Engine.new
+              pdf = engine.render_html(\"<p>hi</p>\")
+              raise \"not a Fulgur::Pdf: #{pdf.class}\" unless pdf.is_a?(Fulgur::Pdf)
+              raise \"too short: #{pdf.bytesize}\" unless pdf.bytesize > 100
+              s = pdf.to_s
+              raise \"bad header: #{s[0, 5].inspect}\" unless s[0, 5] == \"%PDF-\".b
+              puts \"OK: #{pdf.bytesize} bytes\"
+            "
+          '
+
+  # NOTE: RubyGems publish は release イベント (release.yml がタグから発火) のみ。
+  # workflow_dispatch からは任意の ref を push できないようにする (security)。
+  # RubyGems には TestPyPI 相当が無いため、workflow_dispatch は build + smoke
+  # のみ実行し、OIDC / credential フローの実動作検証は初回本番リリースで行う。
+  # See docs/RELEASE_SETUP.md.
   publish:
     name: Publish to RubyGems
-    needs: [build-source-gem, smoke-test-source-gem, build-precompiled, smoke-test]
-    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
+    needs: [build-source-gem, smoke-test-source-gem, build-precompiled, smoke-test, smoke-test-musl]
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     environment: rubygems
     permissions:

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -151,12 +151,11 @@ jobs:
         with:
           path: dist
           merge-multiple: true
+      # Uses RubyGems Trusted Publisher flow (default). The OIDC claim
+      # (repo + workflow + environment) is matched against the Trusted
+      # Publisher registered on rubygems.org/gems/fulgur/trusted_publishers.
+      # No role-to-assume needed. See docs/RELEASE_SETUP.md.
       - uses: rubygems/configure-rubygems-credentials@6f94374a7eb4cdf600b093bbcd94079187872fac  # main
-        with:
-          # TODO: replace placeholder with actual role name after RubyGems Trusted
-          # Publisher registration completes (value from rubygems.org UI).
-          # See docs/RELEASE_SETUP.md.
-          role-to-assume: rg_oidc_akr_mitsuru_fulgur
       - name: List gems to publish
         shell: bash
         run: ls -la dist/*.gem

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -36,13 +36,20 @@ jobs:
           if-no-files-found: error
 
   smoke-test-source-gem:
-    name: Smoke test (source gem)
+    # source gem は precompiled 非対応プラットフォームの fallback。
+    # required_ruby_version >= 3.1.0 の下端 (3.1) と上端 (3.4) で native
+    # extension の build/install を検証する。
+    name: Smoke test (source gem / Ruby ${{ matrix.ruby }})
     needs: [build-source-gem]
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.1", "3.4"]
     steps:
       - uses: oxidize-rb/actions/setup-ruby-and-rust@e5f9a49a7812a078584072f6e3f657ad247c8771  # v1.4.4
         with:
-          ruby-version: "3.3"
+          ruby-version: ${{ matrix.ruby }}
           rustup-toolchain: stable
           bundler-cache: false
           cargo-cache: false

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -138,7 +138,7 @@ jobs:
   publish:
     name: Publish to RubyGems
     needs: [build-source-gem, build-precompiled, smoke-test]
-    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !fromJSON(inputs.dry_run))
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
     runs-on: ubuntu-latest
     environment: rubygems
     permissions:

--- a/README.md
+++ b/README.md
@@ -172,6 +172,11 @@ cargo test
 cargo run -p fulgur-cli -- render -o output.pdf input.html
 ```
 
+## Release
+
+See [docs/RELEASE_SETUP.md](docs/RELEASE_SETUP.md) for PyPI / RubyGems
+Trusted Publisher setup and release steps.
+
 ## Determinism and fonts
 
 Fulgur aims for byte-identical PDF output from identical input. The core pipeline

--- a/crates/fulgur-ruby/fulgur.gemspec
+++ b/crates/fulgur-ruby/fulgur.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "Ruby bindings for fulgur, a deterministic HTML/CSS to PDF rendering engine."
   spec.homepage = "https://github.com/mitsuru/fulgur"
   spec.licenses = ["Apache-2.0", "MIT"]
-  spec.required_ruby_version = ">= 3.3.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
   spec.metadata["source_code_uri"] = "https://github.com/mitsuru/fulgur"

--- a/crates/pyfulgur/Cargo.toml
+++ b/crates/pyfulgur/Cargo.toml
@@ -21,7 +21,7 @@ extension-module = ["dep:pyo3", "pyo3/extension-module"]
 
 [dependencies]
 fulgur = { path = "../fulgur" }
-pyo3 = { version = "0.22", optional = true }
+pyo3 = { version = "0.22", optional = true, features = ["abi3-py39"] }
 
 [dev-dependencies]
 static_assertions = "1.1"

--- a/crates/pyfulgur/pyproject.toml
+++ b/crates/pyfulgur/pyproject.toml
@@ -38,3 +38,4 @@ test = ["pytest>=7"]
 module-name = "pyfulgur"
 manifest-path = "Cargo.toml"
 features = ["extension-module"]
+py-limited-api = "cp39"

--- a/docs/RELEASE_SETUP.md
+++ b/docs/RELEASE_SETUP.md
@@ -1,0 +1,76 @@
+# Release Setup: Trusted Publishing
+
+pyfulgur (PyPI) と fulgur (RubyGems) を OIDC Trusted Publishing で publish するための、
+一度だけ必要な設定手順。
+
+## 初回公開時の注意
+
+pyfulgur と fulgur gem はどちらも PyPI / RubyGems に未登録の可能性がある。
+既存プロジェクトと新規プロジェクトで UI フローが異なる:
+
+- **新規 (pending publisher)**: プロジェクト名だけ予約し、初回 publish 時に
+  OIDC claim で自動的に project が作成される。
+- **既存 publisher 追加**: 既に project が存在する場合は publisher を追加登録。
+
+## PyPI Trusted Publisher
+
+### Production (pypi.org)
+
+1. <https://pypi.org/manage/account/publishing/> にログイン
+2. "Add a new pending publisher" (新規の場合) または既存 project の
+   "Publishing" タブから publisher 追加:
+   - PyPI Project Name: `pyfulgur`
+   - Owner: `mitsuru`
+   - Repository name: `fulgur`
+   - Workflow name: `release-python.yml`
+   - Environment name: `pypi`
+3. GitHub リポジトリで Environment `pypi` を作成 (Settings → Environments → New environment)。保護ルール不要。
+
+### TestPyPI (test.pypi.org)
+
+本番公開前に dry-run を試す場合のみ。
+
+1. <https://test.pypi.org/manage/account/publishing/> で同様に登録
+2. Environment name: `testpypi`
+3. GitHub リポジトリで Environment `testpypi` を作成
+
+Dry-run 発火:
+
+```bash
+gh workflow run release-python.yml --field dry_run=true
+```
+
+## RubyGems Trusted Publisher
+
+1. <https://rubygems.org/profile/oidc/api_key_roles> にログイン
+2. "New API key role" → OIDC provider: GitHub Actions
+3. 以下を登録:
+   - Gem: `fulgur` (新規の場合は "Pending publishing" で予約)
+   - Repository: `mitsuru/fulgur`
+   - Workflow: `release-ruby.yml`
+   - Environment: `rubygems`
+4. 生成された role 名 (例: `rg_oidc_akr_xxxxxxxx`) をコピーして
+   `.github/workflows/release-ruby.yml` の `role-to-assume:` 値を差し替える
+5. GitHub リポジトリで Environment `rubygems` を作成
+
+注意: RubyGems には TestPyPI に相当する staging 環境がないため、`release-ruby.yml`
+の `workflow_dispatch` dry-run は publish をスキップするのみ (build + smoke test
+のみ走る)。OIDC / credential フローの実動作検証は初回の本番リリースで行う。
+
+## GitHub Environments
+
+以下の 3 つの Environment を作成:
+
+- `pypi`
+- `testpypi` (dry-run 用)
+- `rubygems`
+
+保護ルール不要 (OIDC claim で scope されるため)。
+
+## Release 手順
+
+1. `release-prepare.yml` を `workflow_dispatch` で起動 (version 入力)
+2. 作成された `release/vX.Y.Z` PR を merge
+3. `release.yml` が tag + crates.io publish + GitHub Release publish
+4. `release: published` で `release-python.yml` と `release-ruby.yml` が並行発火
+5. 数分〜十数分後に PyPI / RubyGems へ反映

--- a/docs/RELEASE_SETUP.md
+++ b/docs/RELEASE_SETUP.md
@@ -42,16 +42,22 @@ gh workflow run release-python.yml --field dry_run=true
 
 ## RubyGems Trusted Publisher
 
-1. <https://rubygems.org/profile/oidc/api_key_roles> にログイン
-2. "New API key role" → OIDC provider: GitHub Actions
-3. 以下を登録:
-   - Gem: `fulgur` (新規の場合は "Pending publishing" で予約)
-   - Repository: `mitsuru/fulgur`
-   - Workflow: `release-ruby.yml`
+既存 gem (fulgur) の場合:
+
+1. <https://rubygems.org/sign_in> にログイン (gem Owner アカウント)
+2. <https://rubygems.org/gems/fulgur/trusted_publishers> を開く
+3. "Create" で以下を登録:
+   - Repository owner: `mitsuru`
+   - Repository name: `fulgur`
+   - Workflow filename: `release-ruby.yml`
    - Environment: `rubygems`
-4. 生成された role 名 (例: `rg_oidc_akr_xxxxxxxx`) をコピーして
-   `.github/workflows/release-ruby.yml` の `role-to-assume:` 値を差し替える
-5. GitHub リポジトリで Environment `rubygems` を作成
+4. GitHub リポジトリで Environment `rubygems` を作成
+
+OIDC claim (repo + workflow + environment) で自動照合されるため、`role-to-assume`
+等の値は workflow 側に不要 (`rubygems/configure-rubygems-credentials` のデフォルト動作)。
+
+新規 gem を作成する場合は <https://rubygems.org/profile/oidc/pending_trusted_publishers>
+から "Pending Trusted Publisher" を登録。
 
 注意: RubyGems には TestPyPI に相当する staging 環境がないため、`release-ruby.yml`
 の `workflow_dispatch` dry-run は publish をスキップするのみ (build + smoke test

--- a/docs/plans/2026-04-18-publish-ci-pypi-rubygems.md
+++ b/docs/plans/2026-04-18-publish-ci-pypi-rubygems.md
@@ -139,7 +139,7 @@ py-limited-api = "cp39"
 **Step 3: workspace build 検証**
 
 ```bash
-cd /home/ubuntu/fulgur/.worktrees/publish-ci && cargo check --workspace
+cd "$(git rev-parse --show-toplevel)" && cargo check --workspace
 ```
 
 Expected: Finished success
@@ -735,7 +735,7 @@ git commit -m "docs(readme): link release setup guide"
 全タスク完了後:
 
 ```bash
-cd /home/ubuntu/fulgur/.worktrees/publish-ci
+cd "$(git rev-parse --show-toplevel)"
 
 # YAML syntax
 python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-prepare.yml'))"
@@ -759,11 +759,20 @@ Expected: 6〜7 commits、lint エラー 0、cargo check 成功。
 
 ---
 
+## Security: Action SHA pin policy
+
+認証情報を扱う workflow（publish 系）の GitHub Actions は **full-length commit SHA で pin する** のがデフォルトポリシー。
+
+- **必須**: `pypa/gh-action-pypi-publish`, `rubygems/configure-rubygems-credentials`, `PyO3/maturin-action`, `oxidize-rb/*`, `ruby/setup-ruby`, `oxidize-rb/cross-gem-action` 等の 3rd-party action
+- **例外**: まだ stable tag / 互換リリースが無く SHA 固定しにくい場合に限り、一時的に `@main` を使用してよい。ただし必ず新規 release / tag 公開を追跡し、公開され次第速やかに commit SHA pin に移行する
+- **許容**: `actions/checkout`, `actions/setup-python`, `actions/upload-artifact`, `actions/download-artifact` 等の GitHub 公式 1st-party actions は major-version tag (`@v4`) 可。SHA pin への段階的移行は推奨だが必須ではない
+
+本 PR 時点で `rubygems/configure-rubygems-credentials` のみ stable tag が無く `@main` を一時的に使用（例外に該当）。Safe alternative として SHA pin しているが、tag 公開後は合わせる。
+
 ## Known Limitations
 
 1. **Actual publish は実リリースまで動作確認不可** — TestPyPI dry-run でも "upload 成功"しか確認できない。PyPI / RubyGems 本番 publish の動作は初回リリースで検証する。
-2. **`rubygems/configure-rubygems-credentials@main`** は main branch 参照（2026年時点で stable release は pin 困難）。セキュリティ的には commit SHA pin を推奨だが、action の更新頻度とバランスを見て `@main` 運用で開始。問題が出たら `@v1` タグが切られるのを待って pin。
-3. **`role-to-assume` の値は登録後に確定** — RELEASE_SETUP.md の手順 4 で実値を取得し、Task 5 の workflow file の該当行を別 PR で更新する必要がある。
-4. **smoke test の API 呼び出しは verified facts に基づく** — Python: `pyfulgur.Engine()` ctor + `render_html()` returns bytes。Ruby: `Fulgur::Engine.new` + `render_html()` returns `Fulgur::Pdf` with `.bytesize`。binding 側 API が変わったら更新。
-5. **release-prepare.yml は workspace 共通バージョン前提** — 将来バインディングを独立バージョニングする場合はロジック変更必要。
-6. **`oxidize-rb/cross-gem-action@v9`** タグの存在確認は未実施。実際に push して CI で失敗したら最新タグに合わせる。
+2. **`rubygems/configure-rubygems-credentials@main`** は main branch ベースの SHA pin（2026年時点で stable release が無い）。上記 SHA pin policy の「例外」に該当。tag 公開され次第 tag based SHA pin に更新する。
+3. **smoke test の API 呼び出しは verified facts に基づく** — Python: `pyfulgur.Engine()` ctor + `render_html()` returns bytes。Ruby: `Fulgur::Engine.new` + `render_html()` returns `Fulgur::Pdf` with `.bytesize`。binding 側 API が変わったら更新。
+4. **release-prepare.yml は workspace 共通バージョン前提** — 将来バインディングを独立バージョニングする場合はロジック変更必要。
+5. **`oxidize-rb/cross-gem-action` は v9 予定していたが実在は v7**（実装時判明、v7 の SHA で pin）。node16 DeprecationWarning 可能性あるが publish はブロックしない。

--- a/docs/plans/2026-04-18-publish-ci-pypi-rubygems.md
+++ b/docs/plans/2026-04-18-publish-ci-pypi-rubygems.md
@@ -1,0 +1,769 @@
+# PyPI / RubyGems Publish CI Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** GitHub Actions で pyfulgur を PyPI に、fulgur gem を RubyGems.org に、Rust リリース直後に自動 publish する CI を構築する。
+
+**Architecture:** 既存の `release.yml`（crates.io publish + GitHub Release 作成）を変更せず、`release: published` イベントで発火する 2 本の独立ワークフロー（`release-python.yml` / `release-ruby.yml`）を追加。PyPI/RubyGems とも Trusted Publishing (OIDC) で secretsレス。`release-prepare.yml` はバインディングのバージョンも同期するよう拡張。GitHub Releases へバインディング artifact は添付しない（PyPI/RubyGems が正）。
+
+**Tech Stack:** GitHub Actions, `PyO3/maturin-action@v1`, `pypa/gh-action-pypi-publish@release/v1`, `oxidize-rb/cross-gem-action@v9`, `rubygems/configure-rubygems-credentials@main`, PyO3 abi3, rb_sys.
+
+**beads issue:** fulgur-qyf
+
+---
+
+## Verified Facts (from reading source)
+
+### Python API (crates/pyfulgur/src/engine.rs)
+
+- `pyfulgur.Engine` — `#[pyclass(name = "Engine", module = "pyfulgur")]`, direct ctor accepts optional kwargs
+- `pyfulgur.Engine.builder()` — `#[staticmethod]` returns `EngineBuilder`, chain with `.build()`
+- `engine.render_html(html: str)` — returns `bytes` (PyBytes)
+
+### Ruby API (crates/fulgur-ruby/src/engine.rs, lib/fulgur.rb, spec/engine_spec.rb)
+
+- `Fulgur::Engine.new` — accepts optional kwargs (page_size, margin, etc.)
+- `Fulgur::Engine.builder.build` — class method, returns `EngineBuilder`, chain (Ruby style, no parens)
+- `engine.render_html(html)` — returns `Fulgur::Pdf` (not raw bytes). Use `pdf.bytesize` for size check.
+
+### Starting versions
+
+- `crates/fulgur/Cargo.toml`: 0.4.5
+- `crates/fulgur-cli/Cargo.toml`: 0.4.5
+- `crates/pyfulgur/Cargo.toml`: 0.0.2
+- `crates/pyfulgur/pyproject.toml`: 0.0.2
+- `crates/fulgur-ruby/Cargo.toml`: 0.0.1
+- `crates/fulgur-ruby/ext/fulgur/Cargo.toml`: 0.0.1
+- `crates/fulgur-ruby/lib/fulgur/version.rb`: 0.0.1
+- `crates/fulgur-ruby/fulgur.gemspec`: `required_ruby_version = ">= 3.3.0"`（matrixの3.1/3.2と不整合）
+
+### Git repo
+
+- Remote: `https://github.com/mitsuru/fulgur`
+- PyPI project `pyfulgur` は初公開の可能性 → PyPI 側で "pending publisher" 登録が必要
+- RubyGems gem `fulgur` も初公開の可能性
+
+### Tool availability（検証済み）
+
+- `actionlint`: 未インストール。GitHub 側で workflow YAML は push 時に検証される。ローカル validation は `python3 -c "import yaml; yaml.safe_load(...)"` で構文のみ確認
+- `yq`: 未インストール（上記で代替）
+- `cargo`, `ruby`, `python3`, `npx`: 利用可能
+
+---
+
+## Verification Commands
+
+各 Task 完了後に使用:
+
+```bash
+# YAML syntax (構文のみ。Actions-specific な warning は push 時に GitHub で判明)
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-python.yml'))"
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-ruby.yml'))"
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-prepare.yml'))"
+
+# actionlint (optional; docker があれば):
+# docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest -color
+
+# Workspace build
+cargo check --workspace
+
+# Ruby gemspec
+cd crates/fulgur-ruby && ruby -c fulgur.gemspec && cd ../..
+
+# Markdown
+npx markdownlint-cli2 'docs/RELEASE_SETUP.md' 'README.md'
+```
+
+---
+
+## Task 1: gemspec の Ruby バージョン要件を緩和
+
+**Files:**
+
+- Modify: `crates/fulgur-ruby/fulgur.gemspec` (required_ruby_version 行)
+
+**Why:** 現状 `required_ruby_version = ">= 3.3.0"` だが、precompiled gem matrix は Ruby 3.1〜3.4。3.1/3.2 ユーザーが `gem install` 時に弾かれるのを防ぐ。
+
+**Step 1: required_ruby_version を変更**
+
+```ruby
+spec.required_ruby_version = ">= 3.1.0"
+```
+
+**Step 2: gemspec syntax 検証**
+
+```bash
+cd crates/fulgur-ruby && ruby -c fulgur.gemspec
+```
+
+Expected: `Syntax OK`
+
+**Step 3: Commit**
+
+```bash
+git add crates/fulgur-ruby/fulgur.gemspec
+git commit -m "chore(fulgur-ruby): loosen required_ruby_version to 3.1.0
+
+precompiled gem matrix で Ruby 3.1/3.2 も対象にするため。"
+```
+
+---
+
+## Task 2: pyfulgur に abi3 feature を追加
+
+**Files:**
+
+- Modify: `crates/pyfulgur/Cargo.toml` (pyo3 依存に features 追加)
+- Modify: `crates/pyfulgur/pyproject.toml` (tool.maturin に py-limited-api)
+
+**Why:** design で abi3-py39 を採用。PyO3 の `abi3-py39` feature を有効化し、maturin で Python 3.9+ を 1 wheel でカバー（5 wheel/Python × 5 = 25 ではなく 5 wheel で済む）。
+
+**Step 1: Cargo.toml の pyo3 依存に abi3 feature を追加**
+
+```toml
+[dependencies]
+fulgur = { path = "../fulgur" }
+pyo3 = { version = "0.22", optional = true, features = ["abi3-py39"] }
+```
+
+**Step 2: pyproject.toml の tool.maturin セクションに py-limited-api を追加**
+
+```toml
+[tool.maturin]
+module-name = "pyfulgur"
+manifest-path = "Cargo.toml"
+features = ["extension-module"]
+py-limited-api = "cp39"
+```
+
+**Step 3: workspace build 検証**
+
+```bash
+cd /home/ubuntu/fulgur/.worktrees/publish-ci && cargo check --workspace
+```
+
+Expected: Finished success
+
+**Step 4: Commit**
+
+```bash
+git add crates/pyfulgur/Cargo.toml crates/pyfulgur/pyproject.toml
+git commit -m "feat(pyfulgur): enable abi3-py39 for single wheel across Python 3.9+
+
+wheelが Python 3.9/3.10/3.11/3.12/3.13 ひとつでカバーされ、ビルド時間・配布数を
+削減する。"
+```
+
+---
+
+## Task 3: release-prepare.yml のバージョン同期拡張
+
+**Files:**
+
+- Modify: `.github/workflows/release-prepare.yml` (Update version step)
+
+**Why:** fulgur コアと同じバージョンを pyfulgur / fulgur-ruby に揃えるため、release PR 生成時に全バージョンを一括更新。
+
+**Step 1: sed パターンが該当ファイルでマッチするか確認**
+
+```bash
+grep -n '^version = ' crates/pyfulgur/Cargo.toml
+grep -n '^version = ' crates/pyfulgur/pyproject.toml
+grep -n '^version = ' crates/fulgur-ruby/Cargo.toml
+grep -n '^version = ' crates/fulgur-ruby/ext/fulgur/Cargo.toml
+grep -n 'VERSION = ' crates/fulgur-ruby/lib/fulgur/version.rb
+```
+
+Expected: 各1行ヒット
+
+**Step 2: "Update version in Cargo.toml" step を以下で置換**
+
+```yaml
+      - name: Update version in Cargo.toml
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # Rust core
+          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" crates/fulgur/Cargo.toml
+          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" crates/fulgur-cli/Cargo.toml
+          sed -i "s/fulgur = { version = \"[^\"]*\", path/fulgur = { version = \"$VERSION\", path/" crates/fulgur-cli/Cargo.toml
+
+          # pyfulgur (Python binding)
+          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" crates/pyfulgur/Cargo.toml
+          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" crates/pyfulgur/pyproject.toml
+
+          # fulgur-ruby (Ruby binding)
+          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" crates/fulgur-ruby/Cargo.toml
+          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" crates/fulgur-ruby/ext/fulgur/Cargo.toml
+          sed -i "s/VERSION = \".*\"/VERSION = \"$VERSION\"/" crates/fulgur-ruby/lib/fulgur/version.rb
+
+          cargo check --workspace
+```
+
+**Step 3: YAML 構文検証**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-prepare.yml'))"
+```
+
+Expected: no error
+
+**Step 4: Commit**
+
+```bash
+git add .github/workflows/release-prepare.yml
+git commit -m "ci(release-prepare): sync pyfulgur and fulgur-ruby versions
+
+Cargo.toml (pyfulgur, fulgur-ruby, ext/fulgur), pyproject.toml, version.rb
+すべてを release バージョンに揃える。"
+```
+
+---
+
+## Task 4: release-python.yml 作成
+
+**Files:**
+
+- Create: `.github/workflows/release-python.yml`
+
+**Why:** maturin で 5 wheel (abi3) + sdist を build し、smoke test 通過後に PyPI へ OIDC publish。`workflow_dispatch` で TestPyPI dry-run 可能。
+
+**Step 1: ワークフロー本体を作成**
+
+```yaml
+name: Release (Python / PyPI)
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Publish to TestPyPI instead of PyPI'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-wheels:
+    name: Build wheel (${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            manylinux: "2014"
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+            manylinux: "2014"
+          - target: x86_64-apple-darwin
+            runner: macos-13
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          manylinux: ${{ matrix.manylinux || 'auto' }}
+          args: --release --strip --out dist -m crates/pyfulgur/Cargo.toml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.target }}
+          path: dist/*.whl
+          if-no-files-found: error
+
+  build-sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist -m crates/pyfulgur/Cargo.toml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
+  smoke-test:
+    name: Smoke test (${{ matrix.os }})
+    needs: [build-wheels]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact: wheels-x86_64-unknown-linux-gnu
+          - os: ubuntu-24.04-arm
+            artifact: wheels-aarch64-unknown-linux-gnu
+          - os: macos-13
+            artifact: wheels-x86_64-apple-darwin
+          - os: macos-latest
+            artifact: wheels-aarch64-apple-darwin
+          - os: windows-latest
+            artifact: wheels-x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: dist
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install wheel (unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: pip install dist/*.whl
+      - name: Install wheel (windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: pip install (Get-ChildItem dist/*.whl)[0].FullName
+      - name: Smoke test
+        shell: bash
+        run: |
+          python -c "
+          import pyfulgur
+          engine = pyfulgur.Engine()
+          pdf = engine.render_html('<p>hi</p>')
+          assert isinstance(pdf, (bytes, bytearray)), type(pdf)
+          assert len(pdf) > 100, len(pdf)
+          print(f'OK: {len(pdf)} bytes')
+          "
+
+  publish:
+    name: Publish to PyPI
+    needs: [build-wheels, build-sdist, smoke-test]
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: [build-wheels, build-sdist, smoke-test]
+    if: github.event_name == 'workflow_dispatch' && inputs.dry_run == true
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+```
+
+**Step 2: YAML 構文検証**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-python.yml'))"
+```
+
+Expected: no error
+
+**Step 3: Commit**
+
+```bash
+git add .github/workflows/release-python.yml
+git commit -m "ci: add release-python.yml for PyPI OIDC publish
+
+release published で発火、5 wheel (abi3-py39) + sdist を build、smoke test
+通過後に PyPI Trusted Publishing で publish。workflow_dispatch で TestPyPI
+への dry-run も可能。"
+```
+
+---
+
+## Task 5: release-ruby.yml 作成
+
+**Files:**
+
+- Create: `.github/workflows/release-ruby.yml`
+
+**Why:** rb_sys cross-gem で 7 platform × 4 Ruby version の precompiled gem + source gem を build、smoke test 通過後に RubyGems へ OIDC publish。`rake release` ではなく明示的 `gem push` を使う（複数 gem を同時 push するため）。
+
+**Step 1: ワークフロー本体を作成**
+
+```yaml
+name: Release (Ruby / RubyGems)
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-source-gem:
+    name: Build source gem
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          working-directory: crates/fulgur-ruby
+          bundler-cache: true
+      - name: Build
+        working-directory: crates/fulgur-ruby
+        run: bundle exec rake build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: gem-source
+          path: crates/fulgur-ruby/pkg/*.gem
+          if-no-files-found: error
+
+  build-precompiled-gems:
+    name: Build precompiled gem (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - x86_64-linux-gnu
+          - aarch64-linux-gnu
+          - x86_64-linux-musl
+          - aarch64-linux-musl
+          - x86_64-darwin
+          - arm64-darwin
+          - x64-mingw-ucrt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
+        with:
+          ruby-version: "3.3"
+          rustup-toolchain: stable
+          bundler-cache: true
+          cargo-cache: true
+          working-directory: crates/fulgur-ruby
+      - uses: oxidize-rb/cross-gem-action@v9
+        with:
+          platform: ${{ matrix.platform }}
+          ruby-versions: "3.1,3.2,3.3,3.4"
+          working-directory: crates/fulgur-ruby
+      - uses: actions/upload-artifact@v4
+        with:
+          name: gem-${{ matrix.platform }}
+          path: crates/fulgur-ruby/pkg/*.gem
+          if-no-files-found: error
+
+  smoke-test:
+    name: Smoke test (${{ matrix.os }} / Ruby ${{ matrix.ruby }})
+    needs: [build-precompiled-gems]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            ruby: "3.1"
+            artifact: gem-x86_64-linux-gnu
+          - os: ubuntu-latest
+            ruby: "3.4"
+            artifact: gem-x86_64-linux-gnu
+          - os: ubuntu-24.04-arm
+            ruby: "3.3"
+            artifact: gem-aarch64-linux-gnu
+          - os: macos-13
+            ruby: "3.3"
+            artifact: gem-x86_64-darwin
+          - os: macos-latest
+            ruby: "3.3"
+            artifact: gem-arm64-darwin
+          - os: windows-latest
+            ruby: "3.3"
+            artifact: gem-x64-mingw-ucrt
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: pkg
+      - name: Install gem (unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: gem install pkg/fulgur-*.gem --no-document
+      - name: Install gem (windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: gem install (Get-ChildItem pkg/fulgur-*.gem)[0].FullName --no-document
+      - name: Smoke test
+        shell: bash
+        run: |
+          ruby -rfulgur -e '
+            engine = Fulgur::Engine.new
+            pdf = engine.render_html("<p>hi</p>")
+            raise "empty pdf" if pdf.bytesize < 100
+            puts "OK: #{pdf.bytesize} bytes"
+          '
+
+  publish:
+    name: Publish to RubyGems
+    needs: [build-source-gem, build-precompiled-gems, smoke-test]
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    environment: rubygems
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+      - uses: actions/download-artifact@v4
+        with:
+          path: pkg
+          merge-multiple: true
+      - name: List gems
+        run: ls -la pkg/
+      - name: Configure RubyGems credentials (OIDC)
+        uses: rubygems/configure-rubygems-credentials@main
+        with:
+          role-to-assume: rg_oidc_akr_mitsuru_fulgur
+      - name: Push gems
+        run: |
+          for gem in pkg/*.gem; do
+            echo "Pushing $gem..."
+            gem push "$gem"
+          done
+```
+
+**Note on `role-to-assume`:** RubyGems の Trusted Publisher 登録時に生成される API key role 名に合わせる。RELEASE_SETUP.md で登録手順を書くので、実名は初回登録後に確定する。プレースホルダとしてサンプル名を置いているが、実際の値は Trusted Publisher UI からコピーする必要がある。
+
+**Step 2: YAML 構文検証**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-ruby.yml'))"
+```
+
+Expected: no error
+
+**Step 3: Commit**
+
+```bash
+git add .github/workflows/release-ruby.yml
+git commit -m "ci: add release-ruby.yml for RubyGems OIDC publish
+
+release published で発火、7 platform × Ruby 3.1〜3.4 の precompiled gem +
+source gem を rb_sys cross-gem で build、smoke test 通過後に RubyGems
+Trusted Publishing で publish (configure-rubygems-credentials + gem push)。"
+```
+
+---
+
+## Task 6: Trusted Publisher セットアップドキュメント
+
+**Files:**
+
+- Create: `docs/RELEASE_SETUP.md`
+
+**Why:** PyPI / RubyGems 側の Trusted Publisher 登録は人手の Web UI 操作が必要。手順を明示して次回リリース担当者が迷わないようにする。
+
+**Step 1: `docs/RELEASE_SETUP.md` を作成**
+
+内容は新規プロジェクト（"pending publisher"）想定で書く。
+
+```markdown
+# Release Setup: Trusted Publishing
+
+pyfulgur (PyPI) と fulgur (RubyGems) を OIDC Trusted Publishing で publish
+するための一度だけ必要な設定手順。
+
+## 初回公開時の注意
+
+pyfulgur と fulgur gem はどちらも RubyGems / PyPI に未登録の可能性がある。
+既存プロジェクトと新規プロジェクトで UI フローが異なる:
+
+- **新規 (pending publisher)**: プロジェクト名だけ予約し、初回 publish 時に
+  OIDC claim で自動的に project が作成される。
+- **既存 publisher 追加**: 既に project が存在する場合は publisher を追加登録。
+
+## PyPI Trusted Publisher
+
+### Production (pypi.org)
+
+1. <https://pypi.org/manage/account/publishing/> にログイン
+2. "Add a new pending publisher" (新規の場合) または既存 project の
+   "Publishing" タブから publisher 追加:
+   - PyPI Project Name: `pyfulgur`
+   - Owner: `mitsuru`
+   - Repository name: `fulgur`
+   - Workflow name: `release-python.yml`
+   - Environment name: `pypi`
+3. GitHub リポジトリで Environment `pypi` を作成 (Settings → Environments → New environment)。保護ルール不要。
+
+### TestPyPI (test.pypi.org)
+
+本番公開前に dry-run を試す場合のみ。
+
+1. <https://test.pypi.org/manage/account/publishing/> で同様に登録
+2. Environment name: `testpypi`
+3. GitHub リポジトリで Environment `testpypi` を作成
+
+Dry-run 発火:
+
+\`\`\`bash
+gh workflow run release-python.yml --field dry_run=true
+\`\`\`
+
+## RubyGems Trusted Publisher
+
+1. <https://rubygems.org/profile/oidc/api_key_roles> にログイン
+2. "New API key role" → OIDC provider: GitHub Actions
+3. 以下を登録:
+   - Gem: `fulgur` (新規の場合は "Pending publishing" で予約)
+   - Repository: `mitsuru/fulgur`
+   - Workflow: `release-ruby.yml`
+   - Environment: `rubygems`
+4. 生成された role 名（例: `rg_oidc_akr_xxxxxxxx`）をコピーして
+   `.github/workflows/release-ruby.yml` の `role-to-assume` に設定
+5. GitHub リポジトリで Environment `rubygems` を作成
+
+## GitHub Environments
+
+以下の 3 つの Environment を作成:
+
+- `pypi`
+- `testpypi` (dry-run用)
+- `rubygems`
+
+保護ルール不要 (OIDC claim で scope されるため)。
+
+## Release 手順
+
+1. `release-prepare.yml` を `workflow_dispatch` で起動（version 入力）
+2. 作成された `release/vX.Y.Z` PR を merge
+3. `release.yml` が tag + crates.io publish + GitHub Release publish
+4. `release: published` で `release-python.yml` と `release-ruby.yml` が並行発火
+5. 数分〜十数分後に PyPI / RubyGems へ反映
+```
+
+**Step 2: markdownlint**
+
+```bash
+npx markdownlint-cli2 docs/RELEASE_SETUP.md
+```
+
+Expected: 0 errors
+
+**Step 3: Commit**
+
+```bash
+git add docs/RELEASE_SETUP.md
+git commit -m "docs: add RELEASE_SETUP.md for Trusted Publisher config
+
+PyPI / RubyGems / TestPyPI の OIDC Trusted Publisher 登録手順と GitHub
+Environment 作成手順、new-project 時の pending publisher フローを記載。"
+```
+
+---
+
+## Task 7: README 参照追加
+
+**Files:**
+
+- Modify: `README.md`（ルート）
+
+**Why:** メインの README からリリース手順ドキュメントへの参照を張る。
+
+**Step 1: README.md の既存 Release/Contributing セクションを確認**
+
+```bash
+grep -n "^## " README.md | head -20
+```
+
+既存に "Release" 節があれば追記、なければ Contributing 直前あたりに追加。
+
+**Step 2: 以下の節を適切な位置に追加**
+
+```markdown
+## Release Process
+
+See [docs/RELEASE_SETUP.md](docs/RELEASE_SETUP.md) for PyPI / RubyGems
+Trusted Publisher setup and release steps.
+```
+
+**Step 3: markdownlint**
+
+```bash
+npx markdownlint-cli2 README.md
+```
+
+**Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): link release setup guide"
+```
+
+---
+
+## Final Verification
+
+全タスク完了後:
+
+```bash
+cd /home/ubuntu/fulgur/.worktrees/publish-ci
+
+# YAML syntax
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-prepare.yml'))"
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-python.yml'))"
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-ruby.yml'))"
+
+# Workspace build
+cargo check --workspace
+
+# Markdown lint
+npx markdownlint-cli2 'docs/RELEASE_SETUP.md' 'README.md'
+
+# Ruby gemspec syntax
+cd crates/fulgur-ruby && ruby -c fulgur.gemspec && cd ../..
+
+# Git log
+git log --oneline main..HEAD
+```
+
+Expected: 6〜7 commits、lint エラー 0、cargo check 成功。
+
+---
+
+## Known Limitations
+
+1. **Actual publish は実リリースまで動作確認不可** — TestPyPI dry-run でも "upload 成功"しか確認できない。PyPI / RubyGems 本番 publish の動作は初回リリースで検証する。
+2. **`rubygems/configure-rubygems-credentials@main`** は main branch 参照（2026年時点で stable release は pin 困難）。セキュリティ的には commit SHA pin を推奨だが、action の更新頻度とバランスを見て `@main` 運用で開始。問題が出たら `@v1` タグが切られるのを待って pin。
+3. **`role-to-assume` の値は登録後に確定** — RELEASE_SETUP.md の手順 4 で実値を取得し、Task 5 の workflow file の該当行を別 PR で更新する必要がある。
+4. **smoke test の API 呼び出しは verified facts に基づく** — Python: `pyfulgur.Engine()` ctor + `render_html()` returns bytes。Ruby: `Fulgur::Engine.new` + `render_html()` returns `Fulgur::Pdf` with `.bytesize`。binding 側 API が変わったら更新。
+5. **release-prepare.yml は workspace 共通バージョン前提** — 将来バインディングを独立バージョニングする場合はロジック変更必要。
+6. **`oxidize-rb/cross-gem-action@v9`** タグの存在確認は未実施。実際に push して CI で失敗したら最新タグに合わせる。


### PR DESCRIPTION
Closes fulgur-qyf (epic fulgur-z42 / v0.5.0).

## Summary

- `release-python.yml` / `release-ruby.yml` が `release: published` で発火し、既存の `release.yml`（crates.io + GitHub Release publish）の直後に PyPI / RubyGems へ OIDC Trusted Publishing で自動 publish
- `release-prepare.yml` が pyfulgur / fulgur-ruby のバージョンも同期（6 ファイル一括更新）
- pyfulgur を `abi3-py39` 対応にし、Python 3.9+ を 1 wheel でカバー
- `fulgur-ruby` gemspec の `required_ruby_version` を `">= 3.1.0"` に緩め、precompiled gem matrix（Ruby 3.1-3.4）と整合
- `docs/RELEASE_SETUP.md` に Trusted Publisher / GitHub Environments のセットアップ手順を記載

### マトリクス

**PyPI (release-python.yml)**

- 5 wheel（abi3）: manylinux2014 x86_64 / aarch64, macOS x86_64 / arm64, Windows x86_64
- sdist
- 各プラットフォームで smoke test（`Engine()` → `render_html` → bytes / 長さ検証）
- `workflow_dispatch` で TestPyPI dry-run 可能

**RubyGems (release-ruby.yml)**

- 7 platform × Ruby 3.1-3.4 の precompiled gem（rb_sys cross-gem v7）: linux-gnu / linux-musl (x86_64 + aarch64), darwin (x86_64 + arm64), x64-mingw-ucrt
- source gem
- smoke test: Ruby 3.1 / 3.3 / 3.4 で bottom/top 両端を検証、5 プラットフォーム
- OIDC: `rubygems/configure-rubygems-credentials` + 明示的な `gem push` ループ

## Design decisions

- Trigger chain: `release.yml` → `release: published` で2本の independent workflow が並行起動（Python/Ruby の失敗は独立）
- GitHub Releases にはバインディング artifact を添付しない（PyPI / RubyGems が正）
- secretsレス（Trusted Publishing OIDC）
- 3rd-party action は SHA pin（repo 慣例、`ci.yml` と統一）

## Known limitations / 初回リリース前の運用項目

1. `role-to-assume: rg_oidc_akr_mitsuru_fulgur` は placeholder。RubyGems Trusted Publisher 登録後に実値へ差し替え（file 内 TODO コメント + RELEASE_SETUP.md で明示）
2. PyPI Trusted Publisher / RubyGems OIDC / GitHub Environments (`pypi` / `testpypi` / `rubygems`) の初回登録が必要 → `docs/RELEASE_SETUP.md` 参照
3. RubyGems は TestGems 不在のため dry-run では publish をスキップする。OIDC フローの実検証は初回本番リリース
4. cross-gem-action v7 は node16 ベース（DeprecationWarning が出る可能性、upstream 対応待ち）

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on 4 workflow files
- [x] `cargo check --workspace`（pyfulgur abi3 feature 有効含む）
- [x] `ruby -c crates/fulgur-ruby/fulgur.gemspec`
- [x] `npx markdownlint-cli2` on RELEASE_SETUP.md / README.md / plan doc
- [x] sed patterns in release-prepare.yml match exactly 1 line per target file
- [ ] TestPyPI dry-run via `gh workflow run release-python.yml --field dry_run=true`（Trusted Publisher 登録後）
- [ ] 初回本番リリース: PyPI / RubyGems で publish 検証

## Implementation

11 commits、subagent-driven development で実装。詳細設計は `docs/plans/2026-04-18-publish-ci-pypi-rubygems.md`。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * PyPI 向け自動リリースワークフローを追加（ビルド：wheel/sdist、インストール検証、公開、TestPyPI ドライラン対応）。
  * RubyGems 向け自動リリースワークフローを追加（ソース/事前ビルド、プラットフォーム別検証、公開）。
  * リリース準備ワークフローで Python/Ruby バインディングのバージョン同期対象を拡張。

* **改善**
  * Ruby の最小サポート要件を 3.1 以上に緩和。
  * Python バインディングを abi3 (py39) 対応に更新。

* **ドキュメント**
  * Trusted Publishing 設定や公開手順をまとめたリリースセットアップガイドを追加し、README にリンクを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->