### PR TITLE
docs(npm): add README for @fulgur-rs/cli meta and platform packages

### DIFF
--- a/packages/npm/darwin-arm64/README.md
+++ b/packages/npm/darwin-arm64/README.md
@@ -1,0 +1,20 @@
+# @fulgur-rs/cli-darwin-arm64
+
+Platform-specific binary for [`@fulgur-rs/cli`](https://www.npmjs.com/package/@fulgur-rs/cli)
+on macOS arm64 (Apple Silicon).
+
+This package is installed automatically as an optional dependency of the meta
+package. **Do not install it directly.** Install the meta package instead:
+
+```bash
+npm i -g @fulgur-rs/cli
+```
+
+See the [meta package README](https://www.npmjs.com/package/@fulgur-rs/cli) for
+usage and documentation.
+
+## License
+
+Dual-licensed under [MIT](https://github.com/fulgur-rs/fulgur/blob/main/LICENSE-MIT)
+or [Apache-2.0](https://github.com/fulgur-rs/fulgur/blob/main/LICENSE-APACHE)
+at your option.

--- a/packages/npm/darwin-x64/README.md
+++ b/packages/npm/darwin-x64/README.md
@@ -1,0 +1,20 @@
+# @fulgur-rs/cli-darwin-x64
+
+Platform-specific binary for [`@fulgur-rs/cli`](https://www.npmjs.com/package/@fulgur-rs/cli)
+on macOS x64 (Intel).
+
+This package is installed automatically as an optional dependency of the meta
+package. **Do not install it directly.** Install the meta package instead:
+
+```bash
+npm i -g @fulgur-rs/cli
+```
+
+See the [meta package README](https://www.npmjs.com/package/@fulgur-rs/cli) for
+usage and documentation.
+
+## License
+
+Dual-licensed under [MIT](https://github.com/fulgur-rs/fulgur/blob/main/LICENSE-MIT)
+or [Apache-2.0](https://github.com/fulgur-rs/fulgur/blob/main/LICENSE-APACHE)
+at your option.

--- a/packages/npm/linux-arm64/README.md
+++ b/packages/npm/linux-arm64/README.md
@@ -1,0 +1,20 @@
+# @fulgur-rs/cli-linux-arm64
+
+Platform-specific binary for [`@fulgur-rs/cli`](https://www.npmjs.com/package/@fulgur-rs/cli)
+on Linux arm64.
+
+This package is installed automatically as an optional dependency of the meta
+package. **Do not install it directly.** Install the meta package instead:
+
+```bash
+npm i -g @fulgur-rs/cli
+```
+
+See the [meta package README](https://www.npmjs.com/package/@fulgur-rs/cli) for
+usage and documentation.
+
+## License
+
+Dual-licensed under [MIT](https://github.com/fulgur-rs/fulgur/blob/main/LICENSE-MIT)
+or [Apache-2.0](https://github.com/fulgur-rs/fulgur/blob/main/LICENSE-APACHE)
+at your option.

--- a/packages/npm/linux-x64-musl/README.md
+++ b/packages/npm/linux-x64-musl/README.md
@@ -1,0 +1,20 @@
+# @fulgur-rs/cli-linux-x64-musl
+
+Platform-specific binary for [`@fulgur-rs/cli`](https://www.npmjs.com/package/@fulgur-rs/cli)
+on Linux x64 (musl / Alpine).
+
+This package is installed automatically as an optional dependency of the meta
+package. **Do not install it directly.** Install the meta package instead:
+
+```bash
+npm i -g @fulgur-rs/cli
+```
+
+See the [meta package README](https://www.npmjs.com/package/@fulgur-rs/cli) for
+usage and documentation.
+
+## License
+
+Dual-licensed under [MIT](https://github.com/fulgur-rs/fulgur/blob/main/LICENSE-MIT)
+or [Apache-2.0](https://github.com/fulgur-rs/fulgur/blob/main/LICENSE-APACHE)
+at your option.

--- a/packages/npm/linux-x64/README.md
+++ b/packages/npm/linux-x64/README.md
@@ -1,0 +1,20 @@
+# @fulgur-rs/cli-linux-x64
+
+Platform-specific binary for [`@fulgur-rs/cli`](https://www.npmjs.com/package/@fulgur-rs/cli)
+on Linux x64 (glibc).
+
+This package is installed automatically as an optional dependency of the meta
+package. **Do not install it directly.** Install the meta package instead:
+
+```bash
+npm i -g @fulgur-rs/cli
+```
+
+See the [meta package README](https://www.npmjs.com/package/@fulgur-rs/cli) for
+usage and documentation.
+
+## License
+
+Dual-licensed under [MIT](https://github.com/fulgur-rs/fulgur/blob/main/LICENSE-MIT)
+or [Apache-2.0](https://github.com/fulgur-rs/fulgur/blob/main/LICENSE-APACHE)
+at your option.

--- a/packages/npm/meta/README.md
+++ b/packages/npm/meta/README.md
@@ -1,0 +1,196 @@
+# fulgur
+
+[![npm version](https://img.shields.io/npm/v/%40fulgur-rs%2Fcli.svg)](https://www.npmjs.com/package/@fulgur-rs/cli)
+[![License](https://img.shields.io/npm/l/%40fulgur-rs%2Fcli.svg)](https://github.com/fulgur-rs/fulgur/blob/main/LICENSE-MIT)
+[![CI](https://github.com/fulgur-rs/fulgur/actions/workflows/ci.yml/badge.svg)](https://github.com/fulgur-rs/fulgur/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/fulgur-rs/fulgur/graph/badge.svg)](https://codecov.io/gh/fulgur-rs/fulgur)
+
+A modern, lightweight successor to wkhtmltopdf. Converts HTML/CSS to PDF without
+a browser engine. Single binary, instant cold start, deterministic output.
+
+## Why fulgur?
+
+- **No browser required.** No Chromium, no WebKit. Just a single native binary.
+- **Low memory footprint.** Designed for server-side batch generation.
+- **Deterministic output.** Identical input produces byte-identical PDFs — safe
+  for CI/CD and reproducible pipelines.
+- **Template + JSON data.** Feed an HTML template and a JSON file to generate
+  PDFs at scale. Built-in [MiniJinja](https://github.com/mitsuhiko/minijinja)
+  engine.
+- **Offline by design.** No network access. Fonts, images, and CSS must be
+  explicitly bundled.
+
+## Install
+
+```bash
+# Global install
+npm i -g @fulgur-rs/cli
+
+# Or run ad-hoc without installing
+npx @fulgur-rs/cli render input.html -o output.pdf
+```
+
+## Quick start
+
+```bash
+fulgur render input.html -o output.pdf
+```
+
+## Commands
+
+- [`fulgur render`](#fulgur-render) — convert HTML/CSS to PDF
+- [`fulgur template schema`](#fulgur-template-schema) — extract JSON Schema from
+  a template (for AI-driven data generation)
+
+### `fulgur render`
+
+Render an HTML document (optionally a MiniJinja template with `--data`) to PDF.
+
+```bash
+# Basic
+fulgur render input.html -o output.pdf
+
+# Read HTML from stdin, write PDF to stdout
+cat input.html | fulgur render --stdin -o -
+
+# Page size and margins
+fulgur render input.html -o output.pdf --size A4 --landscape --margin "20 30"
+
+# Bundle fonts, CSS, and images
+fulgur render input.html -o output.pdf \
+  -f fonts/NotoSansJP.ttf \
+  --css style.css \
+  -i logo.png=assets/logo.png
+
+# PDF metadata and bookmarks
+fulgur render input.html -o output.pdf \
+  --title "Quarterly Report" \
+  --author "Acme Corp" \
+  --language en \
+  --bookmarks
+
+# Template + JSON data
+fulgur render template.html -o invoice.pdf -d data.json
+```
+
+| Option | Description |
+|---|---|
+| `-o, --output <PATH>` | Output PDF path (required; use `-` for stdout) |
+| `--stdin` | Read HTML from stdin |
+| `-s, --size <SIZE>` | Page size: `A4`, `Letter`, `A3` (default: `A4`) |
+| `-l, --landscape` | Landscape orientation |
+| `--margin <SPEC>` | Margins in mm (CSS shorthand: `"20"`, `"20 30"`, `"10 20 30"`, `"10 20 30 40"`) |
+| `-f, --font <FILE>` | Font file to bundle (repeatable; TTF / OTF / TTC / WOFF2) |
+| `--css <FILE>` | External CSS file (repeatable) |
+| `-i, --image <NAME=PATH>` | Image file to bundle (repeatable) |
+| `-d, --data <FILE>` | JSON data for template rendering (use `-` for stdin) |
+| `--bookmarks` | Generate PDF bookmarks from `h1`–`h6` |
+| `--title`, `--author`, `--description`, `--keyword`, `--language`, `--creator`, `--producer`, `--creation-date` | PDF metadata |
+
+### `fulgur template schema`
+
+Extract a JSON Schema from a MiniJinja HTML template. The CLI analyzes template
+syntax to infer variable names and types; with `--data`, it uses a sample JSON
+file for more precise inference.
+
+```bash
+# Infer schema from template syntax alone
+fulgur template schema template.html -o schema.json
+
+# Sharpen inference with a sample data file
+fulgur template schema template.html -d sample.json -o schema.json
+```
+
+This is primarily intended for AI agents and tooling that need to know the
+shape of the JSON data a template expects — see [Template engine](#template-engine)
+below.
+
+## Template engine
+
+fulgur ships with [MiniJinja](https://github.com/mitsuhiko/minijinja). Supply an
+HTML template and a JSON data file to `fulgur render -d`, and the template is
+expanded before rendering.
+
+`template.html`:
+
+```html
+<h1>Invoice #{{ invoice_number }}</h1>
+<p>Bill to: {{ customer.name }}</p>
+<table>
+  <thead><tr><th>Item</th><th>Price</th></tr></thead>
+  <tbody>
+    {% for item in items %}
+    <tr><td>{{ item.name }}</td><td>{{ item.price }}</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+<p>Total: {{ items | map(attribute="price") | sum }}</p>
+```
+
+`data.json`:
+
+```json
+{
+  "invoice_number": "2026-001",
+  "customer": { "name": "Acme Corp" },
+  "items": [
+    { "name": "Widget", "price": 10 },
+    { "name": "Gadget", "price": 25 }
+  ]
+}
+```
+
+```bash
+fulgur render template.html -o invoice.pdf -d data.json
+```
+
+### Designer + agent workflow
+
+The template / data split is a deliberate separation of concerns that works
+well for AI-agent-driven document generation:
+
+- **Humans (or designers) author the template.** They control layout,
+  typography, and branding in familiar HTML/CSS.
+- **AI agents produce the data.** Given a JSON Schema — which
+  `fulgur template schema` can extract directly from the template — an agent
+  can populate the structured payload without touching the presentation layer.
+
+The result: agents never produce malformed HTML, and designers never need to
+review generated markup. Each side stays on its own contract.
+
+## Supported platforms
+
+| OS | Arch | Package |
+|---|---|---|
+| Linux (glibc) | x64 | `@fulgur-rs/cli-linux-x64` |
+| Linux (musl / Alpine) | x64 | `@fulgur-rs/cli-linux-x64-musl` |
+| Linux | arm64 | `@fulgur-rs/cli-linux-arm64` |
+| macOS | arm64 (Apple Silicon) | `@fulgur-rs/cli-darwin-arm64` |
+| macOS | x64 (Intel) | `@fulgur-rs/cli-darwin-x64` |
+| Windows | x64 | `@fulgur-rs/cli-win32-x64` |
+
+## How it works (distribution)
+
+`@fulgur-rs/cli` is a thin meta package. The actual native binary lives in one
+of the `@fulgur-rs/cli-<platform>` packages above, all declared as
+[`optionalDependencies`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#optionaldependencies).
+npm only installs the one that matches the current `os` / `cpu` / libc, so
+there is no per-platform bloat and no cross-compilation at install time.
+
+A small `postinstall` script copies the platform binary into the meta
+package's `bin/` directory so `fulgur` becomes available on the `PATH`. If you
+install with `--ignore-optional` or on an unsupported platform, the script
+exits with a clear error message.
+
+## Links
+
+- [GitHub repository](https://github.com/fulgur-rs/fulgur)
+- [Issue tracker](https://github.com/fulgur-rs/fulgur/issues)
+- [Full documentation (README)](https://github.com/fulgur-rs/fulgur#readme)
+- [CSS property support reference](https://github.com/fulgur-rs/fulgur/blob/main/docs/css-support.md)
+
+## License
+
+Dual-licensed under either of [MIT](https://github.com/fulgur-rs/fulgur/blob/main/LICENSE-MIT)
+or [Apache-2.0](https://github.com/fulgur-rs/fulgur/blob/main/LICENSE-APACHE)
+at your option.

--- a/packages/npm/win32-x64/README.md
+++ b/packages/npm/win32-x64/README.md
@@ -1,0 +1,20 @@
+# @fulgur-rs/cli-win32-x64
+
+Platform-specific binary for [`@fulgur-rs/cli`](https://www.npmjs.com/package/@fulgur-rs/cli)
+on Windows x64.
+
+This package is installed automatically as an optional dependency of the meta
+package. **Do not install it directly.** Install the meta package instead:
+
+```bash
+npm i -g @fulgur-rs/cli
+```
+
+See the [meta package README](https://www.npmjs.com/package/@fulgur-rs/cli) for
+usage and documentation.
+
+## License
+
+Dual-licensed under [MIT](https://github.com/fulgur-rs/fulgur/blob/main/LICENSE-MIT)
+or [Apache-2.0](https://github.com/fulgur-rs/fulgur/blob/main/LICENSE-APACHE)
+at your option.


### PR DESCRIPTION
## 概要

npm 配布パッケージ (`@fulgur-rs/cli` および各プラットフォーム別 `@fulgur-rs/cli-*`) に README を追加。現状 npmjs.com のパッケージページに何も表示されない状態を解消する。

## 変更内容

### `packages/npm/meta/README.md`（メインの README）

- **Hero**: npm version / license / CI / codecov バッジ、wkhtmltopdf 後継としての positioning（ブラウザエンジン不要、低メモリ、deterministic、offline-first）
- **Install / Quick start**: `npm i -g @fulgur-rs/cli` と `npx` 両パターン
- **Commands**: サブコマンドを一通り
  - `fulgur render`: 主要フラグ表 + 実用サンプル（page options、fonts/css/images、metadata、bookmarks、stdin/stdout、template + data）
  - `fulgur template schema`: AI エージェント向けの schema 抽出用途を明記
- **Template engine**: MiniJinja の template + JSON data サンプル。**Designer + agent workflow** セクションで「人間=テンプレ / エージェント=データ」の関心分離を説明（AI エージェント時代の positioning を反映）
- **Supported platforms**: 6 プラットフォームの対応表
- **How it works (distribution)**: optional deps + postinstall の仕組みを解説（「なぜ platform 別パッケージ？」に先回りで答える）
- **Links / License**

### `packages/npm/<platform>/README.md`（6 本の stub）

`linux-x64`, `linux-x64-musl`, `linux-arm64`, `darwin-x64`, `darwin-arm64`, `win32-x64` の全サブパッケージに共通の短い README を配置。「これは platform-specific binary なので meta パッケージをインストールしてください」と案内し、間違って直接 install されるのを抑止。

## 検証

- [x] `npx markdownlint-cli2 'packages/npm/**/README.md'` — エラーなし
- [x] `npm pack --dry-run` で各パッケージの tarball に README が含まれることを確認
  - meta: 6.9kB README 含む
  - platform: 633B README 含む

## 関連 issue

- fulgur-nhac
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive README documentation for the npm packages, including installation instructions and usage guidelines.
  * Documented CLI commands and features such as HTML/CSS-to-PDF conversion with support for page settings, metadata, bookmarks, and template data rendering.
  * Clarified platform-specific binary package details and how they integrate with the main meta package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->