### PR TITLE
fix(fulgur-ruby): use RbSys::ExtensionTask for cross-compile

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -78,6 +78,9 @@ jobs:
           # fulgur-ruby (Ruby binding)
           sed -i "s/^version = \".*\"/version = \"$VERSION\"/" crates/fulgur-ruby/Cargo.toml
           sed -i "s/^version = \".*\"/version = \"$VERSION\"/" crates/fulgur-ruby/ext/fulgur/Cargo.toml
+          # ext/fulgur は fulgur を crates.io 参照 (container mount 外のため path 不可)。
+          # この依存行も sync する必要がある。
+          sed -i "s/^fulgur = \"[^\"]*\"$/fulgur = \"$VERSION\"/" crates/fulgur-ruby/ext/fulgur/Cargo.toml
           sed -i "s/VERSION = \".*\"/VERSION = \"$VERSION\"/" crates/fulgur-ruby/lib/fulgur/version.rb
 
           cargo check --workspace

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -81,6 +81,12 @@ jobs:
           # ext/fulgur は fulgur を crates.io 参照 (container mount 外のため path 不可)。
           # この依存行も sync する必要がある。
           sed -i "s/^fulgur = \"[^\"]*\"$/fulgur = \"$VERSION\"/" crates/fulgur-ruby/ext/fulgur/Cargo.toml
+          # ext 依存は crates.io 公開版を参照する特殊運用のため、
+          # 置換失敗をリリース後まで気づかないと致命的。即時検証でフェイルファスト。
+          grep -Eq "^fulgur = \"$VERSION\"$" crates/fulgur-ruby/ext/fulgur/Cargo.toml || {
+            echo "::error::Failed to sync fulgur dependency version in crates/fulgur-ruby/ext/fulgur/Cargo.toml"
+            exit 1
+          }
           sed -i "s/VERSION = \".*\"/VERSION = \"$VERSION\"/" crates/fulgur-ruby/lib/fulgur/version.rb
 
           cargo check --workspace

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -92,16 +92,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a  # v1.302.0
-        with:
-          ruby-version: "3.3"
-          bundler-cache: true
-          working-directory: crates/fulgur-ruby
-      - uses: oxidize-rb/cross-gem-action@80f59339d90789841d772f412fe4a8b201a8cfa2  # v7
+      # oxidize-rb/actions/cross-gem@v1 は Gemfile.lock の rb_sys バージョンを
+      # 自動検出して対応する rb-sys-dock container image を pull する。
+      # 旧 oxidize-rb/cross-gem-action@v7 は image tag が 0.9.34 固定で
+      # Ruby 3.3/3.4 未対応のため使わない。
+      # Ruby/bundler 環境は action 内で setup されるので事前 setup は不要。
+      - uses: oxidize-rb/actions/cross-gem@e5f9a49a7812a078584072f6e3f657ad247c8771  # v1.4.4
         with:
           platform: ${{ matrix.platform }}
           ruby-versions: "3.1,3.2,3.3,3.4"
-          directory: crates/fulgur-ruby
+          working-directory: crates/fulgur-ruby
       - uses: actions/upload-artifact@v4
         with:
           name: cross-gem-${{ matrix.platform }}

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -100,14 +100,18 @@ jobs:
           ruby-version: "3.3"
           bundler-cache: true
           working-directory: crates/fulgur-ruby
-      # v1 は Gemfile.lock から rb_sys version (0.9.126) を自動検出して対応
-      # image を pull する。旧 cross-gem-action@v7 の image tag 0.9.34 hardcode
-      # は Ruby 3.3/3.4 未対応のため使わない。
+      # Gemfile.lock は .gitignore で除外されているため、action が Gemfile.lock
+      # から rb_sys version を推論できない。そのまま放置すると fallback で
+      # `gem info rb_sys --remote` が最新版を取りに行き、rb-sys-dock image tag
+      # が float してビルド非決定になる。Gemfile の `rb_sys (~> 0.9)` と整合する
+      # 最新 stable (0.9.126) を `tag:` で明示 pin する。
+      # rb_sys upgrade 時はここと Gemfile 側を両方更新すること。
       - uses: oxidize-rb/actions/cross-gem@e5f9a49a7812a078584072f6e3f657ad247c8771  # v1.4.4
         with:
           platform: ${{ matrix.platform }}
           ruby-versions: "3.1,3.2,3.3,3.4"
           working-directory: crates/fulgur-ruby
+          tag: "0.9.126"
       - uses: actions/upload-artifact@v4
         with:
           name: cross-gem-${{ matrix.platform }}

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -61,6 +61,11 @@ jobs:
         shell: bash
         run: |
           shopt -s failglob
+          # rb_sys は gemspec の runtime dependency なので native ext compile
+          # に先行して必要。`gem install --local` は registry fetch を block する
+          # ため dep 解決が失敗する。user 実環境 (`gem install fulgur`) は
+          # rubygems.org から rb_sys を取得するので、smoke もそれを再現する。
+          gem install rb_sys -v "~> 0.9"
           gem install --local pkg/*.gem
       - name: Smoke test
         shell: bash
@@ -88,7 +93,10 @@ jobs:
           - aarch64-linux-musl
           - x86_64-darwin
           - arm64-darwin
-          - x64-mingw-ucrt
+          # NOTE: x64-mingw-ucrt (Windows) は rb-sys-dock image に python3 が
+          # 無く、stylo crate の build.rs が panic するため precompiled 不可
+          # (fulgur-ynu で追跡)。当面 Windows user は source gem install で対応
+          # (`gem install fulgur` → local compile で rb_sys 0.9.x を pull)。
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -140,9 +148,8 @@ jobs:
           - platform: arm64-darwin
             runner: macos-latest
             ruby: "3.3"
-          - platform: x64-mingw-ucrt
-            runner: windows-latest
-            ruby: "3.3"
+          # x64-mingw-ucrt smoke は build を deferred したため skip (上記 matrix
+          # のコメント参照)。
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a  # v1.302.0

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -92,11 +92,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # oxidize-rb/actions/cross-gem@v1 は Gemfile.lock の rb_sys バージョンを
-      # 自動検出して対応する rb-sys-dock container image を pull する。
-      # 旧 oxidize-rb/cross-gem-action@v7 は image tag が 0.9.34 固定で
-      # Ruby 3.3/3.4 未対応のため使わない。
-      # Ruby/bundler 環境は action 内で setup されるので事前 setup は不要。
+      # oxidize-rb/actions/cross-gem@v1 は `gem install rb_sys` を host 上で
+      # 直接実行するので、user-writable な gem directory を持つ Ruby が必要。
+      # 事前に ruby/setup-ruby で runner owned の Ruby を入れておく。
+      - uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a  # v1.302.0
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: crates/fulgur-ruby
+      # v1 は Gemfile.lock から rb_sys version (0.9.126) を自動検出して対応
+      # image を pull する。旧 cross-gem-action@v7 の image tag 0.9.34 hardcode
+      # は Ruby 3.3/3.4 未対応のため使わない。
       - uses: oxidize-rb/actions/cross-gem@e5f9a49a7812a078584072f6e3f657ad247c8771  # v1.4.4
         with:
           platform: ${{ matrix.platform }}

--- a/crates/fulgur-ruby/Cargo.toml
+++ b/crates/fulgur-ruby/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
 name = "fulgur-ruby"
 version = "0.0.1"
-edition.workspace = true
-rust-version.workspace = true
-license.workspace = true
-repository.workspace = true
-homepage.workspace = true
+# rb_sys cross-gem-action は `directory: crates/fulgur-ruby` のみをコンテナに
+# マウントするため、この Cargo.toml は workspace root 不在でも cargo metadata
+# を解決できる必要がある。したがって workspace 継承 (`.workspace = true`) は
+# 使わず、値は root Cargo.toml [workspace.package] と同期させて inline する。
+edition = "2024"
+rust-version = "1.85.0"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/mitsuru/fulgur"
+homepage = "https://github.com/mitsuru/fulgur"
 description = "Ruby bindings for fulgur — offline HTML/CSS to PDF conversion"
 publish = false
 

--- a/crates/fulgur-ruby/Rakefile
+++ b/crates/fulgur-ruby/Rakefile
@@ -33,4 +33,8 @@ Rake::ExtensionTask.new("fulgur", fulgur_gemspec) do |ext|
   ext.cross_platform = [ENV["RUBY_TARGET"]].compact
 end
 
-task default: %i[compile spec]
+# spec タスクは rspec guard と連動して条件付きで default に含める。
+# rb-sys-dock container など rspec 未 install 環境では spec を除外する。
+default_tasks = [:compile]
+default_tasks << :spec if Rake::Task.task_defined?(:spec)
+task default: default_tasks

--- a/crates/fulgur-ruby/Rakefile
+++ b/crates/fulgur-ruby/Rakefile
@@ -1,20 +1,31 @@
 # frozen_string_literal: true
 
 require "bundler/gem_tasks"
-require "rb_sys/extensiontask"
+require "rake/extensiontask"
 require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-gemspec = Gem::Specification.load("fulgur.gemspec")
-
-# RbSys::ExtensionTask extends Rake::ExtensionTask with rb-sys-dock integration.
-# cross_compile / cross_platform は RUBY_TARGET 環境変数から自動設定される
-# (oxidize-rb/cross-gem-action が rake-compiler-dock 内で設定する)。
-# これにより `rake native:<platform>` タスクが動的に生成される。
-RbSys::ExtensionTask.new("fulgur", gemspec) do |ext|
+# Rake::ExtensionTask with explicit cross_compile + cross_platform.
+# RbSys::ExtensionTask は cargo metadata inference が dual-Cargo.toml (ext/fulgur と
+# crates/fulgur-ruby で package 名が異なる) に合わず使えない。Rake::ExtensionTask は
+# metadata inference をせず、ext/fulgur/extconf.rb が生成する Makefile 経由で cargo を
+# 呼ぶ設計なので、cross-gem-action + rake-compiler-dock 環境下で native:<platform>
+# タスクが動く。
+# cross_platform は release-ruby.yml の build-precompiled マトリクスと一致させること。
+Rake::ExtensionTask.new("fulgur") do |ext|
   ext.lib_dir = "lib/fulgur"
   ext.source_pattern = "*.{rs,toml}"
+  ext.cross_compile = true
+  ext.cross_platform = %w[
+    x86_64-linux
+    x86_64-linux-musl
+    aarch64-linux
+    aarch64-linux-musl
+    x86_64-darwin
+    arm64-darwin
+    x64-mingw-ucrt
+  ]
 end
 
 task default: %i[compile spec]

--- a/crates/fulgur-ruby/Rakefile
+++ b/crates/fulgur-ruby/Rakefile
@@ -1,12 +1,18 @@
 # frozen_string_literal: true
 
 require "bundler/gem_tasks"
-require "rake/extensiontask"
+require "rb_sys/extensiontask"
 require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-Rake::ExtensionTask.new("fulgur") do |ext|
+gemspec = Gem::Specification.load("fulgur.gemspec")
+
+# RbSys::ExtensionTask extends Rake::ExtensionTask with rb-sys-dock integration.
+# cross_compile / cross_platform は RUBY_TARGET 環境変数から自動設定される
+# (oxidize-rb/cross-gem-action が rake-compiler-dock 内で設定する)。
+# これにより `rake native:<platform>` タスクが動的に生成される。
+RbSys::ExtensionTask.new("fulgur", gemspec) do |ext|
   ext.lib_dir = "lib/fulgur"
   ext.source_pattern = "*.{rs,toml}"
 end

--- a/crates/fulgur-ruby/Rakefile
+++ b/crates/fulgur-ruby/Rakefile
@@ -2,30 +2,35 @@
 
 require "bundler/gem_tasks"
 require "rake/extensiontask"
-require "rspec/core/rake_task"
 
-RSpec::Core::RakeTask.new(:spec)
+# rb-sys-dock container には rspec 系 gem が入っていない場合があるため、
+# rspec が解決できない環境でも compile タスクが定義されるように guard する。
+begin
+  require "rspec/core/rake_task"
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
+  # rspec なし環境 (rb-sys-dock container など) では spec タスクを skip。
+end
 
-# Rake::ExtensionTask with explicit cross_compile + cross_platform.
+# Rake::ExtensionTask with dynamic cross_compile from RUBY_TARGET env var.
 # RbSys::ExtensionTask は cargo metadata inference が dual-Cargo.toml (ext/fulgur と
-# crates/fulgur-ruby で package 名が異なる) に合わず使えない。Rake::ExtensionTask は
-# metadata inference をせず、ext/fulgur/extconf.rb が生成する Makefile 経由で cargo を
-# 呼ぶ設計なので、cross-gem-action + rake-compiler-dock 環境下で native:<platform>
-# タスクが動く。
-# cross_platform は release-ruby.yml の build-precompiled マトリクスと一致させること。
-Rake::ExtensionTask.new("fulgur") do |ext|
+# crates/fulgur-ruby で package 名が異なる) に合わず使えないため、Rake::ExtensionTask
+# を使いつつ cross-compile 動作だけ RbSys 同等のパターンで再現する:
+# rb-sys-dock container は --platform で指定された 1 platform のみについて rbconfig
+# を持つため、cross_platform にそれ以外の platform を並べると rake-compiler が
+# rbconfig enumeration で失敗する (rbconfig-<plat>-<ruby> no configuration section)。
+# 対策として RbSys::ExtensionTask と同様に ENV["RUBY_TARGET"] (rb-sys-dock が
+# container 起動時に設定) から 1 platform のみを登録する。
+# rake-compiler の native:<platform> cross-compile task は @gem_spec が設定されて
+# いないと生成されないため、gemspec を明示的に load して渡す。
+# (bundler/gem_tasks は Rake::ExtensionTask に gemspec を注入しない)
+fulgur_gemspec = Gem::Specification.load("fulgur.gemspec")
+
+Rake::ExtensionTask.new("fulgur", fulgur_gemspec) do |ext|
   ext.lib_dir = "lib/fulgur"
   ext.source_pattern = "*.{rs,toml}"
-  ext.cross_compile = true
-  ext.cross_platform = %w[
-    x86_64-linux
-    x86_64-linux-musl
-    aarch64-linux
-    aarch64-linux-musl
-    x86_64-darwin
-    arm64-darwin
-    x64-mingw-ucrt
-  ]
+  ext.cross_compile = ENV.key?("RUBY_TARGET")
+  ext.cross_platform = [ENV["RUBY_TARGET"]].compact
 end
 
 task default: %i[compile spec]

--- a/crates/fulgur-ruby/Rakefile
+++ b/crates/fulgur-ruby/Rakefile
@@ -31,6 +31,19 @@ Rake::ExtensionTask.new("fulgur", fulgur_gemspec) do |ext|
   ext.source_pattern = "*.{rs,toml}"
   ext.cross_compile = ENV.key?("RUBY_TARGET")
   ext.cross_platform = [ENV["RUBY_TARGET"]].compact
+
+  # Precompiled (native) gem では rb_sys は不要 (compile-time dep のみ)。
+  # 宣言したままだと `gem install --local fulgur-*.gem` が registry 無しで
+  # rb_sys を解決できず失敗する。RbSys::ExtensionTask が内部で同じ処理を
+  # しているのを移植。*.rs / Cargo.toml / Cargo.lock / extconf.rb は
+  # native gem に含めない (user は build 済みバイナリしか使わない)。
+  ext.cross_compiling do |native_spec|
+    native_spec.dependencies.reject! { |d| d.name == "rb_sys" }
+    native_spec.files.reject! { |f| f.end_with?(".rs") }
+    native_spec.files.reject! { |f| f.match?(/Cargo\.(toml|lock)\z/) }
+    native_spec.files.reject! { |f| f.end_with?("extconf.rb") }
+    native_spec.extensions.reject! { |f| f.end_with?("Cargo.toml") || f.end_with?("extconf.rb") }
+  end
 end
 
 # spec タスクは rspec guard と連動して条件付きで default に含める。

--- a/crates/fulgur-ruby/ext/fulgur/Cargo.toml
+++ b/crates/fulgur-ruby/ext/fulgur/Cargo.toml
@@ -15,7 +15,12 @@ default = ["ruby-api"]
 ruby-api = ["dep:magnus", "dep:rb-sys"]
 
 [dependencies]
-fulgur = { path = "../../../fulgur" }
+# cross-gem-action は `directory: crates/fulgur-ruby` しか container にマウントしない
+# ため、`path = "../../../fulgur"` では cargo がパスを解決できない。crates.io 公開版
+# を参照する (release 時は release.yml → release: published → release-ruby.yml の順で
+# 発火するため、この時点で fulgur のバージョンは crates.io に存在する)。
+# release-prepare.yml が sed でこの行のバージョンを同期する。
+fulgur = "0.4.5"
 base64 = "0.22"
 magnus = { version = "0.7", optional = true }
 rb-sys = { version = "0.9", optional = true }

--- a/crates/fulgur-ruby/ext/fulgur/Cargo.toml
+++ b/crates/fulgur-ruby/ext/fulgur/Cargo.toml
@@ -3,7 +3,9 @@
 [package]
 name = "fulgur"
 version = "0.0.1"
-edition = "2021"
+# crates/fulgur-ruby/Cargo.toml と同じ src を共有 (path = "../../src/lib.rs")。
+# workspace と同じ edition 2024 に揃える。
+edition = "2024"
 
 [lib]
 name = "fulgur"

--- a/crates/fulgur-ruby/src/asset_bundle.rs
+++ b/crates/fulgur-ruby/src/asset_bundle.rs
@@ -5,7 +5,8 @@
 //! `AssetBundle::new()` に差し替える。
 
 use crate::error::map_fulgur_error;
-use fulgur::AssetBundle;
+// `fulgur::AssetBundle` root re-export は 0.4.5 には存在しないため full path で参照。
+use fulgur::asset::AssetBundle;
 use magnus::{Error, Module, RModule, RString, Ruby, function, method, prelude::*};
 use std::cell::RefCell;
 use std::path::PathBuf;

--- a/crates/fulgur-ruby/src/lib.rs
+++ b/crates/fulgur-ruby/src/lib.rs
@@ -22,7 +22,10 @@ mod pdf;
 mod assertions {
     use static_assertions::assert_impl_all;
     assert_impl_all!(fulgur::Engine: Send, Sync);
-    assert_impl_all!(fulgur::AssetBundle: Send, Sync);
+    // `fulgur::AssetBundle` (root re-export) は 0.4.5 には存在せず HEAD のみ。
+    // release-ruby は crates.io の ext 依存 (0.4.5 時点では 0.4.5) を使うため、
+    // full path `fulgur::asset::AssetBundle` を参照して前方互換を保つ。
+    assert_impl_all!(fulgur::asset::AssetBundle: Send, Sync);
 }
 
 #[magnus::init]


### PR DESCRIPTION
## Summary

`release-ruby.yml` の `build-precompiled` job が初回実行で `rake aborted! Don't know how to build task 'native:x86_64-darwin'` で失敗 (run [24598802230](https://github.com/mitsuru/fulgur/actions/runs/24598802230))。

原因: Rakefile が `Rake::ExtensionTask` を直接使っており、`cross_compile` が常に false なので `define_cross_platform_tasks` が動かず、`native:<platform>` タスクが生成されない。

修正: `RbSys::ExtensionTask` (`oxidize-rb/oxi-test` などの標準パターン) に切り替え。`rb_sys` の `init()` が `@cross_compile = ENV.key?(\"RUBY_TARGET\")` を自動設定するので、`cross-gem-action` が container 内で `RUBY_TARGET` を設定した際に native タスクが動的に生成される。

## Changes

- `crates/fulgur-ruby/Rakefile`: `Rake::ExtensionTask` → `RbSys::ExtensionTask` に切替、`gemspec` を渡す

## Test plan

- [x] Local `bundle exec rake -T` で `compile` / `spec` / `build` タスクが従来通り存在することを確認
- [x] `RUBY_TARGET` なしでも既存の MVP workflow (local compile/spec) が壊れないこと確認
- [ ] PR merge 後に \`gh workflow run release-ruby.yml\` で build-precompiled が通ることを確認

## 参考

- rb_sys ExtensionTask source: https://github.com/oxidize-rb/rb-sys/blob/main/gem/lib/rb_sys/extensiontask.rb
- Reference implementation: https://github.com/oxidize-rb/oxi-test/blob/main/Rakefile
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **ビルド/ネイティブ拡張**
  * クロスコンパイル設定を環境変数に基づき限定化し、ターゲット指定を明確化しました。
* **パッケージ/依存関係**
  * クレートのパッケージ情報を自己完結化し、内部パス依存を公開版（crates.io）バージョンへ切替えました。
* **テスト**
  * テストタスクはrspecが利用可能な場合のみ定義されるよう条件化しました（既定のワイヤリングは維持）。
* **リリース/CIワークフロー**
  * リリース準備で依存バージョンも同期するよう拡張し、Ruby向けビルドで新しいアクションと作業ディレクトリ指定に切替えました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->