### PR TITLE
ci: upload coverage to Codecov alongside octocov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - run: cargo clippy --workspace --all-targets -- -D warnings
 
   test:
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       matrix:
         include:
@@ -72,6 +75,7 @@ jobs:
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           files: lcov.info
+          use_oidc: true
           fail_ci_if_error: false
 
   vrt:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,12 @@ jobs:
           name: lcov
           path: lcov.info
           if-no-files-found: error
+      - name: Upload coverage to Codecov
+        if: matrix.coverage
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
 
   vrt:
     name: Visual Regression Tests

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Fulgur
 
+[![codecov](https://codecov.io/gh/fulgur-rs/fulgur/graph/badge.svg)](https://codecov.io/gh/fulgur-rs/fulgur)
 [![Coverage](https://raw.githubusercontent.com/mitsuru/octocovs/main/badges/mitsuru/fulgur/coverage.svg)](https://github.com/mitsuru/octocovs)
 [![Code to Test Ratio](https://raw.githubusercontent.com/mitsuru/octocovs/main/badges/mitsuru/fulgur/ratio.svg)](https://github.com/mitsuru/octocovs)
 [![Test Execution Time](https://raw.githubusercontent.com/mitsuru/octocovs/main/badges/mitsuru/fulgur/time.svg)](https://github.com/mitsuru/octocovs)


### PR DESCRIPTION
## Summary

- `test` jobで`cargo llvm-cov`が生成する`lcov.info`を、既存のartifact uploadに加えて[Codecov](https://codecov.io)にもアップロードする。
- Public repo のため tokenless で動作（`CODECOV_TOKEN`不要）。
- `fail_ci_if_error: false` でCodecov側障害時にCIを落とさない。
- octocov（code-to-test ratio / 実行時間 / PRコメント）は従来通り併存。
- READMEに Codecov バッジを追加（既存のoctocov群の先頭）。

## Test plan

- [ ] CIでCodecovアップロード step が成功することを確認
- [ ] 初回実行後、https://app.codecov.io/gh/fulgur-rs/fulgur でカバレッジが可視化されることを確認
- [ ] READMEのCodecovバッジが正しく表示されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now uploads test coverage reports to Codecov (configured to use short-lived credentials and tolerate upload errors) so coverage is tracked automatically per build.
  * Added a Codecov coverage badge to the README for visible coverage status alongside existing badges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->