### PR TITLE
ci(cache): consolidate dev shared-keys + scope save-if to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo fmt --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
 
@@ -77,6 +79,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ${{ matrix.cache-key }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install poppler-utils (for fulgur-wpt pdftocairo tests)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y poppler-utils mold
@@ -147,6 +150,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ubuntu-latest-fulgur-wasm
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       # Do NOT set RUSTFLAGS=-C link-arg=-fuse-ld=mold here; env RUSTFLAGS
       # is target-agnostic and would force mold onto the wasm32 build.
       - run: cargo check --target wasm32-unknown-unknown -p fulgur -p fulgur-wasm
@@ -162,6 +166,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ubuntu-latest-fulgur
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Configure mold linker
         run: echo "RUSTFLAGS=-C link-arg=-fuse-ld=mold" >> $GITHUB_ENV
       - name: Run VRT
@@ -221,6 +226,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ubuntu-latest-fulgur
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install poppler-utils
         run: sudo apt-get update && sudo apt-get install -y poppler-utils mold
       - name: Configure mold linker

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -35,7 +35,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ubuntu-release-fulgur
+          shared-key: ubuntu-latest-fulgur
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Determine version
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ubuntu-publish-fulgur
+          shared-key: ubuntu-latest-fulgur
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Configure fast build
         run: |

--- a/.github/workflows/vrt-chrome-update.yml
+++ b/.github/workflows/vrt-chrome-update.yml
@@ -46,6 +46,8 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Cache Chromium download
         uses: actions/cache@v5

--- a/.github/workflows/wpt-nightly.yml
+++ b/.github/workflows/wpt-nightly.yml
@@ -39,6 +39,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install poppler-utils
         run: sudo apt-get update && sudo apt-get install -y poppler-utils
       - name: Fetch WPT subset


### PR DESCRIPTION
## サマリ

`ubuntu-x86_64` の dev profile (debug build) cache が 4 つの shared-key に分裂し、main で温めた cache を release タイミングで再利用できなかった問題と、PR #208 で観測した Windows test の Post Run rust-cache 4m45s を解消する。fulgur-dpux 対応。

| | 変更前 | 変更後 |
|---|---|---|
| `release.yml` publish | `ubuntu-publish-fulgur` | `ubuntu-latest-fulgur` |
| `release-prepare.yml` | `ubuntu-release-fulgur` | `ubuntu-latest-fulgur` |

加えて、main push で温まる shared cache のすべての rust-cache@v2 step に `save-if: \${{ github.ref == 'refs/heads/main' }}` を追加。PR runs は cache 復元のみとなり、Windows save の重さが消える。

## 効果

- main commit ごとに `ubuntu-latest-fulgur` を更新 → ci.yml test/vrt/wpt と release CI が同一 cache を共有
- PR では cache を save しない → Windows test の Post Run 4m45s が消える
- 個々の cache のサイズが PR 間で膨らまず、GitHub の 10 GiB LRU eviction とも自然な相性

## save-if=main を**付けなかった**箇所と理由

main で温まらない (= main push で save できない) isolated cache に save-if=main を付けると、最初の 7 日 LRU eviction 以降は永続的にコールドスタートする。以下は意図的に従来通りの挙動 (常時 save) を維持:

- `update-examples.yml` (`ubuntu-release-fulgur`): PR-only workflow + release profile build。release-prepare.yml が このキーを離れたので、結果的に update-examples 専用の release-profile cache として綺麗に分離される。
- `release.yml` build-binaries (`\${{ matrix.target }}-release`): PR-merge ref で発火。
- `release-python.yml` build-wheels (`\${{ matrix.target }}-python-release`): release event の tag ref で発火。
- `release-ruby.yml` build-platform (`\${{ matrix.platform }}-ruby-cross`): 同上。

## 注意点

1. **Cache contention**: 統合後の `ubuntu-latest-fulgur` は ci.yml test/vrt/wpt (`cargo nextest run --workspace`、大きい artifact) と release-prepare.yml (`cargo check --workspace`、小さい artifact) の両方が main で save する。last-writer-wins で release-prepare が cache を縮める可能性はあるが、ci.yml の頻度 (1日複数 push) のほうが圧倒的に高く、release-prepare は workflow_dispatch (月数回) なので実害は小さい。
2. **`cargo publish` の cache 利用は部分的**: `cargo publish -p fulgur` は `cargo package --verify` で一時 directory にビルドする。`target/` の reuse は限定的だが `~/.cargo/registry` (registry index + crate cache) は再利用されるため、依存解決と source download は速くなる。

## Test plan

- [ ] CI green (この PR 自体で Windows test の Post Run 時間を観察、現状 4m45s)
- [ ] main マージ後、次の PR で Windows save がスキップされることを確認
- [ ] 次回 release 時に release CI の実時間を観察 (具体値は別 issue で記録)

## Related

- fulgur-dpux (本 issue)
- PR #208 (Windows Post Run 4m45s 観測)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build pipeline caching behavior for improved CI/CD efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->