### PR TITLE
chore(deps): group artifact actions in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,14 @@ updates:
     cooldown:
       default-days: 7
     groups:
+      actions-artifact:
+        patterns:
+          - "actions/upload-artifact"
+          - "actions/download-artifact"
+        update-types:
+          - major
+          - minor
+          - patch
       actions-minor-patch:
         update-types:
           - minor


### PR DESCRIPTION
## Summary

- Dependabot 設定の `github-actions` セクションに `actions-artifact` グループを追加し、`actions/upload-artifact` と `actions/download-artifact` を major bump 含めて1本のPRにまとめる
- 既存の `actions-minor-patch` グループより前に置くことで、artifact 系は専用グループへ優先割当される

## なぜ

`actions/upload-artifact` と `actions/download-artifact` は v7/v8 で direct (unzipped) upload に対応し、download 側が `Content-Type` を見て decompress を切り替える挙動になった。片方だけバージョンを上げると CI のアーティファクト転送が壊れる可能性があるため、ペアでバージョンアップしたい。

現状の `actions-minor-patch` は minor/patch のみが対象なので、major bump はバラバラの PR として届く。実際に #174 (download-artifact 4 → 8) と #180 (upload-artifact 4 → 7) が個別 open になっており、これは典型的にグループ化したいケース。

## 既存の open PR について

このマージ後、#174 と #180 を close すれば次回 Dependabot run で1本に統合される（あるいは順番に手動マージしても可。順序は upload → download 推奨）。

## Test plan

- [ ] マージ後、Dependabot が次回 run で artifact ペアをグループ化したPRを生成すること（または既存 #174/#180 を統合した形になること）を確認
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to group GitHub Actions updates, streamlining the update process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->