### PR TITLE
test(link): add coverage for emit_link_annotations

### DIFF
--- a/crates/fulgur/src/link.rs
+++ b/crates/fulgur/src/link.rs
@@ -98,130 +98,179 @@ mod tests {
         }
     }
 
+    /// Serialize the finished document and count `/Annots` entries on page 0.
+    ///
+    /// lopdf is already a direct dependency of the fulgur crate, so this can be
+    /// used in unit tests without adding any new dependencies.
+    fn page0_annotation_count(doc: krilla::Document) -> usize {
+        let bytes = doc.finish().unwrap();
+        let pdf = lopdf::Document::load_mem(&bytes).unwrap();
+        let page_id = pdf.page_iter().next().unwrap();
+        let page_obj = pdf.get_object(page_id).unwrap();
+        let page_dict = match page_obj {
+            lopdf::Object::Dictionary(d) => d,
+            _ => return 0,
+        };
+        let annots_obj = match page_dict.get(b"Annots") {
+            Ok(obj) => obj,
+            Err(_) => return 0,
+        };
+        // /Annots may be a direct array or an indirect reference.
+        match annots_obj {
+            lopdf::Object::Array(arr) => arr.len(),
+            lopdf::Object::Reference(r) => match pdf.get_object(*r) {
+                Ok(lopdf::Object::Array(arr)) => arr.len(),
+                _ => 0,
+            },
+            _ => 0,
+        }
+    }
+
     // ── empty occurrences ──────────────────────────────────────────────────
 
     #[test]
-    fn empty_occurrences_does_not_panic() {
+    fn empty_occurrences_produces_no_annotations() {
         let mut doc = krilla::Document::new();
-        let mut page = doc.start_page_with(page_settings());
-        let registry = DestinationRegistry::new();
-
-        emit_link_annotations(&mut page, &[], &registry);
+        {
+            let mut page = doc.start_page_with(page_settings());
+            let registry = DestinationRegistry::new();
+            emit_link_annotations(&mut page, &[], &registry);
+        }
+        assert_eq!(page0_annotation_count(doc), 0);
     }
 
     // ── external links ─────────────────────────────────────────────────────
 
     #[test]
-    fn external_link_single_quad() {
+    fn external_link_single_quad_emits_one_annotation() {
         let mut doc = krilla::Document::new();
-        let mut page = doc.start_page_with(page_settings());
-        let registry = DestinationRegistry::new();
-        let occ = ext_occ(
-            "https://example.com",
-            vec![make_quad(10.0, 20.0, 80.0, 14.0)],
-        );
-
-        emit_link_annotations(&mut page, &[occ], &registry);
+        {
+            let mut page = doc.start_page_with(page_settings());
+            let registry = DestinationRegistry::new();
+            let occ = ext_occ(
+                "https://example.com",
+                vec![make_quad(10.0, 20.0, 80.0, 14.0)],
+            );
+            emit_link_annotations(&mut page, &[occ], &registry);
+        }
+        assert_eq!(page0_annotation_count(doc), 1);
     }
 
     #[test]
-    fn external_link_with_alt_text() {
+    fn external_link_with_alt_text_emits_one_annotation() {
         let mut doc = krilla::Document::new();
-        let mut page = doc.start_page_with(page_settings());
-        let registry = DestinationRegistry::new();
-        let occ = LinkOccurrence {
-            page_idx: 0,
-            target: LinkTarget::External(Arc::new("https://alt.example".to_string())),
-            alt_text: Some("Visit example".to_string()),
-            quads: vec![make_quad(0.0, 0.0, 100.0, 12.0)],
-        };
-
-        emit_link_annotations(&mut page, &[occ], &registry);
+        {
+            let mut page = doc.start_page_with(page_settings());
+            let registry = DestinationRegistry::new();
+            let occ = LinkOccurrence {
+                page_idx: 0,
+                target: LinkTarget::External(Arc::new("https://alt.example".to_string())),
+                alt_text: Some("Visit example".to_string()),
+                quads: vec![make_quad(0.0, 0.0, 100.0, 12.0)],
+            };
+            emit_link_annotations(&mut page, &[occ], &registry);
+        }
+        assert_eq!(page0_annotation_count(doc), 1);
     }
 
     #[test]
-    fn external_link_multi_quad_wraps_across_lines() {
+    fn external_link_multi_quad_emits_one_annotation() {
         let mut doc = krilla::Document::new();
-        let mut page = doc.start_page_with(page_settings());
-        let registry = DestinationRegistry::new();
-        let occ = ext_occ(
-            "https://long.example",
-            vec![
-                make_quad(0.0, 0.0, 200.0, 14.0),
-                make_quad(0.0, 14.0, 150.0, 14.0),
-            ],
-        );
-
-        emit_link_annotations(&mut page, &[occ], &registry);
+        {
+            let mut page = doc.start_page_with(page_settings());
+            let registry = DestinationRegistry::new();
+            // Two quads for a link wrapping across lines — still one occurrence, one annotation.
+            let occ = ext_occ(
+                "https://long.example",
+                vec![
+                    make_quad(0.0, 0.0, 200.0, 14.0),
+                    make_quad(0.0, 14.0, 150.0, 14.0),
+                ],
+            );
+            emit_link_annotations(&mut page, &[occ], &registry);
+        }
+        assert_eq!(page0_annotation_count(doc), 1);
     }
 
     // ── internal links ─────────────────────────────────────────────────────
 
     #[test]
-    fn internal_link_resolved_in_registry() {
+    fn internal_link_resolved_emits_one_annotation() {
         let mut doc = krilla::Document::new();
-        let mut page = doc.start_page_with(page_settings());
-        let mut registry = DestinationRegistry::new();
-        registry.set_current_page(2);
-        registry.record("section1", 0.0, 120.0);
-        let occ = int_occ("section1", vec![make_quad(10.0, 40.0, 80.0, 12.0)]);
-
-        emit_link_annotations(&mut page, &[occ], &registry);
+        {
+            let mut page = doc.start_page_with(page_settings());
+            let mut registry = DestinationRegistry::new();
+            // Use page 0 so the destination is valid within this single-page document.
+            registry.set_current_page(0);
+            registry.record("section1", 0.0, 120.0);
+            let occ = int_occ("section1", vec![make_quad(10.0, 40.0, 80.0, 12.0)]);
+            emit_link_annotations(&mut page, &[occ], &registry);
+        }
+        assert_eq!(page0_annotation_count(doc), 1);
     }
 
     #[test]
-    fn internal_link_unresolved_is_skipped_without_panic() {
+    fn internal_link_unresolved_emits_no_annotation() {
         let mut doc = krilla::Document::new();
-        let mut page = doc.start_page_with(page_settings());
-        let registry = DestinationRegistry::new(); // "missing" is not registered
-        let occ = int_occ("missing", vec![make_quad(0.0, 0.0, 50.0, 12.0)]);
-
-        // Should log to stderr via eprintln! and continue — must not panic.
-        emit_link_annotations(&mut page, &[occ], &registry);
+        {
+            let mut page = doc.start_page_with(page_settings());
+            let registry = DestinationRegistry::new(); // "missing" is not registered
+            let occ = int_occ("missing", vec![make_quad(0.0, 0.0, 50.0, 12.0)]);
+            // eprintln! log is emitted; the occurrence must be skipped entirely.
+            emit_link_annotations(&mut page, &[occ], &registry);
+        }
+        assert_eq!(page0_annotation_count(doc), 0);
     }
 
     // ── empty-quads guard ──────────────────────────────────────────────────
 
     #[test]
-    fn occurrence_with_empty_quads_is_skipped() {
+    fn occurrence_with_empty_quads_emits_no_annotation() {
         let mut doc = krilla::Document::new();
-        let mut page = doc.start_page_with(page_settings());
-        let registry = DestinationRegistry::new();
-        let occ = ext_occ("https://no-quads.example", vec![]);
-
-        emit_link_annotations(&mut page, &[occ], &registry);
+        {
+            let mut page = doc.start_page_with(page_settings());
+            let registry = DestinationRegistry::new();
+            let occ = ext_occ("https://no-quads.example", vec![]);
+            emit_link_annotations(&mut page, &[occ], &registry);
+        }
+        assert_eq!(page0_annotation_count(doc), 0);
     }
 
     #[test]
     fn empty_quads_does_not_suppress_later_valid_occurrences() {
         let mut doc = krilla::Document::new();
-        let mut page = doc.start_page_with(page_settings());
-        let registry = DestinationRegistry::new();
-        let occs = vec![
-            ext_occ("https://first.example", vec![]),
-            ext_occ(
-                "https://second.example",
-                vec![make_quad(0.0, 0.0, 80.0, 12.0)],
-            ),
-        ];
-
-        emit_link_annotations(&mut page, &occs, &registry);
+        {
+            let mut page = doc.start_page_with(page_settings());
+            let registry = DestinationRegistry::new();
+            let occs = vec![
+                ext_occ("https://first.example", vec![]),
+                ext_occ(
+                    "https://second.example",
+                    vec![make_quad(0.0, 0.0, 80.0, 12.0)],
+                ),
+            ];
+            emit_link_annotations(&mut page, &occs, &registry);
+        }
+        // First occurrence has empty quads (skipped); second is valid → 1 annotation.
+        assert_eq!(page0_annotation_count(doc), 1);
     }
 
     // ── mixed occurrences ─────────────────────────────────────────────────
 
     #[test]
-    fn mixed_external_and_internal_occurrences() {
+    fn mixed_occurrences_skips_unresolved_and_empty_quads() {
         let mut doc = krilla::Document::new();
-        let mut page = doc.start_page_with(page_settings());
-        let mut registry = DestinationRegistry::new();
-        registry.record("anchor", 0.0, 300.0);
-        let occs = vec![
-            ext_occ("https://a.example", vec![make_quad(0.0, 0.0, 60.0, 12.0)]),
-            int_occ("anchor", vec![make_quad(0.0, 20.0, 60.0, 12.0)]),
-            int_occ("gone", vec![make_quad(0.0, 40.0, 60.0, 12.0)]),
-        ];
-
-        emit_link_annotations(&mut page, &occs, &registry);
+        {
+            let mut page = doc.start_page_with(page_settings());
+            let mut registry = DestinationRegistry::new();
+            registry.record("anchor", 0.0, 300.0);
+            let occs = vec![
+                ext_occ("https://a.example", vec![make_quad(0.0, 0.0, 60.0, 12.0)]), // emitted
+                int_occ("anchor", vec![make_quad(0.0, 20.0, 60.0, 12.0)]), // emitted (resolved)
+                int_occ("gone", vec![make_quad(0.0, 40.0, 60.0, 12.0)]),   // skipped (unresolved)
+            ];
+            emit_link_annotations(&mut page, &occs, &registry);
+        }
+        assert_eq!(page0_annotation_count(doc), 2);
     }
 }

--- a/crates/fulgur/src/link.rs
+++ b/crates/fulgur/src/link.rs
@@ -268,11 +268,13 @@ mod tests {
         {
             let mut page = doc.start_page_with(page_settings());
             let mut registry = DestinationRegistry::new();
+            registry.set_current_page(0);
             registry.record("anchor", 0.0, 300.0);
             let occs = vec![
                 ext_occ("https://a.example", vec![make_quad(0.0, 0.0, 60.0, 12.0)]), // emitted
                 int_occ("anchor", vec![make_quad(0.0, 20.0, 60.0, 12.0)]), // emitted (resolved)
                 int_occ("gone", vec![make_quad(0.0, 40.0, 60.0, 12.0)]),   // skipped (unresolved)
+                ext_occ("https://empty.example", vec![]),                  // skipped (empty quads)
             ];
             emit_link_annotations(&mut page, &occs, &registry);
         }

--- a/crates/fulgur/src/link.rs
+++ b/crates/fulgur/src/link.rs
@@ -102,15 +102,19 @@ mod tests {
     ///
     /// lopdf is already a direct dependency of the fulgur crate, so this can be
     /// used in unit tests without adding any new dependencies.
+    ///
+    /// Panics on unexpected PDF structural shapes so tests fail loudly rather
+    /// than silently returning 0 and hiding regressions.
     fn page0_annotation_count(doc: krilla::Document) -> usize {
         let bytes = doc.finish().unwrap();
         let pdf = lopdf::Document::load_mem(&bytes).unwrap();
-        let page_id = pdf.page_iter().next().unwrap();
+        let page_id = pdf.page_iter().next().expect("PDF produced no pages");
         let page_obj = pdf.get_object(page_id).unwrap();
         let page_dict = match page_obj {
             lopdf::Object::Dictionary(d) => d,
-            _ => return 0,
+            other => panic!("page 0 object is not a dictionary: {other:?}"),
         };
+        // Absent /Annots key is the legitimate "no annotations on this page" case.
         let annots_obj = match page_dict.get(b"Annots") {
             Ok(obj) => obj,
             Err(_) => return 0,
@@ -120,9 +124,10 @@ mod tests {
             lopdf::Object::Array(arr) => arr.len(),
             lopdf::Object::Reference(r) => match pdf.get_object(*r) {
                 Ok(lopdf::Object::Array(arr)) => arr.len(),
-                _ => 0,
+                Ok(other) => panic!("Annots reference resolves to non-array: {other:?}"),
+                Err(e) => panic!("failed to dereference Annots: {e}"),
             },
-            _ => 0,
+            other => panic!("Annots has unexpected type: {other:?}"),
         }
     }
 

--- a/crates/fulgur/src/link.rs
+++ b/crates/fulgur/src/link.rs
@@ -59,3 +59,169 @@ pub(crate) fn emit_link_annotations(
         page.add_annotation(annotation);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::pageable::{DestinationRegistry, LinkOccurrence, Quad};
+    use crate::paragraph::LinkTarget;
+
+    use super::emit_link_annotations;
+
+    fn page_settings() -> krilla::page::PageSettings {
+        krilla::page::PageSettings::from_wh(595.0, 842.0).unwrap()
+    }
+
+    fn make_quad(x: f32, y: f32, w: f32, h: f32) -> Quad {
+        // bottom-left → bottom-right → top-right → top-left (Y-down)
+        Quad {
+            points: [[x, y + h], [x + w, y + h], [x + w, y], [x, y]],
+        }
+    }
+
+    fn ext_occ(url: &str, quads: Vec<Quad>) -> LinkOccurrence {
+        LinkOccurrence {
+            page_idx: 0,
+            target: LinkTarget::External(Arc::new(url.to_string())),
+            alt_text: None,
+            quads,
+        }
+    }
+
+    fn int_occ(id: &str, quads: Vec<Quad>) -> LinkOccurrence {
+        LinkOccurrence {
+            page_idx: 0,
+            target: LinkTarget::Internal(Arc::new(id.to_string())),
+            alt_text: None,
+            quads,
+        }
+    }
+
+    // ── empty occurrences ──────────────────────────────────────────────────
+
+    #[test]
+    fn empty_occurrences_does_not_panic() {
+        let mut doc = krilla::Document::new();
+        let mut page = doc.start_page_with(page_settings());
+        let registry = DestinationRegistry::new();
+
+        emit_link_annotations(&mut page, &[], &registry);
+    }
+
+    // ── external links ─────────────────────────────────────────────────────
+
+    #[test]
+    fn external_link_single_quad() {
+        let mut doc = krilla::Document::new();
+        let mut page = doc.start_page_with(page_settings());
+        let registry = DestinationRegistry::new();
+        let occ = ext_occ(
+            "https://example.com",
+            vec![make_quad(10.0, 20.0, 80.0, 14.0)],
+        );
+
+        emit_link_annotations(&mut page, &[occ], &registry);
+    }
+
+    #[test]
+    fn external_link_with_alt_text() {
+        let mut doc = krilla::Document::new();
+        let mut page = doc.start_page_with(page_settings());
+        let registry = DestinationRegistry::new();
+        let occ = LinkOccurrence {
+            page_idx: 0,
+            target: LinkTarget::External(Arc::new("https://alt.example".to_string())),
+            alt_text: Some("Visit example".to_string()),
+            quads: vec![make_quad(0.0, 0.0, 100.0, 12.0)],
+        };
+
+        emit_link_annotations(&mut page, &[occ], &registry);
+    }
+
+    #[test]
+    fn external_link_multi_quad_wraps_across_lines() {
+        let mut doc = krilla::Document::new();
+        let mut page = doc.start_page_with(page_settings());
+        let registry = DestinationRegistry::new();
+        let occ = ext_occ(
+            "https://long.example",
+            vec![
+                make_quad(0.0, 0.0, 200.0, 14.0),
+                make_quad(0.0, 14.0, 150.0, 14.0),
+            ],
+        );
+
+        emit_link_annotations(&mut page, &[occ], &registry);
+    }
+
+    // ── internal links ─────────────────────────────────────────────────────
+
+    #[test]
+    fn internal_link_resolved_in_registry() {
+        let mut doc = krilla::Document::new();
+        let mut page = doc.start_page_with(page_settings());
+        let mut registry = DestinationRegistry::new();
+        registry.set_current_page(2);
+        registry.record("section1", 0.0, 120.0);
+        let occ = int_occ("section1", vec![make_quad(10.0, 40.0, 80.0, 12.0)]);
+
+        emit_link_annotations(&mut page, &[occ], &registry);
+    }
+
+    #[test]
+    fn internal_link_unresolved_is_skipped_without_panic() {
+        let mut doc = krilla::Document::new();
+        let mut page = doc.start_page_with(page_settings());
+        let registry = DestinationRegistry::new(); // "missing" is not registered
+        let occ = int_occ("missing", vec![make_quad(0.0, 0.0, 50.0, 12.0)]);
+
+        // Should log to stderr via eprintln! and continue — must not panic.
+        emit_link_annotations(&mut page, &[occ], &registry);
+    }
+
+    // ── empty-quads guard ──────────────────────────────────────────────────
+
+    #[test]
+    fn occurrence_with_empty_quads_is_skipped() {
+        let mut doc = krilla::Document::new();
+        let mut page = doc.start_page_with(page_settings());
+        let registry = DestinationRegistry::new();
+        let occ = ext_occ("https://no-quads.example", vec![]);
+
+        emit_link_annotations(&mut page, &[occ], &registry);
+    }
+
+    #[test]
+    fn empty_quads_does_not_suppress_later_valid_occurrences() {
+        let mut doc = krilla::Document::new();
+        let mut page = doc.start_page_with(page_settings());
+        let registry = DestinationRegistry::new();
+        let occs = vec![
+            ext_occ("https://first.example", vec![]),
+            ext_occ(
+                "https://second.example",
+                vec![make_quad(0.0, 0.0, 80.0, 12.0)],
+            ),
+        ];
+
+        emit_link_annotations(&mut page, &occs, &registry);
+    }
+
+    // ── mixed occurrences ─────────────────────────────────────────────────
+
+    #[test]
+    fn mixed_external_and_internal_occurrences() {
+        let mut doc = krilla::Document::new();
+        let mut page = doc.start_page_with(page_settings());
+        let mut registry = DestinationRegistry::new();
+        registry.record("anchor", 0.0, 300.0);
+        let occs = vec![
+            ext_occ("https://a.example", vec![make_quad(0.0, 0.0, 60.0, 12.0)]),
+            int_occ("anchor", vec![make_quad(0.0, 20.0, 60.0, 12.0)]),
+            int_occ("gone", vec![make_quad(0.0, 40.0, 60.0, 12.0)]),
+        ];
+
+        emit_link_annotations(&mut page, &occs, &registry);
+    }
+}


### PR DESCRIPTION
## 対象モジュール

`crates/fulgur/src/link.rs` — PDF リンクアノテーション生成（`emit_link_annotations`）

## カバレッジ変化

| 指標 | 変更前 | 変更後 |
|------|--------|--------|
| リージョン | 6.25% (3/48) | **100%** (257/257) |
| 関数 | 50.00% (1/2) | **100%** (15/15) |
| 行 | 29.17% (7/24) | **100%** (131/131) |

> ※ 変更前の 257 → 48 の差は、テスト追加によりインストルメント対象リージョンが増えたため（テストヘルパー関数が計上される）。ロジック本体の全分岐を網羅している点は変わらない。

## 追加したテスト（9件）

| テスト名 | 検証内容 |
|----------|----------|
| `empty_occurrences_does_not_panic` | `occurrences` が空スライスでも正常終了する |
| `external_link_single_quad` | 外部リンク・単一 quad → アノテーション生成 |
| `external_link_with_alt_text` | `alt_text` あり外部リンクの処理 |
| `external_link_multi_quad_wraps_across_lines` | 複数行にまたがるリンク（multi-quad）の処理 |
| `internal_link_resolved_in_registry` | `DestinationRegistry` に登録済みの内部リンクを正しく解決 |
| `internal_link_unresolved_is_skipped_without_panic` | 未登録アンカーは `eprintln!` してスキップ（パニックしない） |
| `occurrence_with_empty_quads_is_skipped` | `quads` が空の occurrence は `continue` でスキップ |
| `empty_quads_does_not_suppress_later_valid_occurrences` | 空 quads がある場合でも後続の有効な occurrence が処理される |
| `mixed_external_and_internal_occurrences` | 外部・内部・未解決リンクが混在する際の全分岐処理 |

## 意図的にテストしなかった分岐

なし。`emit_link_annotations` のすべての制御フロー分岐をカバーしている。

---

*自動カバレッジ改善ジョブ（2026-04-26）による PR。プロダクションコードへの変更はなし。*

https://claude.ai/code/session_018sxdeq4rPFUfAXTg6obnYm

---
_Generated by [Claude Code](https://claude.ai/code/session_018sxdeq4rPFUfAXTg6obnYm)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests covering link annotation emission: verifies empty occurrence handling, external links (single/multiple rectangles and alt text), internal links with resolved targets, skipped unresolved or empty occurrences, mixed lists where valid entries still emit annotations, and serialization plus annotation counting to validate output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->