### PR TITLE
chore: speed up CI build (mold, nextest, shared cache, concurrency)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   markdownlint:
     runs-on: ubuntu-latest
@@ -37,28 +41,36 @@ jobs:
           - os: ubuntu-latest
             arch: amd64
             coverage: true
+            mold: true
           - os: ubuntu-24.04-arm
             arch: arm64
             coverage: false
+            mold: true
           - os: macos-latest
             arch: arm64
             coverage: false
+            mold: false
           - os: windows-latest
             arch: amd64
             coverage: false
+            mold: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ matrix.os }}-fulgur
       - name: Install poppler-utils (for fulgur-wpt pdftocairo tests)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y poppler-utils
+        run: sudo apt-get update && sudo apt-get install -y poppler-utils mold
+      - name: Configure mold linker
+        if: matrix.mold
+        run: echo "RUSTFLAGS=-C link-arg=-fuse-ld=mold" >> $GITHUB_ENV
       - name: Install cargo-llvm-cov
         if: matrix.coverage
         uses: taiki-e/install-action@88ada01c46e65c47040a0ae865537cc76fcd0e1c # cargo-llvm-cov
       - name: Install cargo-nextest
-        if: matrix.coverage
         uses: taiki-e/install-action@dfd6a81ff1efc1c100332d760e0c9edfe2ae0a51 # nextest
       # NOTE: fulgur-wpt integration tests (wpt_css_page, wpt_css_multicol)
       # silently skip here because target/wpt is not fetched in the coverage
@@ -69,10 +81,10 @@ jobs:
       # only reflect unit-test coverage.
       - name: Build tests
         if: ${{ !matrix.coverage }}
-        run: cargo test --workspace --exclude fulgur-vrt --no-run
+        run: cargo nextest run --workspace --exclude fulgur-vrt --no-run
       - name: Run tests
         if: ${{ !matrix.coverage }}
-        run: cargo test --workspace --exclude fulgur-vrt
+        run: cargo nextest run --workspace --exclude fulgur-vrt
       - name: Run tests with coverage
         if: matrix.coverage
         run: cargo llvm-cov nextest --workspace --exclude fulgur-vrt --profile ci --lcov --output-path lcov.info
@@ -104,9 +116,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install poppler-utils
-        run: sudo apt-get update && sudo apt-get install -y poppler-utils
+        run: sudo apt-get update && sudo apt-get install -y poppler-utils mold
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-latest-fulgur
+      - name: Configure mold linker
+        run: echo "RUSTFLAGS=-C link-arg=-fuse-ld=mold" >> $GITHUB_ENV
       - name: Run VRT
         run: cargo test -p fulgur-vrt
       - name: Upload diff artifacts on failure
@@ -149,8 +165,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-latest-fulgur
       - name: Install poppler-utils
-        run: sudo apt-get update && sudo apt-get install -y poppler-utils
+        run: sudo apt-get update && sudo apt-get install -y poppler-utils mold
+      - name: Configure mold linker
+        run: echo "RUSTFLAGS=-C link-arg=-fuse-ld=mold" >> $GITHUB_ENV
       - name: Fetch WPT subset
         run: scripts/wpt/fetch.sh
       - name: Run ${{ matrix.phase }} reftests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,10 @@ jobs:
       - name: Configure mold linker
         if: matrix.mold
         run: echo "RUSTFLAGS=-C link-arg=-fuse-ld=mold" >> $GITHUB_ENV
+      - name: Configure lld-link linker (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: echo "RUSTFLAGS=-C linker=lld-link" >> $GITHUB_ENV
       - name: Install cargo-llvm-cov
         if: matrix.coverage
         uses: taiki-e/install-action@88ada01c46e65c47040a0ae865537cc76fcd0e1c # cargo-llvm-cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,25 +42,29 @@ jobs:
             arch: amd64
             coverage: true
             mold: true
+            cache-key: ubuntu-latest-fulgur-cov
           - os: ubuntu-24.04-arm
             arch: arm64
             coverage: false
             mold: true
+            cache-key: ubuntu-24.04-arm-fulgur
           - os: macos-latest
             arch: arm64
             coverage: false
             mold: false
+            cache-key: macos-latest-fulgur
           - os: windows-latest
             arch: amd64
             coverage: false
             mold: false
+            cache-key: windows-latest-fulgur
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ${{ matrix.os }}-fulgur
+          shared-key: ${{ matrix.cache-key }}
       - name: Install poppler-utils (for fulgur-wpt pdftocairo tests)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y poppler-utils mold

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,11 @@ jobs:
         include:
           - os: ubuntu-latest
             arch: amd64
+            coverage: false
+            mold: true
+            cache-key: ubuntu-latest-fulgur
+          - os: ubuntu-latest
+            arch: amd64
             coverage: true
             mold: true
             cache-key: ubuntu-latest-fulgur-cov

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -28,6 +28,15 @@ jobs:
         with:
           toolchain: stable
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-release-fulgur
+
+      - name: Configure fast build
+        run: |
+          sudo apt-get update && sudo apt-get install -y mold
+          echo "RUSTFLAGS=-C link-arg=-fuse-ld=mold" >> $GITHUB_ENV
+
       - name: Install git-cliff
         env:
           GIT_CLIFF_VERSION: "2.7.0"

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -27,18 +27,30 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-latest
             manylinux: "2014"
+            rustflags: ""
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-24.04-arm
             manylinux: "2014"
+            rustflags: ""
           - target: x86_64-apple-darwin
             runner: macos-15-intel
+            rustflags: ""
           - target: aarch64-apple-darwin
             runner: macos-latest
+            rustflags: ""
           - target: x86_64-pc-windows-msvc
             runner: windows-latest
+            rustflags: "-C linker=lld-link"
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ matrix.target }}-python-release
+      - name: Configure linker
+        if: matrix.rustflags != ''
+        shell: bash
+        run: echo "RUSTFLAGS=${{ matrix.rustflags }}" >> $GITHUB_ENV
       - name: Build wheel
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -100,6 +100,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ matrix.platform }}-ruby-cross
       # oxidize-rb/actions/cross-gem@v1 は `gem install rb_sys` を host 上で
       # 直接実行するので、user-writable な gem directory を持つ Ruby が必要。
       # 事前に ruby/setup-ruby で runner owned の Ruby を入れておく。

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,15 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-publish-fulgur
+
+      - name: Configure fast build
+        run: |
+          sudo apt-get update && sudo apt-get install -y mold
+          echo "RUSTFLAGS=-C link-arg=-fuse-ld=mold" >> $GITHUB_ENV
+
       - name: Extract version from branch name
         id: version
         env:
@@ -109,21 +118,33 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             archive: tar.gz
+            rustflags: "-C link-arg=-fuse-ld=mold"
+            install-mold: true
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             archive: tar.gz
+            rustflags: ""
+            install-mold: false
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
             archive: tar.gz
+            rustflags: "-C link-arg=-fuse-ld=mold"
+            install-mold: true
           - target: aarch64-apple-darwin
             os: macos-latest
             archive: tar.gz
+            rustflags: ""
+            install-mold: false
           - target: x86_64-apple-darwin
             os: macos-latest
             archive: tar.gz
+            rustflags: ""
+            install-mold: false
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             archive: zip
+            rustflags: "-C linker=lld-link"
+            install-mold: false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -132,6 +153,19 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ matrix.target }}-release
+
+      - name: Install mold
+        if: matrix.install-mold
+        run: sudo apt-get update && sudo apt-get install -y mold
+
+      - name: Configure linker
+        if: matrix.rustflags != ''
+        shell: bash
+        run: echo "RUSTFLAGS=${{ matrix.rustflags }}" >> $GITHUB_ENV
 
       - name: Install musl-tools
         if: matrix.target == 'x86_64-unknown-linux-musl'

--- a/.github/workflows/update-examples.yml
+++ b/.github/workflows/update-examples.yml
@@ -17,6 +17,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-release-fulgur
+      - name: Configure fast build
+        run: |
+          sudo apt-get update && sudo apt-get install -y mold
+          echo "RUSTFLAGS=-C link-arg=-fuse-ld=mold" >> $GITHUB_ENV
       - name: Build fulgur
         run: cargo build --bin fulgur --release
       - name: Regenerate example PDFs


### PR DESCRIPTION
## 概要

PR ごとのビルド時間を削減するため、CI に4つの改善を加えた。

- **concurrency グループ追加**: 同一ブランチで複数 push した際に古いビルドを自動キャンセル
- **mold リンカー導入（Linux）**: test・vrt・wpt の全 ubuntu ジョブで `RUSTFLAGS=-C link-arg=-fuse-ld=mold` を設定。リンク時間を大幅短縮（arm64 も対象）
- **nextest 全プラットフォーム対応**: カバレッジセルのみだった nextest を Windows・macOS・ARM にも適用し、テスト実行を並列化
- **Swatinem/rust-cache shared-key**: `ubuntu-latest-fulgur` キーで test・vrt・wpt が fulgur のビルド成果物を共有。VRT が test のコンパイル結果を再利用できるようになる

## 変更ファイル

- `.github/workflows/ci.yml` のみ

## 確認項目

- [ ] CI が通ること（特に mold が Linux で正常動作すること）
- [ ] nextest が Windows・macOS で正常に動作すること
- [ ] VRT が shared-key で test のキャッシュを利用できていること（2回目以降の実行で効果が出る）
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now cancels redundant workflow runs to reduce queuing.
  * Expanded and standardized cross-job build caching with per-target cache keys for better reuse.
  * Faster, more consistent builds by installing a faster linker where applicable and setting linker flags per target (including Windows).
  * Test runs use a faster test runner for non-coverage runs; coverage still uses the existing coverage tool.
  * Release and example workflows configured to use the same fast-build settings for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->