### PR TITLE
refactor(net): hide blitz net imports behind blitz_adapter

### DIFF
--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -31,6 +31,22 @@ use parley::FontContext;
 use std::path::Path;
 use std::sync::Arc;
 
+/// Re-exports of the Blitz network trait surface used by [`crate::net`].
+///
+/// All `blitz_traits::net::*` and `blitz_dom::net::*` references in fulgur
+/// flow through this module so that upstream Blitz API churn (e.g. the
+/// `NetProvider<Resource>` generic removal in blitz-dom 0.3) is contained
+/// to `blitz_adapter.rs` — the same isolation rule documented in the file
+/// header. `crate::net::FulgurNetProvider`'s `impl NetProvider` block still
+/// has to be touched when the trait shape changes, but downstream call sites
+/// and tests no longer name the upstream crates directly.
+pub mod net {
+    pub use blitz_dom::net::Resource;
+    pub use blitz_traits::net::{
+        BoxedHandler, Bytes, NetHandler, NetProvider, Request, SharedCallback, Url,
+    };
+}
+
 /// Parse HTML and return a fully resolved document (styles + layout computed).
 ///
 /// We pass the content width as the viewport width so Taffy wraps text

--- a/crates/fulgur/src/net.rs
+++ b/crates/fulgur/src/net.rs
@@ -28,10 +28,11 @@
 //! cleaned CSS still contains every other declaration, so cascade,
 //! specificity and `@import` resolution remain delegated to stylo.
 
+use crate::blitz_adapter::net::{
+    BoxedHandler, Bytes, NetProvider, Request, Resource, SharedCallback,
+};
 use crate::gcpm::GcpmContext;
 use crate::gcpm::parser::parse_gcpm;
-use blitz_dom::net::Resource;
-use blitz_traits::net::{BoxedHandler, Bytes, NetProvider, Request, SharedCallback};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
@@ -186,7 +187,7 @@ impl NetProvider<Resource> for FulgurNetProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use blitz_traits::net::{NetHandler, Url};
+    use crate::blitz_adapter::net::{NetHandler, Url};
     use std::fs;
 
     fn make_request(url: &str) -> Request {
@@ -204,8 +205,8 @@ mod tests {
         fn bytes(
             self: Box<Self>,
             _doc_id: usize,
-            bytes: blitz_traits::net::Bytes,
-            _callback: blitz_traits::net::SharedCallback<Resource>,
+            bytes: Bytes,
+            _callback: SharedCallback<Resource>,
         ) {
             *self.bytes.lock().unwrap() = Some(bytes.to_vec());
         }


### PR DESCRIPTION
## Summary

`crates/fulgur/src/net.rs` から `blitz_traits::net::*` / `blitz_dom::net::Resource` の直接参照を排除し、`blitz_adapter::net` 経由の薄い再エクスポートに統一しました。CLAUDE.md の adapter-isolation 原則に net.rs を整合させ、blitz-dom 0.3 系 (`NetProvider<Resource>` の generic 削除と net 型エイリアス整理) 移行時の修正範囲を `blitz_adapter.rs` 中心に縮小します。

## 変更点

- `crates/fulgur/src/blitz_adapter.rs` に `pub mod net` を新設し、`BoxedHandler` / `Bytes` / `NetHandler` / `NetProvider` / `Request` / `SharedCallback` / `Url` / `Resource` の 8 種を再エクスポート
- `crates/fulgur/src/net.rs` (本体・tests 両方) の import を `crate::blitz_adapter::net::*` に切り替え
- 振る舞いの変更なし

`grep -rn "blitz_traits::net\|blitz_dom::net" crates/ --include="*.rs"` の結果は `crates/fulgur/src/blitz_adapter.rs` のみ。workspace 全体で他 crate からの直接参照はありません。

## なぜ閉じきれないか (補足)

`impl NetProvider<Resource> for FulgurNetProvider` の `<Resource>` generic 削除は trait の foreign impl なので、blitz 0.3 移行時に net.rs の impl ブロック 1 行は触る必要があります。完全に閉じるには fulgur 独自 trait を介す二段構造が必要ですが、design (fulgur-7v1t) はそこまで求めず「薄い再 export」を選択しています。

## Test plan

- [x] `cargo build -p fulgur`
- [x] `cargo test -p fulgur --lib` (824 pass)
- [x] `cargo test -p fulgur --test render_smoke` (27 pass)
- [x] `cargo test -p fulgur --lib net::` (9 pass)
- [x] `cargo test -p fulgur` (workspace の他 integration test 含めて全 pass)
- [x] `cargo clippy -p fulgur --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `grep -rn "blitz_traits\|blitz_dom" crates/fulgur/src/net.rs` で 0 件確認

Refs: fulgur-7v1t
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal networking type exports for improved modularity. No functional changes to network behavior or existing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->