### PR TITLE
docs(release): document ZeroVer policy + skip_bindings + release-notes labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,31 @@ cargo test
 cargo run -p fulgur-cli -- render -o output.pdf input.html
 ```
 
+## Versioning
+
+Fulgur follows the [ZeroVer](https://0ver.org) convention while still in
+the `0.x` line. The number after the leading zero — the **minor** — is
+what we treat as a release boundary; the patch field exists only to ship
+hotfixes between minors.
+
+- **Each normal release bumps the minor** (`0.5.x` → `0.6` → `0.7`). We
+  refer to it as "Fulgur 0.6" externally; internal artefacts (Cargo.toml,
+  PyPI, RubyGems, npm, git tag) carry the full semver string `0.6.0`
+  because those registries require it.
+- **Patch numbers are reserved for hotfixes** off a previous minor
+  (e.g. `0.6.1` to fix a regression in `0.6.0`). They are not used for
+  routine releases.
+- **`fulgur`, `fulgur-cli`, `fulgur-wasm`, `fulgur-ruby`, `pyfulgur` share
+  the same version**. Independent binding versioning is tracked as future
+  work.
+- **API stability is not guaranteed in `0.x`**. Each minor may introduce
+  breaking changes. The 1.0 line will be cut once the public surface
+  stabilises (criteria TBD).
+
+If you depend on Fulgur from another Rust crate or a binding, pin the
+exact minor (`fulgur = "0.6"` resolves to `>=0.6.0, <0.7.0` under Cargo's
+default caret behaviour) until you are ready to absorb a breaking change.
+
 ## Release
 
 See [docs/RELEASE_SETUP.md](docs/RELEASE_SETUP.md) for PyPI / RubyGems

--- a/docs/RELEASE_SETUP.md
+++ b/docs/RELEASE_SETUP.md
@@ -1,7 +1,80 @@
 # Release Setup: Trusted Publishing
 
-pyfulgur (PyPI) と fulgur (RubyGems) を OIDC Trusted Publishing で publish するための、
-一度だけ必要な設定手順。
+One-time configuration for publishing pyfulgur (PyPI) and fulgur (RubyGems) via
+OIDC Trusted Publishing, plus Fulgur's versioning policy and day-to-day release
+procedure.
+
+## Versioning policy (ZeroVer)
+
+Fulgur follows [ZeroVer](https://0ver.org) while on the `0.x` line. See
+[`docs/plans/2026-04-26-versioning-and-release-simplification-design.md`](plans/2026-04-26-versioning-and-release-simplification-design.md)
+for the full rationale.
+
+Key points:
+
+- **Each normal release bumps the minor** (`0.5.14` → `0.6.0` → `0.7.0`). This
+  matches `release-prepare.yml`'s auto-bump behaviour when the `version` input
+  is left empty.
+- **Patch numbers are reserved for hotfixes.** If `0.6.0` ships with a critical
+  bug, cut `0.6.1` by passing `version=0.6.1` explicitly to
+  `release-prepare.yml`'s `workflow_dispatch`.
+- **External form: `0.6`. Internal form: `0.6.0`.**
+  - Internal (Cargo.toml, npm, PyPI, RubyGems, git tag, CHANGELOG section
+    header): `0.6.0` — required by semver / registry validators.
+  - External (README, blog, announcements, branding): "Fulgur 0.6".
+- **Workspace stays in lockstep** — `fulgur`, `fulgur-cli`, `fulgur-wasm`,
+  `fulgur-ruby`, and `pyfulgur` share the same version string. Independent
+  binding versioning is future work.
+- **No API stability guarantees until `1.0`.** Each minor on the `0.x` line is
+  free to introduce breaking changes.
+
+## Skip bindings (core-only release)
+
+To ship a core-only release (crates.io + GitHub Release + CLI binary) and
+suppress PyPI / RubyGems / npm publish, run `release-prepare.yml` with
+`skip_bindings=true`:
+
+```bash
+gh workflow run release-prepare.yml --field version=0.6.1 --field skip_bindings=true
+```
+
+What happens:
+
+- `release-prepare.yml` attaches the `release:skip-bindings` label to the
+  release PR.
+- After merge, `release.yml` skips `publish-npm` via an `if:` guard.
+- `release-python.yml` and `release-ruby.yml` run a `check-skip-label` job that
+  resolves tag → commit → associated PR labels and skips the `publish` job when
+  the label is present.
+- crates.io publish, GitHub Release publish, and CLI binary uploads are
+  unconditional — the CLI binary is treated as a core release artifact.
+
+If you later need to publish bindings against an already-tagged core release,
+trigger `release-python.yml` / `release-ruby.yml` via `workflow_dispatch`. That
+escape hatch is intentionally left in place but not yet documented as a first-
+class flow.
+
+## PR-based changelog (`release-notes:*` labels)
+
+CHANGELOG and GitHub Release notes are generated **from merged PRs**, not from
+commits. `.github/release.yml` defines the category mapping.
+
+| Label | Category |
+|-------|----------|
+| `release-notes:feature` | Features |
+| `release-notes:fix` | Bug Fixes |
+| `release-notes:docs` | Documentation |
+| `release-notes:internal` | Excluded (CI / refactor / chore / test) |
+| `dependencies` | Excluded (Dependabot) |
+| (no label) | Other Changes |
+
+Labelling responsibility sits with the **PR author and reviewer**. CI does not
+enforce a `release-notes:*` label — unlabelled PRs fall through to "Other
+Changes".
+
+`release-prepare.yml` calls `gh api repos/.../releases/generate-notes`, prepends
+the resulting body to `CHANGELOG.md`, and reuses the same body for the draft
+GitHub Release. git-cliff has been removed.
 
 ## 初回公開時の注意
 
@@ -99,26 +172,48 @@ OIDC claim (repo + workflow + environment) で自動照合されるため、`rol
 
 ### Required reviewers (approval gate)
 
-release は irreversible 操作が多いため、`release` / `pypi` / `rubygems` の
-3 環境すべてで **Required reviewers** を設定する (`testpypi` は dry-run のため不要)。
+The approval gate is **consolidated to the `release` environment only** as of
+2026-04-26 (PR #213). `pypi` and `rubygems` environments are kept for OIDC
+subject claims but no longer set `Required reviewers`.
 
-各 Environment の設定画面 (Settings → Environments → `<name>`) で:
+Rationale: creating a GitHub Release already implies the `release` env approval
+was granted. Adding further approvals downstream collapses cleanly into a
+single gate. Compressing the previous 3-stage gate into 1 substantially reduces
+per-release friction.
 
-- "Required reviewers" にチェック
-- reviewer として自分 (および必要ならリリース権限を持つ共同メンテナ) を追加
+Per-environment configuration (Settings → Environments → `<name>`):
 
-3 段ゲートになるため、release flow で:
+| Environment | Required reviewers | Purpose |
+|-------------|--------------------|---------|
+| `release`   | **Set** (yourself / co-maintainers) | crates.io / GitHub Release / npm publish gate |
+| `pypi`      | Not set | OIDC subject claim (PyPI Trusted Publisher) |
+| `rubygems`  | Not set | OIDC subject claim (RubyGems Trusted Publisher) |
+| `testpypi`  | Not set | Dry-run only |
 
-1. PR merge → `release.yml` の `publish` job が `release` env で pause → 承認
-2. crates.io + tag push + GitHub Release publish が完走 (App token で `release:published` 発火)
-3. `release-python.yml` の `publish` job が `pypi` env で pause → 承認
-4. `release-ruby.yml` の `publish` job が `rubygems` env で pause → 承認
-5. PyPI / RubyGems へ反映
+To remove `required_reviewers` from `pypi` / `rubygems` after the fact:
 
-途中で publish job が失敗した際の re-run も承認を経由する。
+1. GitHub repo → Settings → Environments → `pypi` (or `rubygems`).
+2. Untick "Required reviewers" under "Deployment protection rules".
+3. Click "Save protection rules".
+4. Repeat for the other environment.
 
-OIDC claim による scope (repo + workflow + environment) は reviewer 設定と独立して
-機能するため、両方併用してよい。
+New flow (without `skip_bindings`):
+
+1. PR merge → `release.yml`'s `publish` job pauses on `release` env → approve.
+2. crates.io publish + tag push + GitHub Release publish + npm publish run to
+   completion (App token fires `release:published`).
+3. `release-python.yml` and `release-ruby.yml`'s `publish` jobs run **without
+   any further approval** → PyPI / RubyGems updated.
+
+With `skip_bindings=true`: step 3's `publish` job is skipped via
+`check-skip-label` (`needs.check-skip-label.outputs.skip != 'true'` gate).
+
+A failed re-run still re-prompts for the `release` env approval.
+
+The OIDC claim scope (repo + workflow + environment) is independent of reviewer
+settings, so removing reviewers from `pypi` / `rubygems` does not weaken
+publish authenticity — `if: github.event_name == 'release'` separately blocks
+publishing from arbitrary refs.
 
 ## GitHub App (release publisher)
 
@@ -164,10 +259,48 @@ Settings → Secrets and variables → Actions → New repository secret:
 Actions タブで `release-python.yml` / `release-ruby.yml` が自動的に `release` イベントで
 起動することを確認する。
 
-## Release 手順
+## Release procedure
 
-1. `release-prepare.yml` を `workflow_dispatch` で起動 (version 入力)
-2. 作成された `release/vX.Y.Z` PR を merge
-3. `release.yml` が tag + crates.io publish + GitHub Release publish (App token)
-4. `release: published` で `release-python.yml` と `release-ruby.yml` が並行発火
-5. 数分〜十数分後に PyPI / RubyGems へ反映
+### Normal release (minor bump)
+
+1. Trigger `release-prepare.yml` via `workflow_dispatch`.
+   - Leave `version` **empty** to let auto-bump pick the next minor (`0.x.0`).
+   - For a hotfix, pass an explicit value such as `version=0.6.1`.
+2. Inspect the generated `release/vX.Y.Z` PR (CHANGELOG diff, Cargo.toml
+   bumps).
+3. Merge the PR → `release.yml`'s `publish` job pauses on the `release` env.
+4. Approve from the GitHub Actions UI.
+5. crates.io publish + tag push + GitHub Release publish + npm publish all
+   complete.
+6. `release: published` fires `release-python.yml` and `release-ruby.yml` in
+   parallel.
+7. `check-skip-label` confirms the label is absent → `publish` proceeds.
+8. PyPI / RubyGems reflect the new version within minutes.
+
+### Core-only release (skip bindings)
+
+```bash
+gh workflow run release-prepare.yml \
+  --field version=0.6.1 \
+  --field skip_bindings=true
+```
+
+- The generated PR is auto-labelled `release:skip-bindings`.
+- After merge, `release.yml` skips npm publish (crates.io / GitHub Release /
+  CLI binary still ship).
+- `release-python.yml` / `release-ruby.yml` still run build + smoke tests but
+  `check-skip-label` skips the `publish` job only.
+
+### Previewing release notes
+
+Before triggering `release-prepare.yml`, you can dry-run the notes:
+
+```bash
+gh api repos/fulgur-rs/fulgur/releases/generate-notes \
+  -f tag_name=v0.6.0 \
+  --jq .body
+```
+
+Verify categorisation matches expectations (i.e. that the relevant
+`release-notes:*` labels are attached). Add missing labels with
+`gh pr edit <num> --add-label release-notes:fix` (etc.) and re-run to confirm.

--- a/docs/plans/2026-04-26-versioning-and-release-simplification-design.md
+++ b/docs/plans/2026-04-26-versioning-and-release-simplification-design.md
@@ -1,0 +1,179 @@
+# Versioning Policy & Release Pipeline Simplification — Design
+
+**Date:** 2026-04-26
+**Status:** Approved for implementation
+**Scope:** バージョニング方針切替 + release pipeline の approve / skip / changelog 簡略化
+
+## 背景
+
+現状 `0.5.14` まで patch を 14 回積んできたが、各 release は機能追加・breaking change・bug fix が混在しており、patch 番号が中身を反映していない。
+加えて release pipeline には次の摩擦がある:
+
+- 1 release ごとに 3 箇所 (`release` / `pypi` / `rubygems`) で environment approval 待ちが発生
+- bindings (PyPI / RubyGems / npm) は GH Release 公開で自動発火し、core のみ release したいケースに逃げ道がない
+- CHANGELOG.md は git-cliff (commit 単位) で生成されており、1 PR が複数 commit を持つと "address AI review feedback" や "cargo fmt" のような review 副産物が混入する
+
+本 design はこの 3 つを一括で解消する。
+
+## 1. Versioning Policy: ZeroVer 採用
+
+### 方針
+
+- **全ての通常 release は minor を上げる** (`0.5.14` → `0.6.0` → `0.7.0` → ...)
+- **patch は hotfix 専用** — release 後の致命バグ修正のみ。通常 release では使わない
+- **ワークスペース同期維持** — `fulgur` / `fulgur-cli` / `fulgur-wasm` / `fulgur-ruby` / `pyfulgur` は同じ番号で揃える (現状維持)
+- **next release = `0.6.0`**
+- 1.0.0 到達タイミングは別途検討 (本 design のスコープ外)
+
+### 根拠
+
+- 0.x 期間中であることを ZeroVer (<https://0ver.org>) として明示し、bindings 利用者に「API は安定保証外」を伝える
+- 「次の release = 次の minor」で迷う余地を消し、判断コストを下げる
+- minor の数字が roadmap の節目 (Pageable 廃止、上流移行など) と紐付けやすくなる
+
+## 2. Release Pipeline 簡略化
+
+### 2.1 Approval ゲート集約
+
+| Approval ポイント | before | after |
+|-------------------|--------|-------|
+| Release PR レビュー | あり | あり (現状維持) |
+| `release` env (release.yml) | あり | あり (唯一の environment ゲート) |
+| `pypi` env (release-python.yml) | あり | **削除** (環境は OIDC subject 用に残す) |
+| `rubygems` env (release-ruby.yml) | あり | **削除** (環境は OIDC subject 用に残す) |
+
+GH Release を作成 = 既に `release` environment の approve を通っている、という一段論法で
+下流の追加 approve を省く。`pypi` / `rubygems` environment 自体は OIDC trusted publisher の
+subject claim として必要なので残すが、`required_reviewers` だけ剥がす。
+
+### 2.2 `skip_bindings` フラグ
+
+- **粒度**: 単一フラグ (PyPI / RubyGems / npm を一括制御)
+- **デフォルト**: `false` (= 全部 publish、現状の挙動を維持)
+- **伝播経路**: release-prepare.yml の input → release PR に `release:skip-bindings` ラベル付与 → 各 publish workflow がラベル参照
+
+```text
+release-prepare.yml
+  inputs: { version, skip_bindings }
+    ↓ (skip_bindings=true なら label 付与)
+Release PR (label: release:skip-bindings)
+    ↓ merge
+release.yml
+  - crates.io publish (常に実行)
+  - npm publish (label が無い時のみ実行)
+  - GH Release 作成 (常に実行 — CLI binary 配布のため必要)
+    ↓ release: published
+release-python.yml / release-ruby.yml
+  - 起動時に gh api でラベル取得 → label 有 → exit 0
+  - label 無 → 通常 publish
+```
+
+### 2.3 自動 bump のデフォルト変更
+
+`release-prepare.yml` の auto-bump ロジック: patch → **minor**
+
+```bash
+# before
+PATCH=$((PATCH + 1))
+VERSION="$MAJOR.$MINOR.$PATCH"
+
+# after
+MINOR=$((MINOR + 1))
+VERSION="$MAJOR.$MINOR.0"
+```
+
+`workflow_dispatch` の `version` input は引き続き有効 (hotfix 時に `0.6.1` を明示指定する経路)。
+
+## 3. PR-based Changelog
+
+### 方針
+
+- **ソース**: マージされた PR (commit ではなく)
+- **カテゴリ分類**: PR ラベル (`release-notes:*`)
+- **ツール**: GitHub native `--generate-notes` + `.github/release.yml` config
+- **git-cliff は廃止**
+
+### ラベル設計
+
+| ラベル | カテゴリ |
+|--------|----------|
+| `release-notes:feature` | Features |
+| `release-notes:fix` | Bug Fixes |
+| `release-notes:docs` | Documentation |
+| `release-notes:internal` | (release notes から除外: CI / refactor / chore) |
+| (ラベル無し) | Other Changes |
+
+### `.github/release.yml`
+
+```yaml
+changelog:
+  exclude:
+    labels:
+      - release-notes:internal
+      - dependencies  # Dependabot は別 section にしたければ category 追加
+  categories:
+    - title: Features
+      labels: [release-notes:feature]
+    - title: Bug Fixes
+      labels: [release-notes:fix]
+    - title: Documentation
+      labels: [release-notes:docs]
+    - title: Other Changes
+      labels: ["*"]
+```
+
+### CHANGELOG.md の扱い
+
+- `0.6.0` 以降は GH API から取得した release notes を `release-prepare.yml` で prepend
+- `0.5.14` 以前のエントリは現状のまま温存 (履歴を書き換えない)
+- 生成は `gh api repos/:owner/:repo/releases/generate-notes` または `gh release view` の output を整形
+
+### Migration
+
+- 既存 PR にラベルは backfill しない
+- `0.6.0` の release notes は **手動編集を許容** (移行期の現実解)
+- `0.7.0` 以降はラベル運用が定着している前提
+- ラベル付与の責任: PR 作成者 + reviewer。CI で `release-notes:*` 必須化は **しない** (ラベル無し = "Other Changes" でフォールバック)
+
+## 4. 実装ステップ (file-by-file)
+
+| # | ファイル | 変更内容 |
+|---|----------|----------|
+| 1 | `.github/release.yml` | **新規作成**。category と exclude を定義 |
+| 2 | `.github/workflows/release-prepare.yml` | (a) auto-bump を patch → minor に変更<br>(b) `skip_bindings: boolean` input 追加 + ラベル付与ロジック<br>(c) git-cliff 関連 step 削除<br>(d) CHANGELOG.md 生成を `gh api ... generate-notes` ベースに置換 |
+| 3 | `.github/workflows/release.yml` | npm publish step に `if: !contains(github.event.pull_request.labels.*.name, 'release:skip-bindings')` 追加 |
+| 4 | `.github/workflows/release-python.yml` | 起動時にラベルチェック step 追加 → 該当 release の PR ラベルを `gh api` で取得し `release:skip-bindings` あれば exit 0 |
+| 5 | `.github/workflows/release-ruby.yml` | 同上 |
+| 6 | `cliff.toml` | **削除** |
+| 7 | `docs/RELEASE_SETUP.md` | (a) ZeroVer ポリシー節を追加<br>(b) `pypi` / `rubygems` environment の `required_reviewers` 削除手順を追記<br>(c) `release-notes:*` ラベル運用を追記<br>(d) `skip_bindings` 使い方を追記 |
+| 8 | `README.md` | Versioning section を追加 (短く: ZeroVer 採用、minor = release、patch = hotfix のみ) |
+| 9 | GitHub repository labels | `release:skip-bindings`, `release-notes:feature`, `release-notes:fix`, `release-notes:docs`, `release-notes:internal` を作成 |
+| 10 | GitHub environments (manual) | `pypi` / `rubygems` の `required_reviewers` を解除 |
+
+## 5. リスクと緩和
+
+| リスク | 緩和策 |
+|--------|--------|
+| `release` env approve だけで PyPI/RubyGems が走る = 攻撃面が広がる | OIDC trusted publisher は `environment` 名と repo を strict 検証する。GH Release 作成は `release` env の approve を経由するので、悪意ある tag push で publish が走るシナリオは現状と同じレベル |
+| ラベル付け忘れで release notes が "Other Changes" だらけになる | 移行期は受容。定着後に必要なら PR template に `release-notes:` ラベルチェックを追加 |
+| `skip_bindings` 後に bindings 側だけ後追い release したい | 別途 `workflow_dispatch` で release-python / release-ruby を手動起動する経路を残す。今回は触らない |
+| `0.5.14` → `0.6.0` への jump がユーザーに breaking と誤読される | CHANGELOG.md と README で「番号運用方針変更」を明記 |
+
+## 6. スコープ外
+
+- 1.0.0 到達条件
+- bindings の独立バージョニング (A-2 / A-3 への移行)
+- CLI binary 以外の release artifact 追加
+- `release` env approve 自体の自動化 (現状維持)
+
+## 7. 起票する beads issues
+
+1. **fulgur-XXX (parent epic)**: ZeroVer 採用 + release pipeline 簡略化
+   - **fulgur-XXX**: `.github/release.yml` 新規作成 + ラベル整備
+   - **fulgur-XXX**: `release-prepare.yml` 改修 (auto-bump minor / skip_bindings input / git-cliff 廃止)
+   - **fulgur-XXX**: `release.yml` 改修 (npm skip 条件)
+   - **fulgur-XXX**: `release-python.yml` / `release-ruby.yml` 改修 (skip ラベル check)
+   - **fulgur-XXX**: `cliff.toml` 削除
+   - **fulgur-XXX**: `docs/RELEASE_SETUP.md` / `README.md` の方針記述
+   - **fulgur-XXX**: GitHub environments 設定変更 (manual / 手順 doc 化のみ)
+   - **fulgur-XXX**: `0.6.0` を最初の ZeroVer release として切る (実装後の検証 release)


### PR DESCRIPTION
## 概要

PR #213 で実装した ZeroVer / skip_bindings / PR-based changelog の運用ルールをドキュメント化。`docs/plans/2026-04-26-versioning-and-release-simplification-design.md` の §4 step 7-8 を満たす。

## 含まれる変更

### `README.md`

`## Versioning` section を `## Release` の前に新規追加。

- ZeroVer 採用 (minor=release, patch=hotfix)
- 対外 `0.6` / 内部 `0.6.0` の表記規則
- workspace lockstep (`fulgur` / `fulgur-cli` / `fulgur-wasm` / `fulgur-ruby` / `pyfulgur`)
- 1.0 まで API 安定保証なし
- `fulgur = "0.6"` の cargo 解釈 (`>=0.6.0, <0.7.0`)

### `docs/RELEASE_SETUP.md`

私が触った section は **英語に統一**(既存の日本語 sections は触らない、diff 抑制のため)。

- `## Versioning policy (ZeroVer)` 新規
- `## Skip bindings (core-only release)` 新規
- `` ## PR-based changelog (`release-notes:*` labels) `` 新規
- `### Required reviewers (approval gate)` を新方針 (`release` env のみに集約) に書き換え。`pypi` / `rubygems` から `required_reviewers` を解除する UI 手順を追加 (fulgur-7dmh の手動操作の指針)
- `## Release procedure` (旧 `## Release 手順`) を新フロー対応に書き換え (skip_bindings 経路 / release notes preview の dry-run コマンド)

### `docs/plans/2026-04-26-versioning-and-release-simplification-design.md` (新規)

PR #213 + 本 PR の設計書を repo に commit (これまで untracked だった)。

## 検証

- `npx markdownlint-cli2 README.md docs/RELEASE_SETUP.md docs/plans/2026-04-26-*.md` → 0 errors

## 関連 issue

- fulgur-432s: 本 PR で完了
- fulgur-7dmh: `pypi` / `rubygems` env の `required_reviewers` 実機解除 (本 PR の手順を参照して manual で実行)
- fulgur-ziqq: 0.6.0 cut (validation release)

## Test plan

- [ ] markdownlint-cli2 が CI で 0 errors
- [ ] README の Versioning section が GitHub render で読みやすい (table / code fence の表示確認)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated versioning policy to follow ZeroVer convention, where minor releases mark feature boundaries and patches are reserved for hotfixes.
  * Added guidance for Rust dependency users to pin to exact minor versions to prevent breaking changes.
  * Expanded release process documentation with improved workflow clarity and changelog procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->