### PR TITLE
fix(cla): store signatures on dedicated cla-signatures branch

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           path-to-signatures: '.github/cla-signatures.json'
           path-to-document: 'https://github.com/fulgur-rs/fulgur/blob/main/CLA.md'
-          branch: 'main'
+          branch: 'cla-signatures'
           allowlist: 'dependabot[bot],github-actions[bot],renovate[bot]'
           custom-notsigned-prcomment: >
             Thank you for your pull request! Before we can merge this contribution,


### PR DESCRIPTION
## Summary

After #114 the CLA Assistant workflow still fails on new PRs because \`main\` is protected (PR required, no direct pushes):

> Error occurred when creating the signed contributors file: Repository rule violations found — Changes must be made through a pull request.

See https://github.com/fulgur-rs/fulgur/actions/runs/24615813650/job/71977708776.

contributor-assistant commits signatures directly to the configured branch — with \`branch: main\` it hits the protection rule every time. The pattern the action's README recommends for projects with protected main is to point it at a dedicated unprotected branch.

## Changes

- \`branch: 'main'\` → \`branch: 'cla-signatures'\` in \`.github/workflows/cla.yml\`
- New orphan branch \`cla-signatures\` (created separately) holds a single README explaining its purpose; the bot will append \`.github/cla-signatures.json\` there on first sign-off

## Test plan

- [ ] After merge, open a test PR and confirm the bot posts the sign-off prompt without a repository-rule violation
- [ ] Sign the CLA via the comment and confirm \`.github/cla-signatures.json\` appears on the \`cla-signatures\` branch

## Notes

As with #114, the CLA check on this PR itself will still fail because \`pull_request_target\` executes the base (\`main\`) workflow. Admin merge expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CLA workflow configuration for signature management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->