### PR TITLE
chore(cla): allow Copilot bot commits in CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -31,7 +31,7 @@ jobs:
           path-to-signatures: '.github/cla-signatures.json'
           path-to-document: 'https://github.com/fulgur-rs/fulgur/blob/main/CLA.md'
           branch: 'cla-signatures'
-          allowlist: 'dependabot[bot],github-actions[bot],renovate[bot]'
+          allowlist: 'dependabot[bot],github-actions[bot],renovate[bot],Copilot'
           custom-notsigned-prcomment: >
             Thank you for your pull request! Before we can merge this contribution,
             please sign our Contributor License Agreement (CLA). The CLA is a


### PR DESCRIPTION
## 概要

GitHub Copilot がマージコミットを作る際、author が `Copilot` (`198982749+Copilot@users.noreply.github.com`) として記録され、CLA Assistant が未署名コントリビュータとして検知してしまう問題への対処。

PR #192 で実際にこの状況を確認したため、`.github/workflows/cla.yml` の `allowlist` に `Copilot` を追加して bot 由来のコミットをスキップさせる。

## 変更内容

- `.github/workflows/cla.yml`: `allowlist` に `Copilot` を追記（既存の `dependabot[bot]`, `github-actions[bot]`, `renovate[bot]` と同じ枠組み）

## 適用後の動き

- このPRがmainにマージされた後、PR #192 等で `recheck` コメントを投稿すれば CLA チェックが再実行され、Copilot のコミットは allowlist によりスキップされる

## テストプラン

- [ ] このPRマージ後、PR #192 に `recheck` コメントを投稿し、CLA チェックがパスすることを確認
- [ ] 通常コントリビュータ（allowlist 外）からの未署名コミットは引き続き block されることを別 PR で確認（必要なら）
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CLA workflow configuration to recognize additional contributors in the automated verification process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->