### PR TITLE
test(render): add coverage for parse_datetime, escape_attr, strip_display_none

### DIFF
--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -593,3 +593,188 @@ fn escape_attr(s: &str) -> String {
 fn strip_display_none(css: &str) -> String {
     css.replace("display: none", "").replace("display:none", "")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- escape_attr ---
+
+    #[test]
+    fn escape_attr_no_special_chars() {
+        assert_eq!(escape_attr("plain text"), "plain text");
+    }
+
+    #[test]
+    fn escape_attr_ampersand() {
+        assert_eq!(escape_attr("foo&bar"), "foo&amp;bar");
+    }
+
+    #[test]
+    fn escape_attr_double_quote() {
+        assert_eq!(escape_attr(r#"foo"bar"#), "foo&quot;bar");
+    }
+
+    #[test]
+    fn escape_attr_less_than() {
+        assert_eq!(escape_attr("foo<bar"), "foo&lt;bar");
+    }
+
+    #[test]
+    fn escape_attr_greater_than() {
+        assert_eq!(escape_attr("foo>bar"), "foo&gt;bar");
+    }
+
+    #[test]
+    fn escape_attr_all_specials_combined() {
+        assert_eq!(
+            escape_attr(r#"<"a" & "b">"#),
+            "&lt;&quot;a&quot; &amp; &quot;b&quot;&gt;"
+        );
+    }
+
+    #[test]
+    fn escape_attr_empty_string() {
+        assert_eq!(escape_attr(""), "");
+    }
+
+    // --- strip_display_none ---
+
+    #[test]
+    fn strip_display_none_spaced_variant() {
+        let css = ".x { display: none; color: red; }";
+        let result = strip_display_none(css);
+        assert!(
+            !result.contains("display: none"),
+            "should remove 'display: none'"
+        );
+        assert!(
+            result.contains("color: red"),
+            "should preserve other properties"
+        );
+    }
+
+    #[test]
+    fn strip_display_none_unspaced_variant() {
+        let css = ".x { display:none; margin: 0; }";
+        let result = strip_display_none(css);
+        assert!(
+            !result.contains("display:none"),
+            "should remove 'display:none'"
+        );
+        assert!(
+            result.contains("margin: 0"),
+            "should preserve other properties"
+        );
+    }
+
+    #[test]
+    fn strip_display_none_no_match_is_noop() {
+        let css = "body { color: blue; }";
+        assert_eq!(strip_display_none(css), css);
+    }
+
+    #[test]
+    fn strip_display_none_both_variants_in_same_string() {
+        let css = "a { display: none; } b { display:none; }";
+        let result = strip_display_none(css);
+        assert!(!result.contains("display: none"));
+        assert!(!result.contains("display:none"));
+    }
+
+    // --- width_key ---
+
+    #[test]
+    fn width_key_matches_to_bits() {
+        let w = 42.5_f32;
+        assert_eq!(width_key(w), w.to_bits());
+    }
+
+    #[test]
+    fn width_key_distinct_values_differ() {
+        assert_ne!(width_key(1.0), width_key(2.0));
+    }
+
+    #[test]
+    fn width_key_zero() {
+        assert_eq!(width_key(0.0_f32), 0_f32.to_bits());
+    }
+
+    // --- parse_datetime ---
+
+    #[test]
+    fn parse_datetime_valid_year_only() {
+        assert!(parse_datetime("2024").is_some());
+    }
+
+    #[test]
+    fn parse_datetime_valid_year_month() {
+        assert!(parse_datetime("2024-06").is_some());
+    }
+
+    #[test]
+    fn parse_datetime_valid_year_month_day() {
+        assert!(parse_datetime("2024-06-15").is_some());
+    }
+
+    #[test]
+    fn parse_datetime_valid_full_datetime() {
+        assert!(parse_datetime("2024-06-15T10:30:45").is_some());
+    }
+
+    #[test]
+    fn parse_datetime_valid_full_datetime_with_z() {
+        assert!(parse_datetime("2024-06-15T10:30:45Z").is_some());
+    }
+
+    #[test]
+    fn parse_datetime_valid_midnight() {
+        assert!(parse_datetime("2024-01-01T00:00:00").is_some());
+    }
+
+    #[test]
+    fn parse_datetime_valid_hour_only_in_time() {
+        // only hour field present in time part → still valid
+        assert!(parse_datetime("2024-01-01T12").is_some());
+    }
+
+    #[test]
+    fn parse_datetime_valid_hour_minute_in_time() {
+        assert!(parse_datetime("2024-01-01T12:30").is_some());
+    }
+
+    #[test]
+    fn parse_datetime_invalid_empty_string() {
+        assert!(parse_datetime("").is_none());
+    }
+
+    #[test]
+    fn parse_datetime_invalid_non_numeric_year() {
+        assert!(parse_datetime("abcd").is_none());
+    }
+
+    #[test]
+    fn parse_datetime_invalid_non_numeric_month() {
+        assert!(parse_datetime("2024-ab").is_none());
+    }
+
+    #[test]
+    fn parse_datetime_invalid_non_numeric_day() {
+        assert!(parse_datetime("2024-06-ab").is_none());
+    }
+
+    #[test]
+    fn parse_datetime_invalid_non_numeric_hour() {
+        assert!(parse_datetime("2024-06-15Tabc:30:45").is_none());
+    }
+
+    #[test]
+    fn parse_datetime_invalid_non_numeric_minute() {
+        assert!(parse_datetime("2024-06-15T10:abc:45").is_none());
+    }
+
+    #[test]
+    fn parse_datetime_invalid_non_numeric_second() {
+        assert!(parse_datetime("2024-06-15T10:30:abc").is_none());
+    }
+}


### PR DESCRIPTION
## 対象モジュール

`crates/fulgur/src/render.rs`

## カバレッジ変化

| 指標 | 変更前 | 変更後 | 差分 |
|------|--------|--------|------|
| リージョン | 67.33% | 83.57% | +16.2 pp |
| 関数 | 47.06% | 84.78% | +37.7 pp |
| 行 | 73.58% | 86.02% | +12.4 pp |

## 追加したテスト

### `escape_attr`（7件）

- `escape_attr_no_special_chars` — 特殊文字なしは変更なし
- `escape_attr_ampersand` — `&` → `&amp;`
- `escape_attr_double_quote` — `"` → `&quot;`
- `escape_attr_less_than` — `<` → `&lt;`
- `escape_attr_greater_than` — `>` → `&gt;`
- `escape_attr_all_specials_combined` — 4種類の特殊文字が同時に含まれる場合
- `escape_attr_empty_string` — 空文字列は空文字列を返す

### `strip_display_none`（4件）

- `strip_display_none_spaced_variant` — `display: none`（スペースあり）を除去し他のプロパティを保持
- `strip_display_none_unspaced_variant` — `display:none`（スペースなし）を除去し他のプロパティを保持
- `strip_display_none_no_match_is_noop` — 対象文字列なしは元のCSSのまま
- `strip_display_none_both_variants_in_same_string` — 両形式が混在しても両方除去

### `width_key`（3件）

- `width_key_matches_to_bits` — `f32::to_bits()` と一致することを確認
- `width_key_distinct_values_differ` — 異なる値は異なるキーを返す
- `width_key_zero` — ゼロ値の境界ケース

### `parse_datetime`（15件）

有効な入力（`Some` を返す）:

- `parse_datetime_valid_year_only` — `"2024"`
- `parse_datetime_valid_year_month` — `"2024-06"`
- `parse_datetime_valid_year_month_day` — `"2024-06-15"`
- `parse_datetime_valid_full_datetime` — `"2024-06-15T10:30:45"`
- `parse_datetime_valid_full_datetime_with_z` — `"2024-06-15T10:30:45Z"`（Z 接尾辞の除去）
- `parse_datetime_valid_midnight` — `"2024-01-01T00:00:00"`（境界値）
- `parse_datetime_valid_hour_only_in_time` — `"2024-01-01T12"`（時のみ）
- `parse_datetime_valid_hour_minute_in_time` — `"2024-01-01T12:30"`（時分のみ）

無効な入力（`None` を返す）:

- `parse_datetime_invalid_empty_string` — 空文字列
- `parse_datetime_invalid_non_numeric_year` — 年が数値でない
- `parse_datetime_invalid_non_numeric_month` — 月が数値でない
- `parse_datetime_invalid_non_numeric_day` — 日が数値でない
- `parse_datetime_invalid_non_numeric_hour` — 時が数値でない
- `parse_datetime_invalid_non_numeric_minute` — 分が数値でない
- `parse_datetime_invalid_non_numeric_second` — 秒が数値でない

## あえて除外したブランチ

| 対象 | 除外理由 |
|------|----------|
| `render_to_pdf` / `render_to_pdf_with_gcpm` の内部ブランチ | Blitz + Krilla のフルスタックが必要。統合テストで既に部分的にカバーされており、ユニットテストでの再現は困難 |
| `get_body_child_dimension` | `blitz_html::HtmlDocument` の構築に Blitz レイアウトパスが必要 |
| `build_metadata` | `krilla::metadata::Metadata` のフィールドを検査する公開 API がないため、戻り値の検証が不可能 |

https://claude.ai/code/session_01Ak6Ng5N6MKpZWxYcf4LEUD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ak6Ng5N6MKpZWxYcf4LEUD)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests covering rendering helpers to improve reliability: verifies HTML attribute escaping, CSS handling, numeric edge cases, and date/time parsing. No changes to production behavior or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->