### PR TITLE
feat(fulgur-wpt): WPT reftest runner Phase 1 core (2foo.1-6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Install poppler-utils (for fulgur-wpt pdftocairo tests)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y poppler-utils
       - name: Install cargo-llvm-cov
         if: matrix.coverage
         uses: taiki-e/install-action@88ada01c46e65c47040a0ae865537cc76fcd0e1c # cargo-llvm-cov

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,7 +392,7 @@ dependencies = [
  "bitflags 2.11.0",
  "blitz-traits",
  "color",
- "cssparser",
+ "cssparser 0.35.0",
  "cursor-icon",
  "debug_timer",
  "euclid",
@@ -388,12 +401,12 @@ dependencies = [
  "image",
  "keyboard-types",
  "linebender_resource_handle",
- "markup5ever",
+ "markup5ever 0.35.0",
  "objc2",
  "parley",
  "percent-encoding",
  "rayon",
- "selectors",
+ "selectors 0.32.0",
  "skrifa 0.37.0",
  "slab",
  "smallvec",
@@ -416,7 +429,7 @@ checksum = "e77adcd3cb60e67d365bc897c6120ecb684627f2e2265c2bb75b12cc6c4bc4de"
 dependencies = [
  "blitz-dom",
  "blitz-traits",
- "html5ever",
+ "html5ever 0.35.0",
  "xml5ever",
 ]
 
@@ -761,6 +774,19 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b3df4f93e5fbbe73ec01ec8d3f68bba73107993a5b1e7519273c32db9b0d5be"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.11.3",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
@@ -768,7 +794,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf",
+ "phf 0.11.3",
  "serde",
  "smallvec",
 ]
@@ -840,6 +866,17 @@ name = "debug_timer"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da220af51a1a335e9a930beaaef53d261e41ea9eecfb3d973a3ddae1a7284b9c"
+
+[[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "derive_more"
@@ -933,6 +970,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "ego-tree"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12a0bb14ac04a9fcf170d0bbbef949b44cc492f4452bd20c095636956f653642"
 
 [[package]]
 name = "either"
@@ -1147,7 +1190,7 @@ dependencies = [
  "blitz-dom",
  "blitz-html",
  "blitz-traits",
- "cssparser",
+ "cssparser 0.35.0",
  "image",
  "krilla",
  "krilla-svg",
@@ -1200,6 +1243,18 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+]
+
+[[package]]
+name = "fulgur-wpt"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "fulgur",
+ "fulgur-vrt",
+ "image",
+ "scraper",
+ "tempfile",
 ]
 
 [[package]]
@@ -1326,6 +1381,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1333,6 +1397,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1348,13 +1421,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -1461,12 +1546,26 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "html5ever"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
 dependencies = [
  "log",
- "markup5ever",
+ "markup5ever 0.35.0",
  "match_token",
 ]
 
@@ -1847,7 +1946,7 @@ dependencies = [
  "png",
  "rustc-hash",
  "rustybuzz",
- "siphasher",
+ "siphasher 1.0.2",
  "skrifa 0.37.0",
  "smallvec",
  "subsetter",
@@ -2025,6 +2124,20 @@ dependencies = [
  "proc-macro2",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
+dependencies = [
+ "log",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
 ]
 
 [[package]]
@@ -2305,12 +2418,31 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
 ]
 
 [[package]]
@@ -2319,8 +2451,18 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared 0.10.0",
+ "rand",
 ]
 
 [[package]]
@@ -2329,7 +2471,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand",
 ]
 
@@ -2339,11 +2481,20 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -2352,7 +2503,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher",
+ "siphasher 1.0.2",
 ]
 
 [[package]]
@@ -2549,6 +2700,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -2874,21 +3031,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90460b31bfe1fc07be8262e42c665ad97118d4585869de9345a84d501a9eaf0"
+dependencies = [
+ "ahash",
+ "cssparser 0.31.2",
+ "ego-tree",
+ "getopts",
+ "html5ever 0.27.0",
+ "once_cell",
+ "selectors 0.25.0",
+ "tendril",
+]
+
+[[package]]
+name = "selectors"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb30575f3638fc8f6815f448d50cb1a2e255b0897985c8c59f4d37b72a07b06"
+dependencies = [
+ "bitflags 2.11.0",
+ "cssparser 0.31.2",
+ "derive_more 0.99.20",
+ "fxhash",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.10.1",
+ "phf_codegen 0.10.0",
+ "precomputed-hash",
+ "servo_arc 0.3.0",
+ "smallvec",
+]
+
+[[package]]
 name = "selectors"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09975d3195f34dce9c7b381cb0f00c3c13381d4d3735c0f1a9c894b283b302ab"
 dependencies = [
  "bitflags 2.11.0",
- "cssparser",
- "derive_more",
+ "cssparser 0.35.0",
+ "derive_more 2.1.1",
  "log",
  "new_debug_unreachable",
- "phf",
- "phf_codegen",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
  "precomputed-hash",
  "rustc-hash",
- "servo_arc",
+ "servo_arc 0.4.3",
  "smallvec",
  "to_shmem",
  "to_shmem_derive",
@@ -2972,6 +3164,15 @@ dependencies = [
 
 [[package]]
 name = "servo_arc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d036d71a959e00c77a63538b90a6c2390969f9772b096ea837205c6bd0491a44"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "servo_arc"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
@@ -3027,6 +3228,12 @@ checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
@@ -3129,7 +3336,7 @@ checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.11.3",
  "precomputed-hash",
  "serde",
 ]
@@ -3140,8 +3347,8 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
 ]
@@ -3163,8 +3370,8 @@ dependencies = [
  "atomic_refcell",
  "bitflags 2.11.0",
  "byteorder",
- "cssparser",
- "derive_more",
+ "cssparser 0.35.0",
+ "derive_more 2.1.1",
  "encoding_rs",
  "euclid",
  "icu_segmenter",
@@ -3186,9 +3393,9 @@ dependencies = [
  "rayon",
  "rayon-core",
  "rustc-hash",
- "selectors",
+ "selectors 0.32.0",
  "serde",
- "servo_arc",
+ "servo_arc 0.4.3",
  "smallbitvec",
  "smallvec",
  "static_assertions",
@@ -3256,10 +3463,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8185a7a3cf0716c475ad113b494c276acf534b518dd41ee47ad5aba4af6690e"
 dependencies = [
  "app_units",
- "cssparser",
+ "cssparser 0.35.0",
  "euclid",
- "selectors",
- "servo_arc",
+ "selectors 0.32.0",
+ "servo_arc 0.4.3",
  "smallbitvec",
  "smallvec",
  "string_cache",
@@ -3292,12 +3499,12 @@ checksum = "f58034d08877fb80a5496301fde9111bc57e761f4a78045222af30ce95ec150f"
 dependencies = [
  "app_units",
  "bitflags 2.11.0",
- "cssparser",
+ "cssparser 0.35.0",
  "euclid",
  "malloc_size_of_derive",
- "selectors",
+ "selectors 0.32.0",
  "serde",
- "servo_arc",
+ "servo_arc 0.4.3",
  "stylo_atoms",
  "stylo_malloc_size_of",
  "thin-vec",
@@ -3325,7 +3532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
 dependencies = [
  "kurbo 0.11.3",
- "siphasher",
+ "siphasher 1.0.2",
 ]
 
 [[package]]
@@ -3533,8 +3740,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb61262d1e7e4cc777e40cb2f101d5fa51f3eeac50c3a7355b2027b9274baa35"
 dependencies = [
- "cssparser",
- "servo_arc",
+ "cssparser 0.35.0",
+ "servo_arc 0.4.3",
  "smallbitvec",
  "smallvec",
  "string_cache",
@@ -3795,6 +4002,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3830,7 +4043,7 @@ dependencies = [
  "roxmltree",
  "rustybuzz",
  "simplecss",
- "siphasher",
+ "siphasher 1.0.2",
  "strict-num",
  "svgtypes",
  "tiny-skia-path",
@@ -4030,8 +4243,8 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
 dependencies = [
- "phf",
- "phf_codegen",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
  "string_cache",
  "string_cache_codegen",
 ]
@@ -4456,7 +4669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee3f1e41afb31a75aef076563b0ad3ecc24f5bd9d12a72b132222664eb76b494"
 dependencies = [
  "log",
- "markup5ever",
+ "markup5ever 0.35.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,19 +15,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.4",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,19 +761,6 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b3df4f93e5fbbe73ec01ec8d3f68bba73107993a5b1e7519273c32db9b0d5be"
-dependencies = [
- "cssparser-macros",
- "dtoa-short",
- "itoa",
- "phf 0.11.3",
- "smallvec",
-]
-
-[[package]]
-name = "cssparser"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
@@ -796,6 +770,19 @@ dependencies = [
  "itoa",
  "phf 0.11.3",
  "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.13.1",
  "smallvec",
 ]
 
@@ -866,17 +853,6 @@ name = "debug_timer"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da220af51a1a335e9a930beaaef53d261e41ea9eecfb3d973a3ddae1a7284b9c"
-
-[[package]]
-name = "derive_more"
-version = "0.99.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "derive_more"
@@ -973,9 +949,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ego-tree"
-version = "0.6.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a0bb14ac04a9fcf170d0bbbef949b44cc492f4452bd20c095636956f653642"
+checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
@@ -1381,15 +1357,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,25 +1388,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
  "wasip2",
  "wasip3",
 ]
@@ -1546,20 +1501,6 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
-dependencies = [
- "log",
- "mac",
- "markup5ever 0.12.1",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "html5ever"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
@@ -1567,6 +1508,16 @@ dependencies = [
  "log",
  "markup5ever 0.35.0",
  "match_token",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever 0.39.0",
 ]
 
 [[package]]
@@ -1946,7 +1897,7 @@ dependencies = [
  "png",
  "rustc-hash",
  "rustybuzz",
- "siphasher 1.0.2",
+ "siphasher",
  "skrifa 0.37.0",
  "smallvec",
  "subsetter",
@@ -2128,27 +2079,24 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
-dependencies = [
- "log",
- "phf 0.11.3",
- "phf_codegen 0.11.3",
- "string_cache",
- "string_cache_codegen",
- "tendril",
-]
-
-[[package]]
-name = "markup5ever"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
 dependencies = [
  "log",
- "tendril",
- "web_atoms",
+ "tendril 0.4.3",
+ "web_atoms 0.1.3",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril 0.5.0",
+ "web_atoms 0.2.4",
 ]
 
 [[package]]
@@ -2418,31 +2366,23 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
-dependencies = [
- "phf_shared 0.10.0",
-]
-
-[[package]]
-name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.11.3",
  "phf_shared 0.11.3",
 ]
 
 [[package]]
-name = "phf_codegen"
-version = "0.10.0"
+name = "phf"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_generator 0.10.0",
- "phf_shared 0.10.0",
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -2456,13 +2396,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf_generator"
-version = "0.10.0"
+name = "phf_codegen"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_shared 0.10.0",
- "rand",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -2473,6 +2413,16 @@ checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
  "rand",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -2489,12 +2439,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf_shared"
-version = "0.10.0"
+name = "phf_macros"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "siphasher 0.3.11",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2503,7 +2457,16 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher 1.0.2",
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -2700,12 +2663,6 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -3032,37 +2989,17 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scraper"
-version = "0.20.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90460b31bfe1fc07be8262e42c665ad97118d4585869de9345a84d501a9eaf0"
+checksum = "f0f5297102b8b62b4454ee8561601b2d551b4913148feb4241ca9d1a04bf4526"
 dependencies = [
- "ahash",
- "cssparser 0.31.2",
+ "cssparser 0.36.0",
  "ego-tree",
  "getopts",
- "html5ever 0.27.0",
- "once_cell",
- "selectors 0.25.0",
- "tendril",
-]
-
-[[package]]
-name = "selectors"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb30575f3638fc8f6815f448d50cb1a2e255b0897985c8c59f4d37b72a07b06"
-dependencies = [
- "bitflags 2.11.0",
- "cssparser 0.31.2",
- "derive_more 0.99.20",
- "fxhash",
- "log",
- "new_debug_unreachable",
- "phf 0.10.1",
- "phf_codegen 0.10.0",
+ "html5ever 0.39.0",
  "precomputed-hash",
- "servo_arc 0.3.0",
- "smallvec",
+ "selectors 0.36.1",
+ "tendril 0.5.0",
 ]
 
 [[package]]
@@ -3073,17 +3010,36 @@ checksum = "09975d3195f34dce9c7b381cb0f00c3c13381d4d3735c0f1a9c894b283b302ab"
 dependencies = [
  "bitflags 2.11.0",
  "cssparser 0.35.0",
- "derive_more 2.1.1",
+ "derive_more",
  "log",
  "new_debug_unreachable",
  "phf 0.11.3",
  "phf_codegen 0.11.3",
  "precomputed-hash",
  "rustc-hash",
- "servo_arc 0.4.3",
+ "servo_arc",
  "smallvec",
  "to_shmem",
  "to_shmem_derive",
+]
+
+[[package]]
+name = "selectors"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
+dependencies = [
+ "bitflags 2.11.0",
+ "cssparser 0.36.0",
+ "derive_more",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -3164,15 +3120,6 @@ dependencies = [
 
 [[package]]
 name = "servo_arc"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d036d71a959e00c77a63538b90a6c2390969f9772b096ea837205c6bd0491a44"
-dependencies = [
- "stable_deref_trait",
-]
-
-[[package]]
-name = "servo_arc"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
@@ -3228,12 +3175,6 @@ checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
 dependencies = [
  "log",
 ]
-
-[[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
@@ -3342,6 +3283,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "string_cache_codegen"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3349,6 +3302,18 @@ checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
 ]
@@ -3371,7 +3336,7 @@ dependencies = [
  "bitflags 2.11.0",
  "byteorder",
  "cssparser 0.35.0",
- "derive_more 2.1.1",
+ "derive_more",
  "encoding_rs",
  "euclid",
  "icu_segmenter",
@@ -3395,11 +3360,11 @@ dependencies = [
  "rustc-hash",
  "selectors 0.32.0",
  "serde",
- "servo_arc 0.4.3",
+ "servo_arc",
  "smallbitvec",
  "smallvec",
  "static_assertions",
- "string_cache",
+ "string_cache 0.8.9",
  "stylo_atoms",
  "stylo_config",
  "stylo_derive",
@@ -3414,7 +3379,7 @@ dependencies = [
  "url",
  "void",
  "walkdir",
- "web_atoms",
+ "web_atoms 0.1.3",
 ]
 
 [[package]]
@@ -3423,8 +3388,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d6ff15e6ed626c331663555af48b8f21bc46f729f45711597143dc1bf50fb5"
 dependencies = [
- "string_cache",
- "string_cache_codegen",
+ "string_cache 0.8.9",
+ "string_cache_codegen 0.5.4",
 ]
 
 [[package]]
@@ -3466,10 +3431,10 @@ dependencies = [
  "cssparser 0.35.0",
  "euclid",
  "selectors 0.32.0",
- "servo_arc 0.4.3",
+ "servo_arc",
  "smallbitvec",
  "smallvec",
- "string_cache",
+ "string_cache 0.8.9",
  "thin-vec",
  "void",
 ]
@@ -3504,7 +3469,7 @@ dependencies = [
  "malloc_size_of_derive",
  "selectors 0.32.0",
  "serde",
- "servo_arc 0.4.3",
+ "servo_arc",
  "stylo_atoms",
  "stylo_malloc_size_of",
  "thin-vec",
@@ -3532,7 +3497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
 dependencies = [
  "kurbo 0.11.3",
- "siphasher 1.0.2",
+ "siphasher",
 ]
 
 [[package]]
@@ -3633,6 +3598,16 @@ checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
 dependencies = [
  "futf",
  "mac",
+ "utf-8",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
  "utf-8",
 ]
 
@@ -3741,10 +3716,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb61262d1e7e4cc777e40cb2f101d5fa51f3eeac50c3a7355b2027b9274baa35"
 dependencies = [
  "cssparser 0.35.0",
- "servo_arc 0.4.3",
+ "servo_arc",
  "smallbitvec",
  "smallvec",
- "string_cache",
+ "string_cache 0.8.9",
  "thin-vec",
 ]
 
@@ -4043,7 +4018,7 @@ dependencies = [
  "roxmltree",
  "rustybuzz",
  "simplecss",
- "siphasher 1.0.2",
+ "siphasher",
  "strict-num",
  "svgtypes",
  "tiny-skia-path",
@@ -4245,8 +4220,20 @@ checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
 dependencies = [
  "phf 0.11.3",
  "phf_codegen 0.11.3",
- "string_cache",
- "string_cache_codegen",
+ "string_cache 0.8.9",
+ "string_cache_codegen 0.5.4",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
+dependencies = [
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache 0.9.0",
+ "string_cache_codegen 0.6.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/fulgur", "crates/fulgur-cli", "crates/fulgur-ruby", "crates/fulgur-vrt", "crates/pyfulgur"]
+members = ["crates/fulgur", "crates/fulgur-cli", "crates/fulgur-ruby", "crates/fulgur-vrt", "crates/fulgur-wpt", "crates/pyfulgur"]
 
 [workspace.package]
 edition = "2024"

--- a/crates/fulgur-wpt/Cargo.toml
+++ b/crates/fulgur-wpt/Cargo.toml
@@ -9,10 +9,10 @@ description = "W3C web-platform-tests runner for fulgur (dev-only, not published
 
 [dependencies]
 fulgur = { path = "../fulgur" }
+fulgur-vrt = { path = "../fulgur-vrt" }
 image = { version = "0.25", default-features = false, features = ["png"] }
 anyhow = "1"
 scraper = "0.26"
 
 [dev-dependencies]
-fulgur-vrt = { path = "../fulgur-vrt" }
 tempfile = "3"

--- a/crates/fulgur-wpt/Cargo.toml
+++ b/crates/fulgur-wpt/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "fulgur-wpt"
+version = "0.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+description = "W3C web-platform-tests runner for fulgur (dev-only, not published)"
+
+[dependencies]
+fulgur = { path = "../fulgur" }
+image = { version = "0.25", default-features = false, features = ["png"] }
+anyhow = "1"
+scraper = "0.20"
+
+[dev-dependencies]
+fulgur-vrt = { path = "../fulgur-vrt" }
+tempfile = "3"

--- a/crates/fulgur-wpt/Cargo.toml
+++ b/crates/fulgur-wpt/Cargo.toml
@@ -11,7 +11,7 @@ description = "W3C web-platform-tests runner for fulgur (dev-only, not published
 fulgur = { path = "../fulgur" }
 image = { version = "0.25", default-features = false, features = ["png"] }
 anyhow = "1"
-scraper = "0.20"
+scraper = "0.26"
 
 [dev-dependencies]
 fulgur-vrt = { path = "../fulgur-vrt" }

--- a/crates/fulgur-wpt/README.md
+++ b/crates/fulgur-wpt/README.md
@@ -1,0 +1,17 @@
+# fulgur-wpt
+
+W3C web-platform-tests (WPT) の CSS paged media 系サブセット reftest を fulgur で走らせる自前ランナー。
+
+## 他 crate との責務分担
+
+| crate | 役割 |
+|---|---|
+| `fulgur` | HTML → PDF 本体 |
+| `fulgur-vrt` | 手書きフィクスチャの visual regression, ゆるい tolerance |
+| `fulgur-wpt` | 外部 WPT reftest, WPT 規約準拠 (fuzzy meta, rel=match 等) |
+
+diff ロジックは `fulgur-vrt::diff` を dev-dep 経由で再利用する (Rule of Three 未達のため共有 crate は切り出さない)。
+
+## 使い方
+
+詳細は epic fulgur-2foo と `docs/plans/2026-04-21-wpt-reftest-runner-design.md` を参照。

--- a/crates/fulgur-wpt/examples/run_one.rs
+++ b/crates/fulgur-wpt/examples/run_one.rs
@@ -1,0 +1,59 @@
+//! Run a single WPT reftest end-to-end and print the verdict.
+//!
+//! Usage:
+//!     cargo run -p fulgur-wpt --example run_one -- <test.html> [--dpi N]
+//!
+//! Outputs are written under `target/wpt-run/<test-stem>/` (test/, ref/, diff/).
+
+use anyhow::{Context, Result, bail};
+use fulgur_wpt::expectations::Expectation;
+use fulgur_wpt::harness::run_one;
+use std::path::{Path, PathBuf};
+
+fn main() -> Result<()> {
+    let mut args = std::env::args().skip(1);
+    let test_arg = args
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("usage: run_one <test.html> [--dpi N]"))?;
+    let mut dpi: u32 = 96;
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--dpi" => {
+                let v = args
+                    .next()
+                    .ok_or_else(|| anyhow::anyhow!("--dpi needs a value"))?;
+                dpi = v.parse().context("parse --dpi value")?;
+            }
+            other => bail!("unknown flag: {other}"),
+        }
+    }
+
+    let test_path = PathBuf::from(&test_arg);
+    let stem = Path::new(&test_arg)
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "test".to_string());
+    let out_root = PathBuf::from("target/wpt-run").join(&stem);
+    let work_dir = out_root.join("work");
+    let diff_dir = out_root.join("diff");
+
+    println!("test:    {}", test_path.display());
+    println!("dpi:     {dpi}");
+    println!("work:    {}", work_dir.display());
+    println!("diff:    {}", diff_dir.display());
+
+    let outcome = run_one(&test_path, &work_dir, &diff_dir, dpi)?;
+    let verdict = match outcome.observed {
+        Expectation::Pass => "PASS",
+        Expectation::Fail => "FAIL",
+        Expectation::Skip => "SKIP",
+    };
+    println!("\nverdict: {verdict}");
+    if let Some(reason) = &outcome.reason {
+        println!("reason:  {reason}");
+    }
+    if let Some(diff) = &outcome.diff_dir {
+        println!("diffs:   {}", diff.display());
+    }
+    Ok(())
+}

--- a/crates/fulgur-wpt/examples/run_one.rs
+++ b/crates/fulgur-wpt/examples/run_one.rs
@@ -23,6 +23,9 @@ fn main() -> Result<()> {
                     .next()
                     .ok_or_else(|| anyhow::anyhow!("--dpi needs a value"))?;
                 dpi = v.parse().context("parse --dpi value")?;
+                if dpi == 0 {
+                    bail!("--dpi must be greater than 0");
+                }
             }
             other => bail!("unknown flag: {other}"),
         }

--- a/crates/fulgur-wpt/src/expectations.rs
+++ b/crates/fulgur-wpt/src/expectations.rs
@@ -1,0 +1,231 @@
+//! Expectations file parser and PASS/FAIL/SKIP judgement.
+//!
+//! An expectation file is a plain-text list, one entry per line:
+//!
+//! ```text
+//! # comments start with '#'
+//! PASS css/css-page/a.html
+//! FAIL css/css-page/b.html  # regression since 2026-04
+//! SKIP css/css-page/c.html  # manual-only test
+//! ```
+//!
+//! Blank lines and lines starting with `#` are ignored. An inline `#`
+//! starts a trailing comment that is captured but does not affect
+//! parsing. Duplicate entries for the same path are rejected.
+
+use anyhow::{Result, bail};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Expectation {
+    Pass,
+    Fail,
+    Skip,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ExpectationFile {
+    entries: BTreeMap<String, Entry>,
+}
+
+#[derive(Debug, Clone)]
+struct Entry {
+    expectation: Expectation,
+    #[allow(dead_code)] // comment is informational; kept for future reporting
+    comment: Option<String>,
+}
+
+impl ExpectationFile {
+    pub fn parse(src: &str) -> Result<Self> {
+        let mut entries: BTreeMap<String, Entry> = BTreeMap::new();
+        for (lineno, raw) in src.lines().enumerate() {
+            let line = raw.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let (body, comment) = match line.find('#') {
+                Some(idx) => (line[..idx].trim(), Some(line[idx + 1..].trim().to_string())),
+                None => (line, None),
+            };
+            let mut parts = body.splitn(2, char::is_whitespace);
+            let status = parts.next().unwrap_or("");
+            let path = parts.next().unwrap_or("").trim();
+            if path.is_empty() {
+                bail!("line {}: missing path", lineno + 1);
+            }
+            let expectation = match status {
+                "PASS" => Expectation::Pass,
+                "FAIL" => Expectation::Fail,
+                "SKIP" => Expectation::Skip,
+                other => bail!("line {}: unknown status {other}", lineno + 1),
+            };
+            if entries.contains_key(path) {
+                bail!("line {}: duplicate entry for {path}", lineno + 1);
+            }
+            entries.insert(
+                path.to_string(),
+                Entry {
+                    expectation,
+                    comment,
+                },
+            );
+        }
+        Ok(Self { entries })
+    }
+
+    pub fn load(path: &Path) -> Result<Self> {
+        let s = std::fs::read_to_string(path)?;
+        Self::parse(&s)
+    }
+
+    pub fn get(&self, test_path: &str) -> Option<Expectation> {
+        self.entries.get(test_path).map(|e| e.expectation)
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    Ok,
+    Regression,
+    Promotion,
+    Skipped,
+    UnknownTest,
+}
+
+/// Compare the declared expectation with the observed result.
+pub fn judge(declared: Option<Expectation>, observed: Option<Expectation>) -> Verdict {
+    match (declared, observed) {
+        (Some(Expectation::Skip), _) => Verdict::Skipped,
+        (Some(d), Some(o)) if d == o => Verdict::Ok,
+        (Some(Expectation::Pass), Some(Expectation::Fail)) => Verdict::Regression,
+        (Some(Expectation::Fail), Some(Expectation::Pass)) => Verdict::Promotion,
+        (None, _) => Verdict::UnknownTest,
+        _ => Verdict::Ok,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_all_three_statuses() {
+        let src = "\
+# comment line
+PASS css/css-page/a.html
+FAIL css/css-page/b.html  # reason
+SKIP css/css-page/c.html  # manual
+
+";
+        let f = ExpectationFile::parse(src).unwrap();
+        assert_eq!(f.get("css/css-page/a.html"), Some(Expectation::Pass));
+        assert_eq!(f.get("css/css-page/b.html"), Some(Expectation::Fail));
+        assert_eq!(f.get("css/css-page/c.html"), Some(Expectation::Skip));
+        assert_eq!(f.len(), 3);
+    }
+
+    #[test]
+    fn ignores_blank_and_comment_lines() {
+        let src = "\n  \n# foo\nPASS x\n";
+        let f = ExpectationFile::parse(src).unwrap();
+        assert_eq!(f.len(), 1);
+    }
+
+    #[test]
+    fn rejects_unknown_status() {
+        assert!(ExpectationFile::parse("XYZZY a.html\n").is_err());
+    }
+
+    #[test]
+    fn rejects_duplicate_entry() {
+        let src = "PASS a.html\nFAIL a.html\n";
+        assert!(ExpectationFile::parse(src).is_err());
+    }
+
+    #[test]
+    fn judge_pass_pass_is_ok() {
+        assert_eq!(
+            judge(Some(Expectation::Pass), Some(Expectation::Pass)),
+            Verdict::Ok
+        );
+    }
+
+    #[test]
+    fn judge_pass_fail_is_regression() {
+        assert_eq!(
+            judge(Some(Expectation::Pass), Some(Expectation::Fail)),
+            Verdict::Regression
+        );
+    }
+
+    #[test]
+    fn judge_fail_pass_is_promotion() {
+        assert_eq!(
+            judge(Some(Expectation::Fail), Some(Expectation::Pass)),
+            Verdict::Promotion
+        );
+    }
+
+    #[test]
+    fn judge_skip_wins() {
+        assert_eq!(
+            judge(Some(Expectation::Skip), Some(Expectation::Pass)),
+            Verdict::Skipped
+        );
+    }
+
+    #[test]
+    fn judge_unknown_declared() {
+        assert_eq!(judge(None, Some(Expectation::Pass)), Verdict::UnknownTest);
+    }
+
+    // ---- Extra coverage ----------------------------------------------------
+
+    #[test]
+    fn parses_tab_separated_fields() {
+        let src = "PASS\tcss/css-page/tabbed.html\n";
+        let f = ExpectationFile::parse(src).unwrap();
+        assert_eq!(f.get("css/css-page/tabbed.html"), Some(Expectation::Pass));
+    }
+
+    #[test]
+    fn parses_crlf_line_endings() {
+        let src = "PASS a.html\r\nFAIL b.html  # reason\r\n";
+        let f = ExpectationFile::parse(src).unwrap();
+        assert_eq!(f.get("a.html"), Some(Expectation::Pass));
+        assert_eq!(f.get("b.html"), Some(Expectation::Fail));
+    }
+
+    #[test]
+    fn empty_file_yields_empty() {
+        let f = ExpectationFile::parse("").unwrap();
+        assert!(f.is_empty());
+        assert_eq!(f.len(), 0);
+    }
+
+    #[test]
+    fn rejects_missing_path() {
+        // Bare status with no path.
+        assert!(ExpectationFile::parse("PASS\n").is_err());
+    }
+
+    // Current contract: "declared PASS, observed SKIP" is not a regression.
+    // It falls into the catch-all OK arm. Pinning the behaviour so any
+    // future tightening of the rule is deliberate rather than accidental.
+    #[test]
+    fn judge_pass_declared_skip_observed_is_ok() {
+        assert_eq!(
+            judge(Some(Expectation::Pass), Some(Expectation::Skip)),
+            Verdict::Ok
+        );
+    }
+}

--- a/crates/fulgur-wpt/src/expectations.rs
+++ b/crates/fulgur-wpt/src/expectations.rs
@@ -12,6 +12,10 @@
 //! Blank lines and lines starting with `#` are ignored. An inline `#`
 //! starts a trailing comment that is captured but does not affect
 //! parsing. Duplicate entries for the same path are rejected.
+//!
+//! Note: `#` anywhere inside a line begins an inline comment. WPT test
+//! paths do not contain `#`, so splitting on the first `#` is safe in
+//! practice.
 
 use anyhow::{Result, bail};
 use std::collections::BTreeMap;
@@ -32,7 +36,8 @@ pub struct ExpectationFile {
 #[derive(Debug, Clone)]
 struct Entry {
     expectation: Expectation,
-    #[allow(dead_code)] // comment is informational; kept for future reporting
+    /// Optional trailing `# ...` comment. Exposed via
+    /// [`ExpectationFile::comment`] for report output.
     comment: Option<String>,
 }
 
@@ -83,6 +88,15 @@ impl ExpectationFile {
         self.entries.get(test_path).map(|e| e.expectation)
     }
 
+    /// Return the comment associated with an entry, if any.
+    /// Useful for human-readable report output explaining why a test is
+    /// marked FAIL or SKIP.
+    pub fn comment(&self, test_path: &str) -> Option<&str> {
+        self.entries
+            .get(test_path)
+            .and_then(|e| e.comment.as_deref())
+    }
+
     pub fn len(&self) -> usize {
         self.entries.len()
     }
@@ -102,14 +116,28 @@ pub enum Verdict {
 }
 
 /// Compare the declared expectation with the observed result.
-pub fn judge(declared: Option<Expectation>, observed: Option<Expectation>) -> Verdict {
+///
+/// `observed` is not optional because the harness always produces a
+/// concrete outcome (or errors before calling `judge`). Keeping it
+/// non-Optional makes the match exhaustive and prevents an accidental
+/// `None` from collapsing into the catch-all `Ok` arm.
+pub fn judge(declared: Option<Expectation>, observed: Expectation) -> Verdict {
+    use Expectation::{Fail, Pass, Skip};
     match (declared, observed) {
-        (Some(Expectation::Skip), _) => Verdict::Skipped,
-        (Some(d), Some(o)) if d == o => Verdict::Ok,
-        (Some(Expectation::Pass), Some(Expectation::Fail)) => Verdict::Regression,
-        (Some(Expectation::Fail), Some(Expectation::Pass)) => Verdict::Promotion,
+        // Declared SKIP wins over whatever we observed.
+        (Some(Skip), _) => Verdict::Skipped,
+        // No entry in the expectations file → unknown test.
         (None, _) => Verdict::UnknownTest,
-        _ => Verdict::Ok,
+        // Matches.
+        (Some(Pass), Pass) => Verdict::Ok,
+        (Some(Fail), Fail) => Verdict::Ok,
+        // Mismatches.
+        (Some(Pass), Fail) => Verdict::Regression,
+        (Some(Fail), Pass) => Verdict::Promotion,
+        // Declared PASS/FAIL + observed SKIP: treated as Ok. The harness
+        // opted out of running the test for some reason; not a regression.
+        (Some(Pass), Skip) => Verdict::Ok,
+        (Some(Fail), Skip) => Verdict::Ok,
     }
 }
 
@@ -154,7 +182,7 @@ SKIP css/css-page/c.html  # manual
     #[test]
     fn judge_pass_pass_is_ok() {
         assert_eq!(
-            judge(Some(Expectation::Pass), Some(Expectation::Pass)),
+            judge(Some(Expectation::Pass), Expectation::Pass),
             Verdict::Ok
         );
     }
@@ -162,7 +190,7 @@ SKIP css/css-page/c.html  # manual
     #[test]
     fn judge_pass_fail_is_regression() {
         assert_eq!(
-            judge(Some(Expectation::Pass), Some(Expectation::Fail)),
+            judge(Some(Expectation::Pass), Expectation::Fail),
             Verdict::Regression
         );
     }
@@ -170,7 +198,7 @@ SKIP css/css-page/c.html  # manual
     #[test]
     fn judge_fail_pass_is_promotion() {
         assert_eq!(
-            judge(Some(Expectation::Fail), Some(Expectation::Pass)),
+            judge(Some(Expectation::Fail), Expectation::Pass),
             Verdict::Promotion
         );
     }
@@ -178,14 +206,14 @@ SKIP css/css-page/c.html  # manual
     #[test]
     fn judge_skip_wins() {
         assert_eq!(
-            judge(Some(Expectation::Skip), Some(Expectation::Pass)),
+            judge(Some(Expectation::Skip), Expectation::Pass),
             Verdict::Skipped
         );
     }
 
     #[test]
     fn judge_unknown_declared() {
-        assert_eq!(judge(None, Some(Expectation::Pass)), Verdict::UnknownTest);
+        assert_eq!(judge(None, Expectation::Pass), Verdict::UnknownTest);
     }
 
     // ---- Extra coverage ----------------------------------------------------
@@ -219,13 +247,24 @@ SKIP css/css-page/c.html  # manual
     }
 
     // Current contract: "declared PASS, observed SKIP" is not a regression.
-    // It falls into the catch-all OK arm. Pinning the behaviour so any
-    // future tightening of the rule is deliberate rather than accidental.
+    // It is pinned explicitly by the match so any future tightening of
+    // the rule is deliberate rather than accidental.
     #[test]
     fn judge_pass_declared_skip_observed_is_ok() {
         assert_eq!(
-            judge(Some(Expectation::Pass), Some(Expectation::Skip)),
+            judge(Some(Expectation::Pass), Expectation::Skip),
             Verdict::Ok
         );
+    }
+
+    #[test]
+    fn comment_is_exposed_per_entry() {
+        let src =
+            "PASS a.html  # all good\nFAIL b.html\nSKIP c.html  # manual interaction needed\n";
+        let f = ExpectationFile::parse(src).unwrap();
+        assert_eq!(f.comment("a.html"), Some("all good"));
+        assert_eq!(f.comment("b.html"), None);
+        assert_eq!(f.comment("c.html"), Some("manual interaction needed"));
+        assert_eq!(f.comment("nonexistent.html"), None);
     }
 }

--- a/crates/fulgur-wpt/src/harness.rs
+++ b/crates/fulgur-wpt/src/harness.rs
@@ -1,0 +1,117 @@
+//! Run a single WPT reftest end-to-end: classify, render test + ref,
+//! compare each page, and return an observed PASS/FAIL/SKIP.
+
+use crate::expectations::Expectation;
+use crate::reftest::{ReftestKind, classify};
+use crate::render::render_test;
+use anyhow::{Result, anyhow};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+pub struct RunOutcome {
+    pub observed: Expectation,
+    pub reason: Option<String>,
+    pub diff_dir: Option<PathBuf>,
+}
+
+/// Run one reftest and return an observed PASS/FAIL/SKIP.
+///
+/// - `test_html_path`: path to the test HTML; its parent is passed to
+///   `render_test` as the base_path, and the rel=match href is resolved
+///   relative to the same parent.
+/// - `work_dir`: scratch dir for PDFs/PNGs. `test/` and `ref/` subdirs
+///   will be created under it.
+/// - `diff_out_dir`: where to dump per-page diff PNGs on failure.
+/// - `dpi`: pdftocairo rasterization resolution.
+pub fn run_one(
+    test_html_path: &Path,
+    work_dir: &Path,
+    diff_out_dir: &Path,
+    dpi: u32,
+) -> Result<RunOutcome> {
+    use fulgur_vrt::diff::{compare, write_diff_image};
+    use fulgur_vrt::manifest::Tolerance;
+
+    let reftest = classify(test_html_path)?;
+    let (ref_rel, fuzzy) = match reftest.classification {
+        ReftestKind::Match { ref_path, fuzzy } => (ref_path, fuzzy),
+        ReftestKind::Skip { reason } => {
+            return Ok(RunOutcome {
+                observed: Expectation::Skip,
+                reason: Some(format!("{reason:?}")),
+                diff_dir: None,
+            });
+        }
+    };
+
+    let test_dir = test_html_path
+        .parent()
+        .ok_or_else(|| anyhow!("test has no parent"))?;
+    let ref_abs = test_dir.join(&ref_rel);
+
+    let test_work = work_dir.join("test");
+    let ref_work = work_dir.join("ref");
+    let test_out = render_test(test_html_path, &test_work, dpi)?;
+    let ref_out = render_test(&ref_abs, &ref_work, dpi)?;
+
+    if test_out.pages.len() != ref_out.pages.len() {
+        return Ok(RunOutcome {
+            observed: Expectation::Fail,
+            reason: Some(format!(
+                "page count mismatch: test={} ref={}",
+                test_out.pages.len(),
+                ref_out.pages.len(),
+            )),
+            diff_dir: None,
+        });
+    }
+
+    // Map FuzzyTolerance → fulgur_vrt::Tolerance. WPT fuzzy uses inclusive
+    // ranges; fulgur-vrt uses a single upper-bound threshold. We take the
+    // upper bound (most permissive) as the threshold — this matches the
+    // semantics of "any diff within this range is acceptable".
+    let max_ch = *fuzzy.max_diff.end();
+    let max_total = *fuzzy.total_pixels.end();
+
+    let mut first_failure: Option<String> = None;
+    for (idx, (t, r)) in test_out.pages.iter().zip(ref_out.pages.iter()).enumerate() {
+        let total = u64::from(t.width()) * u64::from(t.height());
+        let ratio_limit = if total == 0 {
+            0.0f32
+        } else {
+            (max_total as f64 / total as f64) as f32
+        };
+        let tol = Tolerance {
+            max_channel_diff: max_ch,
+            max_diff_pixels_ratio: ratio_limit,
+        };
+        let report = compare(r, t, tol);
+        if !report.pass {
+            std::fs::create_dir_all(diff_out_dir)?;
+            let out_path = diff_out_dir.join(format!("page{}.diff.png", idx + 1));
+            write_diff_image(r, t, tol, &out_path)?;
+            if first_failure.is_none() {
+                first_failure = Some(format!(
+                    "page {} diff: {}/{} pixels exceed tol (max_ch={})",
+                    idx + 1,
+                    report.diff_pixels,
+                    report.total_pixels,
+                    report.max_channel_diff,
+                ));
+            }
+        }
+    }
+
+    Ok(match first_failure {
+        Some(reason) => RunOutcome {
+            observed: Expectation::Fail,
+            reason: Some(reason),
+            diff_dir: Some(diff_out_dir.to_path_buf()),
+        },
+        None => RunOutcome {
+            observed: Expectation::Pass,
+            reason: None,
+            diff_dir: None,
+        },
+    })
+}

--- a/crates/fulgur-wpt/src/harness.rs
+++ b/crates/fulgur-wpt/src/harness.rs
@@ -18,7 +18,10 @@ pub struct RunOutcome {
 ///
 /// - `test_html_path`: path to the test HTML; its parent is passed to
 ///   `render_test` as the base_path, and the rel=match href is resolved
-///   relative to the same parent.
+///   relative to the same parent. Prefer an absolute path. Ref resolution
+///   uses `test_html_path.parent().join(ref_href)`; if the test is a bare
+///   filename, `parent()` is empty and `render_test` will canonicalize
+///   against the current working directory.
 /// - `work_dir`: scratch dir for PDFs/PNGs. `test/` and `ref/` subdirs
 ///   will be created under it.
 /// - `diff_out_dir`: where to dump per-page diff PNGs on failure.
@@ -76,6 +79,10 @@ pub fn run_one(
     let mut first_failure: Option<String> = None;
     for (idx, (t, r)) in test_out.pages.iter().zip(ref_out.pages.iter()).enumerate() {
         let total = u64::from(t.width()) * u64::from(t.height());
+        // Note: ratio_limit may legitimately exceed 1.0 when the test's fuzzy
+        // pixel cap is larger than the page area — fulgur-vrt's compare()
+        // clamps to [0, 1] internally, so a >1 limit simply means "unbounded"
+        // under WPT's upper-bound semantics.
         let ratio_limit = if total == 0 {
             0.0f32
         } else {

--- a/crates/fulgur-wpt/src/lib.rs
+++ b/crates/fulgur-wpt/src/lib.rs
@@ -1,5 +1,6 @@
 //! WPT reftest runner for fulgur. See README for scope.
 
 pub mod expectations;
+pub mod harness;
 pub mod reftest;
 pub mod render;

--- a/crates/fulgur-wpt/src/lib.rs
+++ b/crates/fulgur-wpt/src/lib.rs
@@ -1,0 +1,1 @@
+//! WPT reftest runner for fulgur. See README for scope.

--- a/crates/fulgur-wpt/src/lib.rs
+++ b/crates/fulgur-wpt/src/lib.rs
@@ -1,4 +1,5 @@
 //! WPT reftest runner for fulgur. See README for scope.
 
+pub mod expectations;
 pub mod reftest;
 pub mod render;

--- a/crates/fulgur-wpt/src/lib.rs
+++ b/crates/fulgur-wpt/src/lib.rs
@@ -1,3 +1,4 @@
 //! WPT reftest runner for fulgur. See README for scope.
 
 pub mod reftest;
+pub mod render;

--- a/crates/fulgur-wpt/src/lib.rs
+++ b/crates/fulgur-wpt/src/lib.rs
@@ -1,1 +1,3 @@
 //! WPT reftest runner for fulgur. See README for scope.
+
+pub mod reftest;

--- a/crates/fulgur-wpt/src/reftest.rs
+++ b/crates/fulgur-wpt/src/reftest.rs
@@ -165,18 +165,26 @@ pub fn classify(test_path: &Path) -> Result<Reftest> {
     let mut has_mismatch = false;
 
     for el in doc.select(&link_sel) {
-        let rel = el.value().attr("rel").unwrap_or("").to_ascii_lowercase();
-        match rel.as_str() {
-            "match" => {
-                let href = el.value().attr("href").ok_or_else(|| {
-                    anyhow::anyhow!("rel=match link without href in {}", test_path.display())
-                })?;
-                matches.push(PathBuf::from(href));
+        // `rel` is a whitespace-separated token list per HTML spec, so
+        // `rel="match alternate"` must still trigger the match branch.
+        for token in el
+            .value()
+            .attr("rel")
+            .unwrap_or("")
+            .split_ascii_whitespace()
+        {
+            match token.to_ascii_lowercase().as_str() {
+                "match" => {
+                    let href = el.value().attr("href").ok_or_else(|| {
+                        anyhow::anyhow!("rel=match link without href in {}", test_path.display())
+                    })?;
+                    matches.push(PathBuf::from(href));
+                }
+                "mismatch" => {
+                    has_mismatch = true;
+                }
+                _ => {}
             }
-            "mismatch" => {
-                has_mismatch = true;
-            }
-            _ => {}
         }
     }
 
@@ -218,10 +226,12 @@ pub fn classify(test_path: &Path) -> Result<Reftest> {
         let Some(content) = el.value().attr("content") else {
             continue;
         };
-        let parsed = match parse_fuzzy(content) {
-            Ok(p) => p,
-            Err(_) => continue,
-        };
+        let parsed = parse_fuzzy(content).map_err(|e| {
+            anyhow::anyhow!(
+                "invalid <meta name=\"fuzzy\"> in {}: {e}",
+                test_path.display()
+            )
+        })?;
         match &parsed.url {
             Some(u) if u == &ref_path => {
                 chosen = parsed;
@@ -525,5 +535,33 @@ mod reftest_tests {
         let err = classify(&p).unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("rel=match"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn rel_tokenization_finds_match_with_extra_tokens() {
+        // HTML spec: rel is a whitespace-separated token list. "match alternate"
+        // must still be classified as a Match reftest.
+        let (_d, p) = write_tmp(
+            "t.html",
+            r#"<!DOCTYPE html><link rel="match alternate" href="t-ref.html"><body></body>"#,
+        );
+        let r = classify(&p).unwrap();
+        assert!(matches!(r.classification, ReftestKind::Match { .. }));
+    }
+
+    #[test]
+    fn malformed_fuzzy_meta_is_error() {
+        // Broken fuzzy metadata must surface as an error, not silently
+        // fall back to strict tolerance (which would hide bad test authoring).
+        let (_d, p) = write_tmp(
+            "t.html",
+            r#"<!DOCTYPE html>
+<link rel="match" href="t-ref.html">
+<meta name="fuzzy" content="not-a-valid-fuzzy-value">
+<body></body>"#,
+        );
+        let err = classify(&p).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("fuzzy"), "unexpected error: {msg}");
     }
 }

--- a/crates/fulgur-wpt/src/reftest.rs
+++ b/crates/fulgur-wpt/src/reftest.rs
@@ -149,6 +149,8 @@ pub enum SkipReason {
     Mismatch,
     MultipleMatches,
     NoMatch,
+    /// Reserved for Phase 2: reftest chain (ref HTML points at another ref).
+    /// Not yet emitted by `classify()`.
     ChainedReference,
 }
 
@@ -166,9 +168,10 @@ pub fn classify(test_path: &Path) -> Result<Reftest> {
         let rel = el.value().attr("rel").unwrap_or("").to_ascii_lowercase();
         match rel.as_str() {
             "match" => {
-                if let Some(href) = el.value().attr("href") {
-                    matches.push(PathBuf::from(href));
-                }
+                let href = el.value().attr("href").ok_or_else(|| {
+                    anyhow::anyhow!("rel=match link without href in {}", test_path.display())
+                })?;
+                matches.push(PathBuf::from(href));
             }
             "mismatch" => {
                 has_mismatch = true;
@@ -511,5 +514,16 @@ mod reftest_tests {
             }
             _ => unreachable!(),
         }
+    }
+
+    #[test]
+    fn rel_match_without_href_is_error() {
+        let (_d, p) = write_tmp(
+            "t.html",
+            r#"<!DOCTYPE html><link rel="match"><body></body>"#,
+        );
+        let err = classify(&p).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("rel=match"), "unexpected error: {msg}");
     }
 }

--- a/crates/fulgur-wpt/src/reftest.rs
+++ b/crates/fulgur-wpt/src/reftest.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, bail};
 use std::ops::RangeInclusive;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FuzzyTolerance {
@@ -122,6 +122,121 @@ fn parse_range(src: &str, default_lo: u32, default_hi: u32) -> Result<(u32, u32)
             Ok((lo, hi))
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Reftest {
+    pub test: PathBuf,
+    pub classification: ReftestKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ReftestKind {
+    /// Single rel=match + optional fuzzy tolerance. Phase 1 target.
+    Match {
+        ref_path: PathBuf,
+        fuzzy: FuzzyTolerance,
+    },
+    /// Skipped: out-of-scope reftest variant.
+    Skip { reason: SkipReason },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkipReason {
+    Mismatch,
+    MultipleMatches,
+    NoMatch,
+    ChainedReference,
+}
+
+/// Inspect the test HTML at `test_path` and classify it for Phase 1.
+/// File I/O only — does not render.
+pub fn classify(test_path: &Path) -> Result<Reftest> {
+    let html = std::fs::read_to_string(test_path)?;
+    let doc = scraper::Html::parse_document(&html);
+
+    let link_sel = scraper::Selector::parse("link[rel]").unwrap();
+    let mut matches: Vec<PathBuf> = Vec::new();
+    let mut has_mismatch = false;
+
+    for el in doc.select(&link_sel) {
+        let rel = el.value().attr("rel").unwrap_or("").to_ascii_lowercase();
+        match rel.as_str() {
+            "match" => {
+                if let Some(href) = el.value().attr("href") {
+                    matches.push(PathBuf::from(href));
+                }
+            }
+            "mismatch" => {
+                has_mismatch = true;
+            }
+            _ => {}
+        }
+    }
+
+    if has_mismatch {
+        return Ok(Reftest {
+            test: test_path.to_path_buf(),
+            classification: ReftestKind::Skip {
+                reason: SkipReason::Mismatch,
+            },
+        });
+    }
+    let ref_path = match matches.as_slice() {
+        [] => {
+            return Ok(Reftest {
+                test: test_path.to_path_buf(),
+                classification: ReftestKind::Skip {
+                    reason: SkipReason::NoMatch,
+                },
+            });
+        }
+        [one] => one.clone(),
+        _ => {
+            return Ok(Reftest {
+                test: test_path.to_path_buf(),
+                classification: ReftestKind::Skip {
+                    reason: SkipReason::MultipleMatches,
+                },
+            });
+        }
+    };
+
+    // Collect fuzzy metas. Selection policy:
+    // - If any meta has `url == ref_path`, that wins (authoritative, break).
+    // - Otherwise the last unscoped (no url) meta wins.
+    // - Prefix-scoped metas whose url differs from our ref are ignored.
+    let meta_sel = scraper::Selector::parse(r#"meta[name="fuzzy"]"#).unwrap();
+    let mut chosen = FuzzyTolerance::any();
+    for el in doc.select(&meta_sel) {
+        let Some(content) = el.value().attr("content") else {
+            continue;
+        };
+        let parsed = match parse_fuzzy(content) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        match &parsed.url {
+            Some(u) if u == &ref_path => {
+                chosen = parsed;
+                break; // URL-scoped match is authoritative
+            }
+            None => {
+                // Unscoped: accept, but keep iterating in case a scoped
+                // match for our ref appears later (last-wins for unscoped).
+                chosen = parsed;
+            }
+            _ => {} // different url prefix: ignore
+        }
+    }
+
+    Ok(Reftest {
+        test: test_path.to_path_buf(),
+        classification: ReftestKind::Match {
+            ref_path,
+            fuzzy: chosen,
+        },
+    })
 }
 
 #[cfg(test)]
@@ -266,5 +381,132 @@ mod fuzzy_tests {
         assert_eq!(a.url, None);
         assert_eq!(a.max_diff, 0..=255);
         assert_eq!(a.total_pixels, 0..=u32::MAX);
+    }
+}
+
+#[cfg(test)]
+mod reftest_tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_tmp(name: &str, body: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join(name);
+        let mut f = std::fs::File::create(&p).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+        (dir, p)
+    }
+
+    #[test]
+    fn single_match_no_fuzzy() {
+        let (_d, p) = write_tmp(
+            "t.html",
+            r#"<!DOCTYPE html><link rel="match" href="t-ref.html"><body></body>"#,
+        );
+        let r = classify(&p).unwrap();
+        match r.classification {
+            ReftestKind::Match { ref_path, fuzzy } => {
+                assert_eq!(ref_path.file_name().unwrap(), "t-ref.html");
+                assert_eq!(fuzzy, FuzzyTolerance::any());
+            }
+            other => panic!("expected Match, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn single_match_with_fuzzy() {
+        let (_d, p) = write_tmp(
+            "t.html",
+            r#"<!DOCTYPE html>
+<link rel="match" href="t-ref.html">
+<meta name="fuzzy" content="5-10;200-300">
+<body></body>"#,
+        );
+        let r = classify(&p).unwrap();
+        let fuzzy = match r.classification {
+            ReftestKind::Match { fuzzy, .. } => fuzzy,
+            _ => unreachable!(),
+        };
+        assert_eq!(fuzzy.max_diff, 5..=10);
+        assert_eq!(fuzzy.total_pixels, 200..=300);
+    }
+
+    #[test]
+    fn multiple_matches_skip() {
+        let (_d, p) = write_tmp(
+            "t.html",
+            r#"<!DOCTYPE html>
+<link rel="match" href="a.html">
+<link rel="match" href="b.html">
+<body></body>"#,
+        );
+        assert!(matches!(
+            classify(&p).unwrap().classification,
+            ReftestKind::Skip {
+                reason: SkipReason::MultipleMatches
+            }
+        ));
+    }
+
+    #[test]
+    fn mismatch_skip() {
+        let (_d, p) = write_tmp(
+            "t.html",
+            r#"<!DOCTYPE html><link rel="mismatch" href="a.html"><body></body>"#,
+        );
+        assert!(matches!(
+            classify(&p).unwrap().classification,
+            ReftestKind::Skip {
+                reason: SkipReason::Mismatch
+            }
+        ));
+    }
+
+    #[test]
+    fn no_match_skip() {
+        let (_d, p) = write_tmp("t.html", r#"<!DOCTYPE html><body></body>"#);
+        assert!(matches!(
+            classify(&p).unwrap().classification,
+            ReftestKind::Skip {
+                reason: SkipReason::NoMatch
+            }
+        ));
+    }
+
+    #[test]
+    fn fuzzy_url_prefix_matching_ref_is_used() {
+        let (_d, p) = write_tmp(
+            "t.html",
+            r#"<!DOCTYPE html>
+<link rel="match" href="t-ref.html">
+<meta name="fuzzy" content="t-ref.html:5-10;200-300">
+<body></body>"#,
+        );
+        let r = classify(&p).unwrap();
+        match r.classification {
+            ReftestKind::Match { fuzzy, .. } => {
+                assert_eq!(fuzzy.max_diff, 5..=10);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn fuzzy_url_prefix_mismatched_is_ignored() {
+        // Prefix points at a different ref → Phase 1 falls back to permissive
+        let (_d, p) = write_tmp(
+            "t.html",
+            r#"<!DOCTYPE html>
+<link rel="match" href="t-ref.html">
+<meta name="fuzzy" content="other.html:5-10;200-300">
+<body></body>"#,
+        );
+        let r = classify(&p).unwrap();
+        match r.classification {
+            ReftestKind::Match { fuzzy, .. } => {
+                assert_eq!(fuzzy, FuzzyTolerance::any());
+            }
+            _ => unreachable!(),
+        }
     }
 }

--- a/crates/fulgur-wpt/src/reftest.rs
+++ b/crates/fulgur-wpt/src/reftest.rs
@@ -1,0 +1,270 @@
+use anyhow::{Result, bail};
+use std::ops::RangeInclusive;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FuzzyTolerance {
+    pub url: Option<PathBuf>,
+    pub max_diff: RangeInclusive<u8>,
+    pub total_pixels: RangeInclusive<u32>,
+}
+
+impl FuzzyTolerance {
+    /// Permissive tolerance (max_diff 0-255, total_pixels 0-u32::MAX).
+    /// Used when a test declares no fuzzy meta.
+    pub fn any() -> Self {
+        Self {
+            url: None,
+            max_diff: 0..=255,
+            total_pixels: 0..=u32::MAX,
+        }
+    }
+}
+
+/// Parse a WPT `<meta name=fuzzy content=...>` value into a canonical
+/// `FuzzyTolerance`. Accepts every variant from the WPT reftest spec:
+///
+/// - numeric: `10;300`, `5-10;200-300`
+/// - named:   `maxDifference=10;totalPixels=300`, or named + range
+/// - url prefix: `ref.html:10-15;200-300`
+/// - open range: `5-`, `-300`
+pub fn parse_fuzzy(src: &str) -> Result<FuzzyTolerance> {
+    let src = src.trim();
+
+    // URL prefix: split at first ':' if the prefix is non-empty and
+    // contains neither '=' nor ';' (those belong to value syntax, not URL).
+    let (url, body) = match src.find(':') {
+        Some(idx)
+            if !src[..idx].contains('=') && !src[..idx].contains(';') && !src[..idx].is_empty() =>
+        {
+            let (u, rest) = src.split_at(idx);
+            (Some(PathBuf::from(u.trim())), &rest[1..])
+        }
+        _ => (None, src),
+    };
+
+    let mut parts = body.split(';');
+    let first = parts.next().ok_or_else(|| anyhow::anyhow!("empty fuzzy"))?;
+    let second = parts
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("missing ';' in fuzzy: {src}"))?;
+    if parts.next().is_some() {
+        bail!("too many ';' in fuzzy: {src}");
+    }
+
+    let (k1, v1) = split_named(first.trim());
+    let (k2, v2) = split_named(second.trim());
+
+    let (max_diff_src, total_src) = match (k1, k2) {
+        (Some("maxDifference"), Some("totalPixels")) | (None, None) => (v1, v2),
+        (Some("totalPixels"), Some("maxDifference")) => (v2, v1),
+        (Some(k), _) => bail!("unknown fuzzy key: {k}"),
+        (_, Some(k)) => bail!("unknown fuzzy key: {k}"),
+    };
+
+    let max_diff = parse_u8_range(max_diff_src)?;
+    let total_pixels = parse_u32_range(total_src)?;
+    Ok(FuzzyTolerance {
+        url,
+        max_diff,
+        total_pixels,
+    })
+}
+
+fn split_named(s: &str) -> (Option<&str>, &str) {
+    match s.find('=') {
+        Some(idx) => (Some(&s[..idx]), &s[idx + 1..]),
+        None => (None, s),
+    }
+}
+
+fn parse_u8_range(src: &str) -> Result<RangeInclusive<u8>> {
+    let src = src.trim();
+    let (lo, hi) = parse_range(src, 0u32, 255u32)?;
+    if lo > hi {
+        bail!("reversed range: {src}");
+    }
+    if hi > 255 {
+        bail!("max_diff out of u8 range: {src}");
+    }
+    Ok((lo as u8)..=(hi as u8))
+}
+
+fn parse_u32_range(src: &str) -> Result<RangeInclusive<u32>> {
+    let src = src.trim();
+    let (lo, hi) = parse_range(src, 0u32, u32::MAX)?;
+    if lo > hi {
+        bail!("reversed range: {src}");
+    }
+    Ok(lo..=hi)
+}
+
+fn parse_range(src: &str, default_lo: u32, default_hi: u32) -> Result<(u32, u32)> {
+    if src.is_empty() {
+        bail!("empty range");
+    }
+    match src.find('-') {
+        None => {
+            let n: u32 = src.parse()?;
+            Ok((n, n))
+        }
+        Some(0) => {
+            let n: u32 = src[1..].trim().parse()?;
+            Ok((default_lo, n))
+        }
+        Some(idx) if idx == src.len() - 1 => {
+            let n: u32 = src[..idx].trim().parse()?;
+            Ok((n, default_hi))
+        }
+        Some(idx) => {
+            let lo: u32 = src[..idx].trim().parse()?;
+            let hi: u32 = src[idx + 1..].trim().parse()?;
+            Ok((lo, hi))
+        }
+    }
+}
+
+#[cfg(test)]
+mod fuzzy_tests {
+    use super::*;
+
+    #[test]
+    fn plain_numeric() {
+        let t = parse_fuzzy("10;300").unwrap();
+        assert_eq!(t.url, None);
+        assert_eq!(t.max_diff, 10..=10);
+        assert_eq!(t.total_pixels, 300..=300);
+    }
+
+    #[test]
+    fn numeric_range_both() {
+        let t = parse_fuzzy("5-10;200-300").unwrap();
+        assert_eq!(t.max_diff, 5..=10);
+        assert_eq!(t.total_pixels, 200..=300);
+    }
+
+    #[test]
+    fn named_single() {
+        let t = parse_fuzzy("maxDifference=10;totalPixels=300").unwrap();
+        assert_eq!(t.max_diff, 10..=10);
+        assert_eq!(t.total_pixels, 300..=300);
+    }
+
+    #[test]
+    fn named_range() {
+        let t = parse_fuzzy("maxDifference=5-10;totalPixels=200-300").unwrap();
+        assert_eq!(t.max_diff, 5..=10);
+        assert_eq!(t.total_pixels, 200..=300);
+    }
+
+    #[test]
+    fn url_prefix() {
+        let t = parse_fuzzy("ref.html:10-15;200-300").unwrap();
+        assert_eq!(
+            t.url.as_deref().map(|p| p.to_str().unwrap()),
+            Some("ref.html")
+        );
+        assert_eq!(t.max_diff, 10..=15);
+        assert_eq!(t.total_pixels, 200..=300);
+    }
+
+    #[test]
+    fn open_range_lower_only() {
+        let t = parse_fuzzy("5-;200-").unwrap();
+        assert_eq!(t.max_diff, 5..=255);
+        assert_eq!(t.total_pixels, 200..=u32::MAX);
+    }
+
+    #[test]
+    fn open_range_upper_only() {
+        let t = parse_fuzzy("-10;-300").unwrap();
+        assert_eq!(t.max_diff, 0..=10);
+        assert_eq!(t.total_pixels, 0..=300);
+    }
+
+    #[test]
+    fn whitespace_tolerated() {
+        let t = parse_fuzzy("  10 ; 300  ").unwrap();
+        assert_eq!(t.max_diff, 10..=10);
+        assert_eq!(t.total_pixels, 300..=300);
+    }
+
+    #[test]
+    fn rejects_missing_semicolon() {
+        assert!(parse_fuzzy("10").is_err());
+    }
+
+    #[test]
+    fn rejects_reversed_range() {
+        assert!(parse_fuzzy("10-5;300").is_err());
+    }
+
+    #[test]
+    fn rejects_max_diff_over_255() {
+        assert!(parse_fuzzy("256;300").is_err());
+    }
+
+    // ---- Additional edge-case coverage --------------------------------
+
+    /// Named pairs may appear in either order per the WPT spec.
+    #[test]
+    fn named_reversed_order() {
+        let t = parse_fuzzy("totalPixels=200-300;maxDifference=5-10").unwrap();
+        assert_eq!(t.max_diff, 5..=10);
+        assert_eq!(t.total_pixels, 200..=300);
+    }
+
+    /// URL + named syntax should coexist.
+    #[test]
+    fn url_prefix_with_named() {
+        let t = parse_fuzzy("ref.html:maxDifference=10;totalPixels=300").unwrap();
+        assert_eq!(
+            t.url.as_deref().map(|p| p.to_str().unwrap()),
+            Some("ref.html")
+        );
+        assert_eq!(t.max_diff, 10..=10);
+        assert_eq!(t.total_pixels, 300..=300);
+    }
+
+    /// Mixing named + positional is malformed.
+    #[test]
+    fn rejects_mixed_named_and_positional() {
+        assert!(parse_fuzzy("maxDifference=10;300").is_err());
+        assert!(parse_fuzzy("10;totalPixels=300").is_err());
+    }
+
+    /// Unknown named keys must be rejected, not silently treated as pass-any.
+    #[test]
+    fn rejects_unknown_named_key() {
+        assert!(parse_fuzzy("maxDiff=10;totalPixels=300").is_err());
+        assert!(parse_fuzzy("maxDifference=10;pixels=300").is_err());
+    }
+
+    /// Empty input should not panic and must surface as an error.
+    #[test]
+    fn rejects_empty_input() {
+        assert!(parse_fuzzy("").is_err());
+    }
+
+    /// Non-numeric garbage must produce a parse error, not a panic.
+    #[test]
+    fn rejects_non_numeric() {
+        assert!(parse_fuzzy("abc;def").is_err());
+        assert!(parse_fuzzy("10;xyz").is_err());
+    }
+
+    /// Three semicolon-separated parts are malformed.
+    #[test]
+    fn rejects_too_many_parts() {
+        assert!(parse_fuzzy("10;20;30").is_err());
+    }
+
+    /// `any()` constructor must span full u8 / u32 range so it never rejects a diff.
+    #[test]
+    fn any_is_fully_permissive() {
+        let a = FuzzyTolerance::any();
+        assert_eq!(a.url, None);
+        assert_eq!(a.max_diff, 0..=255);
+        assert_eq!(a.total_pixels, 0..=u32::MAX);
+    }
+}

--- a/crates/fulgur-wpt/src/reftest.rs
+++ b/crates/fulgur-wpt/src/reftest.rs
@@ -10,13 +10,16 @@ pub struct FuzzyTolerance {
 }
 
 impl FuzzyTolerance {
-    /// Permissive tolerance (max_diff 0-255, total_pixels 0-u32::MAX).
-    /// Used when a test declares no fuzzy meta.
-    pub fn any() -> Self {
+    /// Strict tolerance (exact pixel match required).
+    ///
+    /// Used when a test declares no `<meta name=fuzzy>`. Per WPT reftest
+    /// spec, absence of fuzzy metadata means the rendering must match
+    /// the reference byte-for-byte at the rasterized resolution.
+    pub fn strict() -> Self {
         Self {
             url: None,
-            max_diff: 0..=255,
-            total_pixels: 0..=u32::MAX,
+            max_diff: 0..=0,
+            total_pixels: 0..=0,
         }
     }
 }
@@ -207,7 +210,7 @@ pub fn classify(test_path: &Path) -> Result<Reftest> {
     // - Otherwise the last unscoped (no url) meta wins.
     // - Prefix-scoped metas whose url differs from our ref are ignored.
     let meta_sel = scraper::Selector::parse(r#"meta[name="fuzzy"]"#).unwrap();
-    let mut chosen = FuzzyTolerance::any();
+    let mut chosen = FuzzyTolerance::strict();
     for el in doc.select(&meta_sel) {
         let Some(content) = el.value().attr("content") else {
             continue;
@@ -374,13 +377,13 @@ mod fuzzy_tests {
         assert!(parse_fuzzy("10;20;30").is_err());
     }
 
-    /// `any()` constructor must span full u8 / u32 range so it never rejects a diff.
+    /// `strict()` constructor must be zero/zero so it enforces exact match.
     #[test]
-    fn any_is_fully_permissive() {
-        let a = FuzzyTolerance::any();
-        assert_eq!(a.url, None);
-        assert_eq!(a.max_diff, 0..=255);
-        assert_eq!(a.total_pixels, 0..=u32::MAX);
+    fn strict_is_zero_zero() {
+        let t = FuzzyTolerance::strict();
+        assert_eq!(t.url, None);
+        assert_eq!(t.max_diff, 0..=0);
+        assert_eq!(t.total_pixels, 0..=0);
     }
 }
 
@@ -407,7 +410,7 @@ mod reftest_tests {
         match r.classification {
             ReftestKind::Match { ref_path, fuzzy } => {
                 assert_eq!(ref_path.file_name().unwrap(), "t-ref.html");
-                assert_eq!(fuzzy, FuzzyTolerance::any());
+                assert_eq!(fuzzy, FuzzyTolerance::strict());
             }
             other => panic!("expected Match, got {other:?}"),
         }
@@ -493,7 +496,7 @@ mod reftest_tests {
 
     #[test]
     fn fuzzy_url_prefix_mismatched_is_ignored() {
-        // Prefix points at a different ref → Phase 1 falls back to permissive
+        // Prefix points at a different ref → Phase 1 falls back to strict
         let (_d, p) = write_tmp(
             "t.html",
             r#"<!DOCTYPE html>
@@ -504,7 +507,7 @@ mod reftest_tests {
         let r = classify(&p).unwrap();
         match r.classification {
             ReftestKind::Match { fuzzy, .. } => {
-                assert_eq!(fuzzy, FuzzyTolerance::any());
+                assert_eq!(fuzzy, FuzzyTolerance::strict());
             }
             _ => unreachable!(),
         }

--- a/crates/fulgur-wpt/src/render.rs
+++ b/crates/fulgur-wpt/src/render.rs
@@ -14,26 +14,27 @@ pub struct RenderedTest {
 
 /// Render `test_html_path` and return one RgbaImage per page.
 ///
-/// `work_dir` receives the PDF and per-page PNGs (left behind for debugging).
+/// The path is canonicalized, and its parent directory is used as
+/// fulgur's `base_path` for resolving CSS/asset links. `work_dir`
+/// receives the PDF and per-page PNGs (left behind for debugging).
 /// `dpi` controls pdftocairo's rasterization resolution.
 pub fn render_test(test_html_path: &Path, work_dir: &Path, dpi: u32) -> Result<RenderedTest> {
     use fulgur::engine::Engine;
 
     std::fs::create_dir_all(work_dir)
         .with_context(|| format!("create work dir {}", work_dir.display()))?;
-    let html = std::fs::read_to_string(test_html_path)
-        .with_context(|| format!("read {}", test_html_path.display()))?;
-    let base = test_html_path
+    let abs = test_html_path
+        .canonicalize()
+        .with_context(|| format!("canonicalize {}", test_html_path.display()))?;
+    let html = std::fs::read_to_string(&abs).with_context(|| format!("read {}", abs.display()))?;
+    let base = abs
         .parent()
-        .ok_or_else(|| anyhow::anyhow!("test has no parent dir: {}", test_html_path.display()))?;
+        .ok_or_else(|| anyhow::anyhow!("test has no parent dir: {}", abs.display()))?;
 
     let engine = Engine::builder().base_path(base).build();
-    let pdf_bytes = engine.render_html(&html).map_err(|e| {
-        anyhow::anyhow!(
-            "fulgur render_html failed for {}: {e}",
-            test_html_path.display()
-        )
-    })?;
+    let pdf_bytes = engine
+        .render_html(&html)
+        .map_err(|e| anyhow::anyhow!("fulgur render_html failed for {}: {e}", abs.display()))?;
 
     let pdf_path = work_dir.join("fixture.pdf");
     std::fs::write(&pdf_path, &pdf_bytes)
@@ -41,14 +42,19 @@ pub fn render_test(test_html_path: &Path, work_dir: &Path, dpi: u32) -> Result<R
 
     let prefix = work_dir.join("page");
     // NOTE: intentionally NOT passing -f/-l so pdftocairo emits every page.
-    let status = Command::new("pdftocairo")
+    let out = Command::new("pdftocairo")
         .args(["-png", "-r", &dpi.to_string()])
         .arg(&pdf_path)
         .arg(&prefix)
-        .status()
+        .output()
         .context("spawn pdftocairo")?;
-    if !status.success() {
-        bail!("pdftocairo exited with {status} for {}", pdf_path.display());
+    if !out.status.success() {
+        bail!(
+            "pdftocairo exited with {} for {}\nstderr: {}",
+            out.status,
+            pdf_path.display(),
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
     }
 
     // Enumerate generated files: pdftocairo names them `<prefix>-<n>.png`.

--- a/crates/fulgur-wpt/src/render.rs
+++ b/crates/fulgur-wpt/src/render.rs
@@ -1,0 +1,88 @@
+//! Render a WPT test HTML through fulgur and rasterize every page via
+//! pdftocairo. CRITICAL: must not pass `-f 1 -l 1` to pdftocairo — we
+//! need every page to catch multi-page regressions (advisor P1-1).
+
+use anyhow::{Context, Result, bail};
+use image::RgbaImage;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub struct RenderedTest {
+    pub pages: Vec<RgbaImage>,
+    pub pdf_path: PathBuf,
+}
+
+/// Render `test_html_path` and return one RgbaImage per page.
+///
+/// `work_dir` receives the PDF and per-page PNGs (left behind for debugging).
+/// `dpi` controls pdftocairo's rasterization resolution.
+pub fn render_test(test_html_path: &Path, work_dir: &Path, dpi: u32) -> Result<RenderedTest> {
+    use fulgur::engine::Engine;
+
+    std::fs::create_dir_all(work_dir)
+        .with_context(|| format!("create work dir {}", work_dir.display()))?;
+    let html = std::fs::read_to_string(test_html_path)
+        .with_context(|| format!("read {}", test_html_path.display()))?;
+    let base = test_html_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("test has no parent dir: {}", test_html_path.display()))?;
+
+    let engine = Engine::builder().base_path(base).build();
+    let pdf_bytes = engine.render_html(&html).map_err(|e| {
+        anyhow::anyhow!(
+            "fulgur render_html failed for {}: {e}",
+            test_html_path.display()
+        )
+    })?;
+
+    let pdf_path = work_dir.join("fixture.pdf");
+    std::fs::write(&pdf_path, &pdf_bytes)
+        .with_context(|| format!("write PDF to {}", pdf_path.display()))?;
+
+    let prefix = work_dir.join("page");
+    // NOTE: intentionally NOT passing -f/-l so pdftocairo emits every page.
+    let status = Command::new("pdftocairo")
+        .args(["-png", "-r", &dpi.to_string()])
+        .arg(&pdf_path)
+        .arg(&prefix)
+        .status()
+        .context("spawn pdftocairo")?;
+    if !status.success() {
+        bail!("pdftocairo exited with {status} for {}", pdf_path.display());
+    }
+
+    // Enumerate generated files: pdftocairo names them `<prefix>-<n>.png`.
+    // For 10+ pages the index is zero-padded to the width of the max; lexical
+    // sort therefore works for both single-digit and padded forms.
+    let stem = prefix
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("bad prefix"))?
+        .to_string_lossy()
+        .into_owned();
+    let needle = format!("{stem}-");
+    let mut entries: Vec<PathBuf> = std::fs::read_dir(work_dir)
+        .with_context(|| format!("read dir {}", work_dir.display()))?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            let name = p.file_name().and_then(|s| s.to_str()).unwrap_or("");
+            name.starts_with(&needle) && name.ends_with(".png")
+        })
+        .collect();
+    entries.sort();
+
+    if entries.is_empty() {
+        bail!("pdftocairo produced no PNGs in {}", work_dir.display());
+    }
+
+    let pages = entries
+        .iter()
+        .map(|p| {
+            image::open(p)
+                .map(|i| i.to_rgba8())
+                .with_context(|| format!("decode PNG {}", p.display()))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(RenderedTest { pages, pdf_path })
+}

--- a/crates/fulgur-wpt/tests/diff_pages.rs
+++ b/crates/fulgur-wpt/tests/diff_pages.rs
@@ -1,0 +1,15 @@
+use fulgur_vrt::diff::compare;
+use fulgur_vrt::manifest::Tolerance;
+use image::{ImageBuffer, Rgba};
+
+#[test]
+fn fulgur_vrt_diff_is_reachable_as_devdep() {
+    let a: image::RgbaImage = ImageBuffer::from_pixel(4, 4, Rgba([0, 0, 0, 255]));
+    let b = a.clone();
+    let tol = Tolerance {
+        max_channel_diff: 0,
+        max_diff_pixels_ratio: 0.0,
+    };
+    let r = compare(&a, &b, tol);
+    assert!(r.pass);
+}

--- a/crates/fulgur-wpt/tests/harness_smoke.rs
+++ b/crates/fulgur-wpt/tests/harness_smoke.rs
@@ -1,0 +1,111 @@
+use fulgur_wpt::expectations::Expectation;
+use fulgur_wpt::harness::run_one;
+use std::io::Write;
+
+fn poppler_available() -> bool {
+    std::process::Command::new("pdftocairo")
+        .arg("-v")
+        .output()
+        .is_ok()
+}
+
+fn write(path: &std::path::Path, body: &str) {
+    std::fs::File::create(path)
+        .unwrap()
+        .write_all(body.as_bytes())
+        .unwrap();
+}
+
+#[test]
+fn identical_test_and_ref_pass() {
+    if !poppler_available() {
+        eprintln!("skip: no pdftocairo");
+        return;
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let test = dir.path().join("t.html");
+    let refh = dir.path().join("t-ref.html");
+
+    // A small multi-page fixture via natural overflow (page-break-after
+    // is not wired through fulgur yet — see Task 5 note).
+    let common_style = r#"<style>
+  @page { size: 300pt 200pt; margin: 0; }
+  p { font-size: 14pt; line-height: 18pt; margin: 0; }
+</style>"#;
+    let common_body: String = (0..40)
+        .map(|i| format!("<p>paragraph {i}</p>"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let test_body = format!(
+        r#"<!DOCTYPE html><link rel="match" href="t-ref.html"><meta name="fuzzy" content="0-2;0-1000000">{common_style}<body>{common_body}</body>"#
+    );
+    let ref_body = format!(r#"<!DOCTYPE html>{common_style}<body>{common_body}</body>"#);
+    write(&test, &test_body);
+    write(&refh, &ref_body);
+
+    let work = dir.path().join("work");
+    let diff = dir.path().join("diff");
+    let out = run_one(&test, &work, &diff, 96).unwrap();
+    assert_eq!(out.observed, Expectation::Pass, "reason: {:?}", out.reason);
+}
+
+#[test]
+fn page_count_mismatch_fails() {
+    if !poppler_available() {
+        eprintln!("skip: no pdftocairo");
+        return;
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let test = dir.path().join("t.html");
+    let refh = dir.path().join("t-ref.html");
+
+    // Test body overflows MUCH more than ref body → different page counts.
+    let style = r#"<style>
+  @page { size: 300pt 200pt; margin: 0; }
+  p { font-size: 14pt; line-height: 18pt; margin: 0; }
+</style>"#;
+    let many_paras: String = (0..80)
+        .map(|i| format!("<p>t{i}</p>"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let few_paras: String = (0..10)
+        .map(|i| format!("<p>r{i}</p>"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let test_body = format!(
+        r#"<!DOCTYPE html><link rel="match" href="t-ref.html">{style}<body>{many_paras}</body>"#
+    );
+    let ref_body = format!(r#"<!DOCTYPE html>{style}<body>{few_paras}</body>"#);
+    write(&test, &test_body);
+    write(&refh, &ref_body);
+
+    let work = dir.path().join("work");
+    let diff = dir.path().join("diff");
+    let out = run_one(&test, &work, &diff, 96).unwrap();
+    assert_eq!(out.observed, Expectation::Fail);
+    assert!(
+        out.reason.as_deref().unwrap_or("").contains("page count"),
+        "unexpected reason: {:?}",
+        out.reason
+    );
+}
+
+#[test]
+fn skipped_reftest_reports_skip() {
+    // No poppler needed: classify() decides before render is invoked.
+    let dir = tempfile::tempdir().unwrap();
+    let test = dir.path().join("t.html");
+    write(
+        &test,
+        r#"<!DOCTYPE html><link rel="mismatch" href="x.html"><body></body>"#,
+    );
+
+    let work = dir.path().join("work");
+    let diff = dir.path().join("diff");
+    let out = run_one(&test, &work, &diff, 96).unwrap();
+    assert_eq!(out.observed, Expectation::Skip);
+}

--- a/crates/fulgur-wpt/tests/harness_smoke.rs
+++ b/crates/fulgur-wpt/tests/harness_smoke.rs
@@ -6,7 +6,8 @@ fn poppler_available() -> bool {
     std::process::Command::new("pdftocairo")
         .arg("-v")
         .output()
-        .is_ok()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
 }
 
 fn write(path: &std::path::Path, body: &str) {

--- a/crates/fulgur-wpt/tests/render_multi_page.rs
+++ b/crates/fulgur-wpt/tests/render_multi_page.rs
@@ -5,7 +5,8 @@ fn poppler_available() -> bool {
     std::process::Command::new("pdftocairo")
         .arg("-v")
         .output()
-        .is_ok()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
 }
 
 #[test]

--- a/crates/fulgur-wpt/tests/render_multi_page.rs
+++ b/crates/fulgur-wpt/tests/render_multi_page.rs
@@ -1,0 +1,54 @@
+use fulgur_wpt::render::render_test;
+use std::io::Write;
+
+fn poppler_available() -> bool {
+    std::process::Command::new("pdftocairo")
+        .arg("-v")
+        .output()
+        .is_ok()
+}
+
+#[test]
+fn renders_all_pages_from_overflow() {
+    if !poppler_available() {
+        eprintln!("skip: pdftocairo not available");
+        return;
+    }
+
+    // NOTE: fulgur currently paginates via natural flow overflow (not
+    // `page-break-after` CSS), so we size the page small and emit more
+    // paragraphs than fit on one page to force a >=2-page render.
+    let mut body = String::new();
+    for i in 1..=40 {
+        body.push_str(&format!(
+            "<p>Paragraph {i} lorem ipsum dolor sit amet.</p>\n"
+        ));
+    }
+    let html = format!(
+        r#"<!DOCTYPE html>
+<html><head><style>
+  @page {{ size: 300pt 200pt; margin: 0; }}
+</style></head>
+<body>
+{body}
+</body></html>"#
+    );
+
+    let dir = tempfile::tempdir().unwrap();
+    let html_path = dir.path().join("t.html");
+    std::fs::File::create(&html_path)
+        .unwrap()
+        .write_all(html.as_bytes())
+        .unwrap();
+
+    let work = dir.path().join("work");
+    let out = render_test(&html_path, &work, 96).expect("render should succeed");
+    assert!(
+        out.pages.len() >= 2,
+        "expected >=2 pages (got {})",
+        out.pages.len()
+    );
+    // 300pt @ 96dpi ≈ 400px wide — sanity check the raster resolution.
+    assert!(out.pages[0].width() > 100);
+    assert!(out.pdf_path.exists());
+}

--- a/crates/fulgur-wpt/tests/wpt_smoke.rs
+++ b/crates/fulgur-wpt/tests/wpt_smoke.rs
@@ -1,0 +1,7 @@
+#[test]
+fn crate_builds_and_links() {
+    // Placeholder smoke test: ensures the crate is wired into the workspace
+    // and `cargo test -p fulgur-wpt` runs at all. Replaced by real tests once
+    // modules are filled in.
+    assert_eq!(2 + 2, 4);
+}

--- a/docs/plans/2026-04-21-wpt-runner-phase1-core.md
+++ b/docs/plans/2026-04-21-wpt-runner-phase1-core.md
@@ -1,0 +1,1538 @@
+# WPT Runner Phase 1 Core Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** W3C web-platform-tests の CSS paged media 系 reftest を fulgur で走らせる自前 runner (`crates/fulgur-wpt/`) の中核部分 (scaffolding + WPT fetch + render + reftest parser + diff harness + expectations) を作る。
+
+**Architecture:** 新規 crate `crates/fulgur-wpt/` (publish=false) に Blitz の WPT runner を参考にした薄いレイヤーを実装。test と ref を両方 fulgur で PDF 化して pdftocairo で全ページ PNG に展開し、`fulgur-vrt::diff` を dev-dep で再利用して比較。fuzzy meta は仕様 5 バリアント全対応。expectations は Blitz の `wpt_expectations.txt` 形式を踏襲して PASS/FAIL/SKIP を宣言管理する。
+
+**Tech Stack:** Rust (edition 2024), `fulgur` (依存), `fulgur-vrt` (dev-dep, diff 再利用), `image`, `anyhow`, `tempfile`, `scraper` または `kuchikiki` (HTML parse for reftest metadata), `pdftocairo` (CLI, PDF→PNG), `git` (WPT sparse-checkout)
+
+**Beads issues covered:** fulgur-2foo.1, .2, .3, .4, .5, .6
+
+**Out of scope (2nd PR):** fulgur-2foo.7 (wptreport.json), .8 (css-page seed), .9 (CI integration)
+
+---
+
+## 実装順序の要点
+
+- TDD で順番を組み替え: parser (fuzzy / reftest meta / expectations) を先に単体テストで固めてから、render → harness に進める
+- 各タスクは fresh subagent で独立実装可能、タスク間でコードレビュー
+- `fulgur-vrt` の `diff.rs` と `pdf_render.rs` を参考にし、必要なら薄く wrap (DRY)
+- 全タスクで `cargo test -p fulgur-wpt` が pass すること + `cargo fmt --check` / `cargo clippy -- -D warnings` が通ること
+
+---
+
+## Task 1: fulgur-wpt crate scaffolding
+
+**Beads:** fulgur-2foo.1
+
+**Files:**
+
+- Create: `crates/fulgur-wpt/Cargo.toml`
+- Create: `crates/fulgur-wpt/README.md`
+- Create: `crates/fulgur-wpt/src/lib.rs`
+- Create: `crates/fulgur-wpt/tests/wpt_smoke.rs`
+- Modify: `Cargo.toml` (workspace members に追加)
+
+**Step 1: Workspace に member を追加**
+
+`Cargo.toml` の `members` に `"crates/fulgur-wpt"` を末尾に追加:
+
+```toml
+members = ["crates/fulgur", "crates/fulgur-cli", "crates/fulgur-ruby", "crates/fulgur-vrt", "crates/fulgur-wpt", "crates/pyfulgur"]
+```
+
+**Step 2: Cargo.toml を作成**
+
+```toml
+[package]
+name = "fulgur-wpt"
+version = "0.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+description = "W3C web-platform-tests runner for fulgur (dev-only, not published)"
+
+[dependencies]
+fulgur = { path = "../fulgur" }
+image = { version = "0.25", default-features = false, features = ["png"] }
+anyhow = "1"
+scraper = "0.20"
+
+[dev-dependencies]
+fulgur-vrt = { path = "../fulgur-vrt" }
+tempfile = "3"
+```
+
+**Step 3: README.md を作成 (責務分担を記載)**
+
+```markdown
+# fulgur-wpt
+
+W3C web-platform-tests (WPT) の CSS paged media 系サブセット reftest を fulgur で走らせる自前ランナー。
+
+## 他 crate との責務分担
+
+| crate | 役割 |
+|---|---|
+| `fulgur` | HTML → PDF 本体 |
+| `fulgur-vrt` | 手書きフィクスチャの visual regression, ゆるい tolerance |
+| `fulgur-wpt` | 外部 WPT reftest, WPT 規約準拠 (fuzzy meta, rel=match 等) |
+
+diff ロジックは `fulgur-vrt::diff` を dev-dep 経由で再利用する (Rule of Three 未達のため共有 crate は切り出さない)。
+
+## 使い方
+
+詳細は epic fulgur-2foo と `docs/plans/2026-04-21-wpt-reftest-runner-design.md` を参照。
+```
+
+**Step 4: src/lib.rs を空で作成**
+
+```rust
+//! WPT reftest runner for fulgur. See README for scope.
+```
+
+**Step 5: tests/wpt_smoke.rs を作成**
+
+```rust
+#[test]
+fn crate_builds_and_links() {
+    // Placeholder smoke test: ensures the crate is wired into the workspace
+    // and `cargo test -p fulgur-wpt` runs at all. Replaced by real tests once
+    // modules are filled in.
+    assert_eq!(2 + 2, 4);
+}
+```
+
+**Step 6: Build と test で pass を確認**
+
+```bash
+cd <worktree-root>
+cargo build --workspace
+cargo test -p fulgur-wpt
+```
+
+期待: `1 passed; 0 failed`。
+
+**Step 7: Commit**
+
+```bash
+git add Cargo.toml crates/fulgur-wpt
+git commit -m "feat(fulgur-wpt): add crate scaffolding (2foo.1)"
+```
+
+---
+
+## Task 2: WPT fetch script + SHA pin + subset
+
+**Beads:** fulgur-2foo.2
+
+**Files:**
+
+- Create: `scripts/wpt/fetch.sh`
+- Create: `scripts/wpt/pinned_sha.txt`
+- Create: `scripts/wpt/subset.txt`
+- Create: `scripts/wpt/README.md`
+- Modify: `.gitignore` (target/wpt/ を無視)
+
+**Step 1: subset.txt を作成 (support も含める)**
+
+```text
+# WPT subset needed for fulgur-wpt. Keep in sync with sparse-checkout.
+# Phase 1 targets css-page; later phases extend below.
+css/css-page
+css/css-break
+css/css-gcpm
+css/css-multicol
+css/support
+css/fonts
+css/CSS2/support
+fonts
+resources
+```
+
+**Step 2: pinned_sha.txt を作成**
+
+```text
+# WPT upstream commit SHA pinned for fulgur-wpt reproducibility.
+# Update via PR. Current pin: 2026-04-21 (HEAD at pin time).
+# Verify before bumping: scripts/wpt/fetch.sh && cargo test -p fulgur-wpt
+# TBD: set actual SHA in the PR that first wires up Phase 1.
+DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF
+```
+
+(実 SHA は PR で上流 WPT `main` の最新安定 commit に差し替える。このタスクではフォーマット確立まで。)
+
+**Step 3: fetch.sh を作成 (冪等、bash strict mode)**
+
+```bash
+#!/usr/bin/env bash
+# Shallow-clone WPT upstream and sparse-checkout only the paths needed
+# by fulgur-wpt. Idempotent: re-running updates to the pinned SHA.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WPT_DIR="$REPO_ROOT/target/wpt"
+SHA_FILE="$SCRIPT_DIR/pinned_sha.txt"
+SUBSET_FILE="$SCRIPT_DIR/subset.txt"
+REMOTE_URL="${WPT_REMOTE_URL:-https://github.com/web-platform-tests/wpt.git}"
+
+SHA="$(grep -v '^#' "$SHA_FILE" | head -n1 | tr -d '[:space:]')"
+if [ -z "$SHA" ]; then
+  echo "error: no SHA in $SHA_FILE" >&2
+  exit 1
+fi
+
+if [ ! -d "$WPT_DIR/.git" ]; then
+  mkdir -p "$WPT_DIR"
+  git -C "$WPT_DIR" init -q
+  git -C "$WPT_DIR" remote add origin "$REMOTE_URL"
+  git -C "$WPT_DIR" config core.sparseCheckout true
+  git -C "$WPT_DIR" config extensions.partialClone origin
+fi
+
+# Write sparse-checkout patterns (strip comments and blanks)
+mkdir -p "$WPT_DIR/.git/info"
+grep -v '^#' "$SUBSET_FILE" | sed '/^[[:space:]]*$/d' > "$WPT_DIR/.git/info/sparse-checkout"
+
+# Fetch only the pinned SHA, filter=blob:none to keep it lean
+git -C "$WPT_DIR" fetch --depth=1 --filter=blob:none origin "$SHA"
+git -C "$WPT_DIR" checkout -q --detach FETCH_HEAD
+
+echo "WPT ready at $WPT_DIR (SHA: $SHA)"
+```
+
+`chmod +x scripts/wpt/fetch.sh` を忘れないこと。
+
+**Step 4: scripts/wpt/README.md を作成**
+
+```markdown
+# scripts/wpt/
+
+`fetch.sh` executes a sparse, shallow clone of the W3C web-platform-tests
+repository into `target/wpt/`, pinned to the SHA in `pinned_sha.txt`.
+
+The set of fetched paths is controlled by `subset.txt` (one pattern per line,
+Git sparse-checkout syntax). Keep in sync with the subset `fulgur-wpt`
+actually exercises.
+
+## Usage
+
+```bash
+scripts/wpt/fetch.sh
+```
+
+Idempotent: re-running updates to the current pinned SHA. Override the remote
+URL with `WPT_REMOTE_URL=...` (useful for mirrors or CI cache warmup).
+
+## Updating the pin
+
+1. Inspect upstream WPT `main` and pick a commit that is green on the
+   relevant subsections.
+2. Replace the SHA line in `pinned_sha.txt`.
+3. Re-run `scripts/wpt/fetch.sh` and `cargo test -p fulgur-wpt`.
+4. Commit both in one PR.
+```
+
+**Step 5: .gitignore に target/wpt を追加**
+
+`.gitignore` に以下を追加 (既存の `target/` 行で既にカバーされていれば不要、要確認):
+
+```text
+# (target/ is already ignored; no change needed if so)
+```
+
+**Step 6: スクリプト構文チェック**
+
+```bash
+bash -n scripts/wpt/fetch.sh
+```
+
+期待: エラーなし (実クローンは Task 8 以降のタスクで実行)。
+
+**Step 7: Commit**
+
+```bash
+git add scripts/wpt
+git commit -m "feat(wpt): add WPT shallow-clone fetch script with SHA pin (2foo.2)"
+```
+
+---
+
+## Task 3: Fuzzy tolerance parser
+
+**Beads:** fulgur-2foo.4 (fuzzy 部分)
+
+**Files:**
+
+- Create: `crates/fulgur-wpt/src/reftest.rs`
+- Modify: `crates/fulgur-wpt/src/lib.rs`
+
+**Step 1: reftest.rs に FuzzyTolerance 型と parse_fuzzy() の unit test を書く**
+
+```rust
+// crates/fulgur-wpt/src/reftest.rs
+use anyhow::{Result, bail};
+use std::ops::RangeInclusive;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FuzzyTolerance {
+    pub url: Option<PathBuf>,
+    pub max_diff: RangeInclusive<u8>,
+    pub total_pixels: RangeInclusive<u32>,
+}
+
+impl FuzzyTolerance {
+    /// Permissive tolerance (max_diff 0-255, total_pixels 0-u32::MAX).
+    /// Used when a test declares no fuzzy meta.
+    pub fn any() -> Self {
+        Self {
+            url: None,
+            max_diff: 0..=255,
+            total_pixels: 0..=u32::MAX,
+        }
+    }
+}
+
+/// Parse a WPT `<meta name=fuzzy content=...>` value into a canonical
+/// `FuzzyTolerance`. Accepts every variant from the WPT reftest spec:
+///
+/// - numeric: `10;300`, `5-10;200-300`
+/// - named:   `maxDifference=10;totalPixels=300`, or named + range
+/// - url prefix: `ref.html:10-15;200-300`
+/// - open range: `5-`, `-300`
+pub fn parse_fuzzy(src: &str) -> Result<FuzzyTolerance> {
+    todo!("implement after writing tests")
+}
+
+#[cfg(test)]
+mod fuzzy_tests {
+    use super::*;
+
+    #[test]
+    fn plain_numeric() {
+        let t = parse_fuzzy("10;300").unwrap();
+        assert_eq!(t.url, None);
+        assert_eq!(t.max_diff, 10..=10);
+        assert_eq!(t.total_pixels, 300..=300);
+    }
+
+    #[test]
+    fn numeric_range_both() {
+        let t = parse_fuzzy("5-10;200-300").unwrap();
+        assert_eq!(t.max_diff, 5..=10);
+        assert_eq!(t.total_pixels, 200..=300);
+    }
+
+    #[test]
+    fn named_single() {
+        let t = parse_fuzzy("maxDifference=10;totalPixels=300").unwrap();
+        assert_eq!(t.max_diff, 10..=10);
+        assert_eq!(t.total_pixels, 300..=300);
+    }
+
+    #[test]
+    fn named_range() {
+        let t = parse_fuzzy("maxDifference=5-10;totalPixels=200-300").unwrap();
+        assert_eq!(t.max_diff, 5..=10);
+        assert_eq!(t.total_pixels, 200..=300);
+    }
+
+    #[test]
+    fn url_prefix() {
+        let t = parse_fuzzy("ref.html:10-15;200-300").unwrap();
+        assert_eq!(t.url.as_deref().map(|p| p.to_str().unwrap()), Some("ref.html"));
+        assert_eq!(t.max_diff, 10..=15);
+        assert_eq!(t.total_pixels, 200..=300);
+    }
+
+    #[test]
+    fn open_range_lower_only() {
+        let t = parse_fuzzy("5-;200-").unwrap();
+        assert_eq!(t.max_diff, 5..=255);
+        assert_eq!(t.total_pixels, 200..=u32::MAX);
+    }
+
+    #[test]
+    fn open_range_upper_only() {
+        let t = parse_fuzzy("-10;-300").unwrap();
+        assert_eq!(t.max_diff, 0..=10);
+        assert_eq!(t.total_pixels, 0..=300);
+    }
+
+    #[test]
+    fn whitespace_tolerated() {
+        let t = parse_fuzzy("  10 ; 300  ").unwrap();
+        assert_eq!(t.max_diff, 10..=10);
+        assert_eq!(t.total_pixels, 300..=300);
+    }
+
+    #[test]
+    fn rejects_missing_semicolon() {
+        assert!(parse_fuzzy("10").is_err());
+    }
+
+    #[test]
+    fn rejects_reversed_range() {
+        assert!(parse_fuzzy("10-5;300").is_err());
+    }
+
+    #[test]
+    fn rejects_max_diff_over_255() {
+        assert!(parse_fuzzy("256;300").is_err());
+    }
+}
+```
+
+lib.rs に `pub mod reftest;` を追加。
+
+**Step 2: Run test to verify they fail**
+
+```bash
+cargo test -p fulgur-wpt fuzzy_
+```
+
+期待: 全テスト compile は通り、runtime で `todo!()` により panic する (FAIL 扱い)。
+
+**Step 3: parse_fuzzy() の実装を書く**
+
+```rust
+pub fn parse_fuzzy(src: &str) -> Result<FuzzyTolerance> {
+    let src = src.trim();
+
+    // URL prefix: split at first ':' if present AND the prefix doesn't
+    // contain '=' or ';' (those belong to value syntax, not URL)
+    let (url, body) = match src.find(':') {
+        Some(idx)
+            if !src[..idx].contains('=') && !src[..idx].contains(';') && !src[..idx].is_empty() =>
+        {
+            let (u, rest) = src.split_at(idx);
+            (Some(PathBuf::from(u.trim())), &rest[1..])
+        }
+        _ => (None, src),
+    };
+
+    // Split into two halves at ';'
+    let mut parts = body.split(';');
+    let first = parts.next().ok_or_else(|| anyhow::anyhow!("empty fuzzy"))?;
+    let second = parts
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("missing ';' in fuzzy: {src}"))?;
+    if parts.next().is_some() {
+        bail!("too many ';' in fuzzy: {src}");
+    }
+
+    let (k1, v1) = split_named(first.trim());
+    let (k2, v2) = split_named(second.trim());
+
+    let (max_diff_src, total_src) = match (k1, k2) {
+        (Some("maxDifference"), Some("totalPixels")) | (None, None) => (v1, v2),
+        (Some("totalPixels"), Some("maxDifference")) => (v2, v1),
+        (Some(k), _) => bail!("unknown fuzzy key: {k}"),
+        (_, Some(k)) => bail!("unknown fuzzy key: {k}"),
+    };
+
+    let max_diff = parse_u8_range(max_diff_src)?;
+    let total_pixels = parse_u32_range(total_src)?;
+    Ok(FuzzyTolerance {
+        url,
+        max_diff,
+        total_pixels,
+    })
+}
+
+fn split_named(s: &str) -> (Option<&str>, &str) {
+    match s.find('=') {
+        Some(idx) => (Some(&s[..idx]), &s[idx + 1..]),
+        None => (None, s),
+    }
+}
+
+fn parse_u8_range(src: &str) -> Result<RangeInclusive<u8>> {
+    let src = src.trim();
+    let (lo, hi) = parse_range(src, 0u32, 255u32)?;
+    if lo > hi {
+        bail!("reversed range: {src}");
+    }
+    if hi > 255 {
+        bail!("max_diff out of u8 range: {src}");
+    }
+    Ok((lo as u8)..=(hi as u8))
+}
+
+fn parse_u32_range(src: &str) -> Result<RangeInclusive<u32>> {
+    let src = src.trim();
+    let (lo, hi) = parse_range(src, 0u32, u32::MAX)?;
+    if lo > hi {
+        bail!("reversed range: {src}");
+    }
+    Ok(lo..=hi)
+}
+
+fn parse_range(src: &str, default_lo: u32, default_hi: u32) -> Result<(u32, u32)> {
+    match src.find('-') {
+        None => {
+            let n: u32 = src.parse()?;
+            Ok((n, n))
+        }
+        Some(0) => {
+            // "-N" → 0..=N
+            let n: u32 = src[1..].trim().parse()?;
+            Ok((default_lo, n))
+        }
+        Some(idx) if idx == src.len() - 1 => {
+            // "N-" → N..=MAX
+            let n: u32 = src[..idx].trim().parse()?;
+            Ok((n, default_hi))
+        }
+        Some(idx) => {
+            let lo: u32 = src[..idx].trim().parse()?;
+            let hi: u32 = src[idx + 1..].trim().parse()?;
+            Ok((lo, hi))
+        }
+    }
+}
+```
+
+**Step 4: Run tests to verify PASS**
+
+```bash
+cargo test -p fulgur-wpt fuzzy_
+```
+
+期待: 11 passed; 0 failed.
+
+**Step 5: Commit**
+
+```bash
+git add crates/fulgur-wpt/src
+git commit -m "feat(fulgur-wpt): add fuzzy meta parser with full WPT variant coverage (2foo.4)"
+```
+
+---
+
+## Task 4: Reftest HTML parser (rel=match + meta fuzzy extraction)
+
+**Beads:** fulgur-2foo.4 (reftest HTML 部分)
+
+**Files:**
+
+- Modify: `crates/fulgur-wpt/src/reftest.rs`
+
+**Step 1: 拡張型とテストを書く**
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+pub struct Reftest {
+    pub test: PathBuf,
+    pub classification: ReftestKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ReftestKind {
+    /// Single rel=match + optional fuzzy tolerance. Phase 1 target.
+    Match {
+        ref_path: PathBuf,
+        fuzzy: FuzzyTolerance,
+    },
+    /// Skipped: out-of-scope reftest variant.
+    Skip { reason: SkipReason },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkipReason {
+    Mismatch,
+    MultipleMatches,
+    NoMatch,
+    ChainedReference,
+}
+
+/// Inspect the test HTML at `test_path` and classify it for Phase 1.
+/// File I/O only — does not render.
+pub fn classify(test_path: &Path) -> Result<Reftest> {
+    todo!()
+}
+```
+
+テスト (reftest_tests モジュール):
+
+```rust
+#[cfg(test)]
+mod reftest_tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_tmp(name: &str, body: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join(name);
+        let mut f = std::fs::File::create(&p).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+        (dir, p)
+    }
+
+    #[test]
+    fn single_match_no_fuzzy() {
+        let (_d, p) = write_tmp(
+            "t.html",
+            r#"<!DOCTYPE html><link rel="match" href="t-ref.html"><body></body>"#,
+        );
+        let r = classify(&p).unwrap();
+        match r.classification {
+            ReftestKind::Match { ref_path, fuzzy } => {
+                assert_eq!(ref_path.file_name().unwrap(), "t-ref.html");
+                assert_eq!(fuzzy, FuzzyTolerance::any());
+            }
+            other => panic!("expected Match, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn single_match_with_fuzzy() {
+        let (_d, p) = write_tmp(
+            "t.html",
+            r#"<!DOCTYPE html>
+<link rel="match" href="t-ref.html">
+<meta name="fuzzy" content="5-10;200-300">
+<body></body>"#,
+        );
+        let r = classify(&p).unwrap();
+        let fuzzy = match r.classification {
+            ReftestKind::Match { fuzzy, .. } => fuzzy,
+            _ => unreachable!(),
+        };
+        assert_eq!(fuzzy.max_diff, 5..=10);
+        assert_eq!(fuzzy.total_pixels, 200..=300);
+    }
+
+    #[test]
+    fn multiple_matches_skip() {
+        let (_d, p) = write_tmp(
+            "t.html",
+            r#"<!DOCTYPE html>
+<link rel="match" href="a.html">
+<link rel="match" href="b.html">
+<body></body>"#,
+        );
+        assert!(matches!(
+            classify(&p).unwrap().classification,
+            ReftestKind::Skip { reason: SkipReason::MultipleMatches }
+        ));
+    }
+
+    #[test]
+    fn mismatch_skip() {
+        let (_d, p) = write_tmp(
+            "t.html",
+            r#"<!DOCTYPE html><link rel="mismatch" href="a.html"><body></body>"#,
+        );
+        assert!(matches!(
+            classify(&p).unwrap().classification,
+            ReftestKind::Skip { reason: SkipReason::Mismatch }
+        ));
+    }
+
+    #[test]
+    fn no_match_skip() {
+        let (_d, p) = write_tmp("t.html", r#"<!DOCTYPE html><body></body>"#);
+        assert!(matches!(
+            classify(&p).unwrap().classification,
+            ReftestKind::Skip { reason: SkipReason::NoMatch }
+        ));
+    }
+
+    #[test]
+    fn fuzzy_url_prefix_matching_ref_is_used() {
+        let (_d, p) = write_tmp(
+            "t.html",
+            r#"<!DOCTYPE html>
+<link rel="match" href="t-ref.html">
+<meta name="fuzzy" content="t-ref.html:5-10;200-300">
+<body></body>"#,
+        );
+        let r = classify(&p).unwrap();
+        match r.classification {
+            ReftestKind::Match { fuzzy, .. } => {
+                assert_eq!(fuzzy.max_diff, 5..=10);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn fuzzy_url_prefix_mismatched_is_ignored() {
+        // Prefix points at a different ref → Phase 1 falls back to permissive
+        let (_d, p) = write_tmp(
+            "t.html",
+            r#"<!DOCTYPE html>
+<link rel="match" href="t-ref.html">
+<meta name="fuzzy" content="other.html:5-10;200-300">
+<body></body>"#,
+        );
+        let r = classify(&p).unwrap();
+        match r.classification {
+            ReftestKind::Match { fuzzy, .. } => {
+                assert_eq!(fuzzy, FuzzyTolerance::any());
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+```bash
+cargo test -p fulgur-wpt reftest_
+```
+
+期待: `todo!()` で panic。
+
+**Step 3: classify() を実装**
+
+```rust
+pub fn classify(test_path: &Path) -> Result<Reftest> {
+    let html = std::fs::read_to_string(test_path)?;
+    let doc = scraper::Html::parse_document(&html);
+
+    let link_sel = scraper::Selector::parse("link[rel]").unwrap();
+    let mut matches: Vec<PathBuf> = Vec::new();
+    let mut has_mismatch = false;
+
+    for el in doc.select(&link_sel) {
+        let rel = el.value().attr("rel").unwrap_or("").to_ascii_lowercase();
+        match rel.as_str() {
+            "match" => {
+                if let Some(href) = el.value().attr("href") {
+                    matches.push(PathBuf::from(href));
+                }
+            }
+            "mismatch" => {
+                has_mismatch = true;
+            }
+            _ => {}
+        }
+    }
+
+    if has_mismatch {
+        return Ok(Reftest {
+            test: test_path.to_path_buf(),
+            classification: ReftestKind::Skip { reason: SkipReason::Mismatch },
+        });
+    }
+    let ref_path = match matches.as_slice() {
+        [] => return Ok(Reftest {
+            test: test_path.to_path_buf(),
+            classification: ReftestKind::Skip { reason: SkipReason::NoMatch },
+        }),
+        [one] => one.clone(),
+        _ => return Ok(Reftest {
+            test: test_path.to_path_buf(),
+            classification: ReftestKind::Skip { reason: SkipReason::MultipleMatches },
+        }),
+    };
+
+    // Collect fuzzy metas
+    let meta_sel = scraper::Selector::parse(r#"meta[name="fuzzy"]"#).unwrap();
+    let mut chosen = FuzzyTolerance::any();
+    let mut unscoped_count = 0usize;
+    for el in doc.select(&meta_sel) {
+        let content = match el.value().attr("content") {
+            Some(c) => c,
+            None => continue,
+        };
+        let parsed = match parse_fuzzy(content) {
+            Ok(p) => p,
+            Err(_) => continue, // ignore malformed, leave permissive
+        };
+        match &parsed.url {
+            Some(u) if u == &ref_path => {
+                chosen = parsed;
+            }
+            None => {
+                if unscoped_count == 0 || !matches!(chosen.url, None) {
+                    chosen = parsed;
+                } else {
+                    // multiple unscoped — take last (Phase 1 rule)
+                    chosen = parsed;
+                }
+                unscoped_count += 1;
+            }
+            _ => {} // different url prefix: ignore
+        }
+    }
+
+    Ok(Reftest {
+        test: test_path.to_path_buf(),
+        classification: ReftestKind::Match { ref_path, fuzzy: chosen },
+    })
+}
+```
+
+**Step 4: Tests should pass**
+
+```bash
+cargo test -p fulgur-wpt reftest_
+```
+
+期待: 7 passed; 0 failed.
+
+**Step 5: Commit**
+
+```bash
+git add crates/fulgur-wpt/src/reftest.rs
+git commit -m "feat(fulgur-wpt): classify reftests from HTML (rel=match, fuzzy meta) (2foo.4)"
+```
+
+---
+
+## Task 5: Multi-page render module
+
+**Beads:** fulgur-2foo.3
+
+**Files:**
+
+- Create: `crates/fulgur-wpt/src/render.rs`
+- Modify: `crates/fulgur-wpt/src/lib.rs`
+
+**Step 1: API と failing test を書く**
+
+```rust
+// crates/fulgur-wpt/src/render.rs
+//! Render a WPT test HTML through fulgur and rasterize every page via
+//! pdftocairo. CRITICAL: must not pass `-f 1 -l 1` to pdftocairo — we
+//! need every page to catch multi-page regressions (advisor P1-1).
+
+use anyhow::{Context, Result, bail};
+use image::RgbaImage;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub struct RenderedTest {
+    pub pages: Vec<RgbaImage>,
+    pub pdf_path: PathBuf,
+}
+
+/// Render `test_html` and return one RgbaImage per page.
+///
+/// `base_path` is the directory the test HTML lives in, used to resolve
+/// support/ and CSS links. `work_dir` receives the PDF and per-page PNGs
+/// (left behind for debugging).
+pub fn render_test(test_html_path: &Path, work_dir: &Path, dpi: u32) -> Result<RenderedTest> {
+    todo!()
+}
+```
+
+lib.rs に `pub mod render;` を追加。
+
+テストは実 fulgur を噛ませるため、integration style (tests/) に置く:
+
+```rust
+// crates/fulgur-wpt/tests/render_multi_page.rs
+use fulgur_wpt::render::render_test;
+use std::io::Write;
+
+#[test]
+fn renders_two_pages_from_page_break() {
+    let html = r#"<!DOCTYPE html>
+<html><head><style>
+  @page { size: 200px 200px; margin: 0; }
+  .p { page-break-after: always; width: 100px; height: 100px; background: red; }
+</style></head>
+<body>
+  <div class="p"></div>
+  <div style="width:100px;height:100px;background:blue"></div>
+</body></html>"#;
+
+    let dir = tempfile::tempdir().unwrap();
+    let html_path = dir.path().join("t.html");
+    std::fs::File::create(&html_path)
+        .unwrap()
+        .write_all(html.as_bytes())
+        .unwrap();
+
+    let work = dir.path().join("work");
+    let out = render_test(&html_path, &work, 96).expect("render should succeed");
+    assert_eq!(out.pages.len(), 2, "expected 2 pages");
+    assert!(out.pages[0].width() > 100);
+}
+```
+
+**Step 2: Run to verify fail**
+
+```bash
+cargo test -p fulgur-wpt --test render_multi_page
+```
+
+期待: `todo!()` panic.
+
+**Step 3: 実装**
+
+```rust
+pub fn render_test(test_html_path: &Path, work_dir: &Path, dpi: u32) -> Result<RenderedTest> {
+    use fulgur::engine::Engine;
+
+    std::fs::create_dir_all(work_dir)?;
+    let html = std::fs::read_to_string(test_html_path)
+        .with_context(|| format!("read {}", test_html_path.display()))?;
+    let base = test_html_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("test has no parent dir: {}", test_html_path.display()))?;
+
+    let engine = Engine::builder().base_path(base).build();
+    let pdf_bytes = engine
+        .render_html(&html)
+        .map_err(|e| anyhow::anyhow!("fulgur render_html failed: {e}"))?;
+
+    let pdf_path = work_dir.join("fixture.pdf");
+    std::fs::write(&pdf_path, &pdf_bytes)?;
+
+    let prefix = work_dir.join("page");
+    // NOTE: intentionally NOT passing -f/-l so pdftocairo emits every page.
+    let status = Command::new("pdftocairo")
+        .args(["-png", "-r", &dpi.to_string()])
+        .arg(&pdf_path)
+        .arg(&prefix)
+        .status()
+        .context("spawn pdftocairo")?;
+    if !status.success() {
+        bail!("pdftocairo exited with {status}");
+    }
+
+    // Enumerate generated files: pdftocairo names them `<prefix>-<n>.png`
+    // (or `<prefix>-01.png` if >9 pages). We glob, sort, and load.
+    let parent = work_dir;
+    let stem = prefix
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("bad prefix"))?
+        .to_string_lossy()
+        .into_owned();
+    let mut entries: Vec<PathBuf> = std::fs::read_dir(parent)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            let name = p.file_name().and_then(|s| s.to_str()).unwrap_or("");
+            name.starts_with(&format!("{stem}-")) && name.ends_with(".png")
+        })
+        .collect();
+    entries.sort();
+
+    if entries.is_empty() {
+        bail!("pdftocairo produced no PNGs in {}", work_dir.display());
+    }
+
+    let pages = entries
+        .iter()
+        .map(|p| image::open(p).map(|i| i.to_rgba8()).map_err(Into::into))
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(RenderedTest { pages, pdf_path })
+}
+```
+
+**Step 4: Test に poppler ガード (skip-if-missing)**
+
+pdftocairo が無い CI 環境向けに、先頭で probe:
+
+```rust
+#[test]
+fn renders_two_pages_from_page_break() {
+    if std::process::Command::new("pdftocairo")
+        .arg("-v")
+        .output()
+        .is_err()
+    {
+        eprintln!("skip: pdftocairo not available");
+        return;
+    }
+    // ... 既存テスト本体
+}
+```
+
+**Step 5: Tests pass**
+
+```bash
+cargo test -p fulgur-wpt --test render_multi_page
+```
+
+期待: 1 passed (or "skip: pdftocairo not available" でも OK)。
+
+**Step 6: Commit**
+
+```bash
+git add crates/fulgur-wpt
+git commit -m "feat(fulgur-wpt): add multi-page render with pdftocairo (2foo.3)"
+```
+
+---
+
+## Task 6: Expectations file I/O
+
+**Beads:** fulgur-2foo.6
+
+**Files:**
+
+- Create: `crates/fulgur-wpt/src/expectations.rs`
+- Modify: `crates/fulgur-wpt/src/lib.rs`
+
+**Step 1: 型と failing test を書く**
+
+```rust
+// crates/fulgur-wpt/src/expectations.rs
+use anyhow::{Result, bail};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Expectation {
+    Pass,
+    Fail,
+    Skip,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ExpectationFile {
+    entries: BTreeMap<String, Entry>,
+}
+
+#[derive(Debug, Clone)]
+struct Entry {
+    expectation: Expectation,
+    comment: Option<String>,
+}
+
+impl ExpectationFile {
+    pub fn parse(src: &str) -> Result<Self> {
+        todo!()
+    }
+
+    pub fn load(path: &Path) -> Result<Self> {
+        let s = std::fs::read_to_string(path)?;
+        Self::parse(&s)
+    }
+
+    pub fn get(&self, test_path: &str) -> Option<Expectation> {
+        self.entries.get(test_path).map(|e| e.expectation)
+    }
+
+    pub fn len(&self) -> usize { self.entries.len() }
+    pub fn is_empty(&self) -> bool { self.entries.is_empty() }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    Ok,
+    Regression,
+    Promotion,
+    Skipped,
+    UnknownTest,
+}
+
+/// Compare the declared expectation with the observed result.
+pub fn judge(declared: Option<Expectation>, observed: Option<Expectation>) -> Verdict {
+    match (declared, observed) {
+        (Some(Expectation::Skip), _) => Verdict::Skipped,
+        (Some(d), Some(o)) if d == o => Verdict::Ok,
+        (Some(Expectation::Pass), Some(Expectation::Fail)) => Verdict::Regression,
+        (Some(Expectation::Fail), Some(Expectation::Pass)) => Verdict::Promotion,
+        (None, _) => Verdict::UnknownTest,
+        _ => Verdict::Ok,
+    }
+}
+```
+
+テスト (同ファイル内 `mod tests`):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_all_three_statuses() {
+        let src = "\
+# comment line
+PASS css/css-page/a.html
+FAIL css/css-page/b.html  # reason
+SKIP css/css-page/c.html  # manual
+
+";
+        let f = ExpectationFile::parse(src).unwrap();
+        assert_eq!(f.get("css/css-page/a.html"), Some(Expectation::Pass));
+        assert_eq!(f.get("css/css-page/b.html"), Some(Expectation::Fail));
+        assert_eq!(f.get("css/css-page/c.html"), Some(Expectation::Skip));
+        assert_eq!(f.len(), 3);
+    }
+
+    #[test]
+    fn ignores_blank_and_comment_lines() {
+        let src = "\n  \n# foo\nPASS x\n";
+        let f = ExpectationFile::parse(src).unwrap();
+        assert_eq!(f.len(), 1);
+    }
+
+    #[test]
+    fn rejects_unknown_status() {
+        assert!(ExpectationFile::parse("XYZZY a.html\n").is_err());
+    }
+
+    #[test]
+    fn rejects_duplicate_entry() {
+        let src = "PASS a.html\nFAIL a.html\n";
+        assert!(ExpectationFile::parse(src).is_err());
+    }
+
+    #[test]
+    fn judge_pass_pass_is_ok() {
+        assert_eq!(
+            judge(Some(Expectation::Pass), Some(Expectation::Pass)),
+            Verdict::Ok
+        );
+    }
+
+    #[test]
+    fn judge_pass_fail_is_regression() {
+        assert_eq!(
+            judge(Some(Expectation::Pass), Some(Expectation::Fail)),
+            Verdict::Regression
+        );
+    }
+
+    #[test]
+    fn judge_fail_pass_is_promotion() {
+        assert_eq!(
+            judge(Some(Expectation::Fail), Some(Expectation::Pass)),
+            Verdict::Promotion
+        );
+    }
+
+    #[test]
+    fn judge_skip_wins() {
+        assert_eq!(
+            judge(Some(Expectation::Skip), Some(Expectation::Pass)),
+            Verdict::Skipped
+        );
+    }
+
+    #[test]
+    fn judge_unknown_declared() {
+        assert_eq!(judge(None, Some(Expectation::Pass)), Verdict::UnknownTest);
+    }
+}
+```
+
+lib.rs に `pub mod expectations;` 追加。
+
+**Step 2: Run — expect fail**
+
+```bash
+cargo test -p fulgur-wpt expectations::
+```
+
+**Step 3: parse() 実装**
+
+```rust
+impl ExpectationFile {
+    pub fn parse(src: &str) -> Result<Self> {
+        let mut entries: BTreeMap<String, Entry> = BTreeMap::new();
+        for (lineno, raw) in src.lines().enumerate() {
+            let line = raw.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let (body, comment) = match line.find('#') {
+                Some(idx) => (line[..idx].trim(), Some(line[idx + 1..].trim().to_string())),
+                None => (line, None),
+            };
+            let mut parts = body.splitn(2, char::is_whitespace);
+            let status = parts.next().unwrap_or("");
+            let path = parts.next().unwrap_or("").trim();
+            if path.is_empty() {
+                bail!("line {}: missing path", lineno + 1);
+            }
+            let expectation = match status {
+                "PASS" => Expectation::Pass,
+                "FAIL" => Expectation::Fail,
+                "SKIP" => Expectation::Skip,
+                other => bail!("line {}: unknown status {other}", lineno + 1),
+            };
+            if entries.contains_key(path) {
+                bail!("line {}: duplicate entry for {path}", lineno + 1);
+            }
+            entries.insert(
+                path.to_string(),
+                Entry { expectation, comment },
+            );
+        }
+        Ok(Self { entries })
+    }
+}
+```
+
+**Step 4: Tests pass**
+
+```bash
+cargo test -p fulgur-wpt expectations::
+```
+
+期待: 15 passed.
+
+**Step 5: Commit**
+
+```bash
+git add crates/fulgur-wpt
+git commit -m "feat(fulgur-wpt): add expectations file parser and judge() (2foo.6)"
+```
+
+---
+
+## Task 7: Diff wrapper
+
+**Beads:** fulgur-2foo.5 (diff 部分)
+
+**Files:**
+
+- Create: `crates/fulgur-wpt/tests/diff_pages.rs`
+- (fulgur-vrt は dev-dep で十分。ラッパ module は作らず、harness.rs 内で直接呼ぶ)
+
+実装の重複を避けるため、薄いラッパは作らない。`fulgur-vrt::diff::compare` を fuzzy tolerance にアダプトする関数は Task 8 (harness.rs) で登場する。このタスクでは dev-dep 経由で diff が呼べることを統合テストで確認するだけ。
+
+**Step 1: tests/diff_pages.rs に fulgur-vrt 経由の diff が動くことを確認するテスト**
+
+```rust
+use fulgur_vrt::diff::compare;
+use fulgur_vrt::manifest::Tolerance;
+use image::{ImageBuffer, Rgba};
+
+#[test]
+fn fulgur_vrt_diff_is_reachable_as_devdep() {
+    let a: image::RgbaImage = ImageBuffer::from_pixel(4, 4, Rgba([0, 0, 0, 255]));
+    let b = a.clone();
+    let tol = Tolerance { max_channel_diff: 0, max_diff_pixels_ratio: 0.0 };
+    let r = compare(&a, &b, tol);
+    assert!(r.pass);
+}
+```
+
+**Step 2: Run**
+
+```bash
+cargo test -p fulgur-wpt --test diff_pages
+```
+
+期待: 1 passed.
+
+**Step 3: Commit**
+
+```bash
+git add crates/fulgur-wpt/tests/diff_pages.rs
+git commit -m "test(fulgur-wpt): verify fulgur-vrt diff reachable as dev-dep (2foo.5)"
+```
+
+---
+
+## Task 8: Harness — end-to-end reftest judgement
+
+**Beads:** fulgur-2foo.5
+
+**Files:**
+
+- Create: `crates/fulgur-wpt/src/harness.rs`
+- Modify: `crates/fulgur-wpt/src/lib.rs`
+- Create: `crates/fulgur-wpt/tests/harness_smoke.rs`
+
+**Step 1: 型と API**
+
+```rust
+// crates/fulgur-wpt/src/harness.rs
+use crate::expectations::Expectation;
+use crate::reftest::{FuzzyTolerance, classify, ReftestKind, SkipReason};
+use crate::render::render_test;
+use anyhow::{Result, bail};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+pub struct RunOutcome {
+    pub observed: Expectation,
+    pub reason: Option<String>,
+    pub diff_dir: Option<PathBuf>,
+}
+
+/// Run one reftest and return an observed PASS/FAIL/SKIP.
+///
+/// - `test_html_path`: absolute or relative path to the test HTML.
+/// - `work_dir`: scratch dir for PDFs/PNGs.
+/// - `diff_out_dir`: where to dump per-page diff PNGs on failure.
+pub fn run_one(
+    test_html_path: &Path,
+    work_dir: &Path,
+    diff_out_dir: &Path,
+    dpi: u32,
+) -> Result<RunOutcome> {
+    todo!()
+}
+```
+
+lib.rs に `pub mod harness;` 追加。
+
+**Step 2: smoke integration test — 2 ページ test/ref が一致する自作ケース**
+
+```rust
+// crates/fulgur-wpt/tests/harness_smoke.rs
+use fulgur_wpt::expectations::Expectation;
+use fulgur_wpt::harness::run_one;
+use std::io::Write;
+
+fn poppler_available() -> bool {
+    std::process::Command::new("pdftocairo").arg("-v").output().is_ok()
+}
+
+#[test]
+fn identical_test_and_ref_pass() {
+    if !poppler_available() { eprintln!("skip: no pdftocairo"); return; }
+
+    let dir = tempfile::tempdir().unwrap();
+    let test = dir.path().join("t.html");
+    let refh = dir.path().join("t-ref.html");
+
+    let shared = r#"<!DOCTYPE html>
+<html><head><style>
+  @page { size: 200px 200px; margin: 0; }
+  .p { width: 100px; height: 100px; background: green; page-break-after: always; }
+</style></head>
+<body>
+  <div class="p"></div>
+  <div style="width:100px;height:100px;background:orange"></div>
+</body></html>"#;
+
+    // Test HTML links to ref
+    let test_body = format!(r#"<!DOCTYPE html><link rel="match" href="t-ref.html"><meta name="fuzzy" content="0-2;0-500">{shared}"#);
+
+    std::fs::File::create(&test).unwrap().write_all(test_body.as_bytes()).unwrap();
+    std::fs::File::create(&refh).unwrap().write_all(shared.as_bytes()).unwrap();
+
+    let work = dir.path().join("work");
+    let diff = dir.path().join("diff");
+    let out = run_one(&test, &work, &diff, 96).unwrap();
+    assert_eq!(out.observed, Expectation::Pass, "reason: {:?}", out.reason);
+}
+
+#[test]
+fn page_count_mismatch_fails() {
+    if !poppler_available() { eprintln!("skip: no pdftocairo"); return; }
+
+    let dir = tempfile::tempdir().unwrap();
+    let test = dir.path().join("t.html");
+    let refh = dir.path().join("t-ref.html");
+
+    let test_body = r#"<!DOCTYPE html>
+<link rel="match" href="t-ref.html">
+<style>@page{size:200px 200px;margin:0}.p{width:100px;height:100px;background:green;page-break-after:always}</style>
+<div class="p"></div>
+<div class="p"></div>
+<div style="width:100px;height:100px"></div>"#;
+    let ref_body = r#"<!DOCTYPE html>
+<style>@page{size:200px 200px;margin:0}.p{width:100px;height:100px;background:green;page-break-after:always}</style>
+<div class="p"></div>
+<div style="width:100px;height:100px"></div>"#;
+
+    std::fs::File::create(&test).unwrap().write_all(test_body.as_bytes()).unwrap();
+    std::fs::File::create(&refh).unwrap().write_all(ref_body.as_bytes()).unwrap();
+
+    let work = dir.path().join("work");
+    let diff = dir.path().join("diff");
+    let out = run_one(&test, &work, &diff, 96).unwrap();
+    assert_eq!(out.observed, Expectation::Fail);
+    assert!(out.reason.as_deref().unwrap_or("").contains("page count"));
+}
+
+#[test]
+fn skipped_reftest_reports_skip() {
+    let dir = tempfile::tempdir().unwrap();
+    let test = dir.path().join("t.html");
+    std::fs::File::create(&test).unwrap()
+        .write_all(br#"<!DOCTYPE html><link rel="mismatch" href="x.html">"#).unwrap();
+
+    let work = dir.path().join("work");
+    let diff = dir.path().join("diff");
+    let out = run_one(&test, &work, &diff, 96).unwrap();
+    assert_eq!(out.observed, Expectation::Skip);
+}
+```
+
+**Step 3: Run — fail**
+
+```bash
+cargo test -p fulgur-wpt --test harness_smoke
+```
+
+期待: `todo!()` panic.
+
+**Step 4: run_one() 実装**
+
+```rust
+pub fn run_one(
+    test_html_path: &Path,
+    work_dir: &Path,
+    diff_out_dir: &Path,
+    dpi: u32,
+) -> Result<RunOutcome> {
+    use fulgur_vrt::diff::{compare, write_diff_image};
+    use fulgur_vrt::manifest::Tolerance;
+
+    let reftest = classify(test_html_path)?;
+    let (ref_rel, fuzzy) = match reftest.classification {
+        ReftestKind::Match { ref_path, fuzzy } => (ref_path, fuzzy),
+        ReftestKind::Skip { reason } => {
+            return Ok(RunOutcome {
+                observed: Expectation::Skip,
+                reason: Some(format!("{:?}", reason)),
+                diff_dir: None,
+            });
+        }
+    };
+
+    let test_dir = test_html_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("test has no parent"))?;
+    let ref_abs = test_dir.join(&ref_rel);
+
+    let test_work = work_dir.join("test");
+    let ref_work = work_dir.join("ref");
+    let test_out = render_test(test_html_path, &test_work, dpi)?;
+    let ref_out = render_test(&ref_abs, &ref_work, dpi)?;
+
+    if test_out.pages.len() != ref_out.pages.len() {
+        return Ok(RunOutcome {
+            observed: Expectation::Fail,
+            reason: Some(format!(
+                "page count mismatch: test={} ref={}",
+                test_out.pages.len(),
+                ref_out.pages.len(),
+            )),
+            diff_dir: None,
+        });
+    }
+
+    // Map fuzzy→fulgur-vrt Tolerance. fulgur-vrt uses a single threshold,
+    // WPT uses inclusive ranges; we take the upper bound (most permissive).
+    let max_ch = *fuzzy.max_diff.end();
+    let max_total = *fuzzy.total_pixels.end();
+
+    let mut first_failure: Option<String> = None;
+    for (idx, (t, r)) in test_out.pages.iter().zip(ref_out.pages.iter()).enumerate() {
+        let total = u64::from(t.width()) * u64::from(t.height());
+        let ratio_limit = if total == 0 {
+            0.0
+        } else {
+            (max_total as f64 / total as f64) as f32
+        };
+        let tol = Tolerance {
+            max_channel_diff: max_ch,
+            max_diff_pixels_ratio: ratio_limit,
+        };
+        let report = compare(r, t, tol);
+        if !report.pass {
+            std::fs::create_dir_all(diff_out_dir)?;
+            let out = diff_out_dir.join(format!("page{}.diff.png", idx + 1));
+            write_diff_image(r, t, tol, &out)?;
+            if first_failure.is_none() {
+                first_failure = Some(format!(
+                    "page {} diff: {}/{} pixels exceed tol (max_ch={})",
+                    idx + 1,
+                    report.diff_pixels,
+                    report.total_pixels,
+                    report.max_channel_diff,
+                ));
+            }
+        }
+    }
+
+    Ok(match first_failure {
+        Some(reason) => RunOutcome {
+            observed: Expectation::Fail,
+            reason: Some(reason),
+            diff_dir: Some(diff_out_dir.to_path_buf()),
+        },
+        None => RunOutcome {
+            observed: Expectation::Pass,
+            reason: None,
+            diff_dir: None,
+        },
+    })
+}
+```
+
+**Step 5: Tests pass**
+
+```bash
+cargo test -p fulgur-wpt --test harness_smoke
+```
+
+期待: 3 passed (poppler 無ければ 3 skipped-via-early-return)。
+
+**Step 6: Commit**
+
+```bash
+git add crates/fulgur-wpt
+git commit -m "feat(fulgur-wpt): end-to-end reftest harness with multi-page diff (2foo.5)"
+```
+
+---
+
+## Task 9: 全テスト再実行 + clippy + fmt の最終ゲート
+
+**Step 1: 全体テスト**
+
+```bash
+cargo test -p fulgur-wpt
+```
+
+期待: 全 unit test + integration test が PASS (pdftocairo 無し環境では該当 2 件が skip)。
+
+**Step 2: Workspace build/test 回帰なし**
+
+```bash
+cargo test -p fulgur --lib
+cargo test -p fulgur-vrt --lib
+```
+
+期待: 既存テスト数と同数 PASS。
+
+**Step 3: Lint**
+
+```bash
+cargo fmt --check
+cargo clippy -p fulgur-wpt -- -D warnings
+```
+
+期待: 両方 clean。
+
+**Step 4: Markdown lint**
+
+```bash
+npx markdownlint-cli2 'docs/plans/2026-04-21-wpt-runner-phase1-core.md' 'crates/fulgur-wpt/README.md' 'scripts/wpt/README.md'
+```
+
+期待: 0 errors。
+
+**Step 5: Squash commit 不要、タスク毎の commit をそのまま残す**
+
+各 task の commit をそのまま feature branch に残す (レビュアが追いやすい)。
+
+---
+
+## Out of scope (別 PR で実装)
+
+- **fulgur-2foo.7** `wptreport.json` 出力 (report.rs) — runner コアが動いてから
+- **fulgur-2foo.8** css-page 全件 FAIL seed — fetch.sh 実行 + harness 実走が必要
+- **fulgur-2foo.9** CI workflow 追加 — 本体が動いてから PR / nightly 分岐
+
+## Known risks
+
+1. **WPT 実ファイルを使わない smoke**: harness テストは自作 HTML で完結。実 WPT ファイルでの検証は 2foo.8 (seed) で行う
+2. **pdftocairo 出力ファイル名の 2桁 padding**: 10ページ以上だと `page-01.png` にならず `page-01.png`/`page-10.png` で sort 順が崩れる可能性 — `std::fs::read_dir` + 自然順 sort が必要かは実測後判断。Phase 1 smoke は 2 ページで事足りるため初版は lexical sort で OK
+3. **fulgur-vrt の Tolerance へのマッピング**: fuzzy range を単一閾値に丸めると false pass の余地 — WPT 公式 runner も likewise なので許容範囲。必要なら Phase 5 以降で再設計

--- a/docs/plans/2026-04-21-wpt-runner-phase1-core.md
+++ b/docs/plans/2026-04-21-wpt-runner-phase1-core.md
@@ -1547,5 +1547,5 @@ npx markdownlint-cli2 'docs/plans/2026-04-21-wpt-runner-phase1-core.md' 'crates/
 ## Known risks
 
 1. **WPT 実ファイルを使わない smoke**: harness テストは自作 HTML で完結。実 WPT ファイルでの検証は 2foo.8 (seed) で行う
-2. **pdftocairo 出力ファイル名の 2桁 padding**: 10ページ以上だと `page-01.png` にならず `page-01.png`/`page-10.png` で sort 順が崩れる可能性 — `std::fs::read_dir` + 自然順 sort が必要かは実測後判断。Phase 1 smoke は 2 ページで事足りるため初版は lexical sort で OK
+2. **pdftocairo 出力ファイル名の桁数 padding**: 9ページ以下は `page-1.png` … `page-9.png` (padding なし)、10ページ以上は `page-01.png` … `page-10.png` (総ページ数の桁幅にゼロ padding) と、1 回の render 内では常に同じ padding 幅が使われる。そのため lexical sort は安全 (実測でも poppler 24.02 で確認済み)。`std::fs::read_dir` + 自然順 sort が必要になるのは将来別 renderer を追加した場合のみ
 3. **fulgur-vrt の Tolerance へのマッピング**: fuzzy range を単一閾値に丸めると false pass の余地 — WPT 公式 runner も likewise なので許容範囲。必要なら Phase 5 以降で再設計

--- a/docs/plans/2026-04-21-wpt-runner-phase1-core.md
+++ b/docs/plans/2026-04-21-wpt-runner-phase1-core.md
@@ -1526,6 +1526,18 @@ npx markdownlint-cli2 'docs/plans/2026-04-21-wpt-runner-phase1-core.md' 'crates/
 
 ---
 
+## 実装時のプランからの差分
+
+- `FuzzyTolerance::any()` を `strict()` にリネームし、デフォルト値を `max_diff=0..=0, total_pixels=0..=0` に修正。WPT 仕様では fuzzy meta 無し = strict 一致のため。
+- `scraper` を 0.20 → 0.26 に bump（Task 4 直前）。API は後方互換。
+- `judge(observed: Option<Expectation>, ...)` を `judge(observed: Expectation, ...)` に締め付け、catch-all `_ => Ok` を排除して型で網羅性を強制。
+- `fulgur-vrt` を `[dev-dependencies]` → `[dependencies]` に昇格。harness.rs が src 配下から `fulgur_vrt::diff` を使うため必須。両 crate とも `publish = false` で publish 汚染はゼロ。
+- `render.rs` で `pdftocairo .status()` → `.output()` に変更し stderr をエラーに含める（2foo.8 triage 用）。
+- `render_test` で test HTML path を `canonicalize` してから parent を取る（bare filename 時の base_path 空落ちを防止）。
+- fetch.sh の remote URL 反映を毎回 `git remote set-url` で上書き（mirror override の冪等性）。
+- `page-break-after: always` が fulgur 本体で未配線のため、multi-page render の smoke test は natural overflow で書いた。`page-break-*` 配線は別 beads issue で追跡予定。
+- `rel=match` で href 欠落時はエラーに（final review 指摘、malformed reftest を silent NoMatch に落とさない）。
+
 ## Out of scope (別 PR で実装)
 
 - **fulgur-2foo.7** `wptreport.json` 出力 (report.rs) — runner コアが動いてから

--- a/docs/plans/2026-04-21-wpt-runner-phase1-core.md
+++ b/docs/plans/2026-04-21-wpt-runner-phase1-core.md
@@ -209,7 +209,7 @@ echo "WPT ready at $WPT_DIR (SHA: $SHA)"
 
 **Step 4: scripts/wpt/README.md を作成**
 
-```markdown
+````markdown
 # scripts/wpt/
 
 `fetch.sh` executes a sparse, shallow clone of the W3C web-platform-tests
@@ -235,7 +235,8 @@ URL with `WPT_REMOTE_URL=...` (useful for mirrors or CI cache warmup).
 2. Replace the SHA line in `pinned_sha.txt`.
 3. Re-run `scripts/wpt/fetch.sh` and `cargo test -p fulgur-wpt`.
 4. Commit both in one PR.
-```
+
+````
 
 **Step 5: .gitignore に target/wpt を追加**
 

--- a/scripts/wpt/README.md
+++ b/scripts/wpt/README.md
@@ -1,0 +1,25 @@
+# scripts/wpt/
+
+`fetch.sh` executes a sparse, shallow clone of the W3C web-platform-tests
+repository into `target/wpt/`, pinned to the SHA in `pinned_sha.txt`.
+
+The set of fetched paths is controlled by `subset.txt` (one pattern per line,
+Git sparse-checkout syntax). Keep in sync with the subset `fulgur-wpt`
+actually exercises.
+
+## Usage
+
+```bash
+scripts/wpt/fetch.sh
+```
+
+Idempotent: re-running updates to the current pinned SHA. Override the remote
+URL with `WPT_REMOTE_URL=...` (useful for mirrors or CI cache warmup).
+
+## Updating the pin
+
+1. Inspect upstream WPT `main` and pick a commit that is green on the
+   relevant subsections.
+2. Replace the SHA line in `pinned_sha.txt`.
+3. Re-run `scripts/wpt/fetch.sh` and `cargo test -p fulgur-wpt`.
+4. Commit both in one PR.

--- a/scripts/wpt/README.md
+++ b/scripts/wpt/README.md
@@ -16,6 +16,8 @@ scripts/wpt/fetch.sh
 Idempotent: re-running updates to the current pinned SHA. Override the remote
 URL with `WPT_REMOTE_URL=...` (useful for mirrors or CI cache warmup).
 
+The placeholder SHA (`DEADBEEF…`) intentionally fails `git fetch`; a real SHA is committed in the PR that seeds fulgur-2foo.8.
+
 ## Updating the pin
 
 1. Inspect upstream WPT `main` and pick a commit that is green on the

--- a/scripts/wpt/fetch.sh
+++ b/scripts/wpt/fetch.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Shallow-clone WPT upstream and sparse-checkout only the paths needed
+# by fulgur-wpt. Idempotent: re-running updates to the pinned SHA.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WPT_DIR="$REPO_ROOT/target/wpt"
+SHA_FILE="$SCRIPT_DIR/pinned_sha.txt"
+SUBSET_FILE="$SCRIPT_DIR/subset.txt"
+REMOTE_URL="${WPT_REMOTE_URL:-https://github.com/web-platform-tests/wpt.git}"
+
+SHA="$(grep -v '^#' "$SHA_FILE" | head -n1 | tr -d '[:space:]')"
+if [ -z "$SHA" ]; then
+  echo "error: no SHA in $SHA_FILE" >&2
+  exit 1
+fi
+
+if [ ! -d "$WPT_DIR/.git" ]; then
+  mkdir -p "$WPT_DIR"
+  git -C "$WPT_DIR" init -q
+  git -C "$WPT_DIR" remote add origin "$REMOTE_URL"
+  git -C "$WPT_DIR" config core.sparseCheckout true
+  git -C "$WPT_DIR" config extensions.partialClone origin
+fi
+
+# Write sparse-checkout patterns (strip comments and blanks)
+mkdir -p "$WPT_DIR/.git/info"
+grep -v '^#' "$SUBSET_FILE" | sed '/^[[:space:]]*$/d' > "$WPT_DIR/.git/info/sparse-checkout"
+
+# Fetch only the pinned SHA, filter=blob:none to keep it lean
+git -C "$WPT_DIR" fetch --depth=1 --filter=blob:none origin "$SHA"
+git -C "$WPT_DIR" checkout -q --detach FETCH_HEAD
+
+echo "WPT ready at $WPT_DIR (SHA: $SHA)"

--- a/scripts/wpt/fetch.sh
+++ b/scripts/wpt/fetch.sh
@@ -10,7 +10,7 @@ SHA_FILE="$SCRIPT_DIR/pinned_sha.txt"
 SUBSET_FILE="$SCRIPT_DIR/subset.txt"
 REMOTE_URL="${WPT_REMOTE_URL:-https://github.com/web-platform-tests/wpt.git}"
 
-SHA="$(grep -v '^#' "$SHA_FILE" | head -n1 | tr -d '[:space:]')"
+SHA="$(awk '!/^#/ && NF { print; exit }' "$SHA_FILE" | tr -d '[:space:]')"
 if [ -z "$SHA" ]; then
   echo "error: no SHA in $SHA_FILE" >&2
   exit 1
@@ -19,10 +19,14 @@ fi
 if [ ! -d "$WPT_DIR/.git" ]; then
   mkdir -p "$WPT_DIR"
   git -C "$WPT_DIR" init -q
-  git -C "$WPT_DIR" remote add origin "$REMOTE_URL"
   git -C "$WPT_DIR" config core.sparseCheckout true
   git -C "$WPT_DIR" config extensions.partialClone origin
 fi
+
+# Keep the remote URL in sync on every run so WPT_REMOTE_URL overrides
+# (mirrors, CI caches) take effect even when target/wpt already exists.
+git -C "$WPT_DIR" remote set-url origin "$REMOTE_URL" 2>/dev/null \
+  || git -C "$WPT_DIR" remote add origin "$REMOTE_URL"
 
 # Write sparse-checkout patterns (strip comments and blanks)
 mkdir -p "$WPT_DIR/.git/info"

--- a/scripts/wpt/pinned_sha.txt
+++ b/scripts/wpt/pinned_sha.txt
@@ -1,0 +1,5 @@
+# WPT upstream commit SHA pinned for fulgur-wpt reproducibility.
+# Update via PR. Current pin: 2026-04-21 (HEAD at pin time).
+# Verify before bumping: scripts/wpt/fetch.sh && cargo test -p fulgur-wpt
+# TBD: set actual SHA in the PR that first wires up Phase 1.
+DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF

--- a/scripts/wpt/subset.txt
+++ b/scripts/wpt/subset.txt
@@ -1,0 +1,11 @@
+# WPT subset needed for fulgur-wpt. Keep in sync with sparse-checkout.
+# Phase 1 targets css-page; later phases extend below.
+css/css-page
+css/css-break
+css/css-gcpm
+css/css-multicol
+css/support
+css/fonts
+css/CSS2/support
+fonts
+resources


### PR DESCRIPTION
## 概要

W3C web-platform-tests の CSS paged media 系 reftest を fulgur で走らせる自前 runner の中核を実装しました。新規 dev-only crate `crates/fulgur-wpt/` (publish=false) として整備し、`classify → render × 2 → per-page fuzzy diff → PASS/FAIL/SKIP 判定` のパイプラインが 1 関数 `run_one()` で完結します。

**Epic:** fulgur-2foo
**Beads issues closed by this PR:** fulgur-2foo.1, .2, .3, .4, .5, .6
**Next PR (out of scope):** fulgur-2foo.7 (wptreport.json), .8 (css-page expectations seed), .9 (CI integration)

## 主要コンポーネント

| モジュール | 役割 |
|---|---|
| `src/reftest.rs` | `parse_fuzzy()` (WPT fuzzy grammar 5 バリアント全対応)、`classify()` (rel=match / mismatch / multi-match / chained 判定)、`FuzzyTolerance::strict()` デフォルト |
| `src/render.rs` | HTML → fulgur PDF → pdftocairo (全ページ PNG、`-f 1 -l 1` 禁止) |
| `src/expectations.rs` | Blitz 形式 `wpt_expectations.txt` parser、`judge(Option<Expectation>, Expectation) -> Verdict` |
| `src/harness.rs` | `run_one(test, work, diff_out, dpi) -> RunOutcome` で end-to-end reftest |
| `scripts/wpt/` | `fetch.sh` + `pinned_sha.txt` + `subset.txt` で WPT を sparse-shallow clone |

## 設計上の主要判断

- **self-consistency**: test と ref を両方 fulgur で描画して比較 (Chrome 非依存)
- **`FuzzyTolerance::strict()` をデフォルト**: fuzzy meta 不在 = WPT 仕様上の厳密一致。当初 plan の `any()` (permissive) は仕様違反と判明し pivot
- **fulgur-vrt の diff 再利用**: 共有 crate は切り出さず dev-dep 経由で `fulgur-vrt::diff` を直接呼ぶ (Rule of Three 未達)
- **pdftocairo 全ページ rasterize**: 単ページ限定の `fulgur-vrt::pdf_render` とは別経路。multi-page regression を絶対に見逃さない
- **expectations 判定は型で網羅**: `judge(observed: Expectation)` を非 Optional に締めて catch-all `_ => Ok` を排除、将来 silent fallback を防止
- **SHA pin + sparse-checkout**: 上流 WPT を全量取得せず fulgur-wpt の対象パスのみ fetch、決定性も担保

## テスト

- `cargo test -p fulgur-wpt`: **48 passed** (lib 42: fuzzy 20 + reftest 8 + expectations 15 + smoke 1 + 他 / integration 6: harness_smoke 3 + render_multi_page 1 + diff_pages 1 + wpt_smoke 1)
- `cargo test -p fulgur --lib`: 497 passed (baseline 回帰なし)
- `cargo test -p fulgur-vrt --lib`: 12 passed (baseline 回帰なし)
- `cargo fmt --check` / `cargo clippy -p fulgur-wpt --all-targets -- -D warnings` / markdownlint すべてクリーン

## フォローアップ TODO (本 PR では入れない)

- fulgur 本体の `page-break-after: always` 配線 (convert.rs で CSS プロパティを `BreakAfter::Page` に mapping する経路が未実装。multi-page テストは natural overflow で代替)
- WPT 実 SHA への pinned_sha.txt 更新 (2foo.8 で対応)
- wptreport.json emitter (2foo.7)
- CI workflow (2foo.9)

## Test Plan

- [x] `cargo test -p fulgur-wpt` pass (48/48)
- [x] baseline crate tests 回帰なし (fulgur 497, fulgur-vrt 12)
- [x] `cargo fmt --check`
- [x] `cargo clippy -p fulgur-wpt --all-targets -- -D warnings`
- [x] markdownlint on plan + README × 2
- [ ] (merge 前) CI で green 確認

## 参考資料

- 設計ドキュメント: `docs/plans/2026-04-21-wpt-reftest-runner-design.md`
- 実装プラン: `docs/plans/2026-04-21-wpt-runner-phase1-core.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a WPT reftest runner with fuzzy-tolerance parsing, multi-page PDF→PNG rendering, per-page visual comparison, diff artifact output, and a runnable example CLI.

* **Tests**
  * Added unit and integration tests covering fuzzy parsing, reftest classification, rendering, comparison, and harness smoke scenarios (Poppler-gated where needed).

* **Documentation**
  * Added implementation plan, crate README, and WPT fetch/use guidance.

* **Chores**
  * Added the new crate to the workspace and CI support for required system tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->