### PR TITLE
test(convert/style/background): add coverage for gradient and bg-image conversion

### DIFF
--- a/crates/fulgur/src/convert/style/background.rs
+++ b/crates/fulgur/src/convert/style/background.rs
@@ -595,3 +595,385 @@ fn convert_bg_clip(
         C::ContentBox => BgClip::ContentBox,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{AssetBundle, Engine};
+
+    /// 1×1 red PNG (minimal valid file with correct CRC sums).
+    const PNG_1X1_RED: &[u8] = &[
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90,
+        0x77, 0x53, 0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0xF8,
+        0xCF, 0xC0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00, 0xC9, 0xFE, 0x92, 0xEF, 0x00, 0x00, 0x00,
+        0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+    ];
+
+    fn render_bg(bg_css: &str) -> Vec<u8> {
+        let html = format!(
+            r#"<html><body><div style="width:120px;height:80px;background:{bg_css}"></div></body></html>"#
+        );
+        Engine::builder()
+            .build()
+            .render_html(&html)
+            .expect("render should succeed")
+    }
+
+    fn assert_pdf(pdf: &[u8], label: &str) {
+        assert!(pdf.starts_with(b"%PDF"), "{label}: expected PDF header");
+    }
+
+    // ── resolve_linear_gradient: direction arms ───────────────────────────────
+
+    /// Exercises all nine `LineDirection` arms of `resolve_linear_gradient`:
+    /// `Angle`, `Horizontal(Left)`, `Horizontal(Right)`, `Vertical(Top)`,
+    /// `Vertical(Bottom)`, and all four `Corner` variants.
+    #[test]
+    fn linear_gradient_direction_variants() {
+        let cases = [
+            ("angle", "linear-gradient(45deg,red,blue)"),
+            ("to_right", "linear-gradient(to right,red,blue)"),
+            ("to_left", "linear-gradient(to left,red,blue)"),
+            ("to_top", "linear-gradient(to top,red,blue)"),
+            ("to_bottom", "linear-gradient(to bottom,red,blue)"),
+            ("to_top_right", "linear-gradient(to top right,red,blue)"),
+            ("to_top_left", "linear-gradient(to top left,red,blue)"),
+            ("to_bottom_left", "linear-gradient(to bottom left,red,blue)"),
+            (
+                "to_bottom_right",
+                "linear-gradient(to bottom right,red,blue)",
+            ),
+        ];
+        for (name, css) in cases {
+            assert_pdf(&render_bg(css), name);
+        }
+    }
+
+    // ── resolve_radial_gradient: shape arms ───────────────────────────────────
+
+    /// Exercises `EndingShape::Circle(Circle::Radius(...))`.
+    #[test]
+    fn radial_gradient_circle_explicit_radius() {
+        assert_pdf(
+            &render_bg("radial-gradient(circle 40px at center,red,blue)"),
+            "circle_radius",
+        );
+    }
+
+    /// Exercises `Circle::Extent` and `Ellipse::Extent` for all four
+    /// `ShapeExtent` keyword values (ClosestSide / FarthestSide /
+    /// ClosestCorner / FarthestCorner), which also covers `map_extent`.
+    #[test]
+    fn radial_gradient_extent_variants() {
+        let cases = [
+            (
+                "circle_closest_side",
+                "radial-gradient(closest-side circle,red,blue)",
+            ),
+            (
+                "circle_farthest_side",
+                "radial-gradient(farthest-side circle,red,blue)",
+            ),
+            (
+                "circle_closest_corner",
+                "radial-gradient(closest-corner circle,red,blue)",
+            ),
+            (
+                "circle_farthest_corner",
+                "radial-gradient(farthest-corner circle,red,blue)",
+            ),
+            (
+                "ellipse_closest_side",
+                "radial-gradient(closest-side ellipse,red,blue)",
+            ),
+            (
+                "ellipse_farthest_side",
+                "radial-gradient(farthest-side ellipse,red,blue)",
+            ),
+            (
+                "ellipse_closest_corner",
+                "radial-gradient(closest-corner ellipse,red,blue)",
+            ),
+            (
+                "ellipse_farthest_corner",
+                "radial-gradient(farthest-corner ellipse,red,blue)",
+            ),
+        ];
+        for (name, css) in cases {
+            assert_pdf(&render_bg(css), name);
+        }
+    }
+
+    /// Exercises `EndingShape::Ellipse(Ellipse::Radii(...))` and the
+    /// `try_convert_lp_to_bg` calls for both rx and ry.
+    #[test]
+    fn radial_gradient_ellipse_explicit_radii() {
+        assert_pdf(
+            &render_bg("radial-gradient(ellipse 50px 30px at center,red,blue)"),
+            "ellipse_radii",
+        );
+    }
+
+    /// Exercises the `position_x` / `position_y` arms of
+    /// `resolve_radial_gradient` with a percentage center.
+    #[test]
+    fn radial_gradient_percentage_position() {
+        assert_pdf(
+            &render_bg("radial-gradient(circle at 25% 75%,red,blue)"),
+            "radial_at_position",
+        );
+    }
+
+    /// `repeating-radial-gradient` exercises the `repeating: true` flag.
+    #[test]
+    fn radial_gradient_repeating() {
+        assert_pdf(
+            &render_bg("repeating-radial-gradient(circle 30px,red,blue)"),
+            "radial_repeating",
+        );
+    }
+
+    // ── resolve_conic_gradient: arms ─────────────────────────────────────────
+
+    /// Exercises the `from_angle` field and basic `SimpleColorStop` items.
+    #[test]
+    fn conic_gradient_from_angle() {
+        assert_pdf(
+            &render_bg("conic-gradient(from 45deg,red,blue)"),
+            "conic_from_angle",
+        );
+    }
+
+    /// Exercises position_x / position_y via `at <position>`.
+    #[test]
+    fn conic_gradient_at_position() {
+        assert_pdf(
+            &render_bg("conic-gradient(at 30% 70%,red,blue)"),
+            "conic_at_pos",
+        );
+    }
+
+    /// `ComplexColorStop` with `Percentage` → `GradientStopPosition::Fraction`.
+    #[test]
+    fn conic_gradient_percentage_stops() {
+        assert_pdf(
+            &render_bg("conic-gradient(red 0%,blue 50%,red 100%)"),
+            "conic_pct_stops",
+        );
+    }
+
+    /// `ComplexColorStop` with `Angle` → fraction via `angle / TAU`.
+    #[test]
+    fn conic_gradient_angle_stops() {
+        assert_pdf(
+            &render_bg("conic-gradient(red 0deg,blue 90deg,red 360deg)"),
+            "conic_angle_stops",
+        );
+    }
+
+    /// `repeating-conic-gradient` exercises the `repeating: true` flag.
+    #[test]
+    fn conic_gradient_repeating() {
+        assert_pdf(
+            &render_bg("repeating-conic-gradient(red 0deg,blue 30deg)"),
+            "conic_repeating",
+        );
+    }
+
+    // ── resolve_color_stops: GradientStopPosition variants ───────────────────
+
+    /// `ComplexColorStop` with `to_length()` → `GradientStopPosition::LengthPx`.
+    #[test]
+    fn linear_gradient_length_px_stops() {
+        assert_pdf(
+            &render_bg("linear-gradient(red 0px,blue 80px)"),
+            "length_px_stops",
+        );
+    }
+
+    /// `ComplexColorStop` with `to_percentage()` → `GradientStopPosition::Fraction`.
+    #[test]
+    fn linear_gradient_fraction_stops() {
+        assert_pdf(
+            &render_bg("linear-gradient(red 0%,blue 100%)"),
+            "fraction_stops",
+        );
+    }
+
+    /// Valid interpolation hint between two color stops. The hint is at 30%
+    /// and drives the power-curve expansion in `expand_interpolation_hints`.
+    #[test]
+    fn linear_gradient_valid_interpolation_hint() {
+        assert_pdf(&render_bg("linear-gradient(red,30%,blue)"), "valid_hint");
+    }
+
+    /// Invalid hint placements cause `resolve_color_stops` to return `None`
+    /// (layer dropped). The element still renders — just without the gradient.
+    #[test]
+    fn linear_gradient_invalid_hint_cases_drop_layer() {
+        let cases = [
+            ("leading_hint", "linear-gradient(30%,red,blue)"),
+            ("trailing_hint", "linear-gradient(red,blue,70%)"),
+            ("consecutive_hints", "linear-gradient(red,30%,60%,blue)"),
+        ];
+        for (name, css) in cases {
+            assert_pdf(&render_bg(css), name);
+        }
+    }
+
+    // ── convert_bg_size: BackgroundSize variant arms ──────────────────────────
+
+    /// All `background-size` keyword / value combinations exercise every arm
+    /// of `convert_bg_size` (Cover, Contain, ExplicitSize with various
+    /// auto/length/percentage combinations).
+    #[test]
+    fn bg_size_variants() {
+        let cases = [
+            ("cover", "background-size:cover"),
+            ("contain", "background-size:contain"),
+            ("explicit_px", "background-size:50px 40px"),
+            ("auto_height", "background-size:50px auto"),
+            ("auto_width", "background-size:auto 40px"),
+            ("auto_auto", "background-size:auto auto"),
+            ("pct", "background-size:50% 50%"),
+        ];
+        for (name, size_css) in cases {
+            let html = format!(
+                r#"<html><body><div style="width:120px;height:80px;background:linear-gradient(red,blue);{size_css}"></div></body></html>"#
+            );
+            let pdf = Engine::builder()
+                .build()
+                .render_html(&html)
+                .unwrap_or_else(|_| panic!("render failed for {name}"));
+            assert!(pdf.starts_with(b"%PDF"), "{name}: expected PDF");
+        }
+    }
+
+    // ── convert_bg_repeat: BackgroundRepeat variant arms ─────────────────────
+
+    /// All four `BackgroundRepeatKeyword` values exercise every arm of
+    /// `convert_bg_repeat`.
+    #[test]
+    fn bg_repeat_variants() {
+        let cases = [
+            ("repeat", "background-repeat:repeat"),
+            ("no_repeat", "background-repeat:no-repeat"),
+            ("space", "background-repeat:space"),
+            ("round", "background-repeat:round"),
+        ];
+        for (name, repeat_css) in cases {
+            let html = format!(
+                r#"<html><body><div style="width:120px;height:80px;background:linear-gradient(red,blue);background-size:30px 20px;{repeat_css}"></div></body></html>"#
+            );
+            let pdf = Engine::builder()
+                .build()
+                .render_html(&html)
+                .unwrap_or_else(|_| panic!("render failed for {name}"));
+            assert!(pdf.starts_with(b"%PDF"), "{name}: expected PDF");
+        }
+    }
+
+    // ── convert_bg_origin / convert_bg_clip: box-type variant arms ───────────
+
+    /// All three `background-origin` + `background-clip` keyword pairs exercise
+    /// every arm of `convert_bg_origin` and `convert_bg_clip`.
+    #[test]
+    fn bg_origin_clip_variants() {
+        let cases = [
+            (
+                "border_box",
+                "background-origin:border-box;background-clip:border-box",
+            ),
+            (
+                "padding_box",
+                "background-origin:padding-box;background-clip:padding-box",
+            ),
+            (
+                "content_box",
+                "background-origin:content-box;background-clip:content-box",
+            ),
+        ];
+        for (name, extra_css) in cases {
+            let html = format!(
+                r#"<html><body><div style="width:120px;height:80px;padding:10px;background:linear-gradient(red,blue);{extra_css}"></div></body></html>"#
+            );
+            let pdf = Engine::builder()
+                .build()
+                .render_html(&html)
+                .unwrap_or_else(|_| panic!("render failed for {name}"));
+            assert!(pdf.starts_with(b"%PDF"), "{name}: expected PDF");
+        }
+    }
+
+    // ── apply_to: background-image URL arms ──────────────────────────────────
+
+    /// `Image::Url` → `AssetKind::Raster` → `BgImageContent::Raster` arm.
+    #[test]
+    fn bg_image_url_raster_png() {
+        let mut bundle = AssetBundle::default();
+        bundle.add_image("dot.png", PNG_1X1_RED.to_vec());
+        let html = r#"<html><body><div style="width:80px;height:80px;background:url(dot.png)"></div></body></html>"#;
+        let pdf = Engine::builder()
+            .assets(bundle)
+            .build()
+            .render_html(html)
+            .expect("render raster bg");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    /// `Image::Url` → `AssetKind::Svg` → `BgImageContent::Svg` arm.
+    #[test]
+    fn bg_image_url_svg() {
+        let svg = b"<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10'><rect width='10' height='10' fill='red'/></svg>";
+        let mut bundle = AssetBundle::default();
+        bundle.add_image("bg.svg", svg.to_vec());
+        let html = r#"<html><body><div style="width:80px;height:80px;background:url(bg.svg)"></div></body></html>"#;
+        let pdf = Engine::builder()
+            .assets(bundle)
+            .build()
+            .render_html(html)
+            .expect("render svg bg");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    /// `Image::Url` → SVG bytes that fail `usvg::Tree::from_data` → `None` arm
+    /// (logs a warning, layer dropped, element still renders).
+    #[test]
+    fn bg_image_url_invalid_svg_logs_and_falls_back() {
+        let mut bundle = AssetBundle::default();
+        bundle.add_image("broken.svg", b"<svg<<NOT_VALID_XML".to_vec());
+        let html = r#"<html><body><div style="width:80px;height:80px;background:url(broken.svg)"></div></body></html>"#;
+        let pdf = Engine::builder()
+            .assets(bundle)
+            .build()
+            .render_html(html)
+            .expect("render broken-svg bg");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    /// `Image::Url` → `AssetKind::Unknown` arm → `None` (layer dropped).
+    #[test]
+    fn bg_image_url_unknown_asset_kind() {
+        let mut bundle = AssetBundle::default();
+        bundle.add_image("file.dat", b"NOT_AN_IMAGE_OR_SVG".to_vec());
+        let html = r#"<html><body><div style="width:80px;height:80px;background:url(file.dat)"></div></body></html>"#;
+        let pdf = Engine::builder()
+            .assets(bundle)
+            .build()
+            .render_html(html)
+            .expect("render unknown-asset bg");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    /// `Image::Url` when no `AssetBundle` is set → `ctx.assets.is_none()` →
+    /// `and_then` returns `None` (layer dropped silently).
+    #[test]
+    fn bg_image_url_without_bundle_returns_none() {
+        let html = r#"<html><body><div style="width:80px;height:80px;background:url(img.png)"></div></body></html>"#;
+        let pdf = Engine::builder()
+            .build()
+            .render_html(html)
+            .expect("render missing-bundle bg");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+}

--- a/crates/fulgur/src/convert/style/background.rs
+++ b/crates/fulgur/src/convert/style/background.rs
@@ -623,6 +623,15 @@ mod tests {
         assert!(pdf.starts_with(b"%PDF"), "{label}: expected PDF header");
     }
 
+    fn render_with_style(style: &str, label: &str) {
+        let html = format!(r#"<html><body><div style="{style}"></div></body></html>"#);
+        let pdf = Engine::builder()
+            .build()
+            .render_html(&html)
+            .unwrap_or_else(|_| panic!("render failed for {label}"));
+        assert!(pdf.starts_with(b"%PDF"), "{label}: expected PDF");
+    }
+
     // ── resolve_linear_gradient: direction arms ───────────────────────────────
 
     /// Exercises all nine `LineDirection` arms of `resolve_linear_gradient`:
@@ -838,14 +847,10 @@ mod tests {
             ("pct", "background-size:50% 50%"),
         ];
         for (name, size_css) in cases {
-            let html = format!(
-                r#"<html><body><div style="width:120px;height:80px;background:linear-gradient(red,blue);{size_css}"></div></body></html>"#
+            render_with_style(
+                &format!("width:120px;height:80px;background:linear-gradient(red,blue);{size_css}"),
+                name,
             );
-            let pdf = Engine::builder()
-                .build()
-                .render_html(&html)
-                .unwrap_or_else(|_| panic!("render failed for {name}"));
-            assert!(pdf.starts_with(b"%PDF"), "{name}: expected PDF");
         }
     }
 
@@ -862,14 +867,12 @@ mod tests {
             ("round", "background-repeat:round"),
         ];
         for (name, repeat_css) in cases {
-            let html = format!(
-                r#"<html><body><div style="width:120px;height:80px;background:linear-gradient(red,blue);background-size:30px 20px;{repeat_css}"></div></body></html>"#
+            render_with_style(
+                &format!(
+                    "width:120px;height:80px;background:linear-gradient(red,blue);background-size:30px 20px;{repeat_css}"
+                ),
+                name,
             );
-            let pdf = Engine::builder()
-                .build()
-                .render_html(&html)
-                .unwrap_or_else(|_| panic!("render failed for {name}"));
-            assert!(pdf.starts_with(b"%PDF"), "{name}: expected PDF");
         }
     }
 
@@ -894,14 +897,12 @@ mod tests {
             ),
         ];
         for (name, extra_css) in cases {
-            let html = format!(
-                r#"<html><body><div style="width:120px;height:80px;padding:10px;background:linear-gradient(red,blue);{extra_css}"></div></body></html>"#
+            render_with_style(
+                &format!(
+                    "width:120px;height:80px;padding:10px;background:linear-gradient(red,blue);{extra_css}"
+                ),
+                name,
             );
-            let pdf = Engine::builder()
-                .build()
-                .render_html(&html)
-                .unwrap_or_else(|_| panic!("render failed for {name}"));
-            assert!(pdf.starts_with(b"%PDF"), "{name}: expected PDF");
         }
     }
 

--- a/crates/fulgur/src/convert/style/background.rs
+++ b/crates/fulgur/src/convert/style/background.rs
@@ -938,9 +938,9 @@ mod tests {
     }
 
     /// `Image::Url` → SVG bytes that fail `usvg::Tree::from_data` → `None` arm
-    /// (logs a warning, layer dropped, element still renders).
+    /// (layer dropped; element still renders).
     #[test]
-    fn bg_image_url_invalid_svg_logs_and_falls_back() {
+    fn bg_image_url_invalid_svg_falls_back() {
         let mut bundle = AssetBundle::default();
         bundle.add_image("broken.svg", b"<svg<<NOT_VALID_XML".to_vec());
         let html = r#"<html><body><div style="width:80px;height:80px;background:url(broken.svg)"></div></body></html>"#;


### PR DESCRIPTION
## 対象モジュール

`crates/fulgur/src/convert/style/background.rs`

`--lib` カバレッジ計測 (`cargo llvm-cov --package fulgur --lib`) で最低カバレッジのファイルとして特定。Stylo 型を直接構築せずにテストできる方法として、`Engine::render_html()` を呼ぶインライン `#[cfg(test)] mod tests` を追加した。これにより `cargo test -p fulgur --lib` の対象となり、codecov の `--lib` 計測でもカバレッジが乗る。

## カバレッジ変化

| 指標 | 変更前 | 変更後 |
|------|--------|--------|
| Region coverage | 4.67 % (23/493) | **94.72 %** (735/776) |
| Function coverage | 5.56 % (1/18) | **93.48 %** (43/46) |
| Line coverage | 4.01 % (15/374) | **95.18 %** (592/622) |

クレート全体も 83.28 % → 86.50 % に改善。

## 追加したテスト (23 件)

| テスト名 | カバーする対象 |
|----------|----------------|
| `linear_gradient_direction_variants` | `resolve_linear_gradient` の全 9 方向アーム (Angle / Horizontal×2 / Vertical×2 / Corner×4) |
| `radial_gradient_circle_explicit_radius` | `Circle::Radius` アーム |
| `radial_gradient_extent_variants` | `Circle::Extent` + `Ellipse::Extent` の 8 バリアント、`map_extent` 全ケース |
| `radial_gradient_ellipse_explicit_radii` | `Ellipse::Radii` アーム、`try_convert_lp_to_bg` × 2 |
| `radial_gradient_percentage_position` | `resolve_radial_gradient` の `position_x`/`position_y` アーム |
| `radial_gradient_repeating` | `repeating: true` フラグ |
| `conic_gradient_from_angle` | `from_angle` フィールド設定パス |
| `conic_gradient_at_position` | `position_x`/`position_y` アーム (conic) |
| `conic_gradient_percentage_stops` | `ComplexColorStop` + `Percentage` → `Fraction` |
| `conic_gradient_angle_stops` | `ComplexColorStop` + `Angle` → `angle / TAU` |
| `conic_gradient_repeating` | `repeating-conic-gradient` フラグ |
| `linear_gradient_length_px_stops` | `GradientStopPosition::LengthPx` (`to_length()` アーム) |
| `linear_gradient_fraction_stops` | `GradientStopPosition::Fraction` (`to_percentage()` アーム) |
| `linear_gradient_valid_interpolation_hint` | 有効なヒント位置 → `is_hint=true` stop |
| `linear_gradient_invalid_hint_cases_drop_layer` | 先頭/末尾/連続ヒント → `resolve_color_stops` が `None` を返す 3 ケース |
| `bg_size_variants` | `convert_bg_size` の Cover / Contain / ExplicitSize (px×2 / auto×3 / pct) 全アーム |
| `bg_repeat_variants` | `convert_bg_repeat` の Repeat / NoRepeat / Space / Round 全アーム |
| `bg_origin_clip_variants` | `convert_bg_origin` / `convert_bg_clip` の BorderBox / PaddingBox / ContentBox |
| `bg_image_url_raster_png` | `Image::Url` → `AssetKind::Raster` → `BgImageContent::Raster` |
| `bg_image_url_svg` | `Image::Url` → `AssetKind::Svg` → `BgImageContent::Svg` |
| `bg_image_url_invalid_svg_logs_and_falls_back` | `usvg::Tree::from_data` エラー → `None` + ログ警告 |
| `bg_image_url_unknown_asset_kind` | `AssetKind::Unknown` → `None` |
| `bg_image_url_without_bundle_returns_none` | `ctx.assets.is_none()` → `and_then` が `None` |

## カバーしなかったブランチと理由

| ブランチ | 理由 |
|----------|------|
| `GradientFlags::HAS_DEFAULT_COLOR_INTERPOLATION_METHOD` が偽の場合 (e.g. `in oklch`) | CSS Color 4 の color-interpolation-method は Stylo/Blitz がまだパースしないため、通常の CSS で到達不能 |
| `Image::_` の `_ => None` アーム (image-set など) | `image-set()` は Blitz/Stylo で未実装のため、テスト用 HTML で再現不可 |
| `ShapeExtent::Contain` / `ShapeExtent::Cover` エイリアス | `radial-gradient` の size キーワードとして `contain`/`cover` は CSS 仕様上有効だが、Stylo がこれらを別 ShapeExtent バリアントにマップするかは不明で到達確認が困難 |
| `convert_lp_to_bg` の calc() 黙示 0.0 フォールバック | `background-position: calc(50% + 10px)` のような calc() 値で `to_percentage()` も `to_length()` も失敗するケース。Stylo が計算値として LengthPercentage::calc を返すか環境依存 |

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZuaPdRPq2UUPrXPPNB9Lf)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for background styles: linear, radial, and conic gradients (direction/angle, shape/size/extent, positioning, repeating), gradient stop formats and interpolation behavior, and cases where invalid gradient layers are dropped.
  * Added tests for background images via URLs covering raster, SVG, invalid SVG, unknown asset types, and missing asset bundle scenarios; tests validate rendering output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->