### PR TITLE
fix(pageable): hoist non-pseudo position:absolute children out of flow

### DIFF
--- a/crates/fulgur-wpt/expectations/css-page.txt
+++ b/crates/fulgur-wpt/expectations/css-page.txt
@@ -28,7 +28,7 @@ SKIP  css/css-page/cssom/margin-002.html  # NoMatch
 SKIP  css/css-page/cssom/margin-003.html  # NoMatch
 SKIP  css/css-page/cssom/page-001.html  # NoMatch
 SKIP  css/css-page/cssom/page-002.html  # NoMatch
-FAIL  css/css-page/fixedpos-001-print.html  # page count mismatch: test=1 ref=3
+PASS  css/css-page/fixedpos-001-print.html
 FAIL  css/css-page/fixedpos-002-print.html  # page count mismatch: test=1 ref=3
 FAIL  css/css-page/fixedpos-003-print.html  # page count mismatch: test=2 ref=3
 FAIL  css/css-page/fixedpos-004-print.html  # page count mismatch: test=2 ref=3
@@ -100,7 +100,7 @@ FAIL  css/css-page/monolithic-overflow-009-print.html  # page 1 diff: 673864/891
 FAIL  css/css-page/monolithic-overflow-010-print.html  # page 1 diff: 673864/891662 pixels exceed tol (max_ch=255)
 FAIL  css/css-page/monolithic-overflow-011-print.html  # page 1 diff: 673864/891662 pixels exceed tol (max_ch=255)
 PASS  css/css-page/monolithic-overflow-012-print.html
-PASS  css/css-page/monolithic-overflow-013-print.html
+FAIL  css/css-page/monolithic-overflow-013-print.html  # fulgur-puml: tall abs content does not drive page generation (regressed by fulgur-aijf — was passing for the wrong reason via abs-in-flow)
 FAIL  css/css-page/monolithic-overflow-014-print.html  # page 1 diff: 53448/891662 pixels exceed tol (max_ch=180)
 FAIL  css/css-page/monolithic-overflow-015-print.html  # page 1 diff: 53448/891662 pixels exceed tol (max_ch=150)
 FAIL  css/css-page/monolithic-overflow-016-print.html  # page count mismatch: test=1 ref=6
@@ -121,8 +121,8 @@ FAIL  css/css-page/monolithic-overflow-030-print.html  # page 1 diff: 12005/8916
 FAIL  css/css-page/monolithic-overflow-031-print.html  # page count mismatch: test=1 ref=2
 FAIL  css/css-page/monolithic-overflow-032-print.tentative.html  # page count mismatch: test=2 ref=3
 PASS  css/css-page/page-background-001-print.html
-FAIL  css/css-page/page-background-002-print.html  # fulgur-zsn8: <img position:absolute> consumes a page (layout fix tracked separately)
-FAIL  css/css-page/page-background-003-print.html  # fulgur-zsn8: <div position:absolute> consumes a page (layout fix tracked separately)
+PASS  css/css-page/page-background-002-print.html
+PASS  css/css-page/page-background-003-print.html
 FAIL  css/css-page/page-background-004-print.html  # page 1 diff: 124867/150000 pixels exceed tol (max_ch=255)
 FAIL  css/css-page/page-background-005-print.html  # page 1 diff: 82120/180000 pixels exceed tol (max_ch=255)
 FAIL  css/css-page/page-background-image-print.html  # page 1 diff: 32446/891662 pixels exceed tol (max_ch=255)
@@ -159,10 +159,10 @@ PASS  css/css-page/page-name-abspos-001-print.html
 PASS  css/css-page/page-name-abspos-002-print.html
 FAIL  css/css-page/page-name-abspos-003-print.html  # page count mismatch: test=1 ref=2 (CSS page property not implemented)
 PASS  css/css-page/page-name-and-break-001-print.html
-FAIL  css/css-page/page-name-and-break-002-print.html  # page count mismatch: test=2 ref=1 (CSS page property not implemented)
+PASS  css/css-page/page-name-and-break-002-print.html
 PASS  css/css-page/page-name-and-break-003-print.html
 PASS  css/css-page/page-name-and-break-004-print.html
-FAIL  css/css-page/page-name-canvas-001-print.html  # page count mismatch: test=1 ref=2 (CSS page property not implemented)
+PASS  css/css-page/page-name-canvas-001-print.html
 PASS  css/css-page/page-name-canvas-002-print.html
 PASS  css/css-page/page-name-canvas-003-print.html
 PASS  css/css-page/page-name-canvas-004-print.html
@@ -174,7 +174,7 @@ FAIL  css/css-page/page-name-flex-003-print.html  # page count mismatch: test=1 
 PASS  css/css-page/page-name-flex-004-print.html
 PASS  css/css-page/page-name-float-001-print.html
 FAIL  css/css-page/page-name-float-002-print.html  # page count mismatch: test=1 ref=2 (CSS page property not implemented)
-FAIL  css/css-page/page-name-img-001-print.html  # page count mismatch: test=1 ref=2 (CSS page property not implemented)
+PASS  css/css-page/page-name-img-001-print.html
 PASS  css/css-page/page-name-img-002-print.html
 PASS  css/css-page/page-name-img-003-print.html
 PASS  css/css-page/page-name-img-004-print.html
@@ -189,7 +189,7 @@ PASS  css/css-page/page-name-orthogonal-writing-003-print.html
 PASS  css/css-page/page-name-orthogonal-writing-004-print.html
 PASS  css/css-page/page-name-propagated-001-print.html
 FAIL  css/css-page/page-name-propagated-002-print.html  # page count mismatch: test=1 ref=3 (CSS page property not implemented)
-PASS  css/css-page/page-name-propagated-003-print.html
+FAIL  css/css-page/page-name-propagated-003-print.html  # fulgur-aijf: small pixel diff (142/891662) from abs no longer reserving in-flow space; surrounding content shifts by sub-pixel amounts
 PASS  css/css-page/page-name-propagated-004-print.html
 PASS  css/css-page/page-name-propagated-005-print.html
 FAIL  css/css-page/page-name-propagated-006-print.html  # page count mismatch: test=1 ref=2 (CSS page property not implemented)
@@ -207,7 +207,7 @@ FAIL  css/css-page/page-name-zero-height-001-print.html  # page count mismatch: 
 FAIL  css/css-page/page-orientation-on-landscape-001-print.html  # page 1 diff: 25830/891662 pixels exceed tol (max_ch=255)
 FAIL  css/css-page/page-orientation-on-portrait-001-print.html  # page 1 diff: 891662/891662 pixels exceed tol (max_ch=255)
 FAIL  css/css-page/page-orientation-on-portrait-002-print.html  # mismatch expected but test matches ref within tolerance
-FAIL  css/css-page/page-orientation-on-portrait-003-print.html  # mismatch expected but test matches ref within tolerance
+PASS  css/css-page/page-orientation-on-portrait-003-print.html
 FAIL  css/css-page/page-orientation-on-square-001-print.html  # page 1 diff: 12227/82944 pixels exceed tol (max_ch=255)
 SKIP  css/css-page/page-orientation.tentative.html  # NoMatch
 SKIP  css/css-page/page-rule-declarations-000.html  # NoMatch
@@ -218,9 +218,9 @@ SKIP  css/css-page/page-rule-declarations-004.html  # NoMatch
 FAIL  css/css-page/page-rule-specificity-001-print.html  # page 1 diff: 1193/891662 pixels exceed tol (max_ch=255)
 FAIL  css/css-page/page-rule-specificity-002-print.html  # page 1 diff: 1193/891662 pixels exceed tol (max_ch=255)
 FAIL  css/css-page/page-rule-specificity-003-print.html  # page 1 diff: 891662/891662 pixels exceed tol (max_ch=255)
-FAIL  css/css-page/page-size-001-print.html  # page 1 diff: 991/120000 pixels exceed tol (max_ch=255)
-FAIL  css/css-page/page-size-002-print.html  # page 1 diff: 516/15000 pixels exceed tol (max_ch=255)
-FAIL  css/css-page/page-size-003-print.html  # page 1 diff: 950/30000 pixels exceed tol (max_ch=255)
+PASS  css/css-page/page-size-001-print.html
+PASS  css/css-page/page-size-002-print.html
+PASS  css/css-page/page-size-003-print.html
 FAIL  css/css-page/page-size-004-print.html  # page 1 diff: 5376/10000 pixels exceed tol (max_ch=255)
 FAIL  css/css-page/page-size-005-print.html  # page 1 diff: 35500/250000 pixels exceed tol (max_ch=255)
 FAIL  css/css-page/page-size-006-print.html  # page 1 diff: 1623/64000 pixels exceed tol (max_ch=255)

--- a/crates/fulgur/src/convert/inline_root.rs
+++ b/crates/fulgur/src/convert/inline_root.rs
@@ -102,7 +102,7 @@ pub(super) fn try_convert(
             // Then existing block pseudo check
             let (before_pseudo, after_pseudo) =
                 pseudo::build_block_pseudo_images(doc, node, content_box, ctx.assets);
-            let abs_pseudos = positioned::build_absolute_pseudo_children(doc, node, ctx, depth);
+            let abs_pseudos = positioned::build_absolute_children(doc, node, ctx, depth);
             let has_pseudo =
                 before_pseudo.is_some() || after_pseudo.is_some() || !abs_pseudos.is_empty();
             let pagination = extract_pagination_from_column_css(ctx, node);
@@ -120,6 +120,7 @@ pub(super) fn try_convert(
                     child: Box::new(p),
                     x: child_x,
                     y: child_y,
+                    out_of_flow: false,
                 }];
                 let mut children = pseudo::wrap_with_block_pseudo_images(
                     before_pseudo,
@@ -164,7 +165,7 @@ pub(super) fn try_convert(
             // Check for block pseudo images too
             let (before_pseudo, after_pseudo) =
                 pseudo::build_block_pseudo_images(doc, node, content_box, ctx.assets);
-            let abs_pseudos = positioned::build_absolute_pseudo_children(doc, node, ctx, depth);
+            let abs_pseudos = positioned::build_absolute_children(doc, node, ctx, depth);
             let has_pseudo =
                 before_pseudo.is_some() || after_pseudo.is_some() || !abs_pseudos.is_empty();
             let pagination = extract_pagination_from_column_css(ctx, node);
@@ -177,6 +178,7 @@ pub(super) fn try_convert(
                     child: Box::new(paragraph),
                     x: child_x,
                     y: child_y,
+                    out_of_flow: false,
                 }];
                 let mut children = pseudo::wrap_with_block_pseudo_images(
                     before_pseudo,

--- a/crates/fulgur/src/convert/list_item.rs
+++ b/crates/fulgur/src/convert/list_item.rs
@@ -211,6 +211,7 @@ pub(super) fn try_convert(
                     child: Box::new(paragraph),
                     x: child_x,
                     y: child_y,
+                    out_of_flow: false,
                 }];
                 let (positioned_children, _has_pseudo) = pseudo::wrap_with_pseudo_content(
                     doc,
@@ -277,6 +278,7 @@ pub(super) fn try_convert(
                             child: Box::new(paragraph),
                             x: 0.0,
                             y: 0.0,
+                            out_of_flow: false,
                         },
                     );
                 }
@@ -377,7 +379,7 @@ fn build_list_item_body(
 
             let (before_pseudo, after_pseudo) =
                 pseudo::build_block_pseudo_images(doc, node, content_box, ctx.assets);
-            let abs_pseudos = positioned::build_absolute_pseudo_children(doc, node, ctx, depth);
+            let abs_pseudos = positioned::build_absolute_children(doc, node, ctx, depth);
             let has_pseudo =
                 before_pseudo.is_some() || after_pseudo.is_some() || !abs_pseudos.is_empty();
             let pagination = extract_pagination_from_column_css(ctx, node);
@@ -392,6 +394,7 @@ fn build_list_item_body(
                     child: Box::new(p),
                     x: child_x,
                     y: child_y,
+                    out_of_flow: false,
                 }];
                 let mut children = pseudo::wrap_with_block_pseudo_images(
                     before_pseudo,
@@ -432,7 +435,7 @@ fn build_list_item_body(
 
             let (before_pseudo, after_pseudo) =
                 pseudo::build_block_pseudo_images(doc, node, content_box, ctx.assets);
-            let abs_pseudos = positioned::build_absolute_pseudo_children(doc, node, ctx, depth);
+            let abs_pseudos = positioned::build_absolute_children(doc, node, ctx, depth);
             let has_pseudo =
                 before_pseudo.is_some() || after_pseudo.is_some() || !abs_pseudos.is_empty();
             let pagination = extract_pagination_from_column_css(ctx, node);
@@ -445,6 +448,7 @@ fn build_list_item_body(
                     child: Box::new(paragraph),
                     x: child_x,
                     y: child_y,
+                    out_of_flow: false,
                 }];
                 let mut children = pseudo::wrap_with_block_pseudo_images(
                     before_pseudo,

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -367,6 +367,7 @@ fn emit_orphan_string_set_markers(
                 child: Box::new(StringSetPageable::new(name, value)),
                 x,
                 y,
+                out_of_flow: false,
             });
         }
     }
@@ -388,6 +389,7 @@ fn emit_counter_op_markers(
             child: Box::new(CounterOpMarkerPageable::new(ops)),
             x,
             y,
+            out_of_flow: false,
         });
     }
 }
@@ -422,6 +424,7 @@ fn emit_orphan_bookmark_marker(
             child: Box::new(BookmarkMarkerPageable::new(info.level, info.label)),
             x,
             y,
+            out_of_flow: false,
         });
     }
 }

--- a/crates/fulgur/src/convert/positioned.rs
+++ b/crates/fulgur/src/convert/positioned.rs
@@ -1,5 +1,22 @@
 use super::*;
 
+/// Whether `node` has at least one direct DOM child that is a non-pseudo
+/// `position: absolute|fixed` element. Used by `collect_positioned_children`
+/// to refuse flattening for zero-size containers whose abs/fixed children
+/// would otherwise be silently dropped by the recursive flatten path
+/// (it skips abs children and the container itself never reaches the
+/// `build_absolute_non_pseudo_children` hoist point). Transitivity is handled
+/// naturally: deeper containers re-evaluate this guard on their own
+/// recursive call.
+fn node_has_absolute_non_pseudo_child(doc: &blitz_dom::BaseDocument, node: &Node) -> bool {
+    let lc_guard = node.layout_children.borrow();
+    let children = lc_guard.as_deref().unwrap_or(&node.children);
+    children.iter().any(|&id| {
+        doc.get_node(id)
+            .is_some_and(|n| is_absolutely_positioned(n) && !is_pseudo_node(doc, n))
+    })
+}
+
 /// Collect positioned children, flattening zero-size pass-through containers
 /// (like thead, tbody, tr) so their children appear directly in the parent.
 ///
@@ -67,6 +84,7 @@ pub(super) fn collect_positioned_children(
             && !pseudo::node_has_inline_pseudo_image(doc, child_node)
             && !ctx.column_styles.contains_key(&child_id)
             && !pseudo::node_has_absolute_pseudo(doc, child_node)
+            && !node_has_absolute_non_pseudo_child(doc, child_node)
         {
             emit_orphan_string_set_markers(child_id, cx, cy, ctx, &mut result);
             emit_counter_op_markers(child_id, cx, cy, ctx, &mut result);
@@ -90,6 +108,7 @@ pub(super) fn collect_positioned_children(
             && cw == 0.0
             && !child_effective_is_empty
             && !pseudo::node_has_absolute_pseudo(doc, child_node)
+            && !node_has_absolute_non_pseudo_child(doc, child_node)
         {
             emit_orphan_string_set_markers(child_id, cx, cy, ctx, &mut result);
             emit_counter_op_markers(child_id, cx, cy, ctx, &mut result);

--- a/crates/fulgur/src/convert/positioned.rs
+++ b/crates/fulgur/src/convert/positioned.rs
@@ -341,11 +341,17 @@ fn resolve_inset_px(
 /// Runs ALONGSIDE `wrap_with_block_pseudo_images` at the call sites that
 /// construct a `BlockPageable` wrapping a node with pseudos; see
 /// fulgur-vlr3 for the full investigation.
+/// Caller selects which pseudo slots to consider via `slots` (typically
+/// `[node.before]`, `[node.after]`, or both). [`build_absolute_children`]
+/// uses single-slot calls to interleave `::before` / direct DOM abs /
+/// `::after` in generated (source) order so `::after` paints AFTER
+/// direct abs siblings.
 pub(super) fn build_absolute_pseudo_children(
     doc: &blitz_dom::BaseDocument,
     node: &Node,
     ctx: &mut ConvertContext<'_>,
     depth: usize,
+    slots: &[Option<usize>],
 ) -> Vec<PositionedChild> {
     let mut out = Vec::new();
     let parent_is_static = is_position_static(node);
@@ -354,7 +360,7 @@ pub(super) fn build_absolute_pseudo_children(
     // ancestor chain repeatedly when both `::before` and `::after` hit.
     let mut cb_absolute: Option<Option<AbsCb>> = None;
     let mut cb_fixed: Option<Option<AbsCb>> = None;
-    for pseudo_id in [node.before, node.after].into_iter().flatten() {
+    for pseudo_id in slots.iter().copied().flatten() {
         let Some(pseudo) = doc.get_node(pseudo_id) else {
             continue;
         };
@@ -595,14 +601,26 @@ pub(super) fn build_absolute_non_pseudo_children(
 /// hoist to `node` — both pseudos (`::before`/`::after`) and direct DOM
 /// children. Call sites that previously used `build_absolute_pseudo_children`
 /// should switch to this so non-pseudo abs descendants are picked up too.
+///
+/// Output order matches **generated/source order**: `::before` first, then
+/// direct DOM abs/fixed children in DOM order, then `::after`. This matches
+/// CSS paint order so a `::after` overlay correctly paints on top of the
+/// direct abs siblings instead of beneath them.
 pub(super) fn build_absolute_children(
     doc: &blitz_dom::BaseDocument,
     node: &Node,
     ctx: &mut ConvertContext<'_>,
     depth: usize,
 ) -> Vec<PositionedChild> {
-    let mut out = build_absolute_pseudo_children(doc, node, ctx, depth);
+    let mut out = build_absolute_pseudo_children(doc, node, ctx, depth, &[node.before]);
     out.extend(build_absolute_non_pseudo_children(doc, node, ctx, depth));
+    out.extend(build_absolute_pseudo_children(
+        doc,
+        node,
+        ctx,
+        depth,
+        &[node.after],
+    ));
     out
 }
 

--- a/crates/fulgur/src/convert/positioned.rs
+++ b/crates/fulgur/src/convert/positioned.rs
@@ -30,6 +30,17 @@ pub(super) fn collect_positioned_children(
         if is_non_visual_element(child_node) {
             continue;
         }
+        // CSS 2.1 §10.6.4: absolutely-positioned descendants are
+        // out-of-flow. They are re-emitted by
+        // `build_absolute_non_pseudo_children` (called at the same hoist
+        // points as `build_absolute_pseudo_children`) with
+        // `out_of_flow: true` so they don't consume in-flow page space.
+        // Skipping here prevents double emission. Non-pseudo only —
+        // abs pseudos are stored in `node.before`/`node.after`, not in
+        // the layout child list, so they don't reach this loop.
+        if is_absolutely_positioned(child_node) {
+            continue;
+        }
 
         let (cx, cy, cw, ch) = layout_in_pt(&child_node.final_layout);
 
@@ -123,6 +134,7 @@ pub(super) fn collect_positioned_children(
             child: child_pageable,
             x: cx,
             y: cy,
+            out_of_flow: false,
         });
     }
 
@@ -134,6 +146,7 @@ pub(super) fn collect_positioned_children(
             child: Box::new(marker),
             x: 0.0,
             y: 0.0,
+            out_of_flow: false,
         });
     }
 
@@ -427,12 +440,150 @@ pub(super) fn build_absolute_pseudo_children(
             (x, y)
         };
         let child = build_absolute_pseudo_child(doc, node, pseudo, pseudo_id, cb, ctx, depth);
+        // CSS 2.1 §10.6.4: abs pseudos are out-of-flow — they don't add to
+        // the parent's flow height and replicate across pagination splits
+        // anchored to their CB.
         out.push(PositionedChild {
             child,
             x: x_pt,
             y: y_pt,
+            out_of_flow: true,
         });
     }
+    out
+}
+
+/// Build `PositionedChild` entries for any direct DOM child of `node` whose
+/// computed `position` is `absolute` or `fixed` and which is not a pseudo
+/// (`::before` / `::after`) — pseudos go through
+/// `build_absolute_pseudo_children`. Returned entries carry
+/// `out_of_flow: true` so they don't contribute to the parent's flow height
+/// and replicate across pagination splits anchored to their CB
+/// (CSS 2.1 §10.6.4 / fulgur-aijf).
+///
+/// CB resolution and inset handling mirror the pseudo path verbatim — the
+/// only differences are:
+///   - we iterate `node.children` (DOM children) instead of pseudo slots;
+///   - the child's effective size comes from Taffy's `final_layout.size`
+///     directly (real elements with real layout, no `content:url()` zero-size
+///     fallback);
+///   - the child Pageable is built via `convert_node` unconditionally — no
+///     `build_pseudo_image` shortcut.
+///
+/// Scope (matches the pseudo path's scope): emits at the **direct parent**,
+/// not at the deepest CB ancestor. Sufficient for the body-direct abs case
+/// (page-background-002/003 reftests). Deeply-nested abs whose CB is several
+/// ancestors above the direct parent and which then needs to participate in
+/// the CB ancestor's pagination is a future enhancement.
+pub(super) fn build_absolute_non_pseudo_children(
+    doc: &blitz_dom::BaseDocument,
+    node: &Node,
+    ctx: &mut ConvertContext<'_>,
+    depth: usize,
+) -> Vec<PositionedChild> {
+    if depth >= MAX_DOM_DEPTH {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    let parent_is_static = is_position_static(node);
+    let mut cb_absolute: Option<Option<AbsCb>> = None;
+    let mut cb_fixed: Option<Option<AbsCb>> = None;
+
+    let lc_guard = node.layout_children.borrow();
+    let effective_children = lc_guard.as_deref().unwrap_or(&node.children);
+
+    for &child_id in effective_children {
+        let Some(child_node) = doc.get_node(child_id) else {
+            continue;
+        };
+        if !is_absolutely_positioned(child_node) {
+            continue;
+        }
+        // Pseudos are handled by `build_absolute_pseudo_children`.
+        if is_pseudo_node(doc, child_node) {
+            continue;
+        }
+
+        let cb = if is_position_fixed(child_node) {
+            *cb_fixed.get_or_insert_with(|| resolve_cb_for_absolute(doc, node, true))
+        } else if parent_is_static {
+            *cb_absolute.get_or_insert_with(|| resolve_cb_for_absolute(doc, node, false))
+        } else {
+            let (padding_box_size, border_top_left) = cb_padding_box(node);
+            Some(AbsCb {
+                padding_box_size,
+                border_top_left,
+                parent_offset_in_cb_bp: (0.0, 0.0),
+            })
+        };
+
+        let (x_pt, y_pt) = if let Some(cb) = cb {
+            if let Some(styles) = child_node.primary_styles() {
+                let pos = styles.get_position();
+                let (cb_w, cb_h) = cb.padding_box_size;
+                // Real elements (not zero-size content:url pseudos), so use
+                // Taffy's final_layout.size directly for over-constrained
+                // inset resolution.
+                let cw = child_node.final_layout.size.width;
+                let ch = child_node.final_layout.size.height;
+                let left = resolve_inset_px(&pos.left, cb_w);
+                let right = resolve_inset_px(&pos.right, cb_w);
+                let top = resolve_inset_px(&pos.top, cb_h);
+                let bottom = resolve_inset_px(&pos.bottom, cb_h);
+                // CSS 2.1 §10.3.7 / §10.6.4 over-constrained resolution:
+                // start-side inset wins (LTR-only). Both `auto` falls back
+                // to 0 — same simplification as the pseudo path.
+                let x_in_pp = if let Some(l) = left {
+                    l
+                } else if let Some(r) = right {
+                    cb_w - cw - r
+                } else {
+                    0.0
+                };
+                let y_in_pp = if let Some(t) = top {
+                    t
+                } else if let Some(b) = bottom {
+                    cb_h - ch - b
+                } else {
+                    0.0
+                };
+                let (bl, bt) = cb.border_top_left;
+                let (ox, oy) = cb.parent_offset_in_cb_bp;
+                (px_to_pt(x_in_pp + bl - ox), px_to_pt(y_in_pp + bt - oy))
+            } else {
+                let (x, y, _, _) = layout_in_pt(&child_node.final_layout);
+                (x, y)
+            }
+        } else {
+            // Parent IS positioned (or CB couldn't be resolved) — Taffy's
+            // final_layout.location is already correct.
+            let (x, y, _, _) = layout_in_pt(&child_node.final_layout);
+            (x, y)
+        };
+
+        let child = convert_node(doc, child_id, ctx, depth + 1);
+        out.push(PositionedChild {
+            child,
+            x: x_pt,
+            y: y_pt,
+            out_of_flow: true,
+        });
+    }
+    out
+}
+
+/// Combined entry point: returns ALL absolutely-positioned children that
+/// hoist to `node` — both pseudos (`::before`/`::after`) and direct DOM
+/// children. Call sites that previously used `build_absolute_pseudo_children`
+/// should switch to this so non-pseudo abs descendants are picked up too.
+pub(super) fn build_absolute_children(
+    doc: &blitz_dom::BaseDocument,
+    node: &Node,
+    ctx: &mut ConvertContext<'_>,
+    depth: usize,
+) -> Vec<PositionedChild> {
+    let mut out = build_absolute_pseudo_children(doc, node, ctx, depth);
+    out.extend(build_absolute_non_pseudo_children(doc, node, ctx, depth));
     out
 }
 

--- a/crates/fulgur/src/convert/pseudo.rs
+++ b/crates/fulgur/src/convert/pseudo.rs
@@ -1,7 +1,6 @@
 use super::inline_root;
 use super::positioned::{
-    AbsCb, build_absolute_pseudo_children, is_absolutely_positioned,
-    try_build_absolute_pseudo_image,
+    AbsCb, build_absolute_children, is_absolutely_positioned, try_build_absolute_pseudo_image,
 };
 use super::replaced::{make_image_pageable, resolve_image_dimensions};
 use super::*;
@@ -111,7 +110,7 @@ pub(super) fn wrap_with_pseudo_content(
     let (before_img, after_img) = build_block_pseudo_images(doc, node, parent_cb, ctx.assets);
     let has_img_pseudo = before_img.is_some() || after_img.is_some();
     let mut out = wrap_with_block_pseudo_images(before_img, after_img, parent_cb, children);
-    let abs = build_absolute_pseudo_children(doc, node, ctx, depth);
+    let abs = build_absolute_children(doc, node, ctx, depth);
     let has_any_pseudo = has_img_pseudo || !abs.is_empty();
     out.extend(abs);
     (out, has_any_pseudo)
@@ -255,6 +254,7 @@ pub(super) fn wrap_with_block_pseudo_images(
             child: Box::new(img),
             x: parent_cb.origin_x,
             y: parent_cb.origin_y,
+            out_of_flow: false,
         });
     }
     out.extend(children);
@@ -263,6 +263,7 @@ pub(super) fn wrap_with_block_pseudo_images(
             child: Box::new(img),
             x: parent_cb.origin_x,
             y: parent_cb.origin_y + parent_cb.height,
+            out_of_flow: false,
         });
     }
     out

--- a/crates/fulgur/src/convert/replaced.rs
+++ b/crates/fulgur/src/convert/replaced.rs
@@ -71,6 +71,7 @@ where
             child: inner,
             x: cx,
             y: cy,
+            out_of_flow: false,
         };
         let mut block = BlockPageable::with_positioned_children(vec![child])
             .with_pagination(pagination)
@@ -91,6 +92,7 @@ where
             child: inner,
             x: 0.0,
             y: 0.0,
+            out_of_flow: false,
         };
         let mut block = BlockPageable::with_positioned_children(vec![child])
             .with_pagination(pagination)

--- a/crates/fulgur/src/convert/table.rs
+++ b/crates/fulgur/src/convert/table.rs
@@ -158,6 +158,7 @@ fn collect_table_cells(
             child: cell_pageable,
             x: cx,
             y: cy,
+            out_of_flow: false,
         };
 
         if is_header {

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -1508,24 +1508,43 @@ fn split_children_at_index(
 }
 
 /// Split `children` for `SplitDecision::WithinChild`. The split-causing
-/// child at `within_idx` is excluded — the caller injects its first/second
-/// fragments. In-flow children before / after `within_idx` go to first /
+/// child at `within_idx` is replaced in-place by `first_part` (in the first
+/// half) and `second_part` (in the second half), preserving the original
+/// DOM-order slot. In-flow children before / after `within_idx` go to first /
 /// second halves; out-of-flow children replicate to both halves (with the
 /// second-half shift applied).
+///
+/// The in-place replacement is critical: appending the split fragments to
+/// the end of either half would move out-of-flow siblings that originally
+/// followed `within_idx` IN FRONT of the fragment on the first page,
+/// changing paint order across the page break (CodeRabbit on PR #260).
 fn split_children_for_within(
     children: &[PositionedChild],
     within_idx: usize,
+    first_part: PositionedChild,
+    second_part: PositionedChild,
     second_y_offset: f32,
 ) -> (Vec<PositionedChild>, Vec<PositionedChild>) {
     let mut first = Vec::with_capacity(children.len());
     let mut second = Vec::with_capacity(children.len());
+    let mut first_part_opt = Some(first_part);
+    let mut second_part_opt = Some(second_part);
     for (i, pc) in children.iter().enumerate() {
-        if pc.out_of_flow {
+        if i == within_idx {
+            // Inject the split fragments at the original DOM slot so paint
+            // order with sibling out-of-flow children is preserved.
+            if let Some(fp) = first_part_opt.take() {
+                first.push(fp);
+            }
+            if let Some(sp) = second_part_opt.take() {
+                second.push(sp);
+            }
+        } else if pc.out_of_flow {
             first.push(clone_pc_with_offset(pc, 0.0));
             second.push(clone_pc_with_offset(pc, second_y_offset));
         } else if i < within_idx {
             first.push(clone_pc_with_offset(pc, 0.0));
-        } else if i > within_idx {
+        } else {
             second.push(clone_pc_with_offset(pc, second_y_offset));
         }
     }
@@ -2008,22 +2027,24 @@ impl Pageable for BlockPageable {
                     .map(|s| s.width)
                     .unwrap_or(0.0);
 
-                let (mut first, mut second) =
-                    split_children_for_within(&self.children, idx, pc.y + consumed_height);
-                first.push(PositionedChild {
+                let first_pc = PositionedChild {
                     child: first_part,
                     x: pc.x,
                     y: pc.y,
                     out_of_flow: false,
-                });
-                second.insert(
-                    0,
-                    PositionedChild {
-                        child: second_part,
-                        x: pc.x,
-                        y: 0.0,
-                        out_of_flow: false,
-                    },
+                };
+                let second_pc = PositionedChild {
+                    child: second_part,
+                    x: pc.x,
+                    y: 0.0,
+                    out_of_flow: false,
+                };
+                let (first, second) = split_children_for_within(
+                    &self.children,
+                    idx,
+                    first_pc,
+                    second_pc,
+                    pc.y + consumed_height,
                 );
 
                 let mut first_block = BlockPageable::with_positioned_children(first)
@@ -2119,25 +2140,27 @@ impl Pageable for BlockPageable {
 
                 // Use the clone-based helper so out-of-flow children
                 // (CSS abs/fixed) are correctly replicated to both halves.
-                // The split-causing in-flow child at `idx` is excluded by
-                // the helper; we inject its first/second fragments below.
-                let (mut first, mut second) =
-                    split_children_for_within(&me.children, idx, split_child_y + consumed_height);
-
-                first.push(PositionedChild {
+                // The helper inserts the split fragments at the original
+                // DOM slot of `idx` so paint order with sibling
+                // out-of-flow children is preserved across the break.
+                let first_pc = PositionedChild {
                     child: first_part,
                     x: split_child_x,
                     y: split_child_y,
                     out_of_flow: false,
-                });
-                second.insert(
-                    0,
-                    PositionedChild {
-                        child: second_part,
-                        x: split_child_x,
-                        y: 0.0,
-                        out_of_flow: false,
-                    },
+                };
+                let second_pc = PositionedChild {
+                    child: second_part,
+                    x: split_child_x,
+                    y: 0.0,
+                    out_of_flow: false,
+                };
+                let (first, second) = split_children_for_within(
+                    &me.children,
+                    idx,
+                    first_pc,
+                    second_pc,
+                    split_child_y + consumed_height,
                 );
 
                 let mut first_block = BlockPageable::with_positioned_children(first)
@@ -4023,26 +4046,47 @@ mod tests {
     }
 
     #[test]
-    fn split_children_for_within_excludes_within_index() {
+    fn split_children_for_within_inserts_fragments_at_dom_slot() {
         // Layout: [in_flow@0, in_flow@50 (split-causing), in_flow@100, out_of_flow@0].
         // Within idx=1, second_y_offset=70 (split caused at y=50, consumed=20).
+        // The first/second fragments occupy idx=1's slot, preserving DOM
+        // order with the trailing in_flow@100 and OOF children
+        // (PR #260 CodeRabbit — "Within-child splits can reorder
+        // replicated out-of-flow siblings on page 1").
         // Expected:
-        //   first  = [in_flow@0, out_of_flow@0]                  (idx=1 excluded)
-        //   second = [in_flow@30 (100-70), out_of_flow@-70]      (idx=1 excluded)
+        //   first  = [in_flow@0, FIRST_PART@77, out_of_flow@0]
+        //   second = [SECOND_PART@88, in_flow@30 (100-70), out_of_flow@-70]
         let children = vec![
             PositionedChild::in_flow(make_spacer(50.0), 0.0, 0.0),
             PositionedChild::in_flow(make_spacer(50.0), 0.0, 50.0),
             PositionedChild::in_flow(make_spacer(10.0), 0.0, 100.0),
             PositionedChild::out_of_flow(make_spacer(99.0), 0.0, 0.0),
         ];
-        let (first, second) = split_children_for_within(&children, 1, 70.0);
-        // The split-causing child at idx=1 must NOT appear in either half;
-        // caller injects its fragments separately.
-        assert_eq!(first.len(), 2, "first: in_flow@0 + out_of_flow@0");
-        assert_eq!(second.len(), 2, "second: in_flow@30 + out_of_flow@-70");
-        // Verify no entry has y == 50 (the within_idx child's position).
+        let first_pc = PositionedChild::in_flow(make_spacer(20.0), 0.0, 77.0);
+        let second_pc = PositionedChild::in_flow(make_spacer(30.0), 0.0, 88.0);
+        let (first, second) = split_children_for_within(&children, 1, first_pc, second_pc, 70.0);
+        // The split-causing child at idx=1 (y=50) must NOT appear; instead
+        // the fragments should occupy that slot.
+        assert_eq!(
+            first.len(),
+            3,
+            "first: in_flow@0 + FIRST_PART@77 + out_of_flow@0"
+        );
+        assert_eq!(
+            second.len(),
+            3,
+            "second: SECOND_PART@88 + in_flow@30 + out_of_flow@-70"
+        );
         assert!(first.iter().all(|p| p.y != 50.0));
         assert!(second.iter().all(|p| p.y != 50.0));
+        // First-part fragment is at the original DOM-slot position
+        // (between in_flow@0 and out_of_flow@0): index 1.
+        assert_eq!(first[1].y, 77.0, "first_part should be at the within slot");
+        // Second-part fragment is at index 0 (before the in_flow@30 and OOF).
+        assert_eq!(
+            second[0].y, 88.0,
+            "second_part should be at the within slot"
+        );
         // Verify out-of-flow replicated with no clamp on negative.
         let second_oof = second.iter().find(|p| p.out_of_flow).unwrap();
         assert_eq!(second_oof.y, -70.0);

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -1089,6 +1089,23 @@ impl BlockPageable {
     /// available height.  Both `split()` and `split_boxed()` call this to
     /// avoid duplicating the scanning logic.
     fn find_split_point(&self, avail_height: Pt) -> SplitDecision {
+        // Pre-compute in-flow markers so index/length checks in the loops
+        // below stay OOF-aware (out-of-flow children may be interleaved or
+        // appended in `self.children`). Returning an `AtIndex` whose index
+        // points to an out-of-flow child would corrupt the split because
+        // `split_y = self.children[idx].y` reads a CB-relative coordinate
+        // (e.g. 0.0 for `top:0`) instead of the flow boundary.
+        let first_in_flow_index = self.children.iter().position(|pc| !pc.out_of_flow);
+        let last_in_flow_index = self.children.iter().rposition(|pc| !pc.out_of_flow);
+        let in_flow_count = self.children.iter().filter(|pc| !pc.out_of_flow).count();
+        let next_in_flow_at_or_after = |from: usize| -> Option<usize> {
+            (from..self.children.len()).find(|&i| !self.children[i].out_of_flow)
+        };
+        let i_is_first_in_flow = |i: usize| first_in_flow_index == Some(i);
+        let i_is_last_in_flow = |i: usize| last_in_flow_index == Some(i);
+        let has_in_flow_after = |i: usize| last_in_flow_index.is_some_and(|last| i < last);
+        let has_in_flow_before = |i: usize| first_in_flow_index.is_some_and(|first| i > first);
+
         if self.pagination.break_inside == BreakInside::Avoid {
             // Prefer layout_size (Taffy-computed, non-zero for empty blocks
             // with explicit CSS height) and fall back to cached_size — same
@@ -1109,9 +1126,10 @@ impl BlockPageable {
                     if pc.out_of_flow {
                         return false;
                     }
-                    (pc.child.pagination().break_before == BreakBefore::Page && i > 0)
+                    (pc.child.pagination().break_before == BreakBefore::Page
+                        && has_in_flow_before(i))
                         || (pc.child.pagination().break_after == BreakAfter::Page
-                            && i < self.children.len() - 1)
+                            && has_in_flow_after(i))
                         || {
                             let child_avail = self.page_height - pc.y;
                             child_avail > 0.0 && pc.child.split(0.0, child_avail).is_some()
@@ -1134,9 +1152,8 @@ impl BlockPageable {
             if pc.out_of_flow {
                 return false;
             }
-            (pc.child.pagination().break_before == BreakBefore::Page && i > 0)
-                || (pc.child.pagination().break_after == BreakAfter::Page
-                    && i < self.children.len() - 1)
+            (pc.child.pagination().break_before == BreakBefore::Page && has_in_flow_before(i))
+                || (pc.child.pagination().break_after == BreakAfter::Page && has_in_flow_after(i))
                 || pc.child.has_forced_break_below()
         });
 
@@ -1170,7 +1187,10 @@ impl BlockPageable {
             if pc.out_of_flow {
                 continue;
             }
-            if pc.child.pagination().break_before == BreakBefore::Page && i > 0 && pc.y > 0.0 {
+            if pc.child.pagination().break_before == BreakBefore::Page
+                && !i_is_first_in_flow(i)
+                && pc.y > 0.0
+            {
                 return SplitDecision::AtIndex(i);
             }
 
@@ -1183,10 +1203,17 @@ impl BlockPageable {
                 {
                     let consumed = parts.0.height();
                     return SplitDecision::WithinChild(i, parts, consumed);
-                } else if i == 0 && self.children.len() == 1 {
+                } else if in_flow_count == 1 {
                     return SplitDecision::NoSplit;
                 } else {
-                    return SplitDecision::AtIndex(i.max(1));
+                    // Push the overflowing in-flow child onto its own page,
+                    // siblings to the next. Skip past trailing OOF children
+                    // when computing the AtIndex target so split_y reads
+                    // the next in-flow's y, not an OOF's CB-relative y.
+                    match next_in_flow_at_or_after(i.max(1)) {
+                        Some(idx) => return SplitDecision::AtIndex(idx),
+                        None => return SplitDecision::NoSplit,
+                    }
                 }
             } else {
                 // Child fits on this page, but may contain a descendant forced break.
@@ -1211,8 +1238,22 @@ impl BlockPageable {
                 }
             }
 
+            if pc.child.pagination().break_after == BreakAfter::Page && i_is_last_in_flow(i) {
+                // No in-flow child follows this break — nothing to push to
+                // the next page. Avoid returning AtIndex past the last
+                // in-flow (which would land on an OOF and corrupt split_y).
+                continue;
+            }
             if pc.child.pagination().break_after == BreakAfter::Page {
-                return SplitDecision::AtIndex(i + 1);
+                // Skip trailing OOF children so AtIndex points to the
+                // first in-flow successor; split_y must come from an
+                // in-flow position, not a CB-relative OOF y.
+                match next_in_flow_at_or_after(i + 1) {
+                    Some(idx) => return SplitDecision::AtIndex(idx),
+                    // unreachable in practice — has_in_flow_after(i) above
+                    // guards this branch — but stay defensive.
+                    None => return SplitDecision::NoSplit,
+                }
             }
         }
 
@@ -2283,7 +2324,14 @@ impl Pageable for BlockPageable {
     }
 
     fn has_forced_break_below(&self) -> bool {
+        // Out-of-flow children (CSS 2.1 §10.6.4) paginate independently
+        // of the parent's flow, so a forced break inside an abs/fixed
+        // descendant must NOT propagate up as the parent's "forced break
+        // below" — that would push ancestors into spurious split paths.
         self.children.iter().any(|pc| {
+            if pc.out_of_flow {
+                return false;
+            }
             pc.child.pagination().break_before == BreakBefore::Page
                 || pc.child.pagination().break_after == BreakAfter::Page
                 || pc.child.has_forced_break_below()

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -923,11 +923,45 @@ impl BlockStyle {
 // ─── PositionedChild ─────────────────────────────────────
 
 /// A child element with its Taffy-computed position.
+///
+/// `out_of_flow` (CSS 2.1 §10.6.4) marks `position: absolute|fixed`
+/// children. They are excluded from `BlockPageable::wrap`'s height fold and
+/// `find_split_point`'s overflow scan (their height does not contribute to
+/// the parent's flow height and must not trigger page splits), and are
+/// replicated to BOTH halves of `BlockPageable::split` with their CB-relative
+/// `y` preserved (negative values allowed) so a tall abs element naturally
+/// slices across the pages where its CB overlaps.
 #[derive(Clone)]
 pub struct PositionedChild {
     pub child: Box<dyn Pageable>,
     pub x: Pt,
     pub y: Pt,
+    pub out_of_flow: bool,
+}
+
+impl PositionedChild {
+    /// Construct an in-flow child (default for normal block layout).
+    pub fn in_flow(child: Box<dyn Pageable>, x: Pt, y: Pt) -> Self {
+        Self {
+            child,
+            x,
+            y,
+            out_of_flow: false,
+        }
+    }
+
+    /// Construct an out-of-flow child (`position: absolute|fixed`). The
+    /// caller must have already resolved `(x, y)` against the appropriate
+    /// containing block (CSS 2.1 §10.3.7 / §10.6.4) and expressed it
+    /// relative to the parent's border-box.
+    pub fn out_of_flow(child: Box<dyn Pageable>, x: Pt, y: Pt) -> Self {
+        Self {
+            child,
+            x,
+            y,
+            out_of_flow: true,
+        }
+    }
 }
 
 pub type SplitPair = (Box<dyn Pageable>, Box<dyn Pageable>);
@@ -995,6 +1029,7 @@ impl BlockPageable {
                     child,
                     x: 0.0,
                     y: child_y,
+                    out_of_flow: false,
                 }
             })
             .collect();
@@ -1068,7 +1103,12 @@ impl BlockPageable {
             if self.page_height <= 0.0 || total_height <= self.page_height {
                 // CSS Fragmentation Level 3 §5.4: forced breaks override break-inside: avoid.
                 // Check direct children and recurse into descendants before returning NoSplit.
+                // Out-of-flow children are skipped per CSS 2.1 §10.6.4 — their
+                // pagination is independent of the parent's flow.
                 let has_forced_break = self.children.iter().enumerate().any(|(i, pc)| {
+                    if pc.out_of_flow {
+                        return false;
+                    }
                     (pc.child.pagination().break_before == BreakBefore::Page && i > 0)
                         || (pc.child.pagination().break_after == BreakAfter::Page
                             && i < self.children.len() - 1)
@@ -1085,7 +1125,15 @@ impl BlockPageable {
             // Fall through to normal splitting logic.
         }
 
+        // Out-of-flow children (CSS 2.1 §10.6.4) are excluded from every
+        // pagination check below: they don't trigger break-before/-after
+        // splits, don't drive overflow detection, and aren't probed for
+        // descendant breaks. They're replicated to both halves of the
+        // split in `clone_children` instead.
         let has_forced_break = self.children.iter().enumerate().any(|(i, pc)| {
+            if pc.out_of_flow {
+                return false;
+            }
             (pc.child.pagination().break_before == BreakBefore::Page && i > 0)
                 || (pc.child.pagination().break_after == BreakAfter::Page
                     && i < self.children.len() - 1)
@@ -1104,6 +1152,9 @@ impl BlockPageable {
             // No overflow and no direct-child forced breaks — check descendants.
             let mut has_descendant_forced_break = false;
             for pc in &self.children {
+                if pc.out_of_flow {
+                    continue;
+                }
                 let child_avail = avail_height - pc.y;
                 if child_avail > 0.0 && pc.child.split(0.0, child_avail).is_some() {
                     has_descendant_forced_break = true;
@@ -1116,6 +1167,9 @@ impl BlockPageable {
         }
 
         for (i, pc) in self.children.iter().enumerate() {
+            if pc.out_of_flow {
+                continue;
+            }
             if pc.child.pagination().break_before == BreakBefore::Page && i > 0 && pc.y > 0.0 {
                 return SplitDecision::AtIndex(i);
             }
@@ -1366,20 +1420,106 @@ fn compute_padding_box_inner_radii(outer: &[[f32; 2]; 4], borders: &[f32; 4]) ->
     ]
 }
 
+/// Clone a single `PositionedChild`, shifting its y by `y_offset`. In-flow
+/// children clamp at 0.0 to keep grid/flex parallel siblings on-page;
+/// out-of-flow children preserve negative y so their CB-anchored position
+/// extends naturally across pages (Krilla clips outside the page area).
+fn clone_pc_with_offset(pc: &PositionedChild, y_offset: f32) -> PositionedChild {
+    let shifted = pc.y - y_offset;
+    let y = if pc.out_of_flow {
+        shifted
+    } else {
+        shifted.max(0.0)
+    };
+    PositionedChild {
+        child: pc.child.clone_box(),
+        x: pc.x,
+        y,
+        out_of_flow: pc.out_of_flow,
+    }
+}
+
+/// Split `children` at `split_index` for `SplitDecision::AtIndex`.
+///
+/// In-flow children are partitioned by index. Out-of-flow children
+/// (CSS 2.1 §10.6.4) are replicated to BOTH halves — they're anchored to
+/// their containing block and apply to every page the CB overlaps. The
+/// second half's y values are shifted by `split_y` (out-of-flow keeps
+/// negative y; in-flow clamps at 0).
+fn split_children_at_index(
+    children: &[PositionedChild],
+    split_index: usize,
+    split_y: f32,
+) -> (Vec<PositionedChild>, Vec<PositionedChild>) {
+    let mut first = Vec::with_capacity(children.len());
+    let mut second = Vec::with_capacity(children.len());
+    for (i, pc) in children.iter().enumerate() {
+        if pc.out_of_flow {
+            first.push(clone_pc_with_offset(pc, 0.0));
+            second.push(clone_pc_with_offset(pc, split_y));
+        } else if i < split_index {
+            first.push(clone_pc_with_offset(pc, 0.0));
+        } else {
+            second.push(clone_pc_with_offset(pc, split_y));
+        }
+    }
+    (first, second)
+}
+
+/// Split `children` for `SplitDecision::WithinChild`. The split-causing
+/// child at `within_idx` is excluded — the caller injects its first/second
+/// fragments. In-flow children before / after `within_idx` go to first /
+/// second halves; out-of-flow children replicate to both halves (with the
+/// second-half shift applied).
+fn split_children_for_within(
+    children: &[PositionedChild],
+    within_idx: usize,
+    second_y_offset: f32,
+) -> (Vec<PositionedChild>, Vec<PositionedChild>) {
+    let mut first = Vec::with_capacity(children.len());
+    let mut second = Vec::with_capacity(children.len());
+    for (i, pc) in children.iter().enumerate() {
+        if pc.out_of_flow {
+            first.push(clone_pc_with_offset(pc, 0.0));
+            second.push(clone_pc_with_offset(pc, second_y_offset));
+        } else if i < within_idx {
+            first.push(clone_pc_with_offset(pc, 0.0));
+        } else if i > within_idx {
+            second.push(clone_pc_with_offset(pc, second_y_offset));
+        }
+    }
+    (first, second)
+}
+
 /// Clone a slice of PositionedChild, optionally shifting y coordinates.
 /// When `y_offset` is 0.0, children are cloned as-is.
 /// A negative `y_offset` shifts children upward (subtracts from y).
 fn clone_children(children: &[PositionedChild], y_offset: f32) -> Vec<PositionedChild> {
-    // Clamp at 0.0 so parallel siblings (grid/flex children sharing the same
-    // y as a split-causing child) don't end up at negative y on the second
-    // fragment, which would push their background+border above the page top
-    // and silently drop them. fulgur-86fo.
+    // In-flow children are clamped at 0.0 so parallel siblings (grid/flex
+    // children sharing the same y as a split-causing child) don't end up at
+    // negative y on the second fragment, which would push their
+    // background+border above the page top and silently drop them
+    // (fulgur-86fo).
+    //
+    // Out-of-flow children (CSS 2.1 §10.6.4 abs/fixed) preserve negative y
+    // so a tall abs element anchored at its CB's top:0 naturally extends
+    // above the second fragment's page area; Krilla clips outside the page,
+    // producing the correct slice on each page (fulgur-aijf).
     children
         .iter()
-        .map(|pc| PositionedChild {
-            child: pc.child.clone_box(),
-            x: pc.x,
-            y: (pc.y - y_offset).max(0.0),
+        .map(|pc| {
+            let shifted = pc.y - y_offset;
+            let y = if pc.out_of_flow {
+                shifted
+            } else {
+                shifted.max(0.0)
+            };
+            PositionedChild {
+                child: pc.child.clone_box(),
+                x: pc.x,
+                y,
+                out_of_flow: pc.out_of_flow,
+            }
         })
         .collect()
 }
@@ -1780,8 +1920,13 @@ impl Pageable for BlockPageable {
                 pc.child.wrap(avail_width, 10000.0);
             }
         }
-        // Use max of children's (y + height) for total height
+        // Use max of children's (y + height) for total height. Out-of-flow
+        // children (`position: absolute|fixed`) are excluded per CSS 2.1
+        // §10.6.4 — they do not contribute to the parent's flow height.
         let total_height = self.children.iter_mut().fold(0.0f32, |max_h, pc| {
+            if pc.out_of_flow {
+                return max_h;
+            }
             let child_h = pc.child.height();
             max_h.max(pc.y + child_h)
         });
@@ -1822,22 +1967,23 @@ impl Pageable for BlockPageable {
                     .map(|s| s.width)
                     .unwrap_or(0.0);
 
-                let mut first = clone_children(&self.children[..idx], 0.0);
+                let (mut first, mut second) =
+                    split_children_for_within(&self.children, idx, pc.y + consumed_height);
                 first.push(PositionedChild {
                     child: first_part,
                     x: pc.x,
                     y: pc.y,
+                    out_of_flow: false,
                 });
-
-                let mut second = vec![PositionedChild {
-                    child: second_part,
-                    x: pc.x,
-                    y: 0.0,
-                }];
-                second.extend(clone_children(
-                    &self.children[idx + 1..],
-                    pc.y + consumed_height,
-                ));
+                second.insert(
+                    0,
+                    PositionedChild {
+                        child: second_part,
+                        x: pc.x,
+                        y: 0.0,
+                        out_of_flow: false,
+                    },
+                );
 
                 let mut first_block = BlockPageable::with_positioned_children(first)
                     .with_pagination(self.pagination)
@@ -1881,8 +2027,7 @@ impl Pageable for BlockPageable {
                     .map(|s| s.width)
                     .unwrap_or(0.0);
 
-                let first = clone_children(&self.children[..split_index], 0.0);
-                let second = clone_children(&self.children[split_index..], split_y);
+                let (first, second) = split_children_at_index(&self.children, split_index, split_y);
 
                 let mut first_block = BlockPageable::with_positioned_children(first)
                     .with_pagination(self.pagination)
@@ -1916,7 +2061,7 @@ impl Pageable for BlockPageable {
             SplitDecision::NoSplit => Err(self),
 
             SplitDecision::WithinChild(idx, (first_part, second_part), consumed_height) => {
-                let mut me = *self;
+                let me = *self;
                 let split_child_x = me.children[idx].x;
                 let split_child_y = me.children[idx].y;
                 let first_height = split_child_y + consumed_height;
@@ -1931,32 +2076,28 @@ impl Pageable for BlockPageable {
                     .map(|s| s.width)
                     .unwrap_or(0.0);
 
-                let mut tail = me.children.split_off(idx + 1);
-                let _split_child = me.children.pop().unwrap(); // remove the split child
-                let mut first = me.children; // children[..idx]
+                // Use the clone-based helper so out-of-flow children
+                // (CSS abs/fixed) are correctly replicated to both halves.
+                // The split-causing in-flow child at `idx` is excluded by
+                // the helper; we inject its first/second fragments below.
+                let (mut first, mut second) =
+                    split_children_for_within(&me.children, idx, split_child_y + consumed_height);
 
                 first.push(PositionedChild {
                     child: first_part,
                     x: split_child_x,
                     y: split_child_y,
+                    out_of_flow: false,
                 });
-
-                // Rebase tail by split_y + consumed_height so siblings sit
-                // flush against the second fragment on page 2, with no extra
-                // gap equal to the first fragment's height. Clamp at 0.0 for
-                // parallel siblings (grid/flex same-row) so they don't end up
-                // above the page top — see clone_children for fulgur-86fo.
-                let tail_offset = split_child_y + consumed_height;
-                for pc in &mut tail {
-                    pc.y = (pc.y - tail_offset).max(0.0);
-                }
-
-                let mut second = vec![PositionedChild {
-                    child: second_part,
-                    x: split_child_x,
-                    y: 0.0,
-                }];
-                second.append(&mut tail);
+                second.insert(
+                    0,
+                    PositionedChild {
+                        child: second_part,
+                        x: split_child_x,
+                        y: 0.0,
+                        out_of_flow: false,
+                    },
+                );
 
                 let mut first_block = BlockPageable::with_positioned_children(first)
                     .with_pagination(me.pagination)
@@ -1984,7 +2125,7 @@ impl Pageable for BlockPageable {
             }
 
             SplitDecision::AtIndex(split_index) => {
-                let mut me = *self;
+                let me = *self;
 
                 if split_index == 0 || split_index >= me.children.len() {
                     return Err(Box::new(me));
@@ -2002,14 +2143,10 @@ impl Pageable for BlockPageable {
                     .map(|s| s.width)
                     .unwrap_or(0.0);
 
-                let mut second_children = me.children.split_off(split_index);
-                let first_children = me.children;
-
-                // Shift y coordinates on second fragment. Clamp at 0.0 for
-                // parallel siblings — see clone_children for fulgur-86fo.
-                for pc in &mut second_children {
-                    pc.y = (pc.y - split_y).max(0.0);
-                }
+                // Use the clone-based helper so out-of-flow children
+                // (CSS abs/fixed) are correctly replicated to both halves.
+                let (first_children, second_children) =
+                    split_children_at_index(&me.children, split_index, split_y);
 
                 let mut first_block = BlockPageable::with_positioned_children(first_children)
                     .with_pagination(me.pagination)
@@ -3560,6 +3697,7 @@ impl Pageable for TablePageable {
                 child: pc.child.clone_box(),
                 x: pc.x,
                 y: self.header_height + (pc.y - split_y),
+                out_of_flow: false,
             })
             .collect();
 
@@ -3788,6 +3926,81 @@ mod tests {
     }
 
     #[test]
+    fn clone_pc_with_offset_in_flow_clamps_negative_y() {
+        // In-flow child: y - offset < 0 should clamp to 0 (fulgur-86fo
+        // grid/flex parallel sibling protection).
+        let pc = PositionedChild::in_flow(make_spacer(10.0), 0.0, 50.0);
+        let cloned = clone_pc_with_offset(&pc, 80.0);
+        assert_eq!(cloned.y, 0.0);
+        assert!(!cloned.out_of_flow);
+    }
+
+    #[test]
+    fn clone_pc_with_offset_out_of_flow_preserves_negative_y() {
+        // Out-of-flow child (CSS abs/fixed): y - offset is allowed to go
+        // negative so the CB-anchored box slices across pages naturally.
+        let pc = PositionedChild::out_of_flow(make_spacer(99.0), 0.0, 0.0);
+        let cloned = clone_pc_with_offset(&pc, 50.0);
+        assert_eq!(cloned.y, -50.0);
+        assert!(cloned.out_of_flow);
+    }
+
+    #[test]
+    fn split_children_at_index_replicates_out_of_flow_to_both_halves() {
+        // Layout: [out_of_flow at y=0, in_flow at y=10, in_flow at y=20].
+        // Split at index 2 (in-flow boundary), split_y=20.
+        // Expected:
+        //   first  = [in_flow@10, out_of_flow@0]
+        //   second = [in_flow@0, out_of_flow@-20] (no clamp on out_of_flow)
+        let children = vec![
+            PositionedChild::out_of_flow(make_spacer(99.0), 0.0, 0.0),
+            PositionedChild::in_flow(make_spacer(5.0), 0.0, 10.0),
+            PositionedChild::in_flow(make_spacer(5.0), 0.0, 20.0),
+        ];
+        let (first, second) = split_children_at_index(&children, 2, 20.0);
+        // First: in-flow at y=10 + out-of-flow at y=0
+        assert_eq!(first.len(), 2);
+        let first_in_flow: Vec<_> = first.iter().filter(|p| !p.out_of_flow).collect();
+        let first_oof: Vec<_> = first.iter().filter(|p| p.out_of_flow).collect();
+        assert_eq!(first_in_flow.len(), 1);
+        assert_eq!(first_in_flow[0].y, 10.0);
+        assert_eq!(first_oof.len(), 1);
+        assert_eq!(first_oof[0].y, 0.0);
+        // Second: in-flow at y=0 (20-20) + out-of-flow at y=-20 (0-20, no clamp)
+        assert_eq!(second.len(), 2);
+        let second_in_flow: Vec<_> = second.iter().filter(|p| !p.out_of_flow).collect();
+        let second_oof: Vec<_> = second.iter().filter(|p| p.out_of_flow).collect();
+        assert_eq!(second_in_flow[0].y, 0.0);
+        assert_eq!(second_oof[0].y, -20.0);
+    }
+
+    #[test]
+    fn split_children_for_within_excludes_within_index() {
+        // Layout: [in_flow@0, in_flow@50 (split-causing), in_flow@100, out_of_flow@0].
+        // Within idx=1, second_y_offset=70 (split caused at y=50, consumed=20).
+        // Expected:
+        //   first  = [in_flow@0, out_of_flow@0]                  (idx=1 excluded)
+        //   second = [in_flow@30 (100-70), out_of_flow@-70]      (idx=1 excluded)
+        let children = vec![
+            PositionedChild::in_flow(make_spacer(50.0), 0.0, 0.0),
+            PositionedChild::in_flow(make_spacer(50.0), 0.0, 50.0),
+            PositionedChild::in_flow(make_spacer(10.0), 0.0, 100.0),
+            PositionedChild::out_of_flow(make_spacer(99.0), 0.0, 0.0),
+        ];
+        let (first, second) = split_children_for_within(&children, 1, 70.0);
+        // The split-causing child at idx=1 must NOT appear in either half;
+        // caller injects its fragments separately.
+        assert_eq!(first.len(), 2, "first: in_flow@0 + out_of_flow@0");
+        assert_eq!(second.len(), 2, "second: in_flow@30 + out_of_flow@-70");
+        // Verify no entry has y == 50 (the within_idx child's position).
+        assert!(first.iter().all(|p| p.y != 50.0));
+        assert!(second.iter().all(|p| p.y != 50.0));
+        // Verify out-of-flow replicated with no clamp on negative.
+        let second_oof = second.iter().find(|p| p.out_of_flow).unwrap();
+        assert_eq!(second_oof.y, -70.0);
+    }
+
+    #[test]
     fn test_block_fits_on_one_page() {
         let mut block = BlockPageable::new(vec![make_spacer(100.0), make_spacer(100.0)]);
         block.wrap(200.0, 300.0);
@@ -3850,11 +4063,13 @@ mod tests {
                 child: Box::new(card_a),
                 x: 0.0,
                 y: 0.0,
+                out_of_flow: false,
             },
             PositionedChild {
                 child: Box::new(card_b),
                 x: 100.0,
                 y: 0.0,
+                out_of_flow: false,
             },
         ]);
         grid.wrap(200.0, 1000.0);
@@ -4026,6 +4241,7 @@ mod tests {
             child: make_spacer(30.0),
             x: 0.0,
             y: 0.0,
+            out_of_flow: false,
         }];
 
         // Three body rows at y=30, y=80, y=130 (each 50pt tall)
@@ -4034,16 +4250,19 @@ mod tests {
                 child: make_spacer(50.0),
                 x: 0.0,
                 y: 30.0,
+                out_of_flow: false,
             },
             PositionedChild {
                 child: make_spacer(50.0),
                 x: 0.0,
                 y: 80.0,
+                out_of_flow: false,
             },
             PositionedChild {
                 child: make_spacer(50.0),
                 x: 0.0,
                 y: 130.0,
+                out_of_flow: false,
             },
         ];
 
@@ -4874,11 +5093,13 @@ mod transform_wrapper_tests {
                 child: Box::new(top),
                 x: 0.0,
                 y: 0.0,
+                out_of_flow: false,
             },
             PositionedChild {
                 child: Box::new(bot),
                 x: 0.0,
                 y: 500.0,
+                out_of_flow: false,
             },
         ]);
         block.wrap(500.0, 1000.0);
@@ -5366,6 +5587,7 @@ mod forced_break_below_tests {
             child: Box::new(block),
             x: 0.0,
             y,
+            out_of_flow: false,
         }
     }
 
@@ -5474,6 +5696,7 @@ mod forced_break_below_tests {
             child: make_inner_with_forced_break(),
             x: 0.0,
             y: 0.0,
+            out_of_flow: false,
         }];
         let wrapped = TablePageable {
             header_cells: vec![],
@@ -5495,6 +5718,7 @@ mod forced_break_below_tests {
                 child: make_inner_without_forced_break(),
                 x: 0.0,
                 y: 0.0,
+                out_of_flow: false,
             }],
             header_height: 0.0,
             style: BlockStyle::default(),
@@ -5529,6 +5753,7 @@ mod forced_break_below_tests {
                 child: Box::new(body),
                 x: 0.0,
                 y: 0.0,
+                out_of_flow: false,
             }],
             35.0,
         );
@@ -5618,6 +5843,7 @@ mod forced_break_below_tests {
                     child: Box::new(inner),
                     x: 0.0,
                     y: 10.0,
+                    out_of_flow: false,
                 },
                 make_block_pc(10.0, BreakBefore::Auto, 40.0),
             ],
@@ -5667,6 +5893,7 @@ mod forced_break_below_tests {
                 child: Box::new(body),
                 x: 0.0,
                 y: 0.0,
+                out_of_flow: false,
             }],
             35.0,
         );

--- a/crates/fulgur/src/paginate.rs
+++ b/crates/fulgur/src/paginate.rs
@@ -322,6 +322,7 @@ mod tests {
             child,
             x: 0.0,
             y: 0.0,
+            out_of_flow: false,
         }
     }
 
@@ -432,6 +433,7 @@ mod tests {
                 child: Box::new(wrapper),
                 x: 0.0,
                 y: 80.0,
+                out_of_flow: false,
             },
         ]);
         block.wrap(100.0, 1000.0);
@@ -489,21 +491,25 @@ mod tests {
                 child: marker_a,
                 x: 0.0,
                 y: 0.0,
+                out_of_flow: false,
             },
             PositionedChild {
                 child: make_spacer(80.0),
                 x: 0.0,
                 y: 0.0,
+                out_of_flow: false,
             },
             PositionedChild {
                 child: marker_b,
                 x: 0.0,
                 y: 120.0,
+                out_of_flow: false,
             },
             PositionedChild {
                 child: make_spacer(80.0),
                 x: 0.0,
                 y: 120.0,
+                out_of_flow: false,
             },
         ]);
         let pages = paginate(Box::new(block), 200.0, 100.0);
@@ -615,16 +621,19 @@ mod tests {
                 child: make_spacer(80.0),
                 x: 0.0,
                 y: 0.0,
+                out_of_flow: false,
             },
             PositionedChild {
                 child: Box::new(m2),
                 x: 0.0,
                 y: 120.0,
+                out_of_flow: false,
             },
             PositionedChild {
                 child: make_spacer(80.0),
                 x: 0.0,
                 y: 120.0,
+                out_of_flow: false,
             },
         ]);
         let pages = paginate(Box::new(block), 200.0, 100.0);

--- a/crates/fulgur/tests/abs_positioned_pagination.rs
+++ b/crates/fulgur/tests/abs_positioned_pagination.rs
@@ -57,6 +57,79 @@ fn abs_positioned_div_is_out_of_flow_in_pagination() {
     );
 }
 
+/// Regression for the coderabbit thread on fulgur-aijf: a zero-size
+/// container (`<table>` synthesizes `<tbody>`-like wrappers Blitz lays out
+/// at 0×0) with a non-pseudo abs/fixed direct child must NOT be flattened
+/// — flattening recurses into `collect_positioned_children`, which now
+/// skips abs descendants. Without the flatten guard, the abs would never
+/// reach a `build_absolute_children` hoist and would silently disappear.
+#[test]
+fn abs_inside_zero_size_container_is_not_dropped_by_flatten() {
+    // Use a `display:contents` wrapper to mimic a zero-size pass-through
+    // container that Blitz/Taffy collapses to 0×0. Its abs child must
+    // still render; we verify by asserting the document has its expected
+    // single page without panic and that the wrapper doesn't suppress the
+    // surrounding in-flow content.
+    let html = r#"<!doctype html><html><head><style>
+        @page { size: 200pt 200pt; margin: 0; }
+        body { margin: 0; }
+        .wrap { display: contents; }
+    </style></head><body>
+      <p>before</p>
+      <div class="wrap">
+        <div style="position:absolute; top:10pt; left:10pt; width:30pt; height:30pt; background:red;"></div>
+      </div>
+      <p>after</p>
+    </body></html>"#;
+    let engine = Engine::builder()
+        .page_size(PageSize {
+            width: 200.0,
+            height: 200.0,
+        })
+        .margin(Margin::uniform(0.0))
+        .build();
+    let pdf = engine.render_html(html).expect("render");
+    assert_eq!(page_count(&pdf), 1, "expected one page");
+    // The body content has 'before' and 'after'. If the abs got dropped
+    // by flatten + collect_positioned_children skip, we'd at least still
+    // see the in-flow text. The crucial behavioural check is that the
+    // engine doesn't panic and the document is non-empty.
+    assert!(!pdf.is_empty(), "PDF must not be empty");
+}
+
+/// Regression for the devin thread on fulgur-aijf: when in-flow children
+/// are followed by out-of-flow children in `BlockPageable::children`,
+/// `find_split_point`'s break-after / overflow-fallback paths must NOT
+/// return AtIndex pointing at an OOF child — that would corrupt
+/// `split_y` (read from CB-relative OOF.y, often 0) and cut the page
+/// at the wrong height. We assert that a `<div break-after:page>` last
+/// in-flow with a trailing abs sibling produces 1 page, not the
+/// spurious 2 pages the buggy path would yield.
+#[test]
+fn break_after_on_last_in_flow_with_trailing_abs_sibling_does_not_split() {
+    let html = r#"<!doctype html><html><head><style>
+        @page { size: 200pt 400pt; margin: 0; }
+        body { margin: 0; }
+    </style></head><body>
+      <div style="height:50pt; break-after:page; background:lightgreen;">only flow</div>
+      <div style="position:absolute; top:0; left:0; width:30pt; height:30pt; background:red;"></div>
+    </body></html>"#;
+    let engine = Engine::builder()
+        .page_size(PageSize {
+            width: 200.0,
+            height: 400.0,
+        })
+        .margin(Margin::uniform(0.0))
+        .build();
+    let pdf = engine.render_html(html).expect("render");
+    let pages = page_count(&pdf);
+    assert_eq!(
+        pages, 1,
+        "break-after:page on the LAST in-flow child must not push a page when the only \
+         remaining sibling is out-of-flow (no in-flow successor to push); got {pages}"
+    );
+}
+
 /// Even when the abs element is much taller than the page, a single
 /// page of in-flow content must stay on one page.
 #[test]

--- a/crates/fulgur/tests/abs_positioned_pagination.rs
+++ b/crates/fulgur/tests/abs_positioned_pagination.rs
@@ -1,0 +1,84 @@
+//! Regression tests for fulgur-aijf: non-pseudo `position: absolute` elements
+//! must be out-of-flow during pagination — they must not consume page space
+//! the way in-flow elements do.
+//!
+//! CSS 2.1 §10.6.4: the height of an absolutely-positioned element does not
+//! contribute to the height of its containing block's normal flow.
+
+use fulgur::{Engine, Margin, PageSize};
+
+fn page_count(pdf: &[u8]) -> usize {
+    let prefix = b"/Type /Page";
+    let mut count = 0usize;
+    let mut i = 0;
+    while i + prefix.len() < pdf.len() {
+        if &pdf[i..i + prefix.len()] == prefix {
+            let next = pdf[i + prefix.len()];
+            if !next.is_ascii_alphanumeric() {
+                count += 1;
+            }
+            i += prefix.len();
+        } else {
+            i += 1;
+        }
+    }
+    count
+}
+
+/// Repro distilled from `page-background-002-print-ref.html`: an
+/// `<img position:absolute>` (here a 50×300 div with explicit dimensions to
+/// avoid PNG plumbing) at the top of the document must not occupy a page of
+/// its own. The three in-flow `<div break-before:page>` siblings determine
+/// the page count (3); abs is out-of-flow.
+#[test]
+fn abs_positioned_div_is_out_of_flow_in_pagination() {
+    let html = r#"<!doctype html><html><head><style>
+        @page { size: 100pt 100pt; margin: 0; }
+        body { margin: 0; }
+    </style></head><body>
+      <div style="position:absolute; top:0; left:0; width:50pt; height:300pt; background:red;"></div>
+      <div>First flow content.</div>
+      <div style="break-before:page;">Second flow content.</div>
+      <div style="break-before:page;">Third flow content.</div>
+    </body></html>"#;
+    let engine = Engine::builder()
+        .page_size(PageSize {
+            width: 100.0,
+            height: 100.0,
+        })
+        .margin(Margin::uniform(0.0))
+        .build();
+    let pdf = engine.render_html(html).expect("render");
+    let pages = page_count(&pdf);
+    assert_eq!(
+        pages, 3,
+        "abs-positioned div must not consume pages; only in-flow break-before:page divs \
+         should determine page count, got {pages}"
+    );
+}
+
+/// Even when the abs element is much taller than the page, a single
+/// page of in-flow content must stay on one page.
+#[test]
+fn abs_positioned_does_not_force_extra_pages_for_short_flow() {
+    let html = r#"<!doctype html><html><head><style>
+        @page { size: 100pt 100pt; margin: 0; }
+        body { margin: 0; }
+    </style></head><body>
+      <div style="position:absolute; top:0; left:0; width:50pt; height:300pt; background:blue;"></div>
+      <p>Single flow paragraph.</p>
+    </body></html>"#;
+    let engine = Engine::builder()
+        .page_size(PageSize {
+            width: 100.0,
+            height: 100.0,
+        })
+        .margin(Margin::uniform(0.0))
+        .build();
+    let pdf = engine.render_html(html).expect("render");
+    let pages = page_count(&pdf);
+    assert_eq!(
+        pages, 1,
+        "300pt-tall abs div must not force extra pages when in-flow content fits a single page; got {pages}"
+    );
+}

--- a/crates/fulgur/tests/abs_positioned_pagination.rs
+++ b/crates/fulgur/tests/abs_positioned_pagination.rs
@@ -5,6 +5,7 @@
 //! CSS 2.1 §10.6.4: the height of an absolutely-positioned element does not
 //! contribute to the height of its containing block's normal flow.
 
+use fulgur::pageable::{BlockPageable, Pageable, PositionedChild};
 use fulgur::{Engine, Margin, PageSize};
 
 fn page_count(pdf: &[u8]) -> usize {
@@ -57,26 +58,83 @@ fn abs_positioned_div_is_out_of_flow_in_pagination() {
     );
 }
 
+/// Walk the Pageable tree and count `BlockPageable` instances whose
+/// border-box (via `cached_size` or `layout_size`) approximately matches
+/// `(target_w, target_h)` and whose `out_of_flow` flag matches `is_oof`.
+/// Used by the flatten-zero-size-container regression test below to
+/// verify the abs child reached the Pageable tree (rather than being
+/// silently dropped by the flatten path).
+fn count_blocks_with_size_and_flow(
+    root: &dyn Pageable,
+    target_w: f32,
+    target_h: f32,
+    is_oof: bool,
+) -> usize {
+    let mut count = 0;
+    fn walk(
+        node: &dyn Pageable,
+        target_w: f32,
+        target_h: f32,
+        is_oof: bool,
+        count: &mut usize,
+        own_oof: bool,
+    ) {
+        if let Some(block) = node.as_any().downcast_ref::<BlockPageable>() {
+            let size = block.layout_size.or(block.cached_size);
+            if let Some(s) = size
+                && (s.width - target_w).abs() < 0.5
+                && (s.height - target_h).abs() < 0.5
+                && own_oof == is_oof
+            {
+                *count += 1;
+            }
+            for PositionedChild {
+                child, out_of_flow, ..
+            } in &block.children
+            {
+                walk(
+                    child.as_ref(),
+                    target_w,
+                    target_h,
+                    is_oof,
+                    count,
+                    *out_of_flow,
+                );
+            }
+        }
+    }
+    walk(root, target_w, target_h, is_oof, &mut count, false);
+    count
+}
+
 /// Regression for the coderabbit thread on fulgur-aijf: a zero-size
-/// container (`<table>` synthesizes `<tbody>`-like wrappers Blitz lays out
-/// at 0×0) with a non-pseudo abs/fixed direct child must NOT be flattened
-/// — flattening recurses into `collect_positioned_children`, which now
-/// skips abs descendants. Without the flatten guard, the abs would never
-/// reach a `build_absolute_children` hoist and would silently disappear.
+/// container with a non-pseudo abs/fixed direct child must NOT be
+/// flattened — flattening recurses into `collect_positioned_children`,
+/// which now skips abs descendants. Without the flatten guard, the abs
+/// would never reach a `build_absolute_children` hoist and would
+/// silently disappear from the Pageable tree.
+///
+/// `assert!(!pdf.is_empty())` and `page_count == 1` are *not* sufficient
+/// oracles here — both stay true even when the abs child is dropped,
+/// because krilla always serialises a complete PDF and the surrounding
+/// in-flow text alone fills one page. We instead inspect the Pageable
+/// tree directly and assert a 30×30 pt out-of-flow `BlockPageable`
+/// (the abs `<div>`) is present (PR #260, CodeRabbit).
 #[test]
 fn abs_inside_zero_size_container_is_not_dropped_by_flatten() {
-    // Use a `display:contents` wrapper to mimic a zero-size pass-through
-    // container that Blitz/Taffy collapses to 0×0. Its abs child must
-    // still render; we verify by asserting the document has its expected
-    // single page without panic and that the wrapper doesn't suppress the
-    // surrounding in-flow content.
+    // A `<div>` with explicit `height:0; width:0;` and `overflow:visible`
+    // is a real zero-size container that Blitz lays out at 0×0 and that
+    // `collect_positioned_children`'s flatten branch would otherwise
+    // collapse — recursing into its children with no parent to pick the
+    // abs back up. Without the flatten guard, the abs `<div>` is silently
+    // dropped from the Pageable tree.
     let html = r#"<!doctype html><html><head><style>
         @page { size: 200pt 200pt; margin: 0; }
         body { margin: 0; }
-        .wrap { display: contents; }
+        .zero { width: 0; height: 0; overflow: visible; }
     </style></head><body>
       <p>before</p>
-      <div class="wrap">
+      <div class="zero">
         <div style="position:absolute; top:10pt; left:10pt; width:30pt; height:30pt; background:red;"></div>
       </div>
       <p>after</p>
@@ -88,13 +146,13 @@ fn abs_inside_zero_size_container_is_not_dropped_by_flatten() {
         })
         .margin(Margin::uniform(0.0))
         .build();
-    let pdf = engine.render_html(html).expect("render");
-    assert_eq!(page_count(&pdf), 1, "expected one page");
-    // The body content has 'before' and 'after'. If the abs got dropped
-    // by flatten + collect_positioned_children skip, we'd at least still
-    // see the in-flow text. The crucial behavioural check is that the
-    // engine doesn't panic and the document is non-empty.
-    assert!(!pdf.is_empty(), "PDF must not be empty");
+    let tree = engine.build_pageable_for_testing_no_gcpm(html);
+    let abs_blocks = count_blocks_with_size_and_flow(tree.as_ref(), 30.0, 30.0, true);
+    assert!(
+        abs_blocks >= 1,
+        "expected at least one out-of-flow 30×30 pt BlockPageable for the abs <div>; \
+         the flatten guard must not drop it. Found {abs_blocks}."
+    );
 }
 
 /// Regression for the devin thread on fulgur-aijf: when in-flow children

--- a/crates/fulgur/tests/pseudo_absolute_content_url.rs
+++ b/crates/fulgur/tests/pseudo_absolute_content_url.rs
@@ -52,7 +52,7 @@ fn collect_positioned_images<'a>(
         out.push((parent_x, parent_y, img));
     }
     if let Some(block) = root.as_any().downcast_ref::<BlockPageable>() {
-        for PositionedChild { child, x, y } in &block.children {
+        for PositionedChild { child, x, y, .. } in &block.children {
             collect_positioned_images(child.as_ref(), parent_x + *x, parent_y + *y, out);
         }
     }
@@ -210,6 +210,7 @@ fn find_marker_origin(root: &dyn Pageable, x: f32, y: f32) -> Option<(f32, f32)>
             child,
             x: cx,
             y: cy,
+            ..
         } in &block.children
         {
             if let Some(found) = find_marker_origin(child.as_ref(), x + *cx, y + *cy) {


### PR DESCRIPTION
## 概要

`<img position:absolute>` / `<div position:absolute>` 等の **非疑似** 絶対配置要素が pagination 中に in-flow 扱いになり、要素高がページ高を超える場合に独立ページを占有していた問題 (`fulgur-aijf`) を修正。

CSS 2.1 §10.3.7 / §10.6.4 に従い、abs/fixed 子要素を out-of-flow として containing block 相対位置で再 emit する。

### 修正前
```html
<style>@page { size: 300px 50px; margin: 0; }</style>
<img style="position:absolute; top:0; left:0;" src="cat.png">
Cat head.
<div style="break-before:page;">Cat body.</div>
<div style="break-before:page;">No cat parts on this page.</div>
```
→ 4 ページ (page 1 = 画像のみ、page 2-4 = 本文)

### 修正後
→ 3 ページ (画像は out-of-flow、break-before の 3 div が page count を決定)

## 設計 (2 ピース構成)

### 1. `PositionedChild::out_of_flow` フラグ

`BlockPageable::wrap` で out-of-flow children を `total_height` 計算から除外し、`find_split_point` の overflow scan / forced-break probe / 主 scan loop からも除外。`split` / `split_boxed` では新ヘルパ `split_children_at_index` / `split_children_for_within` で両 fragment に複製。`clone_pc_with_offset` は out-of-flow に対して y クランプを skip し、CB 相対座標を保持して Krilla の page-area クリップで自然に slicing。

既存の pseudo path にも `out_of_flow: true` を流し込み、tall abs pseudo で再現する latent bug を予防。

### 2. `build_absolute_non_pseudo_children`

`build_absolute_pseudo_children` をミラーする形で `node` の DOM 直接子を走査し、`is_absolutely_positioned` な非疑似要素を `PositionedChild { out_of_flow: true }` として hoist。CB resolve (`resolve_cb_for_absolute` / `cb_padding_box`) と inset 解決ロジックは pseudo 版と共有。

`build_absolute_children` wrapper 経由で 5 つの call site に配線:

- `convert/inline_root.rs` ×2
- `convert/list_item.rs` ×2
- `convert/pseudo.rs` (`wrap_with_pseudo_content`)

`collect_positioned_children` で abs 子を skip して二重 emit を防止。

### スコープ制限

abs 要素は **直接の親に emit** する (pseudo path と同一 semantics)。深くネストした abs (CB が複数階層上にあるケース) は別 issue で対応。`page-background-002/003` (abs が body 直下) には十分。

## 検証

- **fulgur lib tests**: 828 passed (baseline 824 + 新 helper 4)
- **新 regression test** (`tests/abs_positioned_pagination.rs`): 2 件
- **integration / VRT / fulgur-cli**: 全緑
- **fmt / clippy**: 緑

### WPT (css-page) delta

| | main | this PR | delta |
|:-:|:-:|:-:|:-:|
| pass | 45 | 46 | +1 |
| regressions | 17 | 17 | ±0 |
| promotions | 7 | 0 | -7 (= 既 promote) |

- **+3 newly PASSing**: `page-background-002` / `page-background-003` (受け入れ基準) + `fixedpos-001`
- **-2 newly FAILing** (follow-up `fulgur-puml` で tracking):
  - `monolithic-overflow-013`: 350vh の abs 内容がページ生成を駆動できない (以前は abs-as-in-flow で偶然 4 ページになっていた)
  - `page-name-propagated-003`: 142/891662 px の微差 (abs が in-flow space を確保しないため周辺レイアウトが sub-pixel 単位で移動)
- 加えて main で既に observed=PASS だった 7 件を expectations 上で `PASS` に昇格

## 受け入れ基準

- [x] 再現 HTML の page count が 3 になる
- [x] `page-background-002/003` が PASS
- [x] 既存テスト緑
- [x] CSS 2.1 §10.3.7 / §10.6.4 準拠の helper unit test 追加

Closes fulgur-aijf (merge 後)

## Test plan

- [ ] CI green (lib / integration / VRT / fulgur-cli / WPT)
- [ ] fmt / clippy clean
- [ ] WPT regressions/promotions delta 0 (expectations と一致)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved multiple CSS print/page formatting issues (fixed positioning, page backgrounds, page names, page orientation and page-size handling)
  * Improved pagination so absolutely-positioned content no longer consumes page space or is silently dropped

* **Tests**
  * Added regression tests for absolute-element pagination and flattening edge cases
  * Updated web-platform test expectations: many print tests marked passing; two tests noted as regressions (including a small pixel-diff failure)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->