### PR TITLE
feat(gradient): conic-gradient via path wedge decomposition

### DIFF
--- a/crates/fulgur-vrt/fixtures/paint/conic-gradient-quadrant.html
+++ b/crates/fulgur-vrt/fixtures/paint/conic-gradient-quadrant.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>VRT test: conic-gradient 4 quadrant pie chart</title>
+<style>
+  html, body { margin: 0; padding: 0; background: white; }
+  .box {
+    width: 192px;
+    height: 192px;
+    margin: 32px;
+    background: conic-gradient(
+      red 0deg, red 90deg,
+      yellow 90deg, yellow 180deg,
+      green 180deg, green 270deg,
+      blue 270deg, blue 360deg
+    );
+  }
+</style>
+</head>
+<body>
+  <div class="box"></div>
+</body>
+</html>

--- a/crates/fulgur-vrt/tests/conic_gradient_harness.rs
+++ b/crates/fulgur-vrt/tests/conic_gradient_harness.rs
@@ -1,0 +1,148 @@
+//! Test↔ref pixel-diff harness for conic-gradient implementation.
+//!
+//! 4 個の 90° セクターを持つ pie chart を、CSS `clip-path: polygon(...)` で扇形を
+//! 作った 4 個の絶対配置 div の ref と pixel-wise 比較する。conic-gradient の
+//! 角度規約 (CSS: 0deg=top, 増加方向=clockwise) を empirical に検証する。
+//!
+//! red sector   = 0..90deg = top → right (右上 1/4)
+//! yellow sector = 90..180deg = right → bottom (右下 1/4)
+//! green sector = 180..270deg = bottom → left (左下 1/4)
+//! blue sector = 270..360deg = left → top (左上 1/4)
+//!
+//! 採用しなかった案:
+//! - SVG `<linearGradient>` 集合 ref → 自前 SVG パイプラインに依存
+//! - PNG raster ref → CI 再現性で扱いづらい
+//! - サイズが異なる box → ref polygon 頂点の整数化が崩れて tolerance 緩和必要
+
+use fulgur_vrt::diff;
+use fulgur_vrt::manifest::Tolerance;
+use fulgur_vrt::pdf_render::{RenderSpec, pdf_to_rgba, render_html_to_pdf};
+use std::fs;
+use std::path::PathBuf;
+
+const BOX_PX: u32 = 192;
+const MARGIN_PX: u32 = 32;
+
+/// 4 個の 90° セクターを絶対配置の矩形で構築する ref HTML。
+///
+/// 4-sector axis-aligned conic では各セクターが box の 1/4 矩形と一致する
+/// (中心と box 辺の中点が一致するため)。`clip-path: polygon` は Blitz が未対応
+/// なので採用せず、`position: absolute` + `width:50%; height:50%` の単色矩形を
+/// 4 個並べる。
+///
+/// 配置:
+/// - red    = top-right (CSS conic 0..90deg = top → right)
+/// - yellow = bottom-right (90..180deg)
+/// - green  = bottom-left (180..270deg)
+/// - blue   = top-left (270..360deg)
+fn build_quadrant_ref_html() -> String {
+    format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>VRT ref: conic-gradient 4 quadrant pie chart</title>
+<style>
+  html, body {{ margin: 0; padding: 0; background: white; }}
+  .box {{ position: relative; width: {w}px; height: {h}px; margin: {m}px; }}
+  .quad {{ position: absolute; width: 50%; height: 50%; }}
+  .red    {{ top: 0;   right: 0; background: red; }}
+  .yellow {{ bottom: 0; right: 0; background: yellow; }}
+  .green  {{ bottom: 0; left: 0;  background: green; }}
+  .blue   {{ top: 0;   left: 0;  background: blue; }}
+</style>
+</head>
+<body>
+  <div class="box">
+    <div class="quad red"></div>
+    <div class="quad yellow"></div>
+    <div class="quad green"></div>
+    <div class="quad blue"></div>
+  </div>
+</body>
+</html>"#,
+        w = BOX_PX,
+        h = BOX_PX,
+        m = MARGIN_PX,
+    )
+}
+
+#[test]
+fn conic_gradient_quadrants_match_rect_reference() {
+    let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let test_html_path = crate_root.join("fixtures/paint/conic-gradient-quadrant.html");
+    let test_html = fs::read_to_string(&test_html_path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", test_html_path.display()));
+
+    let ref_html = build_quadrant_ref_html();
+
+    let spec = RenderSpec {
+        page_size: "A4",
+        margin_pt: Some(0.0),
+        dpi: 150,
+    };
+
+    let test_pdf = render_html_to_pdf(&test_html, spec).expect("render test pdf");
+    let ref_pdf = render_html_to_pdf(&ref_html, spec).expect("render ref pdf");
+
+    let work_dir = crate_root
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root")
+        .join("target/vrt-conic-gradient-harness");
+    fs::create_dir_all(&work_dir).expect("create work dir");
+
+    let test_dir = work_dir.join("test");
+    let ref_dir = work_dir.join("ref");
+    let _ = fs::remove_dir_all(&test_dir);
+    let _ = fs::remove_dir_all(&ref_dir);
+    fs::create_dir_all(&test_dir).expect("create test dir");
+    fs::create_dir_all(&ref_dir).expect("create ref dir");
+
+    let test_pdf_path = test_dir.join("test.pdf");
+    let ref_pdf_path = ref_dir.join("ref.pdf");
+    fs::write(&test_pdf_path, &test_pdf).expect("write test pdf");
+    fs::write(&ref_pdf_path, &ref_pdf).expect("write ref pdf");
+
+    let test_img = pdf_to_rgba(&test_pdf_path, spec.dpi, &test_dir).expect("rasterize test");
+    let ref_img = pdf_to_rgba(&ref_pdf_path, spec.dpi, &ref_dir).expect("rasterize ref");
+
+    // box 周辺だけを crop して評価 (radial harness と同じ思想):
+    // 150dpi で 1 CSS px = 25/16 raster px、
+    //   margin 32 CSS px  → 50 raster px
+    //   box   192 CSS px  → 300 raster px
+    const CROP_MARGIN_RASTER: u32 = 4;
+    let crop_x = (MARGIN_PX as u64 * 25 / 16) as u32 - CROP_MARGIN_RASTER;
+    let crop_y = crop_x;
+    let crop_w = (BOX_PX as u64 * 25 / 16) as u32 + CROP_MARGIN_RASTER * 2;
+    let crop_h = crop_w;
+    let test_crop = image::imageops::crop_imm(&test_img, crop_x, crop_y, crop_w, crop_h).to_image();
+    let ref_crop = image::imageops::crop_imm(&ref_img, crop_x, crop_y, crop_w, crop_h).to_image();
+
+    // Tolerance:
+    // - 12 channels: sector 境界 (4 本の十字線) AA で局所的に色が滲む
+    // - 2.0%: cropped 308x308 ≈ 95k px に対し 4 本の境界線 (合計 ~600 px) +
+    //   各 wedge edge AA 余裕で 1.5% 程度を見込み、+0.5% headroom
+    let tol = Tolerance {
+        max_channel_diff: 12,
+        max_diff_pixels_ratio: 0.02,
+    };
+
+    let report = diff::compare(&ref_crop, &test_crop, tol);
+
+    assert!(
+        report.pass,
+        "conic gradient quadrant test↔ref harness failed: {} of {} pixels differ ({:.3}%), max channel diff = {} (tolerance: max_diff={}, ratio<={:.3}%). \
+         test PDF: {}\n  ref PDF: {}\n  test img: {}\n  ref img:  {}",
+        report.diff_pixels,
+        report.total_pixels,
+        report.ratio() * 100.0,
+        report.max_channel_diff,
+        tol.max_channel_diff,
+        tol.max_diff_pixels_ratio * 100.0,
+        test_pdf_path.display(),
+        ref_pdf_path.display(),
+        test_dir.join("page-1.png").display(),
+        ref_dir.join("page-1.png").display(),
+    );
+}

--- a/crates/fulgur-wpt/expectations/lists/bugs.txt
+++ b/crates/fulgur-wpt/expectations/lists/bugs.txt
@@ -75,3 +75,19 @@ PASS  css/css-break/zero-height-page-break-001-print.html  # fulgur-y9pu: regres
 # 厳密一致 reftest は無く、monolithic-overflow-001 が page-edge clip primitive を
 # 検証する点で機構が近い。
 PASS  css/css-page/monolithic-overflow-001-print.html  # fulgur-fy42: regression net (page-edge clip primitive)
+
+# fulgur-m92h: conic-gradient Phase 2 実装 (path wedge 分解、PDF/A 適合)。
+# upstream WPT css-images の conic 系 11 件のうち 10 件が実描画として PASS。
+# 視覚比較 / 角度規約検証は VRT
+# (`crates/fulgur-vrt/tests/conic_gradient_harness.rs`) に。
+PASS  css/css-images/conic-gradient-angle.html               # fulgur-m92h: 基本 angle parameter (4 quadrant)
+PASS  css/css-images/conic-gradient-angle-negative.html      # fulgur-m92h: 負角度 from <angle>
+PASS  css/css-images/conic-gradient-center.html              # fulgur-m92h: at <position> 中心オフセット
+PASS  css/css-images/multiple-position-color-stop-conic.html # fulgur-m92h: 双方向 position 短縮形 (single layer)
+FAIL  css/css-images/multiple-position-color-stop-conic-2.html  # fulgur-m92h: 双方向 position の border AA で sub-pixel 差 (548/892k px exceed default tol; 視覚は完全一致)
+PASS  css/css-images/normalization-conic.html                # fulgur-m92h: stop 正規化 (out-of-range fixup)
+PASS  css/css-images/normalization-conic-2.html              # fulgur-m92h: stop 正規化 (variant)
+PASS  css/css-images/normalization-conic-degenerate.html     # fulgur-m92h: degenerate gradient (全 stop 同位置)
+PASS  css/css-images/out-of-range-color-stop-conic.html      # fulgur-m92h: 範囲外 stop の renormalize
+PASS  css/css-images/repeating-conic-gradient.html           # fulgur-m92h: repeating-conic-gradient
+PASS  css/css-images/tiled-conic-gradients.html              # fulgur-m92h: background-size による tiled conic

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -1146,32 +1146,46 @@ fn normalize_conic_stops(stops: &[crate::pageable::GradientStop]) -> Vec<(f32, [
         .collect()
 }
 
-/// 0..1 fraction を normalized stops で線形補間して RGBA を返す。
+/// fraction `t` を normalized stops で線形補間して RGBA を返す。
+///
+/// 範囲外 `t` は first / last 端点の色を返す。`t` が coincident stop
+/// (hard transition) 境界上に乗った場合は **後ろの色を採用する** — CSS Images
+/// §3.5.1: 同位置の複数 stop は seam を後続 stop の色が占める。
+///
+/// アルゴリズム: stops は position 昇順前提。`p <= t` を満たす最右 stop の
+/// 直後を起点 segment にすれば、coincident pair (p1 == p2 == t) の境界上で
+/// 自動的に「後の色」が拾える ([..., (t, A), (t, B), (next, B)] で t を渡すと
+/// 起点 (t, B) → next 区間の alpha=0 → B が返る)。
 fn sample_conic_color(stops: &[(f32, [u8; 4])], t: f32) -> [u8; 4] {
     if stops.is_empty() {
         return [0, 0, 0, 255];
     }
-    if t <= stops[0].0 {
+    if t < stops[0].0 {
         return stops[0].1;
     }
     if t >= stops[stops.len() - 1].0 {
         return stops[stops.len() - 1].1;
     }
-    for w in stops.windows(2) {
-        let (p1, c1) = w[0];
-        let (p2, c2) = w[1];
-        if t >= p1 && t <= p2 {
-            let span = (p2 - p1).max(1e-9);
-            let alpha = ((t - p1) / span).clamp(0.0, 1.0);
-            return [
-                lerp_u8(c1[0], c2[0], alpha),
-                lerp_u8(c1[1], c2[1], alpha),
-                lerp_u8(c1[2], c2[2], alpha),
-                lerp_u8(c1[3], c2[3], alpha),
-            ];
-        }
+
+    // `p <= t` を満たす最右 stop index。stops は昇順なのでこの index 以降
+    // (idx + 1 を含む) は全て p > t。
+    let idx = stops.iter().rposition(|&(p, _)| p <= t).unwrap_or(0);
+    if idx + 1 >= stops.len() {
+        return stops[idx].1;
     }
-    stops[stops.len() - 1].1
+    let (p1, c1) = stops[idx];
+    let (p2, c2) = stops[idx + 1];
+    let span = p2 - p1;
+    if span <= 0.0 {
+        return c2;
+    }
+    let alpha = ((t - p1) / span).clamp(0.0, 1.0);
+    [
+        lerp_u8(c1[0], c2[0], alpha),
+        lerp_u8(c1[1], c2[1], alpha),
+        lerp_u8(c1[2], c2[2], alpha),
+        lerp_u8(c1[3], c2[3], alpha),
+    ]
 }
 
 /// uniform-grid 検出時の Tiling Pattern 描画ヘルパー。
@@ -3520,5 +3534,20 @@ mod conic_helpers_tests {
         let stops = vec![(0.2, [255, 0, 0, 255]), (0.8, [0, 0, 255, 255])];
         assert_eq!(sample_conic_color(&stops, 0.0), [255, 0, 0, 255]);
         assert_eq!(sample_conic_color(&stops, 1.0), [0, 0, 255, 255]);
+    }
+
+    #[test]
+    fn sample_coincident_stops_returns_later_color() {
+        // CSS Images §3.5.1 hard transition: red 0%-50%, blue 50%-100% → t=0.5 should be blue.
+        let stops = vec![
+            (0.0, [255, 0, 0, 255]),
+            (0.5, [255, 0, 0, 255]),
+            (0.5, [0, 0, 255, 255]),
+            (1.0, [0, 0, 255, 255]),
+        ];
+        assert_eq!(sample_conic_color(&stops, 0.5), [0, 0, 255, 255]);
+        // Just before/after seam: still in correct half.
+        assert_eq!(sample_conic_color(&stops, 0.499), [255, 0, 0, 255]);
+        assert_eq!(sample_conic_color(&stops, 0.501), [0, 0, 255, 255]);
     }
 }

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -205,9 +205,9 @@ fn draw_background_layer(
         .push_clip_path(&clip_path, &krilla::paint::FillRule::default());
 
     let (img_w, img_h) = match &layer.content {
-        BgImageContent::LinearGradient { .. } | BgImageContent::RadialGradient { .. } => {
-            resolve_gradient_size(&layer.size, ow, oh)
-        }
+        BgImageContent::LinearGradient { .. }
+        | BgImageContent::RadialGradient { .. }
+        | BgImageContent::ConicGradient { .. } => resolve_gradient_size(&layer.size, ow, oh),
         BgImageContent::Raster { .. } | BgImageContent::Svg { .. } => resolve_size(layer, ow, oh),
     };
     if img_w <= 0.0 || img_h <= 0.0 {
@@ -340,6 +340,28 @@ fn draw_background_layer(
                         *th,
                     );
                 }
+            }
+        }
+        BgImageContent::ConicGradient {
+            from_angle,
+            position_x,
+            position_y,
+            stops,
+            repeating,
+        } => {
+            for (tx, ty, tw, th) in &tiles {
+                draw_conic_gradient(
+                    canvas.surface,
+                    *from_angle,
+                    position_x,
+                    position_y,
+                    stops,
+                    *repeating,
+                    *tx,
+                    *ty,
+                    *tw,
+                    *th,
+                );
             }
         }
         BgImageContent::Raster { data, format } => {
@@ -893,6 +915,236 @@ fn draw_radial_gradient(
     };
     surface.draw_path(&rect_path);
     surface.set_fill(None);
+}
+
+/// SPIKE: Draw a CSS conic-gradient as N triangular path wedges, sampling
+/// color at each wedge's mid-angle.
+///
+/// PostScript shading を使わず PDF/A 適合。N=360 で 1° per wedge。三角形の
+/// outer edge は box 境界との ray intersection で求める (中心から放射した
+/// ray が box 辺と交わる点)。
+///
+/// 制約 (spike):
+/// - GradientStop の Auto 補間は線形 (`fixup_conic_stops` 簡易版)
+/// - 重複 stop の特殊処理なし
+/// - repeating は period = (last - first) で fraction を周期化
+#[allow(clippy::too_many_arguments)]
+fn draw_conic_gradient(
+    surface: &mut krilla::surface::Surface<'_>,
+    from_angle_rad: f32,
+    position_x: &BgLengthPercentage,
+    position_y: &BgLengthPercentage,
+    stops: &[crate::pageable::GradientStop],
+    repeating: bool,
+    ox: f32,
+    oy: f32,
+    ow: f32,
+    oh: f32,
+) {
+    if ow <= 0.0 || oh <= 0.0 || stops.len() < 2 {
+        return;
+    }
+
+    let cx = ox + resolve_point(position_x, ow);
+    let cy = oy + resolve_point(position_y, oh);
+
+    let normalized = normalize_conic_stops(stops);
+    if normalized.len() < 2 {
+        return;
+    }
+    let first = normalized.first().unwrap().0;
+    let last = normalized.last().unwrap().0;
+    let period = (last - first).max(1e-6);
+
+    const N: usize = 360;
+    let two_pi = 2.0 * std::f32::consts::PI;
+
+    // 各 wedge の代表色を先に計算し、隣接同色を 1 個の多角形にマージする。
+    // (pie chart のように step transition が連続する場合、N=360 個の path が
+    // 数個に減って PDF サイズも大幅減・モアレ境界線も消える)
+    let colors: Vec<[u8; 4]> = (0..N)
+        .map(|i| {
+            let mid_f = (i as f32 + 0.5) / N as f32;
+            let mid_t = if repeating {
+                first + ((mid_f - first).rem_euclid(period))
+            } else {
+                mid_f
+            };
+            sample_conic_color(&normalized, mid_t.clamp(0.0, 1.0))
+        })
+        .collect();
+
+    surface.set_stroke(None);
+
+    let mut i = 0usize;
+    while i < N {
+        let color = colors[i];
+        let mut j = i + 1;
+        while j < N && colors[j] == color {
+            j += 1;
+        }
+        // [i, j) は同色 wedge 群。中心 + theta_i から theta_j までの外周点列で多角形化。
+        let theta_start = from_angle_rad + (i as f32 / N as f32) * two_pi;
+        let theta_end = from_angle_rad + (j as f32 / N as f32) * two_pi;
+
+        let mut pb = krilla::geom::PathBuilder::new();
+        pb.move_to(cx, cy);
+        // 開始端点
+        let (sx, sy) = box_edge_at_angle(theta_start, cx, cy, ox, oy, ow, oh);
+        pb.line_to(sx, sy);
+        // 中間 wedge 境界の外周点を順に追加
+        for k in (i + 1)..j {
+            let theta_k = from_angle_rad + (k as f32 / N as f32) * two_pi;
+            let (px, py) = box_edge_at_angle(theta_k, cx, cy, ox, oy, ow, oh);
+            pb.line_to(px, py);
+        }
+        // 終了端点
+        let (ex, ey) = box_edge_at_angle(theta_end, cx, cy, ox, oy, ow, oh);
+        pb.line_to(ex, ey);
+        pb.close();
+
+        let Some(path) = pb.finish() else {
+            i = j;
+            continue;
+        };
+        surface.set_fill(Some(krilla::paint::Fill {
+            paint: krilla::color::rgb::Color::new(color[0], color[1], color[2]).into(),
+            rule: Default::default(),
+            opacity: krilla::num::NormalizedF32::new(color[3] as f32 / 255.0)
+                .unwrap_or(krilla::num::NormalizedF32::ONE),
+        }));
+        surface.draw_path(&path);
+
+        i = j;
+    }
+    surface.set_fill(None);
+}
+
+/// CSS conic ray angle θ から box 辺との交点 (cx + t·sin θ, cy − t·cos θ) を返す
+/// (CSS 規約: θ=0 は top, increasing CW)。
+fn box_edge_at_angle(
+    theta_rad: f32,
+    cx: f32,
+    cy: f32,
+    ox: f32,
+    oy: f32,
+    ow: f32,
+    oh: f32,
+) -> (f32, f32) {
+    // CSS Y-down: 0deg = top (-Y) → ray dir (sin θ, -cos θ)
+    let dx = theta_rad.sin();
+    let dy = -theta_rad.cos();
+
+    let tx = if dx > 1e-9 {
+        (ox + ow - cx) / dx
+    } else if dx < -1e-9 {
+        (ox - cx) / dx
+    } else {
+        f32::INFINITY
+    };
+    let ty = if dy > 1e-9 {
+        (oy + oh - cy) / dy
+    } else if dy < -1e-9 {
+        (oy - cy) / dy
+    } else {
+        f32::INFINITY
+    };
+    let t = tx.min(ty).max(0.0);
+    (cx + t * dx, cy + t * dy)
+}
+
+/// SPIKE: stop position fixup. GradientStop の Auto を線形補間で埋める。
+/// LengthPx は conic ではほぼ来ない (CSS では `<angle>|<percentage>`) ので
+/// 0..1 範囲外として扱い無視する (Phase 1 簡易策)。
+fn normalize_conic_stops(stops: &[crate::pageable::GradientStop]) -> Vec<(f32, [u8; 4])> {
+    use crate::pageable::GradientStopPosition;
+    if stops.is_empty() {
+        return Vec::new();
+    }
+
+    let mut out: Vec<(Option<f32>, [u8; 4])> = stops
+        .iter()
+        .map(|s| {
+            let p = match s.position {
+                GradientStopPosition::Auto => None,
+                GradientStopPosition::Fraction(f) => Some(f),
+                GradientStopPosition::LengthPx(_) => None, // spike: 無視
+            };
+            (p, s.rgba)
+        })
+        .collect();
+
+    if out[0].0.is_none() {
+        out[0].0 = Some(0.0);
+    }
+    let last = out.len() - 1;
+    if out[last].0.is_none() {
+        out[last].0 = Some(1.0);
+    }
+
+    let mut prev: f32 = out[0].0.unwrap();
+    for s in out.iter_mut().skip(1) {
+        if let Some(p) = s.0
+            && p < prev
+        {
+            s.0 = Some(prev);
+        }
+        if let Some(p) = s.0 {
+            prev = p;
+        }
+    }
+
+    let mut i = 0usize;
+    while i < out.len() {
+        if out[i].0.is_some() {
+            i += 1;
+            continue;
+        }
+        let prev_pos = out[i - 1].0.unwrap();
+        let mut j = i;
+        while j < out.len() && out[j].0.is_none() {
+            j += 1;
+        }
+        let next_pos = out[j].0.unwrap();
+        let count = j - i + 1;
+        for k in 0..(j - i) {
+            let t = (k + 1) as f32 / count as f32;
+            out[i + k].0 = Some(prev_pos + (next_pos - prev_pos) * t);
+        }
+        i = j;
+    }
+
+    out.into_iter()
+        .map(|(p, rgba)| (p.unwrap(), rgba))
+        .collect()
+}
+
+/// 0..1 fraction を normalized stops で線形補間して RGBA を返す。
+fn sample_conic_color(stops: &[(f32, [u8; 4])], t: f32) -> [u8; 4] {
+    if stops.is_empty() {
+        return [0, 0, 0, 255];
+    }
+    if t <= stops[0].0 {
+        return stops[0].1;
+    }
+    if t >= stops[stops.len() - 1].0 {
+        return stops[stops.len() - 1].1;
+    }
+    for w in stops.windows(2) {
+        let (p1, c1) = w[0];
+        let (p2, c2) = w[1];
+        if t >= p1 && t <= p2 {
+            let span = (p2 - p1).max(1e-9);
+            let alpha = ((t - p1) / span).clamp(0.0, 1.0);
+            return [
+                lerp_u8(c1[0], c2[0], alpha),
+                lerp_u8(c1[1], c2[1], alpha),
+                lerp_u8(c1[2], c2[2], alpha),
+                lerp_u8(c1[3], c2[3], alpha),
+            ];
+        }
+    }
+    stops[stops.len() - 1].1
 }
 
 /// uniform-grid 検出時の Tiling Pattern 描画ヘルパー。

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -961,11 +961,23 @@ fn draw_conic_gradient(
         return;
     }
 
+    // origin rect への追加クリップ。`at <position>` が origin 外に解決された場合、
+    // wedge polygon の中心頂点 `(cx, cy)` が origin 外でも頂点として含まれてしまい、
+    // 既存 BgClip 用 `clip_path` だけでは `clip \ origin` 領域に塗りが漏れる
+    // (CSS Images §3 では origin の外は当該レイヤーで透明)。linear/radial は
+    // gradient 自体が origin 内で減衰するため顕在化しないが、conic は
+    // 中心からの放射なので明示的に origin で再クリップする。
+    let Some(origin_clip) = build_rect_path(ox, oy, ow, oh) else {
+        return;
+    };
+    surface.push_clip_path(&origin_clip, &krilla::paint::FillRule::default());
+
     let cx = ox + resolve_point(position_x, ow);
     let cy = oy + resolve_point(position_y, oh);
 
     let normalized = normalize_conic_stops(stops);
     if normalized.len() < 2 {
+        surface.pop();
         return;
     }
     let first = normalized.first().unwrap().0;
@@ -976,6 +988,9 @@ fn draw_conic_gradient(
 
     // 各 wedge の中点角度 (CSS fraction) で色をサンプル。repeating 時は
     // CSS Images 4 §3.x の周期展開で fraction を [first, last] にラップする。
+    // `mid_t` は意図的に clamp しない: stops は seam を跨いで負 / 1 超過しうる
+    // (例: `repeating-conic-gradient(red -30deg, blue 30deg)`)。
+    // `sample_conic_color` 側が範囲外を first / last 端点として吸収する。
     let colors: Vec<[u8; 4]> = (0..N)
         .map(|i| {
             let mid_f = (i as f32 + 0.5) / N as f32;
@@ -984,7 +999,7 @@ fn draw_conic_gradient(
             } else {
                 mid_f
             };
-            sample_conic_color(&normalized, mid_t.clamp(0.0, 1.0))
+            sample_conic_color(&normalized, mid_t)
         })
         .collect();
 
@@ -1028,6 +1043,7 @@ fn draw_conic_gradient(
         i = j;
     }
     surface.set_fill(None);
+    surface.pop();
 }
 
 /// CSS conic ray angle θ から box 辺との交点 (cx + t·sin θ, cy − t·cos θ) を返す

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -349,19 +349,39 @@ fn draw_background_layer(
             stops,
             repeating,
         } => {
-            for (tx, ty, tw, th) in &tiles {
-                draw_conic_gradient(
-                    canvas.surface,
-                    *from_angle,
-                    position_x,
-                    position_y,
-                    stops,
-                    *repeating,
-                    *tx,
-                    *ty,
-                    *tw,
-                    *th,
-                );
+            // Linear/Radial と同じく uniform-tile grid なら 1 個の Tiling Pattern
+            // resource に集約する。Conic は wedge path 群 (~数百 byte/conic) が
+            // 各 tile で完全同一になるため、特に N×M タイルで効果が大きい。
+            if let Some(grid) = try_uniform_grid(&tiles) {
+                draw_gradient_tiling_pattern(canvas, grid, |surface, tw, th| {
+                    draw_conic_gradient(
+                        surface,
+                        *from_angle,
+                        position_x,
+                        position_y,
+                        stops,
+                        *repeating,
+                        0.0,
+                        0.0,
+                        tw,
+                        th,
+                    );
+                });
+            } else {
+                for (tx, ty, tw, th) in &tiles {
+                    draw_conic_gradient(
+                        canvas.surface,
+                        *from_angle,
+                        position_x,
+                        position_y,
+                        stops,
+                        *repeating,
+                        *tx,
+                        *ty,
+                        *tw,
+                        *th,
+                    );
+                }
             }
         }
         BgImageContent::Raster { data, format } => {
@@ -917,17 +937,13 @@ fn draw_radial_gradient(
     surface.set_fill(None);
 }
 
-/// SPIKE: Draw a CSS conic-gradient as N triangular path wedges, sampling
-/// color at each wedge's mid-angle.
+/// Draw a CSS conic-gradient as N=360 triangular path wedges, sampling color
+/// at each wedge's mid-angle and merging adjacent same-color wedges into
+/// single polygons. PostScript shading を使わないため PDF/A-1, A-2 適合。
 ///
-/// PostScript shading を使わず PDF/A 適合。N=360 で 1° per wedge。三角形の
-/// outer edge は box 境界との ray intersection で求める (中心から放射した
-/// ray が box 辺と交わる点)。
-///
-/// 制約 (spike):
-/// - GradientStop の Auto 補間は線形 (`fixup_conic_stops` 簡易版)
-/// - 重複 stop の特殊処理なし
-/// - repeating は period = (last - first) で fraction を周期化
+/// 三角形の外周頂点は中心から放射した ray と box 辺の交点で計算する
+/// (`box_edge_at_angle`)。merge により hard step (pie chart) は色変化点数まで
+/// path が減り、見た目の境界 AA も同色 wedge 間で消失する。
 #[allow(clippy::too_many_arguments)]
 fn draw_conic_gradient(
     surface: &mut krilla::surface::Surface<'_>,
@@ -957,20 +973,26 @@ fn draw_conic_gradient(
     let period = (last - first).max(1e-6);
 
     const N: usize = 360;
-    let two_pi = 2.0 * std::f32::consts::PI;
 
-    // 各 wedge の代表色を先に計算し、隣接同色を 1 個の多角形にマージする。
-    // (pie chart のように step transition が連続する場合、N=360 個の path が
-    // 数個に減って PDF サイズも大幅減・モアレ境界線も消える)
+    // 各 wedge の中点角度 (CSS fraction) で色をサンプル。repeating 時は
+    // CSS Images 4 §3.x の周期展開で fraction を [first, last] にラップする。
     let colors: Vec<[u8; 4]> = (0..N)
         .map(|i| {
             let mid_f = (i as f32 + 0.5) / N as f32;
             let mid_t = if repeating {
-                first + ((mid_f - first).rem_euclid(period))
+                first + (mid_f - first).rem_euclid(period)
             } else {
                 mid_f
             };
             sample_conic_color(&normalized, mid_t.clamp(0.0, 1.0))
+        })
+        .collect();
+
+    // box 辺との交点を 0..=N でキャッシュ (隣接 wedge で同じ点を 2 回計算するのを避ける)。
+    let edge_points: Vec<(f32, f32)> = (0..=N)
+        .map(|k| {
+            let theta = from_angle_rad + (k as f32 / N as f32) * std::f32::consts::TAU;
+            box_edge_at_angle(theta, cx, cy, ox, oy, ow, oh)
         })
         .collect();
 
@@ -983,24 +1005,13 @@ fn draw_conic_gradient(
         while j < N && colors[j] == color {
             j += 1;
         }
-        // [i, j) は同色 wedge 群。中心 + theta_i から theta_j までの外周点列で多角形化。
-        let theta_start = from_angle_rad + (i as f32 / N as f32) * two_pi;
-        let theta_end = from_angle_rad + (j as f32 / N as f32) * two_pi;
-
+        // [i, j) の同色 wedge 群を 1 個の多角形にまとめる:
+        //   center → edge_points[i] → edge_points[i+1] → ... → edge_points[j]
         let mut pb = krilla::geom::PathBuilder::new();
         pb.move_to(cx, cy);
-        // 開始端点
-        let (sx, sy) = box_edge_at_angle(theta_start, cx, cy, ox, oy, ow, oh);
-        pb.line_to(sx, sy);
-        // 中間 wedge 境界の外周点を順に追加
-        for k in (i + 1)..j {
-            let theta_k = from_angle_rad + (k as f32 / N as f32) * two_pi;
-            let (px, py) = box_edge_at_angle(theta_k, cx, cy, ox, oy, ow, oh);
+        for &(px, py) in &edge_points[i..=j] {
             pb.line_to(px, py);
         }
-        // 終了端点
-        let (ex, ey) = box_edge_at_angle(theta_end, cx, cy, ox, oy, ow, oh);
-        pb.line_to(ex, ey);
         pb.close();
 
         let Some(path) = pb.finish() else {
@@ -1010,8 +1021,7 @@ fn draw_conic_gradient(
         surface.set_fill(Some(krilla::paint::Fill {
             paint: krilla::color::rgb::Color::new(color[0], color[1], color[2]).into(),
             rule: Default::default(),
-            opacity: krilla::num::NormalizedF32::new(color[3] as f32 / 255.0)
-                .unwrap_or(krilla::num::NormalizedF32::ONE),
+            opacity: crate::pageable::alpha_to_opacity(color[3]),
         }));
         surface.draw_path(&path);
 
@@ -1053,9 +1063,10 @@ fn box_edge_at_angle(
     (cx + t * dx, cy + t * dy)
 }
 
-/// SPIKE: stop position fixup. GradientStop の Auto を線形補間で埋める。
-/// LengthPx は conic ではほぼ来ない (CSS では `<angle>|<percentage>`) ので
-/// 0..1 範囲外として扱い無視する (Phase 1 簡易策)。
+/// stop position fixup. GradientStop の Auto を線形補間で埋める。
+///
+/// CSS では conic の position は `<angle>|<percentage>` のみで `LengthPx` は
+/// 出ないが、共通 `GradientStop` 経由のため変種が来た場合は無視する。
 fn normalize_conic_stops(stops: &[crate::pageable::GradientStop]) -> Vec<(f32, [u8; 4])> {
     use crate::pageable::GradientStopPosition;
     if stops.is_empty() {
@@ -1068,7 +1079,7 @@ fn normalize_conic_stops(stops: &[crate::pageable::GradientStop]) -> Vec<(f32, [
             let p = match s.position {
                 GradientStopPosition::Auto => None,
                 GradientStopPosition::Fraction(f) => Some(f),
-                GradientStopPosition::LengthPx(_) => None, // spike: 無視
+                GradientStopPosition::LengthPx(_) => None,
             };
             (p, s.rgba)
         })

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -3331,3 +3331,167 @@ mod renormalize_stops_to_unit_range_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod conic_helpers_tests {
+    use super::{box_edge_at_angle, normalize_conic_stops, sample_conic_color};
+    use crate::pageable::{GradientStop, GradientStopPosition};
+
+    fn approx_eq(a: f32, b: f32, eps: f32) -> bool {
+        (a - b).abs() < eps
+    }
+
+    #[test]
+    fn box_edge_top() {
+        // CSS 0deg = top → 中心 (50,50) から (50, 0) に向かう
+        let (x, y) = box_edge_at_angle(0.0, 50.0, 50.0, 0.0, 0.0, 100.0, 100.0);
+        assert!(approx_eq(x, 50.0, 0.01));
+        assert!(approx_eq(y, 0.0, 0.01));
+    }
+
+    #[test]
+    fn box_edge_right() {
+        // CSS 90deg = right → 中心から (100, 50) に向かう
+        let (x, y) = box_edge_at_angle(
+            std::f32::consts::FRAC_PI_2,
+            50.0,
+            50.0,
+            0.0,
+            0.0,
+            100.0,
+            100.0,
+        );
+        assert!(approx_eq(x, 100.0, 0.01));
+        assert!(approx_eq(y, 50.0, 0.01));
+    }
+
+    #[test]
+    fn box_edge_bottom() {
+        // CSS 180deg = bottom → 中心から (50, 100) に向かう
+        let (x, y) = box_edge_at_angle(std::f32::consts::PI, 50.0, 50.0, 0.0, 0.0, 100.0, 100.0);
+        assert!(approx_eq(x, 50.0, 0.01));
+        assert!(approx_eq(y, 100.0, 0.01));
+    }
+
+    #[test]
+    fn box_edge_left() {
+        // CSS 270deg = left → 中心から (0, 50) に向かう
+        let (x, y) = box_edge_at_angle(
+            3.0 * std::f32::consts::FRAC_PI_2,
+            50.0,
+            50.0,
+            0.0,
+            0.0,
+            100.0,
+            100.0,
+        );
+        assert!(approx_eq(x, 0.0, 0.01));
+        assert!(approx_eq(y, 50.0, 0.01));
+    }
+
+    #[test]
+    fn box_edge_top_right_corner() {
+        // CSS 45deg = top-right corner direction → ray が top と right の交点に
+        // 当たる前にどちらかの edge にヒット。中心 (50,50)、box (0,0)-(100,100) で
+        // 45deg なら top-right 角 (100, 0) と原点距離が等しいので、辺の早い方に。
+        let (x, y) = box_edge_at_angle(
+            std::f32::consts::FRAC_PI_4,
+            50.0,
+            50.0,
+            0.0,
+            0.0,
+            100.0,
+            100.0,
+        );
+        // 中心から 45deg = (sin, -cos) = (0.707, -0.707)。tx = (100-50)/0.707 = 70.7、
+        // ty = (0-50)/-0.707 = 70.7 → tie。両方の辺に到達 → corner (100, 0) または近傍。
+        assert!(approx_eq(x, 100.0, 0.5));
+        assert!(approx_eq(y, 0.0, 0.5));
+    }
+
+    #[test]
+    fn normalize_with_explicit_fractions() {
+        // 全 stop が Fraction で position 順 → そのまま fraction 化される
+        let stops = vec![
+            GradientStop {
+                position: GradientStopPosition::Fraction(0.0),
+                rgba: [255, 0, 0, 255],
+            },
+            GradientStop {
+                position: GradientStopPosition::Fraction(0.5),
+                rgba: [0, 255, 0, 255],
+            },
+            GradientStop {
+                position: GradientStopPosition::Fraction(1.0),
+                rgba: [0, 0, 255, 255],
+            },
+        ];
+        let n = normalize_conic_stops(&stops);
+        assert_eq!(n.len(), 3);
+        assert_eq!(n[0], (0.0, [255, 0, 0, 255]));
+        assert_eq!(n[1], (0.5, [0, 255, 0, 255]));
+        assert_eq!(n[2], (1.0, [0, 0, 255, 255]));
+    }
+
+    #[test]
+    fn normalize_auto_endpoints_filled() {
+        // Auto Auto Auto → 0.0, 0.5, 1.0 に補間される
+        let stops = vec![
+            GradientStop {
+                position: GradientStopPosition::Auto,
+                rgba: [255, 0, 0, 255],
+            },
+            GradientStop {
+                position: GradientStopPosition::Auto,
+                rgba: [0, 255, 0, 255],
+            },
+            GradientStop {
+                position: GradientStopPosition::Auto,
+                rgba: [0, 0, 255, 255],
+            },
+        ];
+        let n = normalize_conic_stops(&stops);
+        assert_eq!(n.len(), 3);
+        assert!(approx_eq(n[0].0, 0.0, 1e-6));
+        assert!(approx_eq(n[1].0, 0.5, 1e-6));
+        assert!(approx_eq(n[2].0, 1.0, 1e-6));
+    }
+
+    #[test]
+    fn normalize_monotonic_clamp() {
+        // 後ろの stop が前より小さい → 前に合わせる (CSS Images L4 fixup)
+        let stops = vec![
+            GradientStop {
+                position: GradientStopPosition::Fraction(0.5),
+                rgba: [255, 0, 0, 255],
+            },
+            GradientStop {
+                position: GradientStopPosition::Fraction(0.3),
+                rgba: [0, 255, 0, 255],
+            },
+        ];
+        let n = normalize_conic_stops(&stops);
+        assert_eq!(n[1].0, 0.5);
+    }
+
+    #[test]
+    fn sample_at_endpoints() {
+        let stops = vec![(0.0, [255, 0, 0, 255]), (1.0, [0, 0, 255, 255])];
+        assert_eq!(sample_conic_color(&stops, 0.0), [255, 0, 0, 255]);
+        assert_eq!(sample_conic_color(&stops, 1.0), [0, 0, 255, 255]);
+    }
+
+    #[test]
+    fn sample_midpoint_lerps() {
+        let stops = vec![(0.0, [0, 0, 0, 255]), (1.0, [200, 100, 50, 255])];
+        let mid = sample_conic_color(&stops, 0.5);
+        assert_eq!(mid, [100, 50, 25, 255]);
+    }
+
+    #[test]
+    fn sample_clamp_outside_range() {
+        let stops = vec![(0.2, [255, 0, 0, 255]), (0.8, [0, 0, 255, 255])];
+        assert_eq!(sample_conic_color(&stops, 0.0), [255, 0, 0, 255]);
+        assert_eq!(sample_conic_color(&stops, 1.0), [0, 0, 255, 255]);
+    }
+}

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -3048,7 +3048,7 @@ fn extract_block_style(node: &Node, assets: Option<&AssetBundle>) -> BlockStyle 
                         match g.as_ref() {
                             Gradient::Linear { .. } => resolve_linear_gradient(g, &current_color),
                             Gradient::Radial { .. } => resolve_radial_gradient(g, &current_color),
-                            Gradient::Conic { .. } => None,
+                            Gradient::Conic { .. } => resolve_conic_gradient(g, &current_color),
                         }
                     }
                     _ => None,
@@ -3348,6 +3348,92 @@ fn resolve_radial_gradient(
         BgImageContent::RadialGradient {
             shape: out_shape,
             size: out_size,
+            position_x,
+            position_y,
+            stops,
+            repeating,
+        },
+        0.0,
+        0.0,
+    ))
+}
+
+/// SPIKE: Convert Stylo `Gradient::Conic` into `BgImageContent::ConicGradient`.
+///
+/// Phase 1 で sky-bail せず素直に conic を実体化する。stop position は
+/// `<angle>` を `angle / 2π` で fraction 化、`<percentage>` はそのまま fraction
+/// として扱い、共通 `GradientStop` (Auto / Fraction / LengthPx) に正規化する。
+/// 描画は `background.rs::draw_conic_gradient` の path wedge 分解に委ねる。
+fn resolve_conic_gradient(
+    g: &style::values::computed::Gradient,
+    current_color: &style::color::AbsoluteColor,
+) -> Option<(BgImageContent, f32, f32)> {
+    use style::values::computed::AngleOrPercentage;
+    use style::values::computed::image::Gradient;
+    use style::values::generics::image::{GradientFlags, GradientItem};
+
+    let (angle, position, items, flags) = match g {
+        Gradient::Conic {
+            angle,
+            position,
+            items,
+            flags,
+            ..
+        } => (angle, position, items, flags),
+        Gradient::Linear { .. } | Gradient::Radial { .. } => return None,
+    };
+
+    if !flags.contains(GradientFlags::HAS_DEFAULT_COLOR_INTERPOLATION_METHOD) {
+        log::warn!(
+            "conic-gradient: non-default color-interpolation-method is not yet \
+             supported (Phase 2). Layer dropped."
+        );
+        return None;
+    }
+
+    let from_angle = angle.radians();
+    let position_x = try_convert_lp_to_bg(&position.horizontal)?;
+    let position_y = try_convert_lp_to_bg(&position.vertical)?;
+    let repeating = flags.contains(GradientFlags::REPEATING);
+
+    let mut stops: Vec<crate::pageable::GradientStop> = Vec::with_capacity(items.len());
+    for item in items.iter() {
+        use crate::pageable::{GradientStop, GradientStopPosition};
+        match item {
+            GradientItem::SimpleColorStop(c) => {
+                let abs = c.resolve_to_absolute(current_color);
+                stops.push(GradientStop {
+                    position: GradientStopPosition::Auto,
+                    rgba: absolute_to_rgba(abs),
+                });
+            }
+            GradientItem::ComplexColorStop { color, position } => {
+                let abs = color.resolve_to_absolute(current_color);
+                let frac = match position {
+                    AngleOrPercentage::Percentage(p) => p.0,
+                    AngleOrPercentage::Angle(a) => a.radians() / (2.0 * std::f32::consts::PI),
+                };
+                stops.push(GradientStop {
+                    position: GradientStopPosition::Fraction(frac),
+                    rgba: absolute_to_rgba(abs),
+                });
+            }
+            GradientItem::InterpolationHint(_) => {
+                log::warn!(
+                    "conic-gradient: interpolation hints are not yet supported \
+                     (Phase 2). Layer dropped."
+                );
+                return None;
+            }
+        }
+    }
+    if stops.len() < 2 {
+        return None;
+    }
+
+    Some((
+        BgImageContent::ConicGradient {
+            from_angle,
             position_x,
             position_y,
             stops,

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -3361,9 +3361,10 @@ fn resolve_radial_gradient(
 /// Convert Stylo `Gradient::Conic` into `BgImageContent::ConicGradient`.
 ///
 /// stop position は `<angle>` を `angle / 2π` で fraction 化、`<percentage>` は
-/// そのまま fraction として扱い、共通 `GradientStop` (Auto / Fraction / LengthPx)
-/// に正規化する。描画は `background.rs::draw_conic_gradient` の path wedge 分解
-/// に委ねる。
+/// そのまま fraction として `GradientStopPosition::Fraction(f32)` に格納する。
+/// `[0, 1]` 範囲外の生値もそのまま許容し (例: `-30deg → -0.083`, `120% → 1.2`)、
+/// 最終的な周期展開 / 範囲ハンドリングは `background.rs::draw_conic_gradient`
+/// と `sample_conic_color` 側に委ねる。
 fn resolve_conic_gradient(
     g: &style::values::computed::Gradient,
     current_color: &style::color::AbsoluteColor,

--- a/crates/fulgur/src/convert.rs
+++ b/crates/fulgur/src/convert.rs
@@ -3358,12 +3358,12 @@ fn resolve_radial_gradient(
     ))
 }
 
-/// SPIKE: Convert Stylo `Gradient::Conic` into `BgImageContent::ConicGradient`.
+/// Convert Stylo `Gradient::Conic` into `BgImageContent::ConicGradient`.
 ///
-/// Phase 1 で sky-bail せず素直に conic を実体化する。stop position は
-/// `<angle>` を `angle / 2π` で fraction 化、`<percentage>` はそのまま fraction
-/// として扱い、共通 `GradientStop` (Auto / Fraction / LengthPx) に正規化する。
-/// 描画は `background.rs::draw_conic_gradient` の path wedge 分解に委ねる。
+/// stop position は `<angle>` を `angle / 2π` で fraction 化、`<percentage>` は
+/// そのまま fraction として扱い、共通 `GradientStop` (Auto / Fraction / LengthPx)
+/// に正規化する。描画は `background.rs::draw_conic_gradient` の path wedge 分解
+/// に委ねる。
 fn resolve_conic_gradient(
     g: &style::values::computed::Gradient,
     current_color: &style::color::AbsoluteColor,
@@ -3386,7 +3386,7 @@ fn resolve_conic_gradient(
     if !flags.contains(GradientFlags::HAS_DEFAULT_COLOR_INTERPOLATION_METHOD) {
         log::warn!(
             "conic-gradient: non-default color-interpolation-method is not yet \
-             supported (Phase 2). Layer dropped."
+             supported. Layer dropped."
         );
         return None;
     }
@@ -3411,7 +3411,7 @@ fn resolve_conic_gradient(
                 let abs = color.resolve_to_absolute(current_color);
                 let frac = match position {
                     AngleOrPercentage::Percentage(p) => p.0,
-                    AngleOrPercentage::Angle(a) => a.radians() / (2.0 * std::f32::consts::PI),
+                    AngleOrPercentage::Angle(a) => a.radians() / std::f32::consts::TAU,
                 };
                 stops.push(GradientStop {
                     position: GradientStopPosition::Fraction(frac),
@@ -3420,8 +3420,8 @@ fn resolve_conic_gradient(
             }
             GradientItem::InterpolationHint(_) => {
                 log::warn!(
-                    "conic-gradient: interpolation hints are not yet supported \
-                     (Phase 2). Layer dropped."
+                    "conic-gradient: interpolation hints are not yet supported. \
+                     Layer dropped."
                 );
                 return None;
             }

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -844,10 +844,10 @@ pub enum BgImageContent {
     },
     /// CSS `conic-gradient(...)` / `repeating-conic-gradient(...)`.
     ///
-    /// SPIKE 実装: 360 個の固定角三角ウェッジを path で描画する (krilla の
-    /// PostScript shading を使わず、PDF/A 適合)。stops の position は convert 時に
-    /// fraction (0..1) に正規化済み (`<percentage>` はそのまま、`<angle>` は
-    /// `angle / 2π`)。
+    /// stops の position は convert 時に fraction (0..1) に正規化済み
+    /// (`<percentage>` はそのまま、`<angle>` は `angle / 2π`)。draw 経路は
+    /// PostScript shading を使わず path wedge 分解で発行するため PDF/A-1, A-2
+    /// 適合 (`background.rs::draw_conic_gradient`)。
     ConicGradient {
         /// CSS `from <angle>` を radians で保持 (規約: 0=top, CW)。
         from_angle: f32,

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -844,10 +844,12 @@ pub enum BgImageContent {
     },
     /// CSS `conic-gradient(...)` / `repeating-conic-gradient(...)`.
     ///
-    /// stops の position は convert 時に fraction (0..1) に正規化済み
-    /// (`<percentage>` はそのまま、`<angle>` は `angle / 2π`)。draw 経路は
-    /// PostScript shading を使わず path wedge 分解で発行するため PDF/A-1, A-2
-    /// 適合 (`background.rs::draw_conic_gradient`)。
+    /// stops の position は convert 時に **生 fraction** として保持する
+    /// (`<percentage>` はそのまま、`<angle>` は `angle / 2π`)。`[0, 1]` を
+    /// 跨ぐ値 (例: `-30deg → -0.083`, `120% → 1.2`) もそのまま許容し、
+    /// 最終的な範囲ハンドリングと repeating の周期展開は draw 時に行う。
+    /// draw 経路は PostScript shading を使わず path wedge 分解で発行する
+    /// ため PDF/A-1, A-2 適合 (`background.rs::draw_conic_gradient`)。
     ConicGradient {
         /// CSS `from <angle>` を radians で保持 (規約: 0=top, CW)。
         from_angle: f32,

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -842,6 +842,20 @@ pub enum BgImageContent {
         stops: Vec<GradientStop>,
         repeating: bool,
     },
+    /// CSS `conic-gradient(...)` / `repeating-conic-gradient(...)`.
+    ///
+    /// SPIKE 実装: 360 個の固定角三角ウェッジを path で描画する (krilla の
+    /// PostScript shading を使わず、PDF/A 適合)。stops の position は convert 時に
+    /// fraction (0..1) に正規化済み (`<percentage>` はそのまま、`<angle>` は
+    /// `angle / 2π`)。
+    ConicGradient {
+        /// CSS `from <angle>` を radians で保持 (規約: 0=top, CW)。
+        from_angle: f32,
+        position_x: BgLengthPercentage,
+        position_y: BgLengthPercentage,
+        stops: Vec<GradientStop>,
+        repeating: bool,
+    },
 }
 
 /// A single CSS background image layer with all associated properties.

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -218,3 +218,87 @@ fn test_render_linear_gradient_tiled_smoke() {
         .expect("render tiled linear gradient");
     assert!(!pdf.is_empty());
 }
+
+#[test]
+fn test_render_html_conic_gradient_pie_chart() {
+    // 4 セクター pie chart。draw_conic_gradient が path wedge を発行し、
+    // 同色 wedge は merge されて step transition を表現する。
+    let html = r#"<!DOCTYPE html><html><body>
+        <div style="width:200px;height:200px;
+            background:conic-gradient(
+                red 0deg, red 90deg,
+                yellow 90deg, yellow 180deg,
+                green 180deg, green 270deg,
+                blue 270deg, blue 360deg);"></div>
+    </body></html>"#;
+    let pdf = Engine::builder()
+        .build()
+        .render_html(html)
+        .expect("render conic pie chart");
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn test_render_html_conic_gradient_smooth() {
+    // 滑らか conic (auto-positioned stops)。fixup と sample_conic_color が
+    // 360 wedge ぶん補間色を計算する経路を通す。
+    let html = r#"<!DOCTYPE html><html><body>
+        <div style="width:200px;height:200px;
+            background:conic-gradient(red, yellow, green, blue, red);"></div>
+    </body></html>"#;
+    let pdf = Engine::builder()
+        .build()
+        .render_html(html)
+        .expect("render smooth conic");
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn test_render_html_repeating_conic_gradient() {
+    // repeating-conic-gradient: period = (last - first) で fraction を周期化する経路。
+    let html = r#"<!DOCTYPE html><html><body>
+        <div style="width:200px;height:200px;
+            background:repeating-conic-gradient(
+                red 0deg, red 15deg, blue 15deg, blue 30deg);"></div>
+    </body></html>"#;
+    let pdf = Engine::builder()
+        .build()
+        .render_html(html)
+        .expect("render repeating conic");
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn test_render_html_conic_gradient_from_angle() {
+    // from <angle> で sweep 開始位置をシフトする経路。
+    let html = r#"<!DOCTYPE html><html><body>
+        <div style="width:200px;height:200px;
+            background:conic-gradient(from 90deg,
+                red 0deg, red 90deg,
+                blue 90deg, blue 360deg);"></div>
+    </body></html>"#;
+    let pdf = Engine::builder()
+        .build()
+        .render_html(html)
+        .expect("render conic with from angle");
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn test_render_html_conic_gradient_at_position() {
+    // at <position> で中心オフセットする経路。box_edge_at_angle が中心 ≠ box 中央
+    // のケースを扱うことを確認。
+    let html = r#"<!DOCTYPE html><html><body>
+        <div style="width:200px;height:200px;
+            background:conic-gradient(at 25% 75%,
+                red 0deg, red 90deg,
+                yellow 90deg, yellow 180deg,
+                green 180deg, green 270deg,
+                blue 270deg, blue 360deg);"></div>
+    </body></html>"#;
+    let pdf = Engine::builder()
+        .build()
+        .render_html(html)
+        .expect("render conic with offset center");
+    assert!(!pdf.is_empty());
+}

--- a/docs/plans/2026-04-27-conic-gradient.md
+++ b/docs/plans/2026-04-27-conic-gradient.md
@@ -1,1037 +1,114 @@
-# Conic-gradient Implementation Plan
+# Conic-gradient Implementation (fulgur-m92h)
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+**Status:** Implemented (path wedge approach, PDF/A safe by default)
 
-**Goal:** CSS `conic-gradient(...)` / `repeating-conic-gradient(...)` を Krilla の `SweepGradient` 経由で PDF に描画する。Phase 1 (linear) / Phase 2 (radial) と同じく、サポート外の機能は `log::warn!` + `None` 返却で layer drop。
+## Goal
+
+CSS `conic-gradient(...)` / `repeating-conic-gradient(...)` を PDF に描画する。
+PDF/A-1 / PDF/A-2 適合性を初期実装から確保するため、krilla の `SweepGradient`
+(PostScript Type 4 function shading) は使わず、krilla 公開 API のみで完結する
+**path wedge 分解** で実装する。
 
-**Architecture:** `convert.rs` で Stylo の `Gradient::Conic` から `BgImageContent::ConicGradient` を生成し、`background.rs::draw_conic_gradient` が krilla `SweepGradient` を発行する。CSS の角度規約 (0deg=top, CW) と krilla の sweep 規約 (0deg=right, 増加方向は要検証) の差は draw 段階の角度変換で吸収。
+## Design Pivot (2026-04-27)
 
-**Tech Stack:** Stylo (`Gradient::Conic`) / krilla 0.7 (`SweepGradient`) / fulgur-vrt (test↔ref pixel diff harness)
-
-**Issue:** `fulgur-m92h` (parent epic: `fulgur-5166`)
-
-**PDF/A 注記:** krilla `SweepGradient` は内部で PostScript Type 4 function shading を発行 → PDF/A-1, A-2 非適合。本 PR ではフラグ判定をしない。代替経路は `fulgur-batz` (PDF/A-safe fallback) で扱う。
-
----
-
-## Task 1: lib smoke test を先に書く (failing baseline)
-
-**Files:**
-
-- Modify: `crates/fulgur/tests/render_smoke.rs` (末尾に追記)
-
-**Step 1: failing test を書く**
-
-```rust
-#[test]
-fn test_render_html_conic_gradient_basic() {
-    let html = r#"<!DOCTYPE html><html><body>
-        <div style="width:100px;height:100px;
-            background:conic-gradient(red, yellow, green, blue, red);"></div>
-    </body></html>"#;
-    let pdf = Engine::builder()
-        .build()
-        .render_html(html)
-        .expect("render conic-gradient");
-    assert!(!pdf.is_empty(), "PDF should not be empty");
-    // Phase 1 (silent fallback) では gradient が出ないため、
-    // 本 PR 完了後はこのテストが通り、conic 経路が draw されることを保証する。
-}
-
-#[test]
-fn test_render_html_repeating_conic_gradient() {
-    let html = r#"<!DOCTYPE html><html><body>
-        <div style="width:100px;height:100px;
-            background:repeating-conic-gradient(red 0deg, blue 30deg);"></div>
-    </body></html>"#;
-    let pdf = Engine::builder()
-        .build()
-        .render_html(html)
-        .expect("render repeating-conic-gradient");
-    assert!(!pdf.is_empty());
-}
-```
-
-**Step 2: 実行して fail を確認**
-
-```bash
-cargo test -p fulgur --test render_smoke test_render_html_conic_gradient_basic
-cargo test -p fulgur --test render_smoke test_render_html_repeating_conic_gradient
-```
-
-期待: 両方 `assert!(!pdf.is_empty())` の手前で render 自体は成功するはずだが、本 PR 完了後にデータパスを通って実際に描画されることを以後のタスクで担保する。
-
-**Step 3: commit**
-
-```bash
-git add crates/fulgur/tests/render_smoke.rs
-git commit -m "test(gradient): add lib smoke for conic-gradient (failing baseline)"
-```
-
----
-
-## Task 2: pageable.rs にデータモデルを追加
-
-**Files:**
-
-- Modify: `crates/fulgur/src/pageable.rs` (`BgImageContent` enum 周辺、行 819 付近)
-
-**Step 1: 新型を追加**
-
-`pageable.rs` の `RadialGradient` variant の後に挿入:
-
-```rust
-/// CSS conic-gradient stop の位置指定。
-///
-/// CSS Images Level 4 §3.x: stop position は `<angle> | <percentage>`。
-/// `<percentage>` は 360deg を 100% として解釈する。
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum ConicStopPosition {
-    /// 位置省略 — 周囲の固定 stop から等間隔補間で fixup される。
-    Auto,
-    /// `<percentage>` を [0.0, 1.0] の fraction として保持。
-    /// CSS では負値や 1.0 超過もあり得る (out-of-range) — fixup で扱う。
-    Fraction(f32),
-    /// `<angle>` を radians で保持。draw 時に `angle / 2π` で fraction 化。
-    AngleRad(f32),
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct ConicGradientStop {
-    pub position: ConicStopPosition,
-    pub rgba: [u8; 4],
-}
-```
-
-`BgImageContent` enum の `RadialGradient` の後に variant を追加:
-
-```rust
-/// CSS `conic-gradient(...)` / `repeating-conic-gradient(...)`.
-/// `from_angle` は radians (CSS 規約: 0=top, 増加方向=CW)。
-/// `repeating=true` の場合、period = (last_stop_fraction - first_stop_fraction) で
-/// `[0, 1]` を覆うだけ stop 列を平行コピーする (CSS Images 4 §3.x)。
-ConicGradient {
-    from_angle: f32,
-    position_x: BgLengthPercentage,
-    position_y: BgLengthPercentage,
-    stops: Vec<ConicGradientStop>,
-    repeating: bool,
-},
-```
-
-**Step 2: コンパイル確認**
-
-```bash
-cargo build -p fulgur --lib
-```
-
-期待: warning は出る (未使用 variant) が build は通る。
-
-**Step 3: commit**
-
-```bash
-git add crates/fulgur/src/pageable.rs
-git commit -m "feat(gradient): add ConicGradient variant and stop types to BgImageContent"
-```
-
----
-
-## Task 3: convert.rs に `resolve_conic_gradient` を追加
-
-**Files:**
-
-- Modify: `crates/fulgur/src/convert.rs` (`Gradient::Conic { .. } => None` の置き換え + 新関数)
-
-**Step 1: dispatcher 行を変更**
-
-行 3045 付近の match を:
-
-```rust
-Image::Gradient(g) => {
-    use style::values::computed::image::Gradient;
-    match g.as_ref() {
-        Gradient::Linear { .. } => resolve_linear_gradient(g, &current_color),
-        Gradient::Radial { .. } => resolve_radial_gradient(g, &current_color),
-        Gradient::Conic  { .. } => resolve_conic_gradient(g, &current_color),
-    }
-}
-```
-
-**Step 2: `resolve_conic_gradient` を追加**
-
-`resolve_color_stops` の前後に新関数を追加:
-
-```rust
-/// Convert a Stylo computed `Gradient::Conic` into `BgImageContent::ConicGradient`.
-///
-/// 失敗 (None) 条件:
-/// - 非デフォルト color_interpolation_method (例: `in oklch`)
-/// - InterpolationHint
-/// - position の calc() (Length にも Percentage にも resolve できない)
-/// - stops < 2
-fn resolve_conic_gradient(
-    g: &style::values::computed::Gradient,
-    current_color: &style::color::AbsoluteColor,
-) -> Option<(BgImageContent, f32, f32)> {
-    use crate::pageable::BgLengthPercentage;
-    use style::values::computed::image::Gradient;
-    use style::values::generics::image::GradientFlags;
-
-    let (angle, position, items, flags) = match g {
-        Gradient::Conic {
-            angle,
-            position,
-            items,
-            flags,
-            ..
-        } => (angle, position, items, flags),
-        Gradient::Linear { .. } | Gradient::Radial { .. } => return None,
-    };
-
-    if !flags.contains(GradientFlags::HAS_DEFAULT_COLOR_INTERPOLATION_METHOD) {
-        log::warn!(
-            "conic-gradient: non-default color-interpolation-method is not yet \
-             supported (Phase 2). Layer dropped."
-        );
-        return None;
-    }
-
-    // CSS `from <angle>` を radians に変換。Stylo の Angle は内部 deg なので
-    // .radians() を使う (linear と同じ流儀)。
-    let from_angle = angle.radians();
-
-    // Center position は radial と同じヘルパ。calc() は None で bail。
-    let position_x = try_convert_lp_to_bg(&position.horizontal)?;
-    let position_y = try_convert_lp_to_bg(&position.vertical)?;
-
-    let repeating = flags.contains(GradientFlags::REPEATING);
-
-    let stops = resolve_conic_color_stops(items, current_color)?;
-
-    Some((
-        BgImageContent::ConicGradient {
-            from_angle,
-            position_x,
-            position_y,
-            stops,
-            repeating,
-        },
-        0.0,
-        0.0,
-    ))
-}
-
-/// Resolve conic-gradient color stops into `Vec<ConicGradientStop>`.
-///
-/// linear/radial の `resolve_color_stops` は `LengthPercentage` 用なので
-/// conic の `AngleOrPercentage` には別実装が必要。
-fn resolve_conic_color_stops(
-    items: &[style::values::generics::image::GenericGradientItem<
-        style::values::computed::Color,
-        style::values::computed::AngleOrPercentage,
-    >],
-    current_color: &style::color::AbsoluteColor,
-) -> Option<Vec<crate::pageable::ConicGradientStop>> {
-    use crate::pageable::{ConicGradientStop, ConicStopPosition};
-    use style::values::computed::AngleOrPercentage;
-    use style::values::generics::image::GradientItem;
-
-    let mut out: Vec<ConicGradientStop> = Vec::with_capacity(items.len());
-    for item in items.iter() {
-        match item {
-            GradientItem::SimpleColorStop(c) => {
-                let abs = c.resolve_to_absolute(current_color);
-                out.push(ConicGradientStop {
-                    position: ConicStopPosition::Auto,
-                    rgba: absolute_to_rgba(abs),
-                });
-            }
-            GradientItem::ComplexColorStop { color, position } => {
-                let abs = color.resolve_to_absolute(current_color);
-                let pos = match position {
-                    AngleOrPercentage::Angle(a) => ConicStopPosition::AngleRad(a.radians()),
-                    AngleOrPercentage::Percentage(p) => ConicStopPosition::Fraction(p.0),
-                };
-                out.push(ConicGradientStop {
-                    position: pos,
-                    rgba: absolute_to_rgba(abs),
-                });
-            }
-            GradientItem::InterpolationHint(_) => {
-                log::warn!(
-                    "conic-gradient: interpolation hints are not yet supported \
-                     (Phase 2). Layer dropped."
-                );
-                return None;
-            }
-        }
-    }
-
-    if out.len() < 2 {
-        return None;
-    }
-    Some(out)
-}
-```
-
-**注意:** `try_convert_lp_to_bg` は `convert.rs:3406` 付近に radial 用の
-helper として存在する (calc() は None を返す)。新規にヘルパを切り出さず流用すること。
-
-**Step 3: コンパイル確認**
-
-```bash
-cargo build -p fulgur --lib
-```
-
-期待: build 通る。warning は減るはず。
-
-**Step 4: commit**
-
-```bash
-git add crates/fulgur/src/convert.rs
-git commit -m "feat(gradient): resolve Stylo Gradient::Conic into BgImageContent::ConicGradient"
-```
-
----
-
-## Task 4: background.rs に no-op draw 経路を追加 (skeleton)
-
-これは draw を実装する前に、dispatch だけ通して E2E が通る形に仮置きする
-中間 step。次のタスクで実体を入れる。
-
-**Files:**
-
-- Modify: `crates/fulgur/src/background.rs` (行 208 と行 238 の match arm)
-
-**Step 1: image-size 判定に ConicGradient を含める**
-
-行 208:
-
-```rust
-let (img_w, img_h) = match &layer.content {
-    BgImageContent::LinearGradient { .. }
-    | BgImageContent::RadialGradient { .. }
-    | BgImageContent::ConicGradient { .. } => {
-        resolve_gradient_size(&layer.size, ow, oh)
-    }
-    BgImageContent::Raster { .. } | BgImageContent::Svg { .. } => resolve_size(layer, ow, oh),
-};
-```
-
-**Step 2: 主要 match arm に no-op skeleton を追加**
-
-行 344 (Raster の前) に挿入:
-
-```rust
-BgImageContent::ConicGradient {
-    from_angle,
-    position_x,
-    position_y,
-    stops,
-    repeating,
-} => {
-    // Linear/Radial と同じ uniform-tile ショートカットは Phase 1 では入れず、
-    // 必ず per-tile loop で draw する (conic 自体が初回実装で複雑なため)。
-    for (tx, ty, tw, th) in &tiles {
-        draw_conic_gradient(
-            canvas.surface,
-            *from_angle,
-            position_x,
-            position_y,
-            stops,
-            *repeating,
-            *tx,
-            *ty,
-            *tw,
-            *th,
-        );
-    }
-}
-```
-
-そして同ファイル末尾 (行 760 付近、`draw_radial_gradient` の後) に stub:
-
-```rust
-/// Phase 1 stub. 実体は次のタスクで実装する。
-#[allow(clippy::too_many_arguments)]
-fn draw_conic_gradient(
-    _surface: &mut krilla::surface::Surface<'_>,
-    _from_angle_rad: f32,
-    _position_x: &BgLengthPercentage,
-    _position_y: &BgLengthPercentage,
-    _stops: &[crate::pageable::ConicGradientStop],
-    _repeating: bool,
-    _ox: f32,
-    _oy: f32,
-    _ow: f32,
-    _oh: f32,
-) {
-    // TODO(fulgur-m92h): wire krilla::paint::SweepGradient
-}
-```
-
-**Step 3: コンパイル + lib smoke を確認**
-
-```bash
-cargo build -p fulgur --lib
-cargo test -p fulgur --test render_smoke test_render_html_conic_gradient_basic
-cargo test -p fulgur --test render_smoke test_render_html_repeating_conic_gradient
-```
-
-期待: build 通る。smoke はまだ「何も描画しない」が `pdf.is_empty()` ではないので pass する。
-(背景以外の構造で PDF stream は生成されるため)。
-
-**Step 4: commit**
-
-```bash
-git add crates/fulgur/src/background.rs
-git commit -m "feat(gradient): add ConicGradient dispatch skeleton in draw_background_layer"
-```
-
----
-
-## Task 5: 4 象限 VRT harness で direction 検証 (TDD)
-
-ここが本 PR で最も慎重に進めるべき箇所。krilla SweepGradient の角度規約を
-empirical に確定する。
-
-**Files:**
-
-- Create: `crates/fulgur-vrt/tests/conic_gradient_harness.rs`
-- Create: `crates/fulgur-vrt/fixtures/paint/conic-gradient-quadrant.html`
-- Modify: `crates/fulgur-vrt/Cargo.toml` (test 自動検出されるので変更不要のはず)
-
-**Step 1: test fixture HTML を作成**
-
-`crates/fulgur-vrt/fixtures/paint/conic-gradient-quadrant.html`:
-
-```html
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>VRT test: conic-gradient 4 quadrants</title>
-<style>
-  html, body { margin: 0; padding: 0; background: white; }
-  .box {
-    width: 192px;
-    height: 192px;
-    margin: 32px;
-    background: conic-gradient(
-      red 0deg,
-      red 90deg,
-      yellow 90deg,
-      yellow 180deg,
-      green 180deg,
-      green 270deg,
-      blue 270deg,
-      blue 360deg
-    );
-  }
-</style>
-</head>
-<body>
-  <div class="box"></div>
-</body>
-</html>
-```
-
-(連続した同色 stop で 4 セクターを離散化 — gradient 補間ではなく境界の鮮明な
-4 色塗りになる。ref と pixel-perfect 一致させやすい)
-
-**Step 2: ref builder を含む harness を作成**
-
-```rust
-//! Test↔ref pixel-diff harness for conic-gradient implementation.
-//!
-//! 4 個の 90° セクター fixture を、CSS `clip-path: polygon(...)` で扇形を
-//! 作った 4 個の絶対配置 div に置き換えた ref と pixel-wise 比較する。
-//! conic-gradient の角度規約 (0deg=top, CW) を empirical に検証する。
-//!
-//! 採用しなかった案:
-//! - SVG `<linearGradient>` 集合 ref → 自前 SVG パイプラインに依存
-//! - PNG raster ref → CI 再現性で扱いづらい
-
-use fulgur_vrt::diff::{self};
-use fulgur_vrt::manifest::Tolerance;
-use fulgur_vrt::pdf_render::{RenderSpec, pdf_to_rgba, render_html_to_pdf};
-use std::fs;
-use std::path::PathBuf;
-
-const BOX_PX: u32 = 192;
-const MARGIN_PX: u32 = 32;
-
-fn build_quadrant_ref_html() -> String {
-    // 4 sectors. `clip-path: polygon()` の頂点は box の外周 4 辺と中心 (96, 96)。
-    // CSS conic-gradient(red 0deg, red 90deg, ...) の規約:
-    //   - 0deg = box の上端中央
-    //   - 増加方向 = clockwise (画面視点)
-    //   - red sector = 0..90deg = top → right (右上 1/4)
-    //   - yellow sector = 90..180deg = right → bottom (右下 1/4)
-    //   - green sector = 180..270deg = bottom → left (左下 1/4)
-    //   - blue sector = 270..360deg = left → top (左上 1/4)
-    format!(
-        r#"<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>VRT ref: conic-gradient 4 quadrants</title>
-<style>
-  html, body {{ margin: 0; padding: 0; background: white; }}
-  .box {{ position: relative; width: {w}px; height: {h}px; margin: {m}px; }}
-  .sector {{ position: absolute; inset: 0; }}
-  .red    {{ background: red;    clip-path: polygon(50% 50%, 50%   0%, 100%   0%, 100% 50%); }}
-  .yellow {{ background: yellow; clip-path: polygon(50% 50%, 100% 50%, 100% 100%,  50% 100%); }}
-  .green  {{ background: green;  clip-path: polygon(50% 50%,  50% 100%,   0% 100%,   0% 50%); }}
-  .blue   {{ background: blue;   clip-path: polygon(50% 50%,   0% 50%,   0%   0%,  50%   0%); }}
-</style>
-</head>
-<body>
-  <div class="box">
-    <div class="sector red"></div>
-    <div class="sector yellow"></div>
-    <div class="sector green"></div>
-    <div class="sector blue"></div>
-  </div>
-</body>
-</html>"#,
-        w = BOX_PX, h = BOX_PX, m = MARGIN_PX,
-    )
-}
-
-#[test]
-fn conic_gradient_4_quadrants_match_polygon_reference() {
-    let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let test_html_path = crate_root.join("fixtures/paint/conic-gradient-quadrant.html");
-    let test_html = fs::read_to_string(&test_html_path)
-        .unwrap_or_else(|e| panic!("read {}: {e}", test_html_path.display()));
-
-    let ref_html = build_quadrant_ref_html();
-
-    let spec = RenderSpec { page_size: "A4", margin_pt: Some(0.0), dpi: 150 };
-
-    let test_pdf = render_html_to_pdf(&test_html, spec).expect("render test pdf");
-    let ref_pdf = render_html_to_pdf(&ref_html, spec).expect("render ref pdf");
-
-    let work_dir = crate_root.parent().and_then(|p| p.parent())
-        .expect("workspace root")
-        .join("target/vrt-conic-gradient-harness");
-    fs::create_dir_all(&work_dir).expect("create work dir");
-    let test_dir = work_dir.join("test");
-    let ref_dir = work_dir.join("ref");
-    let _ = fs::remove_dir_all(&test_dir);
-    let _ = fs::remove_dir_all(&ref_dir);
-    fs::create_dir_all(&test_dir).expect("create test dir");
-    fs::create_dir_all(&ref_dir).expect("create ref dir");
-
-    let test_png = pdf_to_rgba(&test_pdf, &test_dir).expect("rasterize test pdf");
-    let ref_png = pdf_to_rgba(&ref_pdf, &ref_dir).expect("rasterize ref pdf");
-
-    // セクター境界の AA 1〜2 px を考慮し radial と同レベルの tolerance:
-    let tolerance = Tolerance { max_pixel_diff: 12.0, max_diff_ratio: 0.02 };
-
-    diff::assert_images_match(&test_png, &ref_png, &tolerance, &work_dir)
-        .expect("conic-gradient quadrants should match polygon ref");
-}
-```
-
-(`diff` / `Tolerance` / `pdf_render` の正確な API は `radial_gradient_harness.rs`
-からコピーして参照する)
-
-**Step 3: 実行して fail を確認**
-
-```bash
-FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" \
-    cargo test -p fulgur-vrt --test conic_gradient_harness
-```
-
-期待: test fixture 側は draw stub で何も塗らないので白地、ref は 4 色 → fail。
-
-**Step 4: commit**
-
-```bash
-git add crates/fulgur-vrt/tests/conic_gradient_harness.rs \
-        crates/fulgur-vrt/fixtures/paint/conic-gradient-quadrant.html
-git commit -m "test(gradient): add conic-gradient 4-quadrant VRT harness (failing baseline)"
-```
-
----
-
-## Task 6: `draw_conic_gradient` 実体を実装 (krilla SweepGradient)
-
-**Files:**
-
-- Modify: `crates/fulgur/src/background.rs` (Task 4 で置いた stub)
-
-**Step 1: 実装 — まずは想定マッピング**
-
-```rust
-#[allow(clippy::too_many_arguments)]
-fn draw_conic_gradient(
-    surface: &mut krilla::surface::Surface<'_>,
-    from_angle_rad: f32,
-    position_x: &BgLengthPercentage,
-    position_y: &BgLengthPercentage,
-    stops: &[crate::pageable::ConicGradientStop],
-    repeating: bool,
-    ox: f32, oy: f32, ow: f32, oh: f32,
-) {
-    use crate::pageable::ConicStopPosition;
-
-    if ow <= 0.0 || oh <= 0.0 || stops.len() < 2 {
-        return;
-    }
-
-    let cx = ox + resolve_point(position_x, ow);
-    let cy = oy + resolve_point(position_y, oh);
-
-    // Stop position を fraction (0..1) に正規化:
-    //   Auto      → そのまま (後段 fixup で埋まる)
-    //   Fraction  → そのまま
-    //   AngleRad  → angle_rad / (2π)
-    let normalized: Vec<(Option<f32>, [u8; 4])> = stops
-        .iter()
-        .map(|s| {
-            let frac = match s.position {
-                ConicStopPosition::Auto => None,
-                ConicStopPosition::Fraction(f) => Some(f),
-                ConicStopPosition::AngleRad(a) => Some(a / (2.0 * std::f32::consts::PI)),
-            };
-            (frac, s.rgba)
-        })
-        .collect();
-
-    // CSS Images Level 4 §3.x stop fixup:
-    //   1. 先頭 Auto は 0.0、末尾 Auto は 1.0 に確定
-    //   2. monotonic clamp (前 fixed より小さければ前 fixed に合わせる)
-    //   3. 中間 Auto 群を前後 fixed の等間隔補間で埋める
-    let fixed = fixup_conic_stops(normalized);
-    if fixed.len() < 2 {
-        return;
-    }
-
-    let first_pos = fixed.first().unwrap().0;
-    let last_pos = fixed.last().unwrap().0;
-    let period = (last_pos - first_pos).max(f32::EPSILON);
-
-    // 角度変換 (CSS → krilla):
-    //   - CSS: 0deg = top, 増加方向 = CW (screen view)
-    //   - krilla SweepGradient: 0deg = right, 増加方向は内部 PostScript Atan に依存
-    //   - 想定: krilla_start_deg = 90 - css_from_deg、sweep は -360deg 方向
-    let from_angle_deg = from_angle_rad.to_degrees();
-    let krilla_start_deg = 90.0 - from_angle_deg - first_pos * 360.0;
-    let krilla_end_deg = if repeating {
-        krilla_start_deg - period * 360.0
-    } else {
-        krilla_start_deg - 360.0
-    };
-
-    let spread = if repeating {
-        krilla::paint::SpreadMethod::Repeat
-    } else {
-        krilla::paint::SpreadMethod::Pad
-    };
-
-    // krilla Stop 列を構築。fraction を [0, 1] に再正規化:
-    //   p_norm = (p - first) / period
-    let krilla_stops: Vec<krilla::paint::Stop> = fixed.iter().map(|(p, rgba)| {
-        let p_norm = (p - first_pos) / period;
-        krilla::paint::Stop {
-            offset: krilla::num::NormalizedF32::new(p_norm.clamp(0.0, 1.0)).unwrap(),
-            color: krilla::color::rgb::Rgb::new(rgba[0], rgba[1], rgba[2]).into(),
-            opacity: krilla::num::NormalizedF32::new(rgba[3] as f32 / 255.0).unwrap(),
-        }
-    }).collect();
-
-    let sweep = krilla::paint::SweepGradient {
-        cx,
-        cy,
-        start_angle: krilla_start_deg,
-        end_angle: krilla_end_deg,
-        transform: krilla::geom::Transform::default(),
-        spread_method: spread,
-        stops: krilla_stops,
-        anti_alias: false,
-    };
-
-    surface.set_fill(Some(krilla::paint::Fill {
-        paint: sweep.into(),
-        rule: Default::default(),
-        opacity: krilla::num::NormalizedF32::ONE,
-    }));
-    surface.set_stroke(None);
-
-    let Some(rect_path) = build_rect_path(ox, oy, ow, oh) else {
-        surface.set_fill(None);
-        return;
-    };
-    surface.draw_path(&rect_path);
-    surface.set_fill(None);
-}
-
-/// CSS Images Level 4 stop fixup for conic gradients.
-fn fixup_conic_stops(stops: Vec<(Option<f32>, [u8; 4])>) -> Vec<(f32, [u8; 4])> {
-    if stops.is_empty() {
-        return Vec::new();
-    }
-    let mut fixed: Vec<(Option<f32>, [u8; 4])> = stops;
-
-    // 1. 先頭/末尾の Auto を確定
-    if fixed[0].0.is_none() { fixed[0].0 = Some(0.0); }
-    let last = fixed.len() - 1;
-    if fixed[last].0.is_none() { fixed[last].0 = Some(1.0); }
-
-    // 2. monotonic clamp (前向きスキャンで前 fixed >= 現値なら前に合わせる)
-    let mut prev: f32 = fixed[0].0.unwrap();
-    for s in fixed.iter_mut().skip(1) {
-        if let Some(p) = s.0 {
-            if p < prev { s.0 = Some(prev); }
-            prev = s.0.unwrap();
-        }
-    }
-
-    // 3. 中間 Auto 群を前後 fixed の等間隔で補間
-    let mut i = 0usize;
-    while i < fixed.len() {
-        if fixed[i].0.is_some() { i += 1; continue; }
-        // 連続 Auto 群を見つけて [i..j) を等間隔補間
-        let prev_pos = fixed[i - 1].0.unwrap();
-        let mut j = i;
-        while j < fixed.len() && fixed[j].0.is_none() { j += 1; }
-        let next_pos = fixed[j].0.unwrap();
-        let count = j - i + 1;
-        for k in 0..(j - i) {
-            let t = (k + 1) as f32 / count as f32;
-            fixed[i + k].0 = Some(prev_pos + (next_pos - prev_pos) * t);
-        }
-        i = j;
-    }
-
-    fixed.into_iter().map(|(p, rgba)| (p.unwrap(), rgba)).collect()
-}
-```
-
-**Step 2: lib smoke + 4 象限 VRT を実行**
-
-```bash
-cargo test -p fulgur --test render_smoke test_render_html_conic_gradient
-FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" \
-    cargo test -p fulgur-vrt --test conic_gradient_harness
-```
-
-期待: lib smoke は pass。VRT は **角度規約が想定と合っていれば pass、外れていれば pixel diff が出る**。
-
-**Step 3: angle 規約のデバッグ (VRT が fail した場合のみ)**
-
-VRT が fail した場合、生成された pixel diff 画像 (`target/vrt-conic-gradient-harness/diff_*.png`) を見て、advisor 指摘の 3 分類で判定する:
-
-- **全色が同じ方向に 1 象限ずれ** → `krilla_start_deg` のオフセットを再検討 (90.0 ± k×90)
-- **増加方向だけ逆 (red/blue が左右反転)** → `krilla_end_deg = krilla_start_deg + 360.0` (sweep 反転) + krilla `stops` 逆順 (`fixed.iter().rev()`) + 各 stop の `p_norm` を `1.0 - p_norm` に
-- **完全にランダム / Y-flip 疑い** → krilla COLR (`text/glyph/colr.rs:400`) で
-  `Transform::from_scale(1.0, -1.0)` + `cy: -cy` を入れていた件と同じ。
-  `sweep.transform = krilla::geom::Transform::from_scale(1.0, -1.0)`、`cy: -cy` で再試行。
-
-修正後 もう一度実行。
-
-**重複 stop の注意:** Task 5 の fixture は `red 90deg, yellow 90deg` のような
-同一 offset stop を使う (CSS step transition)。krilla `Stop` の `offset` が
-同値で並ぶと未定義動作の可能性があるため、`fixup_conic_stops` の後で
-**隣接 stop が完全同値の場合のみ** 後者に `1e-6` を足す nudge を入れる:
-
-```rust
-for i in 1..fixed.len() {
-    if (fixed[i].0 - fixed[i - 1].0).abs() < f32::EPSILON {
-        fixed[i].0 = (fixed[i - 1].0 + 1e-6).min(1.0);
-    }
-}
-```
-
-**Step 4: VRT pass を確認 + commit**
-
-```bash
-git add crates/fulgur/src/background.rs
-git commit -m "feat(gradient): implement draw_conic_gradient via krilla SweepGradient"
-```
-
----
-
-## Task 7: `from <angle>` 検証 fixture と test を追加
-
-**Files:**
-
-- Create: `crates/fulgur-vrt/fixtures/paint/conic-gradient-from-90.html`
-- Modify: `crates/fulgur-vrt/tests/conic_gradient_harness.rs`
-
-**Step 1: fixture を追加**
-
-```html
-<!-- conic-gradient-from-90.html -->
-<!DOCTYPE html>
-<html lang="en">
-<head><meta charset="utf-8"><title>VRT test: from 90deg</title>
-<style>
-  html, body { margin:0; padding:0; background:white; }
-  .box {
-    width:192px; height:192px; margin:32px;
-    background: conic-gradient(from 90deg,
-      red 0deg, red 90deg,
-      yellow 90deg, yellow 180deg,
-      green 180deg, green 270deg,
-      blue 270deg, blue 360deg);
-  }
-</style>
-</head>
-<body><div class="box"></div></body>
-</html>
-```
-
-`from 90deg` は CSS 0% を 90deg (= screen 右) にシフトするので、red sector が
-右下 1/4、yellow が左下、green が左上、blue が右上 になる。
-
-**Step 2: ref builder を 90° rotate した版に拡張**
-
-```rust
-fn build_quadrant_ref_html_rotated_90() -> String {
-    format!(
-        r#"...
-  .red    {{ background: red;    clip-path: polygon(50% 50%, 100% 50%, 100% 100%,  50% 100%); }}
-  .yellow {{ background: yellow; clip-path: polygon(50% 50%,  50% 100%,   0% 100%,   0% 50%); }}
-  .green  {{ background: green;  clip-path: polygon(50% 50%,   0% 50%,   0%   0%,  50%   0%); }}
-  .blue   {{ background: blue;   clip-path: polygon(50% 50%,  50%   0%, 100%   0%, 100% 50%); }}
-..."#)
-}
-
-#[test]
-fn conic_gradient_from_90deg_matches_rotated_reference() {
-    // ... harness boilerplate (Task 5 と同じ)
-    let test_html_path = ... "conic-gradient-from-90.html";
-    let ref_html = build_quadrant_ref_html_rotated_90();
-    // ... pixel diff
-}
-```
-
-**Step 3: 実行 + commit**
-
-```bash
-FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" \
-    cargo test -p fulgur-vrt --test conic_gradient_harness
-git add crates/fulgur-vrt/fixtures/paint/conic-gradient-from-90.html \
-        crates/fulgur-vrt/tests/conic_gradient_harness.rs
-git commit -m "test(gradient): add conic-gradient from-angle VRT case"
-```
-
----
-
-## Task 8: `at <position>` (中心オフセット) fixture と test を追加
-
-**Files:**
-
-- Create: `crates/fulgur-vrt/fixtures/paint/conic-gradient-at-25-75.html`
-- Modify: `crates/fulgur-vrt/tests/conic_gradient_harness.rs`
-
-**Step 1: fixture と ref (advisor 提案で穏当な offset に変更)**
-
-box を 96×96 に縮小し、中心を `at 40% 60%` (= 38.4, 57.6 px) にする。これにより
-polygon 頂点の整数化を保てて tolerance を radial harness と同じ `max_diff_ratio: 0.02` に
-維持できる (極端な offset は別 PR で扱う)。
-
-```html
-<!-- conic-gradient-at-40-60.html -->
-<style>
-  .box {
-    width:96px; height:96px; margin:32px;
-    background: conic-gradient(at 40% 60%,
-      red 0deg, red 90deg,
-      yellow 90deg, yellow 180deg,
-      green 180deg, green 270deg,
-      blue 270deg, blue 360deg);
-  }
-</style>
-```
-
-ref は同じ box サイズで polygon 頂点を中心 (38.4, 57.6) からの放射線として計算する。
-
-**Step 2: 実行 + commit**
-
-```bash
-FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" \
-    cargo test -p fulgur-vrt --test conic_gradient_harness conic_gradient_at_position
-git add crates/fulgur-vrt/fixtures/paint/conic-gradient-at-25-75.html \
-        crates/fulgur-vrt/tests/conic_gradient_harness.rs
-git commit -m "test(gradient): add conic-gradient at-position VRT case"
-```
-
----
-
-## Task 9: `repeating-conic-gradient` fixture と test を追加
-
-**Files:**
-
-- Create: `crates/fulgur-vrt/fixtures/paint/repeating-conic-12-stripes.html`
-- Modify: `crates/fulgur-vrt/tests/conic_gradient_harness.rs`
-
-**Step 1: fixture**
-
-```html
-<!DOCTYPE html>
-<html lang="en">
-<head><meta charset="utf-8"><title>VRT test: repeating conic 12 stripes</title>
-<style>
-  html, body { margin:0; padding:0; background:white; }
-  .box {
-    width:192px; height:192px; margin:32px;
-    background: repeating-conic-gradient(
-      red    0deg, red    15deg,
-      blue  15deg, blue   30deg);
-  }
-</style>
-</head>
-<body><div class="box"></div></body>
-</html>
-```
-
-これは 30deg 周期で 12 個の red/blue 縞が回る。
-
-**Step 2: ref (sector polygon ヘルパを切り出す)**
-
-12 個の交互 sector を CSS clip-path で並べる ref を生成する。advisor 指摘に従い、
-sector polygon の頂点は box 辺との交点で変わる (上辺/右辺/下辺/左辺 をまたぐ)
-ため、専用ヘルパに分離して見通しを保つ:
-
-```rust
-/// 中心 (cx_pct, cy_pct) (% 単位) から角度 [start_deg, end_deg) の sector を
-/// 含む clip-path polygon 文字列を返す。CSS conic 規約 (0=top, CW)。
-/// 中心 + 必要な box-edge 交点 + start/end 単位ベクトル endpoint を順に並べる。
-fn sector_polygon_clip_path(
-    cx_pct: f32, cy_pct: f32,
-    start_deg: f32, end_deg: f32,
-) -> String {
-    // 1. start_deg から end_deg まで 0deg, 90deg, 180deg, 270deg 境界で
-    //    box 辺との交点を挟みながら polygon 頂点列を構築
-    // 2. 各角度 θ に対して中心から外周への ray が box 辺と交わる点を
-    //    `tan(θ - boundary)` で計算
-    // 3. CSS clip-path polygon 文字列に整形
-    ...
-}
-
-fn build_12_stripe_ref_html() -> String {
-    let mut sectors = String::new();
-    for i in 0..12 {
-        let color = if i % 2 == 0 { "red" } else { "blue" };
-        let path = sector_polygon_clip_path(50.0, 50.0, i as f32 * 30.0, (i + 1) as f32 * 30.0);
-        sectors.push_str(&format!(
-            r#"<div class="sector" style="background:{color};clip-path:{path};"></div>"#
-        ));
-    }
-    format!(...)
-}
-```
-
-tolerance は 12 個の境界線で AA が増えるため radial と同レベル
-(`max_pixel_diff: 14.0, max_diff_ratio: 0.03`)。
-
-**Step 3: 実行 + commit**
-
-```bash
-FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" \
-    cargo test -p fulgur-vrt --test conic_gradient_harness repeating
-git add crates/fulgur-vrt/fixtures/paint/repeating-conic-12-stripes.html \
-        crates/fulgur-vrt/tests/conic_gradient_harness.rs
-git commit -m "test(gradient): add repeating-conic-gradient VRT case"
-```
-
----
-
-## Task 10: WPT expectations の更新
-
-**Files:**
-
-- Modify: `crates/fulgur-wpt-runner/expectations/lists/bugs.txt` (パスは要確認)
-
-**Step 1: 影響を受ける WPT を一覧化**
-
-```bash
-grep -n "conic-gradient" crates/fulgur-wpt-runner/expectations/lists/bugs.txt
-grep -rn "conic-gradient" crates/fulgur-wpt-runner/expectations/ | head
-```
-
-**Step 2: 実測**
-
-```bash
-# WPT runner で conic-gradient 関連 reftest を実行
-cargo run --bin fulgur-wpt-runner -- --filter conic-gradient
-```
-
-**Step 3: PASS した項目を bugs.txt から削除**
-
-実際に PASS したものを bugs.txt から外し、依然 fail のものはコメントを
-更新 (false PASS 対策が Phase 1 linear で行われたのと同じ)。
-
-**Step 4: commit**
-
-```bash
-git add crates/fulgur-wpt-runner/expectations/lists/bugs.txt
-git commit -m "test(wpt): update conic-gradient expectations after Phase 2 implementation"
-```
-
----
-
-## Task 11: 全体テスト + lint + 確認
-
-**Step 1: full test**
-
-```bash
-cargo test -p fulgur                     # ~340 + 新規 smoke
-cargo test -p fulgur --test gcpm_integration
-FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" \
-    cargo test -p fulgur-vrt --test conic_gradient_harness
-FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" \
-    cargo test -p fulgur-vrt --test gradient_harness
-FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" \
-    cargo test -p fulgur-vrt --test radial_gradient_harness
-```
-
-**Step 2: lint**
-
-```bash
-cargo fmt --check
-cargo clippy -- -D warnings
-npx markdownlint-cli2 'docs/plans/2026-04-27-conic-gradient.md'
-```
-
-**Step 3: regenerate examples (任意・gradient を使う example が変わるなら)**
-
-```bash
-mise run regenerate-examples
-```
-
-**Step 4: 最終 commit (必要なら)**
-
-```bash
-git status
-# fmt 修正があれば commit
-```
-
----
-
-## 完了基準
-
-- [ ] `crates/fulgur/tests/render_smoke.rs` の 2 件の conic smoke が pass
-- [ ] `crates/fulgur-vrt/tests/conic_gradient_harness.rs` の 4 件の VRT が pass
-  - 4 quadrant
-  - from 90deg
-  - at 25% 75%
-  - repeating 12 stripes
-- [ ] `cargo fmt --check` / `cargo clippy -- -D warnings` 通る
-- [ ] WPT bugs.txt から conic-gradient PASS 項目が外れている
-- [ ] `bd close fulgur-m92h` 実行可能な状態
-
-## 設計上の参照
-
-- `fulgur-m92h` (本 issue) の design field
-- `fulgur-batz` — PDF/A-safe fallback の追跡 (本 PR ではフラグ判定なし)
-- `crates/fulgur/src/background.rs::draw_radial_gradient` — 同等パターンの実装参考
-- `crates/fulgur-vrt/tests/radial_gradient_harness.rs` — VRT pixel-diff harness の参考
-- CSS Images Level 4 §3.x — conic-gradient 仕様 (https://drafts.csswg.org/css-images-4/#conic-gradients)
-- krilla 0.7 `src/graphics/paint.rs:103` — `SweepGradient` 型定義
-- krilla 0.7 `src/graphics/shading_function.rs:170,420` — sweep の PostScript 経路
+当初の plan は krilla `SweepGradient` 直接利用 (PostScript Type 4 shading) を
+基本路線にしていたが、ユーザー要件 (円グラフ用途 + PDF/A 適合) と sub-skill
+レベルの設計議論を経て、以下のように pivot した:
+
+- **採用:** Path wedge 分解 — fulgur 内で 360 個の三角ウェッジを作成、隣接同色を
+  merge して polygon 化し krilla `Surface::draw_path` で発行
+- **不採用 (理由):**
+  - krilla `SweepGradient` → PostScript Type 4 で PDF/A-1/A-2 非適合
+  - krilla 上流に Type 0 sampled function を PR → 即時実装の障害になる
+  - Coons mesh (Type 6) → krilla 上流改修必要 + PDF/A-1 非適合
+  - tiny-skia でラスタ化 → tiny-skia は sweep shader 未対応、自前ピクセルループ
+    が必要、PDF サイズが path wedge より大きい (raster 床 ~3.5KB vs path 1.5KB)
+  - SVG 経由で `BgImageContent::Svg` 流用 → usvg も sweep 未対応、結局 path 列
+    を組むので直接 path のほうが見通しが良い
+
+WeasyPrint と Prince はいずれも conic-gradient 自体を未実装であることを web で
+確認済み (上流の選定パターン参考にできず、ゼロから設計)。
+
+## Implementation Summary
+
+### `crates/fulgur/src/pageable.rs`
+
+`BgImageContent::ConicGradient` variant を追加。`from_angle` (radians, CSS 規約:
+0=top, CW)、`position_x/y` (BgLengthPercentage)、`stops` (Vec<GradientStop>)、
+`repeating` を持つ。stop position は convert 時に `<percentage>` および `<angle>`
+を統一 fraction (0..1) に正規化済み。
+
+### `crates/fulgur/src/convert.rs`
+
+`resolve_conic_gradient` を追加し、Stylo の `Gradient::Conic` から ConicGradient
+variant を生成する。bail-out 条件は linear/radial と同じ (非デフォルト
+color-interpolation-method、interpolation hint、calc() position、stops < 2)。
+
+### `crates/fulgur/src/background.rs`
+
+`draw_conic_gradient` を追加:
+
+1. 中心 `(cx, cy)` を `position_x/y` から計算
+2. `normalize_conic_stops` で `Auto` を線形補間で埋める (CSS Images L4 fixup)
+3. N=360 個の wedge について mid-angle で `sample_conic_color` を呼んで RGBA を決定
+4. 隣接同色 wedge を merge して 1 polygon にまとめ、`box_edge_at_angle` で
+   外周頂点を計算しながら `surface.draw_path` で発行
+
+純関数ヘルパは `box_edge_at_angle` / `normalize_conic_stops` /
+`sample_conic_color` の 3 つで、すべて `#[cfg(test)]` モジュールに unit test 配置。
+
+`is_background_image` 判定 (sizing 経路) と `draw_background_layer` の主要 match
+arm にも `BgImageContent::ConicGradient` を追加。
+
+### Tests
+
+- **Unit (`crates/fulgur/src/background.rs::conic_helpers_tests`):** 11 件
+  - `box_edge_at_angle` の 5 case (top/right/bottom/left/corner)
+  - `normalize_conic_stops` の fixup 系 3 case
+  - `sample_conic_color` の lerp 系 3 case
+- **Smoke (`crates/fulgur/tests/render_smoke.rs`):** 5 件
+  - pie chart / smooth / repeating / from-angle / at-position
+  - すべて `Engine::builder().build().render_html(...)` で `assert!(!pdf.is_empty())`
+- **VRT (`crates/fulgur-vrt/tests/conic_gradient_harness.rs`):** 1 件
+  - 4-quadrant pie chart vs 4 個の絶対配置矩形 ref で pixel diff
+  - tolerance: max channel diff 12 / max diff ratio 2%
+  - cropped 308×308 で評価 (radial harness と同じ思想)
+
+## Verified Properties
+
+- ✅ CSS angle convention 正解 (red top-right, yellow bottom-right, green bottom-left,
+      blue top-left for `conic-gradient(red 0deg, red 90deg, yellow 90deg, ...)`)
+- ✅ PDF/A-1 / PDF/A-2 適合 (PostScript shading 不使用、path のみ)
+- ✅ pie chart は完璧な vector 描画 (隣接同色 wedge merge で AA 境界線消失)
+- ✅ smooth conic は 360 wedge の連続色で許容品質
+- ✅ from-angle / at-position / repeating 全シナリオで lib smoke pass
+
+## PDF Size (200×200 box, baseline 1636 byte 差し引き済み)
+
+| ケース | conic 純増 |
+|--------|------------|
+| 4-color pie chart (square) | 1634 byte |
+| 4-color pie chart (circular `border-radius:50%`) | 1701 byte |
+| `from 90deg` 4-color | 1652 byte |
+| `at 25% 75%` 4-color | 1923 byte |
+| `repeating-conic` 12 stripes | 1740 byte |
+| smooth 5-stop | 4875 byte |
+
+PostScript Type 4 (~2 KB) や Coons mesh (~1.8 KB) と同等。raster 床 ~3.5KB より
+小さい。
+
+## Related Beads Issues (impact)
+
+- **fulgur-batz** (PDF/A-safe conic-gradient fallback): 当初 PDF/A 対応のため別
+  issue で扱う予定だったが、本 PR で path wedge により最初から PDF/A 適合。
+  → Close 候補。
+- **fulgur-zao0** (PDF/A output mode epic): 「PostScript shading 禁止 fallback」
+  リストから conic を外す。design 修正のみ。
+
+## Future Work
+
+- パフォーマンス: N=360 は固定値。box サイズに応じた adaptive N 設計、
+  step segment 検出による更なる削減 (現状は wedge 数固定で隣接同色 merge のみ)
+- WPT `css-images-4/conic-gradient-*` reftest の expectations 整理
+- Coons mesh (Type 6) を krilla に PR (任意の品質オプション、PDF/A-2 限定だが
+  smooth conic でサイズ削減可能)

--- a/docs/plans/2026-04-27-conic-gradient.md
+++ b/docs/plans/2026-04-27-conic-gradient.md
@@ -36,7 +36,10 @@ WeasyPrint と Prince はいずれも conic-gradient 自体を未実装である
 `BgImageContent::ConicGradient` variant を追加。`from_angle` (radians, CSS 規約:
 0=top, CW)、`position_x/y` (BgLengthPercentage)、`stops` (Vec<GradientStop>)、
 `repeating` を持つ。stop position は convert 時に `<percentage>` および `<angle>`
-を統一 fraction (0..1) に正規化済み。
+を **生 fraction** (`GradientStopPosition::Fraction(f32)`) として保持する
+(`<angle>` は `angle_rad / 2π` で換算)。`[0, 1]` 外の値もそのまま許容し
+(`-30deg → -0.083`, `120% → 1.2` 等)、最終的な範囲ハンドリングと repeating
+の周期展開は draw 時の `sample_conic_color` / `normalize_conic_stops` に委ねる。
 
 ### `crates/fulgur/src/convert.rs`
 
@@ -68,7 +71,10 @@ arm にも `BgImageContent::ConicGradient` を追加。
   - `sample_conic_color` の lerp 系 3 case
 - **Smoke (`crates/fulgur/tests/render_smoke.rs`):** 5 件
   - pie chart / smooth / repeating / from-angle / at-position
-  - すべて `Engine::builder().build().render_html(...)` で `assert!(!pdf.is_empty())`
+  - 各ケース `Engine::builder().build().render_html(...)` を呼び `assert!(!pdf.is_empty())`
+  - これは crash / シリアライズ smoke + codecov の line coverage 対象化が目的
+    (`krilla::Document::finish()` は何も描画しなくても non-empty PDF を返すため、
+    描画の正しさは保証しない)。視覚 / pixel 検証は VRT と WPT 側で行う
 - **VRT (`crates/fulgur-vrt/tests/conic_gradient_harness.rs`):** 1 件
   - 4-quadrant pie chart vs 4 個の絶対配置矩形 ref で pixel diff
   - tolerance: max channel diff 12 / max diff ratio 2%

--- a/docs/plans/2026-04-27-conic-gradient.md
+++ b/docs/plans/2026-04-27-conic-gradient.md
@@ -73,6 +73,14 @@ arm にも `BgImageContent::ConicGradient` を追加。
   - 4-quadrant pie chart vs 4 個の絶対配置矩形 ref で pixel diff
   - tolerance: max channel diff 12 / max diff ratio 2%
   - cropped 308×308 で評価 (radial harness と同じ思想)
+- **WPT (`crates/fulgur-wpt/expectations/lists/bugs.txt`):** 11 件 (10 PASS + 1 FAIL)
+  - upstream `web-platform-tests/wpt` の `css/css-images/*conic*` 系を vendor
+  - 通った 10 件: `conic-gradient-angle`, `conic-gradient-angle-negative`,
+    `conic-gradient-center`, `normalization-conic{,-2,-degenerate}`,
+    `out-of-range-color-stop-conic`, `multiple-position-color-stop-conic`,
+    `repeating-conic-gradient`, `tiled-conic-gradients`
+  - 通らなかった 1 件: `multiple-position-color-stop-conic-2` (548/892k px が
+    default tolerance 超え。視覚は完全一致だが sub-pixel AA 差で borderline)
 
 ## Verified Properties
 

--- a/docs/plans/2026-04-27-conic-gradient.md
+++ b/docs/plans/2026-04-27-conic-gradient.md
@@ -1,0 +1,1037 @@
+# Conic-gradient Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** CSS `conic-gradient(...)` / `repeating-conic-gradient(...)` を Krilla の `SweepGradient` 経由で PDF に描画する。Phase 1 (linear) / Phase 2 (radial) と同じく、サポート外の機能は `log::warn!` + `None` 返却で layer drop。
+
+**Architecture:** `convert.rs` で Stylo の `Gradient::Conic` から `BgImageContent::ConicGradient` を生成し、`background.rs::draw_conic_gradient` が krilla `SweepGradient` を発行する。CSS の角度規約 (0deg=top, CW) と krilla の sweep 規約 (0deg=right, 増加方向は要検証) の差は draw 段階の角度変換で吸収。
+
+**Tech Stack:** Stylo (`Gradient::Conic`) / krilla 0.7 (`SweepGradient`) / fulgur-vrt (test↔ref pixel diff harness)
+
+**Issue:** `fulgur-m92h` (parent epic: `fulgur-5166`)
+
+**PDF/A 注記:** krilla `SweepGradient` は内部で PostScript Type 4 function shading を発行 → PDF/A-1, A-2 非適合。本 PR ではフラグ判定をしない。代替経路は `fulgur-batz` (PDF/A-safe fallback) で扱う。
+
+---
+
+## Task 1: lib smoke test を先に書く (failing baseline)
+
+**Files:**
+
+- Modify: `crates/fulgur/tests/render_smoke.rs` (末尾に追記)
+
+**Step 1: failing test を書く**
+
+```rust
+#[test]
+fn test_render_html_conic_gradient_basic() {
+    let html = r#"<!DOCTYPE html><html><body>
+        <div style="width:100px;height:100px;
+            background:conic-gradient(red, yellow, green, blue, red);"></div>
+    </body></html>"#;
+    let pdf = Engine::builder()
+        .build()
+        .render_html(html)
+        .expect("render conic-gradient");
+    assert!(!pdf.is_empty(), "PDF should not be empty");
+    // Phase 1 (silent fallback) では gradient が出ないため、
+    // 本 PR 完了後はこのテストが通り、conic 経路が draw されることを保証する。
+}
+
+#[test]
+fn test_render_html_repeating_conic_gradient() {
+    let html = r#"<!DOCTYPE html><html><body>
+        <div style="width:100px;height:100px;
+            background:repeating-conic-gradient(red 0deg, blue 30deg);"></div>
+    </body></html>"#;
+    let pdf = Engine::builder()
+        .build()
+        .render_html(html)
+        .expect("render repeating-conic-gradient");
+    assert!(!pdf.is_empty());
+}
+```
+
+**Step 2: 実行して fail を確認**
+
+```bash
+cargo test -p fulgur --test render_smoke test_render_html_conic_gradient_basic
+cargo test -p fulgur --test render_smoke test_render_html_repeating_conic_gradient
+```
+
+期待: 両方 `assert!(!pdf.is_empty())` の手前で render 自体は成功するはずだが、本 PR 完了後にデータパスを通って実際に描画されることを以後のタスクで担保する。
+
+**Step 3: commit**
+
+```bash
+git add crates/fulgur/tests/render_smoke.rs
+git commit -m "test(gradient): add lib smoke for conic-gradient (failing baseline)"
+```
+
+---
+
+## Task 2: pageable.rs にデータモデルを追加
+
+**Files:**
+
+- Modify: `crates/fulgur/src/pageable.rs` (`BgImageContent` enum 周辺、行 819 付近)
+
+**Step 1: 新型を追加**
+
+`pageable.rs` の `RadialGradient` variant の後に挿入:
+
+```rust
+/// CSS conic-gradient stop の位置指定。
+///
+/// CSS Images Level 4 §3.x: stop position は `<angle> | <percentage>`。
+/// `<percentage>` は 360deg を 100% として解釈する。
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ConicStopPosition {
+    /// 位置省略 — 周囲の固定 stop から等間隔補間で fixup される。
+    Auto,
+    /// `<percentage>` を [0.0, 1.0] の fraction として保持。
+    /// CSS では負値や 1.0 超過もあり得る (out-of-range) — fixup で扱う。
+    Fraction(f32),
+    /// `<angle>` を radians で保持。draw 時に `angle / 2π` で fraction 化。
+    AngleRad(f32),
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ConicGradientStop {
+    pub position: ConicStopPosition,
+    pub rgba: [u8; 4],
+}
+```
+
+`BgImageContent` enum の `RadialGradient` の後に variant を追加:
+
+```rust
+/// CSS `conic-gradient(...)` / `repeating-conic-gradient(...)`.
+/// `from_angle` は radians (CSS 規約: 0=top, 増加方向=CW)。
+/// `repeating=true` の場合、period = (last_stop_fraction - first_stop_fraction) で
+/// `[0, 1]` を覆うだけ stop 列を平行コピーする (CSS Images 4 §3.x)。
+ConicGradient {
+    from_angle: f32,
+    position_x: BgLengthPercentage,
+    position_y: BgLengthPercentage,
+    stops: Vec<ConicGradientStop>,
+    repeating: bool,
+},
+```
+
+**Step 2: コンパイル確認**
+
+```bash
+cargo build -p fulgur --lib
+```
+
+期待: warning は出る (未使用 variant) が build は通る。
+
+**Step 3: commit**
+
+```bash
+git add crates/fulgur/src/pageable.rs
+git commit -m "feat(gradient): add ConicGradient variant and stop types to BgImageContent"
+```
+
+---
+
+## Task 3: convert.rs に `resolve_conic_gradient` を追加
+
+**Files:**
+
+- Modify: `crates/fulgur/src/convert.rs` (`Gradient::Conic { .. } => None` の置き換え + 新関数)
+
+**Step 1: dispatcher 行を変更**
+
+行 3045 付近の match を:
+
+```rust
+Image::Gradient(g) => {
+    use style::values::computed::image::Gradient;
+    match g.as_ref() {
+        Gradient::Linear { .. } => resolve_linear_gradient(g, &current_color),
+        Gradient::Radial { .. } => resolve_radial_gradient(g, &current_color),
+        Gradient::Conic  { .. } => resolve_conic_gradient(g, &current_color),
+    }
+}
+```
+
+**Step 2: `resolve_conic_gradient` を追加**
+
+`resolve_color_stops` の前後に新関数を追加:
+
+```rust
+/// Convert a Stylo computed `Gradient::Conic` into `BgImageContent::ConicGradient`.
+///
+/// 失敗 (None) 条件:
+/// - 非デフォルト color_interpolation_method (例: `in oklch`)
+/// - InterpolationHint
+/// - position の calc() (Length にも Percentage にも resolve できない)
+/// - stops < 2
+fn resolve_conic_gradient(
+    g: &style::values::computed::Gradient,
+    current_color: &style::color::AbsoluteColor,
+) -> Option<(BgImageContent, f32, f32)> {
+    use crate::pageable::BgLengthPercentage;
+    use style::values::computed::image::Gradient;
+    use style::values::generics::image::GradientFlags;
+
+    let (angle, position, items, flags) = match g {
+        Gradient::Conic {
+            angle,
+            position,
+            items,
+            flags,
+            ..
+        } => (angle, position, items, flags),
+        Gradient::Linear { .. } | Gradient::Radial { .. } => return None,
+    };
+
+    if !flags.contains(GradientFlags::HAS_DEFAULT_COLOR_INTERPOLATION_METHOD) {
+        log::warn!(
+            "conic-gradient: non-default color-interpolation-method is not yet \
+             supported (Phase 2). Layer dropped."
+        );
+        return None;
+    }
+
+    // CSS `from <angle>` を radians に変換。Stylo の Angle は内部 deg なので
+    // .radians() を使う (linear と同じ流儀)。
+    let from_angle = angle.radians();
+
+    // Center position は radial と同じヘルパ。calc() は None で bail。
+    let position_x = try_convert_lp_to_bg(&position.horizontal)?;
+    let position_y = try_convert_lp_to_bg(&position.vertical)?;
+
+    let repeating = flags.contains(GradientFlags::REPEATING);
+
+    let stops = resolve_conic_color_stops(items, current_color)?;
+
+    Some((
+        BgImageContent::ConicGradient {
+            from_angle,
+            position_x,
+            position_y,
+            stops,
+            repeating,
+        },
+        0.0,
+        0.0,
+    ))
+}
+
+/// Resolve conic-gradient color stops into `Vec<ConicGradientStop>`.
+///
+/// linear/radial の `resolve_color_stops` は `LengthPercentage` 用なので
+/// conic の `AngleOrPercentage` には別実装が必要。
+fn resolve_conic_color_stops(
+    items: &[style::values::generics::image::GenericGradientItem<
+        style::values::computed::Color,
+        style::values::computed::AngleOrPercentage,
+    >],
+    current_color: &style::color::AbsoluteColor,
+) -> Option<Vec<crate::pageable::ConicGradientStop>> {
+    use crate::pageable::{ConicGradientStop, ConicStopPosition};
+    use style::values::computed::AngleOrPercentage;
+    use style::values::generics::image::GradientItem;
+
+    let mut out: Vec<ConicGradientStop> = Vec::with_capacity(items.len());
+    for item in items.iter() {
+        match item {
+            GradientItem::SimpleColorStop(c) => {
+                let abs = c.resolve_to_absolute(current_color);
+                out.push(ConicGradientStop {
+                    position: ConicStopPosition::Auto,
+                    rgba: absolute_to_rgba(abs),
+                });
+            }
+            GradientItem::ComplexColorStop { color, position } => {
+                let abs = color.resolve_to_absolute(current_color);
+                let pos = match position {
+                    AngleOrPercentage::Angle(a) => ConicStopPosition::AngleRad(a.radians()),
+                    AngleOrPercentage::Percentage(p) => ConicStopPosition::Fraction(p.0),
+                };
+                out.push(ConicGradientStop {
+                    position: pos,
+                    rgba: absolute_to_rgba(abs),
+                });
+            }
+            GradientItem::InterpolationHint(_) => {
+                log::warn!(
+                    "conic-gradient: interpolation hints are not yet supported \
+                     (Phase 2). Layer dropped."
+                );
+                return None;
+            }
+        }
+    }
+
+    if out.len() < 2 {
+        return None;
+    }
+    Some(out)
+}
+```
+
+**注意:** `try_convert_lp_to_bg` は `convert.rs:3406` 付近に radial 用の
+helper として存在する (calc() は None を返す)。新規にヘルパを切り出さず流用すること。
+
+**Step 3: コンパイル確認**
+
+```bash
+cargo build -p fulgur --lib
+```
+
+期待: build 通る。warning は減るはず。
+
+**Step 4: commit**
+
+```bash
+git add crates/fulgur/src/convert.rs
+git commit -m "feat(gradient): resolve Stylo Gradient::Conic into BgImageContent::ConicGradient"
+```
+
+---
+
+## Task 4: background.rs に no-op draw 経路を追加 (skeleton)
+
+これは draw を実装する前に、dispatch だけ通して E2E が通る形に仮置きする
+中間 step。次のタスクで実体を入れる。
+
+**Files:**
+
+- Modify: `crates/fulgur/src/background.rs` (行 208 と行 238 の match arm)
+
+**Step 1: image-size 判定に ConicGradient を含める**
+
+行 208:
+
+```rust
+let (img_w, img_h) = match &layer.content {
+    BgImageContent::LinearGradient { .. }
+    | BgImageContent::RadialGradient { .. }
+    | BgImageContent::ConicGradient { .. } => {
+        resolve_gradient_size(&layer.size, ow, oh)
+    }
+    BgImageContent::Raster { .. } | BgImageContent::Svg { .. } => resolve_size(layer, ow, oh),
+};
+```
+
+**Step 2: 主要 match arm に no-op skeleton を追加**
+
+行 344 (Raster の前) に挿入:
+
+```rust
+BgImageContent::ConicGradient {
+    from_angle,
+    position_x,
+    position_y,
+    stops,
+    repeating,
+} => {
+    // Linear/Radial と同じ uniform-tile ショートカットは Phase 1 では入れず、
+    // 必ず per-tile loop で draw する (conic 自体が初回実装で複雑なため)。
+    for (tx, ty, tw, th) in &tiles {
+        draw_conic_gradient(
+            canvas.surface,
+            *from_angle,
+            position_x,
+            position_y,
+            stops,
+            *repeating,
+            *tx,
+            *ty,
+            *tw,
+            *th,
+        );
+    }
+}
+```
+
+そして同ファイル末尾 (行 760 付近、`draw_radial_gradient` の後) に stub:
+
+```rust
+/// Phase 1 stub. 実体は次のタスクで実装する。
+#[allow(clippy::too_many_arguments)]
+fn draw_conic_gradient(
+    _surface: &mut krilla::surface::Surface<'_>,
+    _from_angle_rad: f32,
+    _position_x: &BgLengthPercentage,
+    _position_y: &BgLengthPercentage,
+    _stops: &[crate::pageable::ConicGradientStop],
+    _repeating: bool,
+    _ox: f32,
+    _oy: f32,
+    _ow: f32,
+    _oh: f32,
+) {
+    // TODO(fulgur-m92h): wire krilla::paint::SweepGradient
+}
+```
+
+**Step 3: コンパイル + lib smoke を確認**
+
+```bash
+cargo build -p fulgur --lib
+cargo test -p fulgur --test render_smoke test_render_html_conic_gradient_basic
+cargo test -p fulgur --test render_smoke test_render_html_repeating_conic_gradient
+```
+
+期待: build 通る。smoke はまだ「何も描画しない」が `pdf.is_empty()` ではないので pass する。
+(背景以外の構造で PDF stream は生成されるため)。
+
+**Step 4: commit**
+
+```bash
+git add crates/fulgur/src/background.rs
+git commit -m "feat(gradient): add ConicGradient dispatch skeleton in draw_background_layer"
+```
+
+---
+
+## Task 5: 4 象限 VRT harness で direction 検証 (TDD)
+
+ここが本 PR で最も慎重に進めるべき箇所。krilla SweepGradient の角度規約を
+empirical に確定する。
+
+**Files:**
+
+- Create: `crates/fulgur-vrt/tests/conic_gradient_harness.rs`
+- Create: `crates/fulgur-vrt/fixtures/paint/conic-gradient-quadrant.html`
+- Modify: `crates/fulgur-vrt/Cargo.toml` (test 自動検出されるので変更不要のはず)
+
+**Step 1: test fixture HTML を作成**
+
+`crates/fulgur-vrt/fixtures/paint/conic-gradient-quadrant.html`:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>VRT test: conic-gradient 4 quadrants</title>
+<style>
+  html, body { margin: 0; padding: 0; background: white; }
+  .box {
+    width: 192px;
+    height: 192px;
+    margin: 32px;
+    background: conic-gradient(
+      red 0deg,
+      red 90deg,
+      yellow 90deg,
+      yellow 180deg,
+      green 180deg,
+      green 270deg,
+      blue 270deg,
+      blue 360deg
+    );
+  }
+</style>
+</head>
+<body>
+  <div class="box"></div>
+</body>
+</html>
+```
+
+(連続した同色 stop で 4 セクターを離散化 — gradient 補間ではなく境界の鮮明な
+4 色塗りになる。ref と pixel-perfect 一致させやすい)
+
+**Step 2: ref builder を含む harness を作成**
+
+```rust
+//! Test↔ref pixel-diff harness for conic-gradient implementation.
+//!
+//! 4 個の 90° セクター fixture を、CSS `clip-path: polygon(...)` で扇形を
+//! 作った 4 個の絶対配置 div に置き換えた ref と pixel-wise 比較する。
+//! conic-gradient の角度規約 (0deg=top, CW) を empirical に検証する。
+//!
+//! 採用しなかった案:
+//! - SVG `<linearGradient>` 集合 ref → 自前 SVG パイプラインに依存
+//! - PNG raster ref → CI 再現性で扱いづらい
+
+use fulgur_vrt::diff::{self};
+use fulgur_vrt::manifest::Tolerance;
+use fulgur_vrt::pdf_render::{RenderSpec, pdf_to_rgba, render_html_to_pdf};
+use std::fs;
+use std::path::PathBuf;
+
+const BOX_PX: u32 = 192;
+const MARGIN_PX: u32 = 32;
+
+fn build_quadrant_ref_html() -> String {
+    // 4 sectors. `clip-path: polygon()` の頂点は box の外周 4 辺と中心 (96, 96)。
+    // CSS conic-gradient(red 0deg, red 90deg, ...) の規約:
+    //   - 0deg = box の上端中央
+    //   - 増加方向 = clockwise (画面視点)
+    //   - red sector = 0..90deg = top → right (右上 1/4)
+    //   - yellow sector = 90..180deg = right → bottom (右下 1/4)
+    //   - green sector = 180..270deg = bottom → left (左下 1/4)
+    //   - blue sector = 270..360deg = left → top (左上 1/4)
+    format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>VRT ref: conic-gradient 4 quadrants</title>
+<style>
+  html, body {{ margin: 0; padding: 0; background: white; }}
+  .box {{ position: relative; width: {w}px; height: {h}px; margin: {m}px; }}
+  .sector {{ position: absolute; inset: 0; }}
+  .red    {{ background: red;    clip-path: polygon(50% 50%, 50%   0%, 100%   0%, 100% 50%); }}
+  .yellow {{ background: yellow; clip-path: polygon(50% 50%, 100% 50%, 100% 100%,  50% 100%); }}
+  .green  {{ background: green;  clip-path: polygon(50% 50%,  50% 100%,   0% 100%,   0% 50%); }}
+  .blue   {{ background: blue;   clip-path: polygon(50% 50%,   0% 50%,   0%   0%,  50%   0%); }}
+</style>
+</head>
+<body>
+  <div class="box">
+    <div class="sector red"></div>
+    <div class="sector yellow"></div>
+    <div class="sector green"></div>
+    <div class="sector blue"></div>
+  </div>
+</body>
+</html>"#,
+        w = BOX_PX, h = BOX_PX, m = MARGIN_PX,
+    )
+}
+
+#[test]
+fn conic_gradient_4_quadrants_match_polygon_reference() {
+    let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let test_html_path = crate_root.join("fixtures/paint/conic-gradient-quadrant.html");
+    let test_html = fs::read_to_string(&test_html_path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", test_html_path.display()));
+
+    let ref_html = build_quadrant_ref_html();
+
+    let spec = RenderSpec { page_size: "A4", margin_pt: Some(0.0), dpi: 150 };
+
+    let test_pdf = render_html_to_pdf(&test_html, spec).expect("render test pdf");
+    let ref_pdf = render_html_to_pdf(&ref_html, spec).expect("render ref pdf");
+
+    let work_dir = crate_root.parent().and_then(|p| p.parent())
+        .expect("workspace root")
+        .join("target/vrt-conic-gradient-harness");
+    fs::create_dir_all(&work_dir).expect("create work dir");
+    let test_dir = work_dir.join("test");
+    let ref_dir = work_dir.join("ref");
+    let _ = fs::remove_dir_all(&test_dir);
+    let _ = fs::remove_dir_all(&ref_dir);
+    fs::create_dir_all(&test_dir).expect("create test dir");
+    fs::create_dir_all(&ref_dir).expect("create ref dir");
+
+    let test_png = pdf_to_rgba(&test_pdf, &test_dir).expect("rasterize test pdf");
+    let ref_png = pdf_to_rgba(&ref_pdf, &ref_dir).expect("rasterize ref pdf");
+
+    // セクター境界の AA 1〜2 px を考慮し radial と同レベルの tolerance:
+    let tolerance = Tolerance { max_pixel_diff: 12.0, max_diff_ratio: 0.02 };
+
+    diff::assert_images_match(&test_png, &ref_png, &tolerance, &work_dir)
+        .expect("conic-gradient quadrants should match polygon ref");
+}
+```
+
+(`diff` / `Tolerance` / `pdf_render` の正確な API は `radial_gradient_harness.rs`
+からコピーして参照する)
+
+**Step 3: 実行して fail を確認**
+
+```bash
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" \
+    cargo test -p fulgur-vrt --test conic_gradient_harness
+```
+
+期待: test fixture 側は draw stub で何も塗らないので白地、ref は 4 色 → fail。
+
+**Step 4: commit**
+
+```bash
+git add crates/fulgur-vrt/tests/conic_gradient_harness.rs \
+        crates/fulgur-vrt/fixtures/paint/conic-gradient-quadrant.html
+git commit -m "test(gradient): add conic-gradient 4-quadrant VRT harness (failing baseline)"
+```
+
+---
+
+## Task 6: `draw_conic_gradient` 実体を実装 (krilla SweepGradient)
+
+**Files:**
+
+- Modify: `crates/fulgur/src/background.rs` (Task 4 で置いた stub)
+
+**Step 1: 実装 — まずは想定マッピング**
+
+```rust
+#[allow(clippy::too_many_arguments)]
+fn draw_conic_gradient(
+    surface: &mut krilla::surface::Surface<'_>,
+    from_angle_rad: f32,
+    position_x: &BgLengthPercentage,
+    position_y: &BgLengthPercentage,
+    stops: &[crate::pageable::ConicGradientStop],
+    repeating: bool,
+    ox: f32, oy: f32, ow: f32, oh: f32,
+) {
+    use crate::pageable::ConicStopPosition;
+
+    if ow <= 0.0 || oh <= 0.0 || stops.len() < 2 {
+        return;
+    }
+
+    let cx = ox + resolve_point(position_x, ow);
+    let cy = oy + resolve_point(position_y, oh);
+
+    // Stop position を fraction (0..1) に正規化:
+    //   Auto      → そのまま (後段 fixup で埋まる)
+    //   Fraction  → そのまま
+    //   AngleRad  → angle_rad / (2π)
+    let normalized: Vec<(Option<f32>, [u8; 4])> = stops
+        .iter()
+        .map(|s| {
+            let frac = match s.position {
+                ConicStopPosition::Auto => None,
+                ConicStopPosition::Fraction(f) => Some(f),
+                ConicStopPosition::AngleRad(a) => Some(a / (2.0 * std::f32::consts::PI)),
+            };
+            (frac, s.rgba)
+        })
+        .collect();
+
+    // CSS Images Level 4 §3.x stop fixup:
+    //   1. 先頭 Auto は 0.0、末尾 Auto は 1.0 に確定
+    //   2. monotonic clamp (前 fixed より小さければ前 fixed に合わせる)
+    //   3. 中間 Auto 群を前後 fixed の等間隔補間で埋める
+    let fixed = fixup_conic_stops(normalized);
+    if fixed.len() < 2 {
+        return;
+    }
+
+    let first_pos = fixed.first().unwrap().0;
+    let last_pos = fixed.last().unwrap().0;
+    let period = (last_pos - first_pos).max(f32::EPSILON);
+
+    // 角度変換 (CSS → krilla):
+    //   - CSS: 0deg = top, 増加方向 = CW (screen view)
+    //   - krilla SweepGradient: 0deg = right, 増加方向は内部 PostScript Atan に依存
+    //   - 想定: krilla_start_deg = 90 - css_from_deg、sweep は -360deg 方向
+    let from_angle_deg = from_angle_rad.to_degrees();
+    let krilla_start_deg = 90.0 - from_angle_deg - first_pos * 360.0;
+    let krilla_end_deg = if repeating {
+        krilla_start_deg - period * 360.0
+    } else {
+        krilla_start_deg - 360.0
+    };
+
+    let spread = if repeating {
+        krilla::paint::SpreadMethod::Repeat
+    } else {
+        krilla::paint::SpreadMethod::Pad
+    };
+
+    // krilla Stop 列を構築。fraction を [0, 1] に再正規化:
+    //   p_norm = (p - first) / period
+    let krilla_stops: Vec<krilla::paint::Stop> = fixed.iter().map(|(p, rgba)| {
+        let p_norm = (p - first_pos) / period;
+        krilla::paint::Stop {
+            offset: krilla::num::NormalizedF32::new(p_norm.clamp(0.0, 1.0)).unwrap(),
+            color: krilla::color::rgb::Rgb::new(rgba[0], rgba[1], rgba[2]).into(),
+            opacity: krilla::num::NormalizedF32::new(rgba[3] as f32 / 255.0).unwrap(),
+        }
+    }).collect();
+
+    let sweep = krilla::paint::SweepGradient {
+        cx,
+        cy,
+        start_angle: krilla_start_deg,
+        end_angle: krilla_end_deg,
+        transform: krilla::geom::Transform::default(),
+        spread_method: spread,
+        stops: krilla_stops,
+        anti_alias: false,
+    };
+
+    surface.set_fill(Some(krilla::paint::Fill {
+        paint: sweep.into(),
+        rule: Default::default(),
+        opacity: krilla::num::NormalizedF32::ONE,
+    }));
+    surface.set_stroke(None);
+
+    let Some(rect_path) = build_rect_path(ox, oy, ow, oh) else {
+        surface.set_fill(None);
+        return;
+    };
+    surface.draw_path(&rect_path);
+    surface.set_fill(None);
+}
+
+/// CSS Images Level 4 stop fixup for conic gradients.
+fn fixup_conic_stops(stops: Vec<(Option<f32>, [u8; 4])>) -> Vec<(f32, [u8; 4])> {
+    if stops.is_empty() {
+        return Vec::new();
+    }
+    let mut fixed: Vec<(Option<f32>, [u8; 4])> = stops;
+
+    // 1. 先頭/末尾の Auto を確定
+    if fixed[0].0.is_none() { fixed[0].0 = Some(0.0); }
+    let last = fixed.len() - 1;
+    if fixed[last].0.is_none() { fixed[last].0 = Some(1.0); }
+
+    // 2. monotonic clamp (前向きスキャンで前 fixed >= 現値なら前に合わせる)
+    let mut prev: f32 = fixed[0].0.unwrap();
+    for s in fixed.iter_mut().skip(1) {
+        if let Some(p) = s.0 {
+            if p < prev { s.0 = Some(prev); }
+            prev = s.0.unwrap();
+        }
+    }
+
+    // 3. 中間 Auto 群を前後 fixed の等間隔で補間
+    let mut i = 0usize;
+    while i < fixed.len() {
+        if fixed[i].0.is_some() { i += 1; continue; }
+        // 連続 Auto 群を見つけて [i..j) を等間隔補間
+        let prev_pos = fixed[i - 1].0.unwrap();
+        let mut j = i;
+        while j < fixed.len() && fixed[j].0.is_none() { j += 1; }
+        let next_pos = fixed[j].0.unwrap();
+        let count = j - i + 1;
+        for k in 0..(j - i) {
+            let t = (k + 1) as f32 / count as f32;
+            fixed[i + k].0 = Some(prev_pos + (next_pos - prev_pos) * t);
+        }
+        i = j;
+    }
+
+    fixed.into_iter().map(|(p, rgba)| (p.unwrap(), rgba)).collect()
+}
+```
+
+**Step 2: lib smoke + 4 象限 VRT を実行**
+
+```bash
+cargo test -p fulgur --test render_smoke test_render_html_conic_gradient
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" \
+    cargo test -p fulgur-vrt --test conic_gradient_harness
+```
+
+期待: lib smoke は pass。VRT は **角度規約が想定と合っていれば pass、外れていれば pixel diff が出る**。
+
+**Step 3: angle 規約のデバッグ (VRT が fail した場合のみ)**
+
+VRT が fail した場合、生成された pixel diff 画像 (`target/vrt-conic-gradient-harness/diff_*.png`) を見て、advisor 指摘の 3 分類で判定する:
+
+- **全色が同じ方向に 1 象限ずれ** → `krilla_start_deg` のオフセットを再検討 (90.0 ± k×90)
+- **増加方向だけ逆 (red/blue が左右反転)** → `krilla_end_deg = krilla_start_deg + 360.0` (sweep 反転) + krilla `stops` 逆順 (`fixed.iter().rev()`) + 各 stop の `p_norm` を `1.0 - p_norm` に
+- **完全にランダム / Y-flip 疑い** → krilla COLR (`text/glyph/colr.rs:400`) で
+  `Transform::from_scale(1.0, -1.0)` + `cy: -cy` を入れていた件と同じ。
+  `sweep.transform = krilla::geom::Transform::from_scale(1.0, -1.0)`、`cy: -cy` で再試行。
+
+修正後 もう一度実行。
+
+**重複 stop の注意:** Task 5 の fixture は `red 90deg, yellow 90deg` のような
+同一 offset stop を使う (CSS step transition)。krilla `Stop` の `offset` が
+同値で並ぶと未定義動作の可能性があるため、`fixup_conic_stops` の後で
+**隣接 stop が完全同値の場合のみ** 後者に `1e-6` を足す nudge を入れる:
+
+```rust
+for i in 1..fixed.len() {
+    if (fixed[i].0 - fixed[i - 1].0).abs() < f32::EPSILON {
+        fixed[i].0 = (fixed[i - 1].0 + 1e-6).min(1.0);
+    }
+}
+```
+
+**Step 4: VRT pass を確認 + commit**
+
+```bash
+git add crates/fulgur/src/background.rs
+git commit -m "feat(gradient): implement draw_conic_gradient via krilla SweepGradient"
+```
+
+---
+
+## Task 7: `from <angle>` 検証 fixture と test を追加
+
+**Files:**
+
+- Create: `crates/fulgur-vrt/fixtures/paint/conic-gradient-from-90.html`
+- Modify: `crates/fulgur-vrt/tests/conic_gradient_harness.rs`
+
+**Step 1: fixture を追加**
+
+```html
+<!-- conic-gradient-from-90.html -->
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>VRT test: from 90deg</title>
+<style>
+  html, body { margin:0; padding:0; background:white; }
+  .box {
+    width:192px; height:192px; margin:32px;
+    background: conic-gradient(from 90deg,
+      red 0deg, red 90deg,
+      yellow 90deg, yellow 180deg,
+      green 180deg, green 270deg,
+      blue 270deg, blue 360deg);
+  }
+</style>
+</head>
+<body><div class="box"></div></body>
+</html>
+```
+
+`from 90deg` は CSS 0% を 90deg (= screen 右) にシフトするので、red sector が
+右下 1/4、yellow が左下、green が左上、blue が右上 になる。
+
+**Step 2: ref builder を 90° rotate した版に拡張**
+
+```rust
+fn build_quadrant_ref_html_rotated_90() -> String {
+    format!(
+        r#"...
+  .red    {{ background: red;    clip-path: polygon(50% 50%, 100% 50%, 100% 100%,  50% 100%); }}
+  .yellow {{ background: yellow; clip-path: polygon(50% 50%,  50% 100%,   0% 100%,   0% 50%); }}
+  .green  {{ background: green;  clip-path: polygon(50% 50%,   0% 50%,   0%   0%,  50%   0%); }}
+  .blue   {{ background: blue;   clip-path: polygon(50% 50%,  50%   0%, 100%   0%, 100% 50%); }}
+..."#)
+}
+
+#[test]
+fn conic_gradient_from_90deg_matches_rotated_reference() {
+    // ... harness boilerplate (Task 5 と同じ)
+    let test_html_path = ... "conic-gradient-from-90.html";
+    let ref_html = build_quadrant_ref_html_rotated_90();
+    // ... pixel diff
+}
+```
+
+**Step 3: 実行 + commit**
+
+```bash
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" \
+    cargo test -p fulgur-vrt --test conic_gradient_harness
+git add crates/fulgur-vrt/fixtures/paint/conic-gradient-from-90.html \
+        crates/fulgur-vrt/tests/conic_gradient_harness.rs
+git commit -m "test(gradient): add conic-gradient from-angle VRT case"
+```
+
+---
+
+## Task 8: `at <position>` (中心オフセット) fixture と test を追加
+
+**Files:**
+
+- Create: `crates/fulgur-vrt/fixtures/paint/conic-gradient-at-25-75.html`
+- Modify: `crates/fulgur-vrt/tests/conic_gradient_harness.rs`
+
+**Step 1: fixture と ref (advisor 提案で穏当な offset に変更)**
+
+box を 96×96 に縮小し、中心を `at 40% 60%` (= 38.4, 57.6 px) にする。これにより
+polygon 頂点の整数化を保てて tolerance を radial harness と同じ `max_diff_ratio: 0.02` に
+維持できる (極端な offset は別 PR で扱う)。
+
+```html
+<!-- conic-gradient-at-40-60.html -->
+<style>
+  .box {
+    width:96px; height:96px; margin:32px;
+    background: conic-gradient(at 40% 60%,
+      red 0deg, red 90deg,
+      yellow 90deg, yellow 180deg,
+      green 180deg, green 270deg,
+      blue 270deg, blue 360deg);
+  }
+</style>
+```
+
+ref は同じ box サイズで polygon 頂点を中心 (38.4, 57.6) からの放射線として計算する。
+
+**Step 2: 実行 + commit**
+
+```bash
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" \
+    cargo test -p fulgur-vrt --test conic_gradient_harness conic_gradient_at_position
+git add crates/fulgur-vrt/fixtures/paint/conic-gradient-at-25-75.html \
+        crates/fulgur-vrt/tests/conic_gradient_harness.rs
+git commit -m "test(gradient): add conic-gradient at-position VRT case"
+```
+
+---
+
+## Task 9: `repeating-conic-gradient` fixture と test を追加
+
+**Files:**
+
+- Create: `crates/fulgur-vrt/fixtures/paint/repeating-conic-12-stripes.html`
+- Modify: `crates/fulgur-vrt/tests/conic_gradient_harness.rs`
+
+**Step 1: fixture**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>VRT test: repeating conic 12 stripes</title>
+<style>
+  html, body { margin:0; padding:0; background:white; }
+  .box {
+    width:192px; height:192px; margin:32px;
+    background: repeating-conic-gradient(
+      red    0deg, red    15deg,
+      blue  15deg, blue   30deg);
+  }
+</style>
+</head>
+<body><div class="box"></div></body>
+</html>
+```
+
+これは 30deg 周期で 12 個の red/blue 縞が回る。
+
+**Step 2: ref (sector polygon ヘルパを切り出す)**
+
+12 個の交互 sector を CSS clip-path で並べる ref を生成する。advisor 指摘に従い、
+sector polygon の頂点は box 辺との交点で変わる (上辺/右辺/下辺/左辺 をまたぐ)
+ため、専用ヘルパに分離して見通しを保つ:
+
+```rust
+/// 中心 (cx_pct, cy_pct) (% 単位) から角度 [start_deg, end_deg) の sector を
+/// 含む clip-path polygon 文字列を返す。CSS conic 規約 (0=top, CW)。
+/// 中心 + 必要な box-edge 交点 + start/end 単位ベクトル endpoint を順に並べる。
+fn sector_polygon_clip_path(
+    cx_pct: f32, cy_pct: f32,
+    start_deg: f32, end_deg: f32,
+) -> String {
+    // 1. start_deg から end_deg まで 0deg, 90deg, 180deg, 270deg 境界で
+    //    box 辺との交点を挟みながら polygon 頂点列を構築
+    // 2. 各角度 θ に対して中心から外周への ray が box 辺と交わる点を
+    //    `tan(θ - boundary)` で計算
+    // 3. CSS clip-path polygon 文字列に整形
+    ...
+}
+
+fn build_12_stripe_ref_html() -> String {
+    let mut sectors = String::new();
+    for i in 0..12 {
+        let color = if i % 2 == 0 { "red" } else { "blue" };
+        let path = sector_polygon_clip_path(50.0, 50.0, i as f32 * 30.0, (i + 1) as f32 * 30.0);
+        sectors.push_str(&format!(
+            r#"<div class="sector" style="background:{color};clip-path:{path};"></div>"#
+        ));
+    }
+    format!(...)
+}
+```
+
+tolerance は 12 個の境界線で AA が増えるため radial と同レベル
+(`max_pixel_diff: 14.0, max_diff_ratio: 0.03`)。
+
+**Step 3: 実行 + commit**
+
+```bash
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" \
+    cargo test -p fulgur-vrt --test conic_gradient_harness repeating
+git add crates/fulgur-vrt/fixtures/paint/repeating-conic-12-stripes.html \
+        crates/fulgur-vrt/tests/conic_gradient_harness.rs
+git commit -m "test(gradient): add repeating-conic-gradient VRT case"
+```
+
+---
+
+## Task 10: WPT expectations の更新
+
+**Files:**
+
+- Modify: `crates/fulgur-wpt-runner/expectations/lists/bugs.txt` (パスは要確認)
+
+**Step 1: 影響を受ける WPT を一覧化**
+
+```bash
+grep -n "conic-gradient" crates/fulgur-wpt-runner/expectations/lists/bugs.txt
+grep -rn "conic-gradient" crates/fulgur-wpt-runner/expectations/ | head
+```
+
+**Step 2: 実測**
+
+```bash
+# WPT runner で conic-gradient 関連 reftest を実行
+cargo run --bin fulgur-wpt-runner -- --filter conic-gradient
+```
+
+**Step 3: PASS した項目を bugs.txt から削除**
+
+実際に PASS したものを bugs.txt から外し、依然 fail のものはコメントを
+更新 (false PASS 対策が Phase 1 linear で行われたのと同じ)。
+
+**Step 4: commit**
+
+```bash
+git add crates/fulgur-wpt-runner/expectations/lists/bugs.txt
+git commit -m "test(wpt): update conic-gradient expectations after Phase 2 implementation"
+```
+
+---
+
+## Task 11: 全体テスト + lint + 確認
+
+**Step 1: full test**
+
+```bash
+cargo test -p fulgur                     # ~340 + 新規 smoke
+cargo test -p fulgur --test gcpm_integration
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" \
+    cargo test -p fulgur-vrt --test conic_gradient_harness
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" \
+    cargo test -p fulgur-vrt --test gradient_harness
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" \
+    cargo test -p fulgur-vrt --test radial_gradient_harness
+```
+
+**Step 2: lint**
+
+```bash
+cargo fmt --check
+cargo clippy -- -D warnings
+npx markdownlint-cli2 'docs/plans/2026-04-27-conic-gradient.md'
+```
+
+**Step 3: regenerate examples (任意・gradient を使う example が変わるなら)**
+
+```bash
+mise run regenerate-examples
+```
+
+**Step 4: 最終 commit (必要なら)**
+
+```bash
+git status
+# fmt 修正があれば commit
+```
+
+---
+
+## 完了基準
+
+- [ ] `crates/fulgur/tests/render_smoke.rs` の 2 件の conic smoke が pass
+- [ ] `crates/fulgur-vrt/tests/conic_gradient_harness.rs` の 4 件の VRT が pass
+  - 4 quadrant
+  - from 90deg
+  - at 25% 75%
+  - repeating 12 stripes
+- [ ] `cargo fmt --check` / `cargo clippy -- -D warnings` 通る
+- [ ] WPT bugs.txt から conic-gradient PASS 項目が外れている
+- [ ] `bd close fulgur-m92h` 実行可能な状態
+
+## 設計上の参照
+
+- `fulgur-m92h` (本 issue) の design field
+- `fulgur-batz` — PDF/A-safe fallback の追跡 (本 PR ではフラグ判定なし)
+- `crates/fulgur/src/background.rs::draw_radial_gradient` — 同等パターンの実装参考
+- `crates/fulgur-vrt/tests/radial_gradient_harness.rs` — VRT pixel-diff harness の参考
+- CSS Images Level 4 §3.x — conic-gradient 仕様 (https://drafts.csswg.org/css-images-4/#conic-gradients)
+- krilla 0.7 `src/graphics/paint.rs:103` — `SweepGradient` 型定義
+- krilla 0.7 `src/graphics/shading_function.rs:170,420` — sweep の PostScript 経路

--- a/scripts/wpt/subset.txt
+++ b/scripts/wpt/subset.txt
@@ -116,3 +116,23 @@ css/css-overflow/overflow-scroll-resize-visibility-hidden-ref.html
 # compositing opacity (rel=match explicit only)
 css/compositing/root-element-background-margin-opacity.html
 css/compositing/root-element-background-margin-opacity-ref.html
+
+# fulgur-m92h (conic-gradient Phase 2: path wedge 分解実装)
+# Bring upstream conic-gradient reftests into the subset. Outcomes
+# (PASS / FAIL / SKIP) are tracked in expectations/lists/bugs.txt.
+css/css-images/conic-gradient-angle.html
+css/css-images/conic-gradient-angle-negative.html
+css/css-images/conic-gradient-center.html
+css/css-images/conic-gradient-center-ref.html
+css/css-images/multiple-position-color-stop-conic.html
+css/css-images/multiple-position-color-stop-conic-2.html
+css/css-images/multiple-position-color-stop-conic-2-ref.html
+css/css-images/normalization-conic.html
+css/css-images/normalization-conic-2.html
+css/css-images/normalization-conic-degenerate.html
+css/css-images/out-of-range-color-stop-conic.html
+css/css-images/repeating-conic-gradient.html
+css/css-images/repeating-conic-gradient-ref.html
+css/css-images/tiled-conic-gradients.html
+css/css-images/tiled-conic-gradients-ref.html
+css/css-images/reference/200x200-blue-black-green-red.html


### PR DESCRIPTION
## Summary

CSS `conic-gradient(...)` / `repeating-conic-gradient(...)` を path wedge 分解で実装 (`fulgur-m92h`)。

- `BgImageContent::ConicGradient` variant を追加し、`convert.rs::resolve_conic_gradient` で Stylo の `Gradient::Conic` から組み立てる
- `background.rs::draw_conic_gradient` は N=360 個の三角ウェッジ中点で色をサンプル → 隣接同色を 1 個の polygon に merge → krilla `Surface::draw_path` で発行
- krilla の `SweepGradient` (PostScript Type 4 function shading) を**使わない**ため **PDF/A-1 / PDF/A-2 自動適合**
- linear/radial と同じ `try_uniform_grid` 経路で tiled conic も dedup
- `<percentage>` / `<angle>` mixed stop position、`from <angle>`、`at <position>`、repeating 全対応

## Design pivot

当初プラン (krilla `SweepGradient` 直接利用) は PDF/A 非適合になるため pivot。raster や Coons mesh 案も検討したが、pie chart で path wedge が圧倒的に小さく (~1.6KB vs raster 床 ~3.5KB)、krilla 上流改修も不要で済むため採用。

詳細: `docs/plans/2026-04-27-conic-gradient.md` (Design Pivot 節)

## サイズ実測 (200×200 box)

| ケース | conic 純増 |
|--------|------------|
| 4-color pie chart (square) | 1634 byte |
| pie chart circular (`border-radius:50%`) | 1701 byte |
| `from 90deg` 4-color | 1652 byte |
| `at 25% 75%` 4-color | 1923 byte |
| repeating 12 stripes | 1740 byte |
| smooth 5-stop | 4875 byte |

## PDF/A 関連 issue 整理

- `fulgur-batz` (PDF/A-safe conic fallback) → close 済 (path wedge で適合済みのため不要)
- `fulgur-zao0` (PDF/A output mode epic) → 非適合 fallback リストから conic を除外

## Test plan

- [x] **lib unit (`background::conic_helpers_tests`):** 11 件 (`box_edge_at_angle` × 5 / `normalize_conic_stops` × 3 / `sample_conic_color` × 3) — pass
- [x] **lib smoke (`render_smoke.rs`):** 5 件 (pie / smooth / repeating / from-angle / at-position) — pass
- [x] **VRT harness (`fulgur-vrt/tests/conic_gradient_harness.rs`):** 4-quadrant pie chart vs 絶対配置 4 矩形 ref で pixel diff — pass (tolerance: max channel 12 / max diff ratio 2%)
- [x] **WPT (vendored 11 件):** 10 PASS + 1 FAIL (`multiple-position-color-stop-conic-2` は 548/892k px が default tol 超え、視覚は完全一致の sub-pixel AA 差) — `crates/fulgur-wpt/expectations/lists/bugs.txt` に登録
- [x] **fulgur lib 全体回帰:** 783 件 (+11 from baseline 772) pass
- [x] **`cargo fmt --check` / `cargo clippy --workspace --all-targets -- -D warnings`** clean

Closes fulgur-m92h.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rendering support for conic-gradient() and repeating-conic-gradient(), including start-angle and center-position handling.

* **Tests**
  * Added visual-regression fixture, a pixel-compare VRT harness, and multiple end-to-end smoke tests covering conic-gradient variants.

* **Documentation**
  * Added implementation plan and design notes for conic-gradient rendering and sampling approach.

* **Chores**
  * Expanded test subset and updated WPT expectations for conic-gradient coverage (one noted visual-expectation difference).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->