### PR TITLE
docs: clarify fd 1 policy per crate, document stdout noise in pyfulgur

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,12 +87,29 @@ callers don't get this guarantee by default — see the tracking issue
   `docs/plans/2026-04-11-blitz-thread-safety-investigation.md` for the full
   root-cause analysis.
 - **Blitz prints html5ever parse errors via `println!` to stdout** during
-  `TreeSink::finish`. This is noise from dependencies, not fulgur. Library
-  callers that need clean stdout must redirect fd 1 at their own call site —
-  `fulgur-cli` does this via `StdoutIsolator` for the render command so the
-  `-o -` mode does not corrupt PDF output. Multi-threaded callers must not
-  manipulate fd 1 process-wide; there is no thread-safe way to suppress
-  blitz's output in-process short of an upstream patch.
+  `TreeSink::finish`. This is noise from dependencies, not fulgur.
+  Policy by crate:
+  - **`crates/fulgur` (core library)** must not touch fd 1 under any
+    circumstance. `blitz_adapter::suppress_stdout` was removed for this
+    reason (see
+    `docs/plans/2026-04-11-blitz-thread-safety-investigation.md`).
+  - **`crates/fulgur-cli`** is single-threaded during render and may
+    manipulate fd 1 via `StdoutIsolator` — this is required for
+    correctness (`-o -` writes PDF bytes to stdout; any noise corrupts
+    the stream).
+  - **`crates/pyfulgur`, `crates/fulgur-ruby`** are multi-threaded
+    bindings. They must not manipulate fd 1 either: a global suppress
+    mutex still races with `suppress=false` callers on the same process,
+    and PDF bytes are returned via the function return value (not
+    stdout), so noise is cosmetic, not a correctness issue. The
+    canonical workaround for binding users is redirection at their own
+    call site (e.g. `os.dup2` / `contextlib.redirect_stdout`) or running
+    renders in a subprocess (`multiprocessing`). A future wrapper-style
+    package that shells out to the CLI is on the roadmap for users who
+    want clean stdout without doing this themselves.
+  - Short version: **touch fd 1 only from a crate that can guarantee
+    single-threaded semantics**. That's CLI today; bindings are
+    multi-threaded by design and must leave fd 1 alone.
 - Use `BTreeMap` (not `HashMap`) for iteration that affects PDF output (determinism)
 - Blitz: `!important` unreliable, `padding-top` on inline roots ignored (use `margin-top`)
 - `cargo fmt --check` enforced by CI

--- a/crates/pyfulgur/README.md
+++ b/crates/pyfulgur/README.md
@@ -59,7 +59,7 @@ engine.render_html_to_file("<h1>Hi</h1>", "out.pdf")
 
 ## Known limitation: blitz parse-error noise on stdout
 
-The underlying `blitz-dom` parser writes non-fatal html5ever parse errors directly to the process's stdout via `println!` — even for well-formed HTML. In Jupyter notebooks or test output, those lines appear as `ERROR: ...` noise alongside your own output. The PDF bytes returned by `render_html` are **not** affected; only the caller's terminal is polluted.
+The underlying `blitz-dom` parser writes non-fatal html5ever parse errors directly to the process's stdout via `println!`. These fire for browser-tolerated but technically invalid HTML — documents without a `<!DOCTYPE>`, missing `<html>`/`<body>` wrappers, or structural quirks that browsers silently auto-correct — and show up as `ERROR: ...` noise in Jupyter notebooks or any environment that captures stdout. The PDF bytes returned by `render_html` are **not** affected; only the caller's terminal is polluted.
 
 pyfulgur intentionally does **not** redirect fd 1 from inside the binding: process-wide fd manipulation in a multi-threaded library context races with concurrent `render_html` calls from other threads (mixed suppress / non-suppress callers would silently lose stdout during a suppressed window). Correctness and parallelism take priority over cosmetic stdout cleanliness.
 

--- a/crates/pyfulgur/README.md
+++ b/crates/pyfulgur/README.md
@@ -57,6 +57,20 @@ engine.render_html_to_file("<h1>Hi</h1>", "out.pdf")
 - `Margin`: `Margin(top, right, bottom, left)`, `Margin.uniform(pt)`, `Margin.symmetric(v, h)`, `Margin.uniform_mm(mm)`
 - Exceptions: `FileNotFoundError`, `ValueError`, `pyfulgur.RenderError`
 
+## Known limitation: blitz parse-error noise on stdout
+
+The underlying `blitz-dom` parser writes non-fatal html5ever parse errors directly to the process's stdout via `println!` — even for well-formed HTML. In Jupyter notebooks or test output, those lines appear as `ERROR: ...` noise alongside your own output. The PDF bytes returned by `render_html` are **not** affected; only the caller's terminal is polluted.
+
+pyfulgur intentionally does **not** redirect fd 1 from inside the binding: process-wide fd manipulation in a multi-threaded library context races with concurrent `render_html` calls from other threads (mixed suppress / non-suppress callers would silently lose stdout during a suppressed window). Correctness and parallelism take priority over cosmetic stdout cleanliness.
+
+If you need clean stdout:
+
+- **Redirect at the caller side** with a Python `contextlib.redirect_stdout` for Python-level writes, or `os.dup2` for fd-level writes. This keeps the fd manipulation scoped to your own call site where you can guarantee single-threaded use.
+- **Run renders in a subprocess** via `multiprocessing` (each worker has its own fd 1).
+- **Use the `fulgur` CLI** (which handles stdout isolation internally) invoked via `subprocess.run` when cold-start cost is acceptable.
+
+A wrapper-style Python package that shells out to the `fulgur` CLI (clean stdout, parallel via process isolation, no native build required) is on the roadmap as a complement to this native binding.
+
 ## Links
 
 - [fulgur on GitHub](https://github.com/mitsuru/fulgur)


### PR DESCRIPTION
## Summary

- CLAUDE.md の "Blitz prints html5ever parse errors" note を crate 単位のポリシーに書き直し
  - `crates/fulgur` (core): fd 1 に触らない
  - `crates/fulgur-cli`: 単一スレッドなので touch 可 (StdoutIsolator で `-o -` correctness を守る)
  - `crates/pyfulgur` / `crates/fulgur-ruby`: multi-threaded binding なので触らない (mixed-mode で race、PDF は return value 経由で stdout 経由ではないため noise は correctness に無関係)
- `crates/pyfulgur/README.md` に known limitation として blitz noise を明記、利用者側の対処オプション (contextlib / os.dup2 / multiprocessing / CLI subprocess) を記載
- wrapper-style Python package が roadmap にある旨も記載

## 経緯

当初は opt-in `suppress_stdout` フラグを追加する方針だったが、Devin review (https://github.com/mitsuru/fulgur/pull/106#discussion_r3105012749) で mixed-mode race を指摘され、以下の検討を経て機能撤去 + policy 明文化に舵を切った:

1. binding では PDF が return value で返るため、noise は cosmetic 問題 (CLI と違い correctness 問題ではない)
2. fd 1 操作はプロセス全体に影響するため、multi-threaded binding では suppress=True と False が同居すると race する
3. wrapper-style binding (CLI をサブプロセス起動) は将来 roadmap にあり、clean stdout が欲しい利用者はそちらで救われる見込み
4. 上記を踏まえ、native binding では noise を許容し policy を明文化する

Refs: fulgur-twv

## Test plan

- [x] CLAUDE.md / README.md の markdownlint 通過
- [x] cargo build -p pyfulgur 通過 (機能コードは main 準拠で変更なし)
- [x] pyfulgur pytest 通過 (45 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * stdout ノイズに関する既知の制限事項と影響（PDF バイト列自体は影響を受けない点）を明確化しました。
  * Python の標準出力リダイレクション、マルチプロセス実行、CLI 経由呼び出しなどの回避策を整理し推奨方法を提示しました。
  * どのコンポーネントがプロセス標準出力を操作できるかという方針を明示し、将来的なラッパーパッケージでの CLI 呼び出し案を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->