### PR TITLE
docs: coordinate system and unit conversion rules

### DIFF
--- a/.claude/rules/coordinate-system.md
+++ b/.claude/rules/coordinate-system.md
@@ -1,0 +1,112 @@
+# Coordinate System and Unit Conversion Rules
+
+Most coordinate bugs in fulgur trace back to either "forgetting to convert CSS px ↔ PDF pt"
+or "misunderstanding Krilla's Y direction."
+Always consult this file when writing or reviewing rendering code.
+
+## Unit layers in the pipeline
+
+```text
+Blitz/Taffy (CSS px) ──px_to_pt()──► Pageable tree / Krilla (PDF pt)
+                     ◄──pt_to_px()──
+```
+
+| Layer | Unit | Notes |
+|-------|------|-------|
+| Blitz input (viewport, width) | CSS px | convert with `pt_to_px(v)` before passing |
+| Taffy `final_layout` | CSS px | extract via `layout_in_pt()` / `size_in_pt()` |
+| Pageable tree internals | PDF pt | |
+| Krilla Surface | PDF pt | |
+| `PageSize::custom(w, h)` | **mm** | `config.rs:22` — converted to pt internally |
+| `Margin::uniform(v)` | **pt** | |
+| `Margin::uniform_mm(v)` | **mm** | |
+
+Conversion constant: `1 CSS px = 0.75 PDF pt` (`PX_TO_PT = 0.75`, `convert.rs:35`)
+
+## Blitz boundary conversion rules (most important)
+
+Forgetting a conversion produces a **4/3× or 3/4× scale bug**.
+
+```rust
+// WRONG: pass pt value directly
+parse_html_with_local_resources(html, config.content_width(), ...)
+
+// CORRECT: convert pt → CSS px first
+parse_html_with_local_resources(html, pt_to_px(config.content_width()), ...)
+```
+
+```rust
+// WRONG: use Taffy layout values directly
+let width = node.final_layout.size.width;
+
+// CORRECT: go through px_to_pt / size_in_pt
+let (width, height) = size_in_pt(node.final_layout.size);
+let (x, y, width, height) = layout_in_pt(&node.final_layout);
+```
+
+Helper definitions: `convert.rs:37-63`
+
+## Exception: `compute_transform` arguments
+
+`blitz_adapter::compute_transform(styles, border_box_width, border_box_height)` takes
+`border_box_width` / `border_box_height` in **CSS px** — do not convert.
+Stylo's `length-percentage` resolution operates in CSS px space.
+The returned `Affine2D.e`/`.f` (translate components) are also in CSS px;
+the call site in `convert.rs` folds them into pt-space later.
+
+## Stylo length-percentage resolution
+
+`LengthPercentage::resolve(basis: Length)` — `basis` must be in **CSS px**.
+Passing a pt value produces a 3/4× error.
+
+```rust
+// WRONG: pt basis
+origin.horizontal.resolve(Length::new(border_box_width_pt))
+
+// CORRECT: px basis (layout values are CSS px)
+origin.horizontal.resolve(Length::new(border_box_width_px))
+```
+
+## Krilla / Pageable coordinate system
+
+- **Origin: top-left, Y axis: downward (Y-down)**
+- PDF spec (ISO 32000) uses bottom-left origin with Y up, but Krilla flips internally
+- All fulgur code assumes top-left origin with Y growing down
+
+`Quadrilateral` vertex order (`pageable.rs:297`):
+bottom-left → bottom-right → top-right → top-left (in Y-down coordinates)
+
+## CSS transform matrix composition (`Affine2D`)
+
+```rust
+// A.mul(&B) returns the matrix product A × B (point p transforms as A * B * p)
+// CSS transform lists apply right-to-left (first operation is innermost)
+let composed = t_origin.mul(&m).mul(&t_neg_origin);
+// = T(ox, oy) · M · T(-ox, -oy)
+```
+
+`Affine2D`'s `(a, b, c, d, e, f)` maps to `krilla::geom::Transform::from_row(a, b, c, d, e, f)`.
+
+## PDF text coordinates in inspect.rs
+
+`Td`/`TD` operands are offsets in text coordinate space, not page space.
+Apply the linear part of the text matrix `(a, b, c, d)` to convert to user-space displacement.
+
+```rust
+// WRONG: add offset directly to page coordinates
+tx += dx; ty += dy;
+
+// CORRECT: transform through text matrix linear part
+tlm_e += dx * tm_a + dy * tm_c;
+tlm_f += dx * tm_b + dy * tm_d;
+```
+
+`BT` resets both the text matrix and text line matrix to identity (PDF §9.4.1).
+Track the CTM stack (`q`/`Q`) to obtain final page coordinates.
+
+## References
+
+- `crates/fulgur/src/convert.rs:29-63` — conversion constants and helper definitions
+- `crates/fulgur/src/config.rs:22` — `PageSize::custom` mm definition
+- `docs/plans/2026-04-17-viewport-pt-to-css-px.md` — deep-dive on the px/pt boundary bug
+- PR #90 (superseded) / beads fulgur-9ul — history of the viewport pt/px misidentification fix

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,12 @@ callers don't get this guarantee by default — see the tracking issue
 
 ### Gotchas
 
+- **Coordinate system and unit conversion**: fulgur uses three distinct unit spaces
+  (Blitz/Taffy in CSS px, Pageable/Krilla in PDF pt, `PageSize::custom` in mm).
+  Forgetting a conversion is the most common source of scale bugs (4/3× or 3/4× off).
+  See `.claude/rules/coordinate-system.md` for the full rules, conversion helpers,
+  and known pitfalls (Krilla Y-down, Stylo px basis, CSS transform composition,
+  PDF text-space operators).
 - **Blitz is thread-safe** (contrary to earlier belief). Multiple threads can
   call `blitz_adapter::parse` / `resolve` / `apply_passes` concurrently on
   independent documents. The previous "Blitz not thread-safe" note was based


### PR DESCRIPTION
## 概要

座標系のバグが多いため、よくある原因をルールとして文書化した。

- `CLAUDE.md` の Gotchas に1行ポインタを追加
- `.claude/rules/coordinate-system.md` を新規作成（詳細リファレンス）

## 追加した内容

過去のセッションログ・設計ドキュメント・commit 履歴を分析して抽出したバグパターン：

| パターン | 症状 |
|---------|------|
| Blitz 境界での px↔pt 変換忘れ | 4/3× または 3/4× のスケールバグ |
| `compute_transform` 引数を pt 変換してしまう | transform-origin がずれる |
| Stylo の length-percentage basis に pt を渡す | パーセンテージ指定が 3/4× になる |
| Krilla の Y 方向を PDF 標準と混同 | Y 座標が上下逆になる |
| `PageSize::custom` の単位を pt と誤解 | ページサイズが誤る（実際は mm） |
| CSS transform 行列の合成順序を誤る | transform が正しく合成されない |
| inspect.rs で Td/TD をページ空間と誤解 | テキスト位置抽出がずれる |

各項目に WRONG / CORRECT のコード例とソースの行番号参照を付けた。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
