### PR TITLE
fix: add registry-url to setup-node for npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,6 +233,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Download all npm artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## 概要

- `setup-node@v4` に `registry-url: 'https://registry.npmjs.org'` を追加

## 背景

v0.5.8 のリリース時に「Publish npm packages」ジョブが `ENEEDAUTH` で失敗。
`setup-node@v4` に `registry-url` が未設定のため `.npmrc` が生成されず、npm が認証情報を認識できない状態だった。

## 修正内容

`registry-url` を設定することで、npm trusted publishing（OIDC）が有効になる。
ワークフローには既に `id-token: write` が付与されており、`NPM_TOKEN` シークレットは不要。

## npmjs.com 側の作業（別途必要）

各パッケージに trusted publisher を設定する：

- Owner: `fulgur-rs`
- Repository: `fulgur`
- Workflow: `.github/workflows/release.yml`
- Environment: `release`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
