### PR TITLE
docs: add npx installation as primary option for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,27 @@ Built in Rust for server-side workloads where memory footprint and startup time 
 
 ## Installation
 
+Run directly with `npx` (no install needed):
+
+```bash
+npx @fulgur-rs/cli render -o output.pdf input.html
+```
+
+Or install globally via npm:
+
+```bash
+npm install -g @fulgur-rs/cli
+fulgur render -o output.pdf input.html
+```
+
+Or via Cargo:
+
+```bash
+cargo install fulgur-cli
+```
+
+From source:
+
 ```bash
 cargo install --path crates/fulgur-cli
 ```

--- a/website/docs/index.en.md
+++ b/website/docs/index.en.md
@@ -24,6 +24,21 @@ Seal the output your AI agent generates into authoritative, permanent documents.
 
 === "CLI"
 
+    No install needed — run directly with `npx`:
+
+    ```bash
+    npx @fulgur-rs/cli render input.html -o output.pdf
+    ```
+
+    Or install globally:
+
+    ```bash
+    npm install -g @fulgur-rs/cli
+    fulgur render input.html -o output.pdf
+    ```
+
+    For Rust users:
+
     ```bash
     cargo install fulgur-cli
     fulgur render input.html -o output.pdf

--- a/website/docs/index.ja.md
+++ b/website/docs/index.ja.md
@@ -30,7 +30,7 @@ AIエージェントが生成した出力を、美しく永続的な文書とし
     npx @fulgur-rs/cli render input.html -o output.pdf
     ```
 
-    ローカルインストールする場合:
+    グローバルインストールする場合:
 
     ```bash
     npm install -g @fulgur-rs/cli

--- a/website/docs/index.ja.md
+++ b/website/docs/index.ja.md
@@ -24,6 +24,21 @@ AIエージェントが生成した出力を、美しく永続的な文書とし
 
 === "CLI"
 
+    インストール不要。`npx` でそのまま実行:
+
+    ```bash
+    npx @fulgur-rs/cli render input.html -o output.pdf
+    ```
+
+    ローカルインストールする場合:
+
+    ```bash
+    npm install -g @fulgur-rs/cli
+    fulgur render input.html -o output.pdf
+    ```
+
+    Rust ユーザー向け:
+
     ```bash
     cargo install fulgur-cli
     fulgur render input.html -o output.pdf


### PR DESCRIPTION
## 概要

`@fulgur-rs/cli` が npm で公開されたので、README と website のクイックスタートに npx 実行例を追加する。

## 変更点

### README.md
Installation セクションを拡充：

1. `npx @fulgur-rs/cli ...`（インストール不要、プライマリ）
2. `npm install -g @fulgur-rs/cli`
3. `cargo install fulgur-cli`
4. `cargo install --path crates/fulgur-cli`（ソースから）

### website/docs/index.{ja,en}.md
Quick Start の CLI タブで npx をプライマリとして先頭に配置。`npm install -g` と `cargo install` も併記。

## 狙い

- **ゼロインストール導線**: 試すだけなら `npx @fulgur-rs/cli` でワンショット実行できる
- **CI との親和性**: Node.js が既に入っている環境なら追加セットアップ不要
- **Rust 非ユーザー層への開放**: cargo install を前提にしない
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded CLI installation documentation with new setup methods: direct execution via npx without installation, global npm package installation, and existing Cargo options. Updated across English and Japanese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->