### PR TITLE
fix(release-ruby): bump rb-sys-dock tag to 0.9.127 (host version drift)

### DIFF
--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -115,14 +115,21 @@ jobs:
       # から rb_sys version を推論できない。そのまま放置すると fallback で
       # `gem info rb_sys --remote` が最新版を取りに行き、rb-sys-dock image tag
       # が float してビルド非決定になる。Gemfile の `rb_sys (~> 0.9)` と整合する
-      # 最新 stable (0.9.126) を `tag:` で明示 pin する。
+      # 最新 stable (0.9.127) を `tag:` で明示 pin する。
+      #
+      # ホスト rb_sys と container image の tag が一致していないと、container 内の
+      # rake-compiler が一部 Ruby 用 rbconfig を持たず fat gem 生成が崩れる
+      # (3.2/3.3/3.4 用 rbconfig 不在 → 3.1 用 .so のみ入った gem が
+      # `required_ruby_version: >= 3.1, < 3.2.dev` で出力され、Ruby 3.2+ で
+      # install 不能になる。v0.7.0 で実際に発生)。
       # rb_sys upgrade 時はここと Gemfile 側を両方更新すること。
+      # Gemfile.lock を commit する構造的修正は fulgur-jdt3 で追跡。
       - uses: oxidize-rb/actions/cross-gem@e5f9a49a7812a078584072f6e3f657ad247c8771  # v1.4.4
         with:
           platform: ${{ matrix.platform }}
           ruby-versions: "3.1,3.2,3.3,3.4"
           working-directory: crates/fulgur-ruby
-          tag: "0.9.126"
+          tag: "0.9.127"
       - uses: actions/upload-artifact@v4
         with:
           name: cross-gem-${{ matrix.platform }}


### PR DESCRIPTION
## 概要

v0.7.0 release で precompiled gem の smoke test (musl + 通常) が大量失敗。原因は **rb-sys host vs container の version 乖離**。

## 根本原因

- `oxidize-rb/actions/cross-gem` は host の rb_sys gem を Gemfile.lock から推論する
- `crates/fulgur-ruby/.gitignore` が `/Gemfile.lock` を除外しているため、host は常に rubygems.org の最新を pull
- workflow は container image を `tag: \"0.9.126\"` で pin
- v0.5.11 cut 時 (2026-04-22): rb_sys 0.9.127 は未 release → host=0.9.126, container=0.9.126 で一致 ✅
- rb_sys 0.9.127 release: **2026-04-23 17:25 UTC**
- v0.7.0 cut 時 (2026-04-25): host=0.9.127, container=0.9.126 で乖離 ❌

container (0.9.126) の rake-compiler は **Ruby 3.1 用 rbconfig しか持たず**、3.2 / 3.3 / 3.4 用が無い。fat gem 化が壊れて 3.1 用 `.so` 1 個のみの gem が生成され、`required_ruby_version: \">= 3.1, < 3.2.dev\"` で出力。Ruby 3.3-alpine の smoke で install 不可となった。

ログ裏付け (v0.7.0 build log):

\`\`\`text
no configuration section for specified version of Ruby (rbconfig-aarch64-linux-3.4.9)
no configuration section for specified version of Ruby (rbconfig-aarch64-linux-3.3.11)
no configuration section for specified version of Ruby (rbconfig-aarch64-linux-3.2.11)
\`\`\`

\`\`\`text
fulgur-0.7.0-aarch64-linux-musl requires Ruby version >= 3.1, < 3.2.dev.
The current ruby version is 3.3.11.
\`\`\`

## 修正

`tag: \"0.9.126\"` → `\"0.9.127\"` に bump。container と host の rb_sys version を再整合。コメントに事故内容と検出手順を残す。

## 構造的修正 (別 issue)

fulgur-jdt3: Gemfile.lock を `.gitignore` から外して commit。これで host rb_sys version は Gemfile.lock の lock 値で決定され、tag: と確実に一致する (今回のような事故が再発しなくなる)。

## 0.7.0 / 0.7.1 の状況

| Registry | 0.7.0 状態 |
|---|---|
| crates.io / npm / GitHub Release | publish 済み |
| PyPI | **0.5.11 のまま** |
| RubyGems | **0.5.11 のまま** |

本 PR merge 後に 0.7.1 hotfix を cut → bindings 初公開予定。

## Test plan

- [ ] 本 PR の CI で release-ruby.yml の workflow_dispatch (build + smoke のみ) が通ることを確認
  - もしくは 0.7.1 cut で実 release event を通す
- [ ] (本 PR merge + 0.7.1 cut 後) PyPI / RubyGems が 0.7.1 として publish されることを確認
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated precompiled gem build configuration to improve build process reliability and compatibility across Ruby versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->