### PR TITLE
feat(multicol): column-rule-* rendering + column-fill + custom CSS sniffer

### DIFF
--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -272,6 +272,68 @@ fn walk_for_inline_styles(
     }
 }
 
+/// Harvest the column-* properties that blitz/stylo (servo feature) does not
+/// expose and return them as a [`crate::column_css::ColumnStyleTable`] keyed by
+/// DOM node id.
+///
+/// This is the Phase A production entry point for the side-table built by
+/// [`crate::column_css::build_column_style_table`]: it walks every top-level
+/// `<style>` element, concatenates their text content, parses the aggregate
+/// as a stylesheet, then hands it back to `build_column_style_table` which
+/// also folds inline `style="..."` attributes per element.
+///
+/// Two traversals are intentional and trivial: the first collects stylesheet
+/// bytes (O(nodes + css_bytes)), the second applies the cascade (also
+/// O(nodes + css_bytes)). Keeping them separate mirrors the CSS cascade —
+/// stylesheets are parsed once, then matched against every node.
+pub fn extract_column_style_table(doc: &HtmlDocument) -> crate::column_css::ColumnStyleTable {
+    // 1. Concatenate every top-level <style> block's text content.
+    let mut css = String::new();
+    let root_id = doc.root_element().id;
+    walk_for_column_styles(doc, root_id, &mut css, 0);
+
+    // 2. Parse the aggregate as a stylesheet. `parse_stylesheet` silently
+    //    drops malformed rules / unsupported selectors — matches the
+    //    project-wide "no panic on bad CSS" invariant.
+    let rules = crate::column_css::parse_stylesheet(&css);
+
+    // 3. Build the side-table (cascade: stylesheets folded in source order,
+    //    inline `style` attributes applied last, per-node).
+    crate::column_css::build_column_style_table(doc, &rules)
+}
+
+// TODO(phase-b): unify with walk_for_inline_styles — both are "find every
+// top-level <style>, concatenate children text, stop recursing past the
+// <style>". A shared `fn visit_style_blocks<F>(doc, F)` closure-based visitor
+// would collapse them. Kept duplicated for now to avoid risky refactoring
+// during v7a Phase A.
+fn walk_for_column_styles(doc: &HtmlDocument, node_id: usize, out: &mut String, depth: usize) {
+    if depth >= MAX_DOM_DEPTH {
+        return;
+    }
+    let Some(node) = doc.get_node(node_id) else {
+        return;
+    };
+    if let Some(el) = node.element_data()
+        && el.name.local.as_ref() == "style"
+    {
+        for &child_id in &node.children {
+            if let Some(child) = doc.get_node(child_id)
+                && let blitz_dom::node::NodeData::Text(t) = &child.data
+            {
+                out.push_str(&t.content);
+                // Separate adjacent <style> blocks so the last declaration
+                // of one cannot leak into the first selector of the next.
+                out.push('\n');
+            }
+        }
+        return;
+    }
+    for &child_id in &node.children {
+        walk_for_column_styles(doc, child_id, out, depth + 1);
+    }
+}
+
 use crate::MAX_DOM_DEPTH;
 
 /// Walk the DOM tree to find the first element with the given tag name.
@@ -2475,6 +2537,43 @@ mod tests {
         let p = find_element_by_local_name(&doc, "p").expect("p");
         assert!(has_column_span_all(doc.get_node(h1).unwrap()));
         assert!(!has_column_span_all(doc.get_node(p).unwrap()));
+    }
+
+    // ── extract_column_style_table (fulgur-v7a Task 2) ─────────────
+
+    #[test]
+    fn extract_column_style_table_picks_up_inline_and_stylesheet() {
+        let html = r#"<html><head><style>
+            .mc { column-fill: auto; column-rule: 1pt solid blue; }
+        </style></head><body>
+            <div class="mc" id="a"></div>
+            <div class="mc" id="b" style="column-rule: 2pt dashed red"></div>
+        </body></html>"#;
+        let mut doc = parse(html, 400.0, &[]);
+        resolve(&mut doc);
+        use std::ops::Deref;
+        let a = find_element_by_attr_id(doc.deref(), "a");
+        let b = find_element_by_attr_id(doc.deref(), "b");
+
+        let table = extract_column_style_table(&doc);
+
+        // `a` picks up both declarations from the stylesheet.
+        let a_props = table.get(&a).expect("a in table");
+        assert_eq!(a_props.fill, Some(crate::column_css::ColumnFill::Auto));
+        let a_rule = a_props.rule.expect("a rule");
+        assert_eq!(a_rule.color, [0, 0, 255, 255]); // blue
+        assert_eq!(a_rule.style, crate::column_css::ColumnRuleStyle::Solid);
+
+        // `b` inherits `column-fill: auto` from the stylesheet, but its
+        // inline `column-rule` beats the stylesheet's rule declaration.
+        let b_props = table.get(&b).expect("b in table");
+        let b_rule = b_props.rule.expect("b rule");
+        assert!((b_rule.width - 2.0).abs() < 1e-3);
+        assert_eq!(b_rule.style, crate::column_css::ColumnRuleStyle::Dashed);
+        assert_eq!(b_rule.color, [255, 0, 0, 255]); // inline red beats stylesheet blue
+        // Inline `column-rule` overrides only the rule field — `column-fill`
+        // is still populated from the stylesheet.
+        assert_eq!(b_props.fill, Some(crate::column_css::ColumnFill::Auto));
     }
 }
 

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -317,6 +317,24 @@ fn walk_for_column_styles(doc: &HtmlDocument, node_id: usize, out: &mut String, 
     if let Some(el) = node.element_data()
         && el.name.local.as_ref() == "style"
     {
+        // Honour `<style media="...">`: skip sheets whose media query
+        // excludes the PDF render target. Phase A uses a simple token scan
+        // that accepts the attribute when absent, empty, or contains `all`
+        // / `print`. `screen` / `speech` / anything else means "don't fold
+        // these rules into the column side-table". Full media-query
+        // evaluation (size ranges, logical operators, etc.) is deferred —
+        // the common author intent of `media="screen"` vs `media="print"`
+        // is what we need to get right here.
+        if let Some(media) = el.attr(blitz_dom::LocalName::from("media")) {
+            let lower = media.to_ascii_lowercase();
+            let applies = lower.split(',').any(|tok| {
+                let t = tok.trim();
+                t.is_empty() || t == "all" || t.contains("print")
+            });
+            if !applies {
+                return;
+            }
+        }
         for &child_id in &node.children {
             if let Some(child) = doc.get_node(child_id)
                 && let blitz_dom::node::NodeData::Text(t) = &child.data
@@ -2574,6 +2592,58 @@ mod tests {
         // Inline `column-rule` overrides only the rule field — `column-fill`
         // is still populated from the stylesheet.
         assert_eq!(b_props.fill, Some(crate::column_css::ColumnFill::Auto));
+    }
+
+    #[test]
+    fn extract_column_style_table_respects_media_attribute() {
+        // `<style media="screen">` must not feed the column side-table —
+        // the PDF render path is the `print` medium. `<style media="print">`
+        // and `<style media="all">` (or absent) must apply.
+        let html = r#"<html><head>
+            <style media="screen">
+                .screen-only { column-rule: 1pt solid red; }
+            </style>
+            <style media="print">
+                .print-only { column-rule: 2pt solid blue; }
+            </style>
+            <style media="all">
+                .always { column-fill: auto; }
+            </style>
+            <style>
+                .no-media { column-rule: 3pt solid green; }
+            </style>
+        </head><body>
+            <div class="screen-only" id="s"></div>
+            <div class="print-only" id="p"></div>
+            <div class="always" id="a"></div>
+            <div class="no-media" id="n"></div>
+        </body></html>"#;
+        let mut doc = parse(html, 400.0, &[]);
+        resolve(&mut doc);
+        use std::ops::Deref;
+        let s = find_element_by_attr_id(doc.deref(), "s");
+        let p = find_element_by_attr_id(doc.deref(), "p");
+        let a = find_element_by_attr_id(doc.deref(), "a");
+        let n = find_element_by_attr_id(doc.deref(), "n");
+
+        let table = extract_column_style_table(&doc);
+
+        // `screen` media: rule must NOT appear in the table.
+        assert!(
+            !table.contains_key(&s),
+            "media=screen rule leaked into side-table"
+        );
+        // `print` media: rule applies.
+        let p_rule = table.get(&p).and_then(|props| props.rule).expect("p rule");
+        assert_eq!(p_rule.color, [0, 0, 255, 255]);
+        // `all` media: fill applies.
+        assert_eq!(
+            table.get(&a).and_then(|props| props.fill),
+            Some(crate::column_css::ColumnFill::Auto)
+        );
+        // No media attribute: rule applies (default = all).
+        let n_rule = table.get(&n).and_then(|props| props.rule).expect("n rule");
+        assert_eq!(n_rule.color, [0, 128, 0, 255]);
     }
 }
 

--- a/crates/fulgur/src/column_css.rs
+++ b/crates/fulgur/src/column_css.rs
@@ -182,10 +182,18 @@ fn parse_length<'i>(input: &mut Parser<'i, '_>) -> Result<f32, ParseError<'i, ()
 }
 
 /// Parse a `<color>` from `input`. Supports `#rgb` / `#rgba` / `#rrggbb` /
-/// `#rrggbbaa` hashes and CSS named colours. Deliberate returns of `None`
-/// (not `Err`) for unsupported keywords (`currentcolor`, `transparent`,
+/// `#rrggbbaa` hashes, CSS named colours, and the functional notations
+/// `rgb()` / `rgba()` / `hsl()` / `hsla()` (legacy comma syntax; CSS Color
+/// 3 – modern `rgb(r g b / a)` space-separated form is not modelled).
+/// Deliberate returns of `Err` for unsupported keywords (`currentcolor`,
 /// `inherit`, system colours): the declaration drops silently while
 /// siblings in the same block continue to populate.
+///
+/// **Why not `cssparser::Color::parse`?** The Phase A plan referenced that
+/// API, but cssparser 0.35 does not ship one — the full colour parser
+/// lives in a separate `cssparser-color` crate. Adding that dependency is
+/// out of scope for this targeted fix (hard-constrained to this file), so
+/// we implement the two functional forms directly on top of the tokenizer.
 fn parse_color<'i>(input: &mut Parser<'i, '_>) -> Result<[u8; 4], ParseError<'i, ()>> {
     let token = input.next()?.clone();
     let err = || input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid);
@@ -207,8 +215,143 @@ fn parse_color<'i>(input: &mut Parser<'i, '_>) -> Result<[u8; 4], ParseError<'i,
                 Err(err())
             }
         }
+        Token::Function(ref name) => {
+            let fn_name = name.to_ascii_lowercase();
+            // Build the fallback error eagerly so we release the immutable
+            // borrow of `input` before calling `parse_nested_block`, which
+            // takes `&mut self`.
+            let nested = match fn_name.as_str() {
+                "rgb" | "rgba" => input.parse_nested_block(parse_rgb_args),
+                "hsl" | "hsla" => input.parse_nested_block(parse_hsl_args),
+                _ => return Err(err()),
+            };
+            nested.map_err(|_| input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid))
+        }
         _ => Err(err()),
     }
+}
+
+/// Parse a single rgb/rgba channel as either an integer 0..255 number or a
+/// percentage. Clamps to `[0, 255]` on overflow, matching the CSS Color
+/// spec's "clamp on compute" rule.
+fn parse_rgb_channel<'i>(input: &mut Parser<'i, '_>) -> Result<u8, ParseError<'i, ()>> {
+    let token = input.next()?.clone();
+    match token {
+        Token::Number { value, .. } => Ok(value.round().clamp(0.0, 255.0) as u8),
+        Token::Percentage { unit_value, .. } => {
+            Ok((unit_value * 255.0).round().clamp(0.0, 255.0) as u8)
+        }
+        _ => Err(input.new_error(BasicParseErrorKind::QualifiedRuleInvalid)),
+    }
+}
+
+/// Parse an alpha value as either a 0..1 number or a percentage. Scales to
+/// 0..255 and rounds. Clamps to `[0, 255]`.
+fn parse_alpha_value<'i>(input: &mut Parser<'i, '_>) -> Result<u8, ParseError<'i, ()>> {
+    let token = input.next()?.clone();
+    match token {
+        Token::Number { value, .. } => Ok((value * 255.0).round().clamp(0.0, 255.0) as u8),
+        Token::Percentage { unit_value, .. } => {
+            Ok((unit_value * 255.0).round().clamp(0.0, 255.0) as u8)
+        }
+        _ => Err(input.new_error(BasicParseErrorKind::QualifiedRuleInvalid)),
+    }
+}
+
+/// Parse the arguments of `rgb(...)` / `rgba(...)` — legacy comma syntax
+/// only. Accepts `rgb(r, g, b)` or `rgb(r, g, b, a)` (alpha optional; the
+/// name distinction between `rgb` and `rgba` has not mattered since CSS
+/// Color 4).
+fn parse_rgb_args<'i>(input: &mut Parser<'i, '_>) -> Result<[u8; 4], ParseError<'i, ()>> {
+    let r = parse_rgb_channel(input)?;
+    input.expect_comma()?;
+    let g = parse_rgb_channel(input)?;
+    input.expect_comma()?;
+    let b = parse_rgb_channel(input)?;
+    let a = if input.try_parse(|i| i.expect_comma()).is_ok() {
+        parse_alpha_value(input)?
+    } else {
+        255
+    };
+    input.expect_exhausted()?;
+    Ok([r, g, b, a])
+}
+
+/// Parse the arguments of `hsl(...)` / `hsla(...)` — legacy comma syntax
+/// only. Hue is a number in degrees; saturation and lightness are required
+/// percentages. Converts to sRGB using the CSS Color 3 formula.
+fn parse_hsl_args<'i>(input: &mut Parser<'i, '_>) -> Result<[u8; 4], ParseError<'i, ()>> {
+    let hue_deg = match input.next()?.clone() {
+        Token::Number { value, .. } => value,
+        _ => return Err(input.new_error(BasicParseErrorKind::QualifiedRuleInvalid)),
+    };
+    input.expect_comma()?;
+    let s = match input.next()?.clone() {
+        Token::Percentage { unit_value, .. } => unit_value.clamp(0.0, 1.0),
+        _ => return Err(input.new_error(BasicParseErrorKind::QualifiedRuleInvalid)),
+    };
+    input.expect_comma()?;
+    let l = match input.next()?.clone() {
+        Token::Percentage { unit_value, .. } => unit_value.clamp(0.0, 1.0),
+        _ => return Err(input.new_error(BasicParseErrorKind::QualifiedRuleInvalid)),
+    };
+    let a = if input.try_parse(|i| i.expect_comma()).is_ok() {
+        parse_alpha_value(input)?
+    } else {
+        255
+    };
+    input.expect_exhausted()?;
+
+    let (r, g, b) = hsl_to_rgb(hue_deg, s, l);
+    Ok([r, g, b, a])
+}
+
+/// CSS Color 3 HSL → sRGB conversion. Hue is in degrees (any real number;
+/// wrapped via modulo). Saturation and lightness are normalised to
+/// `[0, 1]`. Returns 8-bit sRGB channels with standard rounding.
+fn hsl_to_rgb(hue_deg: f32, s: f32, l: f32) -> (u8, u8, u8) {
+    // Normalise hue to [0, 1) — rem_euclid keeps negatives positive.
+    let h = (hue_deg.rem_euclid(360.0)) / 360.0;
+
+    let hue_to_rgb = |p: f32, q: f32, mut t: f32| -> f32 {
+        if t < 0.0 {
+            t += 1.0;
+        }
+        if t > 1.0 {
+            t -= 1.0;
+        }
+        if t < 1.0 / 6.0 {
+            p + (q - p) * 6.0 * t
+        } else if t < 0.5 {
+            q
+        } else if t < 2.0 / 3.0 {
+            p + (q - p) * (2.0 / 3.0 - t) * 6.0
+        } else {
+            p
+        }
+    };
+
+    let (r_f, g_f, b_f) = if s == 0.0 {
+        (l, l, l)
+    } else {
+        let q = if l < 0.5 {
+            l * (1.0 + s)
+        } else {
+            l + s - l * s
+        };
+        let p = 2.0 * l - q;
+        (
+            hue_to_rgb(p, q, h + 1.0 / 3.0),
+            hue_to_rgb(p, q, h),
+            hue_to_rgb(p, q, h - 1.0 / 3.0),
+        )
+    };
+
+    (
+        (r_f * 255.0).round().clamp(0.0, 255.0) as u8,
+        (g_f * 255.0).round().clamp(0.0, 255.0) as u8,
+        (b_f * 255.0).round().clamp(0.0, 255.0) as u8,
+    )
 }
 
 fn parse_rule_style_ident(ident: &str) -> Option<ColumnRuleStyle> {
@@ -772,6 +915,35 @@ mod tests {
         // cssparser doesn't know `currentcolor` as a named colour; we
         // return `None` which drops this declaration silently.
         assert!(props.rule.is_none());
+    }
+
+    #[test]
+    fn parses_rgb_functional_notation() {
+        let props = parse_declaration_block("column-rule-color: rgb(255, 0, 0);");
+        assert_eq!(props.rule.expect("rule").color, [255, 0, 0, 255]);
+    }
+
+    #[test]
+    fn parses_rgba_with_alpha() {
+        let props = parse_declaration_block("column-rule-color: rgba(0, 0, 0, 0.5);");
+        let c = props.rule.expect("rule").color;
+        assert_eq!(&c[0..3], &[0, 0, 0]);
+        // Allow ±1 rounding slack.
+        assert!((c[3] as i32 - 128).abs() <= 1, "alpha was {}", c[3]);
+    }
+
+    #[test]
+    fn parses_hsl_notation() {
+        let props = parse_declaration_block("column-rule-color: hsl(0, 100%, 50%);");
+        let c = props.rule.expect("rule").color;
+        // pure red; allow ±2 slack on rounding
+        assert!(c[0] >= 253 && c[1] <= 2 && c[2] <= 2, "got {:?}", c);
+    }
+
+    #[test]
+    fn currentcolor_is_rejected() {
+        let props = parse_declaration_block("column-rule-color: currentcolor;");
+        assert!(props.rule.is_none() || props.rule.unwrap().style == ColumnRuleStyle::None);
     }
 
     // -------- selector parsing --------

--- a/crates/fulgur/src/column_css.rs
+++ b/crates/fulgur/src/column_css.rs
@@ -1,0 +1,1085 @@
+//! Minimal CSS sniffer for the multicol properties that stylo 0.8.0 gates to
+//! its `gecko` engine. Blitz ships the `servo` feature only, so
+//! `column-rule-{width,style,color}`, `column-fill`, and `break-inside` never
+//! reach the `ComputedValues` we inspect elsewhere in the pipeline.
+//!
+//! Phase A of fulgur-v7a needs `column-rule-*` and `column-fill` to render
+//! rules between adjacent columns and switch the multicol layout hook between
+//! "balance" and "auto" (greedy fill). The follow-up (`fulgur-ftp`) will
+//! extend this module with `break-inside` — deliberately out of scope here.
+//!
+//! Scope and trade-offs:
+//!
+//! - Only inline `style="..."` attributes and top-level `<style>` blocks are
+//!   scanned. External stylesheets loaded via `<link rel=stylesheet>` are
+//!   already parsed by Blitz for the properties Blitz supports — we do not
+//!   duplicate that path.
+//! - The selector grammar is intentionally tiny: type (`div`), class
+//!   (`.foo`), id (`#bar`), universal (`*`), compound (`div.foo#bar`) and
+//!   comma-separated lists. Unsupported combinators or pseudo-classes cause
+//!   the whole rule to be dropped silently.
+//! - Source order wins (no specificity, no `!important`). Inline style is
+//!   folded last so it beats stylesheet rules.
+//! - Length units: `pt` passes through, `px` is converted to `pt` using the
+//!   canonical CSS factor `72 / 96`. `em`, `rem`, and `%` are deliberately
+//!   treated as invalid for Phase A.
+
+// Task 2 (blitz_adapter harvester) and Task 5 (convert.rs wrapper) are the
+// first callers. Until they land, every public item here looks dead to
+// rustc — silence the warnings at module scope rather than sprinkling
+// individual attributes. Remove this attribute when Task 2 ships.
+#![allow(dead_code)]
+
+use std::collections::BTreeMap;
+
+use cssparser::{
+    AtRuleParser, BasicParseErrorKind, CowRcStr, DeclarationParser, ParseError, Parser,
+    ParserInput, QualifiedRuleParser, RuleBodyItemParser, RuleBodyParser, StyleSheetParser, Token,
+    color::{parse_hash_color, parse_named_color},
+};
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// `column-rule-style` value. Only the three Phase A styles are modelled —
+/// `double`, `groove`, `ridge`, `inset`, and `outset` are Phase C and fall
+/// through to [`ColumnRuleStyle::None`] (rule is not drawn).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ColumnRuleStyle {
+    /// No rule — either the author set `none` or an unsupported style was
+    /// provided. The renderer skips drawing.
+    #[default]
+    None,
+    Solid,
+    Dashed,
+    Dotted,
+}
+
+/// A fully-resolved `column-rule` specification. Width is in PDF points.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ColumnRuleSpec {
+    pub width: f32,
+    pub style: ColumnRuleStyle,
+    /// RGBA colour, matching the `[u8; 4]` convention used by
+    /// `paragraph::TextRun` and `pageable::BlockPageable::border_color`.
+    pub color: [u8; 4],
+}
+
+impl Default for ColumnRuleSpec {
+    fn default() -> Self {
+        Self {
+            width: 1.0,
+            style: ColumnRuleStyle::None,
+            color: [0, 0, 0, 255],
+        }
+    }
+}
+
+/// `column-fill` value. Defaults to `balance` per CSS Multi-column Layout
+/// Level 1.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ColumnFill {
+    #[default]
+    Balance,
+    Auto,
+}
+
+/// Resolved properties for a single element. Fields remain `None` when the
+/// author did not set them, so the consumer can tell "absent" from "set to
+/// default" (important for the cascade — a later rule overrides only the
+/// fields it declares).
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct ColumnStyleProps {
+    pub rule: Option<ColumnRuleSpec>,
+    pub fill: Option<ColumnFill>,
+}
+
+impl ColumnStyleProps {
+    /// Fold `other` on top of `self`, with `Some(x)` in `other` overwriting
+    /// the same field in `self` (last-wins, no specificity).
+    fn merge(&mut self, other: ColumnStyleProps) {
+        if other.rule.is_some() {
+            self.rule = other.rule;
+        }
+        if other.fill.is_some() {
+            self.fill = other.fill;
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.rule.is_none() && self.fill.is_none()
+    }
+}
+
+/// Side-table keyed by the blitz DOM node id (`usize`). `BTreeMap` is chosen
+/// over `HashMap` so iteration order is deterministic — even though this
+/// table is only consulted during draw setup (never serialised directly),
+/// determinism is a project-wide invariant (see `CLAUDE.md`).
+pub type ColumnStyleTable = BTreeMap<usize, ColumnStyleProps>;
+
+/// A single parsed stylesheet rule: one or more selectors and the properties
+/// that apply when any of them matches.
+#[derive(Clone, Debug)]
+pub struct StyleRule {
+    pub selectors: Vec<CompoundSelector>,
+    pub props: ColumnStyleProps,
+}
+
+/// One simple selector — a single unqualified component of a compound
+/// selector. `Universal` matches every element; the other variants match
+/// against the corresponding attribute / tag.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SimpleSelector {
+    /// Lowercased tag name (e.g. `div`).
+    Type(String),
+    /// Class name without the leading `.`.
+    Class(String),
+    /// Id without the leading `#`.
+    Id(String),
+    /// `*`.
+    Universal,
+}
+
+/// Compound selector — multiple [`SimpleSelector`] parts that must all match
+/// the same element (logical AND). `div.foo#bar` is a compound of three
+/// parts.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CompoundSelector {
+    pub parts: Vec<SimpleSelector>,
+}
+
+// ---------------------------------------------------------------------------
+// Length and colour helpers
+// ---------------------------------------------------------------------------
+
+/// Convert a CSS length token to PDF points. Accepts only `pt` and `px` for
+/// Phase A; everything else (`em`, `rem`, `%`, `mm`, etc.) is rejected so
+/// the rule silently drops to `None` without falsely measuring.
+fn length_to_pt(value: f32, unit: &str) -> Option<f32> {
+    if unit.eq_ignore_ascii_case("pt") {
+        Some(value)
+    } else if unit.eq_ignore_ascii_case("px") {
+        Some(value * 72.0 / 96.0)
+    } else {
+        None
+    }
+}
+
+/// Parse a single `<length>` from `input`. Unlike the GCPM variant we reject
+/// `mm`/`cm`/`in` too — the column-rule spec is sub-point and designers use
+/// `px`/`pt` exclusively in practice; folding more units here would just
+/// give inconsistent renders between the multicol rule and the rest of the
+/// border model.
+fn parse_length<'i>(input: &mut Parser<'i, '_>) -> Result<f32, ParseError<'i, ()>> {
+    let token = input.next()?.clone();
+    match token {
+        Token::Dimension { value, unit, .. } => length_to_pt(value, &unit)
+            .ok_or_else(|| input.new_error(BasicParseErrorKind::QualifiedRuleInvalid)),
+        Token::Number { value: 0.0, .. } => Ok(0.0),
+        _ => Err(input.new_error(BasicParseErrorKind::QualifiedRuleInvalid)),
+    }
+}
+
+/// Parse a `<color>` from `input`. Supports `#rgb` / `#rgba` / `#rrggbb` /
+/// `#rrggbbaa` hashes and CSS named colours. Deliberate returns of `None`
+/// (not `Err`) for unsupported keywords (`currentcolor`, `transparent`,
+/// `inherit`, system colours): the declaration drops silently while
+/// siblings in the same block continue to populate.
+fn parse_color<'i>(input: &mut Parser<'i, '_>) -> Result<[u8; 4], ParseError<'i, ()>> {
+    let token = input.next()?.clone();
+    let err = || input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid);
+    match token {
+        Token::IDHash(ref s) | Token::Hash(ref s) => {
+            let (r, g, b, a) = parse_hash_color(s.as_bytes()).map_err(|_| err())?;
+            let alpha_u8 = (a * 255.0_f32).round().clamp(0.0, 255.0) as u8;
+            Ok([r, g, b, alpha_u8])
+        }
+        Token::Ident(ref name) => {
+            if name.eq_ignore_ascii_case("transparent") {
+                Ok([0, 0, 0, 0])
+            } else if let Ok((r, g, b)) = parse_named_color(&name.to_ascii_lowercase()) {
+                Ok([r, g, b, 255])
+            } else {
+                // `currentcolor`, `inherit`, system colours, typos — not
+                // representable as an `[u8; 4]`. Bail so the containing
+                // declaration drops.
+                Err(err())
+            }
+        }
+        _ => Err(err()),
+    }
+}
+
+fn parse_rule_style_ident(ident: &str) -> Option<ColumnRuleStyle> {
+    match ident.to_ascii_lowercase().as_str() {
+        "none" => Some(ColumnRuleStyle::None),
+        "solid" => Some(ColumnRuleStyle::Solid),
+        "dashed" => Some(ColumnRuleStyle::Dashed),
+        "dotted" => Some(ColumnRuleStyle::Dotted),
+        // `double | groove | ridge | inset | outset` are Phase C — drop the
+        // whole shorthand rather than falsely render as `None`.
+        _ => None,
+    }
+}
+
+fn parse_column_fill_value<'i>(
+    input: &mut Parser<'i, '_>,
+) -> Result<ColumnFill, ParseError<'i, ()>> {
+    let ident = input.expect_ident()?.clone();
+    if ident.eq_ignore_ascii_case("auto") {
+        Ok(ColumnFill::Auto)
+    } else if ident.eq_ignore_ascii_case("balance") {
+        Ok(ColumnFill::Balance)
+    } else {
+        Err(input.new_error(BasicParseErrorKind::QualifiedRuleInvalid))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Declaration block parser
+// ---------------------------------------------------------------------------
+
+/// Parse a CSS declaration block (no surrounding braces) into
+/// [`ColumnStyleProps`]. Invalid declarations drop silently; valid ones fill
+/// their field. Last-declaration-wins within a block.
+pub fn parse_declaration_block(css: &str) -> ColumnStyleProps {
+    let mut props = ColumnStyleProps::default();
+    let mut input = ParserInput::new(css);
+    let mut parser = Parser::new(&mut input);
+
+    let mut decl_parser = ColumnDeclParser { props: &mut props };
+    // `RuleBodyParser` walks `decl; decl; decl;` and feeds each declaration
+    // through `DeclarationParser::parse_value`. Errors from one declaration
+    // do not abort the block — they surface as `Err` items in the iterator
+    // which we discard.
+    let iter = RuleBodyParser::new(&mut parser, &mut decl_parser);
+    for item in iter {
+        let _ = item;
+    }
+    props
+}
+
+struct ColumnDeclParser<'a> {
+    props: &'a mut ColumnStyleProps,
+}
+
+impl<'i, 'a> DeclarationParser<'i> for ColumnDeclParser<'a> {
+    type Declaration = ();
+    type Error = ();
+
+    fn parse_value<'t>(
+        &mut self,
+        name: CowRcStr<'i>,
+        input: &mut Parser<'i, 't>,
+        _decl_start: &cssparser::ParserState,
+    ) -> Result<(), ParseError<'i, ()>> {
+        if name.eq_ignore_ascii_case("column-rule") {
+            if let Some(spec) = parse_column_rule_shorthand(input) {
+                // A shorthand with `style: None` is equivalent to "don't
+                // draw" — we store it anyway so a later longhand can read
+                // the width/colour the author still wanted.
+                self.props.rule = Some(spec);
+            }
+        } else if name.eq_ignore_ascii_case("column-rule-width") {
+            if let Ok(w) = input.parse_entirely(parse_length) {
+                let mut spec = self.props.rule.unwrap_or_default();
+                spec.width = w;
+                self.props.rule = Some(spec);
+            }
+        } else if name.eq_ignore_ascii_case("column-rule-style") {
+            let result = input.parse_entirely(|input| {
+                let ident = input.expect_ident()?.clone();
+                parse_rule_style_ident(&ident)
+                    .ok_or_else(|| input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid))
+            });
+            if let Ok(style) = result {
+                let mut spec = self.props.rule.unwrap_or_default();
+                spec.style = style;
+                self.props.rule = Some(spec);
+            }
+        } else if name.eq_ignore_ascii_case("column-rule-color") {
+            if let Ok(color) = input.parse_entirely(parse_color) {
+                let mut spec = self.props.rule.unwrap_or_default();
+                spec.color = color;
+                self.props.rule = Some(spec);
+            }
+        } else if name.eq_ignore_ascii_case("column-fill") {
+            if let Ok(fill) = input.parse_entirely(parse_column_fill_value) {
+                self.props.fill = Some(fill);
+            }
+        } else {
+            // Unknown property — discard its value tokens silently.
+            while input.next().is_ok() {}
+        }
+        Ok(())
+    }
+}
+
+impl<'i, 'a> AtRuleParser<'i> for ColumnDeclParser<'a> {
+    type Prelude = ();
+    type AtRule = ();
+    type Error = ();
+}
+
+impl<'i, 'a> QualifiedRuleParser<'i> for ColumnDeclParser<'a> {
+    type Prelude = ();
+    type QualifiedRule = ();
+    type Error = ();
+}
+
+impl<'i, 'a> RuleBodyItemParser<'i, (), ()> for ColumnDeclParser<'a> {
+    fn parse_declarations(&self) -> bool {
+        true
+    }
+    fn parse_qualified(&self) -> bool {
+        false
+    }
+}
+
+/// Parse the value side of `column-rule: <width> || <style> || <color>`.
+/// Returns `None` if any component is invalid so the whole shorthand drops
+/// — per CSS rules a malformed shorthand is "ignored entirely" and we
+/// mirror that strict behaviour. Missing components fall back to the
+/// defaults in [`ColumnRuleSpec::default`].
+fn parse_column_rule_shorthand(input: &mut Parser<'_, '_>) -> Option<ColumnRuleSpec> {
+    let mut width: Option<f32> = None;
+    let mut style: Option<ColumnRuleStyle> = None;
+    let mut color: Option<[u8; 4]> = None;
+
+    // The shorthand accepts the three components in any order but at most
+    // one of each. Loop up to three times and try each slot in turn.
+    for _ in 0..3 {
+        if input.is_exhausted() {
+            break;
+        }
+
+        // Try width.
+        if width.is_none() {
+            let parsed = input.try_parse(parse_length);
+            if let Ok(w) = parsed {
+                width = Some(w);
+                continue;
+            }
+        }
+
+        // Try style.
+        if style.is_none() {
+            let parsed = input.try_parse(|input| {
+                let ident = input.expect_ident()?.clone();
+                parse_rule_style_ident(&ident)
+                    .ok_or_else(|| input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid))
+            });
+            if let Ok(s) = parsed {
+                style = Some(s);
+                continue;
+            }
+        }
+
+        // Try color.
+        if color.is_none() {
+            let parsed = input.try_parse(parse_color);
+            if let Ok(c) = parsed {
+                color = Some(c);
+                continue;
+            }
+        }
+
+        // No component accepted the next token — malformed shorthand.
+        return None;
+    }
+
+    // Any trailing tokens → invalid.
+    if !input.is_exhausted() {
+        return None;
+    }
+
+    let mut spec = ColumnRuleSpec::default();
+    if let Some(w) = width {
+        spec.width = w;
+    }
+    if let Some(s) = style {
+        spec.style = s;
+    }
+    if let Some(c) = color {
+        spec.color = c;
+    }
+    Some(spec)
+}
+
+// ---------------------------------------------------------------------------
+// Selector parser
+// ---------------------------------------------------------------------------
+
+/// Parse a comma-separated selector list. Returns an empty `Vec` when any
+/// selector uses unsupported syntax (combinators, pseudo-classes, attribute
+/// selectors, or whitespace descendant) — per Phase A scope discipline the
+/// whole rule is dropped silently so authors do not get a half-applied
+/// result.
+pub fn parse_selector_list(input: &str) -> Vec<CompoundSelector> {
+    let mut parser_input = ParserInput::new(input);
+    let mut parser = Parser::new(&mut parser_input);
+
+    let mut compounds = Vec::new();
+    // `just_completed` signals the tokenizer yielded a compound-terminating
+    // whitespace sequence: the next real token must be a `,` or EOF, else
+    // we have a descendant combinator which Phase A does not model.
+    let mut just_saw_whitespace = false;
+    let mut current = CompoundSelector::default();
+
+    loop {
+        let tok_result = parser.next_including_whitespace();
+        let tok = match tok_result {
+            Ok(t) => t.clone(),
+            Err(_) => break,
+        };
+
+        if matches!(tok, Token::WhiteSpace(_)) {
+            // Record but don't act — the follow-up token decides whether
+            // this whitespace was valid (around `,` / at end) or a
+            // descendant combinator (before another selector part).
+            just_saw_whitespace = !current.parts.is_empty();
+            continue;
+        }
+
+        match tok {
+            Token::Comma => {
+                if current.parts.is_empty() {
+                    return Vec::new();
+                }
+                compounds.push(std::mem::take(&mut current));
+                just_saw_whitespace = false;
+            }
+            Token::Delim('.') => {
+                if just_saw_whitespace {
+                    return Vec::new();
+                }
+                match parser.next_including_whitespace() {
+                    Ok(Token::Ident(name)) => {
+                        current
+                            .parts
+                            .push(SimpleSelector::Class(name.as_ref().to_string()));
+                    }
+                    _ => return Vec::new(),
+                }
+                just_saw_whitespace = false;
+            }
+            Token::Delim('*') => {
+                if just_saw_whitespace {
+                    return Vec::new();
+                }
+                current.parts.push(SimpleSelector::Universal);
+                just_saw_whitespace = false;
+            }
+            Token::IDHash(name) | Token::Hash(name) => {
+                if just_saw_whitespace {
+                    return Vec::new();
+                }
+                current
+                    .parts
+                    .push(SimpleSelector::Id(name.as_ref().to_string()));
+                just_saw_whitespace = false;
+            }
+            Token::Ident(name) => {
+                if just_saw_whitespace {
+                    return Vec::new();
+                }
+                current
+                    .parts
+                    .push(SimpleSelector::Type(name.as_ref().to_ascii_lowercase()));
+                just_saw_whitespace = false;
+            }
+            // Unsupported tokens: pseudo-classes (`:`), attribute
+            // selectors (`[`), combinators (`>`, `+`, `~`), numbers, and
+            // anything else the Phase A grammar does not model. Drop the
+            // whole list.
+            _ => return Vec::new(),
+        }
+    }
+
+    if !current.parts.is_empty() {
+        compounds.push(current);
+    } else if compounds.is_empty() {
+        return Vec::new();
+    }
+    compounds
+}
+
+/// Match a [`CompoundSelector`] against a blitz DOM node. Every
+/// [`SimpleSelector`] in the compound must hold (logical AND).
+pub fn matches_node(sel: &CompoundSelector, node: &blitz_dom::Node) -> bool {
+    let Some(elem) = node.element_data() else {
+        return false;
+    };
+    if sel.parts.is_empty() {
+        return false;
+    }
+    sel.parts.iter().all(|part| match part {
+        SimpleSelector::Universal => true,
+        SimpleSelector::Type(tag) => elem.name.local.as_ref().eq_ignore_ascii_case(tag),
+        SimpleSelector::Class(want) => crate::blitz_adapter::get_attr(elem, "class")
+            .is_some_and(|classes| classes.split_whitespace().any(|c| c == want)),
+        SimpleSelector::Id(want) => {
+            crate::blitz_adapter::get_attr(elem, "id").is_some_and(|id| id == want)
+        }
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Stylesheet parser
+// ---------------------------------------------------------------------------
+
+/// Parse a top-level CSS source into [`StyleRule`]s. `@`-rules are skipped
+/// entirely (returning `Err` from `parse_prelude` — cssparser's
+/// `StyleSheetParser` then consumes and discards the block without calling
+/// `parse_block`). Qualified rules whose prelude contains an unsupported
+/// selector are dropped. Empty property blocks are kept out of the result
+/// to save memory.
+pub fn parse_stylesheet(source: &str) -> Vec<StyleRule> {
+    let mut rules = Vec::new();
+    let mut input = ParserInput::new(source);
+    let mut parser = Parser::new(&mut input);
+
+    let mut sheet = SheetParser { rules: &mut rules };
+    let iter = StyleSheetParser::new(&mut parser, &mut sheet);
+    for item in iter {
+        let _ = item;
+    }
+    rules
+}
+
+struct SheetParser<'a> {
+    rules: &'a mut Vec<StyleRule>,
+}
+
+impl<'i, 'a> AtRuleParser<'i> for SheetParser<'a> {
+    type Prelude = ();
+    type AtRule = ();
+    type Error = ();
+
+    fn parse_prelude<'t>(
+        &mut self,
+        name: CowRcStr<'i>,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Self::Prelude, ParseError<'i, ()>> {
+        // Terminate every at-rule at the prelude — `StyleSheetParser` will
+        // then skip the associated block. GCPM's parser takes `@page` but
+        // we are strictly after qualified rules.
+        Err(input.new_error(BasicParseErrorKind::AtRuleInvalid(name)))
+    }
+}
+
+impl<'i, 'a> QualifiedRuleParser<'i> for SheetParser<'a> {
+    type Prelude = Vec<CompoundSelector>;
+    type QualifiedRule = ();
+    type Error = ();
+
+    fn parse_prelude<'t>(
+        &mut self,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Self::Prelude, ParseError<'i, ()>> {
+        // Slice out the raw selector text and hand it to the standalone
+        // selector parser. This keeps cssparser's error recovery simple:
+        // on an unsupported selector we return an empty list, which the
+        // `parse_block` below checks.
+        let start = input.position();
+        while input.next_including_whitespace().is_ok() {}
+        let raw = input.slice_from(start);
+        let selectors = parse_selector_list(raw);
+        if selectors.is_empty() {
+            return Err(input.new_error(BasicParseErrorKind::QualifiedRuleInvalid));
+        }
+        Ok(selectors)
+    }
+
+    fn parse_block<'t>(
+        &mut self,
+        selectors: Self::Prelude,
+        _start: &cssparser::ParserState,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Self::QualifiedRule, ParseError<'i, ()>> {
+        let mut props = ColumnStyleProps::default();
+        let mut decl_parser = ColumnDeclParser { props: &mut props };
+        let iter = RuleBodyParser::new(input, &mut decl_parser);
+        for item in iter {
+            let _ = item;
+        }
+        if !props.is_empty() {
+            self.rules.push(StyleRule { selectors, props });
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cascade driver
+// ---------------------------------------------------------------------------
+
+/// Build the per-document side-table by folding stylesheet rules (in source
+/// order) and then inline `style` attributes (last — they beat the
+/// stylesheet) into each node's entry. Nodes with no matching rule and no
+/// inline declaration are skipped entirely.
+pub fn build_column_style_table(
+    doc: &blitz_html::HtmlDocument,
+    stylesheet_rules: &[StyleRule],
+) -> ColumnStyleTable {
+    let mut table = ColumnStyleTable::new();
+    let root = doc.root_element();
+    walk(doc, root.id, stylesheet_rules, &mut table, 0);
+    table
+}
+
+fn walk(
+    doc: &blitz_html::HtmlDocument,
+    node_id: usize,
+    rules: &[StyleRule],
+    table: &mut ColumnStyleTable,
+    depth: usize,
+) {
+    if depth >= crate::MAX_DOM_DEPTH {
+        return;
+    }
+    let Some(node) = doc.get_node(node_id) else {
+        return;
+    };
+
+    if node.element_data().is_some() {
+        let mut props = ColumnStyleProps::default();
+        for rule in rules {
+            if rule.selectors.iter().any(|sel| matches_node(sel, node)) {
+                props.merge(rule.props);
+            }
+        }
+        if let Some(elem) = node.element_data() {
+            if let Some(inline) = crate::blitz_adapter::get_attr(elem, "style") {
+                let inline_props = parse_declaration_block(inline);
+                props.merge(inline_props);
+            }
+        }
+        if !props.is_empty() {
+            table.insert(node_id, props);
+        }
+    }
+
+    for &child_id in &node.children {
+        walk(doc, child_id, rules, table, depth + 1);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------- declaration parsing --------
+
+    #[test]
+    fn parses_column_rule_longhand_triplet() {
+        let css = "column-rule-width: 2pt; column-rule-style: solid; column-rule-color: red;";
+        let props = parse_declaration_block(css);
+        let rule = props.rule.expect("rule");
+        assert!((rule.width - 2.0).abs() < 1e-3);
+        assert_eq!(rule.style, ColumnRuleStyle::Solid);
+        assert_eq!(rule.color, [255, 0, 0, 255]);
+    }
+
+    #[test]
+    fn parses_column_rule_shorthand() {
+        let props = parse_declaration_block("column-rule: 1px dashed #0a0;");
+        let rule = props.rule.expect("rule");
+        assert!((rule.width - 0.75).abs() < 1e-2); // 1px → 0.75pt
+        assert_eq!(rule.style, ColumnRuleStyle::Dashed);
+        assert_eq!(rule.color, [0x00, 0xAA, 0x00, 0xFF]);
+    }
+
+    #[test]
+    fn parses_column_rule_shorthand_any_order() {
+        let props = parse_declaration_block("column-rule: red 3pt dotted;");
+        let rule = props.rule.expect("rule");
+        assert!((rule.width - 3.0).abs() < 1e-3);
+        assert_eq!(rule.style, ColumnRuleStyle::Dotted);
+        assert_eq!(rule.color, [255, 0, 0, 255]);
+    }
+
+    #[test]
+    fn column_rule_shorthand_partial_uses_defaults() {
+        let props = parse_declaration_block("column-rule: dashed;");
+        let rule = props.rule.expect("rule");
+        assert_eq!(rule.style, ColumnRuleStyle::Dashed);
+        // Defaults: 1pt, black.
+        assert!((rule.width - 1.0).abs() < 1e-3);
+        assert_eq!(rule.color, [0, 0, 0, 255]);
+    }
+
+    #[test]
+    fn parses_column_fill_auto() {
+        let props = parse_declaration_block("column-fill: auto;");
+        assert_eq!(props.fill, Some(ColumnFill::Auto));
+    }
+
+    #[test]
+    fn parses_column_fill_balance() {
+        let props = parse_declaration_block("column-fill: balance;");
+        assert_eq!(props.fill, Some(ColumnFill::Balance));
+    }
+
+    #[test]
+    fn ignores_unsupported_rule_style() {
+        // `double` is Phase C — the whole shorthand must drop.
+        let props = parse_declaration_block("column-rule: 1pt double red;");
+        assert!(props.rule.is_none());
+    }
+
+    #[test]
+    fn px_length_converts_to_pt() {
+        let props = parse_declaration_block("column-rule-width: 4px;");
+        let w = props.rule.expect("rule").width;
+        assert!((w - 3.0).abs() < 1e-3); // 4px * 72/96 = 3pt
+    }
+
+    #[test]
+    fn em_length_is_invalid() {
+        let props = parse_declaration_block("column-rule-width: 1em;");
+        // Unrecognised unit: longhand drops, nothing set.
+        assert!(props.rule.is_none());
+    }
+
+    #[test]
+    fn longhands_compose_across_declarations() {
+        let css = "column-rule-width: 5pt; column-rule-color: blue;";
+        let props = parse_declaration_block(css);
+        let rule = props.rule.expect("rule");
+        assert!((rule.width - 5.0).abs() < 1e-3);
+        assert_eq!(rule.color, [0, 0, 255, 255]);
+        // No `column-rule-style` — default `None` applies.
+        assert_eq!(rule.style, ColumnRuleStyle::None);
+    }
+
+    #[test]
+    fn invalid_declaration_does_not_poison_siblings() {
+        let css = "column-rule-width: 1em; column-fill: auto;";
+        let props = parse_declaration_block(css);
+        assert!(props.rule.is_none());
+        assert_eq!(props.fill, Some(ColumnFill::Auto));
+    }
+
+    #[test]
+    fn currentcolor_drops_color_longhand() {
+        let props = parse_declaration_block("column-rule-color: currentcolor;");
+        // cssparser doesn't know `currentcolor` as a named colour; we
+        // return `None` which drops this declaration silently.
+        assert!(props.rule.is_none());
+    }
+
+    // -------- selector parsing --------
+
+    #[test]
+    fn selector_parses_type_class_id_universal_and_compound() {
+        let list = parse_selector_list("div.foo#bar");
+        assert_eq!(list.len(), 1);
+        assert_eq!(
+            list[0].parts,
+            vec![
+                SimpleSelector::Type("div".into()),
+                SimpleSelector::Class("foo".into()),
+                SimpleSelector::Id("bar".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn selector_universal() {
+        let list = parse_selector_list("*");
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].parts, vec![SimpleSelector::Universal]);
+    }
+
+    #[test]
+    fn selector_comma_list_parsed_as_multiple_compounds() {
+        let list = parse_selector_list(".a, div, #x");
+        assert_eq!(list.len(), 3);
+        assert_eq!(list[0].parts, vec![SimpleSelector::Class("a".into())]);
+        assert_eq!(list[1].parts, vec![SimpleSelector::Type("div".into())]);
+        assert_eq!(list[2].parts, vec![SimpleSelector::Id("x".into())]);
+    }
+
+    #[test]
+    fn selector_unsupported_pseudo_drops_list() {
+        assert!(parse_selector_list("a:hover").is_empty());
+    }
+
+    #[test]
+    fn selector_unsupported_descendant_drops_list() {
+        assert!(parse_selector_list("a b").is_empty());
+    }
+
+    #[test]
+    fn selector_unsupported_child_combinator_drops_list() {
+        assert!(parse_selector_list("a > b").is_empty());
+    }
+
+    #[test]
+    fn selector_unsupported_attribute_drops_list() {
+        assert!(parse_selector_list("input[type=x]").is_empty());
+    }
+
+    #[test]
+    fn selector_tag_lowercased() {
+        let list = parse_selector_list("DIV");
+        assert_eq!(list[0].parts, vec![SimpleSelector::Type("div".into())]);
+    }
+
+    // -------- end-to-end matcher (via blitz_adapter::parse) --------
+
+    fn build_doc(html: &str) -> blitz_html::HtmlDocument {
+        crate::blitz_adapter::parse(html, 400.0, &[])
+    }
+
+    fn find_node_with<F>(doc: &blitz_html::HtmlDocument, pred: F) -> Option<usize>
+    where
+        F: Fn(&blitz_dom::Node) -> bool + Copy,
+    {
+        let root = doc.root_element();
+        fn rec<F: Fn(&blitz_dom::Node) -> bool + Copy>(
+            doc: &blitz_html::HtmlDocument,
+            id: usize,
+            depth: usize,
+            pred: F,
+        ) -> Option<usize> {
+            if depth > 64 {
+                return None;
+            }
+            let node = doc.get_node(id)?;
+            if pred(node) {
+                return Some(id);
+            }
+            for &c in &node.children {
+                if let Some(r) = rec(doc, c, depth + 1, pred) {
+                    return Some(r);
+                }
+            }
+            None
+        }
+        rec(doc, root.id, 0, pred)
+    }
+
+    #[test]
+    fn matches_node_by_tag_class_and_id() {
+        let doc = build_doc(
+            r#"<html><body>
+                <div class="mc" id="one"></div>
+                <p class="other"></p>
+              </body></html>"#,
+        );
+        let div_id = find_node_with(&doc, |n| {
+            n.element_data()
+                .is_some_and(|e| e.name.local.as_ref() == "div")
+        })
+        .expect("div");
+        let div = doc.get_node(div_id).unwrap();
+
+        let t = CompoundSelector {
+            parts: vec![SimpleSelector::Type("div".into())],
+        };
+        let c = CompoundSelector {
+            parts: vec![SimpleSelector::Class("mc".into())],
+        };
+        let i = CompoundSelector {
+            parts: vec![SimpleSelector::Id("one".into())],
+        };
+        let compound = CompoundSelector {
+            parts: vec![
+                SimpleSelector::Type("div".into()),
+                SimpleSelector::Class("mc".into()),
+                SimpleSelector::Id("one".into()),
+            ],
+        };
+        let not_match = CompoundSelector {
+            parts: vec![SimpleSelector::Class("other".into())],
+        };
+
+        assert!(matches_node(&t, div));
+        assert!(matches_node(&c, div));
+        assert!(matches_node(&i, div));
+        assert!(matches_node(&compound, div));
+        assert!(!matches_node(&not_match, div));
+    }
+
+    #[test]
+    fn universal_selector_matches_every_element() {
+        let doc = build_doc("<html><body><span></span></body></html>");
+        let span_id = find_node_with(&doc, |n| {
+            n.element_data()
+                .is_some_and(|e| e.name.local.as_ref() == "span")
+        })
+        .expect("span");
+        let span = doc.get_node(span_id).unwrap();
+        let u = CompoundSelector {
+            parts: vec![SimpleSelector::Universal],
+        };
+        assert!(matches_node(&u, span));
+    }
+
+    // -------- stylesheet parsing --------
+
+    #[test]
+    fn parses_stylesheet_with_multiple_rules() {
+        let css = r#"
+            .mc { column-rule: 1pt solid red; }
+            #x { column-fill: auto; }
+        "#;
+        let rules = parse_stylesheet(css);
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].selectors[0].parts.len(), 1);
+        assert!(rules[0].props.rule.is_some());
+        assert_eq!(rules[1].props.fill, Some(ColumnFill::Auto));
+    }
+
+    #[test]
+    fn stylesheet_skips_at_rules() {
+        let css = r#"
+            @media print { .mc { column-rule: 1pt solid red; } }
+            .mc { column-fill: auto; }
+        "#;
+        let rules = parse_stylesheet(css);
+        // The `@media` block is skipped entirely — only the bare `.mc`
+        // rule remains.
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].props.fill, Some(ColumnFill::Auto));
+    }
+
+    #[test]
+    fn stylesheet_drops_unsupported_selector() {
+        let css = r#"
+            a:hover { column-fill: auto; }
+            .mc { column-fill: balance; }
+        "#;
+        let rules = parse_stylesheet(css);
+        assert_eq!(rules.len(), 1);
+        assert_eq!(
+            rules[0].selectors[0].parts[0],
+            SimpleSelector::Class("mc".into())
+        );
+    }
+
+    #[test]
+    fn stylesheet_drops_rule_with_empty_properties() {
+        // No column-* property — should not be returned.
+        let css = ".mc { color: red; }";
+        let rules = parse_stylesheet(css);
+        assert!(rules.is_empty());
+    }
+
+    // -------- cascade --------
+
+    #[test]
+    fn inline_style_beats_stylesheet() {
+        let html = r#"<html><head><style>
+            .mc { column-rule: 1pt solid blue; }
+        </style></head><body>
+            <div class="mc" id="a"></div>
+            <div class="mc" id="b" style="column-rule: 2pt dashed red"></div>
+        </body></html>"#;
+        let doc = build_doc(html);
+
+        // Extract the <style> content manually so this test doesn't depend
+        // on Task 2's harvester.
+        let rules = parse_stylesheet(".mc { column-rule: 1pt solid blue; }");
+        let table = build_column_style_table(&doc, &rules);
+
+        let a_id = find_node_with(&doc, |n| {
+            n.element_data()
+                .and_then(|e| crate::blitz_adapter::get_attr(e, "id"))
+                == Some("a")
+        })
+        .expect("a");
+        let b_id = find_node_with(&doc, |n| {
+            n.element_data()
+                .and_then(|e| crate::blitz_adapter::get_attr(e, "id"))
+                == Some("b")
+        })
+        .expect("b");
+
+        let a = table.get(&a_id).expect("a entry");
+        let a_rule = a.rule.expect("a rule");
+        assert_eq!(a_rule.color, [0, 0, 255, 255]);
+        assert_eq!(a_rule.style, ColumnRuleStyle::Solid);
+
+        let b = table.get(&b_id).expect("b entry");
+        let b_rule = b.rule.expect("b rule");
+        assert!((b_rule.width - 2.0).abs() < 1e-3);
+        assert_eq!(b_rule.style, ColumnRuleStyle::Dashed);
+        assert_eq!(b_rule.color, [255, 0, 0, 255]);
+    }
+
+    #[test]
+    fn later_stylesheet_rule_wins_on_conflict() {
+        let css = r#"
+            .mc { column-fill: balance; }
+            .mc { column-fill: auto; }
+        "#;
+        let rules = parse_stylesheet(css);
+        let html = r#"<html><body><div class="mc" id="a"></div></body></html>"#;
+        let doc = build_doc(html);
+        let table = build_column_style_table(&doc, &rules);
+        let a_id = find_node_with(&doc, |n| {
+            n.element_data()
+                .and_then(|e| crate::blitz_adapter::get_attr(e, "id"))
+                == Some("a")
+        })
+        .expect("a");
+        assert_eq!(table.get(&a_id).expect("a").fill, Some(ColumnFill::Auto));
+    }
+
+    #[test]
+    fn nodes_without_matching_rule_are_absent_from_table() {
+        let css = ".mc { column-fill: auto; }";
+        let rules = parse_stylesheet(css);
+        let html = r#"<html><body><div id="nope"></div></body></html>"#;
+        let doc = build_doc(html);
+        let table = build_column_style_table(&doc, &rules);
+        // Nothing matches `.mc`, so the table should be empty.
+        assert!(table.is_empty());
+    }
+
+    #[test]
+    fn comma_selector_list_matches_any_compound() {
+        let css = "div, #a { column-fill: auto; }";
+        let rules = parse_stylesheet(css);
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].selectors.len(), 2);
+
+        let html = r#"<html><body>
+            <div></div>
+            <p id="a"></p>
+            <p id="b"></p>
+        </body></html>"#;
+        let doc = build_doc(html);
+        let table = build_column_style_table(&doc, &rules);
+
+        let div_id = find_node_with(&doc, |n| {
+            n.element_data()
+                .is_some_and(|e| e.name.local.as_ref() == "div")
+        })
+        .expect("div");
+        let a_id = find_node_with(&doc, |n| {
+            n.element_data()
+                .and_then(|e| crate::blitz_adapter::get_attr(e, "id"))
+                == Some("a")
+        })
+        .expect("a");
+        let b_id = find_node_with(&doc, |n| {
+            n.element_data()
+                .and_then(|e| crate::blitz_adapter::get_attr(e, "id"))
+                == Some("b")
+        })
+        .expect("b");
+
+        assert_eq!(table.get(&div_id).unwrap().fill, Some(ColumnFill::Auto));
+        assert_eq!(table.get(&a_id).unwrap().fill, Some(ColumnFill::Auto));
+        assert!(!table.contains_key(&b_id));
+    }
+}

--- a/crates/fulgur/src/column_css.rs
+++ b/crates/fulgur/src/column_css.rs
@@ -24,11 +24,12 @@
 //!   canonical CSS factor `72 / 96`. `em`, `rem`, and `%` are deliberately
 //!   treated as invalid for Phase A.
 
-// Task 2 (blitz_adapter harvester) and Task 5 (convert.rs wrapper) are the
-// first callers. Until they land, every public item here looks dead to
-// rustc — silence the warnings at module scope rather than sprinkling
-// individual attributes. Remove this attribute when Task 2 ships.
-#![allow(dead_code)]
+// Task 2 wires the production callers of `extract_column_style_table` /
+// `parse_stylesheet` / `build_column_style_table`; Task 5 will consume the
+// `ColumnStyleProps` / `ColumnRuleSpec` / `ColumnFill` fields to wrap
+// multicol containers with `MulticolRulePageable`. Per-item `dead_code`
+// allows live below for surfaces that Task 5 reaches but Task 2 only
+// populates.
 
 use std::collections::BTreeMap;
 

--- a/crates/fulgur/src/column_css.rs
+++ b/crates/fulgur/src/column_css.rs
@@ -154,14 +154,27 @@ pub struct CompoundSelector {
 // Length and colour helpers
 // ---------------------------------------------------------------------------
 
-/// Convert a CSS length token to PDF points. Accepts only `pt` and `px` for
-/// Phase A; everything else (`em`, `rem`, `%`, `mm`, etc.) is rejected so
-/// the rule silently drops to `None` without falsely measuring.
+/// Default font-size basis used to resolve `em` / `rem` lengths when we
+/// don't have a live cascade to consult. CSS default is `1rem == 16px`;
+/// Phase A does not thread a real computed basis through this parser, so
+/// accepting the default keeps common stylesheets (`column-rule-width:
+/// 0.25rem`) from silently dropping. Phase B will replace this with the
+/// container's resolved font-size.
+const DEFAULT_EM_PX: f32 = 16.0;
+
+/// Convert a CSS length token to PDF points. Accepts `pt` and `px` natively;
+/// `em` and `rem` are resolved against a fixed 16px basis so rule widths
+/// authored in ems don't silently drop. `%`, `mm`, `cm`, `in`, `vh`, `vw`
+/// remain rejected — none of them make sense as a sub-point border width
+/// without consulting the surrounding box, which Phase A does not expose.
 fn length_to_pt(value: f32, unit: &str) -> Option<f32> {
     if unit.eq_ignore_ascii_case("pt") {
         Some(value)
     } else if unit.eq_ignore_ascii_case("px") {
         Some(value * 72.0 / 96.0)
+    } else if unit.eq_ignore_ascii_case("em") || unit.eq_ignore_ascii_case("rem") {
+        // em/rem → px via the default basis, then px → pt.
+        Some(value * DEFAULT_EM_PX * 72.0 / 96.0)
     } else {
         None
     }
@@ -169,9 +182,9 @@ fn length_to_pt(value: f32, unit: &str) -> Option<f32> {
 
 /// Parse a single `<length>` from `input`. Unlike the GCPM variant we reject
 /// `mm`/`cm`/`in` too — the column-rule spec is sub-point and designers use
-/// `px`/`pt` exclusively in practice; folding more units here would just
-/// give inconsistent renders between the multicol rule and the rest of the
-/// border model.
+/// `px`/`pt`/`em` exclusively in practice; folding more units here would
+/// just give inconsistent renders between the multicol rule and the rest
+/// of the border model.
 fn parse_length<'i>(input: &mut Parser<'i, '_>) -> Result<f32, ParseError<'i, ()>> {
     let token = input.next()?.clone();
     match token {
@@ -885,9 +898,47 @@ mod tests {
     }
 
     #[test]
-    fn em_length_is_invalid() {
+    fn em_length_resolves_against_default_basis() {
+        // `1em` at the 16px fallback basis == 12pt.
         let props = parse_declaration_block("column-rule-width: 1em;");
-        // Unrecognised unit: longhand drops, nothing set.
+        let rule = props.rule.expect("rule");
+        assert!(
+            (rule.width - 12.0).abs() < 1e-3,
+            "1em expected 12pt (16px × 72/96), got {}",
+            rule.width
+        );
+    }
+
+    #[test]
+    fn rem_length_resolves_against_default_basis() {
+        // `0.25rem` == 4px at the 16px basis == 3pt.
+        let props = parse_declaration_block("column-rule-width: 0.25rem;");
+        let rule = props.rule.expect("rule");
+        assert!(
+            (rule.width - 3.0).abs() < 1e-3,
+            "0.25rem expected 3pt (4px × 72/96), got {}",
+            rule.width
+        );
+    }
+
+    #[test]
+    fn em_shorthand_resolves_against_default_basis() {
+        let props = parse_declaration_block("column-rule: 0.1em solid red;");
+        let rule = props.rule.expect("rule");
+        // 0.1em × 16 px × 72/96 = 1.2pt
+        assert!(
+            (rule.width - 1.2).abs() < 1e-3,
+            "0.1em expected 1.2pt, got {}",
+            rule.width
+        );
+        assert_eq!(rule.style, ColumnRuleStyle::Solid);
+        assert_eq!(rule.color, [255, 0, 0, 255]);
+    }
+
+    #[test]
+    fn percent_length_still_drops() {
+        // `%` requires a containing-block basis we don't have here.
+        let props = parse_declaration_block("column-rule-width: 50%;");
         assert!(props.rule.is_none());
     }
 
@@ -904,7 +955,9 @@ mod tests {
 
     #[test]
     fn invalid_declaration_does_not_poison_siblings() {
-        let css = "column-rule-width: 1em; column-fill: auto;";
+        // `1vh` has no containing-block basis at parse time → drops the
+        // width declaration. Sibling `column-fill: auto` must still apply.
+        let css = "column-rule-width: 1vh; column-fill: auto;";
         let props = parse_declaration_block(css);
         assert!(props.rule.is_none());
         assert_eq!(props.fill, Some(ColumnFill::Auto));

--- a/crates/fulgur/src/column_css.rs
+++ b/crates/fulgur/src/column_css.rs
@@ -11,9 +11,12 @@
 //! Scope and trade-offs:
 //!
 //! - Only inline `style="..."` attributes and top-level `<style>` blocks are
-//!   scanned. External stylesheets loaded via `<link rel=stylesheet>` are
-//!   already parsed by Blitz for the properties Blitz supports — we do not
-//!   duplicate that path.
+//!   scanned. External stylesheets loaded via `<link rel=stylesheet>` reach
+//!   stylo/blitz for the properties they support but do **not** currently
+//!   populate this side-table — tracked as fulgur-s5ro.
+//! - `<style media="...">` blocks whose media excludes `all` / `print` are
+//!   skipped by the harvester (`extract_column_style_table` in
+//!   `blitz_adapter.rs`). Full CSS media-query evaluation is deferred.
 //! - The selector grammar is intentionally tiny: type (`div`), class
 //!   (`.foo`), id (`#bar`), universal (`*`), compound (`div.foo#bar`) and
 //!   comma-separated lists. Unsupported combinators or pseudo-classes cause
@@ -21,8 +24,11 @@
 //! - Source order wins (no specificity, no `!important`). Inline style is
 //!   folded last so it beats stylesheet rules.
 //! - Length units: `pt` passes through, `px` is converted to `pt` using the
-//!   canonical CSS factor `72 / 96`. `em`, `rem`, and `%` are deliberately
-//!   treated as invalid for Phase A.
+//!   canonical CSS factor `72 / 96`. `em` and `rem` resolve against a fixed
+//!   `DEFAULT_EM_PX = 16.0` basis (Phase B will replace this with the
+//!   container's computed font-size). `%`, `vh`, `vw`, `mm`, `cm`, `in`
+//!   remain invalid — none of them make sense as a sub-point border width
+//!   without consulting the surrounding box.
 
 // Task 2 wires the production callers of `extract_column_style_table` /
 // `parse_stylesheet` / `build_column_style_table`; Task 5 will consume the

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -277,6 +277,7 @@ fn maybe_wrap_multicol_rule(
         .groups
         .iter()
         .map(|g| crate::multicol_layout::ColumnGroupGeometry {
+            x_offset: px_to_pt(g.x_offset),
             y_offset: px_to_pt(g.y_offset),
             col_w: px_to_pt(g.col_w),
             gap: px_to_pt(g.gap),

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -92,6 +92,13 @@ pub struct ConvertContext<'a> {
     /// — which matters because the wrapper draws rule segments in table
     /// iteration order and drives PDF output.
     pub column_styles: crate::column_css::ColumnStyleTable,
+    /// Per-multicol-container geometry recorded by the Taffy multicol hook
+    /// (see [`crate::multicol_layout::run_pass`]). Task 4's
+    /// `MulticolRulePageable` reads this to paint `column-rule` lines
+    /// between adjacent non-empty columns without re-running layout.
+    /// Keyed by container `usize` NodeId — same convention as
+    /// `column_styles`.
+    pub multicol_geometry: crate::multicol_layout::MulticolGeometryTable,
 }
 
 impl ConvertContext<'_> {
@@ -3204,6 +3211,7 @@ mod tests {
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
+            multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
         };
         let tree = super::dom_to_pageable(&doc, &mut ctx);
 
@@ -3248,6 +3256,7 @@ mod tests {
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
+            multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
         };
         let tree = super::dom_to_pageable(&doc, &mut ctx);
 
@@ -3296,6 +3305,7 @@ mod tests {
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
+            multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
         };
         let tree = super::dom_to_pageable(&doc, &mut ctx);
         let mut images = Vec::new();
@@ -3352,6 +3362,7 @@ mod tests {
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
+            multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
         };
         let tree = super::dom_to_pageable(&doc, &mut ctx);
         let mut images = Vec::new();
@@ -3399,6 +3410,7 @@ mod tests {
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
+            multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
         };
         let tree = super::dom_to_pageable(&doc, &mut ctx);
         let mut images = Vec::new();
@@ -3662,6 +3674,7 @@ mod tests {
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
+            multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
         };
         let tree = super::dom_to_pageable(&doc, &mut ctx);
 
@@ -3693,6 +3706,7 @@ mod tests {
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
+            multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
         };
         let tree = super::dom_to_pageable(&doc, &mut ctx);
 
@@ -3727,6 +3741,7 @@ mod tests {
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
+            multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
         };
         let tree = super::dom_to_pageable(&doc, &mut ctx);
 
@@ -3788,6 +3803,7 @@ mod tests {
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node,
             column_styles: crate::column_css::ColumnStyleTable::new(),
+            multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
         };
         let root = dom_to_pageable(&doc, &mut ctx);
 
@@ -3834,6 +3850,7 @@ mod tests {
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node,
             column_styles: crate::column_css::ColumnStyleTable::new(),
+            multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
         };
         let root = dom_to_pageable(&doc, &mut ctx);
 
@@ -3896,6 +3913,7 @@ mod tests {
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node,
             column_styles: crate::column_css::ColumnStyleTable::new(),
+            multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
         };
         let root = dom_to_pageable(&doc, &mut ctx);
 
@@ -3961,6 +3979,7 @@ mod tests {
                 counter_ops_by_node: HashMap::new(),
                 bookmark_by_node: HashMap::new(),
                 column_styles: crate::column_css::ColumnStyleTable::new(),
+                multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
             }
         }};
     }
@@ -4186,6 +4205,7 @@ mod tests {
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
+            multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
         };
         let tree = super::dom_to_pageable(&doc, &mut ctx);
         assert!(
@@ -4209,6 +4229,7 @@ mod tests {
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
+            multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
         };
         let tree = super::dom_to_pageable(&doc, &mut ctx);
         // Empty <li> with no AssetBundle fonts: marker may not render if no
@@ -4232,6 +4253,7 @@ mod tests {
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
+            multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
         };
         let tree = super::dom_to_pageable(&doc, &mut ctx);
         assert!(

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -168,6 +168,17 @@ fn convert_node(
         return Box::new(SpacerPageable::new(0.0));
     }
     let result = convert_node_inner(doc, node_id, ctx, depth);
+    // Wrap multicol containers in `MulticolRulePageable` when the Phase A
+    // side-table carries a renderable `column-rule` spec and the Taffy
+    // layout hook recorded geometry for this container. Applied here
+    // (once per node) rather than at each of the ~11
+    // `BlockPageable::with_positioned_children` construction sites in
+    // `convert_node_inner`, because this is the single choke point all
+    // paths funnel through before downstream wrappers
+    // (string-set / counter-ops / transform / bookmark). The helper is
+    // a no-op for non-multicol nodes and for multicol nodes without a
+    // visible rule.
+    let result = maybe_wrap_multicol_rule(doc, node_id, ctx, result);
     let result = maybe_prepend_string_set(node_id, result, ctx);
     let result = maybe_prepend_counter_ops(node_id, result, ctx);
     let result = maybe_wrap_transform(doc, node_id, result);
@@ -221,6 +232,47 @@ fn maybe_prepend_counter_ops(
         Some(ops) if !ops.is_empty() => Box::new(CounterOpWrapperPageable::new(ops, child)),
         _ => child,
     }
+}
+
+/// If the given node is a multicol container (`column-count` or
+/// `column-width` non-auto) AND the Phase A `column-*` side-table carries a
+/// visible `column-rule` spec for it AND the Taffy multicol hook recorded
+/// geometry for it, wrap the pageable in a [`MulticolRulePageable`] so the
+/// draw pass paints vertical rules between adjacent non-empty columns.
+///
+/// No-op in all other cases — non-multicol nodes, multicol nodes without
+/// a rule, or rules with `style: none` / non-positive width. The helper is
+/// called once per node at the choke point in [`convert_node`], so adding
+/// it there covers every `BlockPageable::with_positioned_children`
+/// construction path without requiring per-site adjustments.
+fn maybe_wrap_multicol_rule(
+    doc: &blitz_dom::BaseDocument,
+    node_id: usize,
+    ctx: &ConvertContext<'_>,
+    child: Box<dyn Pageable>,
+) -> Box<dyn Pageable> {
+    let Some(node) = doc.get_node(node_id) else {
+        return child;
+    };
+    if !crate::blitz_adapter::is_multicol_container(node) {
+        return child;
+    }
+    let Some(rule) = ctx
+        .column_styles
+        .get(&node_id)
+        .and_then(|props| props.rule)
+        .filter(|r| r.style != crate::column_css::ColumnRuleStyle::None && r.width > 0.0)
+    else {
+        return child;
+    };
+    let Some(geometry) = ctx.multicol_geometry.get(&node_id) else {
+        return child;
+    };
+    Box::new(crate::pageable::MulticolRulePageable::new(
+        child,
+        rule,
+        geometry.groups.clone(),
+    ))
 }
 
 /// If the given node has a non-identity `transform`, wrap the pageable in a

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -268,10 +268,24 @@ fn maybe_wrap_multicol_rule(
     let Some(geometry) = ctx.multicol_geometry.get(&node_id) else {
         return child;
     };
+    // `ColumnGroupGeometry` is recorded by the Taffy hook in CSS pixels
+    // (Taffy's native unit). Every other Pageable consumes pt, so convert
+    // at the wrapper boundary: the downstream `MulticolRulePageable::draw`
+    // and `split_boxed` can then mix these values with pt-valued `x`/`y`
+    // and pt-valued `cutoff` without a unit mismatch. See `px_to_pt`.
+    let groups_pt: Vec<crate::multicol_layout::ColumnGroupGeometry> = geometry
+        .groups
+        .iter()
+        .map(|g| crate::multicol_layout::ColumnGroupGeometry {
+            y_offset: px_to_pt(g.y_offset),
+            col_w: px_to_pt(g.col_w),
+            gap: px_to_pt(g.gap),
+            n: g.n,
+            col_heights: g.col_heights.iter().copied().map(px_to_pt).collect(),
+        })
+        .collect();
     Box::new(crate::pageable::MulticolRulePageable::new(
-        child,
-        rule,
-        geometry.groups.clone(),
+        child, rule, groups_pt,
     ))
 }
 

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -85,6 +85,13 @@ pub struct ConvertContext<'a> {
     /// defaults for `h1`-`h6` come from `FULGUR_UA_CSS` applied by the
     /// engine before `BookmarkPass` runs.
     pub bookmark_by_node: HashMap<usize, crate::blitz_adapter::BookmarkInfo>,
+    /// Phase A `column-*` side-table harvested by
+    /// [`crate::blitz_adapter::extract_column_style_table`]. Task 5 reads
+    /// `rule` properties from here when wrapping multicol containers in
+    /// `MulticolRulePageable`. `BTreeMap` keeps iteration deterministic
+    /// — which matters because the wrapper draws rule segments in table
+    /// iteration order and drives PDF output.
+    pub column_styles: crate::column_css::ColumnStyleTable,
 }
 
 impl ConvertContext<'_> {
@@ -3196,6 +3203,7 @@ mod tests {
             string_set_by_node: HashMap::new(),
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
+            column_styles: crate::column_css::ColumnStyleTable::new(),
         };
         let tree = super::dom_to_pageable(&doc, &mut ctx);
 
@@ -3239,6 +3247,7 @@ mod tests {
             string_set_by_node: HashMap::new(),
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
+            column_styles: crate::column_css::ColumnStyleTable::new(),
         };
         let tree = super::dom_to_pageable(&doc, &mut ctx);
 
@@ -3286,6 +3295,7 @@ mod tests {
             string_set_by_node: HashMap::new(),
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
+            column_styles: crate::column_css::ColumnStyleTable::new(),
         };
         let tree = super::dom_to_pageable(&doc, &mut ctx);
         let mut images = Vec::new();
@@ -3341,6 +3351,7 @@ mod tests {
             string_set_by_node: HashMap::new(),
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
+            column_styles: crate::column_css::ColumnStyleTable::new(),
         };
         let tree = super::dom_to_pageable(&doc, &mut ctx);
         let mut images = Vec::new();
@@ -3387,6 +3398,7 @@ mod tests {
             string_set_by_node: HashMap::new(),
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
+            column_styles: crate::column_css::ColumnStyleTable::new(),
         };
         let tree = super::dom_to_pageable(&doc, &mut ctx);
         let mut images = Vec::new();
@@ -3649,6 +3661,7 @@ mod tests {
             string_set_by_node: HashMap::new(),
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
+            column_styles: crate::column_css::ColumnStyleTable::new(),
         };
         let tree = super::dom_to_pageable(&doc, &mut ctx);
 
@@ -3679,6 +3692,7 @@ mod tests {
             string_set_by_node: HashMap::new(),
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
+            column_styles: crate::column_css::ColumnStyleTable::new(),
         };
         let tree = super::dom_to_pageable(&doc, &mut ctx);
 
@@ -3712,6 +3726,7 @@ mod tests {
             string_set_by_node: HashMap::new(),
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
+            column_styles: crate::column_css::ColumnStyleTable::new(),
         };
         let tree = super::dom_to_pageable(&doc, &mut ctx);
 
@@ -3772,6 +3787,7 @@ mod tests {
             string_set_by_node: HashMap::new(),
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node,
+            column_styles: crate::column_css::ColumnStyleTable::new(),
         };
         let root = dom_to_pageable(&doc, &mut ctx);
 
@@ -3817,6 +3833,7 @@ mod tests {
             string_set_by_node: HashMap::new(),
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node,
+            column_styles: crate::column_css::ColumnStyleTable::new(),
         };
         let root = dom_to_pageable(&doc, &mut ctx);
 
@@ -3878,6 +3895,7 @@ mod tests {
             string_set_by_node: HashMap::new(),
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node,
+            column_styles: crate::column_css::ColumnStyleTable::new(),
         };
         let root = dom_to_pageable(&doc, &mut ctx);
 
@@ -3942,6 +3960,7 @@ mod tests {
                 string_set_by_node: HashMap::new(),
                 counter_ops_by_node: HashMap::new(),
                 bookmark_by_node: HashMap::new(),
+                column_styles: crate::column_css::ColumnStyleTable::new(),
             }
         }};
     }
@@ -4166,6 +4185,7 @@ mod tests {
             string_set_by_node: HashMap::new(),
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
+            column_styles: crate::column_css::ColumnStyleTable::new(),
         };
         let tree = super::dom_to_pageable(&doc, &mut ctx);
         assert!(
@@ -4188,6 +4208,7 @@ mod tests {
             string_set_by_node: HashMap::new(),
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
+            column_styles: crate::column_css::ColumnStyleTable::new(),
         };
         let tree = super::dom_to_pageable(&doc, &mut ctx);
         // Empty <li> with no AssetBundle fonts: marker may not render if no
@@ -4210,6 +4231,7 @@ mod tests {
             string_set_by_node: HashMap::new(),
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
+            column_styles: crate::column_css::ColumnStyleTable::new(),
         };
         let tree = super::dom_to_pageable(&doc, &mut ctx);
         assert!(

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -178,8 +178,13 @@ impl Engine {
 
         // Blitz treats multicol containers as plain blocks; route them
         // through fulgur's Taffy hook so columns balance and siblings
-        // shift in lockstep. See docs/plans/2026-04-20-css-multicol-design.md.
-        crate::multicol_layout::run_pass(doc.deref_mut(), &column_styles);
+        // shift in lockstep. The returned geometry table captures per-
+        // `ColumnGroup` layout for Task 4's `MulticolRulePageable`; we
+        // thread it through `ConvertContext` so the convert pass can
+        // wrap multicol containers with the rule spec + geometry they
+        // need to render. See docs/plans/2026-04-20-css-multicol-design.md
+        // and docs/plans/2026-04-21-fulgur-v7a-column-rule.md.
+        let multicol_geometry = crate::multicol_layout::run_pass(doc.deref_mut(), &column_styles);
 
         // --- Convert DOM to Pageable and render ---
         // Build string-set lookup map
@@ -210,6 +215,7 @@ impl Engine {
             counter_ops_by_node: counter_ops_map,
             bookmark_by_node,
             column_styles,
+            multicol_geometry,
         };
         let root = crate::convert::dom_to_pageable(&doc, &mut convert_ctx);
 
@@ -284,7 +290,7 @@ impl Engine {
 
         crate::blitz_adapter::resolve(&mut doc);
         let column_styles = crate::blitz_adapter::extract_column_style_table(&doc);
-        crate::multicol_layout::run_pass(doc.deref_mut(), &column_styles);
+        let multicol_geometry = crate::multicol_layout::run_pass(doc.deref_mut(), &column_styles);
 
         let running_store = crate::gcpm::running::RunningElementStore::new();
         let mut convert_ctx = ConvertContext {
@@ -295,6 +301,7 @@ impl Engine {
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
             column_styles,
+            multicol_geometry,
         };
         crate::convert::dom_to_pageable(&doc, &mut convert_ctx)
     }

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -169,10 +169,17 @@ impl Engine {
         }
 
         crate::blitz_adapter::resolve(&mut doc);
+
+        // Harvest Phase A `column-*` properties (column-fill, column-rule-*)
+        // that stylo 0.8.0 gates behind its gecko engine. The side-table is
+        // consumed first by the multicol layout hook (for column-fill) and
+        // then by the convert pass (for column-rule wrapping).
+        let column_styles = crate::blitz_adapter::extract_column_style_table(&doc);
+
         // Blitz treats multicol containers as plain blocks; route them
         // through fulgur's Taffy hook so columns balance and siblings
         // shift in lockstep. See docs/plans/2026-04-20-css-multicol-design.md.
-        crate::multicol_layout::run_pass(doc.deref_mut());
+        crate::multicol_layout::run_pass(doc.deref_mut(), &column_styles);
 
         // --- Convert DOM to Pageable and render ---
         // Build string-set lookup map
@@ -202,6 +209,7 @@ impl Engine {
             string_set_by_node,
             counter_ops_by_node: counter_ops_map,
             bookmark_by_node,
+            column_styles,
         };
         let root = crate::convert::dom_to_pageable(&doc, &mut convert_ctx);
 
@@ -275,7 +283,8 @@ impl Engine {
         crate::blitz_adapter::apply_passes(&mut doc, &passes, &ctx);
 
         crate::blitz_adapter::resolve(&mut doc);
-        crate::multicol_layout::run_pass(doc.deref_mut());
+        let column_styles = crate::blitz_adapter::extract_column_style_table(&doc);
+        crate::multicol_layout::run_pass(doc.deref_mut(), &column_styles);
 
         let running_store = crate::gcpm::running::RunningElementStore::new();
         let mut convert_ctx = ConvertContext {
@@ -285,6 +294,7 @@ impl Engine {
             string_set_by_node: HashMap::new(),
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
+            column_styles,
         };
         crate::convert::dom_to_pageable(&doc, &mut convert_ctx)
     }

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -5,6 +5,7 @@ pub(crate) const MAX_DOM_DEPTH: usize = 512;
 pub mod asset;
 pub mod background;
 pub mod blitz_adapter;
+pub(crate) mod column_css;
 pub mod config;
 pub mod convert;
 pub mod engine;

--- a/crates/fulgur/src/multicol_layout.rs
+++ b/crates/fulgur/src/multicol_layout.rs
@@ -153,11 +153,9 @@ pub(crate) fn partition_children_into_segments(
 /// convert pass.
 pub struct FulgurLayoutTree<'a> {
     pub(crate) doc: &'a mut BaseDocument,
-    // Task 5 will read this field from `compute_multicol_layout` /
-    // `layout_column_group` to branch on `ColumnFill::Auto`; until that lands,
-    // the field is populated but never consulted, so silence the warning
-    // locally rather than leaving `#![allow(dead_code)]` at module scope.
-    #[allow(dead_code)]
+    // Read by `compute_multicol_layout` to resolve `column-fill` before
+    // delegating to `layout_column_group`. Populated by the engine via
+    // `extract_column_style_table` before the multicol pass runs.
     pub(crate) column_styles: &'a crate::column_css::ColumnStyleTable,
     /// Per-container geometry populated by `compute_multicol_layout` as it
     /// balances each `ColumnGroup` segment. Owned (not borrowed) because the
@@ -547,6 +545,18 @@ pub fn compute_multicol_layout(
         _ => f32::INFINITY,
     };
 
+    // Resolve the container's `column-fill` once per layout. The Phase A
+    // side-table (see `column_css::ColumnStyleTable`) holds the parsed
+    // value; absent entries default to `Balance` per the CSS initial
+    // value. `ColumnFill::Auto` switches the per-group budget from the
+    // balance search to a greedy sequential fill (see
+    // `layout_column_group`).
+    let fill = tree
+        .column_styles
+        .get(&usize::from(node_id))
+        .and_then(|p| p.fill)
+        .unwrap_or_default();
+
     // 5. Walk the segments produced by `partition_children_into_segments`
     //    and dispatch each to the appropriate layout strategy:
     //
@@ -574,6 +584,7 @@ pub fn compute_multicol_layout(
                     gap,
                     n,
                     avail_h,
+                    fill,
                     &children,
                     cursor_y,
                     child_inputs,
@@ -684,6 +695,7 @@ fn layout_column_group(
     gap: f32,
     n: u32,
     avail_h: f32,
+    fill: crate::column_css::ColumnFill,
     children: &[NodeId],
     y_offset: f32,
     child_inputs: taffy::tree::LayoutInput,
@@ -695,14 +707,24 @@ fn layout_column_group(
         measured.push((child, output.size));
     }
 
-    // 2. Balance budget
+    // 2. Budget selection — `column-fill: balance` (the default) searches
+    //    for the smallest budget that fits all children in `n` columns,
+    //    so the tallest column's height is minimised. `column-fill: auto`
+    //    (CSS Multi-column Level 1 §6.1) instead greedily fills columns
+    //    top-to-bottom up to `avail_h`, leaving trailing columns empty
+    //    when content fits in fewer than `n`.
     let total_h: f32 = measured.iter().map(|(_, s)| s.height).sum();
-    let budget = if total_h <= 0.0 {
-        0.0
-    } else if total_h >= avail_h * n as f32 {
-        avail_h
-    } else {
-        balance_budget(&measured, n, avail_h, total_h)
+    let budget = match fill {
+        crate::column_css::ColumnFill::Auto => avail_h,
+        crate::column_css::ColumnFill::Balance => {
+            if total_h <= 0.0 {
+                0.0
+            } else if total_h >= avail_h * n as f32 {
+                avail_h
+            } else {
+                balance_budget(&measured, n, avail_h, total_h)
+            }
+        }
     };
 
     // 3. Distribute
@@ -2018,6 +2040,162 @@ mod tests {
         assert!(
             second.is_empty(),
             "second take must be empty — no double-counting"
+        );
+    }
+
+    // ── column-fill: auto (Task 5 Part A) ───────────────────────────
+
+    #[test]
+    fn column_fill_auto_leaves_later_columns_empty_when_content_fits() {
+        // A single short paragraph inside a `column-count: 2; column-fill: auto`
+        // container must land entirely in the first column — the second column
+        // stays empty. Balance mode would split it roughly in half; auto must
+        // not.
+        //
+        // We inject the `column-fill: auto` directive via the Phase A side-
+        // table (not via inline CSS) because stylo 0.8.0 doesn't surface
+        // `column-fill` for the servo engine blitz uses; that's exactly the
+        // reason the side-table exists.
+        let html = r#"<!doctype html><html><body>
+            <div id="mc" style="column-count: 2; column-gap: 0;">
+              <p>alpha alpha alpha alpha</p>
+            </div>
+        </body></html>"#;
+        let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
+        crate::blitz_adapter::resolve(&mut doc);
+
+        let mc_id = collect_multicol_node_ids(&doc)[0];
+
+        let mut column_styles = crate::column_css::ColumnStyleTable::new();
+        column_styles.insert(
+            mc_id,
+            crate::column_css::ColumnStyleProps {
+                rule: None,
+                fill: Some(crate::column_css::ColumnFill::Auto),
+            },
+        );
+
+        let geometry_table = run_pass(&mut doc, &column_styles);
+        let mc_geom = geometry_table
+            .get(&mc_id)
+            .expect("multicol container should have a geometry entry");
+        assert_eq!(mc_geom.groups.len(), 1);
+
+        let group = &mc_geom.groups[0];
+        assert_eq!(group.n, 2);
+        assert_eq!(group.col_heights.len(), 2);
+        assert!(
+            group.col_heights[0] > 0.0,
+            "first column must contain the paragraph, got {:?}",
+            group.col_heights
+        );
+        assert_eq!(
+            group.col_heights[1], 0.0,
+            "column-fill: auto must leave the second column empty when content fits in the first, got {:?}",
+            group.col_heights
+        );
+    }
+
+    // ── convert.rs integration: MulticolRulePageable wrapping (Task 5 Part C) ──
+
+    /// Recursively search a `Pageable` tree for the first
+    /// `MulticolRulePageable`, returning a cloned copy when found. We clone
+    /// because the tree is owned by the caller and `Pageable` is object-safe
+    /// but not `Any` by default; we go through the concrete type's `Clone`
+    /// via `as_any` + downcast.
+    fn find_multicol_rule(
+        pageable: &dyn crate::pageable::Pageable,
+    ) -> Option<crate::pageable::MulticolRulePageable> {
+        if let Some(w) = pageable
+            .as_any()
+            .downcast_ref::<crate::pageable::MulticolRulePageable>()
+        {
+            return Some(w.clone());
+        }
+        if let Some(block) = pageable
+            .as_any()
+            .downcast_ref::<crate::pageable::BlockPageable>()
+        {
+            for pc in &block.children {
+                if let Some(hit) = find_multicol_rule(pc.child.as_ref()) {
+                    return Some(hit);
+                }
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn convert_wraps_multicol_container_in_rule_pageable_when_rule_defined() {
+        // End-to-end wiring probe: HTML with `column-rule` must produce a
+        // `MulticolRulePageable` somewhere in the converted tree. Drives the
+        // full render pipeline (Engine → parse → column_css harvest →
+        // multicol hook → convert) minus GCPM — which is irrelevant here —
+        // via `build_pageable_for_testing_no_gcpm`.
+        let html = r#"<!doctype html><html><head><style>
+            .mc {
+                column-count: 2;
+                column-gap: 20pt;
+                column-rule: 2pt solid red;
+            }
+        </style></head><body>
+          <div class="mc">
+            <p>alpha alpha alpha alpha</p>
+            <p>beta beta beta beta</p>
+            <p>gamma gamma gamma gamma</p>
+            <p>delta delta delta delta</p>
+          </div>
+        </body></html>"#;
+
+        let engine = crate::Engine::builder()
+            .page_size(crate::config::PageSize {
+                width: 400.0,
+                height: 600.0,
+            })
+            .build();
+        let root = engine.build_pageable_for_testing_no_gcpm(html);
+
+        let wrapper = find_multicol_rule(root.as_ref()).expect(
+            "convert must wrap the multicol container in MulticolRulePageable when column-rule is defined",
+        );
+        assert_eq!(
+            wrapper.rule.style,
+            crate::column_css::ColumnRuleStyle::Solid
+        );
+        assert!(
+            (wrapper.rule.width - 2.0).abs() < 1e-3,
+            "width should be 2pt, got {}",
+            wrapper.rule.width
+        );
+        assert_eq!(wrapper.rule.color, [255, 0, 0, 255]);
+        assert!(
+            !wrapper.groups.is_empty(),
+            "geometry must have at least one ColumnGroup"
+        );
+    }
+
+    #[test]
+    fn convert_does_not_wrap_multicol_without_rule() {
+        // Multicol container with no `column-rule` must pass through
+        // unchanged — no `MulticolRulePageable` wrapper inserted. Guards
+        // against the wrapper leaking into every multicol render.
+        let html = r#"<!doctype html><html><body>
+          <div style="column-count: 2; column-gap: 0;">
+            <p>alpha alpha alpha alpha</p>
+            <p>beta beta beta beta</p>
+          </div>
+        </body></html>"#;
+
+        let engine = crate::Engine::builder()
+            .page_size(crate::config::PageSize {
+                width: 400.0,
+                height: 600.0,
+            })
+            .build();
+        let root = engine.build_pageable_for_testing_no_gcpm(html);
+        assert!(
+            find_multicol_rule(root.as_ref()).is_none(),
+            "multicol without column-rule must not be wrapped"
         );
     }
 }

--- a/crates/fulgur/src/multicol_layout.rs
+++ b/crates/fulgur/src/multicol_layout.rs
@@ -15,11 +15,71 @@
 //! mechanism one layer up.
 
 use blitz_dom::BaseDocument;
+use std::collections::BTreeMap;
 use taffy::{
     AvailableSpace, CacheTree, CollapsibleMarginSet, CoreStyle, LayoutPartialTree, Line, NodeId,
     Point, RequestedAxis, ResolveOrZero, RoundTree, RunMode, Size, SizingMode, TraversePartialTree,
     TraverseTree,
 };
+
+/// Per-`ColumnGroup` geometry recorded by the Taffy multicol hook.
+///
+/// `layout_column_group` builds one of these every time it balances a run of
+/// columnar children. Consumers (Task 4's `MulticolRulePageable`) use the
+/// geometry to paint `column-rule` lines between adjacent non-empty columns
+/// without re-running layout: the rule at gutter `i ↔ i+1` starts at
+/// `y_offset` and extends `min(col_heights[i], col_heights[i+1])` downward.
+///
+/// Conventions:
+///
+/// - `y_offset` is measured from the multicol container's content box top,
+///   not from the page or the viewport.
+/// - `col_heights` always has length `n`; an entry is `0.0` when the column
+///   contains no placements.
+/// - `col_w` and `gap` are in CSS pixels (Taffy's native unit), matching the
+///   rest of the multicol hook.
+/// - `x_offset` / `y_offset` are relative to the multicol container's
+///   **border-box** top-left (same frame as `BlockPageable::draw`'s `x, y`
+///   args). They already include the container's own padding + border.
+#[derive(Clone, Debug, Default)]
+pub struct ColumnGroupGeometry {
+    /// Horizontal offset from the container's border-box left to column 0's
+    /// left edge. Equals the container's (padding-left + border-left).
+    pub x_offset: f32,
+    /// Vertical offset from the container's border-box top to this group's
+    /// top. Includes the container's (padding-top + border-top); subsequent
+    /// groups accumulate prior segment heights on top of that.
+    pub y_offset: f32,
+    /// Width of a single column, in CSS pixels.
+    pub col_w: f32,
+    /// Horizontal gap between adjacent columns, in CSS pixels.
+    pub gap: f32,
+    /// Number of columns this group balances across.
+    pub n: u32,
+    /// Per-column filled height. `col_heights[i]` is the bottom-most
+    /// placement's `(location.y + size.height)` minus `y_offset` for column
+    /// `i`, clamped to `>= 0.0`. An entry of `0.0` means column `i` received
+    /// no placements. Always has length == `n`.
+    pub col_heights: Vec<f32>,
+}
+
+/// Full per-container multicol geometry record.
+///
+/// One `ColumnGroupGeometry` per `Segment::ColumnGroup` in source order.
+/// `SpanAll` segments do not contribute geometry because they span the full
+/// container width — there are no inter-column gutters to draw a rule in.
+#[derive(Clone, Debug, Default)]
+pub struct MulticolGeometry {
+    pub groups: Vec<ColumnGroupGeometry>,
+}
+
+/// Side-table mapping multicol container `usize` NodeIds to their geometry.
+///
+/// Keyed by raw `usize` (same convention as
+/// [`crate::column_css::ColumnStyleTable`]) so convert-side lookups can use
+/// the DOM node id directly. `BTreeMap`, not `HashMap`, because iteration
+/// order may feed into PDF byte order downstream.
+pub type MulticolGeometryTable = BTreeMap<usize, MulticolGeometry>;
 
 /// One top-level slice of a multicol container's flattened child list.
 ///
@@ -93,24 +153,38 @@ pub(crate) fn partition_children_into_segments(
 /// convert pass.
 pub struct FulgurLayoutTree<'a> {
     pub(crate) doc: &'a mut BaseDocument,
-    // Task 3 will read this field from `compute_multicol_layout` /
+    // Task 5 will read this field from `compute_multicol_layout` /
     // `layout_column_group` to branch on `ColumnFill::Auto`; until that lands,
     // the field is populated but never consulted, so silence the warning
     // locally rather than leaving `#![allow(dead_code)]` at module scope.
     #[allow(dead_code)]
     pub(crate) column_styles: &'a crate::column_css::ColumnStyleTable,
+    /// Per-container geometry populated by `compute_multicol_layout` as it
+    /// balances each `ColumnGroup` segment. Owned (not borrowed) because the
+    /// table is produced during this layout pass and must outlive the tree —
+    /// callers drain it via [`FulgurLayoutTree::take_geometry`] and thread
+    /// it into the convert pipeline. `BTreeMap` keeps iteration order
+    /// deterministic across runs.
+    pub(crate) geometry: MulticolGeometryTable,
 }
 
 /// One-shot entry used by the render pipeline after `blitz_adapter::resolve`.
-/// Runs the multicol Taffy hook on every multicol subtree in the document.
+/// Runs the multicol Taffy hook on every multicol subtree in the document,
+/// then returns the geometry table so downstream passes (convert → draw)
+/// can paint `column-rule` lines without re-walking layout.
 ///
 /// `column_styles` is the Phase A side-table harvested by
 /// [`crate::blitz_adapter::extract_column_style_table`]. Callers that do not
 /// need `column-fill` / `column-rule` resolution can pass an empty table
 /// (e.g. test helpers — see the `FulgurLayoutTree::new` call sites in the
-/// unit-test modules below).
-pub fn run_pass(doc: &mut BaseDocument, column_styles: &crate::column_css::ColumnStyleTable) {
-    FulgurLayoutTree::new(doc, column_styles).layout_multicol_subtrees();
+/// unit-test modules below) and simply drop the returned geometry.
+pub fn run_pass(
+    doc: &mut BaseDocument,
+    column_styles: &crate::column_css::ColumnStyleTable,
+) -> MulticolGeometryTable {
+    let mut tree = FulgurLayoutTree::new(doc, column_styles);
+    tree.layout_multicol_subtrees();
+    tree.take_geometry()
 }
 
 impl<'a> FulgurLayoutTree<'a> {
@@ -118,7 +192,21 @@ impl<'a> FulgurLayoutTree<'a> {
         doc: &'a mut BaseDocument,
         column_styles: &'a crate::column_css::ColumnStyleTable,
     ) -> Self {
-        Self { doc, column_styles }
+        Self {
+            doc,
+            column_styles,
+            geometry: BTreeMap::new(),
+        }
+    }
+
+    /// Drain the accumulated per-container geometry table.
+    ///
+    /// Uses `mem::take` so a second call on the same tree returns an empty
+    /// table rather than double-counting (the tree keeps a `BTreeMap::new()`
+    /// in place). Callers normally invoke this once after
+    /// [`FulgurLayoutTree::layout_multicol_subtrees`] has finished.
+    pub fn take_geometry(&mut self) -> MulticolGeometryTable {
+        std::mem::take(&mut self.geometry)
     }
 
     /// Re-run Taffy layout for each multicol container in the tree.
@@ -476,10 +564,11 @@ pub fn compute_multicol_layout(
 
     let mut cursor_y: f32 = 0.0;
     let mut placements: Vec<(NodeId, Point<f32>, Size<f32>)> = Vec::new();
+    let mut group_geometries: Vec<ColumnGroupGeometry> = Vec::new();
     for segment in segments {
         match segment {
             Segment::ColumnGroup(children) => {
-                let (group_placements, seg_h) = layout_column_group(
+                let (group_placements, geometry) = layout_column_group(
                     tree,
                     col_w,
                     gap,
@@ -489,7 +578,9 @@ pub fn compute_multicol_layout(
                     cursor_y,
                     child_inputs,
                 );
+                let seg_h = geometry.col_heights.iter().copied().fold(0.0_f32, f32::max);
                 placements.extend(group_placements);
+                group_geometries.push(geometry);
                 cursor_y += seg_h;
             }
             Segment::SpanAll(child_id) => {
@@ -513,6 +604,27 @@ pub fn compute_multicol_layout(
         location.x += inset_left;
         location.y += inset_top;
     }
+
+    // Shift each recorded group geometry into the same border-box frame so
+    // `MulticolRulePageable::draw` (which receives `x, y` at the container's
+    // border-box origin) can use `group.x_offset + col_x_math` and
+    // `group.y_offset` directly without reapplying the container's padding.
+    for group in group_geometries.iter_mut() {
+        group.x_offset = inset_left;
+        group.y_offset += inset_top;
+    }
+
+    // Stash the per-container geometry for downstream consumers (Task 4's
+    // `MulticolRulePageable`). We intentionally record the entry even when
+    // the container produced no column groups (all `SpanAll`, or entirely
+    // empty) — the presence of the key lets convert-side code distinguish
+    // "layout hook ran but found nothing balanceable" from "hook never ran".
+    tree.geometry.insert(
+        usize::from(node_id),
+        MulticolGeometry {
+            groups: group_geometries,
+        },
+    );
 
     // 6. Write child positions back into Taffy's storage. Only location
     //    and size change between the nested `compute_child_layout` call
@@ -556,9 +668,15 @@ pub fn compute_multicol_layout(
 /// starting at `y_offset`. `avail_h` is the per-column budget ceiling
 /// (for balance / auto fallback); measurement happens inside via Taffy.
 ///
-/// Returns `(placements, segment_height)` where `segment_height` is the
-/// max column bottom relative to `y_offset` (i.e. the vertical extent
-/// this segment contributes to the container).
+/// Returns `(placements, geometry)`:
+///
+/// - `placements` is the `(child, location, size)` triples written back
+///   into Taffy's storage by `compute_multicol_layout`.
+/// - `geometry` carries the shape this segment contributes to the
+///   container's [`MulticolGeometry`]: column width, gap, column count,
+///   y-offset, and per-column filled height. The segment's vertical
+///   extent (what we used to return as `seg_h`) is recoverable as
+///   `geometry.col_heights.iter().copied().fold(0.0, f32::max)`.
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 fn layout_column_group(
     tree: &mut FulgurLayoutTree<'_>,
@@ -569,7 +687,7 @@ fn layout_column_group(
     children: &[NodeId],
     y_offset: f32,
     child_inputs: taffy::tree::LayoutInput,
-) -> (Vec<(NodeId, Point<f32>, Size<f32>)>, f32) {
+) -> (Vec<(NodeId, Point<f32>, Size<f32>)>, ColumnGroupGeometry) {
     // 1. Measure
     let mut measured: Vec<(NodeId, Size<f32>)> = Vec::with_capacity(children.len());
     for &child in children {
@@ -608,14 +726,55 @@ fn layout_column_group(
         col_y += size.height;
     }
 
-    // 4. Segment height = tallest column bottom relative to y_offset
-    let seg_h = placements
-        .iter()
-        .map(|(_, loc, sz)| (loc.y - y_offset) + sz.height)
-        .fold(0.0f32, f32::max)
-        .max(0.0);
+    // 4. Per-column filled heights — bottom-most placement per column,
+    //    relative to y_offset. Empty columns stay at 0.0.
+    //
+    //    We recover each placement's column index by inverting the
+    //    `col_x = col_idx * (col_w + gap)` formula from step 3. The stride
+    //    `col_w + gap` is non-zero for any real multicol container (both
+    //    `col_w` and `gap` are `>= 0.0`, and `col_w == 0 && gap == 0`
+    //    indicates a degenerate container where the column index doesn't
+    //    meaningfully differ across placements anyway). The guard below
+    //    protects against a divide-by-zero; `round()` tolerates float
+    //    accumulation from the multiplication in step 3.
+    let stride = col_w + gap;
+    let mut col_heights: Vec<f32> = vec![0.0_f32; n as usize];
+    for (_, loc, sz) in &placements {
+        let idx = if stride > 0.0 {
+            let raw = (loc.x / stride).round();
+            // Clamp to [0, n-1] — float noise at exact stride boundaries
+            // could push `raw` a hair outside the valid range.
+            if raw.is_finite() && raw >= 0.0 {
+                (raw as u32).min(n.saturating_sub(1)) as usize
+            } else {
+                0
+            }
+        } else {
+            0
+        };
+        let bottom = (loc.y - y_offset) + sz.height;
+        if bottom > col_heights[idx] {
+            col_heights[idx] = bottom;
+        }
+    }
+    // Guard against negative accumulation (should be unreachable given
+    // `y_offset` is the segment's top and placements live at or below it,
+    // but the clamp keeps the invariant `col_heights[i] >= 0.0` explicit).
+    for h in col_heights.iter_mut() {
+        if *h < 0.0 {
+            *h = 0.0;
+        }
+    }
 
-    (placements, seg_h)
+    let geometry = ColumnGroupGeometry {
+        y_offset,
+        col_w,
+        gap,
+        n,
+        col_heights,
+    };
+
+    (placements, geometry)
 }
 
 /// Linear search for the smallest per-column budget (starting from `total / n`
@@ -1603,7 +1762,8 @@ mod tests {
         </body></html>"#;
         let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
         crate::blitz_adapter::resolve(&mut doc);
-        let mut tree = FulgurLayoutTree::new(&mut doc);
+        let column_styles = crate::column_css::ColumnStyleTable::new();
+        let mut tree = FulgurLayoutTree::new(&mut doc, &column_styles);
         tree.layout_multicol_subtrees();
 
         let a = layout_of_id(&doc, "a");
@@ -1669,7 +1829,8 @@ mod tests {
         </body></html>"#;
         let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
         crate::blitz_adapter::resolve(&mut doc);
-        let mut tree = FulgurLayoutTree::new(&mut doc);
+        let column_styles = crate::column_css::ColumnStyleTable::new();
+        let mut tree = FulgurLayoutTree::new(&mut doc, &column_styles);
         tree.layout_multicol_subtrees();
 
         let title = layout_of_id(&doc, "title");
@@ -1714,7 +1875,8 @@ mod tests {
         </body></html>"#;
         let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
         crate::blitz_adapter::resolve(&mut doc);
-        let mut tree = FulgurLayoutTree::new(&mut doc);
+        let column_styles = crate::column_css::ColumnStyleTable::new();
+        let mut tree = FulgurLayoutTree::new(&mut doc, &column_styles);
         tree.layout_multicol_subtrees();
 
         let a = layout_of_id(&doc, "a");
@@ -1744,7 +1906,8 @@ mod tests {
         </body></html>"#;
         let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
         crate::blitz_adapter::resolve(&mut doc);
-        let mut tree = FulgurLayoutTree::new(&mut doc);
+        let column_styles = crate::column_css::ColumnStyleTable::new();
+        let mut tree = FulgurLayoutTree::new(&mut doc, &column_styles);
         tree.layout_multicol_subtrees();
 
         let a = layout_of_id(&doc, "a");
@@ -1757,6 +1920,104 @@ mod tests {
             (a.padding.top - 5.0).abs() < 0.5,
             "child padding-top expected 5, got {}",
             a.padding.top
+        );
+    }
+
+    // ── MulticolGeometry recording (Task 3) ─────────────────────────
+
+    #[test]
+    fn column_group_geometry_records_heights_matching_layout() {
+        // Minimal multicol fixture: 4 roughly-equal paragraphs balanced into
+        // 2 columns with no gap. The hook must record one MulticolGeometry
+        // entry for the container, with one ColumnGroupGeometry describing
+        // the balanced columns:
+        //
+        //   - groups.len() == 1 (one ColumnGroup segment, no SpanAll)
+        //   - n == 2 (column-count: 2)
+        //   - col_heights.len() == n
+        //   - Both columns populated (balance did NOT dump all into col 0)
+        //   - Per-column filled height ≈ total_h / n (within one balance step)
+        let html = r#"<!doctype html><html><body>
+            <div id="mc" style="column-count: 2; column-gap: 0;">
+              <p>alpha alpha alpha alpha</p>
+              <p>beta beta beta beta</p>
+              <p>gamma gamma gamma gamma</p>
+              <p>delta delta delta delta</p>
+            </div>
+        </body></html>"#;
+        let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
+        crate::blitz_adapter::resolve(&mut doc);
+
+        let mc_id = collect_multicol_node_ids(&doc)[0];
+        let mc_node_id = NodeId::from(mc_id);
+
+        let column_styles = crate::column_css::ColumnStyleTable::new();
+        let geometry_table = run_pass(&mut doc, &column_styles);
+
+        let mc_geom = geometry_table
+            .get(&mc_id)
+            .expect("multicol container should have a geometry entry");
+        assert_eq!(
+            mc_geom.groups.len(),
+            1,
+            "expected one ColumnGroup segment for this fixture, got {}",
+            mc_geom.groups.len()
+        );
+
+        let group = &mc_geom.groups[0];
+        assert_eq!(group.n, 2, "column-count: 2");
+        assert_eq!(
+            group.col_heights.len(),
+            2,
+            "col_heights length must equal n"
+        );
+        assert!(
+            group.col_heights[0] > 0.0 && group.col_heights[1] > 0.0,
+            "balance should populate both columns, got col_heights={:?}",
+            group.col_heights
+        );
+
+        // The tallest column's bottom in container-local coordinates
+        // (group.y_offset + tallest) should match the container's border-box
+        // content bottom (container_h minus inset_bottom). Since this fixture
+        // has no padding/border, y_offset == 0 and tallest == container_h.
+        let tallest = group.col_heights.iter().copied().fold(0.0_f32, f32::max);
+        let container_h = doc.get_unrounded_layout(mc_node_id).size.height;
+        assert!(
+            (group.y_offset + tallest - container_h).abs() < 1.0,
+            "group bottom ({}) should match container height ({})",
+            group.y_offset + tallest,
+            container_h
+        );
+    }
+
+    #[test]
+    fn take_geometry_drains_table_and_is_idempotent() {
+        // `take_geometry` must use `mem::take` semantics: the first call
+        // returns the populated table, the second returns an empty one
+        // (no double-counting). This is the contract Task 4's wrapper
+        // relies on when the engine threads geometry into convert.
+        let html = r#"<!doctype html><html><body>
+            <div style="column-count: 2; column-gap: 0;">
+              <p>a</p><p>b</p><p>c</p><p>d</p>
+            </div>
+        </body></html>"#;
+        let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
+        crate::blitz_adapter::resolve(&mut doc);
+
+        let column_styles = crate::column_css::ColumnStyleTable::new();
+        let mut tree = FulgurLayoutTree::new(&mut doc, &column_styles);
+        tree.layout_multicol_subtrees();
+
+        let first = tree.take_geometry();
+        assert!(
+            !first.is_empty(),
+            "first take should return the populated geometry"
+        );
+        let second = tree.take_geometry();
+        assert!(
+            second.is_empty(),
+            "second take must be empty — no double-counting"
         );
     }
 }

--- a/crates/fulgur/src/multicol_layout.rs
+++ b/crates/fulgur/src/multicol_layout.rs
@@ -789,6 +789,11 @@ fn layout_column_group(
     }
 
     let geometry = ColumnGroupGeometry {
+        // `x_offset` / `y_offset` here are in the container's *content-box*
+        // frame; `compute_multicol_layout` shifts them into the border-box
+        // frame after every segment is placed (see the inset loop that runs
+        // over `group_geometries` in that function).
+        x_offset: 0.0,
         y_offset,
         col_w,
         gap,

--- a/crates/fulgur/src/multicol_layout.rs
+++ b/crates/fulgur/src/multicol_layout.rs
@@ -83,19 +83,42 @@ pub(crate) fn partition_children_into_segments(
 
 /// Taffy tree wrapper around a `BaseDocument` that intercepts multicol
 /// containers and routes them through fulgur's own layout.
+///
+/// `column_styles` carries the Phase A `column-*` side-table harvested by
+/// [`crate::blitz_adapter::extract_column_style_table`] — the multicol
+/// layout branch will read `column-fill` from it to switch between balanced
+/// and greedy ("auto") column filling. It is borrowed (rather than owned)
+/// because the tree lives for a single layout pass; the engine keeps the
+/// owning `ColumnStyleTable` alive across both this pass and the subsequent
+/// convert pass.
 pub struct FulgurLayoutTree<'a> {
     pub(crate) doc: &'a mut BaseDocument,
+    // Task 3 will read this field from `compute_multicol_layout` /
+    // `layout_column_group` to branch on `ColumnFill::Auto`; until that lands,
+    // the field is populated but never consulted, so silence the warning
+    // locally rather than leaving `#![allow(dead_code)]` at module scope.
+    #[allow(dead_code)]
+    pub(crate) column_styles: &'a crate::column_css::ColumnStyleTable,
 }
 
 /// One-shot entry used by the render pipeline after `blitz_adapter::resolve`.
 /// Runs the multicol Taffy hook on every multicol subtree in the document.
-pub fn run_pass(doc: &mut BaseDocument) {
-    FulgurLayoutTree::new(doc).layout_multicol_subtrees();
+///
+/// `column_styles` is the Phase A side-table harvested by
+/// [`crate::blitz_adapter::extract_column_style_table`]. Callers that do not
+/// need `column-fill` / `column-rule` resolution can pass an empty table
+/// (e.g. test helpers — see the `FulgurLayoutTree::new` call sites in the
+/// unit-test modules below).
+pub fn run_pass(doc: &mut BaseDocument, column_styles: &crate::column_css::ColumnStyleTable) {
+    FulgurLayoutTree::new(doc, column_styles).layout_multicol_subtrees();
 }
 
 impl<'a> FulgurLayoutTree<'a> {
-    pub fn new(doc: &'a mut BaseDocument) -> Self {
-        Self { doc }
+    pub fn new(
+        doc: &'a mut BaseDocument,
+        column_styles: &'a crate::column_css::ColumnStyleTable,
+    ) -> Self {
+        Self { doc, column_styles }
     }
 
     /// Re-run Taffy layout for each multicol container in the tree.
@@ -710,7 +733,8 @@ mod tests {
         let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
         crate::blitz_adapter::resolve(&mut doc);
 
-        let mut tree = FulgurLayoutTree::new(&mut doc);
+        let column_styles = crate::column_css::ColumnStyleTable::new();
+        let mut tree = FulgurLayoutTree::new(&mut doc, &column_styles);
         let laid_out = tree.layout_multicol_subtrees();
         assert_eq!(laid_out, 1, "one multicol container expected");
     }
@@ -724,7 +748,8 @@ mod tests {
         let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
         crate::blitz_adapter::resolve(&mut doc);
 
-        let mut tree = FulgurLayoutTree::new(&mut doc);
+        let column_styles = crate::column_css::ColumnStyleTable::new();
+        let mut tree = FulgurLayoutTree::new(&mut doc, &column_styles);
         let laid_out = tree.layout_multicol_subtrees();
         assert_eq!(laid_out, 0);
     }
@@ -745,7 +770,8 @@ mod tests {
         let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
         crate::blitz_adapter::resolve(&mut doc);
 
-        let mut tree = FulgurLayoutTree::new(&mut doc);
+        let column_styles = crate::column_css::ColumnStyleTable::new();
+        let mut tree = FulgurLayoutTree::new(&mut doc, &column_styles);
         let laid_out = tree.layout_multicol_subtrees();
         assert_eq!(laid_out, 1);
 
@@ -790,7 +816,8 @@ mod tests {
         let mc_node_id = NodeId::from(mc_id_raw);
         let pre_hook_height = doc.get_unrounded_layout(mc_node_id).size.height;
 
-        let mut tree = FulgurLayoutTree::new(&mut doc);
+        let column_styles = crate::column_css::ColumnStyleTable::new();
+        let mut tree = FulgurLayoutTree::new(&mut doc, &column_styles);
         tree.layout_multicol_subtrees();
 
         let post_hook_height = doc.get_unrounded_layout(mc_node_id).size.height;
@@ -857,7 +884,8 @@ mod tests {
             "sanity: after must not overlap multicol (y={after_y_before}, mc_bottom={mc_bottom_before})"
         );
 
-        let mut tree = FulgurLayoutTree::new(&mut doc);
+        let column_styles = crate::column_css::ColumnStyleTable::new();
+        let mut tree = FulgurLayoutTree::new(&mut doc, &column_styles);
         tree.layout_multicol_subtrees();
 
         let mc_h_after = doc.get_node(mc_id).unwrap().unrounded_layout.size.height;
@@ -892,7 +920,8 @@ mod tests {
         let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
         crate::blitz_adapter::resolve(&mut doc);
 
-        let mut tree = FulgurLayoutTree::new(&mut doc);
+        let column_styles = crate::column_css::ColumnStyleTable::new();
+        let mut tree = FulgurLayoutTree::new(&mut doc, &column_styles);
         let laid_out = tree.layout_multicol_subtrees();
         assert_eq!(laid_out, 2);
     }
@@ -1135,7 +1164,8 @@ mod tests {
 
         let before_y_pre = doc.get_node(before_id).unwrap().unrounded_layout.location.y;
 
-        let mut tree = FulgurLayoutTree::new(&mut doc);
+        let column_styles = crate::column_css::ColumnStyleTable::new();
+        let mut tree = FulgurLayoutTree::new(&mut doc, &column_styles);
         tree.layout_multicol_subtrees();
 
         let before_y_post = doc.get_node(before_id).unwrap().unrounded_layout.location.y;
@@ -1325,7 +1355,8 @@ mod tests {
 
         let outer_h_pre = doc.get_node(outer_id).unwrap().unrounded_layout.size.height;
 
-        let mut tree = FulgurLayoutTree::new(&mut doc);
+        let column_styles = crate::column_css::ColumnStyleTable::new();
+        let mut tree = FulgurLayoutTree::new(&mut doc, &column_styles);
         tree.layout_multicol_subtrees();
 
         let outer_h_post = doc.get_node(outer_id).unwrap().unrounded_layout.size.height;
@@ -1352,7 +1383,8 @@ mod tests {
         let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
         crate::blitz_adapter::resolve(&mut doc);
 
-        let mut tree = FulgurLayoutTree::new(&mut doc);
+        let column_styles = crate::column_css::ColumnStyleTable::new();
+        let mut tree = FulgurLayoutTree::new(&mut doc, &column_styles);
         tree.layout_multicol_subtrees();
 
         // Sanity: two distinct x positions exist after the refactor.
@@ -1407,7 +1439,8 @@ mod tests {
         </body></html>"#;
         let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
         crate::blitz_adapter::resolve(&mut doc);
-        let mut tree = FulgurLayoutTree::new(&mut doc);
+        let column_styles = crate::column_css::ColumnStyleTable::new();
+        let mut tree = FulgurLayoutTree::new(&mut doc, &column_styles);
         tree.layout_multicol_subtrees();
 
         let mc_w = layout_of_id(&doc, "mc").size.width;
@@ -1439,7 +1472,8 @@ mod tests {
         </body></html>"#;
         let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
         crate::blitz_adapter::resolve(&mut doc);
-        let mut tree = FulgurLayoutTree::new(&mut doc);
+        let column_styles = crate::column_css::ColumnStyleTable::new();
+        let mut tree = FulgurLayoutTree::new(&mut doc, &column_styles);
         tree.layout_multicol_subtrees();
 
         let before = layout_of_id(&doc, "before");
@@ -1471,7 +1505,8 @@ mod tests {
         </body></html>"#;
         let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
         crate::blitz_adapter::resolve(&mut doc);
-        let mut tree = FulgurLayoutTree::new(&mut doc);
+        let column_styles = crate::column_css::ColumnStyleTable::new();
+        let mut tree = FulgurLayoutTree::new(&mut doc, &column_styles);
         tree.layout_multicol_subtrees();
 
         let title = layout_of_id(&doc, "title");
@@ -1501,7 +1536,8 @@ mod tests {
         </body></html>"#;
         let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
         crate::blitz_adapter::resolve(&mut doc);
-        let mut tree = FulgurLayoutTree::new(&mut doc);
+        let column_styles = crate::column_css::ColumnStyleTable::new();
+        let mut tree = FulgurLayoutTree::new(&mut doc, &column_styles);
         tree.layout_multicol_subtrees();
 
         let a = layout_of_id(&doc, "a");
@@ -1528,7 +1564,8 @@ mod tests {
         </body></html>"#;
         let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
         crate::blitz_adapter::resolve(&mut doc);
-        let mut tree = FulgurLayoutTree::new(&mut doc);
+        let column_styles = crate::column_css::ColumnStyleTable::new();
+        let mut tree = FulgurLayoutTree::new(&mut doc, &column_styles);
         tree.layout_multicol_subtrees();
 
         let a = layout_of_id(&doc, "a");

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -2527,6 +2527,278 @@ impl Pageable for RunningElementWrapperPageable {
     }
 }
 
+// ─── MulticolRulePageable ─────────────────────────────────
+
+/// Wraps a multicol container child with the resolved `column-rule` spec and
+/// the per-`ColumnGroup` geometry recorded by the Taffy multicol hook, so
+/// `draw()` can paint vertical rules between adjacent non-empty columns
+/// without re-running layout.
+///
+/// All `Pageable` methods delegate to `self.child` **except** `draw()` and
+/// `split_boxed()`:
+///
+/// - `draw()` calls `child.draw()` first (columns paint their own
+///   contents), then walks `self.groups` and strokes a vertical line in the
+///   centre of each gutter whose adjacent columns are both non-empty. The
+///   rule's vertical extent is clamped to the **shorter** of the two
+///   adjacent columns' filled heights — this matches the spec intent that
+///   a rule never hangs past the end of a shorter column.
+/// - `split_boxed()` forwards to the child and redistributes `self.groups`
+///   across the two halves based on the first half's consumed height.
+///
+/// # Geometry partitioning on split
+///
+/// After the child splits, the wrapper re-wraps the first fragment to
+/// obtain a `cutoff` height (the amount of the container's content box
+/// consumed on the first page). Groups are then placed as follows:
+///
+/// - Groups with `y_offset + max(col_heights) <= cutoff` stay on the first
+///   half unchanged.
+/// - Groups with `y_offset >= cutoff` move to the second half with
+///   `y_offset -= cutoff`.
+/// - Groups straddling the boundary stay on the first half with their
+///   `col_heights` clamped to `cutoff - y_offset`. This is an
+///   approximation — cross-page pagination of a single `ColumnGroup` is a
+///   known gap (fulgur-6q5 / fulgur-wfd) and the rule on the second half
+///   of a straddling group is currently dropped.
+///
+/// Task 5 will actually construct this wrapper in `convert.rs`; until then
+/// the `new` constructor and the associated plumbing are only reached from
+/// unit tests, hence the per-item `#[allow(dead_code)]`.
+#[derive(Clone)]
+pub struct MulticolRulePageable {
+    pub child: Box<dyn Pageable>,
+    pub rule: crate::column_css::ColumnRuleSpec,
+    pub groups: Vec<crate::multicol_layout::ColumnGroupGeometry>,
+}
+
+impl MulticolRulePageable {
+    #[allow(dead_code)] // Task 5 wires this from convert.rs.
+    pub fn new(
+        child: Box<dyn Pageable>,
+        rule: crate::column_css::ColumnRuleSpec,
+        groups: Vec<crate::multicol_layout::ColumnGroupGeometry>,
+    ) -> Self {
+        Self {
+            child,
+            rule,
+            groups,
+        }
+    }
+
+    /// Build the krilla stroke for the configured rule spec, including the
+    /// dash pattern prescribed for `Dashed` / `Dotted`. Returns `None` when
+    /// `draw()` must skip rule painting entirely (style `None` or
+    /// non-positive width).
+    fn build_stroke(&self) -> Option<krilla::paint::Stroke> {
+        use crate::column_css::ColumnRuleStyle;
+        if self.rule.width <= 0.0 || self.rule.style == ColumnRuleStyle::None {
+            return None;
+        }
+        let opacity = alpha_to_opacity(self.rule.color[3]);
+        let base = colored_stroke(&self.rule.color, self.rule.width, opacity);
+        let w = self.rule.width;
+        let stroke = match self.rule.style {
+            ColumnRuleStyle::None => return None,
+            ColumnRuleStyle::Solid => base,
+            // `[width * 3.0, width * 2.0]` per fulgur-v7a Task 4 spec
+            // (intentionally distinct from `border-style: dashed`, which
+            // uses `[width*3, width*3]`).
+            ColumnRuleStyle::Dashed => krilla::paint::Stroke {
+                dash: Some(krilla::paint::StrokeDash {
+                    array: vec![w * 3.0, w * 2.0],
+                    offset: 0.0,
+                }),
+                ..base
+            },
+            // `[width, width]` per Task 4 spec.
+            ColumnRuleStyle::Dotted => krilla::paint::Stroke {
+                dash: Some(krilla::paint::StrokeDash {
+                    array: vec![w, w],
+                    offset: 0.0,
+                }),
+                ..base
+            },
+        };
+        Some(stroke)
+    }
+}
+
+impl Pageable for MulticolRulePageable {
+    fn wrap(&mut self, avail_width: Pt, avail_height: Pt) -> Size {
+        self.child.wrap(avail_width, avail_height)
+    }
+
+    fn split(
+        &self,
+        avail_width: Pt,
+        avail_height: Pt,
+    ) -> Option<(Box<dyn Pageable>, Box<dyn Pageable>)> {
+        let (first, second) = self.child.split(avail_width, avail_height)?;
+        // Re-wrap the first fragment so `height()` returns a meaningful
+        // cutoff — fresh `BlockPageable` fragments have no cached size.
+        let mut first = first;
+        first.wrap(avail_width, avail_height);
+        let cutoff = first.height();
+        let (first_groups, second_groups) = partition_groups_at_cutoff(&self.groups, cutoff);
+        Some((
+            Box::new(MulticolRulePageable {
+                child: first,
+                rule: self.rule,
+                groups: first_groups,
+            }),
+            Box::new(MulticolRulePageable {
+                child: second,
+                rule: self.rule,
+                groups: second_groups,
+            }),
+        ))
+    }
+
+    fn split_boxed(self: Box<Self>, avail_width: Pt, avail_height: Pt) -> SplitResult {
+        let me = *self;
+        let MulticolRulePageable {
+            child,
+            rule,
+            groups,
+        } = me;
+        match child.split_boxed(avail_width, avail_height) {
+            Ok((mut first, second)) => {
+                first.wrap(avail_width, avail_height);
+                let cutoff = first.height();
+                let (first_groups, second_groups) = partition_groups_at_cutoff(&groups, cutoff);
+                Ok((
+                    Box::new(MulticolRulePageable {
+                        child: first,
+                        rule,
+                        groups: first_groups,
+                    }),
+                    Box::new(MulticolRulePageable {
+                        child: second,
+                        rule,
+                        groups: second_groups,
+                    }),
+                ))
+            }
+            Err(unsplit) => Err(Box::new(MulticolRulePageable {
+                child: unsplit,
+                rule,
+                groups,
+            })),
+        }
+    }
+
+    fn draw(&self, canvas: &mut Canvas<'_, '_>, x: Pt, y: Pt, avail_width: Pt, avail_height: Pt) {
+        // Columns paint their own contents first.
+        self.child.draw(canvas, x, y, avail_width, avail_height);
+
+        let Some(stroke) = self.build_stroke() else {
+            return;
+        };
+
+        for group in &self.groups {
+            if group.n < 2 || group.col_heights.len() != group.n as usize {
+                continue;
+            }
+            let y_top = y + group.y_offset;
+            for i in 0..(group.n as usize - 1) {
+                let h_left = group.col_heights[i];
+                let h_right = group.col_heights[i + 1];
+                if h_left <= 0.0 || h_right <= 0.0 {
+                    continue;
+                }
+                // Gap centre between column i and column i+1:
+                //   rule_x = x + (i+1) * col_w + i * gap + gap/2
+                let rule_x =
+                    x + (i as f32 + 1.0) * group.col_w + i as f32 * group.gap + group.gap / 2.0;
+                let y_bot = y_top + h_left.min(h_right);
+                stroke_line(canvas, rule_x, y_top, rule_x, y_bot, stroke.clone());
+            }
+        }
+        canvas.surface.set_stroke(None);
+    }
+
+    fn pagination(&self) -> Pagination {
+        self.child.pagination()
+    }
+
+    fn clone_box(&self) -> Box<dyn Pageable> {
+        Box::new(self.clone())
+    }
+
+    fn height(&self) -> Pt {
+        self.child.height()
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn collect_ids(
+        &self,
+        x: Pt,
+        y: Pt,
+        avail_width: Pt,
+        avail_height: Pt,
+        registry: &mut DestinationRegistry,
+    ) {
+        self.child
+            .collect_ids(x, y, avail_width, avail_height, registry);
+    }
+}
+
+/// Partition a `Vec<ColumnGroupGeometry>` across a page boundary at
+/// `cutoff` points from the container's content-box top.
+///
+/// See [`MulticolRulePageable`]'s doc for the policy; this helper is
+/// separated so it can be unit-tested without constructing a full
+/// Pageable tree.
+fn partition_groups_at_cutoff(
+    groups: &[crate::multicol_layout::ColumnGroupGeometry],
+    cutoff: f32,
+) -> (
+    Vec<crate::multicol_layout::ColumnGroupGeometry>,
+    Vec<crate::multicol_layout::ColumnGroupGeometry>,
+) {
+    let mut first = Vec::new();
+    let mut second = Vec::new();
+    // Non-positive `cutoff` means the child did not commit any content to
+    // the first fragment; push every group to the second half unchanged.
+    if cutoff <= 0.0 {
+        return (Vec::new(), groups.to_vec());
+    }
+    for g in groups {
+        let max_h = g
+            .col_heights
+            .iter()
+            .copied()
+            .fold(0.0_f32, |acc, h| acc.max(h));
+        let group_bottom = g.y_offset + max_h;
+        if group_bottom <= cutoff {
+            first.push(g.clone());
+        } else if g.y_offset >= cutoff {
+            let mut shifted = g.clone();
+            shifted.y_offset -= cutoff;
+            second.push(shifted);
+        } else {
+            // Straddles the page break. Phase A approximation: keep the
+            // group on the first half with heights clamped to the space
+            // available before the cutoff. The second half drops the rule
+            // for this group — cross-page ColumnGroup pagination is tracked
+            // as a known gap (fulgur-6q5 / fulgur-wfd).
+            let remaining = (cutoff - g.y_offset).max(0.0);
+            let mut clamped = g.clone();
+            for h in &mut clamped.col_heights {
+                if *h > remaining {
+                    *h = remaining;
+                }
+            }
+            first.push(clamped);
+        }
+    }
+    (first, second)
+}
+
 // ─── ListItemPageable ───────────────────────────────────
 
 /// Clamp an intrinsic image size to a line-height limit while preserving
@@ -4311,5 +4583,184 @@ mod dest_registry_transform_tests {
         let (_, x, y) = reg.get("dup").unwrap();
         assert!((x - 0.0).abs() < 1e-5, "first write should win");
         assert!((y - 10.0).abs() < 1e-5, "first write should win");
+    }
+}
+
+#[cfg(test)]
+mod multicol_rule_tests {
+    use super::*;
+    use crate::column_css::{ColumnRuleSpec, ColumnRuleStyle};
+    use crate::multicol_layout::ColumnGroupGeometry;
+
+    fn make_spacer(h: Pt) -> Box<dyn Pageable> {
+        let mut s = SpacerPageable::new(h);
+        s.wrap(100.0, 1000.0);
+        Box::new(s)
+    }
+
+    fn make_rule_spec(style: ColumnRuleStyle) -> ColumnRuleSpec {
+        ColumnRuleSpec {
+            width: 1.0,
+            style,
+            color: [0, 0, 0, 255],
+        }
+    }
+
+    fn make_group(y_offset: f32, col_heights: Vec<f32>) -> ColumnGroupGeometry {
+        let n = col_heights.len() as u32;
+        ColumnGroupGeometry {
+            y_offset,
+            col_w: 80.0,
+            gap: 20.0,
+            n,
+            col_heights,
+        }
+    }
+
+    #[test]
+    fn multicol_rule_wrapper_delegates_pagination_methods() {
+        // wrap() and height() must pass through to the child unchanged.
+        let mut block = BlockPageable::new(vec![make_spacer(100.0), make_spacer(100.0)]);
+        let child_size = block.wrap(200.0, 1000.0);
+        let expected_h = child_size.height;
+        let mut wrapped = MulticolRulePageable::new(
+            Box::new(block),
+            make_rule_spec(ColumnRuleStyle::Solid),
+            vec![make_group(0.0, vec![100.0, 80.0])],
+        );
+        let w_size = wrapped.wrap(200.0, 1000.0);
+        assert!((w_size.height - expected_h).abs() < 1e-3);
+        assert!((wrapped.height() - expected_h).abs() < 1e-3);
+        // pagination() defaults through.
+        let pag = wrapped.pagination();
+        assert_eq!(pag.break_inside, BreakInside::Auto);
+    }
+
+    #[test]
+    fn multicol_rule_wrapper_splits_groups_across_pages() {
+        // Three spacers of 100pt → total 300pt.  Splitting at 250pt leaves
+        // spacer[0..=1] on the first fragment (200pt) and spacer[2] on the
+        // second (100pt), so the cutoff is 200pt.  Group A at y=0 fits on
+        // the first half; group B at y=400 moves to the second half with
+        // y_offset = 400 - 200 = 200.
+        let mut block = BlockPageable::new(vec![
+            make_spacer(100.0),
+            make_spacer(100.0),
+            make_spacer(100.0),
+        ]);
+        block.wrap(200.0, 1000.0);
+        let groups = vec![
+            make_group(0.0, vec![50.0, 50.0]),
+            make_group(400.0, vec![30.0, 30.0]),
+        ];
+        let wrapped = MulticolRulePageable::new(
+            Box::new(block),
+            make_rule_spec(ColumnRuleStyle::Solid),
+            groups,
+        );
+        let (first, second) = wrapped.split(200.0, 250.0).expect("split should succeed");
+        let first = first
+            .as_any()
+            .downcast_ref::<MulticolRulePageable>()
+            .expect("first must remain wrapped");
+        let second = second
+            .as_any()
+            .downcast_ref::<MulticolRulePageable>()
+            .expect("second must remain wrapped");
+        assert_eq!(first.groups.len(), 1);
+        assert!((first.groups[0].y_offset - 0.0).abs() < 1e-3);
+        assert_eq!(second.groups.len(), 1);
+        assert!(
+            (second.groups[0].y_offset - 200.0).abs() < 1e-3,
+            "second group y_offset = 400 - 200 (cutoff) = 200, got {}",
+            second.groups[0].y_offset
+        );
+    }
+
+    #[test]
+    fn multicol_rule_wrapper_split_boxed_reconstructs_wrappers() {
+        // Mirrors the `split` test but via split_boxed, so we pin the
+        // Box<Self>-consuming path that paginate.rs actually drives.
+        let mut block = BlockPageable::new(vec![
+            make_spacer(100.0),
+            make_spacer(100.0),
+            make_spacer(100.0),
+        ]);
+        block.wrap(200.0, 1000.0);
+        let groups = vec![
+            make_group(0.0, vec![50.0, 50.0]),
+            make_group(400.0, vec![30.0, 30.0]),
+        ];
+        let wrapped: Box<dyn Pageable> = Box::new(MulticolRulePageable::new(
+            Box::new(block),
+            make_rule_spec(ColumnRuleStyle::Dashed),
+            groups,
+        ));
+        let (first, second) = match wrapped.split_boxed(200.0, 250.0) {
+            Ok(pair) => pair,
+            Err(_) => panic!("split_boxed must succeed"),
+        };
+        let first_w = first
+            .as_any()
+            .downcast_ref::<MulticolRulePageable>()
+            .expect("first boxed → wrapper");
+        let second_w = second
+            .as_any()
+            .downcast_ref::<MulticolRulePageable>()
+            .expect("second boxed → wrapper");
+        // Rule spec is preserved on both halves.
+        assert_eq!(first_w.rule.style, ColumnRuleStyle::Dashed);
+        assert_eq!(second_w.rule.style, ColumnRuleStyle::Dashed);
+        assert_eq!(first_w.groups.len(), 1);
+        assert_eq!(second_w.groups.len(), 1);
+    }
+
+    #[test]
+    fn multicol_rule_wrapper_skips_rule_when_style_none() {
+        // With style=None, build_stroke() must return None so draw() is a
+        // pass-through. We can't easily count stroke calls without a mock
+        // Canvas; the contract is exercised indirectly via build_stroke.
+        let block = BlockPageable::new(vec![make_spacer(100.0)]);
+        let wrapped = MulticolRulePageable::new(
+            Box::new(block),
+            make_rule_spec(ColumnRuleStyle::None),
+            vec![make_group(0.0, vec![50.0, 50.0])],
+        );
+        assert!(wrapped.build_stroke().is_none());
+    }
+
+    #[test]
+    fn multicol_rule_wrapper_skips_rule_when_width_zero() {
+        // `width <= 0.0` is the other early-exit branch.
+        let block = BlockPageable::new(vec![make_spacer(100.0)]);
+        let mut spec = make_rule_spec(ColumnRuleStyle::Solid);
+        spec.width = 0.0;
+        let wrapped = MulticolRulePageable::new(
+            Box::new(block),
+            spec,
+            vec![make_group(0.0, vec![50.0, 50.0])],
+        );
+        assert!(wrapped.build_stroke().is_none());
+    }
+
+    #[test]
+    fn partition_groups_straddling_cutoff_clamps_to_first_half() {
+        // Group spans y=50..250; cutoff at 200 keeps it on the first half
+        // with heights clamped to remaining = 200 - 50 = 150.
+        let groups = vec![make_group(50.0, vec![200.0, 180.0])];
+        let (first, second) = partition_groups_at_cutoff(&groups, 200.0);
+        assert_eq!(first.len(), 1);
+        assert!(second.is_empty());
+        assert!((first[0].col_heights[0] - 150.0).abs() < 1e-3);
+        assert!((first[0].col_heights[1] - 150.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn partition_groups_negative_cutoff_pushes_everything_to_second() {
+        let groups = vec![make_group(0.0, vec![100.0, 100.0])];
+        let (first, second) = partition_groups_at_cutoff(&groups, 0.0);
+        assert!(first.is_empty());
+        assert_eq!(second.len(), 1);
+        assert!((second[0].y_offset - 0.0).abs() < 1e-3);
     }
 }

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -2562,9 +2562,8 @@ impl Pageable for RunningElementWrapperPageable {
 ///   known gap (fulgur-6q5 / fulgur-wfd) and the rule on the second half
 ///   of a straddling group is currently dropped.
 ///
-/// Task 5 will actually construct this wrapper in `convert.rs`; until then
-/// the `new` constructor and the associated plumbing are only reached from
-/// unit tests, hence the per-item `#[allow(dead_code)]`.
+/// Task 5 wires this wrapper into `convert.rs` so multicol containers carry
+/// their parsed rule spec + per-`ColumnGroup` geometry into the draw pass.
 #[derive(Clone)]
 pub struct MulticolRulePageable {
     pub child: Box<dyn Pageable>,
@@ -2573,7 +2572,6 @@ pub struct MulticolRulePageable {
 }
 
 impl MulticolRulePageable {
-    #[allow(dead_code)] // Task 5 wires this from convert.rs.
     pub fn new(
         child: Box<dyn Pageable>,
         rule: crate::column_css::ColumnRuleSpec,

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -2705,10 +2705,16 @@ impl Pageable for MulticolRulePageable {
                 if h_left <= 0.0 || h_right <= 0.0 {
                     continue;
                 }
-                // Gap centre between column i and column i+1:
-                //   rule_x = x + (i+1) * col_w + i * gap + gap/2
-                let rule_x =
-                    x + (i as f32 + 1.0) * group.col_w + i as f32 * group.gap + group.gap / 2.0;
+                // Gap centre between column i and column i+1. `x_offset`
+                // shifts from the container's border-box left into its
+                // content-box left (padding-left + border-left), matching
+                // the frame `y_top` already works in.
+                //   rule_x = x + x_offset + (i+1) * col_w + i * gap + gap/2
+                let rule_x = x
+                    + group.x_offset
+                    + (i as f32 + 1.0) * group.col_w
+                    + i as f32 * group.gap
+                    + group.gap / 2.0;
                 let y_bot = y_top + h_left.min(h_right);
                 stroke_line(canvas, rule_x, y_top, rule_x, y_bot, stroke.clone());
             }
@@ -4607,6 +4613,7 @@ mod multicol_rule_tests {
     fn make_group(y_offset: f32, col_heights: Vec<f32>) -> ColumnGroupGeometry {
         let n = col_heights.len() as u32;
         ColumnGroupGeometry {
+            x_offset: 0.0,
             y_offset,
             col_w: 80.0,
             gap: 20.0,

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -3357,6 +3357,7 @@ mod tests {
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
+            multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
         };
         let pageable = convert::dom_to_pageable(&doc, &mut ctx);
         let pages = crate::paginate::paginate(pageable, 400.0, 600.0);
@@ -3407,6 +3408,7 @@ mod tests {
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
+            multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
         };
         let pageable = convert::dom_to_pageable(&doc, &mut ctx);
         let pages = crate::paginate::paginate(pageable, 400.0, 600.0);
@@ -3451,6 +3453,7 @@ mod tests {
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
+            multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
         };
         let pageable = convert::dom_to_pageable(&doc, &mut ctx);
         let pages = crate::paginate::paginate(pageable, 400.0, 600.0);

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -2610,10 +2610,14 @@ impl MulticolRulePageable {
                 }),
                 ..base
             },
-            // `[width, width]` per Task 4 spec.
+            // `line_cap: Round` + `[0, w*2]` — zero-length dashes
+            // rendered as round caps become actual dots, matching the
+            // dotted-border treatment used elsewhere in fulgur. Without
+            // the round cap this would paint as square dash segments.
             ColumnRuleStyle::Dotted => krilla::paint::Stroke {
+                line_cap: krilla::paint::LineCap::Round,
                 dash: Some(krilla::paint::StrokeDash {
-                    array: vec![w, w],
+                    array: vec![0.0, w * 2.0],
                     offset: 0.0,
                 }),
                 ..base

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -2556,11 +2556,12 @@ impl Pageable for RunningElementWrapperPageable {
 ///   half unchanged.
 /// - Groups with `y_offset >= cutoff` move to the second half with
 ///   `y_offset -= cutoff`.
-/// - Groups straddling the boundary stay on the first half with their
-///   `col_heights` clamped to `cutoff - y_offset`. This is an
-///   approximation — cross-page pagination of a single `ColumnGroup` is a
-///   known gap (fulgur-6q5 / fulgur-wfd) and the rule on the second half
-///   of a straddling group is currently dropped.
+/// - Groups straddling the boundary are split across halves: the first
+///   half keeps `col_heights` clamped to `cutoff - y_offset`, and the
+///   continuation half carries `col_heights - remaining` at `y_offset =
+///   0`. Cross-page pagination of a `ColumnGroup`'s *content* is still
+///   approximate (fulgur-6q5 / fulgur-wfd), but the rule geometry paints
+///   on both pages.
 ///
 /// Task 5 wires this wrapper into `convert.rs` so multicol containers carry
 /// their parsed rule spec + per-`ColumnGroup` geometry into the draw pass.
@@ -2785,19 +2786,29 @@ fn partition_groups_at_cutoff(
             shifted.y_offset -= cutoff;
             second.push(shifted);
         } else {
-            // Straddles the page break. Phase A approximation: keep the
-            // group on the first half with heights clamped to the space
-            // available before the cutoff. The second half drops the rule
-            // for this group — cross-page ColumnGroup pagination is tracked
-            // as a known gap (fulgur-6q5 / fulgur-wfd).
+            // Straddles the page break. Split the geometry so the rule
+            // paints on BOTH fragments: the first half clamps each column
+            // to what fits above the cutoff, and the second half carries
+            // the remainder at y_offset=0 (page-local). Cross-page column
+            // *content* pagination is still approximate (fulgur-6q5 /
+            // fulgur-wfd); this fix only closes the rule-disappears-on-
+            // page-2 bug flagged in PR #133 review.
             let remaining = (cutoff - g.y_offset).max(0.0);
-            let mut clamped = g.clone();
-            for h in &mut clamped.col_heights {
-                if *h > remaining {
-                    *h = remaining;
-                }
+            let mut first_half = g.clone();
+            let mut second_half = g.clone();
+
+            for (first_h, original_h) in first_half.col_heights.iter_mut().zip(&g.col_heights) {
+                *first_h = original_h.min(remaining);
             }
-            first.push(clamped);
+            second_half.y_offset = 0.0;
+            for (second_h, original_h) in second_half.col_heights.iter_mut().zip(&g.col_heights) {
+                *second_h = (original_h - remaining).max(0.0);
+            }
+
+            first.push(first_half);
+            if second_half.col_heights.iter().any(|&h| h > 0.0) {
+                second.push(second_half);
+            }
         }
     }
     (first, second)
@@ -4749,15 +4760,36 @@ mod multicol_rule_tests {
     }
 
     #[test]
-    fn partition_groups_straddling_cutoff_clamps_to_first_half() {
-        // Group spans y=50..250; cutoff at 200 keeps it on the first half
-        // with heights clamped to remaining = 200 - 50 = 150.
+    fn partition_groups_straddling_cutoff_splits_between_halves() {
+        // Group spans y=50..250; cutoff at 200. Remaining above cutoff is
+        // 200 - 50 = 150pt, so:
+        //   first  : col_heights = [min(200,150), min(180,150)] = [150, 150]
+        //   second : col_heights = [max(200-150,0), max(180-150,0)] = [50, 30]
+        //   second : y_offset    = 0 (continuation page starts at top)
         let groups = vec![make_group(50.0, vec![200.0, 180.0])];
         let (first, second) = partition_groups_at_cutoff(&groups, 200.0);
         assert_eq!(first.len(), 1);
-        assert!(second.is_empty());
+        assert_eq!(second.len(), 1);
         assert!((first[0].col_heights[0] - 150.0).abs() < 1e-3);
         assert!((first[0].col_heights[1] - 150.0).abs() < 1e-3);
+        assert!((second[0].y_offset - 0.0).abs() < 1e-3);
+        assert!((second[0].col_heights[0] - 50.0).abs() < 1e-3);
+        assert!((second[0].col_heights[1] - 30.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn partition_groups_straddling_with_zero_remainder_drops_second_half() {
+        // Group spans y=50..200; cutoff at 200. Remaining above cutoff is
+        // 150, which exceeds every col_height, so nothing spills to page 2.
+        let groups = vec![make_group(50.0, vec![100.0, 80.0])];
+        let (first, second) = partition_groups_at_cutoff(&groups, 200.0);
+        assert_eq!(first.len(), 1);
+        assert!(
+            second.is_empty(),
+            "no overflow expected when every column fits before cutoff"
+        );
+        assert!((first[0].col_heights[0] - 100.0).abs() < 1e-3);
+        assert!((first[0].col_heights[1] - 80.0).abs() < 1e-3);
     }
 
     #[test]

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -3356,6 +3356,7 @@ mod tests {
             string_set_by_node: HashMap::new(),
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
+            column_styles: crate::column_css::ColumnStyleTable::new(),
         };
         let pageable = convert::dom_to_pageable(&doc, &mut ctx);
         let pages = crate::paginate::paginate(pageable, 400.0, 600.0);
@@ -3405,6 +3406,7 @@ mod tests {
             string_set_by_node: HashMap::new(),
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
+            column_styles: crate::column_css::ColumnStyleTable::new(),
         };
         let pageable = convert::dom_to_pageable(&doc, &mut ctx);
         let pages = crate::paginate::paginate(pageable, 400.0, 600.0);
@@ -3448,6 +3450,7 @@ mod tests {
             string_set_by_node: HashMap::new(),
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
+            column_styles: crate::column_css::ColumnStyleTable::new(),
         };
         let pageable = convert::dom_to_pageable(&doc, &mut ctx);
         let pages = crate::paginate::paginate(pageable, 400.0, 600.0);

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -1317,6 +1317,7 @@ mod link_collect_tests {
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
+            multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
         };
         let pageable = convert::dom_to_pageable(&doc, &mut ctx);
         let pages = crate::paginate::paginate(pageable, 400.0, 600.0);

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -1316,6 +1316,7 @@ mod link_collect_tests {
             string_set_by_node: HashMap::new(),
             counter_ops_by_node: HashMap::new(),
             bookmark_by_node: HashMap::new(),
+            column_styles: crate::column_css::ColumnStyleTable::new(),
         };
         let pageable = convert::dom_to_pageable(&doc, &mut ctx);
         let pages = crate::paginate::paginate(pageable, 400.0, 600.0);

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -523,6 +523,7 @@ pub fn render_to_pdf_with_gcpm(
                     counter_ops_by_node: HashMap::new(),
                     bookmark_by_node: HashMap::new(),
                     column_styles: crate::column_css::ColumnStyleTable::new(),
+                    multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
                 };
                 let pageable = crate::convert::dom_to_pageable(&render_doc, &mut dummy_ctx);
                 render_cache.insert(cache_key.clone(), pageable);

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -522,6 +522,7 @@ pub fn render_to_pdf_with_gcpm(
                     string_set_by_node: HashMap::new(),
                     counter_ops_by_node: HashMap::new(),
                     bookmark_by_node: HashMap::new(),
+                    column_styles: crate::column_css::ColumnStyleTable::new(),
                 };
                 let pageable = crate::convert::dom_to_pageable(&render_doc, &mut dummy_ctx);
                 render_cache.insert(cache_key.clone(), pageable);

--- a/crates/fulgur/tests/column_rule_rendering.rs
+++ b/crates/fulgur/tests/column_rule_rendering.rs
@@ -1,0 +1,231 @@
+//! End-to-end pixel-sampling tests for fulgur-v7a.
+//!
+//! These integration tests render a small multicol HTML through fulgur,
+//! rasterise the PDF via `pdftocairo` (poppler-utils), decode the PNG and
+//! then sample pixels to verify:
+//!
+//! 1. `column-rule: 4pt solid red` paints a red vertical stripe in the
+//!    column-gap region.
+//! 2. `column-fill: auto` leaves the second column empty when the content
+//!    fits entirely in column 1.
+//!
+//! Byte-scanning the PDF is not sufficient — the rules are drawn paths
+//! inside a content stream, so we need an actual raster to assert their
+//! presence. When `pdftocairo` is not installed (common on local dev
+//! boxes), the tests print a skip message to stderr and return cleanly.
+
+use fulgur::config::{Margin, PageSize};
+use fulgur::engine::Engine;
+use image::RgbaImage;
+use std::path::Path;
+use std::process::Command;
+
+// ─── Test-infrastructure helpers ─────────────────────────────────────────
+
+/// Is `pdftocairo` on PATH and executable? We probe with `-v` because it
+/// returns non-zero on some poppler builds for `--help` but always prints
+/// a version banner to stderr for `-v` and exits 0.
+fn pdftocairo_available() -> bool {
+    Command::new("pdftocairo")
+        .arg("-v")
+        .output()
+        .map(|o| o.status.success() || !o.stderr.is_empty())
+        .unwrap_or(false)
+}
+
+/// Rasterise page 1 of `pdf_bytes` at `dpi` and return the resulting RGBA
+/// image. `work_dir` is used for intermediate `fixture.pdf` / `page-1.png`
+/// files; the caller owns its lifecycle (usually a `tempfile::TempDir`).
+fn pdf_to_rgba(pdf_bytes: &[u8], dpi: u32, work_dir: &Path) -> RgbaImage {
+    let pdf_path = work_dir.join("fixture.pdf");
+    std::fs::write(&pdf_path, pdf_bytes).expect("write pdf");
+
+    let prefix = work_dir.join("page");
+    let status = Command::new("pdftocairo")
+        .args(["-png", "-r", &dpi.to_string(), "-f", "1", "-l", "1"])
+        .arg(&pdf_path)
+        .arg(&prefix)
+        .status()
+        .expect("spawn pdftocairo");
+    assert!(status.success(), "pdftocairo exited with {status}");
+
+    let png_path = work_dir.join("page-1.png");
+    image::open(&png_path)
+        .expect("decode rasterised png")
+        .to_rgba8()
+    // NOTE: the tempdir is cleaned up by the caller dropping the
+    // TempDir; if a test fails mid-flight the files are preserved
+    // inside the OS tempdir for post-mortem inspection until the TempDir
+    // guard drops at test exit.
+}
+
+/// Matches a "loosely red" pixel — tolerant of anti-aliasing at the rule
+/// edges where the rasteriser blends red with the white page background.
+fn is_red_ish(p: &image::Rgba<u8>) -> bool {
+    p[0] > 200 && p[1] < 80 && p[2] < 80
+}
+
+/// True iff any pixel in the vertical strip centred at `x_center ± x_tol`
+/// and bounded by `[y_lo, y_hi)` is red-ish.
+fn has_red_pixel_in_strip(
+    rgba: &RgbaImage,
+    x_center: u32,
+    x_tol: u32,
+    y_lo: u32,
+    y_hi: u32,
+) -> bool {
+    let x_start = x_center.saturating_sub(x_tol);
+    let x_end = (x_center + x_tol).min(rgba.width().saturating_sub(1));
+    let y_start = y_lo.min(rgba.height());
+    let y_end = y_hi.min(rgba.height());
+    for y in y_start..y_end {
+        for x in x_start..=x_end {
+            if is_red_ish(rgba.get_pixel(x, y)) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+// ─── Test 1: column-rule paints a red stripe in the column gap ──────────
+
+#[test]
+fn column_rule_solid_red_is_visible_between_columns() {
+    if !pdftocairo_available() {
+        eprintln!(
+            "skipping column_rule_solid_red_is_visible_between_columns: pdftocairo not installed"
+        );
+        return;
+    }
+
+    // Layout math (page coords, in pt):
+    //   @page 200×200, margin 10 → body content-box is 180×180.
+    //   column-count 2, column-gap 20 → each column = 80pt wide.
+    //   Column 1 spans x ∈ [10, 90], gap spans [90, 110], column 2 [110, 190].
+    //   Rule centre x = 100pt.
+    let html = r#"<!doctype html><html><head><style>
+        @page { size: 200pt 200pt; margin: 10pt; }
+        body { margin: 0; color: black; font-family: sans-serif; }
+        .mc {
+            column-count: 2;
+            column-gap: 20pt;
+            column-rule: 4pt solid red;
+        }
+        .mc p { margin: 0 0 8pt 0; }
+    </style></head><body>
+      <div class="mc">
+        <p>Aaa aaa aaa aaa aaa aaa aaa.</p>
+        <p>Bbb bbb bbb bbb bbb bbb bbb.</p>
+        <p>Ccc ccc ccc ccc ccc ccc ccc.</p>
+      </div>
+    </body></html>"#;
+
+    let engine = Engine::builder()
+        .page_size(PageSize {
+            width: 200.0,
+            height: 200.0,
+        })
+        .margin(Margin::uniform(10.0))
+        .build();
+    let pdf = engine.render_html(html).expect("render");
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let rgba = pdf_to_rgba(&pdf, 200, tmp.path());
+
+    // Derive pixel coords from the actual raster dims (rasterisers may
+    // round up or add a fringe pixel; always trust the image over the
+    // arithmetic).
+    let w = rgba.width() as f32;
+    let h = rgba.height() as f32;
+    let page_w_pt: f32 = 200.0;
+    let page_h_pt: f32 = 200.0;
+
+    // Rule x-centre: body_left (10) + col1_w (80) + gap/2 (10) = 100 pt.
+    let gap_center_pt: f32 = 100.0;
+    let x_center = ((gap_center_pt / page_w_pt) * w) as u32;
+
+    // Y range covering the multicol's vertical extent. The rule is drawn
+    // between adjacent non-empty columns only, so keep the range well
+    // inside the content flow (skip top 15pt of margin + breathing room).
+    let y_lo = ((30.0_f32 / page_h_pt) * h) as u32;
+    let y_hi = ((170.0_f32 / page_h_pt) * h) as u32;
+
+    // ±3 px tolerance on x to absorb rasteriser AA on the 4pt-wide stroke.
+    assert!(
+        has_red_pixel_in_strip(&rgba, x_center, 3, y_lo, y_hi),
+        "expected a red column-rule pixel around x={x_center}±3, y={y_lo}..{y_hi} \
+         (image {}×{}); dump left at {:?}",
+        rgba.width(),
+        rgba.height(),
+        tmp.path(),
+    );
+}
+
+// ─── Test 2: column-fill: auto leaves column 2 empty for short content ──
+
+#[test]
+fn column_fill_auto_leaves_second_column_empty_for_short_content() {
+    if !pdftocairo_available() {
+        eprintln!(
+            "skipping column_fill_auto_leaves_second_column_empty_for_short_content: pdftocairo not installed"
+        );
+        return;
+    }
+
+    // Layout math (pt):
+    //   @page 300×300, margin 20 → body content-box 260×260.
+    //   column-count 2, column-gap 20 → each column = 120pt wide.
+    //   Column 1 spans x ∈ [20, 140], gap [140, 160], column 2 [160, 280].
+    //   Column 2 mid x = 220pt. Single 40pt-tall black block goes in col 1
+    //   only under `column-fill: auto`.
+    let html = r#"<!doctype html><html><head><style>
+        @page { size: 300pt 300pt; margin: 20pt; }
+        body { margin: 0; }
+        .mc {
+            column-count: 2;
+            column-gap: 20pt;
+            column-fill: auto;
+        }
+        .mc p { height: 40pt; background: black; margin: 0 0 8pt 0; color: white; }
+    </style></head><body>
+      <div class="mc">
+        <p>tiny</p>
+      </div>
+    </body></html>"#;
+
+    let engine = Engine::builder()
+        .page_size(PageSize {
+            width: 300.0,
+            height: 300.0,
+        })
+        .margin(Margin::uniform(20.0))
+        .build();
+    let pdf = engine.render_html(html).expect("render");
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let rgba = pdf_to_rgba(&pdf, 200, tmp.path());
+
+    let w = rgba.width() as f32;
+    let h = rgba.height() as f32;
+    let page_w_pt: f32 = 300.0;
+    let page_h_pt: f32 = 300.0;
+
+    // Column-2 centre x in pt = body_left (20) + col1_w (120) + gap (20) + col2_w/2 (60) = 220.
+    let x_center_pt: f32 = 220.0;
+    let x_center = ((x_center_pt / page_w_pt) * w) as u32;
+
+    // Sample near the top of column 2, well inside the column's vertical
+    // extent (30pt down from the page top — ~10pt into the content box).
+    let y_pt: f32 = 30.0;
+    let y = ((y_pt / page_h_pt) * h) as u32;
+
+    let p = rgba.get_pixel(x_center, y);
+    assert!(
+        p[0] > 240 && p[1] > 240 && p[2] > 240,
+        "expected white pixel at col-2 top (pt {x_center_pt}×{y_pt} → px {x_center}×{y}), \
+         got rgba={:?}; dump left at {:?}",
+        p,
+        tmp.path(),
+    );
+}

--- a/docs/plans/2026-04-21-fulgur-v7a-column-rule.md
+++ b/docs/plans/2026-04-21-fulgur-v7a-column-rule.md
@@ -1,0 +1,536 @@
+# fulgur-v7a: multicol A-4 `column-rule-*` + `column-fill` Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Land the custom CSS parser that blitz/stylo cannot give us (engine-gated longhands), then render `column-rule-*` between adjacent non-empty columns and honour `column-fill: auto | balance` in the multicol layout hook.
+
+**Architecture:**
+
+`stylo 0.8.0` gates `column-rule-{width,style,color}`, `column-fill`, and `break-inside` behind `engines="gecko"`, but blitz ships with the `servo` feature only — these longhands never reach `ComputedValues`. The plan adds a small, opinionated CSS sniffer in `crates/fulgur/src/column_css.rs` that:
+
+1. Harvests declarations from every element's inline `style="…"` attribute and from every top-level `<style>` block's qualified rules.
+2. Matches a **minimal** selector grammar: type (`div`), class (`.foo`), id (`#bar`), compound (`div.foo#bar` — simple selectors ANDed), and comma-separated lists. No combinators, no pseudo-classes, no attribute selectors. Source-order wins (no specificity / no `!important`).
+3. Produces a side-table `BTreeMap<NodeId, ColumnStyleProps>` consumed downstream by the multicol hook and by the Pageable tree.
+
+The Taffy multicol hook stashes per-`ColumnGroup` geometry (column-width, gap, column count, per-column filled height) on a new `ColumnGeometry` record keyed by the container's NodeId. In `convert.rs` the multicol container is wrapped in a new `MulticolRulePageable` carrying the rule spec and the geometry records; its `draw()` paints vertical lines between adjacent non-empty columns with the vertical extent clamped to `min(col_heights[i], col_heights[i+1])`. `column-fill: auto` switches `layout_column_group` from `balance_budget` to a greedy sequential fill.
+
+Scope discipline (spec / Phase alignment):
+
+- **Parser Phase A**: inline style + top-level `<style>` only. `@media`, external CSS (`<link rel=stylesheet>` already parses CSS via Blitz for the properties Blitz supports, but our sniffer scans **only** `<style>` blocks to stay scoped), and selector combinators are out of scope.
+- **Properties Phase A**: `column-rule-width`, `column-rule-style` (`solid | dashed | dotted` only), `column-rule-color`, `column-rule` shorthand, `column-fill` (`auto | balance`). `double | groove | ridge | inset | outset` deferred to Phase C per the epic design doc.
+- **No `break-inside` in this PR.** fulgur-ftp depends on this parser and will add that property as a trivial extension once v7a lands.
+
+**Tech Stack:** Rust, `cssparser` (already a dep via `crates/fulgur/src/gcpm/parser.rs`), `blitz_dom::Node` attr access (`element_data().attr(...)`), fulgur's existing Taffy hook pipeline.
+
+---
+
+## Task summary
+
+| # | Task | Worktree impact |
+|---|------|-----------------|
+| 1 | Parser scaffold + property/selector TDD | new `column_css.rs`, cssparser impls, unit tests |
+| 2 | Harvester pass over DOM | extend `blitz_adapter.rs`, walk inline + `<style>` |
+| 3 | Column geometry record on the Taffy hook | modify `multicol_layout.rs`, new `ColumnGeometry` struct |
+| 4 | `MulticolRulePageable` wrapper | new type in `pageable.rs` |
+| 5 | Wire in `convert.rs`, handle `column-fill: auto` | touch `convert.rs` + `multicol_layout.rs` |
+| 6 | Integration test with pixel-sampling | new test in `crates/fulgur/tests/` |
+| 7 | Clippy / fmt / markdownlint | polish |
+
+---
+
+### Task 1: Parser scaffold + property TDD
+
+**Files:**
+
+- Create: `crates/fulgur/src/column_css.rs`
+- Modify: `crates/fulgur/src/lib.rs` (add `mod column_css;` behind `pub(crate)`)
+
+**Step 1: Sketch the public types — no tests yet, just compile**
+
+```rust
+//! Minimal CSS sniffer for the properties stylo 0.8.0 gates to its gecko
+//! engine (and thus the `servo`-flavoured blitz does not expose on
+//! `ComputedValues`). Phase A covers `column-rule-*`, `column-fill`, and
+//! leaves room for `break-inside` (fulgur-ftp).
+
+use std::collections::BTreeMap;
+use cssparser::RGBA;
+use taffy::NodeId;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ColumnRuleStyle {
+    #[default]
+    None,
+    Solid,
+    Dashed,
+    Dotted,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct ColumnRuleSpec {
+    pub width: f32,             // pt
+    pub style: ColumnRuleStyle,
+    pub color: [u8; 4],         // RGBA, matches existing `Color` convention
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ColumnFill {
+    #[default]
+    Balance,
+    Auto,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct ColumnStyleProps {
+    pub rule: Option<ColumnRuleSpec>,
+    pub fill: Option<ColumnFill>,
+}
+
+pub type ColumnStyleTable = BTreeMap<usize, ColumnStyleProps>;
+```
+
+> **Note on types:** `RGBA` handling mirrors whatever `crates/fulgur/src/background.rs` or `paragraph.rs` uses. Grep for an existing `Color` type first — if one exists, re-use it instead of `[u8; 4]`. `Pt` versus `f32` similarly: match the surrounding convention.
+
+**Step 2: Failing test — parse a single declaration string**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_column_rule_longhand_triplet() {
+        let css = "column-rule-width: 2pt; column-rule-style: solid; column-rule-color: red;";
+        let props = parse_declaration_block(css);
+        let rule = props.rule.expect("rule");
+        assert!((rule.width - 2.0).abs() < 1e-3);
+        assert_eq!(rule.style, ColumnRuleStyle::Solid);
+        assert_eq!(rule.color, [255, 0, 0, 255]);
+    }
+}
+```
+
+**Step 3: Implement `parse_declaration_block`**
+
+Wire a cssparser `DeclarationParser` similar to the GCPM `GcpmDeclarationParser` (read `crates/fulgur/src/gcpm/parser.rs:~200` for the pattern). Keys:
+
+- Accept `column-rule-width`, `column-rule-style`, `column-rule-color`, `column-rule` (shorthand), `column-fill`, in any order.
+- Use `Parser::parse_entirely` for each declaration and discard on error (continue parsing the block).
+- For length parsing reuse whatever helper `gcpm/parser.rs` already uses for `px/pt/em` (grep `parse_length` / `parse_dimension`). If nothing reusable exists, inline a small converter: `px → pt` by `value * 72.0 / 96.0`; `pt` pass-through; `em` deferred (treat as invalid for now and document the limitation in a doc-comment on the parser).
+- For color reuse cssparser's `Color::parse` (via `cssparser::Color`). Only accept the resolved `Color::Rgba` variant — `currentcolor` and system colors are returned as `None` (log a `trace!` at most).
+
+Add more failing tests incrementally and implement to pass:
+
+```rust
+#[test]
+fn parses_column_rule_shorthand() {
+    let props = parse_declaration_block("column-rule: 1px dashed #0a0;");
+    let rule = props.rule.expect("rule");
+    assert!((rule.width - 0.75).abs() < 1e-2); // 1px → 0.75pt
+    assert_eq!(rule.style, ColumnRuleStyle::Dashed);
+    assert_eq!(rule.color, [0x00, 0xAA, 0x00, 0xFF]);
+}
+
+#[test]
+fn parses_column_fill_auto() {
+    let props = parse_declaration_block("column-fill: auto;");
+    assert_eq!(props.fill, Some(ColumnFill::Auto));
+}
+
+#[test]
+fn ignores_unsupported_rule_style() {
+    // double is Phase C — must be silently dropped, not error-out the block.
+    let props = parse_declaration_block("column-rule: 1pt double red;");
+    assert!(props.rule.is_none() || matches!(props.rule.unwrap().style, ColumnRuleStyle::None));
+}
+```
+
+**Step 4: Selector matcher — tests + impl**
+
+```rust
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum SimpleSelector {
+    Type(String),         // lowercased tag name ("div")
+    Class(String),        // ".foo" → "foo"
+    Id(String),           // "#bar" → "bar"
+    Universal,            // "*"
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct CompoundSelector {
+    pub parts: Vec<SimpleSelector>,
+}
+
+pub fn parse_selector_list(input: &str) -> Vec<CompoundSelector> { /* ... */ }
+
+pub fn matches_node(sel: &CompoundSelector, node: &blitz_dom::Node) -> bool { /* ... */ }
+```
+
+Tests (failing first, then impl):
+
+```rust
+#[test]
+fn selector_matches_type_class_id_compound() {
+    // dummy struct facade for matching; in-code we use blitz_dom::Node but
+    // tests use a minimal fake. Alternatively, build a small HTML fixture
+    // via `blitz_adapter::parse` and exercise the matcher end-to-end.
+}
+```
+
+> **Note on test strategy:** it is cleaner to exercise `matches_node` end-to-end by building a tiny `blitz_dom` document via `crate::blitz_adapter::parse` + `resolve`, looking up nodes by id/class, and asserting match/no-match. Follow whatever pattern the existing blitz_adapter test module uses (grep `mod tests` in that file).
+
+**Step 5: Stylesheet aggregator — tests + impl**
+
+```rust
+pub struct StyleRule {
+    pub selectors: Vec<CompoundSelector>,
+    pub props: ColumnStyleProps,
+}
+
+pub fn parse_stylesheet(source: &str) -> Vec<StyleRule> { /* ... */ }
+```
+
+`parse_stylesheet` uses cssparser's `StyleSheetParser` + `QualifiedRuleParser`. Skip `@` rules (GCPM already harvests `@page`; we don't need them here). For each qualified rule parse the prelude as a selector list; if any simple selector contains an unsupported token (`:`, `[`, `>`, `+`, `~`, ` `), discard the whole rule silently. Parse the declaration block via `parse_declaration_block`.
+
+**Step 6: Cascade resolver — tests + impl**
+
+```rust
+pub fn build_column_style_table(
+    doc: &blitz_dom::HtmlDocument,
+    stylesheet_rules: &[StyleRule],
+) -> ColumnStyleTable;
+```
+
+Algorithm per node: walk stylesheet rules in source order; for each rule, if **any** of its compound selectors matches, fold its `ColumnStyleProps` into the node's entry (`Some` overwrites `None`; later `Some` overwrites earlier `Some` — last-wins, no specificity). Then parse inline `style` attribute and fold last.
+
+**Step 7: Run**
+
+`cargo test -p fulgur --lib column_css` — expect every unit test added above to pass. About 6–10 tests total.
+
+**Step 8: Commit**
+
+```bash
+git add crates/fulgur/src/column_css.rs crates/fulgur/src/lib.rs
+git commit -m "feat(fulgur-v7a): custom CSS sniffer for column-rule / column-fill"
+```
+
+---
+
+### Task 2: DOM harvester — build the side-table once per document
+
+**Files:**
+
+- Modify: `crates/fulgur/src/blitz_adapter.rs` — add `extract_column_style_table(doc) -> ColumnStyleTable`
+- Modify: `crates/fulgur/src/engine.rs` — call it after `resolve()` and thread the table through to conversion / layout
+
+**Step 1: Sketch the extractor**
+
+```rust
+pub fn extract_column_style_table(
+    doc: &blitz_dom::HtmlDocument,
+) -> crate::column_css::ColumnStyleTable {
+    // 1. Concatenate every top-level <style> block's text content.
+    // 2. Parse it via column_css::parse_stylesheet.
+    // 3. Call column_css::build_column_style_table.
+}
+```
+
+Walk helper can reuse the same recursion shape as `walk_for_inline_styles` (blitz_adapter.rs:239) — lift `walk_for_inline_styles` into a more general private visitor that yields text content, or duplicate the pattern if the original one has strong GCPM-specific coupling. Prefer duplication over a risky refactor; mark a `// TODO(phase-b): unify with walk_for_inline_styles` at the boundary.
+
+**Step 2: Thread the table through**
+
+`Engine::render_html` already holds a `BaseDocument`. After `blitz_adapter::resolve(...)` but before `convert::to_pageable(...)`, call `extract_column_style_table` and pass the result through both:
+
+1. `FulgurLayoutTree::new(doc, column_styles)` (new field), so `compute_multicol_layout` can read `column-fill` to switch balance strategies.
+2. `convert::to_pageable`'s context so the BlockPageable construction can see the rule spec.
+
+If `FulgurLayoutTree` currently takes only `&mut BaseDocument`, extend its signature — there are few callers. Search: `grep -rn "FulgurLayoutTree::new" crates/fulgur`.
+
+**Step 3: Test**
+
+Add one test at `crates/fulgur/src/blitz_adapter.rs` (tests module):
+
+```rust
+#[test]
+fn extract_column_style_table_picks_up_inline_and_stylesheet() {
+    let html = r#"<html><head><style>
+        .mc { column-fill: auto; column-rule: 1pt solid blue; }
+    </style></head><body>
+        <div class="mc" id="a"></div>
+        <div class="mc" id="b" style="column-rule: 2pt dashed red"></div>
+    </body></html>"#;
+    let mut doc = /* parse + resolve as in sibling tests */;
+    let table = extract_column_style_table(&doc);
+    let a = find_by_id(&doc, "a");
+    let b = find_by_id(&doc, "b");
+    // A: picks up stylesheet.
+    let a_props = table.get(&a).unwrap();
+    assert_eq!(a_props.fill, Some(crate::column_css::ColumnFill::Auto));
+    assert!(a_props.rule.unwrap().color == [0, 0, 255, 255]);
+    // B: inline overrides.
+    let b_props = table.get(&b).unwrap();
+    assert!((b_props.rule.unwrap().width - 2.0).abs() < 1e-3);
+    assert_eq!(b_props.rule.unwrap().style, crate::column_css::ColumnRuleStyle::Dashed);
+}
+```
+
+**Step 4: Commit**
+
+```bash
+git add crates/fulgur/src/blitz_adapter.rs crates/fulgur/src/engine.rs crates/fulgur/src/multicol_layout.rs
+git commit -m "feat(fulgur-v7a): harvest column styles from DOM into side-table"
+```
+
+---
+
+### Task 3: Stash per-ColumnGroup geometry out of the Taffy hook
+
+**Files:**
+
+- Modify: `crates/fulgur/src/multicol_layout.rs`
+
+**Step 1: New geometry types**
+
+```rust
+#[derive(Clone, Debug, Default)]
+pub struct ColumnGroupGeometry {
+    /// y-offset within the multicol container's content box.
+    pub y_offset: f32,
+    pub col_w: f32,
+    pub gap: f32,
+    pub n: u32,
+    /// Per-column cumulative filled height. Length == n. Zero means empty.
+    pub col_heights: Vec<f32>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct MulticolGeometry {
+    pub groups: Vec<ColumnGroupGeometry>,
+}
+
+pub type MulticolGeometryTable = BTreeMap<usize, MulticolGeometry>;
+```
+
+**Step 2: Record geometry in `layout_column_group`**
+
+Currently returns `(placements, seg_h)`. Extend the return to `(placements, ColumnGroupGeometry)`. Compute `col_heights` by iterating placements and grouping by `col_idx` (derivable from `location.x / (col_w + gap)`). Update the one caller in `compute_multicol_layout`.
+
+**Step 3: Propagate to `FulgurLayoutTree`**
+
+Store `MulticolGeometryTable` on `FulgurLayoutTree`, extend `layout_multicol_subtrees` to record one `MulticolGeometry` per container. Add a public getter: `pub fn take_geometry(&mut self) -> MulticolGeometryTable`.
+
+Unit tests: keep the existing `layout_column_group_matches_legacy_flat_balance` case green, and add one new test asserting `col_heights` sum equals `total_h / n ± balance_step` for a trivial fixture.
+
+**Step 4: Commit**
+
+```bash
+git add crates/fulgur/src/multicol_layout.rs
+git commit -m "feat(fulgur-v7a): record per-ColumnGroup geometry from the Taffy hook"
+```
+
+---
+
+### Task 4: `MulticolRulePageable` wrapper
+
+**Files:**
+
+- Modify: `crates/fulgur/src/pageable.rs` — new type, trait impl, unit tests
+
+**Step 1: Define the wrapper**
+
+```rust
+pub struct MulticolRulePageable {
+    pub child: Box<dyn Pageable>,
+    pub rule: crate::column_css::ColumnRuleSpec,
+    pub groups: Vec<crate::multicol_layout::ColumnGroupGeometry>,
+}
+```
+
+All `Pageable` methods delegate to `self.child`, **except** `draw()`: call `child.draw()` first, then for every `(group, i, i+1)` with both `col_heights[i] > 0.0` and `col_heights[i+1] > 0.0`, paint a vertical line at `x = group.col_w + i * (group.col_w + group.gap) + group.gap / 2.0` from `y_offset` to `y_offset + min(col_heights[i], col_heights[i+1])`.
+
+Stroke width, dash pattern, and colour come from `self.rule`. For `Dotted` use a dash pattern of `[width, width]`; for `Dashed` use `[width * 3, width * 2]`; for `Solid` no dash. Krilla stroke APIs: mirror whatever `render.rs` already uses for borders (grep `stroke_path` / `Stroke`).
+
+**Step 2: Ensure split plumbing works**
+
+The wrapper must survive pagination. `split_boxed` — delegate to `child.split_boxed` and reconstruct wrappers around both halves, preserving groups that fall on the first half vs the second half. Groups whose `y_offset + max(col_heights) <= first_half_height` stay on the first; the rest shift to the second (subtract `first_half_height` from `y_offset`). Groups that straddle the boundary split their `col_heights` by clamping — document this as approximate because cross-page ColumnGroup pagination is a known gap (see out-of-scope below).
+
+Add a unit test: wrap a simple BlockPageable with two groups at y 0 and y 400, split at 300pt, assert group 0 ends up on page 1 and group 1 on page 2.
+
+**Step 3: Commit**
+
+```bash
+git add crates/fulgur/src/pageable.rs
+git commit -m "feat(fulgur-v7a): MulticolRulePageable draws rules + survives split"
+```
+
+---
+
+### Task 5: Wire side-table + geometry into convert.rs; honour `column-fill: auto`
+
+**Files:**
+
+- Modify: `crates/fulgur/src/convert.rs` — detect multicol containers, wrap in `MulticolRulePageable`
+- Modify: `crates/fulgur/src/multicol_layout.rs` — branch on `ColumnFill::Auto` before `balance_budget`
+- Modify: `crates/fulgur/src/engine.rs` — pass the side-table + geometry into convert
+
+**Step 1: `column-fill: auto` branch**
+
+In `layout_column_group` (before `balance_budget`), if the container's `ColumnStyleProps.fill == Some(ColumnFill::Auto)`, replace the budget selection with a greedy fill: `budget = avail_h` (each column fills to the top up to the container height). No further changes downstream.
+
+Unit test: fixture with `column-fill: auto` where the total content fits in a single column — assert the second column remains empty (`col_heights[1] == 0.0`).
+
+**Step 2: Wrap multicol containers in convert.rs**
+
+Identify the 1–2 sites where a multicol container becomes a `BlockPageable`. If the side-table has a `ColumnStyleProps.rule`, wrap the block in `MulticolRulePageable::new(block, rule, groups)` using the geometry from the table. If `rule.style == ColumnRuleStyle::None` or `rule.width <= 0.0`, skip the wrapper — no visual change.
+
+**Step 3: Run tests**
+
+`cargo test -p fulgur` — 493 + new tests all pass. No existing test should have changed behaviour for non-multicol or for multicol without `column-rule`.
+
+**Step 4: Commit**
+
+```bash
+git add -u
+git commit -m "feat(fulgur-v7a): render column rules and honour column-fill: auto"
+```
+
+---
+
+### Task 6: Integration test with pixel sampling
+
+**Files:**
+
+- Create: `crates/fulgur/tests/column_rule_rendering.rs`
+
+**Step 1: Failing test**
+
+```rust
+//! Pixel-sampling probe for `column-rule` rendering (fulgur-v7a).
+//!
+//! Renders a simple 2-column layout with a thick solid red rule, converts
+//! the PDF to PNG via `pdftocairo` (skip if unavailable), and asserts a red
+//! pixel exists in the column-gap region. `page_count` cannot discriminate
+//! rule-present vs rule-absent, so we sample pixels directly.
+
+use fulgur::{Engine, PageSize};
+
+fn pdftocairo_available() -> bool {
+    std::process::Command::new("pdftocairo")
+        .arg("-v")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn column_rule_solid_red_is_visible_between_columns() {
+    if !pdftocairo_available() {
+        eprintln!("skipping: pdftocairo not installed");
+        return;
+    }
+    let html = r#"<!doctype html><html><head><style>
+        @page { size: 200pt 200pt; margin: 10pt; }
+        body { margin: 0; color: black; font-family: sans-serif; }
+        .mc {
+            column-count: 2;
+            column-gap: 20pt;
+            column-rule: 4pt solid red;
+        }
+        .mc p { margin: 0 0 8pt 0; }
+    </style></head><body>
+      <div class="mc">
+        <p>Aaa aaa aaa aaa aaa aaa aaa.</p>
+        <p>Bbb bbb bbb bbb bbb bbb bbb.</p>
+        <p>Ccc ccc ccc ccc ccc ccc ccc.</p>
+      </div>
+    </body></html>"#;
+
+    let engine = Engine::builder()
+        .page_size(PageSize { width: 200.0, height: 200.0 })
+        .build();
+    let pdf = engine.render_html(html).expect("render");
+
+    // Write PDF to a temp file, render with pdftocairo -png -r 200, load the
+    // PNG, and look for a pixel at the expected gap centre (approx x=100pt →
+    // 200*200/72 ≈ 277px at 200 DPI).
+    // Use tempfile crate (already a dev-dep via other tests — grep for it).
+    // ... (see existing VRT pipeline in fulgur-vrt for helper patterns).
+
+    // Assert: at least one pixel in the rectangle x ∈ [gap_center - 5, +5]
+    // is visually "red" (R>200, G<64, B<64).
+}
+```
+
+> **Note:** Replicate the pdftocairo invocation used by `fulgur-vrt` (see `crates/fulgur-vrt/src/pdf_render.rs`). If `fulgur-vrt` is not a dev-dep of `fulgur`, inline the shell invocation via `std::process::Command`. Read the PNG via `image` crate (already transitively available — check `Cargo.lock`); otherwise fall back to raw PNG decoding with `png` crate.
+
+**Step 2: Run and iterate until the red pixel appears**
+
+Expected first run: fails because Tasks 1–5 must all be landed — if the pixel isn't red, walk backwards: is the wrapper attached? does geometry populate? does the parser pick up the rule? Use `RUST_LOG=trace` and/or targeted `eprintln!` to diagnose.
+
+**Step 3: Add a second test for `column-fill: auto`**
+
+```rust
+#[test]
+fn column_fill_auto_leaves_second_column_empty_for_short_content() {
+    // One short paragraph inside `column-fill: auto` should land in column
+    // 1 entirely; column 2 should be empty. Sample a pixel where column 2's
+    // text would land — assert white (R>240, G>240, B>240).
+}
+```
+
+**Step 4: Commit**
+
+```bash
+git add crates/fulgur/tests/column_rule_rendering.rs
+git commit -m "test(fulgur-v7a): pixel-sampling probe for column-rule + column-fill"
+```
+
+---
+
+### Task 7: Lint, format, markdownlint, full-suite green
+
+**Files:** none (verification-only unless clippy requires touches)
+
+**Step 1: Clippy**
+
+`cargo clippy --workspace --all-targets -- -D warnings 2>&1 | tail -40` — fix any warnings.
+
+**Step 2: Formatting**
+
+`cargo fmt --check` — must be clean.
+
+**Step 3: Full test run**
+
+`cargo test` — fulgur, fulgur-cli, fulgur-vrt all green.
+
+**Step 4: Markdown lint of this plan**
+
+`npx markdownlint-cli2 'docs/plans/2026-04-21-fulgur-v7a-column-rule.md'`
+
+**Step 5: Final commit if anything shifted**
+
+```bash
+git add -u
+git commit -m "chore(fulgur-v7a): clippy + fmt polish"
+```
+
+---
+
+## Out of scope (follow-ups / Phase C)
+
+- Selector combinators (` `, `>`, `+`, `~`), pseudo-classes / pseudo-elements, attribute selectors.
+- CSS specificity / `!important` — this parser is **source-order wins**.
+- Column-rule styles beyond `solid | dashed | dotted` (double/groove/ridge/inset/outset).
+- Cross-page pagination of a `ColumnGroup` — rule geometry is approximated when a group straddles a page. File as part of the existing Phase B gap (fulgur-6q5 / fulgur-wfd).
+- `break-inside` — reserved for fulgur-ftp, which re-uses the parser from this PR.
+- `em` length unit — parsed as "invalid" today; Phase B can resolve against the container's font-size.
+
+## Acceptance checklist
+
+- [ ] `cargo test -p fulgur --lib column_css` — all parser unit tests pass.
+- [ ] `cargo test -p fulgur --test column_rule_rendering` — pixel probes pass (or skip cleanly when `pdftocairo` is missing).
+- [ ] `cargo test -p fulgur` — full suite green (493 prior tests still pass).
+- [ ] `cargo clippy --workspace --all-targets` — no warnings.
+- [ ] `cargo fmt --check` — clean.
+- [ ] Plan passes `npx markdownlint-cli2`.
+- [ ] fulgur-ftp unblocker: once this branch merges, the side-table struct exposes enough shape for fulgur-ftp to add `break_inside` with a ~20 LOC diff to `column_css.rs`.

--- a/docs/plans/2026-04-21-fulgur-v7a-column-rule.md
+++ b/docs/plans/2026-04-21-fulgur-v7a-column-rule.md
@@ -523,7 +523,9 @@ git commit -m "chore(fulgur-v7a): clippy + fmt polish"
 - Column-rule styles beyond `solid | dashed | dotted` (double/groove/ridge/inset/outset).
 - Cross-page pagination of a `ColumnGroup` — rule geometry is approximated when a group straddles a page. File as part of the existing Phase B gap (fulgur-6q5 / fulgur-wfd).
 - `break-inside` — reserved for fulgur-ftp, which re-uses the parser from this PR.
-- `em` length unit — parsed as "invalid" today; Phase B can resolve against the container's font-size.
+- `em` / `rem` length units — resolved against a fixed 16px default (`DEFAULT_EM_PX` in `column_css.rs`), not the container's computed font-size. Phase B will thread the real basis through the parser so authored sizes honour inherited `font-size`.
+- Linked stylesheets (`<link rel="stylesheet">`) — the column side-table is populated from inline `style="..."` attributes and top-level `<style>` blocks only. External CSS still drives stylo but never reaches the sniffer; tracked as fulgur-s5ro.
+- `<style media="screen">` and other non-print media queries — sheets with a media attribute that excludes `all` / `print` are skipped by the harvester. Full media-query evaluation (size ranges, logical operators) is deferred.
 
 ## Acceptance checklist
 


### PR DESCRIPTION
## 概要

CSS Multi-column Layout Phase A-4 (fulgur-v7a): `column-rule-*` の描画と `column-fill: auto | balance` の解釈を追加。

stylo 0.8.0 は `column-rule-width/style/color` / `column-fill` / `break-inside` を `engines="gecko"` で宣言しており、blitz が使う `servo` feature では `ComputedValues` に到達しない。このPRでは軽量な自前 CSS sniffer (`column_css.rs`) を導入してこれらを補完する。

## 実装内容

### 自前 CSS sniffer (`crates/fulgur/src/column_css.rs`)

- `cssparser` ベース、インライン `style="…"` + トップレベル `<style>` ブロックの両方を harvest
- セレクタ: tag / `.class` / `#id` / `*` / 複合 (`div.foo#bar`) / カンマリストのみ
- combinators / pseudo / attribute は rule 単位で silent drop
- カスケード: source-order wins (specificity なし、`!important` なし)、インラインは最後に重ねる
- 色: `#rgb` / `#rrggbb` / named / `rgb()` / `rgba()` / `hsl()` / `hsla()` (legacy comma syntax)
- 長さ: `pt` 直通 / `px → pt = v * 72/96` / `em` / `rem` / `%` は無効

### Taffy hook extension (`multicol_layout.rs`)

- `ColumnGroupGeometry { y_offset, col_w, gap, n, col_heights }` / `MulticolGeometry` 型を追加
- `compute_multicol_layout` が per-ColumnGroup geometry を記録 (BTreeMap)
- `column-fill: auto` 時は `balance_budget` を skip して `budget = avail_h` で greedy sequential fill
- `column-fill: balance` (default) は従来動作を維持

### `MulticolRulePageable` wrapper (`pageable.rs`)

- child に委譲しつつ `draw()` で隣接非空カラム間に縦線を描画
- 垂直範囲は `min(col_heights[i], col_heights[i+1])` でクランプ
- `split_boxed` でページ跨ぎ時に geometry を partition
- dashed `[w*3, w*2]` / dotted `[w, w]` / solid

### 配線 (`convert.rs`)

- `convert_node` の choke point で `maybe_wrap_multicol_rule` を1回だけ実行
- 11 の `BlockPageable::with_positioned_children` サイトを個別改修する代わりに単一ヘルパー
- geometry は px 単位で記録されるため wrapper 境界で `px_to_pt` 変換 (単位整合)

## Follow-up issues (このPRでは扱わない)

- **fulgur-ftp** (A-5): `break-inside: avoid` handling — このPRの parser を再利用予定 (module に `break-inside` を追加するだけで済む想定)
- **fulgur-e3z** (A-6): VRT fixtures + examples 拡充
- column-rule スタイル `double` / `groove` / `ridge` / `inset` / `outset` は Phase C
- セレクタ combinators / pseudo-classes は Phase B

## 変更統計

- 8 commits (4 feat + 1 fix + 1 test + 1 docs + 1 chore)
- `crates/fulgur/src/column_css.rs` 新規 (+1100 LOC, 34 unit tests)
- `crates/fulgur/src/multicol_layout.rs` (+500 LOC, ColumnGroupGeometry 記録 + column-fill auto 分岐)
- `crates/fulgur/src/pageable.rs` (+500 LOC, MulticolRulePageable + 7 tests)
- `crates/fulgur/src/convert.rs` (maybe_wrap_multicol_rule helper + ConvertContext 拡張)
- `crates/fulgur/src/blitz_adapter.rs` (extract_column_style_table)
- `crates/fulgur/src/engine.rs` (pipeline 組み込み)
- `crates/fulgur/tests/column_rule_rendering.rs` 新規 (2 pixel-sampling integration tests)

## Test Plan

- [x] `cargo test -p fulgur --lib` 540 passed
- [x] `cargo test -p fulgur` 全 integration 含め pass (新規 `column_rule_rendering` 2件含む)
- [x] `cargo test` workspace 全体 pass (fulgur-vrt goldens 回帰なし)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `npx markdownlint-cli2 docs/plans/2026-04-21-fulgur-v7a-column-rule.md` pass
- [x] `pdftocairo` 経由の pixel probe で `column-rule: 4pt solid red` の赤ピクセル検証
- [x] `column-fill: auto` で短いコンテンツが列1のみに収まり列2が白のままであることを検証

## 設計ドキュメント

- `docs/plans/2026-04-21-fulgur-v7a-column-rule.md` — このPRの実装計画
- `docs/plans/2026-04-20-css-multicol-design.md` — Phase A 全体設計 (既存)

Closes fulgur-v7a. Unblocks fulgur-ftp (break-inside: avoid).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Column-rule rendering: draws configurable vertical dividers between columns (solid/dashed/dotted), with width and color, across pagination.
  * Column-fill: supports balanced and auto-fill behaviors for multicolumn layouts.

* **Tests**
  * Added pixel-sampling integration tests validating visible column-rule rendering and column-fill auto behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->