### PR TITLE
chore(cla): allow Devin AI bot in CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -31,7 +31,7 @@ jobs:
           path-to-signatures: '.github/cla-signatures.json'
           path-to-document: 'https://github.com/fulgur-rs/fulgur/blob/main/CLA.md'
           branch: 'cla-signatures'
-          allowlist: 'dependabot[bot],github-actions[bot],renovate[bot],Copilot'
+          allowlist: 'dependabot[bot],github-actions[bot],renovate[bot],Copilot,devin-ai-integration[bot]'
           custom-notsigned-prcomment: >
             Thank you for your pull request! Before we can merge this contribution,
             please sign our Contributor License Agreement (CLA). The CLA is a


### PR DESCRIPTION
## Summary

- Devin AI が author となる commit (`devin-ai-integration[bot]`) を CLA Assistant の allowlist に追加。
- 例えば PR #188 の [6b8e17c](https://github.com/fulgur-rs/fulgur/pull/188/commits/6b8e17cd974d9894fe8ba87dee9813158556135d) のように Devin が直接 commit するケースで、署名なしと判定されてしまうのを回避するため。
- 先行する Copilot 追加 (#200, 1cc3a11) と同じ方針。

## Test plan

- [ ] PR を作成すると CLA Assistant が `devin-ai-integration[bot]` を skip し、署名なしの誤検知を出さないこと（次回 Devin co-author commit 入りの PR で確認）
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the contributor license agreement workflow configuration to allow an additional bot account in the approval process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->