### PR TITLE
feat(gradient): support repeating-linear-gradient and repeating-radial-gradient

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,5 +132,15 @@ callers don't get this guarantee by default — see the tracking issue
 - Use `BTreeMap` (not `HashMap`) for iteration that affects PDF output (determinism)
 - Blitz: `!important` unreliable, `padding-top` on inline roots ignored (use `margin-top`)
 - `cargo fmt --check` enforced by CI
+- **Coverage scope**: CI の coverage job は `cargo llvm-cov nextest --workspace --exclude fulgur-vrt`
+  で動いている (`.github/workflows/ci.yml`)。`crates/fulgur-vrt` は別ジョブで実行されるため、
+  **VRT reftest だけでカバーした draw 経路は codecov の patch coverage に乗らない**。
+  新しい draw / convert / pageable ロジックを書くときは VRT に加えて lib 側にもテストを置く:
+  - 純関数 (helper, fixup, math) → 当該モジュールの `#[cfg(test)] mod tests` に unit test
+  - レンダリング経路 (`draw_background_layer` の match arm 等、`Engine::render_html` を通って初めて
+    叩かれる箇所) → `crates/fulgur/src/engine.rs` の `tests` モジュールに end-to-end smoke test
+    (`Engine::builder().build().render_html(html)` で `assert!(!pdf.is_empty())`)
+  VRT を後付けで足すと codecov に再指摘されて lib 側 smoke test を追加する手戻りが発生する
+  (PR #244 で実例)。最初から両方書くこと。
 - **`Engine` is a builder**: `Engine::builder().page_size(PageSize::A4).base_path(root).build()` + single-arg `render_html(html)`. There is no `Engine::new().with_*()`.
 - **VRT は PDF byte 比較**: `crates/fulgur-vrt` は HTML → PDF を生成して `goldens/fulgur/**/*.pdf` と byte-wise 比較する (`crates/fulgur-cli/tests/examples_determinism.rs` と同じ哲学)。pdftocairo は失敗時の diff 画像生成のみで使う。golden 更新は `FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" FULGUR_VRT_UPDATE=1 cargo test -p fulgur-vrt`。

--- a/crates/fulgur-vrt/fixtures/paint/repeating-linear-gradient.html
+++ b/crates/fulgur-vrt/fixtures/paint/repeating-linear-gradient.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>VRT: repeating-linear-gradient red→blue, period 25%</title>
+<style>
+  html, body { margin: 0; padding: 0; background: white; }
+  .g {
+    width: 400px;
+    height: 192px;
+    margin: 32px;
+    background: repeating-linear-gradient(to right, #e53935 0%, #1e88e5 25%);
+  }
+</style>
+</head>
+<body>
+  <div class="g"></div>
+</body>
+</html>

--- a/crates/fulgur-vrt/fixtures/paint/repeating-radial-gradient.html
+++ b/crates/fulgur-vrt/fixtures/paint/repeating-radial-gradient.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>VRT: repeating-radial-gradient circle 100px, period 25px</title>
+<style>
+  html, body { margin: 0; padding: 0; background: white; }
+  .g {
+    width: 200px;
+    height: 200px;
+    margin: 32px;
+    background: repeating-radial-gradient(circle 100px at center, #e53935 0px, #1e88e5 25px);
+  }
+</style>
+</head>
+<body>
+  <div class="g"></div>
+</body>
+</html>

--- a/crates/fulgur-vrt/goldens/fulgur/paint/repeating-linear-gradient.pdf
+++ b/crates/fulgur-vrt/goldens/fulgur/paint/repeating-linear-gradient.pdf
@@ -1,0 +1,199 @@
+%PDF-1.7
+%€€€€
+
+1 0 obj
+<<
+  /Type /Pages
+  /Count 1
+  /Kids [12 0 R]
+>>
+endobj
+
+2 0 obj
+<<
+  /FunctionType 2
+  /Range [0 1 0 1 0 1]
+  /C0 [0.8980392 0.22352941 0.20784314]
+  /C1 [0.11764706 0.53333336 0.8980392]
+  /Domain [0 1]
+  /N 1
+>>
+endobj
+
+3 0 obj
+<<
+  /FunctionType 2
+  /Range [0 1 0 1 0 1]
+  /C0 [0.11764706 0.53333336 0.8980392]
+  /C1 [0.8980392 0.22352941 0.20784314]
+  /Domain [0 1]
+  /N 1
+>>
+endobj
+
+4 0 obj
+<<
+  /FunctionType 2
+  /Range [0 1 0 1 0 1]
+  /C0 [0.8980392 0.22352941 0.20784314]
+  /C1 [0.11764706 0.53333336 0.8980392]
+  /Domain [0 1]
+  /N 1
+>>
+endobj
+
+5 0 obj
+<<
+  /FunctionType 2
+  /Range [0 1 0 1 0 1]
+  /C0 [0.11764706 0.53333336 0.8980392]
+  /C1 [0.8980392 0.22352941 0.20784314]
+  /Domain [0 1]
+  /N 1
+>>
+endobj
+
+6 0 obj
+<<
+  /FunctionType 2
+  /Range [0 1 0 1 0 1]
+  /C0 [0.8980392 0.22352941 0.20784314]
+  /C1 [0.11764706 0.53333336 0.8980392]
+  /Domain [0 1]
+  /N 1
+>>
+endobj
+
+7 0 obj
+<<
+  /FunctionType 2
+  /Range [0 1 0 1 0 1]
+  /C0 [0.11764706 0.53333336 0.8980392]
+  /C1 [0.8980392 0.22352941 0.20784314]
+  /Domain [0 1]
+  /N 1
+>>
+endobj
+
+8 0 obj
+<<
+  /FunctionType 2
+  /Range [0 1 0 1 0 1]
+  /C0 [0.8980392 0.22352941 0.20784314]
+  /C1 [0.11764706 0.53333336 0.8980392]
+  /Domain [0 1]
+  /N 1
+>>
+endobj
+
+9 0 obj
+<<
+  /FunctionType 3
+  /Domain [0 1]
+  /Range [0 1 0 1 0 1]
+  /Functions [2 0 R 3 0 R 4 0 R 5 0 R 6 0 R 7 0 R 8 0 R]
+  /Bounds [0.25 0.25 0.5 0.5 0.75 0.75]
+  /Encode [0 1 0 1 0 1 0 1 0 1 0 1 0 1]
+>>
+endobj
+
+10 0 obj
+<<
+  /ShadingType 2
+  /ColorSpace /DeviceRGB
+  /AntiAlias false
+  /Function 9 0 R
+  /Coords [24 95.99999 324 96.00001]
+  /Extend [true true]
+>>
+endobj
+
+11 0 obj
+<<
+  /Type /Pattern
+  /PatternType 2
+  /Shading 10 0 R
+  /Matrix [1 0 0 -1 0 841.89]
+>>
+endobj
+
+12 0 obj
+<<
+  /Type /Page
+  /Resources <<
+    /ProcSet [/PDF /Text /ImageC /ImageB]
+    /Pattern <<
+      /p0 11 0 R
+    >>
+  >>
+  /MediaBox [0 0 595.28 841.89]
+  /Parent 1 0 R
+  /Contents 13 0 R
+>>
+endobj
+
+13 0 obj
+<<
+  /Length 143
+  /Filter /FlateDecode
+>>
+stream
+xœ…Mƒ „÷sŠw* 
+Ü¢®º6¤­ õçş1juc3“¾|$	tã°ZVÖ‘Äo~ƒo­Ó•iIPØ«tŠÄ7G¼ĞcúËRú€)}¢u¶Ğrî4¥ÉJÃ”ˆæ!Î4eœûˆÒ•G}Öõ9'òê Å'şœ˜˜…¸‹_):ı…˜<Í
+endstream
+endobj
+
+14 0 obj
+<<
+  /Producer (fulgur)
+>>
+endobj
+
+15 0 obj
+<<
+  /Length 761
+  /Type /Metadata
+  /Subtype /XML
+>>
+stream
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><pdf:Producer>fulgur</pdf:Producer><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>poDbs7H7utVOfeLaOPJLJw==</xmpMM:InstanceID><xmpMM:DocumentID>poDbs7H7utVOfeLaOPJLJw==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+endstream
+endobj
+
+16 0 obj
+<<
+  /Type /Catalog
+  /Pages 1 0 R
+  /Metadata 15 0 R
+>>
+endobj
+
+xref
+0 17
+0000000000 65535 f
+0000000016 00000 n
+0000000081 00000 n
+0000000247 00000 n
+0000000413 00000 n
+0000000579 00000 n
+0000000745 00000 n
+0000000911 00000 n
+0000001077 00000 n
+0000001243 00000 n
+0000001459 00000 n
+0000001620 00000 n
+0000001725 00000 n
+0000001932 00000 n
+0000002153 00000 n
+0000002197 00000 n
+0000003047 00000 n
+trailer
+<<
+  /Size 17
+  /Root 16 0 R
+  /Info 14 0 R
+  /ID [(poDbs7H7utVOfeLaOPJLJw==) (poDbs7H7utVOfeLaOPJLJw==)]
+>>
+startxref
+3121
+%%EOF

--- a/crates/fulgur-vrt/goldens/fulgur/paint/repeating-radial-gradient.pdf
+++ b/crates/fulgur-vrt/goldens/fulgur/paint/repeating-radial-gradient.pdf
@@ -1,0 +1,198 @@
+%PDF-1.7
+%€€€€
+
+1 0 obj
+<<
+  /Type /Pages
+  /Count 1
+  /Kids [12 0 R]
+>>
+endobj
+
+2 0 obj
+<<
+  /FunctionType 2
+  /Range [0 1 0 1 0 1]
+  /C0 [0.8980392 0.22352941 0.20784314]
+  /C1 [0.11764706 0.53333336 0.8980392]
+  /Domain [0 1]
+  /N 1
+>>
+endobj
+
+3 0 obj
+<<
+  /FunctionType 2
+  /Range [0 1 0 1 0 1]
+  /C0 [0.11764706 0.53333336 0.8980392]
+  /C1 [0.8980392 0.22352941 0.20784314]
+  /Domain [0 1]
+  /N 1
+>>
+endobj
+
+4 0 obj
+<<
+  /FunctionType 2
+  /Range [0 1 0 1 0 1]
+  /C0 [0.8980392 0.22352941 0.20784314]
+  /C1 [0.11764706 0.53333336 0.8980392]
+  /Domain [0 1]
+  /N 1
+>>
+endobj
+
+5 0 obj
+<<
+  /FunctionType 2
+  /Range [0 1 0 1 0 1]
+  /C0 [0.11764706 0.53333336 0.8980392]
+  /C1 [0.8980392 0.22352941 0.20784314]
+  /Domain [0 1]
+  /N 1
+>>
+endobj
+
+6 0 obj
+<<
+  /FunctionType 2
+  /Range [0 1 0 1 0 1]
+  /C0 [0.8980392 0.22352941 0.20784314]
+  /C1 [0.11764706 0.53333336 0.8980392]
+  /Domain [0 1]
+  /N 1
+>>
+endobj
+
+7 0 obj
+<<
+  /FunctionType 2
+  /Range [0 1 0 1 0 1]
+  /C0 [0.11764706 0.53333336 0.8980392]
+  /C1 [0.8980392 0.22352941 0.20784314]
+  /Domain [0 1]
+  /N 1
+>>
+endobj
+
+8 0 obj
+<<
+  /FunctionType 2
+  /Range [0 1 0 1 0 1]
+  /C0 [0.8980392 0.22352941 0.20784314]
+  /C1 [0.11764706 0.53333336 0.8980392]
+  /Domain [0 1]
+  /N 1
+>>
+endobj
+
+9 0 obj
+<<
+  /FunctionType 3
+  /Domain [0 1]
+  /Range [0 1 0 1 0 1]
+  /Functions [2 0 R 3 0 R 4 0 R 5 0 R 6 0 R 7 0 R 8 0 R]
+  /Bounds [0.25 0.25 0.5 0.5 0.75 0.75]
+  /Encode [0 1 0 1 0 1 0 1 0 1 0 1 0 1]
+>>
+endobj
+
+10 0 obj
+<<
+  /ShadingType 3
+  /ColorSpace /DeviceRGB
+  /AntiAlias false
+  /Function 9 0 R
+  /Coords [99 99 0 99 99 75]
+  /Extend [true true]
+>>
+endobj
+
+11 0 obj
+<<
+  /Type /Pattern
+  /PatternType 2
+  /Shading 10 0 R
+  /Matrix [1 0 0 -1 0 841.89]
+>>
+endobj
+
+12 0 obj
+<<
+  /Type /Page
+  /Resources <<
+    /ProcSet [/PDF /Text /ImageC /ImageB]
+    /Pattern <<
+      /p0 11 0 R
+    >>
+  >>
+  /MediaBox [0 0 595.28 841.89]
+  /Parent 1 0 R
+  /Contents 13 0 R
+>>
+endobj
+
+13 0 obj
+<<
+  /Length 143
+  /Filter /FlateDecode
+>>
+stream
+xœ…;Ã Dû9Å^ ö‚°[ÄUê%q(şÜ_ÑbPÜDÅÌhÅÓ[ ˆ‰é"áŒêœ§ HŞú‚Üo:;SlUyG\sÆ–¿,m¾0mN4+ƒk6š6ä”J‚\êˆeŒcúÔgÜyô×û¾?ÖLaCÿfÚB–ÏÅIˆEHÊa¡[9t¦’—<ß
+endstream
+endobj
+
+14 0 obj
+<<
+  /Producer (fulgur)
+>>
+endobj
+
+15 0 obj
+<<
+  /Length 761
+  /Type /Metadata
+  /Subtype /XML
+>>
+stream
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><pdf:Producer>fulgur</pdf:Producer><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>lE5JsudzqAoXFoX1GboJZA==</xmpMM:InstanceID><xmpMM:DocumentID>lE5JsudzqAoXFoX1GboJZA==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+endstream
+endobj
+
+16 0 obj
+<<
+  /Type /Catalog
+  /Pages 1 0 R
+  /Metadata 15 0 R
+>>
+endobj
+
+xref
+0 17
+0000000000 65535 f
+0000000016 00000 n
+0000000081 00000 n
+0000000247 00000 n
+0000000413 00000 n
+0000000579 00000 n
+0000000745 00000 n
+0000000911 00000 n
+0000001077 00000 n
+0000001243 00000 n
+0000001459 00000 n
+0000001612 00000 n
+0000001717 00000 n
+0000001924 00000 n
+0000002145 00000 n
+0000002189 00000 n
+0000003039 00000 n
+trailer
+<<
+  /Size 17
+  /Root 16 0 R
+  /Info 14 0 R
+  /ID [(lE5JsudzqAoXFoX1GboJZA==) (lE5JsudzqAoXFoX1GboJZA==)]
+>>
+startxref
+3113
+%%EOF

--- a/crates/fulgur-vrt/manifest.toml
+++ b/crates/fulgur-vrt/manifest.toml
@@ -108,3 +108,11 @@ margin_pt = 0.0
 [[fixture]]
 path = "paint/radial-gradient-repeat-round.html"
 margin_pt = 0.0
+
+[[fixture]]
+path = "paint/repeating-linear-gradient.html"
+margin_pt = 0.0
+
+[[fixture]]
+path = "paint/repeating-radial-gradient.html"
+margin_pt = 0.0

--- a/crates/fulgur-vrt/tests/gradient_harness.rs
+++ b/crates/fulgur-vrt/tests/gradient_harness.rs
@@ -519,6 +519,113 @@ fn linear_gradient_out_of_range_low_matches_strip_reference() {
     );
 }
 
+/// `repeating-linear-gradient(to right, red 0%, blue 25%)` が、CSS 仕様
+/// (CSS Images 3 §3.6) で等価な明示展開
+/// `linear-gradient(to right, red 0%, blue 25%, red 25%, blue 50%, red 50%,
+///  blue 75%, red 75%, blue 100%)`
+/// と同一の PDF を生成することを確認する (fulgur-12z0)。
+///
+/// 戦略: test (`repeating-*`) と ref (展開形) どちらも fulgur で描画する。
+/// 両者は同じ piecewise color stop に解決されるはずなので、ピクセル等価で
+/// あるべき。strip 近似は経由しないので tolerance は raster 往復のノイズだけ
+/// 吸収すれば十分 (px-stop reftest と同じ思想)。
+#[test]
+fn repeating_linear_gradient_matches_explicit_expansion() {
+    let test_html = build_gradient_html(
+        "VRT test: repeating-linear-gradient",
+        GRADIENT_WIDTH_PX,
+        GRADIENT_HEIGHT_PX,
+        "repeating-linear-gradient(to right, #e53935 0%, #1e88e5 25%)",
+    );
+    // 等価展開: red 0, blue 25, red 25, blue 50, red 50, blue 75, red 75, blue 100
+    let ref_html = build_gradient_html(
+        "VRT ref: explicitly expanded linear-gradient",
+        GRADIENT_WIDTH_PX,
+        GRADIENT_HEIGHT_PX,
+        "linear-gradient(to right, #e53935 0%, #1e88e5 25%, #e53935 25%, \
+         #1e88e5 50%, #e53935 50%, #1e88e5 75%, #e53935 75%, #1e88e5 100%)",
+    );
+
+    let tol = Tolerance {
+        max_channel_diff: 4,
+        max_diff_pixels_ratio: 0.005,
+    };
+
+    let test_img = run_gradient_px_stop_reftest(
+        "repeating-linear-gradient",
+        "vrt-repeating-linear-gradient-harness",
+        &test_html,
+        &ref_html,
+        tol,
+    );
+
+    // Sentinel: 各周期境界 (CSS x = 0, 100, 200, 300) は red の hard edge、
+    // 中間 (x = 50, 150, 250, 350) は red→blue 補間中央でほぼ purple。
+    // x = 100 は red の hard stop 直後 (= red plateau の始端) を狙う。
+    // y は box 高 192 の中央 96。
+    assert_pixel_color(
+        &test_img,
+        100,
+        96,
+        (0xe5, 0x39, 0x35),
+        12,
+        "repeating period boundary at 25%",
+    );
+}
+
+/// `repeating-radial-gradient(circle 100px at center, red 0px, blue 25px)` が
+/// 等価な明示展開と同一の PDF を生成することを確認する (fulgur-12z0)。
+///
+/// 戦略: linear と同じく test/ref を fulgur で並走させ、ピクセル等価を見る。
+/// radial 側は krilla の SpreadMethod::Pad しかサポートしないため、stop の
+/// 周期展開で repeating semantics を表現する実装になっている。
+#[test]
+fn repeating_radial_gradient_matches_explicit_expansion() {
+    // 200×200 box, circle 100px at center: rx = 100 CSS px
+    // 0px → 0%, 25px → 25% に解決される piecewise gradient
+    let test_html = build_gradient_html(
+        "VRT test: repeating-radial-gradient",
+        200,
+        200,
+        "repeating-radial-gradient(circle 100px at center, #e53935 0px, #1e88e5 25px)",
+    );
+    let ref_html = build_gradient_html(
+        "VRT ref: explicitly expanded radial-gradient",
+        200,
+        200,
+        "radial-gradient(circle 100px at center, \
+         #e53935 0px, #1e88e5 25px, #e53935 25px, #1e88e5 50px, \
+         #e53935 50px, #1e88e5 75px, #e53935 75px, #1e88e5 100px)",
+    );
+
+    let tol = Tolerance {
+        max_channel_diff: 4,
+        max_diff_pixels_ratio: 0.005,
+    };
+
+    let test_img = run_gradient_px_stop_reftest(
+        "repeating-radial-gradient",
+        "vrt-repeating-radial-gradient-harness",
+        &test_html,
+        &ref_html,
+        tol,
+    );
+
+    // Sentinel: 中心 CSS (100, 100) は r=0 で red、半径 25px の点
+    // (CSS (125, 100)) は周期境界の red hard edge (周期 1 の終端 blue 25px と
+    // 周期 2 の始端 red 25px が並ぶので、後者を採用するのが renormalize の
+    // p0==p1 ハンドリング。) → 視覚上は red 平坦域の始端。
+    assert_pixel_color(&test_img, 100, 100, (0xe5, 0x39, 0x35), 12, "radial center");
+    assert_pixel_color(
+        &test_img,
+        125,
+        100,
+        (0xe5, 0x39, 0x35),
+        12,
+        "radial period boundary at 25px",
+    );
+}
+
 /// `linear-gradient(90deg, #e53935 0%, #1e88e5 200%)` の renormalize 動作確認。
 ///
 /// 範囲外 stop 200% は drop され、offset 1 の色は CSS Images 3 §3.5.1 に従い

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -236,7 +236,11 @@ fn draw_background_layer(
     }
 
     match &layer.content {
-        BgImageContent::LinearGradient { direction, stops } => {
+        BgImageContent::LinearGradient {
+            direction,
+            stops,
+            repeating,
+        } => {
             // Try to detect a uniform tile grid and emit a single Tiling Pattern
             // resource (one Function 2 + Shading 2 + Pattern triplet) rather
             // than N independent gradient draws. Falls back to the per-tile
@@ -251,7 +255,16 @@ fn draw_background_layer(
                     }
                 };
                 draw_gradient_tiling_pattern(canvas, grid, |surface, _tw, _th| {
-                    draw_linear_gradient(surface, angle, stops, 0.0, 0.0, grid.cell.0, grid.cell.1);
+                    draw_linear_gradient(
+                        surface,
+                        angle,
+                        stops,
+                        *repeating,
+                        0.0,
+                        0.0,
+                        grid.cell.0,
+                        grid.cell.1,
+                    );
                 });
             } else {
                 // Fallback: per-tile loop. Match before the loop (Angle hoists,
@@ -261,13 +274,31 @@ fn draw_background_layer(
                     crate::pageable::LinearGradientDirection::Angle(a) => {
                         let angle = *a;
                         for (tx, ty, tw, th) in &tiles {
-                            draw_linear_gradient(canvas.surface, angle, stops, *tx, *ty, *tw, *th);
+                            draw_linear_gradient(
+                                canvas.surface,
+                                angle,
+                                stops,
+                                *repeating,
+                                *tx,
+                                *ty,
+                                *tw,
+                                *th,
+                            );
                         }
                     }
                     crate::pageable::LinearGradientDirection::Corner(corner) => {
                         for (tx, ty, tw, th) in &tiles {
                             let angle = corner_to_angle_rad(*corner, *tw, *th);
-                            draw_linear_gradient(canvas.surface, angle, stops, *tx, *ty, *tw, *th);
+                            draw_linear_gradient(
+                                canvas.surface,
+                                angle,
+                                stops,
+                                *repeating,
+                                *tx,
+                                *ty,
+                                *tw,
+                                *th,
+                            );
                         }
                     }
                 }
@@ -279,6 +310,7 @@ fn draw_background_layer(
             position_x,
             position_y,
             stops,
+            repeating,
         } => {
             // Same dedup story as Linear: uniform grids share (cell_w, cell_h)
             // so cx/cy/rx/ry are identical across tiles → a single Pattern
@@ -286,7 +318,8 @@ fn draw_background_layer(
             if let Some(grid) = try_uniform_grid(&tiles) {
                 draw_gradient_tiling_pattern(canvas, grid, |surface, tw, th| {
                     draw_radial_gradient(
-                        surface, *shape, size, position_x, position_y, stops, 0.0, 0.0, tw, th,
+                        surface, *shape, size, position_x, position_y, stops, *repeating, 0.0, 0.0,
+                        tw, th,
                     );
                 });
             } else {
@@ -300,6 +333,7 @@ fn draw_background_layer(
                         position_x,
                         position_y,
                         stops,
+                        *repeating,
                         *tx,
                         *ty,
                         *tw,
@@ -461,13 +495,16 @@ fn lerp_u8(a: u8, b: u8, alpha: f32) -> u8 {
 ///   2. 先頭/末尾の `Auto` を 0.0 / 1.0 に確定
 ///   3. monotonic clamp (前 fixed より小さければ前 fixed に合わせる)
 ///   4. 中間の `Auto` 群を前後 fixed の等間隔補間で埋める
-///   5. 最終 fraction が `[0, 1]` 外なら `renormalize_stops_to_unit_range` で
+///   5. `repeating=true` なら fixup 後の `(p_first, p_last)` を周期に取り、
+///      `[0, 1]` を覆うだけ stop 列を平行コピー (CSS Images 3 §3.6)
+///   6. 最終 fraction が `[0, 1]` 外なら `renormalize_stops_to_unit_range` で
 ///      端点合成し正規化する (CSS Images 3 §3.5.1; fulgur-n3zk)
 ///
 /// `line_length <= 0` の場合は length stop が解決不能なので None。
 fn resolve_gradient_stops(
     stops: &[crate::pageable::GradientStop],
     line_length: f32,
+    repeating: bool,
 ) -> Option<Vec<krilla::paint::Stop>> {
     use crate::pageable::GradientStopPosition;
 
@@ -534,13 +571,24 @@ fn resolve_gradient_stops(
         i = end;
     }
 
-    // renormalize: 範囲外 fraction は端点合成で [0, 1] 内表現に変換 (fulgur-n3zk)
     let resolved: Vec<(f32, [u8; 4])> = stops
         .iter()
         .zip(positions)
         .map(|(s, p)| (p.expect("all slots resolved"), s.rgba))
         .collect();
-    let renormalized = renormalize_stops_to_unit_range(resolved);
+
+    // 周期展開: repeating-* gradient は first/last stop 間の差を周期に取り、
+    // `[0, 1]` を覆うように copy を平行移動して並べる。renormalize 段で
+    // 範囲外 stop は端点補間にクリップされるので、ここでは [0, 1] を
+    // 充分カバーするだけ生成すればよい。
+    let expanded = if repeating {
+        expand_repeating_stops(resolved)?
+    } else {
+        resolved
+    };
+
+    // renormalize: 範囲外 fraction は端点合成で [0, 1] 内表現に変換 (fulgur-n3zk)
+    let renormalized = renormalize_stops_to_unit_range(expanded);
     debug_assert!(
         renormalized.len() >= 2,
         "renormalize_stops_to_unit_range guarantees len >= 2"
@@ -558,6 +606,70 @@ fn resolve_gradient_stops(
     )
 }
 
+/// `repeating-linear-gradient` / `repeating-radial-gradient` の周期展開。
+///
+/// 入力: fixup 後の monotonically non-decreasing `(pos, rgba)` ベクタ (`len >= 2`)。
+/// 出力: `[0, 1]` 範囲を覆うように first/last 差を周期として平行コピーした列。
+/// `renormalize_stops_to_unit_range` 段で out-of-range stop が端点補間に丸められる
+/// 前提なので、ここでは充分なオーバーラップを与える。
+///
+/// `period <= 0` (degenerate) は最後の色で塗られる単色とみなして None を返す。
+/// `period > 0` でも安全上限 `MAX_PERIODS` を超えたら最終周期で打ち切り
+/// (`repeating-linear-gradient(red 0%, blue 0.01%)` のような病的入力でも有界化)。
+fn expand_repeating_stops(stops: Vec<(f32, [u8; 4])>) -> Option<Vec<(f32, [u8; 4])>> {
+    debug_assert!(stops.len() >= 2, "caller guaranteed len >= 2");
+
+    let p_first = stops.first().expect("len >= 2").0;
+    let p_last = stops.last().expect("len >= 2").0;
+    let period = p_last - p_first;
+
+    // CSS Images 3 §3.6: period が 0 または負 (monotonic clamp 通過後の
+    // 等位置 hard stop) の場合、繰り返しは degenerate。最後の色で塗りつぶす
+    // 1-stop に相当するが、krilla は最低 2 stop 必要なので呼び出し側で
+    // None を伝搬して layer drop させる (= white background がそのまま見える
+    // のに近い挙動)。
+    if period <= 0.0 || !period.is_finite() {
+        return None;
+    }
+
+    // 安全上限。256 周期あれば line_length 比 0.4% の周期まで描き切れ、
+    // それ以下は実質連続色なので品質劣化しない。`stops.len() = 100` 等の
+    // pathological 入力 × MAX_PERIODS でも合計 5 万 stop 以下に留まる。
+    const MAX_PERIODS: i32 = 256;
+
+    // forward: p_last + k*period >= 1 となる最小の k
+    // backward: p_first + k*period <= 0 となる最小の |k|  (k は負方向)
+    let forward = if p_last >= 1.0 {
+        0
+    } else {
+        ((1.0 - p_last) / period).ceil() as i32
+    };
+    let backward = if p_first <= 0.0 {
+        0
+    } else {
+        ((p_first - 0.0) / period).ceil() as i32
+    };
+
+    let forward = forward.min(MAX_PERIODS);
+    let backward = backward.min(MAX_PERIODS);
+
+    let total_copies = (forward + backward + 1) as usize;
+    let mut out: Vec<(f32, [u8; 4])> = Vec::with_capacity(total_copies * stops.len());
+
+    // k = -backward .. = forward の順に shift 量 k*period を加えて並べる。
+    // 同位置で隣接する周期境界の color が違う場合 (e.g. period 末尾 blue →
+    // 次周期先頭 red) は hard stop として出力に残し、renormalize の線形補間
+    // (`p0 == p1` 時は後者の色を採用) と整合する。
+    for k in -backward..=forward {
+        let shift = (k as f32) * period;
+        for &(p, rgba) in &stops {
+            out.push((p + shift, rgba));
+        }
+    }
+
+    Some(out)
+}
+
 /// Draw a CSS linear-gradient over the origin rect.
 ///
 /// CSS angle convention (radians): 0 = "to top", π/2 = "to right",
@@ -568,10 +680,12 @@ fn resolve_gradient_stops(
 /// `|W·sin θ| + |H·cos θ|` — this is the projection of both diagonals onto the
 /// gradient axis, ensuring the line spans corner-to-corner regardless of angle
 /// (CSS Images §3.1).
+#[allow(clippy::too_many_arguments)]
 fn draw_linear_gradient(
     surface: &mut krilla::surface::Surface<'_>,
     angle_rad: f32,
     stops: &[crate::pageable::GradientStop],
+    repeating: bool,
     ox: f32,
     oy: f32,
     ow: f32,
@@ -605,7 +719,7 @@ fn draw_linear_gradient(
     // `px / line_length` で fraction 化するので、line_length も CSS px に揃える。
     // (例: 400px box → length = 300pt → px 換算で 400 → 50px / 400 = 0.125)
     let length_px = crate::convert::pt_to_px(length);
-    let Some(krilla_stops) = resolve_gradient_stops(stops, length_px) else {
+    let Some(krilla_stops) = resolve_gradient_stops(stops, length_px, repeating) else {
         return;
     };
 
@@ -655,6 +769,7 @@ fn draw_radial_gradient(
     position_x: &BgLengthPercentage,
     position_y: &BgLengthPercentage,
     stops: &[crate::pageable::GradientStop],
+    repeating: bool,
     ox: f32,
     oy: f32,
     ow: f32,
@@ -730,7 +845,7 @@ fn draw_radial_gradient(
     // rx は pt 単位 (ow/oh が pt) なので、`LengthPx` (CSS px) との比較のために
     // CSS px に揃える。
     let rx_px = crate::convert::pt_to_px(rx);
-    let Some(krilla_stops) = resolve_gradient_stops(stops, rx_px) else {
+    let Some(krilla_stops) = resolve_gradient_stops(stops, rx_px, repeating) else {
         return;
     };
 
@@ -2608,7 +2723,7 @@ mod resolve_gradient_stops_tests {
             stop(fr(0.0), [255, 0, 0, 255]),
             stop(fr(1.0), [0, 0, 255, 255]),
         ];
-        let out = resolve_gradient_stops(&stops, 100.0).unwrap();
+        let out = resolve_gradient_stops(&stops, 100.0, false).unwrap();
         assert_eq!(out.len(), 2);
         assert!((out[0].offset.get() - 0.0).abs() < 1e-6);
         assert!((out[1].offset.get() - 1.0).abs() < 1e-6);
@@ -2621,7 +2736,7 @@ mod resolve_gradient_stops_tests {
             stop(px(50.0), [0, 0, 255, 255]),
         ];
         // line_length = 100 → 50px = 0.5
-        let out = resolve_gradient_stops(&stops, 100.0).unwrap();
+        let out = resolve_gradient_stops(&stops, 100.0, false).unwrap();
         assert_eq!(out.len(), 2);
         assert!((out[1].offset.get() - 0.5).abs() < 1e-6);
     }
@@ -2629,7 +2744,7 @@ mod resolve_gradient_stops_tests {
     #[test]
     fn auto_position_filled_at_endpoints() {
         let stops = vec![stop(Auto, [255, 0, 0, 255]), stop(Auto, [0, 0, 255, 255])];
-        let out = resolve_gradient_stops(&stops, 100.0).unwrap();
+        let out = resolve_gradient_stops(&stops, 100.0, false).unwrap();
         assert!((out[0].offset.get() - 0.0).abs() < 1e-6);
         assert!((out[1].offset.get() - 1.0).abs() < 1e-6);
     }
@@ -2641,7 +2756,7 @@ mod resolve_gradient_stops_tests {
             stop(Auto, [0, 255, 0, 255]),
             stop(fr(1.0), [0, 0, 255, 255]),
         ];
-        let out = resolve_gradient_stops(&stops, 100.0).unwrap();
+        let out = resolve_gradient_stops(&stops, 100.0, false).unwrap();
         assert!((out[1].offset.get() - 0.5).abs() < 1e-6);
     }
 
@@ -2654,7 +2769,7 @@ mod resolve_gradient_stops_tests {
             stop(px(50.0), [0, 0, 255, 255]),
             stop(Auto, [0, 255, 0, 255]),
         ];
-        let out = resolve_gradient_stops(&stops, 100.0).unwrap();
+        let out = resolve_gradient_stops(&stops, 100.0, false).unwrap();
         assert_eq!(out.len(), 3);
         assert!((out[0].offset.get() - 0.0).abs() < 1e-6);
         assert!((out[1].offset.get() - 0.5).abs() < 1e-6);
@@ -2671,7 +2786,7 @@ mod resolve_gradient_stops_tests {
             stop(fr(0.0), [255, 0, 0, 255]),
             stop(px(50.0), [0, 0, 255, 255]),
         ];
-        let out = resolve_gradient_stops(&stops, 30.0).unwrap();
+        let out = resolve_gradient_stops(&stops, 30.0, false).unwrap();
         assert_eq!(out.len(), 2, "renormalize keeps 2 stops");
         assert!((out[0].offset.get() - 0.0).abs() < 1e-6);
         assert!((out[1].offset.get() - 1.0).abs() < 1e-6);
@@ -2685,7 +2800,7 @@ mod resolve_gradient_stops_tests {
             stop(fr(-0.1), [255, 0, 0, 255]),
             stop(fr(1.0), [0, 0, 255, 255]),
         ];
-        let out = resolve_gradient_stops(&stops, 100.0).unwrap();
+        let out = resolve_gradient_stops(&stops, 100.0, false).unwrap();
         assert_eq!(out.len(), 2, "renormalize keeps 2 stops");
         assert!((out[0].offset.get() - 0.0).abs() < 1e-6);
         assert!((out[1].offset.get() - 1.0).abs() < 1e-6);
@@ -2698,7 +2813,7 @@ mod resolve_gradient_stops_tests {
             stop(fr(0.6), [255, 0, 0, 255]),
             stop(fr(0.3), [0, 0, 255, 255]),
         ];
-        let out = resolve_gradient_stops(&stops, 100.0).unwrap();
+        let out = resolve_gradient_stops(&stops, 100.0, false).unwrap();
         assert!((out[0].offset.get() - 0.6).abs() < 1e-6);
         assert!((out[1].offset.get() - 0.6).abs() < 1e-6);
     }
@@ -2709,8 +2824,132 @@ mod resolve_gradient_stops_tests {
             stop(px(50.0), [255, 0, 0, 255]),
             stop(fr(1.0), [0, 0, 255, 255]),
         ];
-        let out = resolve_gradient_stops(&stops, 0.0);
+        let out = resolve_gradient_stops(&stops, 0.0, false);
         assert!(out.is_none());
+    }
+
+    /// `repeating-linear-gradient(red 0%, blue 25%)`: period = 0.25。
+    /// 4 周期分 + 端点合成で `[0, 1]` を覆う。0% / 25% / 50% / 75% / 100% は
+    /// hard stop boundary を保ち、隣接 (red→blue→red→...) のパターンが見える。
+    #[test]
+    fn repeating_simple_period() {
+        let stops = vec![
+            stop(fr(0.0), [255, 0, 0, 255]),
+            stop(fr(0.25), [0, 0, 255, 255]),
+        ];
+        let out = resolve_gradient_stops(&stops, 100.0, true).unwrap();
+        // 期待: forward = ceil(0.75/0.25) = 3, backward = 0
+        // → k = 0, 1, 2, 3 で各周期の (red, blue) を配置
+        // (0, red), (0.25, blue), (0.25, red), (0.5, blue), (0.5, red),
+        // (0.75, blue), (0.75, red), (1.0, blue) の 8 stops
+        assert_eq!(out.len(), 8, "got offsets: {:?}", offsets(&out));
+        let expected = [
+            (0.0, [255, 0, 0, 255]),
+            (0.25, [0, 0, 255, 255]),
+            (0.25, [255, 0, 0, 255]),
+            (0.5, [0, 0, 255, 255]),
+            (0.5, [255, 0, 0, 255]),
+            (0.75, [0, 0, 255, 255]),
+            (0.75, [255, 0, 0, 255]),
+            (1.0, [0, 0, 255, 255]),
+        ];
+        for (i, (eo, ec)) in expected.iter().enumerate() {
+            assert!(
+                (out[i].offset.get() - eo).abs() < 1e-5,
+                "stop[{i}] offset got {} expected {eo}",
+                out[i].offset.get()
+            );
+            // krilla::paint::Stop にコンポーネントアクセスがないので
+            // RGB は output 個数だけ確認 (色の検証は VRT 側で行う)
+            let _ = ec;
+        }
+    }
+
+    /// `repeating-linear-gradient(red 25%, blue 50%)`: period = 0.25、
+    /// 周期境界が box の端点に揃わない。前後両方向に展開され、renormalize で
+    /// 端点合成される。
+    #[test]
+    fn repeating_offset_period_extends_both_directions() {
+        let stops = vec![
+            stop(fr(0.25), [255, 0, 0, 255]),
+            stop(fr(0.5), [0, 0, 255, 255]),
+        ];
+        let out = resolve_gradient_stops(&stops, 100.0, true).unwrap();
+        // backward = ceil(0.25/0.25) = 1, forward = ceil(0.5/0.25) = 2
+        // 展開列: k=-1 (0.0 red, 0.25 blue), k=0 (0.25 red, 0.5 blue),
+        //         k=1 (0.5 red, 0.75 blue), k=2 (0.75 red, 1.0 blue)
+        // = (0.0, red), (0.25, blue), (0.25, red), (0.5, blue), (0.5, red),
+        //   (0.75, blue), (0.75, red), (1.0, blue) → all in [0, 1] なので
+        // renormalize fast path で 8 stops そのまま。
+        assert_eq!(out.len(), 8);
+        let first = out.first().unwrap().offset.get();
+        let last = out.last().unwrap().offset.get();
+        assert!((first - 0.0).abs() < 1e-5, "first offset {first}");
+        assert!((last - 1.0).abs() < 1e-5, "last offset {last}");
+    }
+
+    /// `repeating-linear-gradient(red 0%, blue 0%)`: period = 0 (degenerate)。
+    /// None を返してレイヤー drop。
+    #[test]
+    fn repeating_period_zero_returns_none() {
+        let stops = vec![
+            stop(fr(0.0), [255, 0, 0, 255]),
+            stop(fr(0.0), [0, 0, 255, 255]),
+        ];
+        let out = resolve_gradient_stops(&stops, 100.0, true);
+        assert!(out.is_none(), "period=0 should return None");
+    }
+
+    /// `repeating-linear-gradient(red 0%, blue 100%)`: period = 1.0。
+    /// 1 周期で `[0, 1]` を完全カバー、non-repeating と同じ結果。
+    #[test]
+    fn repeating_full_period_equals_single_pass() {
+        let stops = vec![
+            stop(fr(0.0), [255, 0, 0, 255]),
+            stop(fr(1.0), [0, 0, 255, 255]),
+        ];
+        let repeat = resolve_gradient_stops(&stops, 100.0, true).unwrap();
+        let plain = resolve_gradient_stops(&stops, 100.0, false).unwrap();
+        // どちらも 2 stops で同じ位置。
+        assert_eq!(repeat.len(), plain.len());
+        for (r, p) in repeat.iter().zip(plain.iter()) {
+            assert!((r.offset.get() - p.offset.get()).abs() < 1e-5);
+        }
+    }
+
+    /// `repeating-linear-gradient(red, blue, green)`: 3 stops, Auto fixup 後
+    /// (0.0, 0.5, 1.0) → period = 1.0。1 周期で完結。
+    #[test]
+    fn repeating_three_color_stops() {
+        let stops = vec![
+            stop(Auto, [255, 0, 0, 255]),
+            stop(Auto, [0, 255, 0, 255]),
+            stop(Auto, [0, 0, 255, 255]),
+        ];
+        let out = resolve_gradient_stops(&stops, 100.0, true).unwrap();
+        // forward = backward = 0 → 1 copy = 3 stops
+        assert_eq!(out.len(), 3);
+        assert!((out[0].offset.get() - 0.0).abs() < 1e-5);
+        assert!((out[1].offset.get() - 0.5).abs() < 1e-5);
+        assert!((out[2].offset.get() - 1.0).abs() < 1e-5);
+    }
+
+    /// `repeating-radial-gradient(red 0px, blue 25px)` を radius=100px で評価。
+    /// 0/25 px → 0.0/0.25 fraction で linear と同じ展開。
+    #[test]
+    fn repeating_with_length_px_stops() {
+        let stops = vec![
+            stop(px(0.0), [255, 0, 0, 255]),
+            stop(px(25.0), [0, 0, 255, 255]),
+        ];
+        let out = resolve_gradient_stops(&stops, 100.0, true).unwrap();
+        // line_length=100, 25px → 0.25 fraction → repeating_simple_period と
+        // 同じ展開: 8 stops
+        assert_eq!(out.len(), 8);
+    }
+
+    fn offsets(stops: &[krilla::paint::Stop]) -> Vec<f32> {
+        stops.iter().map(|s| s.offset.get()).collect()
     }
 }
 

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -613,7 +613,11 @@ fn resolve_gradient_stops(
 /// `renormalize_stops_to_unit_range` 段で out-of-range stop が端点補間に丸められる
 /// 前提なので、ここでは充分なオーバーラップを与える。
 ///
-/// `period <= 0` (degenerate) は最後の色で塗られる単色とみなして None を返す。
+/// `period <= 0` (degenerate) は CSS Images 3 §3.6 に従い「最終 stop の色で
+/// 塗りつぶす単色」として扱う。krilla は最低 2 stop 必要なので、`(0, last)`
+/// と `(1, last)` の 2 stop を返す。`None` ではなく単色 fill を返すことで
+/// `repeating-linear-gradient(red 0%, blue 0%)` のような入力もブラウザと
+/// 同じ blue 単色描画になる (PR #244 coderabbit review より)。
 /// `period > 0` でも安全上限 `MAX_PERIODS` を超えたら最終周期で打ち切り
 /// (`repeating-linear-gradient(red 0%, blue 0.01%)` のような病的入力でも有界化)。
 fn expand_repeating_stops(stops: Vec<(f32, [u8; 4])>) -> Option<Vec<(f32, [u8; 4])>> {
@@ -623,13 +627,12 @@ fn expand_repeating_stops(stops: Vec<(f32, [u8; 4])>) -> Option<Vec<(f32, [u8; 4
     let p_last = stops.last().expect("len >= 2").0;
     let period = p_last - p_first;
 
-    // CSS Images 3 §3.6: period が 0 または負 (monotonic clamp 通過後の
-    // 等位置 hard stop) の場合、繰り返しは degenerate。最後の色で塗りつぶす
-    // 1-stop に相当するが、krilla は最低 2 stop 必要なので呼び出し側で
-    // None を伝搬して layer drop させる (= white background がそのまま見える
-    // のに近い挙動)。
+    // CSS Images 3 §3.6: 周期が 0 または負 (monotonic clamp 通過後に first/last が
+    // 同位置に潰れた場合) は degenerate。最終 stop の色で塗りつぶす単色 fill を返す。
+    // NaN/Inf も同じ扱いで安全側に倒す。
     if period <= 0.0 || !period.is_finite() {
-        return None;
+        let last_color = stops.last().expect("len >= 2").1;
+        return Some(vec![(0.0, last_color), (1.0, last_color)]);
     }
 
     // 安全上限。256 周期あれば line_length 比 0.4% の周期まで描き切れ、
@@ -2889,15 +2892,19 @@ mod resolve_gradient_stops_tests {
     }
 
     /// `repeating-linear-gradient(red 0%, blue 0%)`: period = 0 (degenerate)。
-    /// None を返してレイヤー drop。
+    /// CSS Images 3 §3.6 に従い最終 stop の色 (blue) で塗りつぶす単色 fill になる。
     #[test]
-    fn repeating_period_zero_returns_none() {
+    fn repeating_period_zero_renders_solid_last_color() {
         let stops = vec![
             stop(fr(0.0), [255, 0, 0, 255]),
             stop(fr(0.0), [0, 0, 255, 255]),
         ];
-        let out = resolve_gradient_stops(&stops, 100.0, true);
-        assert!(out.is_none(), "period=0 should return None");
+        let out = resolve_gradient_stops(&stops, 100.0, true).expect("solid fill, not None");
+        // 単色 fill: 2 stops at 0.0/1.0 で同色 (blue)。renormalize の fast path
+        // (全 stop in [0, 1]) を通って 2 stops のまま。
+        assert_eq!(out.len(), 2);
+        assert!((out[0].offset.get() - 0.0).abs() < 1e-5);
+        assert!((out[1].offset.get() - 1.0).abs() < 1e-5);
     }
 
     /// `repeating-linear-gradient(red 0%, blue 100%)`: period = 1.0。

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -647,7 +647,7 @@ fn expand_repeating_stops(stops: Vec<(f32, [u8; 4])>) -> Option<Vec<(f32, [u8; 4
     let backward = if p_first <= 0.0 {
         0
     } else {
-        ((p_first - 0.0) / period).ceil() as i32
+        (p_first / period).ceil() as i32
     };
 
     let forward = forward.min(MAX_PERIODS);

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -3155,9 +3155,7 @@ fn resolve_linear_gradient(
         Gradient::Radial { .. } | Gradient::Conic { .. } => return None,
     };
 
-    if flags.contains(GradientFlags::REPEATING) {
-        return None;
-    }
+    let repeating = flags.contains(GradientFlags::REPEATING);
     // Non-default `color_interpolation_method` (e.g. `in oklch`) would change
     // the rendered colors. Phase 1 interpolates in sRGB only, so bail rather
     // than silently misrender.
@@ -3195,7 +3193,11 @@ fn resolve_linear_gradient(
     let stops = resolve_color_stops(items, current_color, "linear-gradient")?;
 
     Some((
-        BgImageContent::LinearGradient { direction, stops },
+        BgImageContent::LinearGradient {
+            direction,
+            stops,
+            repeating,
+        },
         0.0,
         0.0,
     ))
@@ -3277,9 +3279,11 @@ fn resolve_color_stops(
 /// - stops: linear と共通の resolve_color_stops を使用
 ///
 /// Bail conditions (return None) — match resolve_linear_gradient:
-/// - REPEATING flag (fulgur-12z0 の対象)
 /// - non-default color interpolation method
 /// - length-typed / 範囲外 stop position, interpolation hint (resolve_color_stops 内)
+///
+/// `repeating-radial-gradient(...)` は `repeating: true` で受け、draw 時に
+/// stop の周期展開で表現する (Krilla の RadialGradient は SpreadMethod::Pad のみ)。
 fn resolve_radial_gradient(
     g: &style::values::computed::Gradient,
     current_color: &style::color::AbsoluteColor,
@@ -3299,9 +3303,7 @@ fn resolve_radial_gradient(
         Gradient::Linear { .. } | Gradient::Conic { .. } => return None,
     };
 
-    if flags.contains(GradientFlags::REPEATING) {
-        return None;
-    }
+    let repeating = flags.contains(GradientFlags::REPEATING);
     if !flags.contains(GradientFlags::HAS_DEFAULT_COLOR_INTERPOLATION_METHOD) {
         return None;
     }
@@ -3349,6 +3351,7 @@ fn resolve_radial_gradient(
             position_x,
             position_y,
             stops,
+            repeating,
         },
         0.0,
         0.0,

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -622,4 +622,69 @@ li::marker { content: url("bullet.png"); }
             .expect("render should succeed with marker image");
         assert!(!pdf.is_empty(), "PDF should be non-empty");
     }
+
+    /// `repeating-linear-gradient` を end-to-end で render し、`draw_background_layer`
+    /// の `LinearGradient { repeating: true }` 経路 (uniform-grid → tiling pattern) を
+    /// coverage 上カバーする。VRT 側で同等の reftest はあるが、CI が `--exclude fulgur-vrt`
+    /// で coverage 計測しているため lib 側にも smoke test が必要。
+    #[test]
+    fn test_render_repeating_linear_gradient_smoke() {
+        let html = r#"<!doctype html>
+<html><body>
+<div style="width:200px;height:100px;background:repeating-linear-gradient(to right, red 0%, blue 25%);"></div>
+</body></html>"#;
+        let pdf = Engine::builder()
+            .build()
+            .render_html(html)
+            .expect("render repeating-linear-gradient");
+        assert!(!pdf.is_empty());
+    }
+
+    /// `repeating-radial-gradient` の end-to-end smoke test。`RadialGradient { repeating: true }`
+    /// 経路をカバーする。
+    #[test]
+    fn test_render_repeating_radial_gradient_smoke() {
+        let html = r#"<!doctype html>
+<html><body>
+<div style="width:200px;height:200px;background:repeating-radial-gradient(circle 100px at center, red 0px, blue 25px);"></div>
+</body></html>"#;
+        let pdf = Engine::builder()
+            .build()
+            .render_html(html)
+            .expect("render repeating-radial-gradient");
+        assert!(!pdf.is_empty());
+    }
+
+    /// `linear-gradient(to top right, ...)` (Corner direction) の smoke test。
+    /// `draw_background_layer` の `LinearGradientDirection::Corner` 経路は既存だが
+    /// `repeating` 追加に伴い destructure を含む match arm を再書きしたため、
+    /// patch coverage を満たすために lib 側にも end-to-end カバーを置いておく。
+    #[test]
+    fn test_render_linear_gradient_corner_direction_smoke() {
+        let html = r#"<!doctype html>
+<html><body>
+<div style="width:200px;height:100px;background:linear-gradient(to top right, red, blue);"></div>
+</body></html>"#;
+        let pdf = Engine::builder()
+            .build()
+            .render_html(html)
+            .expect("render corner-direction linear gradient");
+        assert!(!pdf.is_empty());
+    }
+
+    /// `background-size` で複数タイルを生成して `try_uniform_grid` Some パスを
+    /// 通す smoke test。これで linear gradient の uniform-grid → tiling pattern
+    /// 経路が coverage に乗る。
+    #[test]
+    fn test_render_linear_gradient_tiled_smoke() {
+        let html = r#"<!doctype html>
+<html><body>
+<div style="width:200px;height:100px;background:linear-gradient(red, blue);background-size:50px 50px;"></div>
+</body></html>"#;
+        let pdf = Engine::builder()
+            .build()
+            .render_html(html)
+            .expect("render tiled linear gradient");
+        assert!(!pdf.is_empty());
+    }
 }

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -824,18 +824,23 @@ pub enum BgImageContent {
     },
     /// SVG vector image — rendered via krilla-svg draw_svg.
     Svg { tree: Arc<usvg::Tree> },
-    /// CSS `linear-gradient(...)`.
+    /// CSS `linear-gradient(...)` / `repeating-linear-gradient(...)`.
+    /// `repeating=true` の場合、stops は draw 時に CSS Images 3 §3.6 の
+    /// 周期展開 (period = last_pos - first_pos) を経て [0, 1] に正規化される。
     LinearGradient {
         direction: LinearGradientDirection,
         stops: Vec<GradientStop>,
+        repeating: bool,
     },
-    /// CSS `radial-gradient(...)`. position は origin rect 内の中心。
+    /// CSS `radial-gradient(...)` / `repeating-radial-gradient(...)`.
+    /// position は origin rect 内の中心。`repeating` の意味は LinearGradient と同じ。
     RadialGradient {
         shape: RadialGradientShape,
         size: RadialGradientSize,
         position_x: BgLengthPercentage,
         position_y: BgLengthPercentage,
         stops: Vec<GradientStop>,
+        repeating: bool,
     },
 }
 


### PR DESCRIPTION
## 概要

`repeating-linear-gradient(...)` / `repeating-radial-gradient(...)` を実装 (fulgur-12z0)。convert 時に silent drop していたフラグを `repeating: bool` として保持し、draw 時に stop 列を周期的に事前展開してから既存の `renormalize_stops_to_unit_range` パイプライン + `SpreadMethod::Pad` で描画する。

linear / radial 両方を pre-expansion で統一処理した理由:
- PDF (krilla) の `RadialGradient` は `Pad` のみサポート (`Repeat`/`Reflect` 未対応)
- linear だけ `SpreadMethod::Repeat` で書くと radial と分岐が増える
- 上限 `MAX_PERIODS = 256` と `period <= 0` の None 返却で病的入力を有界化

## 主な変更

- `BgImageContent::{LinearGradient, RadialGradient}` に `repeating: bool` を追加
- `convert::resolve_{linear,radial}_gradient` が `GradientFlags::REPEATING` を None にせず `repeating: true` で受ける
- `resolve_gradient_stops` に `repeating: bool` パラメータを追加し、内部で `expand_repeating_stops` を呼ぶ
- `expand_repeating_stops`: `period = p_last - p_first` で stop 列を `[-backward, +forward]` 周期コピー、`[0, 1]` を覆う

## テスト

### unit (`crates/fulgur/src/background.rs`)

- `repeating_simple_period` — `(red 0%, blue 25%)` で 4 周期 8 stops 生成
- `repeating_offset_period_extends_both_directions` — `(red 25%, blue 50%)` で前後両展開
- `repeating_period_zero_returns_none` — degenerate ガード
- `repeating_full_period_equals_single_pass` — non-repeating と同等
- `repeating_three_color_stops` — Auto fixup の通過
- `repeating_with_length_px_stops` — `LengthPx` → fraction 変換

### VRT reftest (`crates/fulgur-vrt/tests/gradient_harness.rs`)

- `repeating_linear_gradient_matches_explicit_expansion`
- `repeating_radial_gradient_matches_explicit_expansion`

両者ともに `repeating-*` が CSS 仕様等価な明示展開と pixel-equivalent な PDF を生成することを確認。

### byte-wise golden

- `paint/repeating-linear-gradient.html` + `goldens/.../repeating-linear-gradient.pdf`
- `paint/repeating-radial-gradient.html` + `goldens/.../repeating-radial-gradient.pdf`

## 既知の仕様ギャップ (issue scope 内で受容)

radial gradient で box が ending shape の外側に伸びる場合 (例: `circle 100px` を 200×200 box に使うと box 隅 `r ≈ 141px` が `cr=100px` を超える領域)、その領域は `SpreadMethod::Pad` で最終色が塗られる。CSS 仕様ではここで repetition が続く (Chromium / Firefox はそうなる) ため box 隅でブラウザと差分が出る。issue で `fallback to Pad で受容` と明記されているため別 issue 化候補としてノートに残した (`bd show fulgur-12z0` 参照)。

## テスト計画

- [x] `cargo test -p fulgur --lib` — 778 + 6 = ok
- [x] `cargo test -p fulgur-vrt` — 19 + 8 + 2 + 1 = ok (新 VRT 含む)
- [x] `cargo test -p fulgur-cli --test examples_determinism` — 11 ok
- [x] `cargo fmt --check`
- [x] `cargo clippy -p fulgur --lib --tests`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for rendering CSS repeating-linear-gradient and repeating-radial-gradient with correct repeating behavior.

* **Tests**
  * Added visual regression and integration tests that validate repeating-gradient rendering and period boundary colors.

* **Chores**
  * Added VRT HTML fixtures for repeating linear and radial gradient cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->