### PR TITLE
ci(release): publish GitHub Release with App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,9 +135,20 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      # GITHUB_TOKEN で発火した release:published は別 workflow を起動しない
+      # (無限ループ防止仕様)。release-python.yml / release-ruby.yml を連鎖発火
+      # させるため、App token で publish する。
+      # 手順は docs/RELEASE_SETUP.md を参照。
+      - name: Generate App token for release publish
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Upload binaries and publish release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           VERSION="${{ needs.publish.outputs.version }}"
           REPO="${{ github.repository }}"
@@ -149,6 +160,6 @@ jobs:
               --draft \
               --repo "$REPO"
           fi
-          # Upload binaries and publish
+          # Upload binaries and publish (App token → release:published が連鎖発火)
           gh release upload "v$VERSION" artifacts/* --repo "$REPO"
           gh release edit "v$VERSION" --draft=false --repo "$REPO"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
     name: Publish to crates.io
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
+    # tag push / crates.io publish は irreversible なので required_reviewers で gate する。
+    # Environment `release` に reviewers を設定すること (docs/RELEASE_SETUP.md)。
+    environment: release
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,5 +164,6 @@ jobs:
               --repo "$REPO"
           fi
           # Upload binaries and publish (App token → release:published が連鎖発火)
-          gh release upload "v$VERSION" artifacts/* --repo "$REPO"
+          # --clobber: approval gate reject 等での re-run 時に同名 asset を上書き
+          gh release upload "v$VERSION" artifacts/* --clobber --repo "$REPO"
           gh release edit "v$VERSION" --draft=false --repo "$REPO"

--- a/docs/RELEASE_SETUP.md
+++ b/docs/RELEASE_SETUP.md
@@ -73,10 +73,47 @@ OIDC claim (repo + workflow + environment) で自動照合されるため、`rol
 
 保護ルール不要 (OIDC claim で scope されるため)。
 
+## GitHub App (release publisher)
+
+`release.yml` の最終 `gh release edit --draft=false` は `release:published` イベントを
+発火させ、`release-python.yml` / `release-ruby.yml` を連鎖起動する。しかし GitHub の
+無限ループ防止仕様により **`GITHUB_TOKEN` で発火したイベントは別 workflow を起動しない**
+([docs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow))。
+そのため GitHub App token で publish する必要がある。
+
+### App 作成手順
+
+1. <https://github.com/settings/apps/new> で新規 App を作成 (個人アカウント所有でも可)
+   - GitHub App name: `fulgur-release-bot` 等 (任意・グローバル一意)
+   - Homepage URL: 任意 (例: リポジトリ URL)
+   - Webhook: "Active" のチェックを外す
+   - Repository permissions:
+     - **Contents: Read and write** (release 作成・編集に必要)
+   - Where can this GitHub App be installed?: "Only on this account"
+2. 作成後の App 設定画面で:
+   - **App ID** を控える (数値)
+   - **Private keys** → "Generate a private key" で `.pem` をダウンロード
+3. 左メニュー "Install App" から対象リポジトリ (`mitsuru/fulgur`) に install
+   - "Only select repositories" で fulgur のみに限定
+
+### リポジトリ secrets に登録
+
+Settings → Secrets and variables → Actions → New repository secret:
+
+- `RELEASE_APP_ID`: 上記 App ID (数値)
+- `RELEASE_APP_PRIVATE_KEY`: ダウンロードした `.pem` ファイルの内容全体
+  (`-----BEGIN RSA PRIVATE KEY-----` から `-----END RSA PRIVATE KEY-----` まで)
+
+### 動作確認
+
+次回 release で GitHub Actions の `release.yml` → `release` job が成功したあと、
+Actions タブで `release-python.yml` / `release-ruby.yml` が自動的に `release` イベントで
+起動することを確認する。
+
 ## Release 手順
 
 1. `release-prepare.yml` を `workflow_dispatch` で起動 (version 入力)
 2. 作成された `release/vX.Y.Z` PR を merge
-3. `release.yml` が tag + crates.io publish + GitHub Release publish
+3. `release.yml` が tag + crates.io publish + GitHub Release publish (App token)
 4. `release: published` で `release-python.yml` と `release-ruby.yml` が並行発火
 5. 数分〜十数分後に PyPI / RubyGems へ反映

--- a/docs/RELEASE_SETUP.md
+++ b/docs/RELEASE_SETUP.md
@@ -65,13 +65,35 @@ OIDC claim (repo + workflow + environment) で自動照合されるため、`rol
 
 ## GitHub Environments
 
-以下の 3 つの Environment を作成:
+以下の Environment を作成:
 
-- `pypi`
+- `release` — crates.io / GitHub Release publish を gate する
+- `pypi` — PyPI publish を gate する
 - `testpypi` (dry-run 用)
-- `rubygems`
+- `rubygems` — RubyGems publish を gate する
 
-保護ルール不要 (OIDC claim で scope されるため)。
+### Required reviewers (approval gate)
+
+release は irreversible 操作が多いため、`release` / `pypi` / `rubygems` の
+3 環境すべてで **Required reviewers** を設定する (`testpypi` は dry-run のため不要)。
+
+各 Environment の設定画面 (Settings → Environments → `<name>`) で:
+
+- "Required reviewers" にチェック
+- reviewer として自分 (および必要ならリリース権限を持つ共同メンテナ) を追加
+
+3 段ゲートになるため、release flow で:
+
+1. PR merge → `release.yml` の `publish` job が `release` env で pause → 承認
+2. crates.io + tag push + GitHub Release publish が完走 (App token で `release:published` 発火)
+3. `release-python.yml` の `publish` job が `pypi` env で pause → 承認
+4. `release-ruby.yml` の `publish` job が `rubygems` env で pause → 承認
+5. PyPI / RubyGems へ反映
+
+途中で publish job が失敗した際の re-run も承認を経由する。
+
+OIDC claim による scope (repo + workflow + environment) は reviewer 設定と独立して
+機能するため、両方併用してよい。
 
 ## GitHub App (release publisher)
 


### PR DESCRIPTION
## Summary

- `GITHUB_TOKEN` で発火した `release:published` event は別 workflow を起動しない ([GitHub 無限ループ防止仕様](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)) ため、`release-python.yml` / `release-ruby.yml` の OIDC publish job が連鎖しない問題を修正
- `actions/create-github-app-token@v2` で App token を取得、`gh release create/upload/edit` を App token で実行するように変更
- `docs/RELEASE_SETUP.md` に GitHub App 作成・install・secrets 登録手順を追記

## Background

v0.5.0 release 時、release.yml の最終 `gh release edit --draft=false` が GITHUB_TOKEN で実行されたため `release:published` が発火せず、PyPI / RubyGems の OIDC publish がトリガされなかった (run: [24601177094](https://github.com/mitsuru/fulgur/actions/runs/24601177094))。暫定復旧として user token での `gh release edit --draft` トグルで対応した。

Refs: fulgur-j41

## Required Setup (既に完了)

- GitHub App `fulgur-release-bot` 作成 (App ID: `3419957`, `contents: write` 権限)
- App を `mitsuru/fulgur` に install
- Secrets 登録:
  - `RELEASE_APP_ID`
  - `RELEASE_APP_PRIVATE_KEY`

## Test plan

- [ ] Merge 後、次 release (v0.5.1 以降) で `release.yml` → `release` job が App token で publish されることを確認
- [ ] `release-python.yml` / `release-ruby.yml` が `release:published` で自動起動することを確認
- [ ] PyPI / RubyGems に自動 publish されることを確認
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mitsuru/fulgur/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * リリース手順を更新：専用の「release」環境と手動承認ゲートの導入、pypi/rubygems 含む多段承認フローを明記。GitHub Appトークンの導入手順と必要なシークレット／確認手順を追記。

* **Chores**
  * 公開ワークフローの認証を App トークンへ切替え。リリース公開時の再実行で同名アセットを上書きできるよう改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->