### PR TITLE
fix(cla): drop remote-* config to use default GITHUB_TOKEN

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -32,8 +32,6 @@ jobs:
           path-to-document: 'https://github.com/fulgur-rs/fulgur/blob/main/CLA.md'
           branch: 'main'
           allowlist: 'dependabot[bot],github-actions[bot],renovate[bot]'
-          remote-organization-name: 'fulgur-rs'
-          remote-repository-name: 'fulgur'
           custom-notsigned-prcomment: >
             Thank you for your pull request! Before we can merge this contribution,
             please sign our Contributor License Agreement (CLA). The CLA is a


### PR DESCRIPTION
## Summary

The CLA Assistant workflow failed after merging #109 with:

> Please add a personal access token as an environment variable for writing signatures in a remote repository/organization

(See the failed run: https://github.com/fulgur-rs/fulgur/actions/runs/24615597965/job/71977181737.)

Setting \`remote-organization-name\` / \`remote-repository-name\` in \`contributor-assistant/github-action\` switches it to "remote mode", which requires a \`PERSONAL_ACCESS_TOKEN\` because the action needs write access to a *different* repository. Signatures here live in the same repo (\`.github/cla-signatures.json\`), so those two options were pointing the action at itself and forcing the PAT requirement with no benefit. Removing them lets the workflow fall back to \`GITHUB_TOKEN\`.

## Test plan

- [ ] After merge, open a test PR and confirm CLA Assistant comments successfully with the default \`GITHUB_TOKEN\`.
- [ ] Confirm \`.github/cla-signatures.json\` is updated on sign-off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration by removing unused parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->