### PR TITLE
deps(pyfulgur): upgrade pyo3 0.22 → 0.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,15 +1760,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2084,15 +2075,6 @@ name = "memo-map"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mime"
@@ -2497,37 +2479,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2535,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2547,9 +2524,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3424,9 +3401,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -3822,12 +3799,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "url"

--- a/crates/pyfulgur/Cargo.toml
+++ b/crates/pyfulgur/Cargo.toml
@@ -21,7 +21,7 @@ extension-module = ["dep:pyo3", "pyo3/extension-module"]
 
 [dependencies]
 fulgur = { path = "../fulgur" }
-pyo3 = { version = "0.22", optional = true, features = ["abi3-py39"] }
+pyo3 = { version = "0.28", optional = true, features = ["abi3-py39"] }
 
 [dev-dependencies]
 static_assertions = "1.1"

--- a/crates/pyfulgur/pyproject.toml
+++ b/crates/pyfulgur/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=1.7,<2.0"]
+requires = ["maturin>=1.9.4,<2.0"]
 build-backend = "maturin"
 
 [project]

--- a/crates/pyfulgur/src/engine.rs
+++ b/crates/pyfulgur/src/engine.rs
@@ -176,13 +176,13 @@ impl PyEngine {
         // assert_impl_all! で compile time に検査している。Python スレッドから
         // 並列で render できるよう、GIL を解放してから呼ぶ。
         let bytes = py
-            .allow_threads(|| self.inner.render_html(&html))
+            .detach(|| self.inner.render_html(&html))
             .map_err(crate::error::map_fulgur_error)?;
-        Ok(PyBytes::new_bound(py, &bytes))
+        Ok(PyBytes::new(py, &bytes))
     }
 
     fn render_html_to_file(&self, py: Python<'_>, html: String, path: PathBuf) -> PyResult<()> {
-        py.allow_threads(|| self.inner.render_html_to_file(&html, &path))
+        py.detach(|| self.inner.render_html_to_file(&html, &path))
             .map_err(crate::error::map_fulgur_error)
     }
 }

--- a/crates/pyfulgur/src/error.rs
+++ b/crates/pyfulgur/src/error.rs
@@ -22,6 +22,6 @@ pub fn map_fulgur_error(err: FulgurError) -> PyErr {
 }
 
 pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add("RenderError", m.py().get_type_bound::<RenderError>())?;
+    m.add("RenderError", m.py().get_type::<RenderError>())?;
     Ok(())
 }

--- a/crates/pyfulgur/src/margin.rs
+++ b/crates/pyfulgur/src/margin.rs
@@ -1,7 +1,7 @@
 use fulgur::Margin;
 use pyo3::prelude::*;
 
-#[pyclass(name = "Margin", module = "pyfulgur", frozen)]
+#[pyclass(name = "Margin", module = "pyfulgur", frozen, from_py_object)]
 #[derive(Clone, Copy)]
 pub struct PyMargin {
     pub(crate) inner: Margin,

--- a/crates/pyfulgur/src/page_size.rs
+++ b/crates/pyfulgur/src/page_size.rs
@@ -1,7 +1,7 @@
 use fulgur::PageSize;
 use pyo3::prelude::*;
 
-#[pyclass(name = "PageSize", module = "pyfulgur", frozen)]
+#[pyclass(name = "PageSize", module = "pyfulgur", frozen, from_py_object)]
 #[derive(Clone, Copy)]
 pub struct PyPageSize {
     pub(crate) inner: PageSize,


### PR DESCRIPTION
## Summary

- Resolves Dependabot alert #4 / [GHSA-pph8-gcv7-4qj5](https://github.com/advisories/GHSA-pph8-gcv7-4qj5) (PyString::from_object buffer overflow, low severity). pyfulgur does not call the vulnerable API directly, but the pinned version (0.22.6) is in the vulnerable range.
- Bumps pyo3 0.22 → 0.28 (latest) in `crates/pyfulgur/Cargo.toml` and adapts to the breaking changes along the way.

## API changes

| Old | New |
|---|---|
| `Python::allow_threads` | `Python::detach` |
| `PyBytes::new_bound` | `PyBytes::new` |
| `PyModule::get_type_bound` | `PyModule::get_type` |
| `#[pyclass]` auto `FromPyObject` for `Clone` | opt-in via `#[pyclass(from_py_object)]` |

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo build -p pyfulgur --features extension-module`
- [x] `cargo clippy -p pyfulgur --features extension-module -- -D warnings`
- [x] `cargo fmt --check`
- [x] `maturin develop --features extension-module` + `pytest tests/` → 45/45 pass
- [ ] CI green (wheel builds across platforms, maturin ≥ 1.7 requirement satisfied)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated PyO3 dependency to 0.28 and raised the minimum maturin build-tool version for the Rust/Python build.
  * Improved Python binding behavior: better conversion from Python objects and more robust handling of Python call/run and binary result creation to align with newer PyO3 patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->