### PR TITLE
fix(borders): fall back border-style: double to solid when width < 3px (fulgur-xca)

### DIFF
--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -1325,7 +1325,8 @@ fn draw_border_line(
     }
 
     match style {
-        BorderStyleValue::Double => {
+        // CSS Backgrounds L3: border-width < 3 の double は solid として描画。
+        BorderStyleValue::Double if width >= 3.0 => {
             let gap = width / 3.0;
             let dx = x2 - x1;
             let dy = y2 - y1;

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -1226,6 +1226,9 @@ fn apply_border_style(
             }),
             ..stroke
         }),
+        // NOTE: `Double` here is the solid-stroke fallback used by
+        // draw_border_line / draw_block_border when width < 3 (CSS Backgrounds L3).
+        // Returning `None` for Double would silently break that fallback.
         BorderStyleValue::Double
         | BorderStyleValue::Groove
         | BorderStyleValue::Ridge

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -1440,7 +1440,8 @@ fn draw_block_border(
         let opacity = alpha_to_opacity(bc[3]);
         canvas.surface.set_fill(None);
 
-        if st == BorderStyleValue::Double {
+        // CSS Backgrounds L3: border-width < 3 の double は solid として描画。
+        if st == BorderStyleValue::Double && bt >= 3.0 {
             // Double = 3 equal bands (border/gap/border): thin_w = bt/3.
             // Stroke centerlines: outer at bt/6, inner at bt*5/6.
             let thin_w = bt / 3.0;

--- a/crates/fulgur/tests/rect_borders_test.rs
+++ b/crates/fulgur/tests/rect_borders_test.rs
@@ -135,3 +135,44 @@ fn double_uniform_border_below_3px_falls_back_to_solid() {
         counts.re,
     );
 }
+
+#[test]
+fn double_per_edge_below_3px_falls_back_to_solid() {
+    // non-uniform 境界（幅不一致）で rect fast path を避け、
+    // draw_border_line の Double arm を通す経路。
+    // < 3px のとき hairline 2 本ではなく単一 solid stroke になるか検証する。
+    let html = r#"
+        <html><head><style>
+            .b {
+                width: 200px;
+                height: 100px;
+                border-style: double;
+                border-top-width: 2px;
+                border-right-width: 4px;
+                border-bottom-width: 2px;
+                border-left-width: 4px;
+                border-color: #444;
+            }
+        </style></head><body><div class="b"></div></body></html>
+    "#;
+
+    let engine = Engine::builder().page_size(PageSize::A4).build();
+    let pdf = engine.render_html(html).unwrap();
+
+    let Some(counts) = count_ops(&pdf) else {
+        eprintln!("qpdf not installed — skipping");
+        return;
+    };
+
+    // 修正前: 4 辺とも double で 2 本ずつ = 8 本の線 (m=8)。
+    // 修正後: top/bottom (2px) は solid fallback で 1 本ずつ = 2 本、
+    //         left/right (4px) は double のまま 2 本ずつ = 4 本、合計 6 本。
+    // m <= 6 で未修正状態と区別できる。
+    eprintln!("per-edge double: m={} l={}", counts.m, counts.l);
+    assert!(
+        counts.m <= 6,
+        "double < 3px per-edge should reduce stroke count, got m={} l={}",
+        counts.m,
+        counts.l,
+    );
+}

--- a/crates/fulgur/tests/rect_borders_test.rs
+++ b/crates/fulgur/tests/rect_borders_test.rs
@@ -107,3 +107,31 @@ fn double_uniform_border_uses_two_rects() {
         counts.re,
     );
 }
+
+#[test]
+fn double_uniform_border_below_3px_falls_back_to_solid() {
+    // CSS Backgrounds L3: computed border-width < 3 の double は solid で描く。
+    // rect fast path (draw_block_border の Double 分岐) が < 3px のとき
+    // 2 本の hairline を emit せず、solid と同じ 1 本の rect 経路になるかを確認する。
+    let html = r#"
+        <html><head><style>
+            .b { width: 200px; height: 100px; border: 2px double #444; }
+        </style></head><body><div class="b"></div></body></html>
+    "#;
+
+    let engine = Engine::builder().page_size(PageSize::A4).build();
+    let pdf = engine.render_html(html).unwrap();
+
+    let Some(counts) = count_ops(&pdf) else {
+        eprintln!("qpdf not installed — skipping");
+        return;
+    };
+
+    // Solid と同じく 1 本の rect subpath のみ許容。2 本なら未修正。
+    assert!(
+        counts.m + counts.re <= 1,
+        "double < 3px should collapse to single solid rect, got m={} re={}",
+        counts.m,
+        counts.re,
+    );
+}

--- a/docs/plans/2026-04-21-border-double-hairline-fallback.md
+++ b/docs/plans/2026-04-21-border-double-hairline-fallback.md
@@ -130,7 +130,7 @@ Expected: PASS
 
 Run: `cargo test -p fulgur --test rect_borders_test`
 
-Expected: all 3 tests pass (`table_header_uses_rect_for_uniform_borders`, `dashed_uniform_border_keeps_per_edge_phase`, `double_uniform_border_uses_two_rects`, `double_uniform_border_below_3px_falls_back_to_solid`)。
+Expected: all 4 tests pass (`table_header_uses_rect_for_uniform_borders`, `dashed_uniform_border_keeps_per_edge_phase`, `double_uniform_border_uses_two_rects`, `double_uniform_border_below_3px_falls_back_to_solid`)。
 
 **Step 5: Commit**
 

--- a/docs/plans/2026-04-21-border-double-hairline-fallback.md
+++ b/docs/plans/2026-04-21-border-double-hairline-fallback.md
@@ -1,0 +1,324 @@
+# border-style: double hairline fallback (fulgur-xca) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** CSS Backgrounds Level 3 準拠で `border-style: double` かつ `border-width < 3px` のとき solid として描画する。
+
+**Architecture:** `pageable.rs` の 2 箇所（`draw_border_line` の `Double` arm と `draw_block_border` の `Double` uniform rect branch）でガードを追加し、`width < 3.0` のときは solid と同じ描画経路へフォールバックする。
+
+**Tech Stack:** Rust / Krilla / fulgur `pageable.rs`
+
+**Spec reference:** [CSS Backgrounds Level 3 §4.2](https://www.w3.org/TR/css-backgrounds-3/#border-style) — *If the border width is less than 3 CSS pixels, the double border should be drawn as a solid border.*
+
+**Issue:** [fulgur-xca](../../.beads/) — per-edge fallback (`pageable.rs` の `draw_border_line::Double`) と rect fast path (`draw_block_border` の `st == Double` 分岐) の双方で現在 `bt < 3` 判定がなく、`border: 2px double` が 0.67px x 2 本の hairline になる。
+
+---
+
+## Task 1: Failing test for rect fast path
+
+**Files:**
+
+- Test: `crates/fulgur/tests/rect_borders_test.rs`
+
+**Step 1: Write the failing test**
+
+`crates/fulgur/tests/rect_borders_test.rs` の末尾に追加（既存 `double_uniform_border_uses_two_rects` の下）:
+
+```rust
+#[test]
+fn double_uniform_border_below_3px_falls_back_to_solid() {
+    // CSS Backgrounds L3: computed border-width < 3 の double は solid で描く。
+    // rect fast path (draw_block_border の Double 分岐) が < 3px のとき
+    // 2 本の hairline を emit せず、solid と同じ 1 本の rect 経路になるかを確認する。
+    let html = r#"
+        <html><head><style>
+            .b { width: 200px; height: 100px; border: 2px double #444; }
+        </style></head><body><div class="b"></div></body></html>
+    "#;
+
+    let engine = Engine::builder().page_size(PageSize::A4).build();
+    let pdf = engine.render_html(html).unwrap();
+
+    let Some(counts) = count_ops(&pdf) else {
+        eprintln!("qpdf not installed — skipping");
+        return;
+    };
+
+    // Solid と同じく 1 本の rect subpath のみ許容。2 本なら未修正。
+    assert!(
+        counts.m + counts.re <= 1,
+        "double < 3px should collapse to single solid rect, got m={} re={}",
+        counts.m,
+        counts.re,
+    );
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p fulgur --test rect_borders_test double_uniform_border_below_3px_falls_back_to_solid -- --nocapture`
+
+Expected: FAIL — `m + re = 2` で "should collapse to single solid rect" assertion が落ちる。
+
+**Step 3: Commit failing test**
+
+```bash
+git add crates/fulgur/tests/rect_borders_test.rs
+git commit -m "test(borders): failing test for double < 3px fast path fallback"
+```
+
+---
+
+## Task 2: Fix rect fast path
+
+**Files:**
+
+- Modify: `crates/fulgur/src/pageable.rs` (`draw_block_border` の Double 分岐)
+
+**Step 1: Locate the Double branch**
+
+`draw_block_border` 内、`matches!(st, BorderStyleValue::Solid | BorderStyleValue::Double)` の分岐（現行 `pageable.rs:1438` 周辺）。
+
+**Step 2: Add `< 3` guard**
+
+`if st == BorderStyleValue::Double` ブロックの先頭でガードし、solid 経路へ落とす。現行コード:
+
+```rust
+if st == BorderStyleValue::Double {
+    // Double = 3 equal bands (border/gap/border): thin_w = bt/3.
+    // Stroke centerlines: outer at bt/6, inner at bt*5/6.
+    let thin_w = bt / 3.0;
+    let stroke_thin = colored_stroke(bc, thin_w, opacity);
+    stroke_inset_rect(canvas, x, y, w, h, thin_w / 2.0, stroke_thin.clone());
+    stroke_inset_rect(canvas, x, y, w, h, bt - thin_w / 2.0, stroke_thin);
+} else {
+    let base = colored_stroke(bc, bt, opacity);
+    if let Some(styled) = apply_border_style(base, st, bt) {
+        stroke_inset_rect(canvas, x, y, w, h, bt / 2.0, styled);
+    }
+}
+```
+
+改修後:
+
+```rust
+// CSS Backgrounds L3: border-width < 3 の double は solid として描画。
+if st == BorderStyleValue::Double && bt >= 3.0 {
+    // Double = 3 equal bands (border/gap/border): thin_w = bt/3.
+    // Stroke centerlines: outer at bt/6, inner at bt*5/6.
+    let thin_w = bt / 3.0;
+    let stroke_thin = colored_stroke(bc, thin_w, opacity);
+    stroke_inset_rect(canvas, x, y, w, h, thin_w / 2.0, stroke_thin.clone());
+    stroke_inset_rect(canvas, x, y, w, h, bt - thin_w / 2.0, stroke_thin);
+} else {
+    let base = colored_stroke(bc, bt, opacity);
+    if let Some(styled) = apply_border_style(base, st, bt) {
+        stroke_inset_rect(canvas, x, y, w, h, bt / 2.0, styled);
+    }
+}
+```
+
+注: `apply_border_style` は `Double` を `Some(stroke)` で返すため（pageable.rs:1229-1233）、else 側に落ちても solid 相当で 1 本の rect stroke になる。
+
+**Step 3: Run test to verify it passes**
+
+Run: `cargo test -p fulgur --test rect_borders_test double_uniform_border_below_3px_falls_back_to_solid -- --nocapture`
+
+Expected: PASS
+
+**Step 4: Verify no regressions**
+
+Run: `cargo test -p fulgur --test rect_borders_test`
+
+Expected: all 3 tests pass (`table_header_uses_rect_for_uniform_borders`, `dashed_uniform_border_keeps_per_edge_phase`, `double_uniform_border_uses_two_rects`, `double_uniform_border_below_3px_falls_back_to_solid`)。
+
+**Step 5: Commit**
+
+```bash
+git add crates/fulgur/src/pageable.rs
+git commit -m "fix(borders): double < 3px falls back to solid in rect fast path"
+```
+
+---
+
+## Task 3: Failing test for per-edge fallback
+
+**Files:**
+
+- Test: `crates/fulgur/tests/rect_borders_test.rs`
+
+**Step 1: Write the failing test**
+
+non-uniform style または `has_radius()` を使い、rect fast path ではなく `draw_border_line` を走らせる。最もシンプルなのは `border-radius` を追加して rounded path 分岐を避け、かつ uniform style を崩して per-edge へ落とす。簡易なやり方は non-uniform width:
+
+```rust
+#[test]
+fn double_per_edge_below_3px_falls_back_to_solid() {
+    // non-uniform 境界（幅不一致）で rect fast path を避け、
+    // draw_border_line の Double arm を通す経路。
+    // < 3px のとき hairline 2 本ではなく単一 solid stroke になるか検証する。
+    let html = r#"
+        <html><head><style>
+            .b {
+                width: 200px;
+                height: 100px;
+                border-style: double;
+                border-top-width: 2px;
+                border-right-width: 4px;
+                border-bottom-width: 2px;
+                border-left-width: 4px;
+                border-color: #444;
+            }
+        </style></head><body><div class="b"></div></body></html>
+    "#;
+
+    let engine = Engine::builder().page_size(PageSize::A4).build();
+    let pdf = engine.render_html(html).unwrap();
+
+    let Some(counts) = count_ops(&pdf) else {
+        eprintln!("qpdf not installed — skipping");
+        return;
+    };
+
+    // top/bottom 2px double → solid fallback で 1 本ずつ = 2 本
+    // left/right 4px double → 3 本 stroke 扱いで 2 本ずつ = 4 本
+    // 合計 <= 6 本の stroke。fallback 無し (< 3px で 2 本ずつ emit) だと
+    // top/bottom が 2 本ずつ = 4、left/right が 2 本ずつ = 4 で合計 8 本になる。
+    // 線ごとに `m` が 1 個出るので m をしきい値にする。
+    assert!(
+        counts.m <= 6,
+        "double < 3px per-edge should reduce stroke count, got m={} l={}",
+        counts.m,
+        counts.l,
+    );
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p fulgur --test rect_borders_test double_per_edge_below_3px_falls_back_to_solid -- --nocapture`
+
+Expected: FAIL — 修正前は top/bottom も double で 2 本 × 2 辺 = 4、left/right も double で 2 本 × 2 辺 = 4、合計 `m=8`。
+
+注: しきい値は実測で確認する。最初の実行で actual `m` を控え、solid fallback 後の actual `m` も測って、fallback 有無を区別できる境界値に置き換える。
+
+**Step 3: Measure actual counts**
+
+失敗出力（`--nocapture` の eprintln で実数を出してもよい）で修正前 `m` と修正後 `m` を確認し、閾値を両者の中間に調整。
+
+**Step 4: Commit failing test**
+
+```bash
+git add crates/fulgur/tests/rect_borders_test.rs
+git commit -m "test(borders): failing test for double < 3px per-edge fallback"
+```
+
+---
+
+## Task 4: Fix per-edge fallback
+
+**Files:**
+
+- Modify: `crates/fulgur/src/pageable.rs` (`draw_border_line` の Double arm)
+
+**Step 1: Add `< 3` guard in `draw_border_line`**
+
+現行 (pageable.rs:1327-1341):
+
+```rust
+match style {
+    BorderStyleValue::Double => {
+        let gap = width / 3.0;
+        let dx = x2 - x1;
+        let dy = y2 - y1;
+        let len = (dx * dx + dy * dy).sqrt();
+        if len == 0.0 {
+            return;
+        }
+        let nx = -dy / len * gap;
+        let ny = dx / len * gap;
+        let thin = colored_stroke(base_color, width / 3.0, opacity);
+        stroke_line(canvas, x1 + nx, y1 + ny, x2 + nx, y2 + ny, thin.clone());
+        stroke_line(canvas, x1 - nx, y1 - ny, x2 - nx, y2 - ny, thin);
+    }
+```
+
+改修後（`width < 3.0` のとき match の末尾 `_` アームと同じ solid 経路へ落とす）:
+
+```rust
+match style {
+    BorderStyleValue::Double if width >= 3.0 => {
+        let gap = width / 3.0;
+        let dx = x2 - x1;
+        let dy = y2 - y1;
+        let len = (dx * dx + dy * dy).sqrt();
+        if len == 0.0 {
+            return;
+        }
+        let nx = -dy / len * gap;
+        let ny = dx / len * gap;
+        let thin = colored_stroke(base_color, width / 3.0, opacity);
+        stroke_line(canvas, x1 + nx, y1 + ny, x2 + nx, y2 + ny, thin.clone());
+        stroke_line(canvas, x1 - nx, y1 - ny, x2 - nx, y2 - ny, thin);
+    }
+```
+
+理由: match guard `if width >= 3.0` を付けることで、`width < 3.0` の Double は最終 `_` arm（`apply_border_style` 経由の solid）に流れる。`apply_border_style` は Double を `Some(stroke)` で返すため、solid と同じ 1 本 stroke を emit する。
+
+**Step 2: Run test to verify it passes**
+
+Run: `cargo test -p fulgur --test rect_borders_test double_per_edge_below_3px_falls_back_to_solid -- --nocapture`
+
+Expected: PASS
+
+**Step 3: Verify no regressions**
+
+Run: `cargo test -p fulgur --test rect_borders_test`
+
+Expected: 全 pass。
+
+**Step 4: Commit**
+
+```bash
+git add crates/fulgur/src/pageable.rs
+git commit -m "fix(borders): double < 3px falls back to solid in per-edge path"
+```
+
+---
+
+## Task 5: Full-suite verification
+
+**Step 1: Run all fulgur tests**
+
+Run: `cargo test -p fulgur`
+
+Expected: 全 pass（unit ~497 + integration）。
+
+**Step 2: Lint**
+
+Run:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+```
+
+Expected: どちらも成功。
+
+**Step 3: If any fail, fix and re-run**
+
+lint 指摘が出たら fix、`git add` して amend ではなく新規コミット（CLAUDE.md: "Always create NEW commits rather than amending"）。
+
+---
+
+## Out of scope
+
+- `border-style: double` で `width >= 3` のときの描画ロジックの改善。
+- 3D styles (`groove`, `ridge`, `inset`, `outset`) の < 3px 挙動（別仕様）。
+- rect fast path で `has_radius()` かつ `Double` の fallback（既存は rounded 分岐へ、今回の問題は発生しない）。
+
+## Notes
+
+- テスト戦略: `count_ops` で PDF operator 数を境界に取る。既存の `double_uniform_border_uses_two_rects` と同じ手法。
+- spec 境界値（3px 丁度のとき）は double として描画。`bt >= 3.0` と書く。
+- `apply_border_style` の Double → `Some(stroke)` 挙動（pageable.rs:1229-1233）が fallback 経路の正しさを担保する。


### PR DESCRIPTION
## 概要

CSS Backgrounds Level 3 に準拠し、`border-style: double` かつ `border-width < 3px` のとき solid として描画するようにしました。

仕様: https://www.w3.org/TR/css-backgrounds-3/#border-style
> If the border width is less than 3 CSS pixels, the double border should be drawn as a solid border.

### 修正前の挙動

`border: 2px double` → 0.67px の 2 本 hairline として描画されてしまい、視認性が極端に悪い。

### 修正後の挙動

`border: 2px double` → 単一の 2px solid stroke（仕様準拠）。`border: 3px double` 以上は従来通り 2 本描画。

## 変更内容

2 箇所で `width >= 3.0` のガードを追加しています。

| 修正箇所 | ファイル | 変更 |
|---|---|---|
| rect fast path | `pageable.rs` `draw_block_border` | `if st == BorderStyleValue::Double && bt >= 3.0 {` |
| per-edge path | `pageable.rs` `draw_border_line` | `BorderStyleValue::Double if width >= 3.0 =>` |

どちらも `apply_border_style` が `Double` に対して `Some(stroke)` を返す既存挙動（`pageable.rs:1229-1233`）を経由して solid 相当の 1 本 stroke にフォールバックします。この依存関係を保全するコメントを `apply_border_style` にも追記しました。

## テスト

- `double_uniform_border_below_3px_falls_back_to_solid` — rect fast path のフォールバックを検証（`m + re <= 1`）。
- `double_per_edge_below_3px_falls_back_to_solid` — 非対称 width で `draw_border_line` を通した経路で検証（`m <= 6`、修正前 m=8 → 修正後 m=6）。
- 既存の `double_uniform_border_uses_two_rects`（`9px double`）は `>= 3px` 経路なので引き続き 2 本描画を保護。

`cargo test -p fulgur` で 497 lib + 全 integration tests pass、`cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` クリーン。

## Scope 外（フォローアップ）

- `border-radius` + `border-style: double` で rounded rect の double が常に単一 stroke になる既存バグ → beads `fulgur-u8o4` として起票。
- 3D styles (`groove` / `ridge` / `inset` / `outset`) の `< 3px` 挙動は別仕様扱いで今回対象外。

## 関連 issue

- beads: `fulgur-xca`

## Test plan

- [x] \`cargo test -p fulgur\` 全 pass
- [x] \`cargo fmt --check\` クリーン
- [x] \`cargo clippy --all-targets -- -D warnings\` クリーン
- [x] 既存 \`double_uniform_border_uses_two_rects\`（9px double）がリグレッションなく pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `border-style: double` now follows CSS Backgrounds L3: double behaves as solid when border width is under 3px, reducing incorrect double-hairline rendering.

* **Tests**
  * Added rendering tests covering thin double borders for uniform and per-edge configurations to verify the fallback to solid output.

* **Documentation**
  * Added an implementation plan explaining the thin-double fallback and associated test strategy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->