### PR TITLE
feat(fulgur): add wasm32-unknown-unknown build check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,27 @@ jobs:
           use_oidc: true
           fail_ci_if_error: false
 
+  wasm-check:
+    name: WASM build check
+    runs-on: ubuntu-latest
+    # Strategic gate: keeps the `fulgur` library buildable on
+    # `wasm32-unknown-unknown` so the future `fulgur-wasm` wrapper crate
+    # (browser HTML→PDF, AI agent sandboxes) stays one step away.
+    # Failure means a dependency or new code added a non-WASM-compatible
+    # surface (filesystem, native-only API, missing target cfg) — fix or
+    # cfg-gate it before merging. Tracking: fulgur-iym, fulgur-g5bn.
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-latest-fulgur-wasm
+      # Do NOT set RUSTFLAGS=-C link-arg=-fuse-ld=mold here; env RUSTFLAGS
+      # is target-agnostic and would force mold onto the wasm32 build.
+      - run: cargo check --target wasm32-unknown-unknown -p fulgur
+
   vrt:
     name: Visual Regression Tests
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,6 +1083,7 @@ dependencies = [
  "blitz-html",
  "blitz-traits",
  "cssparser 0.36.0",
+ "getrandom 0.4.2",
  "image",
  "krilla",
  "krilla-svg",
@@ -1313,11 +1314,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/fulgur/Cargo.toml
+++ b/crates/fulgur/Cargo.toml
@@ -31,6 +31,14 @@ log = "0.4"
 lopdf = "0.40.0"
 serde = { version = "1", features = ["derive"] }
 
+# WASM (wasm32-unknown-unknown) build support: pulled in transitively by lopdf/rand.
+# Feature unification propagates `wasm_js` to the lopdf-side dependency so the
+# crate selects the `crypto.getRandomValues()` backend instead of failing with
+# `compile_error!`. Browser-class targets only — WASI requires a different
+# backend selection. Tracking: fulgur-iym (strategic v0.7.0).
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.4", default-features = false, features = ["wasm_js"] }
+
 [dev-dependencies]
 tempfile = "3.27.0"
 image = { version = "0.25", default-features = false, features = ["png"] }

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -23,7 +23,9 @@
 use blitz_dom::DocumentConfig;
 use blitz_dom::net::Resource;
 use blitz_html::HtmlDocument;
-use blitz_traits::net::{NetProvider, Url};
+use blitz_traits::net::NetProvider;
+#[cfg(not(target_arch = "wasm32"))]
+use blitz_traits::net::Url;
 use blitz_traits::shell::{ColorScheme, Viewport};
 use parley::FontContext;
 use std::path::Path;
@@ -108,10 +110,22 @@ pub fn parse_html_with_local_resources(
         base_path.map(|p| p.to_path_buf()),
     ));
     let provider: Arc<dyn NetProvider<Resource>> = net_provider.clone();
+    // `Url::from_directory_path` and `Path::canonicalize` are gated to
+    // non-wasm targets in `url`/`std`. On WASM, base-URL derivation is
+    // skipped because there is no native filesystem to canonicalise a
+    // path against; callers are expected to deliver pre-loaded bytes
+    // through `AssetBundle` (e.g. fed from JS `fetch` / `FileReader` /
+    // OPFS via a wasm-bindgen wrapper).
+    #[cfg(not(target_arch = "wasm32"))]
     let base_url = base_path
         .and_then(|p| p.canonicalize().ok())
         .and_then(|p| Url::from_directory_path(&p).ok())
         .map(|u| u.to_string());
+    #[cfg(target_arch = "wasm32")]
+    let base_url: Option<String> = {
+        let _ = base_path;
+        None
+    };
 
     let mut doc = parse_inner(
         html,

--- a/crates/fulgur/src/net.rs
+++ b/crates/fulgur/src/net.rs
@@ -47,6 +47,10 @@ use std::sync::{Arc, Mutex};
 /// (CLAUDE.md adapter-isolation rule). The `drain_*` methods below
 /// exist for that internal use only.
 pub struct FulgurNetProvider {
+    // `canonical_base` is consulted only by the native
+    // `resolve_local_path`; on `wasm32-unknown-unknown` the resolver is a
+    // stub that returns `None`, leaving this field intentionally unread.
+    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
     canonical_base: Option<PathBuf>,
     inner: Arc<Mutex<Inner>>,
 }
@@ -87,6 +91,7 @@ impl FulgurNetProvider {
     /// configured base directory. Returns `None` if the URL is not
     /// `file://`, the file does not exist, or the resolved path escapes
     /// the base directory.
+    #[cfg(not(target_arch = "wasm32"))]
     fn resolve_local_path(&self, request: &Request) -> Option<PathBuf> {
         if request.url.scheme() != "file" {
             return None;
@@ -98,6 +103,18 @@ impl FulgurNetProvider {
             return None;
         }
         Some(canonical)
+    }
+
+    /// WASM stub: `Url::to_file_path` and `Path::canonicalize` are gated
+    /// off on `wasm32-unknown-unknown`. Browsers also forbid JS access to
+    /// `file://`, so this resolver can never succeed there. Resources for
+    /// WASM must be delivered as bytes through `AssetBundle` (typically
+    /// fed from JS `fetch` / `FileReader` / OPFS via a wasm-bindgen
+    /// wrapper). A future async `NetProvider` could re-route `<link>` /
+    /// `@import` through a JS-side fetch callback.
+    #[cfg(target_arch = "wasm32")]
+    fn resolve_local_path(&self, _request: &Request) -> Option<PathBuf> {
+        None
     }
 
     fn looks_like_css(request: &Request, path: &Path) -> bool {


### PR DESCRIPTION
## Summary

- `fulgur` ライブラリ本体が `wasm32-unknown-unknown` ターゲットでビルドできるよう最小限の対応
- 戦略 issue **fulgur-iym** (v0.7.0 strategic、AI エージェント sandbox 仮説に基づく WASM ready 死守) の先行 step として、ビルド可能性を CI で機械的に保証する防壁を立てる
- 子 issue: **fulgur-g5bn** (scope 1: build check のみ。実行・wasm-bindgen wrapper は対象外)

## 変更内容

### 1. `getrandom 0.4` の WASM サポート

`lopdf` / `rand` 経由で transitive に pull in される `getrandom 0.4.2` が、`wasm32-unknown-unknown` で `compile_error!` を出すのを feature unification で解消。

```toml
[target.'cfg(target_arch = "wasm32")'.dependencies]
getrandom = { version = "0.4", default-features = false, features = ["wasm_js"] }
```

これにより lopdf 側の getrandom にも `wasm_js` feature が伝播し、`crypto.getRandomValues()` バックエンドが選択される。ブラウザ向けターゲット限定 (WASI は将来別対応)。

### 2. ファイルシステム前提コードの cfg gate

`Url::from_directory_path` / `Url::to_file_path` は `url` crate で wasm32 では disabled。`Path::canonicalize` も同様。WASM 環境では filesystem アクセス自体が無いので、これらを `cfg(not(target_arch = "wasm32"))` で gate し、wasm32 では stub に分岐:

- `crates/fulgur/src/blitz_adapter.rs`: `base_url` 計算を skip (None)
- `crates/fulgur/src/net.rs`: `resolve_local_path` を `None` 固定の stub に
- `canonical_base` field は wasm32 では未参照になるので `cfg_attr` で `dead_code` 抑制

WASM 環境では `AssetBundle` 経由 (JS 側の `fetch` / `FileReader` / OPFS から取得した bytes を渡す) がリソース受け渡しの正攻法になる前提。コードコメントもその方向に書き直し。

### 3. CI ジョブ追加 `.github/workflows/ci.yml`

`wasm-check` ジョブを追加:

- `cargo check --target wasm32-unknown-unknown -p fulgur`
- 緑必須 (continue-on-error なし)
- `RUSTFLAGS=-fuse-ld=mold` は target-agnostic な env なので明示的に流さない (linker 不整合回避)
- shared-key を別にしてキャッシュ衝突を回避

## 検証

- ✅ `cargo check --target wasm32-unknown-unknown -p fulgur` 緑
- ✅ `cargo clippy --workspace --all-targets -- -D warnings` 緑
- ✅ `cargo fmt --check` 緑
- ✅ `cargo test -p fulgur --lib` 702 passed / 0 failed (regression なし)

## やっていないこと (scope creep 回避)

- 実際の WASM 実行 / ブラウザ動作確認
- `crates/fulgur-wasm/` wasm-bindgen wrapper crate
- WASI ターゲット (`wasm32-wasip1` など) 対応
- ブラウザ demo / playground

これらは fulgur-iym 本体 (scope 3) で別 PR。本 PR は「WASM ready を CI で守る」最小ステップ。

## 戦略的位置付け

memory `project_pdf_optimize_wasm_strategy.md` (2026-04-19 決定) で、v0.5.6 の PDF 最適化を qpdf でなく lopdf で実装した理由が「pure Rust / WASM ready 死守」。本 PR はその裏付けを CI で実証する一手。今後の依存追加・コード変更で WASM ビルドが破壊された場合に即検出できる。

## Test plan

- [ ] CI の `wasm-check` ジョブが緑になる
- [ ] 既存 ジョブ (lint / test / vrt / wpt) の挙動に変化なし
- [ ] `cargo build` (native) も問題なし

Refs: fulgur-iym, fulgur-g5bn
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebAssembly support: `fulgur` crate now compiles for WebAssembly (wasm32) targets with proper handling for web environments.
* **Tests**
  * Added continuous integration job to verify WebAssembly compilation remains functional across updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->