### PR TITLE
fix(bindings): handle fulgur::Error::Other in pyfulgur and fulgur-ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo fmt --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
 
@@ -77,6 +79,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ${{ matrix.cache-key }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install poppler-utils (for fulgur-wpt pdftocairo tests)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y poppler-utils mold
@@ -147,6 +150,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ubuntu-latest-fulgur-wasm
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       # Do NOT set RUSTFLAGS=-C link-arg=-fuse-ld=mold here; env RUSTFLAGS
       # is target-agnostic and would force mold onto the wasm32 build.
       - run: cargo check --target wasm32-unknown-unknown -p fulgur -p fulgur-wasm
@@ -162,6 +166,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ubuntu-latest-fulgur
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Configure mold linker
         run: echo "RUSTFLAGS=-C link-arg=-fuse-ld=mold" >> $GITHUB_ENV
       - name: Run VRT
@@ -221,6 +226,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ubuntu-latest-fulgur
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install poppler-utils
         run: sudo apt-get update && sudo apt-get install -y poppler-utils mold
       - name: Configure mold linker

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -35,7 +35,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ubuntu-release-fulgur
+          shared-key: ubuntu-latest-fulgur
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Determine version
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ubuntu-publish-fulgur
+          shared-key: ubuntu-latest-fulgur
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Configure fast build
         run: |

--- a/.github/workflows/vrt-chrome-update.yml
+++ b/.github/workflows/vrt-chrome-update.yml
@@ -46,6 +46,8 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Cache Chromium download
         uses: actions/cache@v5

--- a/.github/workflows/wpt-nightly.yml
+++ b/.github/workflows/wpt-nightly.yml
@@ -39,6 +39,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install poppler-utils
         run: sudo apt-get update && sudo apt-get install -y poppler-utils
       - name: Fetch WPT subset

--- a/crates/fulgur-ruby/src/error.rs
+++ b/crates/fulgur-ruby/src/error.rs
@@ -38,7 +38,8 @@ pub fn map_fulgur_error(ruby: &Ruby, err: FulgurError) -> Error {
         | FulgurError::HtmlParse(msg)
         | FulgurError::Layout(msg)
         | FulgurError::PdfGeneration(msg)
-        | FulgurError::Template(msg) => render_error(ruby, msg),
+        | FulgurError::Template(msg)
+        | FulgurError::Other(msg) => render_error(ruby, msg),
     }
 }
 

--- a/crates/pyfulgur/src/error.rs
+++ b/crates/pyfulgur/src/error.rs
@@ -17,7 +17,8 @@ pub fn map_fulgur_error(err: FulgurError) -> PyErr {
         FulgurError::HtmlParse(msg)
         | FulgurError::Layout(msg)
         | FulgurError::PdfGeneration(msg)
-        | FulgurError::Template(msg) => RenderError::new_err(msg),
+        | FulgurError::Template(msg)
+        | FulgurError::Other(msg) => RenderError::new_err(msg),
     }
 }
 


### PR DESCRIPTION
## 概要

0.6.0 release で PyPI / RubyGems publish が失敗。`fulgur::Error::Other(String)` (commit 5f0b7a9 `feat(fulgur): add inspect module` で追加) が両 binding の `match err {}` で覆われておらず、`E0004 non-exhaustive patterns` で compile fail。

両 binding の error.rs に `Other` arm を追加 (generic render error として `RenderError` にマップ)。

## 根本原因

両 binding crate は `#![cfg(feature = "ruby-api")]` / `#![cfg(feature = "extension-module")]` で全体 gate されているため、workspace 標準の `cargo check --workspace` ではマッチ式が空コンパイルされてエラーが検出されなかった。

実際に検出されたのは:

- `release-ruby.yml` の `Build precompiled gem`: ext/fulgur が crates.io から `fulgur = \"0.6.0\"` を pull → compile fail
- `release-python.yml` の `Build wheel`: maturin が `extension-module` 有効でビルド → compile fail

(0.5.x までは ext/fulgur が古い fulgur version を pull していたので Other variant 自体が無く、たまたま通っていた)

## 0.6.0 の現状

| Registry | 0.6.0 状態 |
|---|---|
| crates.io `fulgur` / `fulgur-cli` | publish 済み |
| GitHub Release v0.6.0 | publish 済み (CLI binary 6 platform) |
| npm `@fulgur-rs/cli-*` | publish 済み |
| PyPI `pyfulgur` | **0.5.11 のまま** |
| RubyGems `fulgur` | **0.5.11 のまま** |

crates.io / npm 0.6.0 は library として valid (Other variant は public API として公開) なので yank しない方針。

## 次のアクション (本 PR merge 後)

`release-prepare.yml` を `version=0.6.1` で起動 → 0.6.1 hotfix release。これで PyPI / RubyGems も 0.6.1 として publish される (0.5.11 → 0.6.1 への jump)。

## CI gap (別 issue 化推奨)

`cargo check --workspace` が両 binding を空コンパイルしてしまう問題は、別途 CI に `cargo check -p pyfulgur --features extension-module` / `cargo check -p fulgur-ruby --features ruby-api` 相当を追加する issue として起票する (本 PR の scope 外)。

## 検証

- ローカル: `cargo check -p pyfulgur --features extension-module` ✅ pass
- fulgur-ruby は rb-sys が ruby env を要求するためローカル check 不可、patch 自体は pyfulgur と対称的なので CI で検証

## Test plan

- [ ] `release-python.yml` / `release-ruby.yml` を `workflow_dispatch` で発火 (publish なし) → build / smoke が通ることを確認
- [ ] (本 PR merge 後) 0.6.1 を cut して bindings publish が完走するか確認
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow cache configuration by restricting cache persistence to the main branch across multiple workflow files.

* **Bug Fixes**
  * Fixed error handling consistency in Ruby and Python bindings to properly map all error variants to exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->