### PR TITLE
ci: set default contents:read permissions on workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,13 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# Default least-privilege token scope. Jobs that need more (e.g. test's
+# id-token: write for Codecov OIDC, octocov's pull-requests: write) override
+# this with their own `permissions:` block — job-level permissions fully
+# replace the workflow-level set, they do not merge.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/vrt-chrome-update.yml
+++ b/.github/workflows/vrt-chrome-update.yml
@@ -19,6 +19,9 @@ name: VRT Chrome Golden Update
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   chrome-goldens:
     name: Regenerate Chromium goldens


### PR DESCRIPTION
## Summary

GitHub Code Scanning（CodeQL）が `actions/missing-workflow-permissions`（severity: medium）を 5 件報告していたので、対象の 2 つの workflow のトップレベルに最小権限の `permissions: contents: read` を追加して解消する。

| # | ファイル | 対象 job |
|---|---|---|
| 6 | `.github/workflows/ci.yml` | `markdownlint` |
| 5 | `.github/workflows/vrt-chrome-update.yml` | `chrome-goldens` |
| 4 | `.github/workflows/ci.yml` | `wpt` |
| 3 | `.github/workflows/ci.yml` | `vrt` |
| 2 | `.github/workflows/ci.yml` | `lint` |

`ci.yml` の `test` / `octocov` は既に job 単位で `id-token: write` / `pull-requests: write` を明示しており、**job 単位の `permissions:` はワークフローレベルを完全置換する**ためそのまま機能する（merge ではない）。挙動変化はなし。

他の workflow（`cla.yml`, `release*.yml`, `update-examples.yml`, `wpt-nightly.yml`）はすでにトップレベルで `permissions:` を絞っているので変更不要。

Fixes: fulgur-rs/fulgur#（GHAS code scanning alerts 2/3/4/5/6）
Closes: beads fulgur-ixgl

## Test plan

- [ ] CI（lint / test / vrt / wpt / markdownlint）が green になる
- [ ] CodeQL の再スキャンで該当 5 アラートが fixed に遷移する
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permission scopes for improved security configuration. Workflows now explicitly define minimum required permissions, with elevated permissions specified only where necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->