### PR TITLE
fix(release-ruby): commit Gemfile.lock to pin rb_sys host version

### DIFF
--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -111,19 +111,15 @@ jobs:
           ruby-version: "3.3"
           bundler-cache: true
           working-directory: crates/fulgur-ruby
-      # Gemfile.lock は .gitignore で除外されているため、action が Gemfile.lock
-      # から rb_sys version を推論できない。そのまま放置すると fallback で
-      # `gem info rb_sys --remote` が最新版を取りに行き、rb-sys-dock image tag
-      # が float してビルド非決定になる。Gemfile の `rb_sys (~> 0.9)` と整合する
-      # 最新 stable (0.9.127) を `tag:` で明示 pin する。
-      #
-      # ホスト rb_sys と container image の tag が一致していないと、container 内の
-      # rake-compiler が一部 Ruby 用 rbconfig を持たず fat gem 生成が崩れる
-      # (3.2/3.3/3.4 用 rbconfig 不在 → 3.1 用 .so のみ入った gem が
-      # `required_ruby_version: >= 3.1, < 3.2.dev` で出力され、Ruby 3.2+ で
-      # install 不能になる。v0.7.0 で実際に発生)。
-      # rb_sys upgrade 時はここと Gemfile 側を両方更新すること。
-      # Gemfile.lock を commit する構造的修正は fulgur-jdt3 で追跡。
+      # rb_sys version は crates/fulgur-ruby/Gemfile.lock で pin している
+      # (fulgur-jdt3)。action は Gemfile.lock を読んでホスト側 rb_sys version を
+      # 解決し、`tag:` で指定した container image と一致させる必要がある。
+      # 両者がずれると container 内 rake-compiler が一部 Ruby 用 rbconfig を持たず
+      # fat gem 生成が崩れる (3.2/3.3/3.4 用 rbconfig 不在 → 3.1 用 .so のみ入った
+      # gem が `required_ruby_version: >= 3.1, < 3.2.dev` で出力され、Ruby 3.2+ で
+      # install 不能。v0.7.0 で実際に発生)。
+      # rb_sys upgrade 時は Gemfile.lock (`bundle update rb_sys`) と下記 `tag:` を
+      # 同じ version に揃えて更新すること。
       - uses: oxidize-rb/actions/cross-gem@e5f9a49a7812a078584072f6e3f657ad247c8771  # v1.4.4
         with:
           platform: ${{ matrix.platform }}

--- a/crates/fulgur-ruby/.gitignore
+++ b/crates/fulgur-ruby/.gitignore
@@ -2,7 +2,6 @@
 /tmp
 /.bundle
 /vendor
-/Gemfile.lock
 /lib/fulgur/*.so
 /ext/fulgur/target
 /ext/fulgur/Cargo.lock

--- a/crates/fulgur-ruby/Gemfile.lock
+++ b/crates/fulgur-ruby/Gemfile.lock
@@ -1,0 +1,45 @@
+PATH
+  remote: .
+  specs:
+    fulgur (0.8.0)
+      rb_sys (~> 0.9)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.6.2)
+    rake (13.4.2)
+    rake-compiler (1.3.1)
+      rake
+    rake-compiler-dock (1.12.0)
+    rb_sys (0.9.127)
+      rake-compiler-dock (= 1.12.0)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+
+PLATFORMS
+  aarch64-linux
+  arm64-darwin
+  ruby
+  x86_64-darwin
+  x86_64-linux
+
+DEPENDENCIES
+  fulgur!
+  rake (~> 13.0)
+  rake-compiler (~> 1.2)
+  rspec (~> 3.12)
+
+BUNDLED WITH
+   2.5.22


### PR DESCRIPTION
## 背景

`oxidize-rb/actions/cross-gem` は `crates/fulgur-ruby/Gemfile.lock` を読んで host 側の `rb_sys` version を解決する。これまで `Gemfile.lock` を `.gitignore` していたため、host は常に rubygems.org 最新を pull する一方、workflow の `tag:` で container image を pin していた。

両者が乖離すると、container 内 `rake-compiler` が一部 Ruby 用の rbconfig を欠いた状態で fat gem を生成し、`required_ruby_version: >= 3.1, < 3.2.dev` の壊れた gem が出てしまう。実際 v0.7.0 リリースで host=`0.9.127` / container=`0.9.126` の齟齬から Ruby 3.2+ で install 不能な gem が rubygems.org に publish された (緊急修正は #220 で `tag:` を `0.9.127` に bump)。

本 PR は構造的修正として `Gemfile.lock` を track 対象にし、host rb_sys version を lock 値で決定する。

## 変更点

- `crates/fulgur-ruby/.gitignore` から `/Gemfile.lock` を除外
- `crates/fulgur-ruby/Gemfile.lock` を新規追加
  - `rb_sys (0.9.127)` で pin (workflow `tag: \"0.9.127\"` と一致)
  - PLATFORMS に `ruby`, `x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, `arm64-darwin` を含める (各環境での `bundle install` で churn しないよう preadded)
- `.github/workflows/release-ruby.yml` のコメントを「Gemfile.lock 除外前提」から「Gemfile.lock を読んでホスト側 rb_sys version を解決する前提」に更新

## 検証

- `bundle install` で `rb_sys (0.9.127)` が解決されることを確認
- `bundle exec rake compile` 成功
- `bundle exec rspec` 62 examples / 0 failures

## 今後

`rb_sys` を upgrade する際は、`bundle update rb_sys` で `Gemfile.lock` を更新すると同時に `.github/workflows/release-ruby.yml` の `tag:` も同じ version に揃えること (workflow コメントにも明記済み)。

Closes fulgur-jdt3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced release workflow documentation with clearer explanations of how dependency versions ensure build consistency across releases and updated procedures for upgrading dependencies.

* **Chores**
  * Updated repository configuration to properly track Ruby dependency lockfile, ensuring deterministic and consistent builds across all development and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->