### PR TITLE
ci(wpt): add opacity / visibility cherry-pick coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,9 @@ jobs:
           - phase: bugs
             test: wpt_lists
             filter: wpt_list_bugs
+          - phase: opacity-visibility
+            test: wpt_lists
+            filter: wpt_list_opacity_visibility
           - phase: smoke
             test: wpt_lists
             filter: wpt_list_smoke

--- a/.github/workflows/wpt-nightly.yml
+++ b/.github/workflows/wpt-nightly.yml
@@ -32,6 +32,9 @@ jobs:
           - phase: bugs
             test: wpt_lists
             filter: wpt_list_bugs
+          - phase: opacity-visibility
+            test: wpt_lists
+            filter: wpt_list_opacity_visibility
           - phase: smoke
             test: wpt_lists
             filter: wpt_list_smoke

--- a/crates/fulgur-wpt/expectations/lists/opacity-visibility.txt
+++ b/crates/fulgur-wpt/expectations/lists/opacity-visibility.txt
@@ -1,0 +1,47 @@
+# opacity / visibility coverage (fulgur-i3u9).
+# Cherry-picked WPT reftests across css/CSS2/visufx, css/css-tables,
+# css/css-color, css/css-pseudo, css/css-position, css/css-overflow,
+# and css/compositing. The implementation lives in fulgur-luu (closed),
+# this list is the regression net.
+#
+# Skipped from coverage (not in this list):
+#   - css/CSS2/visufx visibility-* manual tests without rel=match (~21)
+#   - css/css-tables visibility-{collapse,hidden}-* testharness/crash variants (~31)
+#   - css/css-overflow outline-with-opacity-crash.html
+#   - css/compositing opacity-and-transform-animation-crash.html
+#   - css/compositing Blending_in_a_group_with_opacity.html (filename-pair, no rel=match)
+#
+# Summary: 13 PASS, 18 FAIL, 0 SKIP (total 31).
+# Promote FAILs to PASS by editing this file in a PR after fixing the harness.
+
+FAIL  css/CSS2/visufx/visibility-005.xht  # page 1 diff 10201/891662 pixels exceed tol (max_ch=255)
+PASS  css/CSS2/visufx/visibility-block-001.xht
+FAIL  css/css-tables/visibility-collapse-border-spacing-001.html  # page 1 diff 2380/891662 pixels exceed tol (max_ch=255)
+FAIL  css/css-tables/visibility-collapse-border-spacing-002.html  # page 1 diff 40401/891662 pixels exceed tol (max_ch=255)
+FAIL  css/css-tables/visibility-collapse-colspan-003.html  # page 1 diff 5685/891662 pixels exceed tol (max_ch=255)
+FAIL  css/css-tables/visibility-collapse-rowspan-005.html  # page 1 diff 1286/891662 pixels exceed tol (max_ch=255)
+PASS  css/css-tables/visibility-hidden-collapsed-borders.html
+PASS  css/css-color/t32-opacity-basic-0.0-a.xht
+PASS  css/css-color/t32-opacity-basic-0.6-a.xht
+PASS  css/css-color/t32-opacity-basic-1.0-a.xht
+PASS  css/css-color/t32-opacity-clamping-0.0-b.xht
+PASS  css/css-color/t32-opacity-clamping-1.0-b.xht
+FAIL  css/css-color/t32-opacity-offscreen-b.xht  # page 1 diff 702/891662 pixels exceed tol (max_ch=26)
+FAIL  css/css-color/t32-opacity-offscreen-multiple-boxes-1-c.xht  # page 1 diff 430/891662 pixels exceed tol (max_ch=255)
+FAIL  css/css-color/t32-opacity-offscreen-multiple-boxes-2-c.xht  # page 1 diff 138/891662 pixels exceed tol (max_ch=255)
+PASS  css/css-color/t32-opacity-offscreen-with-alpha-c.xht
+FAIL  css/css-color/t32-opacity-zorder-c.xht  # page 1 diff 1290/891662 pixels exceed tol (max_ch=255)
+FAIL  css/css-color/body-opacity-0-to-1-stacking-context.html  # page 1 diff 39454/891662 pixels exceed tol (max_ch=255)
+FAIL  css/css-color/canvas-change-opacity.html  # page 1 diff 37249/891662 pixels exceed tol (max_ch=255)
+PASS  css/css-color/clip-opacity-out-of-flow.html
+FAIL  css/css-color/composited-filters-under-opacity.html  # page 1 diff 22801/891662 pixels exceed tol (max_ch=255)
+FAIL  css/css-color/filters-under-will-change-opacity.html  # page 1 diff 22801/891662 pixels exceed tol (max_ch=255)
+PASS  css/css-color/inline-opacity-float-child.html
+FAIL  css/css-color/opacity-overlapping-letters.html  # page 1 diff 5699/891662 pixels exceed tol (max_ch=128)
+FAIL  css/css-pseudo/first-letter-opacity-001.html  # page 1 diff 10/891662 pixels exceed tol (max_ch=44)
+PASS  css/css-pseudo/first-letter-opacity-float-001.html
+PASS  css/css-pseudo/first-line-opacity-001.html
+FAIL  css/css-position/invalidate-opacity-negative-z-index.html  # page 1 diff 2601/891662 pixels exceed tol (max_ch=202)
+PASS  css/css-overflow/overflow-inline-block-with-opacity.html
+FAIL  css/css-overflow/overflow-scroll-resize-visibility-hidden.html  # page 1 diff 501/891662 pixels exceed tol (max_ch=3)
+FAIL  css/compositing/root-element-background-margin-opacity.html  # page 1 diff 10201/891662 pixels exceed tol (max_ch=128)

--- a/scripts/wpt/subset.txt
+++ b/scripts/wpt/subset.txt
@@ -32,3 +32,70 @@ css/css-images/linear-gradient-1.html
 css/css-images/linear-gradient-non-square.html
 css/css-images/linear-gradient-ref.html
 css/css-images/reference/linear-gradient-non-square-ref.html
+
+# fulgur-i3u9: opacity / visibility WPT coverage (expectations/lists/opacity-visibility.txt).
+# Existing `css/reference` (line 8) already covers shared refs under that path.
+# CSS 2.1 visibility — visufx (only the 2 reftests with rel=match; the rest are manual)
+css/CSS2/visufx/visibility-005.xht
+css/CSS2/visufx/visibility-block-001.xht
+css/CSS2/reference/ref-filled-green-100px-square.xht
+css/CSS2/reference/no-red-on-blank-page-ref.xht
+# css-tables visibility (reftests only; testharness/crash variants excluded)
+css/css-tables/visibility-collapse-border-spacing-001.html
+css/css-tables/visibility-collapse-border-spacing-002.html
+css/css-tables/visibility-collapse-colspan-003.html
+css/css-tables/visibility-collapse-colspan-003-ref.html
+css/css-tables/visibility-collapse-rowspan-005.html
+css/css-tables/visibility-collapse-rowspan-005-ref.html
+css/css-tables/visibility-hidden-collapsed-borders.html
+# css-color opacity — t32 series + neighbours
+css/css-color/t32-opacity-basic-0.0-a.xht
+css/css-color/t32-opacity-basic-0.0-a-ref.html
+css/css-color/t32-opacity-basic-0.6-a.xht
+css/css-color/t32-opacity-basic-0.6-a-ref.xht
+css/css-color/t32-opacity-basic-1.0-a.xht
+css/css-color/t32-opacity-basic-1.0-a-ref.html
+css/css-color/t32-opacity-clamping-0.0-b.xht
+css/css-color/t32-opacity-clamping-1.0-b.xht
+css/css-color/t32-opacity-clamping-1.0-b-ref.html
+css/css-color/t32-opacity-offscreen-b.xht
+css/css-color/t32-opacity-offscreen-b-ref.html
+css/css-color/t32-opacity-offscreen-multiple-boxes-1-c.xht
+css/css-color/t32-opacity-offscreen-multiple-boxes-1-c-ref.html
+css/css-color/t32-opacity-offscreen-multiple-boxes-2-c.xht
+css/css-color/t32-opacity-offscreen-multiple-boxes-2-c-ref.html
+css/css-color/t32-opacity-offscreen-with-alpha-c.xht
+css/css-color/t32-opacity-offscreen-with-alpha-c-ref.html
+css/css-color/t32-opacity-zorder-c.xht
+css/css-color/t32-opacity-zorder-c-ref.html
+css/css-color/body-opacity-0-to-1-stacking-context.html
+css/css-color/canvas-change-opacity.html
+css/css-color/greensquare-ref.html
+css/css-color/clip-opacity-out-of-flow.html
+css/css-color/clip-opacity-out-of-flow-ref.html
+css/css-color/composited-filters-under-opacity.html
+css/css-color/composited-filters-under-opacity-ref.html
+css/css-color/filters-under-will-change-opacity.html
+css/css-color/inline-opacity-float-child.html
+css/css-color/opacity-overlapping-letters.html
+css/css-color/opacity-overlapping-letters-ref.html
+# css-pseudo first-letter / first-line opacity (notref needed for mismatch reftest)
+css/css-pseudo/first-letter-opacity-001.html
+css/css-pseudo/first-letter-opacity-001-ref.html
+css/css-pseudo/first-letter-opacity-001-not-ref.html
+css/css-pseudo/first-letter-opacity-float-001.html
+css/css-pseudo/first-letter-opacity-float-001-ref.html
+css/css-pseudo/first-line-opacity-001.html
+css/css-pseudo/first-line-opacity-001-ref.html
+css/css-pseudo/first-line-opacity-001-not-ref.html
+# css-position invalidate-opacity
+css/css-position/invalidate-opacity-negative-z-index.html
+css/css-position/invalidate-opacity-negative-z-index-ref.html
+# css-overflow opacity / visibility (crash test excluded)
+css/css-overflow/overflow-inline-block-with-opacity.html
+css/css-overflow/reference/overflow-inline-block-with-opacity-ref.html
+css/css-overflow/overflow-scroll-resize-visibility-hidden.html
+css/css-overflow/overflow-scroll-resize-visibility-hidden-ref.html
+# compositing opacity (rel=match explicit only)
+css/compositing/root-element-background-margin-opacity.html
+css/compositing/root-element-background-margin-opacity-ref.html


### PR DESCRIPTION
## Summary

- WPT cherry-pick の opacity / visibility カバレッジを追加 (fulgur-i3u9)。
- `expectations/lists/opacity-visibility.txt` に 31 reftests を登録 — 初期値 **13 PASS / 18 FAIL**。
- 該当範囲: `css/CSS2/visufx`, `css/css-tables`, `css/css-color`, `css/css-pseudo`, `css/css-position`, `css/css-overflow`, `css/compositing`。
- 実装本体は fulgur-luu で完了済 (commits `19e2d71`, `70c3ccb`, `5470f23`, `15cd591`, `5f24bc8`)。本 PR はそのリグレッションネット。

## 取り込み判断

- **採用**: `<link rel="match">` または `<link rel="mismatch">` を持つ reftest のみ。
- **除外**:
  - `css/CSS2/visufx` の visibility-* manual テスト 21 件 (rel=match なし)。
  - `css/css-tables` の visibility-{collapse,hidden}-* testharness/crash バリアント ~31 件。
  - `css/css-overflow/outline-with-opacity-crash.html`、`css/compositing/opacity-and-transform-animation-crash.html`。
  - `css/compositing/Blending_in_a_group_with_opacity.html` (filename-pair convention のみ、明示的 rel=match なし)。

## 観察事項 (triage 候補)

**1. ピクセル diff の同値ペア — 共通の根本原因の可能性**

- `visibility-005.xht` ↔ `root-element-background-margin-opacity.html` (両方 `10201/891662`)
- `composited-filters-under-opacity.html` ↔ `filters-under-will-change-opacity.html` (両方 `22801/891662`)

**2. `css-tables/visibility-collapse-*` 4 件 FAIL は別カテゴリの未対応スコープ**

fulgur-luu の現実装は `Visibility::Collapse` を `Hidden` 扱い (描画スキップ) としているが、本来は table の row / column を 0-height / 0-width に collapse する必要がある。これは tolerance ノイズではなく仕様未対応。フォローアップ起票済: **fulgur-ahqr** (P3)。

**3. `first-letter-opacity-001.html` は diff 10 px** — ほぼアンチエイリアスノイズ、優先度低。

## Test plan

- [x] `cargo build -p fulgur-wpt --example run_one` — green
- [x] `bash scripts/wpt/fetch.sh` — 追加 cherry-pick が `target/wpt/` にチェックアウト
- [x] `FULGUR_WPT_REQUIRED=1 cargo test -p fulgur-wpt --test wpt_lists -- wpt_list_opacity_visibility` — green (`13 PASS / 18 FAIL / 0 regression / 0 promotion`)
- [x] `cargo fmt --check` — clean
- [ ] CI の `wpt` matrix job で再生 (PR 後 GitHub Actions に委譲)

## 関連 issue

- Closes fulgur-i3u9 (本作業)
- Closes fulgur-luu (実装は既に main)
- Refs fulgur-ahqr (visibility:collapse table semantics のフォローアップ)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded Web Platform Test coverage for opacity and visibility across multiple CSS modules, adding curated expectations and additional reftest/reference pairings to improve validation and coverage reporting.
* **Chores**
  * Added a dedicated test phase/shard for opacity-visibility to CI and nightly runs so phase-specific reports and artifacts are produced and aggregated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->