### PR TITLE
fix(release-prepare): refresh fulgur-ruby Gemfile.lock on version bump

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -100,6 +100,17 @@ jobs:
 
           cargo check --workspace
 
+      # Gemfile.lock は fulgur-jdt3 で commit 方針 (rb_sys host/container drift 防止)。
+      # gemspec 側 version が変わると frozen-mode bundler が exit 16 で失敗するため、
+      # version bump に合わせて lockfile も更新する。
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: false
+      - name: Refresh fulgur-ruby Gemfile.lock
+        working-directory: crates/fulgur-ruby
+        run: bundle install
+
       # PR-based changelog: ask GitHub to render notes from merged PRs since the
       # last release, classified by `release-notes:*` labels per .github/release.yml.
       # `previous_tag_name` is auto-detected when omitted.

--- a/crates/fulgur-ruby/Gemfile.lock
+++ b/crates/fulgur-ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fulgur (0.8.0)
+    fulgur (0.10.0)
       rb_sys (~> 0.9)
 
 GEM


### PR DESCRIPTION
## Summary

- v0.10.0 の Ruby gem release が `bundle install` exit 16 で失敗 ([job](https://github.com/fulgur-rs/fulgur/actions/runs/25005758586/job/73227937234))
- 原因: `release-prepare.yml` が `lib/fulgur/version.rb` を更新する一方で `Gemfile.lock` を触っていない。Gemfile.lock は fulgur-jdt3 で commit 方針 (rb_sys host/container drift 防止) のため、gemspec=N+1 / lockfile=N の食い違いが残り frozen-mode bundler に拒否される
- fix: `cargo check --workspace` 直後に Ruby setup + `crates/fulgur-ruby` で `bundle install` を実行して lockfile を再解決

`fulgur-jdt3` (Gemfile.lock commit 方針) と組み合わせで完成する欠けピース。

Refs: fulgur-618g, fulgur-jdt3, fulgur-3cd2 (ZeroVer + release pipeline simplification)

## Test plan

- [ ] PR マージ後 `workflow_dispatch` で v0.11.0 を切り、release-prepare ジョブの `Refresh fulgur-ruby Gemfile.lock` ステップで Gemfile.lock の `fulgur (X.Y.Z)` 行が新版に書き換わることを確認
- [ ] release-ruby.yml の Build source gem が exit 16 で落ちないことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This pull request contains no user-facing changes. The modifications are internal infrastructure updates to the release preparation workflow.

* **Chores**
  * Updated release preparation automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
