### PR TITLE
feat(fulgur-ftp): CSS break-inside: avoid support (multicol A-5)

### DIFF
--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -2645,6 +2645,32 @@ mod tests {
         let n_rule = table.get(&n).and_then(|props| props.rule).expect("n rule");
         assert_eq!(n_rule.color, [0, 128, 0, 255]);
     }
+
+    #[test]
+    fn extract_column_style_table_populates_break_inside() {
+        // Regression guard: `break-inside: avoid` declared in a <style> block
+        // must survive the parser → ColumnStyleTable roundtrip keyed by node
+        // id. column_css.rs is unit-tested directly; this test pins down the
+        // blitz-dom integration so the property cannot silently get dropped
+        // between parser and side-table.
+        let html = r#"<!doctype html><html><head><style>
+            .k { break-inside: avoid; }
+        </style></head><body>
+          <div class="k" id="k"></div>
+        </body></html>"#;
+        let mut doc = parse(html, 400.0, &[]);
+        resolve(&mut doc);
+        use std::ops::Deref;
+        let k = find_element_by_attr_id(doc.deref(), "k");
+
+        let table = extract_column_style_table(&doc);
+
+        let props = table.get(&k).expect("k in table");
+        assert_eq!(
+            props.break_inside,
+            Some(crate::pageable::BreakInside::Avoid)
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/fulgur/src/column_css.rs
+++ b/crates/fulgur/src/column_css.rs
@@ -45,6 +45,8 @@ use cssparser::{
     color::{parse_hash_color, parse_named_color},
 };
 
+use crate::pageable::BreakInside;
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -105,7 +107,7 @@ pub struct ColumnStyleProps {
     /// initial value (`BreakInside::Auto`). Stored as `Option` for the same
     /// reason as the other fields: a later rule overwrites only the
     /// properties it declares (see [`merge`](Self::merge)).
-    pub break_inside: Option<crate::pageable::BreakInside>,
+    pub break_inside: Option<BreakInside>,
 }
 
 impl ColumnStyleProps {
@@ -414,11 +416,11 @@ fn parse_column_fill_value<'i>(
 /// `left`, `right`, typos …) drop the declaration so siblings still apply.
 fn parse_break_inside_value<'i>(
     input: &mut Parser<'i, '_>,
-) -> Result<crate::pageable::BreakInside, ParseError<'i, ()>> {
+) -> Result<BreakInside, ParseError<'i, ()>> {
     let ident = input.expect_ident()?.clone();
     match ident.as_ref().to_ascii_lowercase().as_str() {
-        "avoid" | "avoid-page" | "avoid-column" => Ok(crate::pageable::BreakInside::Avoid),
-        "auto" => Ok(crate::pageable::BreakInside::Auto),
+        "avoid" | "avoid-page" | "avoid-column" => Ok(BreakInside::Avoid),
+        "auto" => Ok(BreakInside::Auto),
         _ => Err(input.new_error(BasicParseErrorKind::QualifiedRuleInvalid)),
     }
 }
@@ -929,24 +931,21 @@ mod tests {
     #[test]
     fn parse_break_inside_avoid_inline() {
         let props = parse_declaration_block("break-inside: avoid;");
-        assert_eq!(
-            props.break_inside,
-            Some(crate::pageable::BreakInside::Avoid)
-        );
+        assert_eq!(props.break_inside, Some(BreakInside::Avoid));
     }
 
     #[test]
     fn parse_break_inside_avoid_page_and_column_collapse_to_avoid() {
         let p1 = parse_declaration_block("break-inside: avoid-page;");
         let p2 = parse_declaration_block("break-inside: avoid-column;");
-        assert_eq!(p1.break_inside, Some(crate::pageable::BreakInside::Avoid));
-        assert_eq!(p2.break_inside, Some(crate::pageable::BreakInside::Avoid));
+        assert_eq!(p1.break_inside, Some(BreakInside::Avoid));
+        assert_eq!(p2.break_inside, Some(BreakInside::Avoid));
     }
 
     #[test]
     fn parse_break_inside_auto_is_auto_variant() {
         let props = parse_declaration_block("break-inside: auto;");
-        assert_eq!(props.break_inside, Some(crate::pageable::BreakInside::Auto));
+        assert_eq!(props.break_inside, Some(BreakInside::Auto));
     }
 
     #[test]
@@ -959,10 +958,7 @@ mod tests {
     fn parse_break_inside_via_selector() {
         let rules = parse_stylesheet(".keep { break-inside: avoid; }");
         assert_eq!(rules.len(), 1);
-        assert_eq!(
-            rules[0].props.break_inside,
-            Some(crate::pageable::BreakInside::Avoid)
-        );
+        assert_eq!(rules[0].props.break_inside, Some(BreakInside::Avoid));
     }
 
     #[test]

--- a/crates/fulgur/src/column_css.rs
+++ b/crates/fulgur/src/column_css.rs
@@ -5,8 +5,8 @@
 //!
 //! Phase A of fulgur-v7a needs `column-rule-*` and `column-fill` to render
 //! rules between adjacent columns and switch the multicol layout hook between
-//! "balance" and "auto" (greedy fill). The follow-up (`fulgur-ftp`) will
-//! extend this module with `break-inside` — deliberately out of scope here.
+//! "balance" and "auto" (greedy fill). The follow-up (`fulgur-ftp`) extends
+//! this module with `break-inside` (see [`ColumnStyleProps::break_inside`]).
 //!
 //! Scope and trade-offs:
 //!
@@ -100,6 +100,12 @@ pub enum ColumnFill {
 pub struct ColumnStyleProps {
     pub rule: Option<ColumnRuleSpec>,
     pub fill: Option<ColumnFill>,
+    /// `break-inside` as resolved by the fulgur-ftp sniffer. `None` means the
+    /// author did not set the property — consumers should treat that as the
+    /// initial value (`BreakInside::Auto`). Stored as `Option` for the same
+    /// reason as the other fields: a later rule overwrites only the
+    /// properties it declares (see [`merge`](Self::merge)).
+    pub break_inside: Option<crate::pageable::BreakInside>,
 }
 
 impl ColumnStyleProps {
@@ -112,10 +118,13 @@ impl ColumnStyleProps {
         if other.fill.is_some() {
             self.fill = other.fill;
         }
+        if other.break_inside.is_some() {
+            self.break_inside = other.break_inside;
+        }
     }
 
     fn is_empty(&self) -> bool {
-        self.rule.is_none() && self.fill.is_none()
+        self.rule.is_none() && self.fill.is_none() && self.break_inside.is_none()
     }
 }
 
@@ -399,6 +408,21 @@ fn parse_column_fill_value<'i>(
     }
 }
 
+/// Parse the value side of `break-inside`. Accepts the three avoid flavours
+/// (`avoid`, `avoid-page`, `avoid-column`) as `BreakInside::Avoid`, and
+/// `auto` as `BreakInside::Auto`. Other idents (`avoid-region`,
+/// `left`, `right`, typos …) drop the declaration so siblings still apply.
+fn parse_break_inside_value<'i>(
+    input: &mut Parser<'i, '_>,
+) -> Result<crate::pageable::BreakInside, ParseError<'i, ()>> {
+    let ident = input.expect_ident()?.clone();
+    match ident.as_ref().to_ascii_lowercase().as_str() {
+        "avoid" | "avoid-page" | "avoid-column" => Ok(crate::pageable::BreakInside::Avoid),
+        "auto" => Ok(crate::pageable::BreakInside::Auto),
+        _ => Err(input.new_error(BasicParseErrorKind::QualifiedRuleInvalid)),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Declaration block parser
 // ---------------------------------------------------------------------------
@@ -470,6 +494,17 @@ impl<'i, 'a> DeclarationParser<'i> for ColumnDeclParser<'a> {
         } else if name.eq_ignore_ascii_case("column-fill") {
             if let Ok(fill) = input.parse_entirely(parse_column_fill_value) {
                 self.props.fill = Some(fill);
+            }
+        } else if name.eq_ignore_ascii_case("break-inside") {
+            // `break-inside` (CSS Fragmentation Level 3) maps
+            // `avoid-page` / `avoid-column` / `avoid` all onto
+            // [`BreakInside::Avoid`]: fulgur's fragmentation model only
+            // distinguishes "may split" from "atomic", so the three avoid
+            // flavours collapse into a single lattice point. `auto` is the
+            // initial value; unknown idents drop the declaration silently
+            // so siblings keep applying.
+            if let Ok(bi) = input.parse_entirely(parse_break_inside_value) {
+                self.props.break_inside = Some(bi);
             }
         } else {
             // Unknown property — discard its value tokens silently.
@@ -887,6 +922,47 @@ mod tests {
     fn parses_column_fill_balance() {
         let props = parse_declaration_block("column-fill: balance;");
         assert_eq!(props.fill, Some(ColumnFill::Balance));
+    }
+
+    // -------- break-inside (fulgur-ftp) --------
+
+    #[test]
+    fn parse_break_inside_avoid_inline() {
+        let props = parse_declaration_block("break-inside: avoid;");
+        assert_eq!(
+            props.break_inside,
+            Some(crate::pageable::BreakInside::Avoid)
+        );
+    }
+
+    #[test]
+    fn parse_break_inside_avoid_page_and_column_collapse_to_avoid() {
+        let p1 = parse_declaration_block("break-inside: avoid-page;");
+        let p2 = parse_declaration_block("break-inside: avoid-column;");
+        assert_eq!(p1.break_inside, Some(crate::pageable::BreakInside::Avoid));
+        assert_eq!(p2.break_inside, Some(crate::pageable::BreakInside::Avoid));
+    }
+
+    #[test]
+    fn parse_break_inside_auto_is_auto_variant() {
+        let props = parse_declaration_block("break-inside: auto;");
+        assert_eq!(props.break_inside, Some(crate::pageable::BreakInside::Auto));
+    }
+
+    #[test]
+    fn parse_break_inside_invalid_value_is_silently_dropped() {
+        let props = parse_declaration_block("break-inside: banana;");
+        assert_eq!(props.break_inside, None);
+    }
+
+    #[test]
+    fn parse_break_inside_via_selector() {
+        let rules = parse_stylesheet(".keep { break-inside: avoid; }");
+        assert_eq!(rules.len(), 1);
+        assert_eq!(
+            rules[0].props.break_inside,
+            Some(crate::pageable::BreakInside::Avoid)
+        );
     }
 
     #[test]

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -505,6 +505,7 @@ fn build_list_item_body(
                     paragraph_children,
                 );
                 let mut block = BlockPageable::with_positioned_children(children)
+                    .with_pagination(extract_pagination_from_column_css(ctx, node))
                     .with_style(style)
                     .with_visible(visible)
                     .with_id(extract_block_id(node));
@@ -550,6 +551,7 @@ fn build_list_item_body(
                     paragraph_children,
                 );
                 let mut block = BlockPageable::with_positioned_children(children)
+                    .with_pagination(extract_pagination_from_column_css(ctx, node))
                     .with_style(style)
                     .with_visible(visible)
                     .with_id(extract_block_id(node));
@@ -573,6 +575,7 @@ fn build_list_item_body(
                 positioned_children,
             );
             let mut block = BlockPageable::with_positioned_children(positioned_children)
+                .with_pagination(extract_pagination_from_column_css(ctx, node))
                 .with_style(style)
                 .with_visible(visible)
                 .with_id(extract_block_id(node));
@@ -591,6 +594,7 @@ fn build_list_item_body(
             positioned_children,
         );
         let mut block = BlockPageable::with_positioned_children(positioned_children)
+            .with_pagination(extract_pagination_from_column_css(ctx, node))
             .with_style(style)
             .with_visible(visible)
             .with_id(extract_block_id(node));
@@ -798,6 +802,7 @@ fn convert_node_inner(
                 );
                 let needs_wrapper = style.needs_block_wrapper();
                 let mut block = BlockPageable::with_positioned_children(positioned_children)
+                    .with_pagination(extract_pagination_from_column_css(ctx, node))
                     .with_style(style)
                     .with_opacity(opacity)
                     .with_visible(visible)
@@ -854,6 +859,7 @@ fn convert_node_inner(
             );
             let has_style = style.needs_block_wrapper();
             let mut block = BlockPageable::with_positioned_children(positioned_children)
+                .with_pagination(extract_pagination_from_column_css(ctx, node))
                 .with_style(style)
                 .with_opacity(opacity)
                 .with_visible(visible)
@@ -873,13 +879,13 @@ fn convert_node_inner(
             return convert_table(doc, node, ctx, depth);
         }
         if tag == "img" {
-            if let Some(img) = convert_image(node, ctx.assets) {
+            if let Some(img) = convert_image(ctx, node, ctx.assets) {
                 return img;
             }
             // Fall through to generic handling below to preserve Taffy-computed dimensions
         }
         if tag == "svg" {
-            if let Some(svg) = convert_svg(node, ctx.assets) {
+            if let Some(svg) = convert_svg(ctx, node, ctx.assets) {
                 return svg;
             }
             // Fall through — e.g., ImageData::None (parse failure upstream)
@@ -891,7 +897,7 @@ fn convert_node_inner(
     // in layout, so we read the computed value and build an ImagePageable.
     // Early return skips pseudo-element processing (spec-correct: replaced
     // elements do not generate ::before/::after).
-    if let Some(img) = convert_content_url(node, ctx.assets) {
+    if let Some(img) = convert_content_url(ctx, node, ctx.assets) {
         return img;
     }
 
@@ -986,6 +992,7 @@ fn convert_node_inner(
                     paragraph_children,
                 );
                 let mut block = BlockPageable::with_positioned_children(children)
+                    .with_pagination(extract_pagination_from_column_css(ctx, node))
                     .with_style(style)
                     .with_opacity(opacity)
                     .with_visible(visible)
@@ -1036,6 +1043,7 @@ fn convert_node_inner(
                     paragraph_children,
                 );
                 let mut block = BlockPageable::with_positioned_children(children)
+                    .with_pagination(extract_pagination_from_column_css(ctx, node))
                     .with_style(style)
                     .with_opacity(opacity)
                     .with_visible(visible)
@@ -1065,6 +1073,7 @@ fn convert_node_inner(
             let positioned_children =
                 wrap_with_block_pseudo_images(before_pseudo, after_pseudo, content_box, Vec::new());
             let mut block = BlockPageable::with_positioned_children(positioned_children)
+                .with_pagination(extract_pagination_from_column_css(ctx, node))
                 .with_style(style)
                 .with_opacity(opacity)
                 .with_visible(visible)
@@ -1095,6 +1104,7 @@ fn convert_node_inner(
     let has_style = style.needs_block_wrapper();
     let (opacity, visible) = extract_opacity_visible(node);
     let mut block = BlockPageable::with_positioned_children(positioned_children)
+        .with_pagination(extract_pagination_from_column_css(ctx, node))
         .with_style(style)
         .with_opacity(opacity)
         .with_visible(visible)
@@ -1240,6 +1250,27 @@ fn extract_block_id(node: &Node) -> Option<Arc<String>> {
     }
 }
 
+/// Build a [`Pagination`] for `node` from the fulgur-ftp column_css sniffer.
+///
+/// Only `break-inside` flows through today — `break-before` / `break-after` /
+/// `orphans` / `widows` stay at their defaults (see
+/// [`Pagination::default`]). Absence of the node from `ctx.column_styles`
+/// collapses cleanly to [`BreakInside::Auto`], so every
+/// `BlockPageable::with_positioned_children` site can call this
+/// unconditionally without regressing the baseline behaviour that the
+/// existing test suite depends on.
+fn extract_pagination_from_column_css(
+    ctx: &ConvertContext<'_>,
+    node: &Node,
+) -> crate::pageable::Pagination {
+    use crate::pageable::{BreakInside, Pagination};
+    let props = ctx.column_styles.get(&node.id).copied().unwrap_or_default();
+    Pagination {
+        break_inside: props.break_inside.unwrap_or(BreakInside::Auto),
+        ..Pagination::default()
+    }
+}
+
 /// Wrap an atomic replaced element (image, svg) in a styled `BlockPageable`
 /// when the node has visual styling, or return the inner Pageable directly.
 ///
@@ -1249,6 +1280,7 @@ fn extract_block_id(node: &Node) -> Option<Arc<String>> {
 /// and the dimensions are the content-box, not the border-box. In the unstyled
 /// branch the inner receives the node's own opacity/visibility and full size.
 fn wrap_replaced_in_block_style<F>(
+    ctx: &ConvertContext<'_>,
     node: &Node,
     assets: Option<&AssetBundle>,
     build_inner: F,
@@ -1278,6 +1310,7 @@ where
             y: cy,
         };
         let mut block = BlockPageable::with_positioned_children(vec![child])
+            .with_pagination(extract_pagination_from_column_css(ctx, node))
             .with_style(style)
             .with_opacity(opacity)
             .with_visible(visible)
@@ -1762,7 +1795,11 @@ fn resolve_pseudo_size(size: &style::values::computed::Size, parent_width: f32) 
 /// Returns `None` when the element has no `content: url()`, the asset is
 /// missing, or the format is unsupported — callers fall through to the
 /// standard conversion path.
-fn convert_content_url(node: &Node, assets: Option<&AssetBundle>) -> Option<Box<dyn Pageable>> {
+fn convert_content_url(
+    ctx: &ConvertContext<'_>,
+    node: &Node,
+    assets: Option<&AssetBundle>,
+) -> Option<Box<dyn Pageable>> {
     let raw_url = crate::blitz_adapter::extract_content_image_url(node)?;
     let asset_name = extract_asset_name(&raw_url);
     let bundle = assets?;
@@ -1770,6 +1807,7 @@ fn convert_content_url(node: &Node, assets: Option<&AssetBundle>) -> Option<Box<
     let format = ImagePageable::detect_format(&data)?;
 
     Some(wrap_replaced_in_block_style(
+        ctx,
         node,
         assets,
         move |w, h, opacity, visible| {
@@ -1780,7 +1818,11 @@ fn convert_content_url(node: &Node, assets: Option<&AssetBundle>) -> Option<Box<
 }
 
 /// Convert an `<img>` element into an `ImagePageable`, wrapped in `BlockPageable` if styled.
-fn convert_image(node: &Node, assets: Option<&AssetBundle>) -> Option<Box<dyn Pageable>> {
+fn convert_image(
+    ctx: &ConvertContext<'_>,
+    node: &Node,
+    assets: Option<&AssetBundle>,
+) -> Option<Box<dyn Pageable>> {
     let elem = node.element_data()?;
     let src = get_attr(elem, "src")?;
     let bundle = assets?;
@@ -1788,6 +1830,7 @@ fn convert_image(node: &Node, assets: Option<&AssetBundle>) -> Option<Box<dyn Pa
     let format = ImagePageable::detect_format(&data)?;
 
     Some(wrap_replaced_in_block_style(
+        ctx,
         node,
         assets,
         move |w, h, opacity, visible| {
@@ -1807,11 +1850,16 @@ fn convert_image(node: &Node, assets: Option<&AssetBundle>) -> Option<Box<dyn Pa
 /// Blitz parses the inline SVG into a `usvg::Tree` during DOM construction;
 /// `blitz_adapter::extract_inline_svg_tree` retrieves it without exposing
 /// blitz-internal types here.
-fn convert_svg(node: &Node, assets: Option<&AssetBundle>) -> Option<Box<dyn Pageable>> {
+fn convert_svg(
+    ctx: &ConvertContext<'_>,
+    node: &Node,
+    assets: Option<&AssetBundle>,
+) -> Option<Box<dyn Pageable>> {
     let elem = node.element_data()?;
     let tree = extract_inline_svg_tree(elem)?;
 
     Some(wrap_replaced_in_block_style(
+        ctx,
         node,
         assets,
         move |w, h, opacity, visible| {

--- a/crates/fulgur/src/multicol_layout.rs
+++ b/crates/fulgur/src/multicol_layout.rs
@@ -2077,6 +2077,7 @@ mod tests {
             crate::column_css::ColumnStyleProps {
                 rule: None,
                 fill: Some(crate::column_css::ColumnFill::Auto),
+                ..Default::default()
             },
         );
 

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -581,6 +581,12 @@ pub trait Pageable: Send + Sync {
     ///
     /// Default: no-op. Containers should override to forward the value to
     /// every descendant that participates in pagination.
+    ///
+    /// **Contract:** call after every `wrap()`. Fragments emitted by
+    /// `split()` / `split_boxed()` start with `page_height = 0.0` (honour
+    /// avoid, no fallback); re-propagate before the next pagination round
+    /// if you intend to run `find_split_point` on a freshly-split fragment
+    /// directly (outside the `paginate` loop, which already re-propagates).
     fn propagate_page_height(&mut self, _page_height: Pt) {}
 }
 
@@ -913,7 +919,7 @@ impl BlockPageable {
         if self.pagination.break_inside == BreakInside::Avoid {
             // Prefer layout_size (Taffy-computed, non-zero for empty blocks
             // with explicit CSS height) and fall back to cached_size — same
-            // ordering the draw path uses (see lines ~1714, ~1782).
+            // ordering the draw path uses in `impl Pageable for BlockPageable::draw`.
             let total_height = self
                 .layout_size
                 .or(self.cached_size)

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -569,6 +569,19 @@ pub trait Pageable: Send + Sync {
     fn is_visible(&self) -> bool {
         true
     }
+
+    /// Propagate the true page-height budget down the tree. Called by
+    /// `paginate` after `wrap` so `BlockPageable::find_split_point` can detect
+    /// "content taller than any possible page" and fall back from
+    /// `break-inside: avoid` to a normal split.
+    ///
+    /// Cannot piggy-back on `wrap()` because `BlockPageable::wrap` calls
+    /// `child.wrap(avail_width, 10000.0)` as a sizing probe; using
+    /// `avail_height` there would record 10000.0 for every non-root node.
+    ///
+    /// Default: no-op. Containers should override to forward the value to
+    /// every descendant that participates in pagination.
+    fn propagate_page_height(&mut self, _page_height: Pt) {}
 }
 
 impl Clone for Box<dyn Pageable> {
@@ -818,6 +831,11 @@ pub struct BlockPageable {
     /// for internal `href="#..."` links. `Arc<String>` so split fragments
     /// can share without cloning the string.
     pub id: Option<Arc<String>>,
+    /// Last `avail_height` received by `wrap()`. `find_split_point` uses this
+    /// to detect "content taller than any possible page" and fall back to a
+    /// normal split rather than honour `break-inside: avoid` to the point of
+    /// silently dropping content.
+    page_height: Pt,
 }
 
 impl BlockPageable {
@@ -845,6 +863,7 @@ impl BlockPageable {
             opacity: 1.0,
             visible: true,
             id: None,
+            page_height: 0.0,
         }
     }
 
@@ -858,6 +877,7 @@ impl BlockPageable {
             opacity: 1.0,
             visible: true,
             id: None,
+            page_height: 0.0,
         }
     }
 
@@ -891,7 +911,20 @@ impl BlockPageable {
     /// avoid duplicating the scanning logic.
     fn find_split_point(&self, avail_height: Pt) -> SplitDecision {
         if self.pagination.break_inside == BreakInside::Avoid {
-            return SplitDecision::NoSplit;
+            // Prefer layout_size (Taffy-computed, non-zero for empty blocks
+            // with explicit CSS height) and fall back to cached_size — same
+            // ordering the draw path uses (see lines ~1714, ~1782).
+            let total_height = self
+                .layout_size
+                .or(self.cached_size)
+                .map(|s| s.height)
+                .unwrap_or(0.0);
+            // page_height == 0.0 means `propagate_page_height` was never called
+            // (defensive) — treat as "honour avoid, no fallback available".
+            if self.page_height <= 0.0 || total_height <= self.page_height {
+                return SplitDecision::NoSplit;
+            }
+            // Fall through to normal splitting logic.
         }
 
         let has_forced_break = self.children.iter().enumerate().any(|(i, pc)| {
@@ -1557,6 +1590,13 @@ impl Pageable for BlockPageable {
         size
     }
 
+    fn propagate_page_height(&mut self, page_height: Pt) {
+        self.page_height = page_height;
+        for pc in &mut self.children {
+            pc.child.propagate_page_height(page_height);
+        }
+    }
+
     fn split(
         &self,
         _avail_width: Pt,
@@ -1997,6 +2037,10 @@ impl Pageable for BookmarkMarkerWrapperPageable {
         self.child.wrap(avail_width, avail_height)
     }
 
+    fn propagate_page_height(&mut self, page_height: Pt) {
+        self.child.propagate_page_height(page_height);
+    }
+
     fn split(
         &self,
         avail_width: Pt,
@@ -2239,6 +2283,10 @@ impl Pageable for CounterOpWrapperPageable {
         self.child.wrap(avail_width, avail_height)
     }
 
+    fn propagate_page_height(&mut self, page_height: Pt) {
+        self.child.propagate_page_height(page_height);
+    }
+
     fn split(
         &self,
         avail_width: Pt,
@@ -2340,6 +2388,10 @@ impl Pageable for TransformWrapperPageable {
         self.inner.wrap(avail_width, avail_height)
     }
 
+    fn propagate_page_height(&mut self, page_height: Pt) {
+        self.inner.propagate_page_height(page_height);
+    }
+
     fn split(
         &self,
         _avail_width: Pt,
@@ -2435,6 +2487,10 @@ impl Pageable for StringSetWrapperPageable {
         self.child.wrap(avail_width, avail_height)
     }
 
+    fn propagate_page_height(&mut self, page_height: Pt) {
+        self.child.propagate_page_height(page_height);
+    }
+
     fn split(
         &self,
         avail_width: Pt,
@@ -2516,6 +2572,10 @@ impl RunningElementWrapperPageable {
 impl Pageable for RunningElementWrapperPageable {
     fn wrap(&mut self, avail_width: Pt, avail_height: Pt) -> Size {
         self.child.wrap(avail_width, avail_height)
+    }
+
+    fn propagate_page_height(&mut self, page_height: Pt) {
+        self.child.propagate_page_height(page_height);
     }
 
     fn split(
@@ -2671,6 +2731,10 @@ impl MulticolRulePageable {
 impl Pageable for MulticolRulePageable {
     fn wrap(&mut self, avail_width: Pt, avail_height: Pt) -> Size {
         self.child.wrap(avail_width, avail_height)
+    }
+
+    fn propagate_page_height(&mut self, page_height: Pt) {
+        self.child.propagate_page_height(page_height);
     }
 
     fn split(
@@ -2937,6 +3001,10 @@ pub struct ListItemPageable {
 }
 
 impl Pageable for ListItemPageable {
+    fn propagate_page_height(&mut self, page_height: Pt) {
+        self.body.propagate_page_height(page_height);
+    }
+
     fn wrap(&mut self, avail_width: Pt, avail_height: Pt) -> Size {
         let body_size = self.body.wrap(avail_width, avail_height);
         self.height = body_size.height;
@@ -3099,6 +3167,15 @@ pub struct TablePageable {
 }
 
 impl Pageable for TablePageable {
+    fn propagate_page_height(&mut self, page_height: Pt) {
+        for pc in &mut self.header_cells {
+            pc.child.propagate_page_height(page_height);
+        }
+        for pc in &mut self.body_cells {
+            pc.child.propagate_page_height(page_height);
+        }
+    }
+
     fn wrap(&mut self, _avail_width: Pt, _avail_height: Pt) -> Size {
         if let Some(ls) = self.layout_size {
             self.cached_height = ls.height;

--- a/crates/fulgur/src/paginate.rs
+++ b/crates/fulgur/src/paginate.rs
@@ -26,6 +26,11 @@ pub fn paginate(
     page_height: Pt,
 ) -> Vec<Box<dyn Pageable>> {
     root.wrap(page_width, page_height);
+    // Propagate the true page budget so `break-inside: avoid` can detect
+    // "content taller than any possible page" and fall back to a normal
+    // split. wrap() can't carry this itself because BlockPageable::wrap
+    // probes children with avail_height=10000.0.
+    root.propagate_page_height(page_height);
 
     let mut pages = vec![];
     let mut remaining = root;
@@ -37,6 +42,7 @@ pub fn paginate(
                 remaining = rest;
                 // Re-wrap the remaining content
                 remaining.wrap(page_width, page_height);
+                remaining.propagate_page_height(page_height);
             }
             Err(unsplit) => {
                 pages.push(unsplit);

--- a/crates/fulgur/tests/break_inside_avoid.rs
+++ b/crates/fulgur/tests/break_inside_avoid.rs
@@ -42,3 +42,38 @@ fn avoid_block_straddling_boundary_promotes_to_next_page() {
         page_count(&pdf)
     );
 }
+
+/// 1ページより大きい avoid block は無限ループせず通常 split へ fallback。
+///
+/// Note: `.huge` has splittable children (rows). An empty `<div style="height:
+/// 500pt">` would not exercise the fallback because `BlockPageable::split`
+/// cannot synthesise children out of pure CSS-sized boxes; that is a separate
+/// concern beyond Task 5's scope.
+#[test]
+fn avoid_block_taller_than_page_falls_back_to_split() {
+    let html = r#"<!doctype html><html><head><style>
+        @page { size: 200pt 200pt; margin: 0; }
+        body { margin: 0; }
+        .huge { break-inside: avoid; }
+        .row { height: 80pt; background: #036; }
+    </style></head><body>
+      <div class="huge">
+        <div class="row"></div>
+        <div class="row"></div>
+        <div class="row"></div>
+        <div class="row"></div>
+        <div class="row"></div>
+        <div class="row"></div>
+        <div class="row"></div>
+      </div>
+    </body></html>"#;
+    let engine = Engine::builder()
+        .page_size(PageSize::custom(70.5556, 70.5556))
+        .build();
+    let pdf = engine.render_html(html).expect("render");
+    assert!(
+        page_count(&pdf) >= 2,
+        "expected oversized avoid block to still paginate, got {} pages",
+        page_count(&pdf)
+    );
+}

--- a/crates/fulgur/tests/break_inside_avoid.rs
+++ b/crates/fulgur/tests/break_inside_avoid.rs
@@ -33,6 +33,7 @@ fn avoid_block_straddling_boundary_promotes_to_next_page() {
       <div class="keep"></div>
     </body></html>"#;
     let engine = Engine::builder()
+        // 200pt × 200pt expressed in mm (PageSize::custom_pt not yet available)
         .page_size(PageSize::custom(70.5556, 70.5556))
         .build();
     let pdf = engine.render_html(html).expect("render");
@@ -68,6 +69,7 @@ fn avoid_block_taller_than_page_falls_back_to_split() {
       </div>
     </body></html>"#;
     let engine = Engine::builder()
+        // 200pt × 200pt expressed in mm (PageSize::custom_pt not yet available)
         .page_size(PageSize::custom(70.5556, 70.5556))
         .build();
     let pdf = engine.render_html(html).expect("render");
@@ -96,6 +98,7 @@ fn avoid_child_inside_multicol_fits_whole_column() {
       </div>
     </body></html>"#;
     let engine = Engine::builder()
+        // 300pt × 400pt expressed in mm (PageSize::custom_pt not yet available)
         .page_size(PageSize::custom(105.8333, 141.1111))
         .build();
     let pdf = engine.render_html(html).expect("render");

--- a/crates/fulgur/tests/break_inside_avoid.rs
+++ b/crates/fulgur/tests/break_inside_avoid.rs
@@ -77,3 +77,29 @@ fn avoid_block_taller_than_page_falls_back_to_split() {
         page_count(&pdf)
     );
 }
+
+/// ColumnGroup 内の avoid-child は `distribute` の whole placement で
+/// 自動保護される。この挙動を regression-proof する。
+#[test]
+fn avoid_child_inside_multicol_fits_whole_column() {
+    let html = r#"<!doctype html><html><head><style>
+        @page { size: 300pt 400pt; margin: 10pt; }
+        .mc { column-count: 2; column-gap: 10pt; }
+        .block { height: 120pt; margin-bottom: 10pt; background: #ddd; }
+        .keep { break-inside: avoid; }
+    </style></head><body>
+      <div class="mc">
+        <div class="block"></div>
+        <div class="block keep"></div>
+        <div class="block"></div>
+        <div class="block keep"></div>
+      </div>
+    </body></html>"#;
+    let engine = Engine::builder()
+        .page_size(PageSize::custom(105.8333, 141.1111))
+        .build();
+    let pdf = engine.render_html(html).expect("render");
+    assert!(page_count(&pdf) >= 1);
+    assert!(page_count(&pdf) <= 2);
+    assert!(pdf.len() > 500, "PDF looks truncated");
+}

--- a/crates/fulgur/tests/break_inside_avoid.rs
+++ b/crates/fulgur/tests/break_inside_avoid.rs
@@ -1,0 +1,44 @@
+//! Integration tests for CSS `break-inside: avoid` (fulgur-ftp).
+
+use fulgur::{Engine, PageSize};
+
+fn page_count(pdf: &[u8]) -> usize {
+    let prefix = b"/Type /Page";
+    let mut count = 0usize;
+    let mut i = 0;
+    while i + prefix.len() < pdf.len() {
+        if &pdf[i..i + prefix.len()] == prefix {
+            let next = pdf[i + prefix.len()];
+            if !next.is_ascii_alphanumeric() {
+                count += 1;
+            }
+            i += prefix.len();
+        } else {
+            i += 1;
+        }
+    }
+    count
+}
+
+/// avoid block がページ境界にまたがる → 次ページへ promote。
+#[test]
+fn avoid_block_straddling_boundary_promotes_to_next_page() {
+    let html = r#"<!doctype html><html><head><style>
+        @page { size: 200pt 200pt; margin: 0; }
+        body { margin: 0; }
+        .spacer { height: 160pt; background: #eee; }
+        .keep { height: 60pt; background: #c00; break-inside: avoid; }
+    </style></head><body>
+      <div class="spacer"></div>
+      <div class="keep"></div>
+    </body></html>"#;
+    let engine = Engine::builder()
+        .page_size(PageSize::custom(70.5556, 70.5556))
+        .build();
+    let pdf = engine.render_html(html).expect("render");
+    assert!(
+        page_count(&pdf) >= 2,
+        "expected avoid block to promote to page 2, got {} pages",
+        page_count(&pdf)
+    );
+}

--- a/docs/plans/2026-04-21-fulgur-ftp-break-inside-avoid.md
+++ b/docs/plans/2026-04-21-fulgur-ftp-break-inside-avoid.md
@@ -1,0 +1,530 @@
+# fulgur-ftp: multicol A-5 `break-inside: avoid` Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** CSS `break-inside: avoid` / `avoid-page` / `avoid-column` を fulgur のページ送りで honour する。ブロックがページ境界をまたぐなら次ページへ promote。1ページより大きい avoid block は silent overflow / 無限ループを避けるため通常 split へ fall back。
+
+**Architecture:** (1) `column_css.rs` の `ColumnStyleProps` に `break_inside` を追加し、既存の selector + cascade 基盤で拾う。(2) `convert.rs` の全 `BlockPageable::with_positioned_children` サイト（12箇所）に `.with_pagination(...)` を配線。(3) `BlockPageable` に `page_height` を持たせ、`find_split_point` で oversized-avoid を detect して通常 split に fall through。`multicol_layout.rs` への変更は不要（`distribute` の whole placement が ColumnGroup 内 avoid-child を自動保護する）。
+
+**Tech Stack:** Rust, cssparser 0.35, fulgur `ColumnStyleTable` / `BlockPageable` / `Pagination`.
+
+**Worktree:** `.worktrees/fulgur-ftp-break-inside-avoid` (branch `feature/fulgur-ftp-break-inside-avoid`, baseline: 549 lib tests green)
+
+**Issue:** `fulgur-ftp`. Follow-up for `break-before` / `break-after` is `fulgur-4zje`.
+
+---
+
+### Task 1: Probe integration test (straddling avoid block)
+
+**Files:**
+
+- Create: `crates/fulgur/tests/break_inside_avoid.rs`
+
+**Step 1: Write failing test**
+
+```rust
+//! Integration tests for CSS `break-inside: avoid` (fulgur-ftp).
+
+use fulgur::{Engine, PageSize};
+
+fn page_count(pdf: &[u8]) -> usize {
+    let prefix = b"/Type /Page";
+    let mut count = 0usize;
+    let mut i = 0;
+    while i + prefix.len() < pdf.len() {
+        if &pdf[i..i + prefix.len()] == prefix {
+            let next = pdf[i + prefix.len()];
+            if !next.is_ascii_alphanumeric() {
+                count += 1;
+            }
+            i += prefix.len();
+        } else {
+            i += 1;
+        }
+    }
+    count
+}
+
+/// avoid block がページ境界にまたがる → 次ページへ promote。
+#[test]
+fn avoid_block_straddling_boundary_promotes_to_next_page() {
+    let html = r#"<!doctype html><html><head><style>
+        @page { size: 200pt 200pt; margin: 0; }
+        body { margin: 0; }
+        .spacer { height: 160pt; background: #eee; }
+        .keep { height: 60pt; background: #c00; break-inside: avoid; }
+    </style></head><body>
+      <div class="spacer"></div>
+      <div class="keep"></div>
+    </body></html>"#;
+    let engine = Engine::builder()
+        .page_size(PageSize::custom_pt(200.0, 200.0))
+        .build();
+    let pdf = engine.render_html(html).expect("render");
+    assert!(
+        page_count(&pdf) >= 2,
+        "expected avoid block to promote to page 2, got {} pages",
+        page_count(&pdf)
+    );
+}
+```
+
+> **Note:** `PageSize::custom_pt` が未定義なら `PageSize::custom(70.56, 70.56)` (200pt ≈ 70.56mm) に置換。`grep -n "custom_pt\|pub fn custom" crates/fulgur/src/config.rs` で確認。
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p fulgur --test break_inside_avoid -- --nocapture`
+Expected: FAIL — 現状 `break-inside` は pipeline に流れていないので 1 ページだけ生成される。
+
+> **Probe test の検証力についての note:** この probe は `break-inside` 配線が効いていることを弱くしか検証しない。spacer(160pt) + keep(60pt) = 220pt > page(200pt) のため、配線の有無にかかわらず `page_count >= 2` は満たされる（keep の開始位置だけが変わる）。CSS仕様上 `page_count` だけで avoid 効果を区別する HTML は作れないため、本 PR の最終 acceptance は Task 5 の oversized-avoid test (`avoid_block_taller_than_page_falls_back_to_split`) が、配線 + fallback を強く検証することで達成される。Tasks 1-3 単体ではなく、Tasks 1-5 を合わせて merge 可能性を判断すること。
+
+**Step 3: Do not commit yet.** Tasks 2–3 の acceptance check。
+
+---
+
+### Task 2: column_css.rs 拡張 — `break_inside` フィールド + parser
+
+**Files:**
+
+- Modify: `crates/fulgur/src/column_css.rs`
+
+**Step 1: `ColumnStyleProps` に `break_inside` を追加**
+
+`crates/fulgur/src/column_css.rs:100` の struct に1フィールド追加:
+
+```rust
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct ColumnStyleProps {
+    pub rule: Option<ColumnRuleSpec>,
+    pub fill: Option<ColumnFill>,
+    pub break_inside: Option<crate::pageable::BreakInside>,
+}
+```
+
+`merge()` (line 108) と `is_empty()` (line 117) も拡張:
+
+```rust
+fn merge(&mut self, other: ColumnStyleProps) {
+    if other.rule.is_some() { self.rule = other.rule; }
+    if other.fill.is_some() { self.fill = other.fill; }
+    if other.break_inside.is_some() { self.break_inside = other.break_inside; }
+}
+
+fn is_empty(&self) -> bool {
+    self.rule.is_none() && self.fill.is_none() && self.break_inside.is_none()
+}
+```
+
+**Step 2: DeclarationParser に `break-inside` ブランチを追加**
+
+`impl DeclarationParser for ColumnDeclParser` の `parse_value` (line 434) の elif chain 末尾に追加:
+
+```rust
+} else if name.eq_ignore_ascii_case("break-inside") {
+    let ident = input.expect_ident()?;
+    let bi = match ident.as_ref().to_ascii_lowercase().as_str() {
+        "avoid" | "avoid-page" | "avoid-column" => crate::pageable::BreakInside::Avoid,
+        "auto" => crate::pageable::BreakInside::Auto,
+        _ => return Err(input.new_unexpected_token_error(
+            cssparser::Token::Ident(ident.clone())
+        )),
+    };
+    self.props.break_inside = Some(bi);
+    Ok(())
+}
+```
+
+> **Note:** 既存の分岐で `self.props.*` に直接代入しているか、それとも mutable ref を使うかは既存コードの書き方に合わせる。`column-rule-width` (line 447) の実装を参考にする。
+
+**Step 3: Unit tests を追加**
+
+`column_css.rs` の既存 `#[cfg(test)] mod tests` ブロック末尾に追加:
+
+```rust
+#[test]
+fn parse_break_inside_avoid_inline() {
+    let props = parse_declaration_block("break-inside: avoid;");
+    assert_eq!(props.break_inside, Some(crate::pageable::BreakInside::Avoid));
+}
+
+#[test]
+fn parse_break_inside_avoid_page_and_column_collapse_to_avoid() {
+    let p1 = parse_declaration_block("break-inside: avoid-page;");
+    let p2 = parse_declaration_block("break-inside: avoid-column;");
+    assert_eq!(p1.break_inside, Some(crate::pageable::BreakInside::Avoid));
+    assert_eq!(p2.break_inside, Some(crate::pageable::BreakInside::Avoid));
+}
+
+#[test]
+fn parse_break_inside_auto_is_auto_variant() {
+    let props = parse_declaration_block("break-inside: auto;");
+    assert_eq!(props.break_inside, Some(crate::pageable::BreakInside::Auto));
+}
+
+#[test]
+fn parse_break_inside_invalid_value_is_silently_dropped() {
+    let props = parse_declaration_block("break-inside: banana;");
+    assert_eq!(props.break_inside, None);
+}
+
+#[test]
+fn parse_break_inside_via_selector() {
+    let rules = parse_stylesheet(".keep { break-inside: avoid; }");
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0].props.break_inside, Some(crate::pageable::BreakInside::Avoid));
+}
+```
+
+**Step 4: Run unit tests**
+
+Run: `cargo test -p fulgur --lib column_css::`
+Expected: PASS (5 new tests + all pre-existing).
+
+**Step 5: Module doc を更新**
+
+`crates/fulgur/src/column_css.rs:9` の「extend this module with `break-inside` — deliberately out of scope here」を「`break-inside` is handled here as of fulgur-ftp」に差し替え。
+
+**Step 6: Commit**
+
+```bash
+git add crates/fulgur/src/column_css.rs crates/fulgur/tests/break_inside_avoid.rs
+git commit -m "feat(fulgur-ftp): parse break-inside in column_css"
+```
+
+---
+
+### Task 3: convert.rs 配線 — 全 BlockPageable サイトに `.with_pagination(...)`
+
+**Files:**
+
+- Modify: `crates/fulgur/src/convert.rs`
+
+**Step 1: ヘルパー関数を追加**
+
+`crates/fulgur/src/convert.rs` の既存ヘルパー（`extract_block_id` 近辺）の隣に追加:
+
+```rust
+fn extract_pagination_from_column_css(
+    ctx: &ConvertContext,
+    node: &blitz_dom::Node,
+) -> crate::pageable::Pagination {
+    use crate::pageable::{BreakInside, Pagination};
+    let props = ctx.column_styles.get(&node.id).copied().unwrap_or_default();
+    Pagination {
+        break_inside: props.break_inside.unwrap_or(BreakInside::Auto),
+        ..Pagination::default()
+    }
+}
+```
+
+> **Note:** `ConvertContext` の正確な借用方法、`blitz_dom::Node` の正確な型は既存の `extract_*` ヘルパー（例: `extract_block_id`、`has_column_span_all`）と同じスタイルで揃える。
+
+**Step 2: 全 12 サイトに `.with_pagination(...)` を挿入**
+
+grep で全サイトを列挙:
+
+```bash
+grep -n "BlockPageable::with_positioned_children" crates/fulgur/src/convert.rs
+```
+
+想定サイト（現在の tree）: lines 498, 543, 566, 584, 791, 847, 978, 1028, 1057, 1087, 1270（加えて `BlockPageable::new` サイトがあれば同様に処理）
+
+各サイトで builder chain に `.with_pagination(extract_pagination_from_column_css(ctx, node))` を挿入:
+
+```rust
+// Before
+let mut block = BlockPageable::with_positioned_children(children)
+    .with_style(style)
+    .with_visible(visible)
+    .with_id(extract_block_id(node));
+
+// After
+let mut block = BlockPageable::with_positioned_children(children)
+    .with_pagination(extract_pagination_from_column_css(ctx, node))
+    .with_style(style)
+    .with_visible(visible)
+    .with_id(extract_block_id(node));
+```
+
+> **Note:** サイトによって `ctx` / `node` のスコープ名が違う可能性あり (`cx`, `parent_node` など)。まわりの `extract_block_id(node)` と同じ引数を渡せば基本的には OK。もし `node` binding がないサイトがあれば、直近の caller から渡す — ヘルパー追加ではなく inline で。
+
+**Step 3: Run Task 1's integration probe**
+
+Run: `cargo test -p fulgur --test break_inside_avoid`
+Expected: PASS — `avoid_block_straddling_boundary_promotes_to_next_page` が2ページ生成する。
+
+**Step 4: 全 fulgur スイート**
+
+Run: `cargo test -p fulgur`
+Expected: PASS — 既存テストも green を維持（`BreakInside::Auto` のデフォルトで `Pagination::default()` と完全一致）。
+
+**Step 5: Commit**
+
+```bash
+git add crates/fulgur/src/convert.rs
+git commit -m "feat(fulgur-ftp): wire break-inside through convert.rs"
+```
+
+---
+
+### Task 4: Oversized-avoid の failing test
+
+**Files:**
+
+- Modify: `crates/fulgur/tests/break_inside_avoid.rs`
+
+**Step 1: テストを追記**
+
+```rust
+/// 1ページより大きい avoid block は無限ループせず通常 split へ fallback。
+#[test]
+fn avoid_block_taller_than_page_falls_back_to_split() {
+    let html = r#"<!doctype html><html><head><style>
+        @page { size: 200pt 200pt; margin: 0; }
+        body { margin: 0; }
+        .huge { height: 500pt; background: #036; break-inside: avoid; }
+    </style></head><body>
+      <div class="huge"></div>
+    </body></html>"#;
+    let engine = Engine::builder()
+        .page_size(PageSize::custom_pt(200.0, 200.0))
+        .build();
+    let pdf = engine.render_html(html).expect("render");
+    assert!(
+        page_count(&pdf) >= 2,
+        "expected oversized avoid block to still paginate, got {} pages",
+        page_count(&pdf)
+    );
+}
+```
+
+**Step 2: Run — Failure mode を確認**
+
+Run: `cargo test -p fulgur --test break_inside_avoid avoid_block_taller_than_page -- --nocapture`
+Expected: FAIL（1 ページで silent overflow、または paginate の Err(unsplit) パスで single-page として押し込まれる）。
+
+**Step 3: Do not commit.** Task 5 の acceptance check。
+
+---
+
+### Task 5: oversized-avoid fallback 実装
+
+**Files:**
+
+- Modify: `crates/fulgur/src/pageable.rs`
+
+**Step 1: `BlockPageable` に `page_height` フィールドを追加**
+
+`pageable.rs:796` の struct に追加:
+
+```rust
+pub struct BlockPageable {
+    // ... existing fields ...
+    /// 最後の `wrap()` で受け取った `avail_height`。`find_split_point` で
+    /// 「block 自体がどのページにも収まらない」ことを検出し、
+    /// `break-inside: avoid` を無視して通常 split へ fall back するのに使う。
+    page_height: Pt,
+}
+```
+
+すべての constructor (`new`, `with_positioned_children`, `..Self` literal) で `page_height: 0.0` を初期化。
+
+**Step 2: `wrap()` で `page_height` を記録**
+
+`impl Pageable for BlockPageable { fn wrap(...)` (line 1528) の `_avail_height` を `avail_height` に戻し、body 冒頭で記録:
+
+```rust
+fn wrap(&mut self, avail_width: Pt, avail_height: Pt) -> Size {
+    self.page_height = avail_height;
+    // ... existing body ...
+}
+```
+
+**Step 3: `find_split_point` の guard を差し替え**
+
+`pageable.rs:880` 付近:
+
+```rust
+// Before
+if self.pagination.break_inside == BreakInside::Avoid {
+    return SplitDecision::NoSplit;
+}
+
+// After
+if self.pagination.break_inside == BreakInside::Avoid {
+    let total_height = self.cached_size.map(|s| s.height).unwrap_or(0.0);
+    // page_height == 0.0 means wrap() was never called with a real page
+    // budget (defensive) — treat as "honour avoid, no fallback available".
+    if self.page_height <= 0.0 || total_height <= self.page_height {
+        return SplitDecision::NoSplit;
+    }
+    // Fall through to normal splitting logic.
+}
+```
+
+**Step 4: 両 integration test を run**
+
+Run: `cargo test -p fulgur --test break_inside_avoid`
+Expected: 2 tests PASS (`avoid_block_straddling_boundary_promotes_to_next_page` と `avoid_block_taller_than_page_falls_back_to_split`)。
+
+**Step 5: 全 fulgur スイート**
+
+Run: `cargo test -p fulgur`
+Expected: 全 green。既存の `test_break_inside_avoid` (pageable.rs:3374 付近) が既に `block.wrap(200, 1000)` を呼んでいるので fallback invariant は保たれる。もし regress したら `block.wrap(...)` を追加。
+
+**Step 6: Commit**
+
+```bash
+git add crates/fulgur/src/pageable.rs crates/fulgur/tests/break_inside_avoid.rs
+git commit -m "feat(fulgur-ftp): fall back to split when avoid block exceeds page"
+```
+
+---
+
+### Task 6: multicol ColumnGroup 内の avoid-child regression test
+
+**Files:**
+
+- Modify: `crates/fulgur/tests/break_inside_avoid.rs`
+
+**Step 1: テストを追記**
+
+```rust
+/// ColumnGroup 内の avoid-child は `distribute` の whole placement で
+/// 自動保護される。この挙動を regression-proof する。
+#[test]
+fn avoid_child_inside_multicol_fits_whole_column() {
+    let html = r#"<!doctype html><html><head><style>
+        @page { size: 300pt 400pt; margin: 10pt; }
+        .mc { column-count: 2; column-gap: 10pt; }
+        .block { height: 120pt; margin-bottom: 10pt; background: #ddd; }
+        .keep { break-inside: avoid; }
+    </style></head><body>
+      <div class="mc">
+        <div class="block"></div>
+        <div class="block keep"></div>
+        <div class="block"></div>
+        <div class="block keep"></div>
+      </div>
+    </body></html>"#;
+    let engine = Engine::builder()
+        .page_size(PageSize::custom_pt(300.0, 400.0))
+        .build();
+    let pdf = engine.render_html(html).expect("render");
+    assert!(page_count(&pdf) >= 1);
+    assert!(page_count(&pdf) <= 2);
+    assert!(pdf.len() > 500, "PDF looks truncated");
+}
+```
+
+**Step 2: Run**
+
+Run: `cargo test -p fulgur --test break_inside_avoid avoid_child_inside_multicol`
+Expected: PASS（コード変更不要 — 現在の挙動を lock in するテスト）。
+
+**Step 3: Commit**
+
+```bash
+git add crates/fulgur/tests/break_inside_avoid.rs
+git commit -m "test(fulgur-ftp): lock in break-inside: avoid in multicol"
+```
+
+---
+
+### Task 7: blitz_adapter の extract_column_style_table テストに break-inside ケースを追加
+
+**Files:**
+
+- Modify: `crates/fulgur/src/blitz_adapter.rs`
+
+**Step 1: 既存 `extract_column_style_table` test (line 2580 付近) の隣に追加**
+
+`column_css.rs` の parser 単体は Task 2 でテスト済み。ここでは blitz 統合経由で node.id にマップされることを保証:
+
+```rust
+#[test]
+fn extract_column_style_table_populates_break_inside() {
+    let html = r#"<!doctype html><html><head><style>
+        .k { break-inside: avoid; }
+    </style></head><body>
+      <div class="k" id="k"></div>
+    </body></html>"#;
+    let mut doc = parse(html).expect("parse");
+    resolve(&mut doc, None);
+    let table = extract_column_style_table(&doc);
+
+    let keep_id = doc
+        .tree()
+        .iter()
+        .find(|n| n.attr(local_name!("id")) == Some("k"))
+        .expect("keep node")
+        .id;
+    let props = table.get(&keep_id).copied().unwrap_or_default();
+    assert_eq!(props.break_inside, Some(crate::pageable::BreakInside::Avoid));
+}
+```
+
+> **Note:** 周辺の test の parse/resolve 呼び方と揃える（line 2580 の既存 test を参考）。`doc.tree().iter().find(...)` の API が異なれば置換。
+
+**Step 2: Run**
+
+Run: `cargo test -p fulgur --lib blitz_adapter::tests::extract_column_style_table_populates_break_inside`
+Expected: PASS。
+
+**Step 3: Commit**
+
+```bash
+git add crates/fulgur/src/blitz_adapter.rs
+git commit -m "test(fulgur-ftp): break-inside roundtrip via extract_column_style_table"
+```
+
+---
+
+### Task 8: Lint, format, final verification
+
+**Files:** none (verification only)
+
+**Step 1: Clippy**
+
+Run: `cargo clippy --workspace --all-targets -- -D warnings 2>&1 | tail -40`
+Expected: No warnings.
+
+**Step 2: Formatting**
+
+Run: `cargo fmt --check`
+Expected: Clean。汚れていれば `cargo fmt` → `git diff` 確認。
+
+**Step 3: 全 workspace テスト**
+
+Run: `cargo test`
+Expected: fulgur / fulgur-cli / fulgur-vrt すべて green。
+
+**Step 4: Markdown lint**
+
+Run: `npx markdownlint-cli2 'docs/plans/2026-04-21-fulgur-ftp-break-inside-avoid.md'`
+Expected: No errors。
+
+**Step 5: Final commit（fmt / clippy が動かしたもの）**
+
+```bash
+git add -u
+git commit -m "chore(fulgur-ftp): clippy + fmt polish"
+```
+
+---
+
+## Out of scope for this PR
+
+- **`break-before` / `break-after` 配線** — `fulgur-4zje` で別途起票済み。本 PR のヘルパー `extract_pagination_from_column_css` を拡張する形で実装される。
+- **`avoid-page` vs `avoid-column` 軸分離** — Phase B。現在は collapse。
+- **Cross-page ColumnGroup pagination** — `fulgur-6q5` / `fulgur-wfd` でカバー済み。
+- **External `<link rel=stylesheet>` harvesting** — `fulgur-s5ro` でカバー済み。
+
+## Acceptance checklist
+
+- [ ] `cargo test -p fulgur --test break_inside_avoid` — 3 tests pass
+- [ ] `cargo test -p fulgur` — 全スイート green（既存 regression なし）
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean
+- [ ] `cargo fmt --check` — clean
+- [ ] `column_css.rs` のモジュールコメントが「`break-inside` is handled here」に更新されている
+- [ ] `bd close fulgur-ftp` — worktree merge 後

--- a/docs/plans/2026-04-21-fulgur-ftp-break-inside-avoid.md
+++ b/docs/plans/2026-04-21-fulgur-ftp-break-inside-avoid.md
@@ -449,22 +449,17 @@ fn extract_column_style_table_populates_break_inside() {
     </style></head><body>
       <div class="k" id="k"></div>
     </body></html>"#;
-    let mut doc = parse(html).expect("parse");
-    resolve(&mut doc, None);
+    let mut doc = parse(html, 400.0, &[]);
+    resolve(&mut doc);
+    use std::ops::Deref;
+    let keep_id = find_element_by_attr_id(doc.deref(), "k");
     let table = extract_column_style_table(&doc);
-
-    let keep_id = doc
-        .tree()
-        .iter()
-        .find(|n| n.attr(local_name!("id")) == Some("k"))
-        .expect("keep node")
-        .id;
-    let props = table.get(&keep_id).copied().unwrap_or_default();
+    let props = table.get(&keep_id).expect("keep node in table");
     assert_eq!(props.break_inside, Some(crate::pageable::BreakInside::Avoid));
 }
 ```
 
-> **Note:** 周辺の test の parse/resolve 呼び方と揃える（line 2580 の既存 test を参考）。`doc.tree().iter().find(...)` の API が異なれば置換。
+> **Note:** 周辺の test の parse/resolve 呼び方と揃える（line 2580 の既存 test を参考）。`find_element_by_attr_id(doc.deref(), "k")` は sibling test (`extract_column_style_table_picks_up_inline_and_stylesheet`) と同じ helper パターン。
 
 **Step 2: Run**
 
@@ -501,7 +496,7 @@ Expected: fulgur / fulgur-cli / fulgur-vrt すべて green。
 
 **Step 4: Markdown lint**
 
-Run: `npx markdownlint-cli2 'docs/plans/2026-04-21-fulgur-ftp-break-inside-avoid.md'`
+Run: `npx markdownlint-cli2 '**/*.md'`
 Expected: No errors。
 
 **Step 5: Final commit（fmt / clippy が動かしたもの）**


### PR DESCRIPTION
## 概要

CSS `break-inside: avoid` / `avoid-page` / `avoid-column` サポートを追加。段組み/通常フロー両方で、ブロックがページ境界をまたぐ場合は次ページへ promote し、1ページに収まらない巨大な avoid ブロックは silent overflow / 無限ループを避けて通常 split にフォールバックする。

Closes fulgur-ftp (Phase A-5 of fulgur-qkg / multicol epic).

## 3層アーキテクチャ

1. **`column_css.rs` 拡張** — `ColumnStyleProps` に `break_inside: Option<BreakInside>` を追加。stylo 0.8.0 が `break-inside` を gecko engine にゲートしているため、既存の custom CSS sniffer（Phase A-4 / fulgur-v7a で導入）を流用。
2. **`convert.rs` 配線** — `extract_pagination_from_column_css(ctx, node)` ヘルパーを全 12 `BlockPageable::with_positioned_children` サイトに挿入。置換要素経路（`wrap_replaced_in_block_style` / `convert_image` / `convert_svg` / `convert_content_url`）にも `ctx` を透過させて配線完遂。
3. **`pageable.rs` oversized-avoid fallback** — `BlockPageable::page_height` 新規フィールド + `Pageable::propagate_page_height` 新 trait method (8 wrapper に forwarding)。`find_split_point` でブロックが `page_height` を超える場合のみ通常 split に fall through。`layout_size.or(cached_size)` で draw パスと一貫。

## 変更サマリー

- `crates/fulgur/src/column_css.rs` — parser 拡張 + 5 unit tests
- `crates/fulgur/src/convert.rs` — 12 サイト配線 + helper
- `crates/fulgur/src/pageable.rs` — trait method + field + fallback guard
- `crates/fulgur/src/paginate.rs` — propagate 呼び出し追加
- `crates/fulgur/src/blitz_adapter.rs` — roundtrip unit test
- `crates/fulgur/tests/break_inside_avoid.rs` — 3 integration tests
- `crates/fulgur/src/multicol_layout.rs` — `..Default::default()` 1 行（新フィールド追加の波及）

## 検証

- [x] `cargo test -p fulgur --test break_inside_avoid` — 3/3 pass
- [x] `cargo test -p fulgur` — 555 lib + 全 integration pass、regression なし
- [x] `cargo test` (workspace) — 全クレート green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] markdownlint plan doc — clean

## Plan からの deviation（コミットメッセージに記録済み）

1. `cached_size` → `layout_size.or(cached_size)`: 空 div の `cached_size.height == 0` 問題を避けるため、draw パスと同じ precedence に揃えた。
2. `wrap()` での `page_height` 記録 → 新 `Pageable::propagate_page_height` trait method: `BlockPageable::wrap` が子に `avail_height=10000.0` を sizing probe として渡す都合、wrap 時記録では全子孫が 10000.0 を相続してしまうため。
3. Task 4 テストが 7×80pt row 子を持つ: 空 content-box + avoid fallback は新 `SplitDecision` variant が必要で scope 外（follow-up `fulgur-31n8` で起票済み）。

## Follow-up issues（起票済み）

- `fulgur-4zje` — `break-before` / `break-after` 配線（同じ `extract_pagination_from_column_css` ヘルパーを拡張する形で実装予定）
- `fulgur-31n8` — empty content-box + oversized avoid で `SplitDecision` 変種を導入して content-box 自体を複数ページに薄切りする機能（P3）

## Test plan

- [x] 通常フロー: avoid ブロックがページ境界をまたぐ → 次ページへ promote される
- [x] 1ページより大きい avoid ブロック → 無限ループせず通常 split にフォールバック
- [x] multicol ColumnGroup 内の avoid 子 → `distribute` の whole placement で自動保護
- [x] CSS → blitz-dom → `ColumnStyleTable` roundtrip で `break-inside` が保持される
- [x] `break-inside: avoid-page` / `avoid-column` も `Avoid` に collapse
- [x] 不正値は silently drop、既存挙動に regression なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for CSS break-inside: avoid / avoid-page / avoid-column; multi-column layouts respect avoidance.
  * Pagination now considers page height so oversized avoid-blocks fall back to normal splitting instead of hanging.

* **Tests**
  * New unit and integration tests covering parsing, selector-based rules, page promotion, oversized-avoid fallback, and multicol behavior.

* **Documentation**
  * Added an implementation plan describing behavior, tests, and acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->