### PR TITLE
test(svg): add coverage for draw, pagination, and as_any

### DIFF
--- a/crates/fulgur/src/svg.rs
+++ b/crates/fulgur/src/svg.rs
@@ -94,6 +94,7 @@ impl Pageable for SvgPageable {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pageable::Canvas;
 
     // Minimal valid SVG: 100x50 red rectangle
     const MINIMAL_SVG: &str = r#"<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50"><rect width="100" height="50" fill="red"/></svg>"#;
@@ -102,6 +103,27 @@ mod tests {
         let opts = usvg::Options::default();
         let tree = Tree::from_str(MINIMAL_SVG, &opts).expect("parse minimal svg");
         Arc::new(tree)
+    }
+
+    /// Draw `svg` onto a freshly-created krilla Document and discard the output.
+    /// Used to exercise `draw()` without asserting on surface state.
+    fn draw_onto_surface(svg: &SvgPageable) {
+        let mut doc = krilla::Document::new();
+        {
+            let settings = krilla::page::PageSettings::from_wh(400.0, 400.0)
+                .expect("400×400 is a valid page size");
+            let mut page = doc.start_page_with(settings);
+            let mut surface = page.surface();
+            {
+                let mut canvas = Canvas {
+                    surface: &mut surface,
+                    bookmark_collector: None,
+                    link_collector: None,
+                };
+                svg.draw(&mut canvas, 10.0, 20.0, 400.0, 400.0);
+            }
+        }
+        let _ = doc.finish();
     }
 
     #[test]
@@ -141,5 +163,53 @@ mod tests {
         let svg = SvgPageable::new(parse_tree(), 100.0, 50.0);
         assert_eq!(svg.opacity, 1.0);
         assert!(svg.visible);
+    }
+
+    #[test]
+    fn test_pagination_returns_default() {
+        let svg = SvgPageable::new(parse_tree(), 100.0, 50.0);
+        assert_eq!(svg.pagination(), Pagination::default());
+    }
+
+    #[test]
+    fn test_as_any_downcasts_to_svg_pageable() {
+        let svg = SvgPageable::new(parse_tree(), 100.0, 50.0);
+        assert!(svg.as_any().downcast_ref::<SvgPageable>().is_some());
+    }
+
+    #[test]
+    fn test_draw_visible_does_not_panic() {
+        let svg = SvgPageable::new(parse_tree(), 100.0, 50.0);
+        draw_onto_surface(&svg);
+    }
+
+    #[test]
+    fn test_draw_not_visible_returns_early() {
+        let mut svg = SvgPageable::new(parse_tree(), 100.0, 50.0);
+        svg.visible = false;
+        draw_onto_surface(&svg);
+    }
+
+    #[test]
+    fn test_draw_zero_size_skips_draw() {
+        // Size::from_wh(0.0, …) returns None (NonZeroPositiveF32 rejects zero);
+        // this exercises the `let Some(size) = … else { return; }` branch.
+        let svg = SvgPageable::new(parse_tree(), 0.0, 50.0);
+        draw_onto_surface(&svg);
+    }
+
+    #[test]
+    fn test_draw_partial_opacity() {
+        let mut svg = SvgPageable::new(parse_tree(), 100.0, 50.0);
+        svg.opacity = 0.5;
+        draw_onto_surface(&svg);
+    }
+
+    #[test]
+    fn test_draw_zero_opacity_returns_early() {
+        // draw_with_opacity short-circuits when opacity == 0.0.
+        let mut svg = SvgPageable::new(parse_tree(), 100.0, 50.0);
+        svg.opacity = 0.0;
+        draw_onto_surface(&svg);
     }
 }


### PR DESCRIPTION
## 対象モジュール

`crates/fulgur/src/svg.rs` — `SvgPageable` の描画・ページネーション・ダウンキャスト処理

## カバレッジ変化

| 指標 | 変更前 | 変更後 |
|------|--------|--------|
| 行カバレッジ | 69.14% (81行中25行未カバー) | 97.66% (128行中3行未カバー) |
| 関数カバレッジ | 66.67% (15関数中5関数未カバー) | 95.65% (23関数中1関数未カバー) |

※ 新テスト追加によりカバー対象行数自体も増加（81→128行）しています。

## 追加したテスト

`draw_onto_surface` ヘルパー（krilla Document/Surface を作成してキャンバスに描画するユーティリティ）を追加し、以下のテストを実装しました。

| テスト名 | カバーするパス |
|----------|---------------|
| `test_pagination_returns_default` | `pagination()` が `Pagination::default()` を返すことを確認 |
| `test_as_any_downcasts_to_svg_pageable` | `as_any()` が `SvgPageable` にダウンキャスト可能であることを確認 |
| `test_draw_visible_does_not_panic` | 通常描画パス（`visible=true`, `opacity=1.0`）をカバー |
| `test_draw_not_visible_returns_early` | `visible=false` 時の早期リターンをカバー |
| `test_draw_zero_size_skips_draw` | `Size::from_wh(0.0, …)` が `None` を返す分岐をカバー（`NonZeroPositiveF32` がゼロを拒否） |
| `test_draw_partial_opacity` | `opacity=0.5` 時の Krilla 透明度グループ処理をカバー |
| `test_draw_zero_opacity_returns_early` | `draw_with_opacity` の `opacity==0.0` 早期リターンをカバー |

## 意図的に外したカバレッジ

残り未カバーの3行は `draw_svg` の戻り値（`Option<()>`）の `None` パス（SVGツリーが壊れている場合のサイレントスキップ）。有効な `usvg::Tree` を使う限りこのパスは到達不可能であり、壊れたツリーを作るための API が公開されていないため、テストを追加しませんでした。

https://claude.ai/code/session_01Cp29FPmT2GPCon7DFNNBsc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cp29FPmT2GPCon7DFNNBsc)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for SVG rendering functionality, including validation of pagination behavior, type downcasting, and draw operation handling across multiple control-flow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->