### PR TITLE
feat(gradient): support length-typed stop position in linear/radial gradients

### DIFF
--- a/crates/fulgur-vrt/tests/gradient_harness.rs
+++ b/crates/fulgur-vrt/tests/gradient_harness.rs
@@ -286,3 +286,120 @@ fn linear_gradient_px_stop_matches_percentage_reference() {
         ref_dir.join("page-1.png").display(),
     );
 }
+
+/// 200×200 box の上に任意の `background` プロパティ値を載せた HTML を生成する。
+/// radial gradient の reftest 用に正方形固定レイアウトを採用する。
+fn build_radial_gradient_html(title: &str, background: &str) -> String {
+    format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{title}</title>
+<style>
+  html, body {{ margin: 0; padding: 0; background: white; }}
+  .g {{
+    width: 200px;
+    height: 200px;
+    margin: {m}px;
+    background: {bg};
+  }}
+</style>
+</head>
+<body>
+  <div class="g"></div>
+</body>
+</html>"#,
+        title = title,
+        m = GRADIENT_MARGIN_PX,
+        bg = background,
+    )
+}
+
+/// `radial-gradient(circle 100px at center, red 0px, blue 50px, blue 100px)` のような
+/// `<length>` 型 stop が、対応する `<percentage>` 解決 (CSS Images §3.6.1) と等価な
+/// PDF を生成することを確認する。
+///
+/// 戦略: test と ref をどちらも fulgur で描画する。test 側は px 指定で
+/// `LengthPx → Fraction` 変換 (radial gradient の場合の基準は ending shape の半径
+/// = `rx` = 100 CSS px) を経由し、ref 側は最初から `<percentage>` で書く。
+/// CSS Images §3.6.1 で「radial gradient の gradient line length は ending shape
+/// の中心から境界までの長さ」と定義されており、circle 100px 指定では rx = 100px。
+/// したがって 0px / 50px / 100px はそれぞれ 0% / 50% / 100% に解決される。
+///
+/// このテストは Task 5 で linear path に対して修正された pt → CSS px 変換が
+/// radial path でも正しく機能していることを保証する (`gradient_line_length_px`
+/// は radial の場合は `rx_px` を渡している)。
+#[test]
+fn radial_gradient_px_stop_matches_percentage_reference() {
+    // 200×200 box, circle 100px at center: rx = 100 CSS px
+    // 0px = 0%, 50px = 50%, 100px = 100% に解決される piecewise gradient
+    let test_html = build_radial_gradient_html(
+        "VRT test: radial-gradient with px-typed stops",
+        "radial-gradient(circle 100px at center, red 0px, blue 50px, blue 100px)",
+    );
+    let ref_html = build_radial_gradient_html(
+        "VRT ref: radial-gradient with percentage-typed stops",
+        "radial-gradient(circle 100px at center, red 0%, blue 50%, blue 100%)",
+    );
+
+    let spec = RenderSpec {
+        page_size: "A4",
+        margin_pt: Some(0.0),
+        dpi: 150,
+    };
+
+    let test_pdf = render_html_to_pdf(&test_html, spec).expect("render test pdf");
+    let ref_pdf = render_html_to_pdf(&ref_html, spec).expect("render ref pdf");
+
+    let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let work_dir = crate_root
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root")
+        .join("target/vrt-radial-gradient-px-stops-harness");
+    fs::create_dir_all(&work_dir).expect("create work dir");
+
+    let test_dir = work_dir.join("test");
+    let ref_dir = work_dir.join("ref");
+    let _ = fs::remove_dir_all(&test_dir);
+    let _ = fs::remove_dir_all(&ref_dir);
+    fs::create_dir_all(&test_dir).expect("create test dir");
+    fs::create_dir_all(&ref_dir).expect("create ref dir");
+
+    let test_pdf_path = test_dir.join("test.pdf");
+    let ref_pdf_path = ref_dir.join("ref.pdf");
+    fs::write(&test_pdf_path, &test_pdf).expect("write test pdf");
+    fs::write(&ref_pdf_path, &ref_pdf).expect("write ref pdf");
+
+    let test_img = pdf_to_rgba(&test_pdf_path, spec.dpi, &test_dir).expect("rasterize test");
+    let ref_img = pdf_to_rgba(&ref_pdf_path, spec.dpi, &ref_dir).expect("rasterize ref");
+
+    // px → fraction 変換が正しければ test と ref は同一の color stop function を
+    // 持つので、tolerance はラスタライズ往復のノイズだけ吸収すれば十分。
+    // 4 ch / 0.5% は実質「ほぼ完全一致」を要求する厳しい設定で、
+    // LengthPx 解決のオフバイ誤差 (例えば rx の pt/px 取り違えによる 4/3× ずれ)
+    // は確実に弾ける。
+    let tol = Tolerance {
+        max_channel_diff: 4,
+        max_diff_pixels_ratio: 0.005,
+    };
+
+    let report = diff::compare(&ref_img, &test_img, tol);
+
+    assert!(
+        report.pass,
+        "radial-gradient px-stop test↔ref harness failed: {} of {} pixels differ ({:.3}%), max channel diff = {} (tolerance: max_diff={}, ratio<={:.3}%). \
+         test PDF: {}\n  ref PDF: {}\n  test img: {}\n  ref img:  {}",
+        report.diff_pixels,
+        report.total_pixels,
+        report.ratio() * 100.0,
+        report.max_channel_diff,
+        tol.max_channel_diff,
+        tol.max_diff_pixels_ratio * 100.0,
+        test_pdf_path.display(),
+        ref_pdf_path.display(),
+        test_dir.join("page-1.png").display(),
+        ref_dir.join("page-1.png").display(),
+    );
+}

--- a/crates/fulgur-vrt/tests/gradient_harness.rs
+++ b/crates/fulgur-vrt/tests/gradient_harness.rs
@@ -17,6 +17,7 @@
 use fulgur_vrt::diff::{self};
 use fulgur_vrt::manifest::Tolerance;
 use fulgur_vrt::pdf_render::{RenderSpec, pdf_to_rgba, render_html_to_pdf};
+use image::RgbaImage;
 use std::fs;
 use std::path::PathBuf;
 
@@ -43,6 +44,49 @@ fn lerp_u8(a: u8, b: u8, t: f32) -> u8 {
     let av = a as f32;
     let bv = b as f32;
     (av + (bv - av) * t).round().clamp(0.0, 255.0) as u8
+}
+
+/// Convert a (CSS x, CSS y) coordinate inside a margin-offset box to raster
+/// pixel coords at 150dpi. CSS px → raster: `1 CSS px = 25/16 raster px`
+/// (96 px/in → 150 px/in)、box の (0, 0) 起点はマージン分オフセット。
+fn css_to_raster(css_x: u32, css_y: u32) -> (u32, u32) {
+    let scale = 25.0 / 16.0;
+    let margin_raster = (GRADIENT_MARGIN_PX as f32 * scale) as u32;
+    let rx = margin_raster + (css_x as f32 * scale) as u32;
+    let ry = margin_raster + (css_y as f32 * scale) as u32;
+    (rx, ry)
+}
+
+/// Sentinel pixel-color check. Reads RGBA at the raster coord that maps to
+/// CSS `(css_x, css_y)` (with the standard `GRADIENT_MARGIN_PX` offset) and
+/// asserts it is within `tol` of `expected` per channel.
+///
+/// Used alongside the test↔ref equivalence diff to defend against the
+/// false-positive mode noted in the file header: if both `px` and `%` renders
+/// silently break the same way (e.g. layer entirely dropped → both white) the
+/// equivalence still passes, but a sentinel for a known plateau color flags
+/// the failure.
+fn assert_pixel_color(
+    img: &RgbaImage,
+    css_x: u32,
+    css_y: u32,
+    expected: (u8, u8, u8),
+    tol: u8,
+    label: &str,
+) {
+    let (rx, ry) = css_to_raster(css_x, css_y);
+    let p = img.get_pixel(rx, ry);
+    let (r, g, b) = (p[0], p[1], p[2]);
+    let (er, eg, eb) = expected;
+    let max_diff = (r as i32 - er as i32)
+        .abs()
+        .max((g as i32 - eg as i32).abs())
+        .max((b as i32 - eb as i32).abs());
+    assert!(
+        max_diff <= tol as i32,
+        "{label}: pixel at CSS ({css_x}, {css_y}) → raster ({rx}, {ry}) \
+         expected ~({er}, {eg}, {eb}) ± {tol}, got ({r}, {g}, {b}), max_diff = {max_diff}"
+    );
 }
 
 /// Build a strip-approximation reference HTML. `c0` is the color at the
@@ -211,7 +255,7 @@ fn run_gradient_px_stop_reftest(
     test_html: &str,
     ref_html: &str,
     tol: Tolerance,
-) {
+) -> RgbaImage {
     let spec = RenderSpec {
         page_size: "A4",
         margin_pt: Some(0.0),
@@ -262,6 +306,8 @@ fn run_gradient_px_stop_reftest(
         test_dir.join("page-1.png").display(),
         ref_dir.join("page-1.png").display(),
     );
+
+    test_img
 }
 
 /// `linear-gradient(to right, red 0px, blue 50px, blue 350px, green 400px)` のような
@@ -302,12 +348,26 @@ fn linear_gradient_px_stop_matches_percentage_reference() {
         max_diff_pixels_ratio: 0.005,
     };
 
-    run_gradient_px_stop_reftest(
+    let test_img = run_gradient_px_stop_reftest(
         "linear-gradient",
         "vrt-gradient-px-stops-harness",
         &test_html,
         &ref_html,
         tol,
+    );
+
+    // Sentinel: CSS x=200 は box の中央で stop の `blue 50px` (12.5%) と
+    // `blue 350px` (87.5%) のあいだに広がる純 blue plateau に位置する。
+    // y は box 高 192 の中央 (96)。両方の render が同じ way で壊れた場合
+    // (e.g. layer drop → 白背景) 等価性 diff だけでは false-positive に倒れるが、
+    // この pixel sentinel が確実に拾う。
+    assert_pixel_color(
+        &test_img,
+        200,
+        96,
+        (0, 0, 255),
+        8,
+        "linear blue plateau center",
     );
 }
 
@@ -348,11 +408,82 @@ fn radial_gradient_px_stop_matches_percentage_reference() {
         max_diff_pixels_ratio: 0.005,
     };
 
-    run_gradient_px_stop_reftest(
+    let test_img = run_gradient_px_stop_reftest(
         "radial-gradient",
         "vrt-radial-gradient-px-stops-harness",
         &test_html,
         &ref_html,
         tol,
+    );
+
+    // Sentinel: 中心は CSS (100, 100) で `red 0px` 由来の純 red、半径 75 CSS px の
+    // 点 (CSS (175, 100)) は `blue 50px` (50%) と `blue 100px` (100%) のあいだの
+    // 純 blue plateau。両者を assert することで「全 layer drop → 白」のような
+    // 共通破綻モードを false-positive で通さない。
+    assert_pixel_color(&test_img, 100, 100, (255, 0, 0), 8, "radial center red");
+    assert_pixel_color(
+        &test_img,
+        175,
+        100,
+        (0, 0, 255),
+        8,
+        "radial blue plateau (radius 75)",
+    );
+}
+
+/// `linear-gradient(60deg, ...)` を非正方形 (400×200) box にかけて
+/// `|W·sinθ| + |H·cosθ|` 経路を実際に走らせる reftest。
+///
+/// `to right` (= 90deg, sin=1, cos=0) では gradient line length が box width
+/// に縮退して新しい formula を実質テストできない。60deg では
+/// `L = 400·sin(60°) + 200·cos(60°) = 200·√3 + 100 ≈ 446.41 CSS px` となり、
+/// box width とは ~10% 違うので「常に W を line length にする」バグは確実に
+/// 弾ける。
+///
+/// 戦略: test (px) と ref (precomputed %) の equivalence + box 中央の sentinel。
+/// 60deg でも box 中心は対称性から t=0.5 で blue plateau (22.4% < 50% < 78.4%)。
+#[test]
+fn linear_gradient_px_stop_angled_matches_percentage_reference() {
+    let test_html = build_gradient_html(
+        "VRT test: angled linear-gradient with px-typed stops",
+        400,
+        200,
+        "linear-gradient(60deg, red 0px, blue 100px, blue 350px, green 446px)",
+    );
+    // L = 200·√3 + 100 ≈ 446.41016151..., precomputed % to 4 decimal places:
+    //   100 / L ≈ 22.4015%
+    //   350 / L ≈ 78.4051%
+    //   446 / L ≈ 99.9082%
+    let ref_html = build_gradient_html(
+        "VRT ref: angled linear-gradient with percentage-typed stops",
+        400,
+        200,
+        "linear-gradient(60deg, red 0%, blue 22.4015%, blue 78.4051%, green 99.9082%)",
+    );
+
+    // 角度付き gradient は raster boundary で AA が広がるので、to right より少し緩い。
+    // それでも line length 計算が `W` ベースだとフラクションが ~10% ずれて
+    // ピクセル diff が一桁% に出るので、これでバグは捕捉できる。
+    let tol = Tolerance {
+        max_channel_diff: 6,
+        max_diff_pixels_ratio: 0.01,
+    };
+
+    let test_img = run_gradient_px_stop_reftest(
+        "linear-gradient angled (60deg)",
+        "vrt-gradient-px-stops-angled-harness",
+        &test_html,
+        &ref_html,
+        tol,
+    );
+
+    // Sentinel: 60deg の box 中央 (CSS 200, 100) は対称性で t=0.5 → blue plateau。
+    assert_pixel_color(
+        &test_img,
+        200,
+        100,
+        (0, 0, 255),
+        12,
+        "60deg angled gradient blue plateau center",
     );
 }

--- a/crates/fulgur-vrt/tests/gradient_harness.rs
+++ b/crates/fulgur-vrt/tests/gradient_harness.rs
@@ -169,3 +169,120 @@ fn linear_gradient_horizontal_matches_strip_reference() {
         ref_dir.join("page-1.png").display(),
     );
 }
+
+/// 共通レイアウト (`linear-gradient-horizontal.html` と同じ box geometry) で
+/// 任意の `background` プロパティ値を載せた HTML を生成する。
+fn build_gradient_html(title: &str, background: &str) -> String {
+    format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{title}</title>
+<style>
+  html, body {{ margin: 0; padding: 0; background: white; }}
+  .g {{
+    width: {w}px;
+    height: {h}px;
+    margin: {m}px;
+    background: {bg};
+  }}
+</style>
+</head>
+<body>
+  <div class="g"></div>
+</body>
+</html>"#,
+        title = title,
+        w = GRADIENT_WIDTH_PX,
+        h = GRADIENT_HEIGHT_PX,
+        m = GRADIENT_MARGIN_PX,
+        bg = background,
+    )
+}
+
+/// `linear-gradient(to right, red 0px, blue 50px, blue 350px, green 400px)` のような
+/// `<length>` 型 stop が、対応する `<percentage>` 解決 (CSS Images §3.5.1) と等価な
+/// PDF を生成することを確認する。
+///
+/// 戦略: test と ref をどちらも fulgur で描画する。test 側は px 指定で
+/// `LengthPx → Fraction` 変換 (基準は gradient line length = box width = 400 CSS px)
+/// を経由し、ref 側は最初から `<percentage>` で書く。両者は同じ piecewise color stop
+/// に解決されるはずなので、PDF は (kr フローの非決定要素を除き) ピクセル等価になる。
+///
+/// strip 近似ではなく直接比較を選んだ理由:
+/// - LengthPx → Fraction の変換そのものに焦点が当たる
+/// - strip 近似では steep transition (12.5% 幅) で量子化誤差が ~33ch まで膨らみ、
+///   tolerance を緩めざるを得なかった
+/// - Task 6 の radial gradient と同じ哲学 (test=px, ref=%)
+#[test]
+fn linear_gradient_px_stop_matches_percentage_reference() {
+    // 400px box の上で 50px = 12.5%, 350px = 87.5% に解決される piecewise gradient
+    let test_html = build_gradient_html(
+        "VRT test: linear-gradient with px-typed stops",
+        "linear-gradient(to right, red 0px, blue 50px, blue 350px, green 400px)",
+    );
+    let ref_html = build_gradient_html(
+        "VRT ref: linear-gradient with percentage-typed stops",
+        "linear-gradient(to right, red 0%, blue 12.5%, blue 87.5%, green 100%)",
+    );
+
+    let spec = RenderSpec {
+        page_size: "A4",
+        margin_pt: Some(0.0),
+        dpi: 150,
+    };
+
+    let test_pdf = render_html_to_pdf(&test_html, spec).expect("render test pdf");
+    let ref_pdf = render_html_to_pdf(&ref_html, spec).expect("render ref pdf");
+
+    let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let work_dir = crate_root
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root")
+        .join("target/vrt-gradient-px-stops-harness");
+    fs::create_dir_all(&work_dir).expect("create work dir");
+
+    let test_dir = work_dir.join("test");
+    let ref_dir = work_dir.join("ref");
+    let _ = fs::remove_dir_all(&test_dir);
+    let _ = fs::remove_dir_all(&ref_dir);
+    fs::create_dir_all(&test_dir).expect("create test dir");
+    fs::create_dir_all(&ref_dir).expect("create ref dir");
+
+    let test_pdf_path = test_dir.join("test.pdf");
+    let ref_pdf_path = ref_dir.join("ref.pdf");
+    fs::write(&test_pdf_path, &test_pdf).expect("write test pdf");
+    fs::write(&ref_pdf_path, &ref_pdf).expect("write ref pdf");
+
+    let test_img = pdf_to_rgba(&test_pdf_path, spec.dpi, &test_dir).expect("rasterize test");
+    let ref_img = pdf_to_rgba(&ref_pdf_path, spec.dpi, &ref_dir).expect("rasterize ref");
+
+    // px → fraction 変換が正しければ test と ref は同一の color stop function を
+    // 持つので、tolerance はラスタライズ往復のノイズだけ吸収すれば十分。
+    // 4 ch / 0.5% は実質「ほぼ完全一致」を要求する厳しい設定で、
+    // LengthPx 解決のオフバイ誤差 (例えば一桁 % ずれ) は確実に弾ける。
+    let tol = Tolerance {
+        max_channel_diff: 4,
+        max_diff_pixels_ratio: 0.005,
+    };
+
+    let report = diff::compare(&ref_img, &test_img, tol);
+
+    assert!(
+        report.pass,
+        "linear-gradient px-stop test↔ref harness failed: {} of {} pixels differ ({:.3}%), max channel diff = {} (tolerance: max_diff={}, ratio<={:.3}%). \
+         test PDF: {}\n  ref PDF: {}\n  test img: {}\n  ref img:  {}",
+        report.diff_pixels,
+        report.total_pixels,
+        report.ratio() * 100.0,
+        report.max_channel_diff,
+        tol.max_channel_diff,
+        tol.max_diff_pixels_ratio * 100.0,
+        test_pdf_path.display(),
+        ref_pdf_path.display(),
+        test_dir.join("page-1.png").display(),
+        ref_dir.join("page-1.png").display(),
+    );
+}

--- a/crates/fulgur-vrt/tests/gradient_harness.rs
+++ b/crates/fulgur-vrt/tests/gradient_harness.rs
@@ -93,6 +93,37 @@ fn build_strip_ref_html(c0: (u8, u8, u8), c1: (u8, u8, u8)) -> String {
     )
 }
 
+/// 任意サイズの box (`width_px` × `height_px`) に `background` プロパティ値を
+/// 載せた HTML を生成する共通ヘルパー。linear / radial 両方の reftest で再利用される。
+fn build_gradient_html(title: &str, width_px: u32, height_px: u32, background: &str) -> String {
+    format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{title}</title>
+<style>
+  html, body {{ margin: 0; padding: 0; background: white; }}
+  .g {{
+    width: {w}px;
+    height: {h}px;
+    margin: {m}px;
+    background: {bg};
+  }}
+</style>
+</head>
+<body>
+  <div class="g"></div>
+</body>
+</html>"#,
+        title = title,
+        w = width_px,
+        h = height_px,
+        m = GRADIENT_MARGIN_PX,
+        bg = background,
+    )
+}
+
 #[test]
 fn linear_gradient_horizontal_matches_strip_reference() {
     let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -170,35 +201,67 @@ fn linear_gradient_horizontal_matches_strip_reference() {
     );
 }
 
-/// 共通レイアウト (`linear-gradient-horizontal.html` と同じ box geometry) で
-/// 任意の `background` プロパティ値を載せた HTML を生成する。
-fn build_gradient_html(title: &str, background: &str) -> String {
-    format!(
-        r#"<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>{title}</title>
-<style>
-  html, body {{ margin: 0; padding: 0; background: white; }}
-  .g {{
-    width: {w}px;
-    height: {h}px;
-    margin: {m}px;
-    background: {bg};
-  }}
-</style>
-</head>
-<body>
-  <div class="g"></div>
-</body>
-</html>"#,
-        title = title,
-        w = GRADIENT_WIDTH_PX,
-        h = GRADIENT_HEIGHT_PX,
-        m = GRADIENT_MARGIN_PX,
-        bg = background,
-    )
+/// `test_html` と `ref_html` を fulgur で PDF に書き出し、150dpi でラスタライズして
+/// `tol` で diff を取る共通スキャフォルディング。中間成果物は
+/// `target/<work_dir_name>/{test,ref}/` に残り、失敗時の `assert!` メッセージで
+/// 直接参照できる。`label` は assert メッセージ用の人間可読な識別子。
+fn run_gradient_px_stop_reftest(
+    label: &str,
+    work_dir_name: &str,
+    test_html: &str,
+    ref_html: &str,
+    tol: Tolerance,
+) {
+    let spec = RenderSpec {
+        page_size: "A4",
+        margin_pt: Some(0.0),
+        dpi: 150,
+    };
+
+    let test_pdf = render_html_to_pdf(test_html, spec).expect("render test pdf");
+    let ref_pdf = render_html_to_pdf(ref_html, spec).expect("render ref pdf");
+
+    let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let work_dir = crate_root
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root")
+        .join("target")
+        .join(work_dir_name);
+    fs::create_dir_all(&work_dir).expect("create work dir");
+
+    let test_dir = work_dir.join("test");
+    let ref_dir = work_dir.join("ref");
+    let _ = fs::remove_dir_all(&test_dir);
+    let _ = fs::remove_dir_all(&ref_dir);
+    fs::create_dir_all(&test_dir).expect("create test dir");
+    fs::create_dir_all(&ref_dir).expect("create ref dir");
+
+    let test_pdf_path = test_dir.join("test.pdf");
+    let ref_pdf_path = ref_dir.join("ref.pdf");
+    fs::write(&test_pdf_path, &test_pdf).expect("write test pdf");
+    fs::write(&ref_pdf_path, &ref_pdf).expect("write ref pdf");
+
+    let test_img = pdf_to_rgba(&test_pdf_path, spec.dpi, &test_dir).expect("rasterize test");
+    let ref_img = pdf_to_rgba(&ref_pdf_path, spec.dpi, &ref_dir).expect("rasterize ref");
+
+    let report = diff::compare(&ref_img, &test_img, tol);
+
+    assert!(
+        report.pass,
+        "{label} px-stop test↔ref harness failed: {} of {} pixels differ ({:.3}%), max channel diff = {} (tolerance: max_diff={}, ratio<={:.3}%). \
+         test PDF: {}\n  ref PDF: {}\n  test img: {}\n  ref img:  {}",
+        report.diff_pixels,
+        report.total_pixels,
+        report.ratio() * 100.0,
+        report.max_channel_diff,
+        tol.max_channel_diff,
+        tol.max_diff_pixels_ratio * 100.0,
+        test_pdf_path.display(),
+        ref_pdf_path.display(),
+        test_dir.join("page-1.png").display(),
+        ref_dir.join("page-1.png").display(),
+    );
 }
 
 /// `linear-gradient(to right, red 0px, blue 50px, blue 350px, green 400px)` のような
@@ -214,50 +277,21 @@ fn build_gradient_html(title: &str, background: &str) -> String {
 /// - LengthPx → Fraction の変換そのものに焦点が当たる
 /// - strip 近似では steep transition (12.5% 幅) で量子化誤差が ~33ch まで膨らみ、
 ///   tolerance を緩めざるを得なかった
-/// - Task 6 の radial gradient と同じ哲学 (test=px, ref=%)
 #[test]
 fn linear_gradient_px_stop_matches_percentage_reference() {
     // 400px box の上で 50px = 12.5%, 350px = 87.5% に解決される piecewise gradient
     let test_html = build_gradient_html(
         "VRT test: linear-gradient with px-typed stops",
+        GRADIENT_WIDTH_PX,
+        GRADIENT_HEIGHT_PX,
         "linear-gradient(to right, red 0px, blue 50px, blue 350px, green 400px)",
     );
     let ref_html = build_gradient_html(
         "VRT ref: linear-gradient with percentage-typed stops",
+        GRADIENT_WIDTH_PX,
+        GRADIENT_HEIGHT_PX,
         "linear-gradient(to right, red 0%, blue 12.5%, blue 87.5%, green 100%)",
     );
-
-    let spec = RenderSpec {
-        page_size: "A4",
-        margin_pt: Some(0.0),
-        dpi: 150,
-    };
-
-    let test_pdf = render_html_to_pdf(&test_html, spec).expect("render test pdf");
-    let ref_pdf = render_html_to_pdf(&ref_html, spec).expect("render ref pdf");
-
-    let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let work_dir = crate_root
-        .parent()
-        .and_then(|p| p.parent())
-        .expect("workspace root")
-        .join("target/vrt-gradient-px-stops-harness");
-    fs::create_dir_all(&work_dir).expect("create work dir");
-
-    let test_dir = work_dir.join("test");
-    let ref_dir = work_dir.join("ref");
-    let _ = fs::remove_dir_all(&test_dir);
-    let _ = fs::remove_dir_all(&ref_dir);
-    fs::create_dir_all(&test_dir).expect("create test dir");
-    fs::create_dir_all(&ref_dir).expect("create ref dir");
-
-    let test_pdf_path = test_dir.join("test.pdf");
-    let ref_pdf_path = ref_dir.join("ref.pdf");
-    fs::write(&test_pdf_path, &test_pdf).expect("write test pdf");
-    fs::write(&ref_pdf_path, &ref_pdf).expect("write ref pdf");
-
-    let test_img = pdf_to_rgba(&test_pdf_path, spec.dpi, &test_dir).expect("rasterize test");
-    let ref_img = pdf_to_rgba(&ref_pdf_path, spec.dpi, &ref_dir).expect("rasterize ref");
 
     // px → fraction 変換が正しければ test と ref は同一の color stop function を
     // 持つので、tolerance はラスタライズ往復のノイズだけ吸収すれば十分。
@@ -268,57 +302,18 @@ fn linear_gradient_px_stop_matches_percentage_reference() {
         max_diff_pixels_ratio: 0.005,
     };
 
-    let report = diff::compare(&ref_img, &test_img, tol);
-
-    assert!(
-        report.pass,
-        "linear-gradient px-stop test↔ref harness failed: {} of {} pixels differ ({:.3}%), max channel diff = {} (tolerance: max_diff={}, ratio<={:.3}%). \
-         test PDF: {}\n  ref PDF: {}\n  test img: {}\n  ref img:  {}",
-        report.diff_pixels,
-        report.total_pixels,
-        report.ratio() * 100.0,
-        report.max_channel_diff,
-        tol.max_channel_diff,
-        tol.max_diff_pixels_ratio * 100.0,
-        test_pdf_path.display(),
-        ref_pdf_path.display(),
-        test_dir.join("page-1.png").display(),
-        ref_dir.join("page-1.png").display(),
+    run_gradient_px_stop_reftest(
+        "linear-gradient",
+        "vrt-gradient-px-stops-harness",
+        &test_html,
+        &ref_html,
+        tol,
     );
-}
-
-/// 200×200 box の上に任意の `background` プロパティ値を載せた HTML を生成する。
-/// radial gradient の reftest 用に正方形固定レイアウトを採用する。
-fn build_radial_gradient_html(title: &str, background: &str) -> String {
-    format!(
-        r#"<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>{title}</title>
-<style>
-  html, body {{ margin: 0; padding: 0; background: white; }}
-  .g {{
-    width: 200px;
-    height: 200px;
-    margin: {m}px;
-    background: {bg};
-  }}
-</style>
-</head>
-<body>
-  <div class="g"></div>
-</body>
-</html>"#,
-        title = title,
-        m = GRADIENT_MARGIN_PX,
-        bg = background,
-    )
 }
 
 /// `radial-gradient(circle 100px at center, red 0px, blue 50px, blue 100px)` のような
 /// `<length>` 型 stop が、対応する `<percentage>` 解決 (CSS Images §3.6.1) と等価な
-/// PDF を生成することを確認する。
+/// PDF を生成することを確認する (fulgur-n3zk)。
 ///
 /// 戦略: test と ref をどちらも fulgur で描画する。test 側は px 指定で
 /// `LengthPx → Fraction` 変換 (radial gradient の場合の基準は ending shape の半径
@@ -326,54 +321,22 @@ fn build_radial_gradient_html(title: &str, background: &str) -> String {
 /// CSS Images §3.6.1 で「radial gradient の gradient line length は ending shape
 /// の中心から境界までの長さ」と定義されており、circle 100px 指定では rx = 100px。
 /// したがって 0px / 50px / 100px はそれぞれ 0% / 50% / 100% に解決される。
-///
-/// このテストは Task 5 で linear path に対して修正された pt → CSS px 変換が
-/// radial path でも正しく機能していることを保証する (`gradient_line_length_px`
-/// は radial の場合は `rx_px` を渡している)。
 #[test]
 fn radial_gradient_px_stop_matches_percentage_reference() {
     // 200×200 box, circle 100px at center: rx = 100 CSS px
     // 0px = 0%, 50px = 50%, 100px = 100% に解決される piecewise gradient
-    let test_html = build_radial_gradient_html(
+    let test_html = build_gradient_html(
         "VRT test: radial-gradient with px-typed stops",
+        200,
+        200,
         "radial-gradient(circle 100px at center, red 0px, blue 50px, blue 100px)",
     );
-    let ref_html = build_radial_gradient_html(
+    let ref_html = build_gradient_html(
         "VRT ref: radial-gradient with percentage-typed stops",
+        200,
+        200,
         "radial-gradient(circle 100px at center, red 0%, blue 50%, blue 100%)",
     );
-
-    let spec = RenderSpec {
-        page_size: "A4",
-        margin_pt: Some(0.0),
-        dpi: 150,
-    };
-
-    let test_pdf = render_html_to_pdf(&test_html, spec).expect("render test pdf");
-    let ref_pdf = render_html_to_pdf(&ref_html, spec).expect("render ref pdf");
-
-    let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let work_dir = crate_root
-        .parent()
-        .and_then(|p| p.parent())
-        .expect("workspace root")
-        .join("target/vrt-radial-gradient-px-stops-harness");
-    fs::create_dir_all(&work_dir).expect("create work dir");
-
-    let test_dir = work_dir.join("test");
-    let ref_dir = work_dir.join("ref");
-    let _ = fs::remove_dir_all(&test_dir);
-    let _ = fs::remove_dir_all(&ref_dir);
-    fs::create_dir_all(&test_dir).expect("create test dir");
-    fs::create_dir_all(&ref_dir).expect("create ref dir");
-
-    let test_pdf_path = test_dir.join("test.pdf");
-    let ref_pdf_path = ref_dir.join("ref.pdf");
-    fs::write(&test_pdf_path, &test_pdf).expect("write test pdf");
-    fs::write(&ref_pdf_path, &ref_pdf).expect("write ref pdf");
-
-    let test_img = pdf_to_rgba(&test_pdf_path, spec.dpi, &test_dir).expect("rasterize test");
-    let ref_img = pdf_to_rgba(&ref_pdf_path, spec.dpi, &ref_dir).expect("rasterize ref");
 
     // px → fraction 変換が正しければ test と ref は同一の color stop function を
     // 持つので、tolerance はラスタライズ往復のノイズだけ吸収すれば十分。
@@ -385,21 +348,11 @@ fn radial_gradient_px_stop_matches_percentage_reference() {
         max_diff_pixels_ratio: 0.005,
     };
 
-    let report = diff::compare(&ref_img, &test_img, tol);
-
-    assert!(
-        report.pass,
-        "radial-gradient px-stop test↔ref harness failed: {} of {} pixels differ ({:.3}%), max channel diff = {} (tolerance: max_diff={}, ratio<={:.3}%). \
-         test PDF: {}\n  ref PDF: {}\n  test img: {}\n  ref img:  {}",
-        report.diff_pixels,
-        report.total_pixels,
-        report.ratio() * 100.0,
-        report.max_channel_diff,
-        tol.max_channel_diff,
-        tol.max_diff_pixels_ratio * 100.0,
-        test_pdf_path.display(),
-        ref_pdf_path.display(),
-        test_dir.join("page-1.png").display(),
-        ref_dir.join("page-1.png").display(),
+    run_gradient_px_stop_reftest(
+        "radial-gradient",
+        "vrt-radial-gradient-px-stops-harness",
+        &test_html,
+        &ref_html,
+        tol,
     );
 }

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -517,7 +517,12 @@ fn draw_linear_gradient(
     let x2 = cx_box + sin * half;
     let y2 = cy_box + cos_neg * half;
 
-    let Some(krilla_stops) = resolve_gradient_stops(stops, length, "linear-gradient") else {
+    // length は pt 単位 (ow, oh が pt) だが、`GradientStopPosition::LengthPx` は
+    // CSS px で保持されている。`resolve_gradient_stops` は同一単位空間での
+    // `px / line_length` で fraction 化するので、line_length も CSS px に揃える。
+    // (例: 400px box → length = 300pt → px 換算で 400 → 50px / 400 = 0.125)
+    let length_px = crate::convert::pt_to_px(length);
+    let Some(krilla_stops) = resolve_gradient_stops(stops, length_px, "linear-gradient") else {
         return;
     };
 
@@ -638,8 +643,11 @@ fn draw_radial_gradient(
         return;
     }
 
-    // Radial gradient line length = rx (CSS Images §3.6.1, ellipse でも +X 軸)
-    let Some(krilla_stops) = resolve_gradient_stops(stops, rx, "radial-gradient") else {
+    // Radial gradient line length = rx (CSS Images §3.6.1, ellipse でも +X 軸)。
+    // rx は pt 単位 (ow/oh が pt) なので、`LengthPx` (CSS px) との比較のために
+    // CSS px に揃える。
+    let rx_px = crate::convert::pt_to_px(rx);
+    let Some(krilla_stops) = resolve_gradient_stops(stops, rx_px, "radial-gradient") else {
         return;
     };
 

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -411,13 +411,20 @@ fn draw_linear_gradient(
 
     let krilla_stops: Vec<krilla::paint::Stop> = stops
         .iter()
-        .map(|s| krilla::paint::Stop {
-            // `s.offset` is convert-time-clamped to [0, 1] in resolve_linear_gradient,
-            // so the explicit clamp + expect documents the invariant.
-            offset: krilla::num::NormalizedF32::new(s.offset.clamp(0.0, 1.0))
-                .expect("offset is clamped to [0, 1]"),
-            color: krilla::color::rgb::Color::new(s.rgba[0], s.rgba[1], s.rgba[2]).into(),
-            opacity: crate::pageable::alpha_to_opacity(s.rgba[3]),
+        .map(|s| {
+            let offset_f = match s.position {
+                crate::pageable::GradientStopPosition::Fraction(f) => f.clamp(0.0, 1.0),
+                // Task 1: convert 側が Fraction のみ生成するため到達しない。
+                // Task 4 で resolve_gradient_stops 経由に切り替わる。
+                crate::pageable::GradientStopPosition::Auto
+                | crate::pageable::GradientStopPosition::LengthPx(_) => 0.0,
+            };
+            krilla::paint::Stop {
+                offset: krilla::num::NormalizedF32::new(offset_f)
+                    .expect("offset is clamped to [0, 1]"),
+                color: krilla::color::rgb::Color::new(s.rgba[0], s.rgba[1], s.rgba[2]).into(),
+                opacity: crate::pageable::alpha_to_opacity(s.rgba[3]),
+            }
         })
         .collect();
 
@@ -540,11 +547,20 @@ fn draw_radial_gradient(
 
     let krilla_stops: Vec<krilla::paint::Stop> = stops
         .iter()
-        .map(|s| krilla::paint::Stop {
-            offset: krilla::num::NormalizedF32::new(s.offset.clamp(0.0, 1.0))
-                .expect("offset is clamped to [0, 1]"),
-            color: krilla::color::rgb::Color::new(s.rgba[0], s.rgba[1], s.rgba[2]).into(),
-            opacity: crate::pageable::alpha_to_opacity(s.rgba[3]),
+        .map(|s| {
+            let offset_f = match s.position {
+                crate::pageable::GradientStopPosition::Fraction(f) => f.clamp(0.0, 1.0),
+                // Task 1: convert 側が Fraction のみ生成するため到達しない。
+                // Task 4 で resolve_gradient_stops 経由に切り替わる。
+                crate::pageable::GradientStopPosition::Auto
+                | crate::pageable::GradientStopPosition::LengthPx(_) => 0.0,
+            };
+            krilla::paint::Stop {
+                offset: krilla::num::NormalizedF32::new(offset_f)
+                    .expect("offset is clamped to [0, 1]"),
+                color: krilla::color::rgb::Color::new(s.rgba[0], s.rgba[1], s.rgba[2]).into(),
+                opacity: crate::pageable::alpha_to_opacity(s.rgba[3]),
+            }
         })
         .collect();
 

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -367,6 +367,118 @@ fn corner_to_angle_rad(corner: crate::pageable::LinearGradientCorner, w: f32, h:
     (h * h_sign).atan2(-w * v_sign)
 }
 
+/// Resolve `Vec<GradientStop>` (length / fraction / auto 混在) を krilla の
+/// `Stop` 列に変換する。
+///
+/// CSS Images Level 3 §3.5.1 の color-stop fixup に従って:
+///   1. `LengthPx(px)` を `px / line_length` で fraction 化
+///   2. 先頭/末尾の `Auto` を 0.0 / 1.0 に確定
+///   3. monotonic clamp (前 fixed より小さければ前 fixed に合わせる)
+///   4. 中間の `Auto` 群を前後 fixed の等間隔補間で埋める
+///   5. 最終 fraction が `[0, 1]` 外なら `Layer drop` (None)
+///
+/// `line_length <= 0` の場合は length stop が解決不能なので None。
+// Wired into draw_linear_gradient / draw_radial_gradient in Task 4
+// (fulgur-78sl). Until then the helper is only exercised by the test module
+// below, so the non-test build sees it as dead. Allow until Task 4 lands.
+#[allow(dead_code)]
+fn resolve_gradient_stops(
+    stops: &[crate::pageable::GradientStop],
+    line_length: f32,
+    gradient_kind: &'static str,
+) -> Option<Vec<krilla::paint::Stop>> {
+    use crate::pageable::GradientStopPosition;
+
+    if stops.len() < 2 {
+        return None;
+    }
+    if line_length <= 0.0 {
+        // length-typed stop が一つでもあれば解決不能。fraction-only でも
+        // 退化した gradient なので Layer drop 相当 (caller で先に early
+        // return しているため通常到達しない)。
+        return None;
+    }
+
+    let n = stops.len();
+    let mut positions: Vec<Option<f32>> = stops
+        .iter()
+        .map(|s| match s.position {
+            GradientStopPosition::Auto => None,
+            GradientStopPosition::Fraction(f) => Some(f),
+            GradientStopPosition::LengthPx(px) => Some(px / line_length),
+        })
+        .collect();
+
+    // 先頭/末尾の Auto を 0/1 に
+    if positions[0].is_none() {
+        positions[0] = Some(0.0);
+    }
+    if positions[n - 1].is_none() {
+        positions[n - 1] = Some(1.0);
+    }
+
+    // monotonic clamp.
+    // 初期値が NEG_INFINITY (not 0.0) なのは意図的: 旧 convert.rs は
+    // ComplexColorStop を事前に [0, 1] バリデーションしていたが、本 helper は
+    // 負値を通過させて末尾の range check で drop する。0.0 初期値だと
+    // Fraction(-0.1) が暗黙に 0.0 に押し上げられて range check を擦り抜ける。
+    let mut last_resolved = f32::NEG_INFINITY;
+    for v in positions.iter_mut().flatten() {
+        if *v < last_resolved {
+            *v = last_resolved;
+        }
+        last_resolved = *v;
+    }
+
+    // 中間 Auto を前後 fixed の等間隔補間で埋める
+    let mut i = 0;
+    while i < n {
+        if positions[i].is_some() {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        let mut end = start;
+        while end < n && positions[end].is_none() {
+            end += 1;
+        }
+        let p_prev = positions[start - 1].expect("first slot resolved");
+        let p_next = positions[end].expect("last slot resolved");
+        let span = (end - start + 1) as f32;
+        for (k, slot) in positions.iter_mut().enumerate().take(end).skip(start) {
+            let t = (k - start + 1) as f32 / span;
+            *slot = Some(p_prev + (p_next - p_prev) * t);
+        }
+        i = end;
+    }
+
+    // 範囲外チェック (fulgur-n3zk が解くまでは Layer drop)
+    for (idx, p_opt) in positions.iter().enumerate() {
+        let p = p_opt.expect("all slots resolved");
+        if !(0.0..=1.0).contains(&p) {
+            log::warn!(
+                "{gradient_kind}: stop {idx} resolved offset {p:.4} is outside \
+                 [0, 1]. Out-of-range stops require gradient-line recompute \
+                 (fulgur-n3zk). Layer dropped."
+            );
+            return None;
+        }
+    }
+
+    // krilla::paint::Stop 構築
+    Some(
+        stops
+            .iter()
+            .zip(positions)
+            .map(|(s, p)| krilla::paint::Stop {
+                offset: krilla::num::NormalizedF32::new(p.unwrap()).expect("offset is in [0, 1]"),
+                color: krilla::color::rgb::Color::new(s.rgba[0], s.rgba[1], s.rgba[2]).into(),
+                opacity: crate::pageable::alpha_to_opacity(s.rgba[3]),
+            })
+            .collect(),
+    )
+}
+
 /// Draw a CSS linear-gradient over the origin rect.
 ///
 /// CSS angle convention (radians): 0 = "to top", π/2 = "to right",
@@ -2236,5 +2348,124 @@ mod tests {
             (0.0, 5.0, 5.0, 5.0),
         ];
         assert_eq!(try_uniform_grid(&canonical), try_uniform_grid(&shuffled));
+    }
+}
+
+#[cfg(test)]
+mod resolve_gradient_stops_tests {
+    use super::*;
+    use crate::pageable::GradientStop;
+    use crate::pageable::GradientStopPosition::{self, *};
+
+    fn fr(f: f32) -> GradientStopPosition {
+        Fraction(f)
+    }
+    fn px(f: f32) -> GradientStopPosition {
+        LengthPx(f)
+    }
+    fn stop(p: GradientStopPosition, rgba: [u8; 4]) -> GradientStop {
+        GradientStop { position: p, rgba }
+    }
+
+    #[test]
+    fn fraction_only_passes_through() {
+        let stops = vec![
+            stop(fr(0.0), [255, 0, 0, 255]),
+            stop(fr(1.0), [0, 0, 255, 255]),
+        ];
+        let out = resolve_gradient_stops(&stops, 100.0, "linear-gradient").unwrap();
+        assert_eq!(out.len(), 2);
+        assert!((out[0].offset.get() - 0.0).abs() < 1e-6);
+        assert!((out[1].offset.get() - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn length_px_resolved_by_line_length() {
+        let stops = vec![
+            stop(px(0.0), [255, 0, 0, 255]),
+            stop(px(50.0), [0, 0, 255, 255]),
+        ];
+        // line_length = 100 → 50px = 0.5
+        let out = resolve_gradient_stops(&stops, 100.0, "linear-gradient").unwrap();
+        assert_eq!(out.len(), 2);
+        assert!((out[1].offset.get() - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn auto_position_filled_at_endpoints() {
+        let stops = vec![stop(Auto, [255, 0, 0, 255]), stop(Auto, [0, 0, 255, 255])];
+        let out = resolve_gradient_stops(&stops, 100.0, "linear-gradient").unwrap();
+        assert!((out[0].offset.get() - 0.0).abs() < 1e-6);
+        assert!((out[1].offset.get() - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn auto_position_filled_in_middle() {
+        let stops = vec![
+            stop(fr(0.0), [255, 0, 0, 255]),
+            stop(Auto, [0, 255, 0, 255]),
+            stop(fr(1.0), [0, 0, 255, 255]),
+        ];
+        let out = resolve_gradient_stops(&stops, 100.0, "linear-gradient").unwrap();
+        assert!((out[1].offset.get() - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn mixed_length_fraction_auto() {
+        // linear-gradient(red, blue 50px, green) on line_length=100
+        // → red Auto (→0), blue 0.5, green Auto (→1)
+        let stops = vec![
+            stop(Auto, [255, 0, 0, 255]),
+            stop(px(50.0), [0, 0, 255, 255]),
+            stop(Auto, [0, 255, 0, 255]),
+        ];
+        let out = resolve_gradient_stops(&stops, 100.0, "linear-gradient").unwrap();
+        assert_eq!(out.len(), 3);
+        assert!((out[0].offset.get() - 0.0).abs() < 1e-6);
+        assert!((out[1].offset.get() - 0.5).abs() < 1e-6);
+        assert!((out[2].offset.get() - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn out_of_range_length_returns_none() {
+        // 50px on line_length=30 → 50/30 ≈ 1.67 > 1 → Layer drop
+        let stops = vec![
+            stop(fr(0.0), [255, 0, 0, 255]),
+            stop(px(50.0), [0, 0, 255, 255]),
+        ];
+        let out = resolve_gradient_stops(&stops, 30.0, "linear-gradient");
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn negative_fraction_returns_none() {
+        let stops = vec![
+            stop(fr(-0.1), [255, 0, 0, 255]),
+            stop(fr(1.0), [0, 0, 255, 255]),
+        ];
+        let out = resolve_gradient_stops(&stops, 100.0, "linear-gradient");
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn monotonic_clamp_applied() {
+        // [0.6, 0.3] → [0.6, 0.6] (monotonic fix)
+        let stops = vec![
+            stop(fr(0.6), [255, 0, 0, 255]),
+            stop(fr(0.3), [0, 0, 255, 255]),
+        ];
+        let out = resolve_gradient_stops(&stops, 100.0, "linear-gradient").unwrap();
+        assert!((out[0].offset.get() - 0.6).abs() < 1e-6);
+        assert!((out[1].offset.get() - 0.6).abs() < 1e-6);
+    }
+
+    #[test]
+    fn line_length_zero_returns_none() {
+        let stops = vec![
+            stop(px(50.0), [255, 0, 0, 255]),
+            stop(fr(1.0), [0, 0, 255, 255]),
+        ];
+        let out = resolve_gradient_stops(&stops, 0.0, "linear-gradient");
+        assert!(out.is_none());
     }
 }

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -370,6 +370,10 @@ fn corner_to_angle_rad(corner: crate::pageable::LinearGradientCorner, w: f32, h:
 /// Resolve `Vec<GradientStop>` (length / fraction / auto 混在) を krilla の
 /// `Stop` 列に変換する。
 ///
+/// **Unit contract:** `line_length` must be in **CSS px** (matching
+/// `GradientStopPosition::LengthPx`). Callers in pt-space (Krilla draw
+/// surface) convert with `crate::convert::pt_to_px` before invoking.
+///
 /// CSS Images Level 3 §3.5.1 の color-stop fixup に従って:
 ///   1. `LengthPx(px)` を `px / line_length` で fraction 化
 ///   2. 先頭/末尾の `Auto` を 0.0 / 1.0 に確定

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -378,10 +378,6 @@ fn corner_to_angle_rad(corner: crate::pageable::LinearGradientCorner, w: f32, h:
 ///   5. 最終 fraction が `[0, 1]` 外なら `Layer drop` (None)
 ///
 /// `line_length <= 0` の場合は length stop が解決不能なので None。
-// Wired into draw_linear_gradient / draw_radial_gradient in Task 4
-// (fulgur-78sl). Until then the helper is only exercised by the test module
-// below, so the non-test build sees it as dead. Allow until Task 4 lands.
-#[allow(dead_code)]
 fn resolve_gradient_stops(
     stops: &[crate::pageable::GradientStop],
     line_length: f32,
@@ -521,24 +517,9 @@ fn draw_linear_gradient(
     let x2 = cx_box + sin * half;
     let y2 = cy_box + cos_neg * half;
 
-    let krilla_stops: Vec<krilla::paint::Stop> = stops
-        .iter()
-        .map(|s| {
-            let offset_f = match s.position {
-                crate::pageable::GradientStopPosition::Fraction(f) => f.clamp(0.0, 1.0),
-                // Task 1: convert 側が Fraction のみ生成するため到達しない。
-                // Task 4 で resolve_gradient_stops 経由に切り替わる。
-                crate::pageable::GradientStopPosition::Auto
-                | crate::pageable::GradientStopPosition::LengthPx(_) => 0.0,
-            };
-            krilla::paint::Stop {
-                offset: krilla::num::NormalizedF32::new(offset_f)
-                    .expect("offset is clamped to [0, 1]"),
-                color: krilla::color::rgb::Color::new(s.rgba[0], s.rgba[1], s.rgba[2]).into(),
-                opacity: crate::pageable::alpha_to_opacity(s.rgba[3]),
-            }
-        })
-        .collect();
+    let Some(krilla_stops) = resolve_gradient_stops(stops, length, "linear-gradient") else {
+        return;
+    };
 
     let lg = krilla::paint::LinearGradient {
         x1,
@@ -657,24 +638,10 @@ fn draw_radial_gradient(
         return;
     }
 
-    let krilla_stops: Vec<krilla::paint::Stop> = stops
-        .iter()
-        .map(|s| {
-            let offset_f = match s.position {
-                crate::pageable::GradientStopPosition::Fraction(f) => f.clamp(0.0, 1.0),
-                // Task 1: convert 側が Fraction のみ生成するため到達しない。
-                // Task 4 で resolve_gradient_stops 経由に切り替わる。
-                crate::pageable::GradientStopPosition::Auto
-                | crate::pageable::GradientStopPosition::LengthPx(_) => 0.0,
-            };
-            krilla::paint::Stop {
-                offset: krilla::num::NormalizedF32::new(offset_f)
-                    .expect("offset is clamped to [0, 1]"),
-                color: krilla::color::rgb::Color::new(s.rgba[0], s.rgba[1], s.rgba[2]).into(),
-                opacity: crate::pageable::alpha_to_opacity(s.rgba[3]),
-            }
-        })
-        .collect();
+    // Radial gradient line length = rx (CSS Images §3.6.1, ellipse でも +X 軸)
+    let Some(krilla_stops) = resolve_gradient_stops(stops, rx, "radial-gradient") else {
+        return;
+    };
 
     // Krilla の RadialGradient は円のみ。楕円は cr=rx + transform で y 軸を ry/rx に scale。
     // 合成 T(cx,cy) · S(1, ry/rx) · T(-cx,-cy) を直接展開:

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -3215,7 +3215,6 @@ fn resolve_color_stops(
     current_color: &style::color::AbsoluteColor,
     gradient_kind: &'static str,
 ) -> Option<Vec<crate::pageable::GradientStop>> {
-    use crate::pageable::GradientStop;
     use style::values::generics::image::GradientItem;
 
     let mut raw: Vec<(Option<f32>, [u8; 4])> = Vec::with_capacity(items.len());
@@ -3297,8 +3296,10 @@ fn resolve_color_stops(
     Some(
         raw.into_iter()
             .zip(positions)
-            .map(|((_, rgba), pos)| GradientStop {
-                offset: pos.unwrap().clamp(0.0, 1.0),
+            .map(|((_, rgba), pos)| crate::pageable::GradientStop {
+                position: crate::pageable::GradientStopPosition::Fraction(
+                    pos.unwrap().clamp(0.0, 1.0),
+                ),
                 rgba,
             })
             .collect(),

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -3203,10 +3203,14 @@ fn resolve_linear_gradient(
 
 /// CSS gradient items から GradientStop ベクタを解決する。linear / radial 共通。
 ///
-/// - length-typed stop position は None を返す (gradient line 長さ依存のため Phase 2)
-/// - 範囲外 stop position も None (recompute が必要、Phase 2)
-/// - interpolation hint も None (Phase 2)
-/// - auto position は CSS Images §3.5.1 に従い等間隔で埋める
+/// position は `GradientStopPosition` で保持され (Auto / Fraction / LengthPx)、
+/// draw 時に `background::resolve_gradient_stops` で gradient line 長さを
+/// 使って fraction 化される。convert 時の fixup は行わない。
+///
+/// Bail 条件:
+/// - stops.len() < 2 (規定上 invalid)
+/// - interpolation hint (Phase 2 別 issue)
+/// - position が percentage でも length でもない (calc() 等 — Phase 2)
 fn resolve_color_stops(
     items: &[style::values::generics::image::GenericGradientItem<
         style::values::computed::Color,
@@ -3215,33 +3219,36 @@ fn resolve_color_stops(
     current_color: &style::color::AbsoluteColor,
     gradient_kind: &'static str,
 ) -> Option<Vec<crate::pageable::GradientStop>> {
+    use crate::pageable::{GradientStop, GradientStopPosition};
     use style::values::generics::image::GradientItem;
 
-    let mut raw: Vec<(Option<f32>, [u8; 4])> = Vec::with_capacity(items.len());
+    let mut out: Vec<GradientStop> = Vec::with_capacity(items.len());
     for item in items.iter() {
         match item {
             GradientItem::SimpleColorStop(c) => {
                 let abs = c.resolve_to_absolute(current_color);
-                raw.push((None, absolute_to_rgba(abs)));
+                out.push(GradientStop {
+                    position: GradientStopPosition::Auto,
+                    rgba: absolute_to_rgba(abs),
+                });
             }
             GradientItem::ComplexColorStop { color, position } => {
-                let Some(pct) = position.to_percentage().map(|p| p.0) else {
+                let abs = color.resolve_to_absolute(current_color);
+                let pos = if let Some(pct) = position.to_percentage() {
+                    GradientStopPosition::Fraction(pct.0)
+                } else if let Some(len) = position.to_length() {
+                    GradientStopPosition::LengthPx(len.px())
+                } else {
                     log::warn!(
-                        "{gradient_kind}: length-typed stop position is not yet \
-                         supported (Phase 2). Layer dropped."
+                        "{gradient_kind}: stop position is neither percentage \
+                         nor length (calc() etc.). Layer dropped."
                     );
                     return None;
                 };
-                if !(0.0..=1.0).contains(&pct) {
-                    log::warn!(
-                        "{gradient_kind}: stop position {pct:.4} is outside [0, 1]. \
-                         Negative / >100% positions require recomputing the gradient \
-                         line (Phase 2). Layer dropped."
-                    );
-                    return None;
-                }
-                let abs = color.resolve_to_absolute(current_color);
-                raw.push((Some(pct), absolute_to_rgba(abs)));
+                out.push(GradientStop {
+                    position: pos,
+                    rgba: absolute_to_rgba(abs),
+                });
             }
             GradientItem::InterpolationHint(_) => {
                 log::warn!(
@@ -3253,57 +3260,11 @@ fn resolve_color_stops(
         }
     }
 
-    if raw.len() < 2 {
+    if out.len() < 2 {
         return None;
     }
 
-    let n = raw.len();
-    let mut positions: Vec<Option<f32>> = raw.iter().map(|(p, _)| *p).collect();
-    if positions[0].is_none() {
-        positions[0] = Some(0.0);
-    }
-    if positions[n - 1].is_none() {
-        positions[n - 1] = Some(1.0);
-    }
-    let mut last_resolved = 0.0_f32;
-    for v in positions.iter_mut().flatten() {
-        if *v < last_resolved {
-            *v = last_resolved;
-        }
-        last_resolved = *v;
-    }
-    let mut i = 0;
-    while i < n {
-        if positions[i].is_some() {
-            i += 1;
-            continue;
-        }
-        let start = i;
-        let mut end = start;
-        while end < n && positions[end].is_none() {
-            end += 1;
-        }
-        let p_prev = positions[start - 1].expect("first slot resolved");
-        let p_next = positions[end].expect("last slot resolved");
-        let span = (end - start + 1) as f32;
-        for (k, slot) in positions.iter_mut().enumerate().take(end).skip(start) {
-            let t = (k - start + 1) as f32 / span;
-            *slot = Some(p_prev + (p_next - p_prev) * t);
-        }
-        i = end;
-    }
-
-    Some(
-        raw.into_iter()
-            .zip(positions)
-            .map(|((_, rgba), pos)| crate::pageable::GradientStop {
-                position: crate::pageable::GradientStopPosition::Fraction(
-                    pos.unwrap().clamp(0.0, 1.0),
-                ),
-                rgba,
-            })
-            .collect(),
-    )
+    Some(out)
 }
 
 /// Convert a Stylo computed `Gradient::Radial` into fulgur's `BgImageContent::RadialGradient`.

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -735,14 +735,25 @@ pub enum BgClip {
     Text,
 }
 
-/// A single color stop in a CSS gradient, after position resolution.
+/// CSS gradient color stop の位置。
 ///
-/// `offset` is the resolved fraction along the gradient line in `[0.0, 1.0]`.
-/// CSS allows `auto` stop positions which `convert::resolve_linear_gradient`
-/// fills in via even spacing between adjacent fixed stops.
+/// - `Fraction` は `[0, 1]` 域内の % / 0%/100% 由来 (convert 時に解決)。
+/// - `LengthPx` は `<length>` 形式で記述された値 (例 `50px`)。draw 時に
+///   gradient line 長さで割って fraction 化する。
+/// - `Auto` は CSS auto。draw 時に CSS Images §3.5.1 fixup で前後の fixed
+///   stop から補間される。
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum GradientStopPosition {
+    Auto,
+    Fraction(f32),
+    LengthPx(f32),
+}
+
+/// A single color stop in a CSS gradient. Position は `GradientStopPosition`
+/// で保持され、draw 時に gradient line 長さで fraction に解決される。
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GradientStop {
-    pub offset: f32,
+    pub position: GradientStopPosition,
     pub rgba: [u8; 4],
 }
 

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -737,7 +737,10 @@ pub enum BgClip {
 
 /// CSS gradient color stop の位置。
 ///
-/// - `Fraction` は `[0, 1]` 域内の % / 0%/100% 由来 (convert 時に解決)。
+/// - `Fraction` は `%` 由来の比率値 (convert 時に `pct.0` として保持)。
+///   convert は値域チェックを行わないため範囲外も入りうる。最終的な
+///   範囲検証 (`[0, 1]` 外なら Layer drop) は draw 時の
+///   `background::resolve_gradient_stops` が担う (CSS Images §3.5.1)。
 /// - `LengthPx` は `<length>` 形式で記述された値 (例 `50px`)。draw 時に
 ///   gradient line 長さで割って fraction 化する。
 /// - `Auto` は CSS auto。draw 時に CSS Images §3.5.1 fixup で前後の fixed

--- a/crates/fulgur/tests/gradient_test.rs
+++ b/crates/fulgur/tests/gradient_test.rs
@@ -1,0 +1,131 @@
+//! Integration coverage for convert.rs gradient paths and the
+//! background.rs `resolve_gradient_stops` helper.
+//!
+//! Visual / pixel-level checks live in `crates/fulgur-vrt`; that crate is
+//! excluded from the codecov measurement (`cargo llvm-cov nextest --workspace
+//! --exclude fulgur-vrt`). These tests therefore exist purely to drive the
+//! convert / draw paths through `Engine::render_html` so coverage attribution
+//! is recorded.
+//!
+//! Each test renders a full PDF through fulgur and asserts the bytes start
+//! with the PDF header. We do not pixel-compare here — we just need every
+//! convert branch (`Auto` / `Fraction` / `LengthPx` / `InterpolationHint`,
+//! linear / radial) and every draw fixup branch (length resolution, monotonic
+//! clamp, out-of-range drop) to execute.
+
+use fulgur::config::{Margin, PageSize};
+use fulgur::engine::Engine;
+
+fn render(css_background: &str) -> Vec<u8> {
+    let html = format!(
+        r#"<html><body><div style="width:200px;height:100px;background:{css_background}">x</div></body></html>"#
+    );
+    Engine::builder()
+        .page_size(PageSize::A4)
+        .margin(Margin::uniform(72.0))
+        .build()
+        .render_html(&html)
+        .expect("render gradient")
+}
+
+fn assert_pdf(pdf: &[u8]) {
+    assert!(
+        pdf.starts_with(b"%PDF"),
+        "expected PDF, got {} bytes",
+        pdf.len()
+    );
+}
+
+// ---------- linear-gradient: convert.rs::resolve_color_stops branches ----
+
+#[test]
+fn linear_gradient_auto_stops_render() {
+    // SimpleColorStop arms (2x) → GradientStopPosition::Auto. Exercises
+    // background::resolve_gradient_stops endpoint-fill (Auto → 0.0 / 1.0).
+    assert_pdf(&render("linear-gradient(red, blue)"));
+}
+
+#[test]
+fn linear_gradient_percentage_stops_render() {
+    // ComplexColorStop with `to_percentage()` → Fraction(f).
+    assert_pdf(&render("linear-gradient(red 0%, blue 100%)"));
+}
+
+#[test]
+fn linear_gradient_length_px_stops_render() {
+    // ComplexColorStop with `to_length()` → LengthPx(px). The new path
+    // gated by this PR (fulgur-78sl).
+    assert_pdf(&render(
+        "linear-gradient(red 0px, blue 50px, blue 150px, green 200px)",
+    ));
+}
+
+#[test]
+fn linear_gradient_mixed_auto_and_fraction_render() {
+    // Mixed Auto + Fraction; exercises middle Auto interpolation in the
+    // draw-time fixup loop.
+    assert_pdf(&render("linear-gradient(red 0%, blue, green 100%)"));
+}
+
+#[test]
+fn linear_gradient_mixed_auto_length_render() {
+    // Mixed Auto + LengthPx; exercises the LengthPx path together with
+    // endpoint Auto fill.
+    assert_pdf(&render("linear-gradient(red, blue 50px, green)"));
+}
+
+#[test]
+fn linear_gradient_interpolation_hint_drops_layer() {
+    // InterpolationHint arm → log::warn + None. Layer is dropped, but
+    // overall render still succeeds (background just becomes solid white).
+    assert_pdf(&render("linear-gradient(red, 30%, blue)"));
+}
+
+#[test]
+fn linear_gradient_out_of_range_fraction_drops_layer() {
+    // Fraction(-0.5) reaches background::resolve_gradient_stops, fails
+    // range check, layer dropped (handoff to fulgur-n3zk).
+    assert_pdf(&render("linear-gradient(red -50%, blue 100%)"));
+}
+
+#[test]
+fn linear_gradient_with_angle_render() {
+    // `60deg` exercises `|W·sinθ| + |H·cosθ|` gradient line length formula
+    // in draw-time helper (CSS Images §3.5.1).
+    assert_pdf(&render(
+        "linear-gradient(60deg, red 0px, blue 50px, green 100%)",
+    ));
+}
+
+// ---------- radial-gradient: shared resolve_color_stops + radial draw ----
+
+#[test]
+fn radial_gradient_auto_stops_render() {
+    assert_pdf(&render("radial-gradient(red, blue)"));
+}
+
+#[test]
+fn radial_gradient_percentage_stops_render() {
+    assert_pdf(&render("radial-gradient(red 0%, blue 100%)"));
+}
+
+#[test]
+fn radial_gradient_length_px_stops_render() {
+    // px stops resolved against rx (CSS Images §3.6.1).
+    assert_pdf(&render(
+        "radial-gradient(circle 100px at center, red 0px, blue 50px, blue 100px)",
+    ));
+}
+
+#[test]
+fn radial_gradient_ellipse_with_length_stops_render() {
+    // Ellipse path: gradient ray length = rx (X-axis radius), even when ry differs.
+    assert_pdf(&render(
+        "radial-gradient(ellipse 100px 50px at center, red 0px, blue 50px, green 100px)",
+    ));
+}
+
+#[test]
+fn radial_gradient_interpolation_hint_drops_layer() {
+    assert_pdf(&render("radial-gradient(red, 30%, blue)"));
+}

--- a/docs/plans/2026-04-26-fulgur-78sl-length-typed-stops.md
+++ b/docs/plans/2026-04-26-fulgur-78sl-length-typed-stops.md
@@ -1,0 +1,893 @@
+# gradient: length-typed stop position 対応 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** `linear-gradient(red 50px, blue)` のような length-typed stop position を Phase 1 の `Layer dropped` 廃止し、draw 時に gradient line 長さで fraction 化して正しくレンダリングする。
+
+**Architecture:** `GradientStop.offset: f32` を `position: GradientStopPosition` (enum: `Auto` / `Fraction(f32)` / `LengthPx(f32)`) に変更。convert 時は length 値を保持するだけで CSS fixup を行わない。draw 時に新ヘルパー `resolve_gradient_stops` で gradient line 長さ (linear: `|W·sinθ|+|H·cosθ|`, radial: rx) を使って解決 → CSS Images §3.5.1 の auto/monotonic fixup → 範囲外は Layer drop (fulgur-n3zk と境界統一)。
+
+**Tech Stack:** Rust / Stylo (LengthPercentage::to_length / to_percentage) / Krilla LinearGradient / RadialGradient / fulgur-vrt strip-approximation harness
+
+**Working directory:** `/home/ubuntu/fulgur/.worktrees/fulgur-78sl-px-stops` (branch `feature/fulgur-78sl-length-stops`)
+
+**Reference:**
+
+- beads: fulgur-78sl (design 保存済)
+- 関連: fulgur-n3zk (out-of-range stop, 別 issue)
+- CSS: <https://drafts.csswg.org/css-images-3/#color-stop-syntax>
+- CSS Images §3.6.1: gradient ray 長さ = ending shape の +X 軸 radius (ellipse でも rx)
+
+---
+
+## Task 1: 型の刷新 — `GradientStopPosition` 導入 (no-op refactor)
+
+**目的:** 既存挙動を維持したまま `GradientStop.offset: f32` を `position: GradientStopPosition` に置換。新 `LengthPx` variant の導入はあとで使い、まずは `Fraction(f)` のみで動かす。
+
+**Files:**
+
+- Modify: `crates/fulgur/src/pageable.rs:738-747`
+- Modify: `crates/fulgur/src/convert.rs:3297-3305` (resolve_color_stops の末尾 map)
+- Modify: `crates/fulgur/src/background.rs:412-422` (draw_linear_gradient の krilla::Stop 構築)
+- Modify: `crates/fulgur/src/background.rs:541-549` (draw_radial_gradient の krilla::Stop 構築)
+
+**Step 1: 型を pageable.rs に追加**
+
+`crates/fulgur/src/pageable.rs:743` 直前に enum を追加し `GradientStop` を書き換え:
+
+```rust
+/// CSS gradient color stop の位置。
+///
+/// - `Fraction` は `[0, 1]` 域内の % / 0%/100% 由来 (convert 時に解決)。
+/// - `LengthPx` は `<length>` 形式で記述された値 (例 `50px`)。draw 時に
+///   gradient line 長さで割って fraction 化する。
+/// - `Auto` は CSS auto。draw 時に CSS Images §3.5.1 fixup で前後の fixed
+///   stop から補間される。
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum GradientStopPosition {
+    Auto,
+    Fraction(f32),
+    LengthPx(f32),
+}
+
+/// A single color stop in a CSS gradient. Position は `GradientStopPosition`
+/// で保持され、draw 時に gradient line 長さで fraction に解決される。
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct GradientStop {
+    pub position: GradientStopPosition,
+    pub rgba: [u8; 4],
+}
+```
+
+**Step 2: convert.rs の構築箇所を更新 (一旦 Fraction のみ)**
+
+`crates/fulgur/src/convert.rs:3297-3305` の `.map(|((_, rgba), pos)| GradientStop { ... })` を:
+
+```rust
+.map(|((_, rgba), pos)| crate::pageable::GradientStop {
+    position: crate::pageable::GradientStopPosition::Fraction(
+        pos.unwrap().clamp(0.0, 1.0),
+    ),
+    rgba,
+})
+```
+
+(fixup は残ったまま)
+
+**Step 3: background.rs draw_linear_gradient 修正**
+
+`crates/fulgur/src/background.rs:412-422` の krilla::paint::Stop 構築を、enum match で fraction を取り出す形に変更:
+
+```rust
+let krilla_stops: Vec<krilla::paint::Stop> = stops
+    .iter()
+    .map(|s| {
+        let offset_f = match s.position {
+            crate::pageable::GradientStopPosition::Fraction(f) => f.clamp(0.0, 1.0),
+            // Task 1 では convert 側が Fraction のみ生成するため到達しない
+            crate::pageable::GradientStopPosition::Auto
+            | crate::pageable::GradientStopPosition::LengthPx(_) => 0.0,
+        };
+        krilla::paint::Stop {
+            offset: krilla::num::NormalizedF32::new(offset_f)
+                .expect("offset is clamped to [0, 1]"),
+            color: krilla::color::rgb::Color::new(s.rgba[0], s.rgba[1], s.rgba[2]).into(),
+            opacity: crate::pageable::alpha_to_opacity(s.rgba[3]),
+        }
+    })
+    .collect();
+```
+
+**Step 4: background.rs draw_radial_gradient 同等修正**
+
+`crates/fulgur/src/background.rs:541-549` も同じ enum match パターンで書き換える。
+
+**Step 5: ビルド確認**
+
+```bash
+cd /home/ubuntu/fulgur/.worktrees/fulgur-78sl-px-stops
+cargo build -p fulgur 2>&1 | tail -3
+```
+
+期待: コンパイル成功 (warning が出る可能性あり、Task 3 で fix)
+
+**Step 6: 既存テスト全 PASS 確認**
+
+```bash
+cargo test -p fulgur --lib 2>&1 | tail -5
+cargo test -p fulgur-vrt 2>&1 | tail -5
+```
+
+期待: `test result: ok. 738 passed`、VRT 全 fixture green。pixel-byte 互換が維持されること (no-op refactor)。
+
+**Step 7: コミット**
+
+```bash
+git add crates/fulgur/src/pageable.rs crates/fulgur/src/convert.rs crates/fulgur/src/background.rs
+git commit -m "refactor(gradient): introduce GradientStopPosition enum (no-op)"
+```
+
+---
+
+## Task 2: `resolve_gradient_stops` ヘルパー追加 (TDD)
+
+**目的:** convert 時の fixup ロジックを background.rs に移植し、length-typed と auto を draw 時に解決するヘルパーを TDD で実装する。
+
+**Files:**
+
+- Create / Modify: `crates/fulgur/src/background.rs` (関数追加 + テストモジュール)
+
+**Step 1: 失敗テストを書く**
+
+`crates/fulgur/src/background.rs` の末尾 `#[cfg(test)] mod tests` (なければ新規作成) に以下を追加:
+
+```rust
+#[cfg(test)]
+mod resolve_gradient_stops_tests {
+    use super::*;
+    use crate::pageable::{GradientStop, GradientStopPosition::*};
+
+    fn fr(f: f32) -> GradientStopPosition { Fraction(f) }
+    fn px(f: f32) -> GradientStopPosition { LengthPx(f) }
+    fn stop(p: GradientStopPosition, rgba: [u8; 4]) -> GradientStop {
+        GradientStop { position: p, rgba }
+    }
+
+    #[test]
+    fn fraction_only_passes_through() {
+        let stops = vec![
+            stop(fr(0.0), [255, 0, 0, 255]),
+            stop(fr(1.0), [0, 0, 255, 255]),
+        ];
+        let out = resolve_gradient_stops(&stops, 100.0, "linear-gradient").unwrap();
+        assert_eq!(out.len(), 2);
+        assert!((out[0].offset.get() - 0.0).abs() < 1e-6);
+        assert!((out[1].offset.get() - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn length_px_resolved_by_line_length() {
+        let stops = vec![
+            stop(px(0.0), [255, 0, 0, 255]),
+            stop(px(50.0), [0, 0, 255, 255]),
+        ];
+        // line_length = 100 → 50px = 0.5
+        let out = resolve_gradient_stops(&stops, 100.0, "linear-gradient").unwrap();
+        assert_eq!(out.len(), 2);
+        assert!((out[1].offset.get() - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn auto_position_filled_at_endpoints() {
+        let stops = vec![
+            stop(Auto, [255, 0, 0, 255]),
+            stop(Auto, [0, 0, 255, 255]),
+        ];
+        let out = resolve_gradient_stops(&stops, 100.0, "linear-gradient").unwrap();
+        assert!((out[0].offset.get() - 0.0).abs() < 1e-6);
+        assert!((out[1].offset.get() - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn auto_position_filled_in_middle() {
+        let stops = vec![
+            stop(fr(0.0), [255, 0, 0, 255]),
+            stop(Auto, [0, 255, 0, 255]),
+            stop(fr(1.0), [0, 0, 255, 255]),
+        ];
+        let out = resolve_gradient_stops(&stops, 100.0, "linear-gradient").unwrap();
+        assert!((out[1].offset.get() - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn mixed_length_fraction_auto() {
+        // linear-gradient(red, blue 50px, green) on line_length=100
+        // → red Auto (→0), blue 0.5, green Auto (→1)
+        let stops = vec![
+            stop(Auto, [255, 0, 0, 255]),
+            stop(px(50.0), [0, 0, 255, 255]),
+            stop(Auto, [0, 255, 0, 255]),
+        ];
+        let out = resolve_gradient_stops(&stops, 100.0, "linear-gradient").unwrap();
+        assert_eq!(out.len(), 3);
+        assert!((out[0].offset.get() - 0.0).abs() < 1e-6);
+        assert!((out[1].offset.get() - 0.5).abs() < 1e-6);
+        assert!((out[2].offset.get() - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn out_of_range_length_returns_none() {
+        // 50px on line_length=30 → 50/30 ≈ 1.67 > 1 → Layer drop
+        let stops = vec![
+            stop(fr(0.0), [255, 0, 0, 255]),
+            stop(px(50.0), [0, 0, 255, 255]),
+        ];
+        let out = resolve_gradient_stops(&stops, 30.0, "linear-gradient");
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn negative_fraction_returns_none() {
+        let stops = vec![
+            stop(fr(-0.1), [255, 0, 0, 255]),
+            stop(fr(1.0), [0, 0, 255, 255]),
+        ];
+        let out = resolve_gradient_stops(&stops, 100.0, "linear-gradient");
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn monotonic_clamp_applied() {
+        // [0.6, 0.3] → [0.6, 0.6] (monotonic fix)
+        let stops = vec![
+            stop(fr(0.6), [255, 0, 0, 255]),
+            stop(fr(0.3), [0, 0, 255, 255]),
+        ];
+        let out = resolve_gradient_stops(&stops, 100.0, "linear-gradient").unwrap();
+        assert!((out[0].offset.get() - 0.6).abs() < 1e-6);
+        assert!((out[1].offset.get() - 0.6).abs() < 1e-6);
+    }
+
+    #[test]
+    fn line_length_zero_returns_none() {
+        let stops = vec![
+            stop(px(50.0), [255, 0, 0, 255]),
+            stop(fr(1.0), [0, 0, 255, 255]),
+        ];
+        let out = resolve_gradient_stops(&stops, 0.0, "linear-gradient");
+        assert!(out.is_none());
+    }
+}
+```
+
+**Step 2: テスト実行 (失敗確認)**
+
+```bash
+cargo test -p fulgur --lib resolve_gradient_stops_tests 2>&1 | tail -5
+```
+
+期待: `error[E0425]: cannot find function 'resolve_gradient_stops'`
+
+**Step 3: ヘルパー本体を実装**
+
+`crates/fulgur/src/background.rs` の `draw_linear_gradient` の直前あたりに追加:
+
+```rust
+/// Resolve `Vec<GradientStop>` (length / fraction / auto 混在) を krilla の
+/// `Stop` 列に変換する。
+///
+/// CSS Images Level 3 §3.5.1 の color-stop fixup に従って:
+///   1. `LengthPx(px)` を `px / line_length` で fraction 化
+///   2. 先頭/末尾の `Auto` を 0.0 / 1.0 に確定
+///   3. monotonic clamp (前 fixed より小さければ前 fixed に合わせる)
+///   4. 中間の `Auto` 群を前後 fixed の等間隔補間で埋める
+///   5. 最終 fraction が `[0, 1]` 外なら `Layer drop` (None)
+///
+/// `line_length <= 0` の場合は length stop が解決不能なので None。
+fn resolve_gradient_stops(
+    stops: &[crate::pageable::GradientStop],
+    line_length: f32,
+    gradient_kind: &'static str,
+) -> Option<Vec<krilla::paint::Stop>> {
+    use crate::pageable::GradientStopPosition;
+
+    if stops.len() < 2 {
+        return None;
+    }
+    if line_length <= 0.0 {
+        // length-typed stop が一つでもあれば解決不能。fraction-only でも
+        // 退化した gradient なので Layer drop 相当 (caller で先に early
+        // return しているため通常到達しない)。
+        return None;
+    }
+
+    let n = stops.len();
+    let mut positions: Vec<Option<f32>> = stops
+        .iter()
+        .map(|s| match s.position {
+            GradientStopPosition::Auto => None,
+            GradientStopPosition::Fraction(f) => Some(f),
+            GradientStopPosition::LengthPx(px) => Some(px / line_length),
+        })
+        .collect();
+
+    // 先頭/末尾の Auto を 0/1 に
+    if positions[0].is_none() {
+        positions[0] = Some(0.0);
+    }
+    if positions[n - 1].is_none() {
+        positions[n - 1] = Some(1.0);
+    }
+
+    // monotonic clamp
+    let mut last_resolved = f32::NEG_INFINITY;
+    for v in positions.iter_mut().flatten() {
+        if *v < last_resolved {
+            *v = last_resolved;
+        }
+        last_resolved = *v;
+    }
+
+    // 中間 Auto を前後 fixed の等間隔補間で埋める
+    let mut i = 0;
+    while i < n {
+        if positions[i].is_some() {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        let mut end = start;
+        while end < n && positions[end].is_none() {
+            end += 1;
+        }
+        let p_prev = positions[start - 1].expect("first slot resolved");
+        let p_next = positions[end].expect("last slot resolved");
+        let span = (end - start + 1) as f32;
+        for (k, slot) in positions.iter_mut().enumerate().take(end).skip(start) {
+            let t = (k - start + 1) as f32 / span;
+            *slot = Some(p_prev + (p_next - p_prev) * t);
+        }
+        i = end;
+    }
+
+    // 範囲外チェック (fulgur-n3zk が解くまでは Layer drop)
+    for (idx, p_opt) in positions.iter().enumerate() {
+        let p = p_opt.expect("all slots resolved");
+        if !(0.0..=1.0).contains(&p) {
+            log::warn!(
+                "{gradient_kind}: stop {idx} resolved offset {p:.4} is outside \
+                 [0, 1]. Out-of-range stops require gradient-line recompute \
+                 (fulgur-n3zk). Layer dropped."
+            );
+            return None;
+        }
+    }
+
+    // krilla::paint::Stop 構築
+    Some(
+        stops
+            .iter()
+            .zip(positions)
+            .map(|(s, p)| krilla::paint::Stop {
+                offset: krilla::num::NormalizedF32::new(p.unwrap())
+                    .expect("offset is in [0, 1]"),
+                color: krilla::color::rgb::Color::new(s.rgba[0], s.rgba[1], s.rgba[2]).into(),
+                opacity: crate::pageable::alpha_to_opacity(s.rgba[3]),
+            })
+            .collect(),
+    )
+}
+```
+
+**Step 4: テスト実行 (PASS 確認)**
+
+```bash
+cargo test -p fulgur --lib resolve_gradient_stops_tests 2>&1 | tail -10
+```
+
+期待: `test result: ok. 9 passed; 0 failed`
+
+**Step 5: コミット**
+
+```bash
+git add crates/fulgur/src/background.rs
+git commit -m "feat(gradient): add resolve_gradient_stops helper with CSS fixup"
+```
+
+---
+
+## Task 3: convert.rs から fixup 削除 + LengthPx 生成
+
+**目的:** convert 側で length-typed stop を `LengthPx` として保持し、fixup を draw 時に委譲する。
+
+**Files:**
+
+- Modify: `crates/fulgur/src/convert.rs:3204-3306` (resolve_color_stops 全面書き換え)
+
+**Step 1: 失敗テストを書く**
+
+`crates/fulgur/src/convert.rs` の `mod tests` または同 file 末尾の test mod に追加 (既存 test mod が convert.rs にない場合は新規作成):
+
+```rust
+#[cfg(test)]
+mod resolve_color_stops_tests {
+    use super::*;
+    use crate::pageable::GradientStopPosition;
+
+    fn parse_and_resolve(css: &str) -> Option<Vec<crate::pageable::GradientStop>> {
+        // CSS gradient items を直接構築するヘルパーを書くのは複雑なので、
+        // 末端 unit test では convert.rs 内部関数を直接呼ぶ代わりに
+        // VRT で end-to-end カバー。ここでは LengthPx variant の保持のみ
+        // 簡易確認する。
+        let _ = css;
+        None
+    }
+
+    #[test]
+    fn length_typed_stop_preserved_as_length_px() {
+        // この unit test は対外型 (BgImageContent) を経由した integration が
+        // 主目的なので、convert.rs 単体での test は割愛し VRT で網羅する。
+        // 代わりに resolve_color_stops の戻り値型が
+        // GradientStopPosition::LengthPx を含むことを型レベルで担保。
+        let p: GradientStopPosition = GradientStopPosition::LengthPx(50.0);
+        assert!(matches!(p, GradientStopPosition::LengthPx(_)));
+    }
+}
+```
+
+(注: convert.rs の resolve_color_stops は `style::values::generics::image::GenericGradientItem` を引数にとるため、unit test で synthesize するのが煩雑。E2E は VRT で担保する方針。)
+
+**Step 2: resolve_color_stops を書き換え**
+
+`crates/fulgur/src/convert.rs:3210-3306` の `resolve_color_stops` を以下に置換:
+
+```rust
+/// CSS gradient items から GradientStop ベクタを解決する。linear / radial 共通。
+///
+/// position は `GradientStopPosition` で保持され (Auto / Fraction / LengthPx)、
+/// draw 時に `background::resolve_gradient_stops` で gradient line 長さを
+/// 使って fraction 化される。convert 時の fixup は行わない。
+///
+/// Bail 条件:
+/// - stops.len() < 2 (規定上 invalid)
+/// - interpolation hint (Phase 2 別 issue)
+/// - position が percentage でも length でもない (calc() 等 — Phase 2)
+fn resolve_color_stops(
+    items: &[style::values::generics::image::GenericGradientItem<
+        style::values::computed::Color,
+        style::values::computed::LengthPercentage,
+    >],
+    current_color: &style::color::AbsoluteColor,
+    gradient_kind: &'static str,
+) -> Option<Vec<crate::pageable::GradientStop>> {
+    use crate::pageable::{GradientStop, GradientStopPosition};
+    use style::values::generics::image::GradientItem;
+
+    let mut out: Vec<GradientStop> = Vec::with_capacity(items.len());
+    for item in items.iter() {
+        match item {
+            GradientItem::SimpleColorStop(c) => {
+                let abs = c.resolve_to_absolute(current_color);
+                out.push(GradientStop {
+                    position: GradientStopPosition::Auto,
+                    rgba: absolute_to_rgba(abs),
+                });
+            }
+            GradientItem::ComplexColorStop { color, position } => {
+                let abs = color.resolve_to_absolute(current_color);
+                let pos = if let Some(pct) = position.to_percentage() {
+                    GradientStopPosition::Fraction(pct.0)
+                } else if let Some(len) = position.to_length() {
+                    GradientStopPosition::LengthPx(len.px())
+                } else {
+                    log::warn!(
+                        "{gradient_kind}: stop position is neither percentage \
+                         nor length (calc() etc.). Layer dropped."
+                    );
+                    return None;
+                };
+                out.push(GradientStop {
+                    position: pos,
+                    rgba: absolute_to_rgba(abs),
+                });
+            }
+            GradientItem::InterpolationHint(_) => {
+                log::warn!(
+                    "{gradient_kind}: interpolation hints are not yet supported \
+                     (Phase 2). Layer dropped."
+                );
+                return None;
+            }
+        }
+    }
+
+    if out.len() < 2 {
+        return None;
+    }
+
+    Some(out)
+}
+```
+
+**Step 3: コンパイル確認**
+
+```bash
+cargo build -p fulgur 2>&1 | tail -3
+```
+
+期待: 成功 (Task 1 で更新した draw 側 match で Auto / LengthPx も明示処理されている)。ただし draw_linear / draw_radial はまだ Task 1 の no-op match で 0.0 を返してしまう → このタスクではまだ pixel が崩れる可能性あり、Task 4 で fix。
+
+**Step 4: 既存テスト確認 (回帰)**
+
+```bash
+cargo test -p fulgur --lib 2>&1 | tail -5
+```
+
+期待: 738 PASS (この時点では VRT は壊れる可能性あり、Task 4 で修正)。fulgur lib 内 unit test は通るはず。
+
+**Step 5: コミット**
+
+```bash
+git add crates/fulgur/src/convert.rs
+git commit -m "feat(gradient): preserve length-typed stops as LengthPx in convert"
+```
+
+---
+
+## Task 4: draw_linear_gradient / draw_radial_gradient を新ヘルパーに切替
+
+**目的:** draw 時に `resolve_gradient_stops` を経由して length / auto を解決する。Task 1 で残した暫定 match (Auto / LengthPx → 0.0) を撤去。
+
+**Files:**
+
+- Modify: `crates/fulgur/src/background.rs::draw_linear_gradient` (412-422)
+- Modify: `crates/fulgur/src/background.rs::draw_radial_gradient` (541-549)
+
+**Step 1: draw_linear_gradient の stops 構築を置換**
+
+`crates/fulgur/src/background.rs:412-422` の `let krilla_stops: Vec<...> = stops.iter().map(...)` を以下に変更:
+
+```rust
+let Some(krilla_stops) = resolve_gradient_stops(stops, length, "linear-gradient") else {
+    return;
+};
+```
+
+(注: `length` は同関数 line 399 で計算済の gradient line 長さ。)
+
+**Step 2: draw_radial_gradient の stops 構築を置換**
+
+`crates/fulgur/src/background.rs:541-549` も同様に:
+
+```rust
+// Radial gradient line length = rx (CSS Images §3.6.1, ellipse でも +X 軸)
+let Some(krilla_stops) = resolve_gradient_stops(stops, rx, "radial-gradient") else {
+    return;
+};
+```
+
+**Step 3: 既存テスト全 PASS 確認**
+
+```bash
+cargo test -p fulgur --lib 2>&1 | tail -5
+cargo test -p fulgur-vrt 2>&1 | tail -10
+```
+
+期待: lib 738 PASS, VRT 全 fixture green。length-typed stop を含まない既存 fixture は byte-identical (fixup ロジックが pixel 互換であれば)。
+
+**Note:** もし VRT が fail したら、`resolve_gradient_stops` の monotonic / auto 補間ロジックが `convert::resolve_color_stops` の旧ロジックと数値的に同等か再確認すること。特に `last_resolved` の初期値 (旧: `0.0_f32`, 新: `f32::NEG_INFINITY`) の挙動差に注意。旧コードは `<= 0.0` の値も `last_resolved=0.0` 以上に押し上げていたが、新コードは負値も保持して後段 range check で drop する。fraction-only かつ範囲内の入力に限ればどちらも同じ結果。
+
+**Step 4: コミット**
+
+```bash
+git add crates/fulgur/src/background.rs
+git commit -m "feat(gradient): wire draw_*_gradient through resolve_gradient_stops"
+```
+
+---
+
+## Task 5: VRT fixture 追加 (linear gradient + px stop)
+
+**目的:** `linear-gradient(red 0px, red 200px, blue 200px, blue 400px)` のような px-typed stop が visually 正しく描画されることを strip-approximation で確認する。
+
+**Files:**
+
+- Create: `crates/fulgur-vrt/fixtures/paint/linear-gradient-px-stop.html`
+- Create: `crates/fulgur-vrt/fixtures/paint/linear-gradient-px-stop-ref.html` (or use existing strip harness)
+- Modify: `crates/fulgur-vrt/tests/gradient_harness.rs` (新規 test 関数)
+
+**Step 1: 仕様確認 — どんな gradient で何を assert するか決定**
+
+ターゲット CSS: `linear-gradient(to right, red 0px, blue 50px, blue 350px, green 400px)` を `width: 400px` の box にかけると:
+
+- 0px (=0%): red
+- 50px (=12.5%): blue (赤→青の急峻な遷移、12.5% で青に到達)
+- 350px (=87.5%): blue (87.5% まで blue 一定)
+- 400px (=100%): green
+
+実装が正しければ **40-300px の範囲は完全に純 blue**、両端付近に short transition がある。
+
+**Step 2: test fixture 作成**
+
+`crates/fulgur-vrt/fixtures/paint/linear-gradient-px-stop.html`:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>VRT test: linear-gradient with px-typed stops</title>
+<style>
+  html, body { margin: 0; padding: 0; }
+  #g {
+    margin: 32px;
+    width: 400px;
+    height: 192px;
+    background: linear-gradient(to right, red 0px, blue 50px, blue 350px, green 400px);
+  }
+</style>
+</head>
+<body>
+<div id="g"></div>
+</body>
+</html>
+```
+
+**Step 3: ref fixture 作成**
+
+`crates/fulgur-vrt/fixtures/paint/linear-gradient-px-stop-ref.html` を strip-approximation で。`gradient_harness.rs` の `build_strip_ref_html` パターンを利用するため、ref も harness が動的生成する形が望ましい。**実装方針: harness に新 test 関数 `linear_gradient_px_stop` を追加し、test/ref 双方を動的生成する。**
+
+**Step 4: harness 拡張**
+
+`crates/fulgur-vrt/tests/gradient_harness.rs` の末尾に以下 test 関数を追加:
+
+```rust
+/// linear-gradient(red 0px, blue 50px, blue 350px, green 400px) を
+/// strip-approximation ref と比較する。50px = 12.5%, 350px = 87.5% を
+/// CSS spec 通り解決できるかを検証。
+#[test]
+fn linear_gradient_px_stop() {
+    use crate::pdf_render::{RenderSpec, pdf_to_rgba, render_html_to_pdf};
+
+    // sampling: position-aware strip ref
+    fn lerp_color(t: f32) -> (u8, u8, u8) {
+        // 0..=0.125: red→blue, 0.125..=0.875: blue, 0.875..=1.0: blue→green
+        const RED: (u8, u8, u8) = (255, 0, 0);
+        const BLUE: (u8, u8, u8) = (0, 0, 255);
+        const GREEN: (u8, u8, u8) = (0, 128, 0);
+        if t <= 0.125 {
+            let s = t / 0.125;
+            (
+                lerp_u8(RED.0, BLUE.0, s),
+                lerp_u8(RED.1, BLUE.1, s),
+                lerp_u8(RED.2, BLUE.2, s),
+            )
+        } else if t >= 0.875 {
+            let s = (t - 0.875) / 0.125;
+            (
+                lerp_u8(BLUE.0, GREEN.0, s),
+                lerp_u8(BLUE.1, GREEN.1, s),
+                lerp_u8(BLUE.2, GREEN.2, s),
+            )
+        } else {
+            BLUE
+        }
+    }
+
+    let test_html = format!(
+        r#"<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><style>
+html,body{{margin:0;padding:0;}}
+#g{{margin:{margin}px;width:{w}px;height:{h}px;
+   background:linear-gradient(to right, red 0px, blue 50px, blue 350px, green 400px);}}
+</style></head><body><div id="g"></div></body></html>"#,
+        margin = GRADIENT_MARGIN_PX,
+        w = GRADIENT_WIDTH_PX,
+        h = GRADIENT_HEIGHT_PX,
+    );
+
+    // ref: strip approximation with custom color function
+    let strip_w = GRADIENT_WIDTH_PX / STRIP_COUNT;
+    let mut strips = String::new();
+    for i in 0..STRIP_COUNT {
+        let t = (i as f32 + 0.5) / STRIP_COUNT as f32;
+        let (r, g, b) = lerp_color(t);
+        let left = i * strip_w;
+        strips.push_str(&format!(
+            r#"<div style="position:absolute;top:0;bottom:0;left:{left}px;width:{strip_w}px;background:rgb({r},{g},{b});"></div>"#
+        ));
+    }
+    let ref_html = format!(
+        r#"<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><style>
+html,body{{margin:0;padding:0;}}
+#g{{margin:{margin}px;width:{w}px;height:{h}px;position:relative;}}
+</style></head><body><div id="g">{strips}</div></body></html>"#,
+        margin = GRADIENT_MARGIN_PX,
+        w = GRADIENT_WIDTH_PX,
+        h = GRADIENT_HEIGHT_PX,
+    );
+
+    let test_pdf = render_html_to_pdf(&test_html, &RenderSpec::default()).unwrap();
+    let ref_pdf = render_html_to_pdf(&ref_html, &RenderSpec::default()).unwrap();
+    let test_rgba = pdf_to_rgba(&test_pdf, 150).unwrap();
+    let ref_rgba = pdf_to_rgba(&ref_pdf, 150).unwrap();
+
+    let tol = Tolerance { per_channel: 12, allowed_pixel_pct: 0.5 };
+    let report = diff::compare(&test_rgba, &ref_rgba, &tol).unwrap();
+    assert!(report.passed, "linear-gradient-px-stop test: {report:?}");
+}
+```
+
+(注: `lerp_u8` は同 file 内既存関数、`Tolerance` / `diff::compare` の API は既存 harness を踏襲。詳細は `gradient_harness.rs:42` `lerp_u8` 周辺と既存 test を参照。)
+
+**Step 5: テスト実行**
+
+```bash
+cargo test -p fulgur-vrt --test gradient_harness linear_gradient_px_stop 2>&1 | tail -20
+```
+
+期待: `test result: ok. 1 passed`。失敗時は実装側 (`resolve_gradient_stops` の length 解決) の数値を log で確認。
+
+**Step 6: 既存 VRT 全体回帰確認**
+
+```bash
+cargo test -p fulgur-vrt 2>&1 | tail -10
+```
+
+期待: 全 fixture green。
+
+**Step 7: コミット**
+
+```bash
+git add crates/fulgur-vrt/tests/gradient_harness.rs
+git commit -m "test(vrt): add linear-gradient px-typed stop reftest"
+```
+
+---
+
+## Task 6: VRT fixture 追加 (radial gradient + px stop) [optional but recommended]
+
+**目的:** radial gradient における length-typed stop の解決 (rx 基準) を確認する。
+
+**Files:**
+
+- Modify: `crates/fulgur-vrt/tests/gradient_harness.rs` (test 追加)
+
+**Step 1: ターゲット CSS**
+
+`radial-gradient(circle, red 0px, blue 50px, blue 100px)` を 200x200 box の中心に配置すれば、半径 50px までは red→blue グラデ、50-100px は blue 単色、100px 以遠も blue (clamp)。
+
+**Step 2: test 関数追加**
+
+linear と同じ pattern で radial 版を `gradient_harness.rs` に追加。ref は同心円 strip ではなく `radial-gradient` で **fraction だけを使った同等表現** を ref にする手法もあり (linear で言うと strip ref のかわりに)。
+
+ただし「実装をテストするのに同じ実装でリファレンスを作る」のは false positive のリスク。代替案: ref も `linear-gradient` で側面 sampling し、円形 mask で円に切り抜く — 複雑。
+
+**簡易代替**: 純粋に "解決後 fraction" が等価な percentage gradient を ref にする:
+
+- test: `radial-gradient(circle 100px, red 0px, blue 50px, blue 100px)`
+- ref:  `radial-gradient(circle 100px, red 0%, blue 50%, blue 100%)`
+
+両者の解決結果は同一であるべき。**ただし test/ref 共に gradient を使うため、もし `LengthPx` 解決自体がバグっていれば test が間違った PDF を、ref が正しい PDF を生成し、diff で fail する**。これで length 解決ロジックは検証できる。
+
+これに倣って:
+
+```rust
+#[test]
+fn radial_gradient_px_stop() {
+    let test_html = format!(
+        r#"<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><style>
+html,body{{margin:0;padding:0;}}
+#g{{margin:{margin}px;width:200px;height:200px;
+   background:radial-gradient(circle 100px at center, red 0px, blue 50px, blue 100px);}}
+</style></head><body><div id="g"></div></body></html>"#,
+        margin = GRADIENT_MARGIN_PX,
+    );
+    let ref_html = format!(
+        r#"<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><style>
+html,body{{margin:0;padding:0;}}
+#g{{margin:{margin}px;width:200px;height:200px;
+   background:radial-gradient(circle 100px at center, red 0%, blue 50%, blue 100%);}}
+</style></head><body><div id="g"></div></body></html>"#,
+        margin = GRADIENT_MARGIN_PX,
+    );
+    let test_pdf = pdf_render::render_html_to_pdf(&test_html, &pdf_render::RenderSpec::default()).unwrap();
+    let ref_pdf = pdf_render::render_html_to_pdf(&ref_html, &pdf_render::RenderSpec::default()).unwrap();
+    let test_rgba = pdf_render::pdf_to_rgba(&test_pdf, 150).unwrap();
+    let ref_rgba = pdf_render::pdf_to_rgba(&ref_pdf, 150).unwrap();
+    let tol = Tolerance { per_channel: 4, allowed_pixel_pct: 0.1 };
+    let report = diff::compare(&test_rgba, &ref_rgba, &tol).unwrap();
+    assert!(report.passed, "radial-gradient-px-stop test: {report:?}");
+}
+```
+
+(test/ref が同じ gradient 実装を使うので tolerance はタイトに 4 channel)
+
+**Step 3: テスト実行**
+
+```bash
+cargo test -p fulgur-vrt --test gradient_harness radial_gradient_px_stop 2>&1 | tail -15
+```
+
+期待: PASS
+
+**Step 4: コミット**
+
+```bash
+git add crates/fulgur-vrt/tests/gradient_harness.rs
+git commit -m "test(vrt): add radial-gradient px-typed stop reftest"
+```
+
+---
+
+## Task 7: 全体回帰 + clippy + format
+
+**目的:** 最終的なコード品質チェック。
+
+**Step 1: 全テスト実行**
+
+```bash
+cd /home/ubuntu/fulgur/.worktrees/fulgur-78sl-px-stops
+cargo test -p fulgur --lib 2>&1 | tail -3
+cargo test -p fulgur 2>&1 | tail -3
+cargo test -p fulgur-vrt 2>&1 | tail -3
+```
+
+期待: 全 PASS。
+
+**Step 2: clippy / fmt**
+
+```bash
+cargo clippy --all-targets -- -D warnings 2>&1 | tail -10
+cargo fmt --check 2>&1 | tail -5
+```
+
+期待: warning 0、format diff なし。失敗時は `cargo fmt` を実行して再コミット。
+
+**Step 3: ログ確認**
+
+`linear-gradient: length-typed stop position is not yet supported (Phase 2)` ログが消えたか:
+
+```bash
+grep -rn "length-typed stop position is not yet" crates/fulgur/src/
+```
+
+期待: 結果なし (Phase 1 ログが残っていれば Task 3 で削除漏れ)。
+
+**Step 4: 関連 PR を予期した最終ファイルテスト**
+
+CLI で簡易確認:
+
+```bash
+echo '<style>div{width:400px;height:100px;background:linear-gradient(to right, red 0px, blue 50px, green 100px);}</style><div></div>' | \
+  cargo run -q --bin fulgur -- render /dev/stdin -o /tmp/px-stop.pdf
+ls -la /tmp/px-stop.pdf
+```
+
+期待: PDF が生成され、Layer drop ログは出ない。
+
+**Step 5: 最終コミット (まだ修正があれば)**
+
+```bash
+git status
+# 必要なら git add -p で fix を commit
+```
+
+---
+
+## 完了条件 (Acceptance)
+
+1. `cargo test -p fulgur --lib` 全 PASS (738+ tests, 新規 `resolve_gradient_stops_tests` 含む)
+2. `cargo test -p fulgur-vrt` 全 PASS (`linear_gradient_px_stop` / `radial_gradient_px_stop` 含む)
+3. `cargo clippy --all-targets -- -D warnings` 警告 0
+4. `cargo fmt --check` 差分なし
+5. `linear-gradient: length-typed stop position is not yet supported` ログが convert.rs から消えている
+6. `linear-gradient(red 0px, blue 50px, green 100px)` 等が正しく PDF に描画される (CLI 手動確認)
+7. out-of-range (length 解決後 > 1.0 / < 0.0) は `log::warn` + Layer drop で fulgur-n3zk 用に残されている
+
+## Implementation Notes / Risks
+
+- **Task 1 (no-op refactor)** で既存 VRT が pixel-byte 互換である必要がある。fixup ロジック移動 (Task 2-4) は no-op refactor 内では発生しないので、Task 1 単独では既存テスト全 green を期待。
+- **Task 4 (draw 切替)** で初めて fixup ロジックが新ヘルパー側になる。`last_resolved` 初期値の差 (旧 `0.0` / 新 `-∞`) で挙動が分岐するのは "全 stop が負値" のような病的入力のみ。実テストには影響しないはず。万一 VRT が崩れたら Task 4 内で再現性を確認。
+- **Task 5/6 VRT** は既に存在する `gradient_harness.rs` が strip-approximation を使っているので `Tolerance::per_channel = 12` 程度で安定する想定。実環境で fail したら tol を調整。
+- **out-of-range の log message** は fulgur-n3zk への hand-off ポイントなので、明示的に issue ID を入れて将来追跡しやすくする。

--- a/docs/plans/2026-04-26-fulgur-78sl-length-typed-stops.md
+++ b/docs/plans/2026-04-26-fulgur-78sl-length-typed-stops.md
@@ -547,23 +547,31 @@ git commit -m "feat(gradient): preserve length-typed stops as LengthPx in conver
 `crates/fulgur/src/background.rs:412-422` の `let krilla_stops: Vec<...> = stops.iter().map(...)` を以下に変更:
 
 ```rust
-let Some(krilla_stops) = resolve_gradient_stops(stops, length, "linear-gradient") else {
+// `length` は pt 単位 (ow, oh が pt) だが、`GradientStopPosition::LengthPx` は
+// CSS px なので、helper の単位契約 (CSS px) に合わせて変換してから渡す。
+// pt のまま渡すと 4/3× ずれる (coordinate-system.md 参照)。
+let length_px = crate::convert::pt_to_px(length);
+let Some(krilla_stops) = resolve_gradient_stops(stops, length_px, "linear-gradient") else {
     return;
 };
 ```
 
-(注: `length` は同関数 line 399 で計算済の gradient line 長さ。)
+(注: `length` は同関数 line 399 で計算済の gradient line 長さ pt 値。)
 
 **Step 2: draw_radial_gradient の stops 構築を置換**
 
 `crates/fulgur/src/background.rs:541-549` も同様に:
 
 ```rust
-// Radial gradient line length = rx (CSS Images §3.6.1, ellipse でも +X 軸)
-let Some(krilla_stops) = resolve_gradient_stops(stops, rx, "radial-gradient") else {
+// Radial gradient line length = rx (CSS Images §3.6.1, ellipse でも +X 軸)。
+// `rx` は draw 内で pt 単位で計算されるので CSS px に揃える。
+let rx_px = crate::convert::pt_to_px(rx);
+let Some(krilla_stops) = resolve_gradient_stops(stops, rx_px, "radial-gradient") else {
     return;
 };
 ```
+
+**注:** Plan の初回ドラフトでは pt 単位の `length` / `rx` をそのまま helper に渡していたが、これは fulgur-78sl 実装中に発見された 4/3× scale バグの原因 (commit `12d707f` で修正)。Helper は CSS px 契約 (`GradientStopPosition::LengthPx` と単位を揃える) なので、call site で `crate::convert::pt_to_px` で変換するのが正しい。
 
 **Step 3: 既存テスト全 PASS 確認**
 


### PR DESCRIPTION
## 概要

beads issue: [fulgur-78sl](https://github.com/fulgur-rs/fulgur/issues?q=fulgur-78sl) (epic [fulgur-5166](https://github.com/fulgur-rs/fulgur/issues?q=fulgur-5166) Gradient Phase 2 の一部)

`linear-gradient(red 50px, blue)` のような length-typed stop position を Phase 1 では `Layer dropped` (log::warn) で処理していたが、CSS Images Level 3 §3.5.1 に従い draw 時に gradient line 長さで fraction 化して正しく描画する。

## 主な変更

### Type design (`pageable.rs`)

`GradientStop.offset: f32` を `position: GradientStopPosition` (enum: `Auto` / `Fraction(f32)` / `LengthPx(f32)`) に置換。length 値を draw 時まで保持し、CSS spec §3.5.1 の color-stop fixup を draw 時に適用する設計に変更。

**※ `GradientStop` は `pub struct` で `BackgroundLayer` 経由で公開されているため、これは破壊的変更**。次回マイナーバージョンアップで取り込み予定。

### Convert side (`convert.rs`)

`resolve_color_stops` を簡素化:

- `SimpleColorStop` → `GradientStopPosition::Auto` (placeholder ではない、draw 時 fixup で 0/1 に解決)
- `ComplexColorStop` の length position → `GradientStopPosition::LengthPx(px)` (Phase 1 の `Layer dropped` 廃止)
- 範囲外 fraction の事前検査削除 (draw 時 range check に委譲)
- §3.5.1 fixup loop (auto-fill / monotonic clamp / middle interpolation) を撤去

### Draw side (`background.rs`)

新ヘルパー `resolve_gradient_stops(stops, line_length, gradient_kind)` を追加し、`draw_linear_gradient` / `draw_radial_gradient` の両方を経由させる:

1. `LengthPx(px)` を `px / line_length` で fraction 化
2. 先頭/末尾 `Auto` を 0.0 / 1.0 に確定
3. monotonic clamp (初期値は `f32::NEG_INFINITY` — 旧 convert.rs の `0.0` と異なる、負値を range check で drop するため意図的)
4. 中間 `Auto` 群を前後 fixed の等間隔補間
5. 解決後 `[0, 1]` 外なら `log::warn` + Layer drop (fulgur-n3zk へ handoff)

gradient line length:

- linear: `\|W·sinθ\| + \|H·cosθ\|`
- radial (circle / ellipse): `rx` (CSS Images §3.6.1, ellipse でも +X 軸 radius)

### 単位ミスマッチ修正 (`12d707f`)

実装中に Tasks 1-4 で隠れていた単位バグを VRT で発見。`length` (linear) / `rx` (radial) は draw 内で **PDF pt** 単位、一方 `LengthPx` は **CSS px** 単位。call site で `crate::convert::pt_to_px(length)` を介して CSS px に揃える形で修正。`coordinate-system.md` で警告されている 4/3× バグの典型例で、Phase 1 の既存 fixture が `LengthPx` を使わないため Tasks 1-4 では VRT が green のまま隠れていた。

ヘルパー側は unit-agnostic に保ち、call site で変換 + doc コメントで `Unit contract: line_length is in CSS px` を明記。

## VRT (`crates/fulgur-vrt/tests/gradient_harness.rs`)

`test=px / ref=%` 直接比較で 2 件追加。両者が同一 fraction 解決に到達することを byte 近似で検証 (max_channel_diff=4 / 0.5%):

- `linear_gradient_px_stop_matches_percentage_reference` — `linear-gradient(to right, red 0px, blue 50px, blue 350px, green 400px)` (400px box) vs `red 0%, blue 12.5%, blue 87.5%, green 100%`
- `radial_gradient_px_stop_matches_percentage_reference` — `radial-gradient(circle 100px at center, red 0px, blue 50px, blue 100px)` (200×200 box) vs `red 0%, blue 50%, blue 100%`

## スコープ外 (別 issue)

- 範囲外 stop (`linear-gradient(red -50%, blue 100%)` の gradient line 再計算) → [fulgur-n3zk](https://github.com/fulgur-rs/fulgur/issues?q=fulgur-n3zk)。本 PR の draw 時 range check で `log::warn` + Layer drop は維持
- interpolation hints (`linear-gradient(red, 30%, blue)`) → 別 issue。引き続き Layer drop
- non-default color interpolation method (`in oklch` 等) → 別 issue
- ellipse + length-typed stop の VRT カバレッジ → circle path で検証済みだが、`ellipse Wpx Hpx` 形式のテストは将来追加候補

## Commit history (bisect-friendly, 8 commits)

1. `c10508f` refactor(gradient): introduce GradientStopPosition enum (no-op) — 型刷新、VRT byte 一致
2. `1f74fcb` feat(gradient): add resolve_gradient_stops helper with CSS fixup — TDD で 9 unit tests、未配線
3. `96f068b` feat(gradient): preserve length-typed stops as LengthPx in convert — convert 側 fixup 撤去 (intermediate state、VRT 一時破綻)
4. `d789f41` feat(gradient): wire draw_*_gradient through resolve_gradient_stops — draw 配線、VRT 復活
5. `12d707f` fix(gradient): convert gradient line length pt->px before stop resolution — 単位ミスマッチ修正
6. `fd2b8c8` test(vrt): add linear-gradient px-typed stop reftest
7. `6700c6f` docs(gradient): document CSS px unit contract on resolve_gradient_stops
8. `95d2099` test(vrt): add radial-gradient px-typed stop reftest

## Test plan

- [x] `cargo test -p fulgur --lib` — 747 passed (738 既存 + 9 新 `resolve_gradient_stops_tests`)
- [x] `cargo test -p fulgur-vrt` — 全 24 tests green (linear/radial px-stop reftest 含む)
- [x] `cargo clippy --all-targets -- -D warnings` — 0 warnings
- [x] `cargo fmt --check` clean
- [x] CLI 手動確認: `linear-gradient(red 0px, blue 50px, green 100px)` が `Layer dropped` ログなしで PDF 描画される
- [x] 旧 log `length-typed stop position is not yet supported (Phase 2)` / `stop position {pct:.4} is outside [0, 1]` が convert.rs から消失

## Acceptance (beads fulgur-78sl design)

1. ✅ `cargo test -p fulgur --lib` 全 PASS (747 = 738 + 9)
2. ✅ `cargo test -p fulgur-vrt` 全 PASS (新 px-stop reftest 含む)
3. ✅ `cargo clippy --all-targets -- -D warnings` 警告 0
4. ✅ `cargo fmt --check` 差分なし
5. ✅ Phase 1 の `length-typed stop position is not yet supported` ログが消失
6. ✅ length-typed stop が PDF に正しく描画される (CLI 手動確認)
7. ✅ out-of-range (length 解決後) は `log::warn` + Layer drop で fulgur-n3zk へ handoff (background.rs:455-462)

## 設計ドキュメント

- beads issue [fulgur-78sl](https://github.com/fulgur-rs/fulgur/issues?q=fulgur-78sl) の `design` フィールドに完全な設計を保存
- 実装プラン: `docs/plans/2026-04-26-fulgur-78sl-length-typed-stops.md`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gradients now support color stops specified with length units (px) alongside percentages for linear and radial gradients.

* **Improvements**
  * Stop resolution is more robust for mixed/auto/length positions, improving correctness and handling of out‑of‑range or ambiguous stops.

* **Tests**
  * Added visual regression tests comparing length‑based and percentage‑based stop rendering with targeted per‑pixel assertions.

* **Documentation**
  * Added a design plan documenting the staged implementation and acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->