### PR TITLE
fix: use Node.js 24 (npm 11+) for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,6 +245,7 @@ jobs:
       - name: Publish platform packages
         env:
           VERSION: ${{ needs.publish.outputs.version }}
+          NODE_AUTH_TOKEN: ""
         run: |
           set -e
           declare -A TARGET_TO_DIR=(
@@ -282,6 +283,7 @@ jobs:
       - name: Publish meta package
         env:
           VERSION: ${{ needs.publish.outputs.version }}
+          NODE_AUTH_TOKEN: ""
         run: |
           cd packages/npm/meta
           node -e "

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,7 +233,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
+
+      - name: Update npm and configure registry
+        run: |
+          npm install -g npm@latest
+          npm config set registry https://registry.npmjs.org/
 
       - name: Download all npm artifacts
         uses: actions/download-artifact@v4
@@ -245,7 +249,6 @@ jobs:
       - name: Publish platform packages
         env:
           VERSION: ${{ needs.publish.outputs.version }}
-          NODE_AUTH_TOKEN: ""
         run: |
           set -e
           declare -A TARGET_TO_DIR=(
@@ -283,7 +286,6 @@ jobs:
       - name: Publish meta package
         env:
           VERSION: ${{ needs.publish.outputs.version }}
-          NODE_AUTH_TOKEN: ""
         run: |
           cd packages/npm/meta
           node -e "

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,14 +230,10 @@ jobs:
         with:
           ref: "v${{ needs.publish.outputs.version }}"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
-
-      - name: Update npm and configure registry
-        run: |
-          npm install -g npm@latest
-          npm config set registry https://registry.npmjs.org/
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Download all npm artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## 概要

npm publish ジョブの Node.js/setup-node を更新し、OIDC trusted publishing が確実に動作するようにする。

- `actions/setup-node@v4` → `@v6`
- Node.js `20` → `24`（npm 11+ 同梱）

## 背景

v0.5.8〜v0.5.11 のリリースで `Publish npm packages` ジョブが連続失敗していた。

調査の経緯：

1. **v0.5.8**: `ENEEDAUTH` → `setup-node` に `registry-url` が未設定で `.npmrc` が生成されていなかった → #150 で修正
2. **v0.5.9〜v0.5.11**: `E404 Not Found - PUT ... - Not found` + `NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX`
   - npmjs.com の org/teams/trusted publisher を順次整備しても解消せず
   - ログの `XXXXX-XXXXX-XXXXX-XXXXX` は GitHub Actions のマスクではなく、`setup-node` が token 未指定時に自動挿入するプレースホルダー値（[`authutil.ts` L54-L58](https://github.com/actions/setup-node/blob/main/src/authutil.ts#L54-L58)）と判明

## 根本原因

- Node.js 20 同梱の npm（10.x）は OIDC trusted publishing を完全にはサポートしていない
- npm 10.x は `.npmrc` の `_authToken=<プレースホルダー>` をそのまま送り、OIDC にフォールバックしないため registry が 404 を返す
- npm 11.5.1+（Node.js 24 同梱）は OIDC 環境（`ACTIONS_ID_TOKEN_REQUEST_URL`）を自動検出し、プレースホルダー token があっても OIDC を優先する

[`actions/setup-node#1440`](https://github.com/actions/setup-node/issues/1440) のコメントでも、Node.js 24 にするだけで解決した事例が多数報告されている。

## 修正内容

```yaml
- uses: actions/setup-node@v6
  with:
    node-version: '24'
    registry-url: 'https://registry.npmjs.org'
```

- `registry-url` は維持（npm 11+ ではプレースホルダーがあっても OIDC が優先されるため問題なし）
- `NODE_AUTH_TOKEN` を触る workaround は不要

## 前提（npmjs.com 側の設定、既に完了）

- `@fulgur-rs` org に 7 パッケージ所属
- 全パッケージに trusted publisher を設定（Owner: `fulgur-rs`、Repository: `fulgur`、Workflow: `release.yml`、Environment: `release`）
- CI トークン（`NPM_TOKEN`）は不要