### PR TITLE
ci: enable Codecov Test Analytics via nextest JUnit output

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.ci.junit]
+path = "junit.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Install cargo-llvm-cov
         if: matrix.coverage
         uses: taiki-e/install-action@88ada01c46e65c47040a0ae865537cc76fcd0e1c # cargo-llvm-cov
+      - name: Install cargo-nextest
+        if: matrix.coverage
+        uses: taiki-e/install-action@dfd6a81ff1efc1c100332d760e0c9edfe2ae0a51 # nextest
       - name: Build tests
         if: ${{ !matrix.coverage }}
         run: cargo test --workspace --exclude fulgur-vrt --no-run
@@ -62,7 +65,7 @@ jobs:
         run: cargo test --workspace --exclude fulgur-vrt
       - name: Run tests with coverage
         if: matrix.coverage
-        run: cargo llvm-cov --workspace --exclude fulgur-vrt --lcov --output-path lcov.info
+        run: cargo llvm-cov nextest --workspace --exclude fulgur-vrt --profile ci --lcov --output-path lcov.info
       - name: Upload coverage artifact
         if: matrix.coverage
         uses: actions/upload-artifact@v4
@@ -75,6 +78,13 @@ jobs:
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           files: lcov.info
+          use_oidc: true
+          fail_ci_if_error: false
+      - name: Upload test results to Codecov
+        if: ${{ matrix.coverage && !cancelled() }}
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        with:
+          files: target/nextest/ci/junit.xml
           use_oidc: true
           fail_ci_if_error: false
 


### PR DESCRIPTION
## Summary

- カバレッジマトリクスのテスト実行を `cargo test` → `cargo llvm-cov nextest --profile ci` に切り替え、JUnit XML (`target/nextest/ci/junit.xml`) を生成する。
- `codecov/test-results-action` (OIDC) で JUnit XML を Codecov にアップロードし、**Test Analytics**（flaky/slow/failing テスト可視化）を有効化する。
- `.config/nextest.toml` を新規追加（`ci` プロファイルで JUnit 出力）。
- 影響範囲は `ubuntu-latest` amd64（coverage有効platform）のみ。他のマトリクスエントリは `cargo test` のまま。

## Test plan

- [ ] CIで `Install cargo-nextest` step が成功
- [ ] `Run tests with coverage` step で JUnit XML が `target/nextest/ci/junit.xml` に生成される
- [ ] `Upload test results to Codecov` step が OIDC で成功
- [ ] https://app.codecov.io/gh/fulgur-rs/fulgur → **Tests** タブに test 実行結果が反映される
- [ ] Coverage upload（既存）も引き続き機能することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved continuous integration configuration for test result tracking and coverage analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->