### PR TITLE
fix(layout): relayout position:fixed against the viewport

### DIFF
--- a/crates/fulgur-wpt/expectations/css-page.txt
+++ b/crates/fulgur-wpt/expectations/css-page.txt
@@ -29,13 +29,13 @@ SKIP  css/css-page/cssom/margin-003.html  # NoMatch
 SKIP  css/css-page/cssom/page-001.html  # NoMatch
 SKIP  css/css-page/cssom/page-002.html  # NoMatch
 PASS  css/css-page/fixedpos-001-print.html
-FAIL  css/css-page/fixedpos-002-print.html  # page count mismatch: test=1 ref=3
+PASS  css/css-page/fixedpos-002-print.html
 FAIL  css/css-page/fixedpos-003-print.html  # page count mismatch: test=2 ref=3
 FAIL  css/css-page/fixedpos-004-print.html  # page count mismatch: test=2 ref=3
 FAIL  css/css-page/fixedpos-005-print.html  # page count mismatch: test=3 ref=5
 FAIL  css/css-page/fixedpos-006-print.html  # page count mismatch: test=3 ref=5
 FAIL  css/css-page/fixedpos-007-print.html  # page 1 diff: 1765/891662 pixels exceed tol (max_ch=255)
-FAIL  css/css-page/fixedpos-008-print.html  # page count mismatch: test=3 ref=6
+PASS  css/css-page/fixedpos-008-print.html
 FAIL  css/css-page/fixedpos-009-print.html  # page count mismatch: test=1 ref=2
 FAIL  css/css-page/fixedpos-010-print.html  # page 1 diff: 10844/160000 pixels exceed tol (max_ch=255)
 FAIL  css/css-page/fixedpos-011-print.html  # page 1 diff: 84920/891662 pixels exceed tol (max_ch=255)
@@ -189,7 +189,7 @@ PASS  css/css-page/page-name-orthogonal-writing-003-print.html
 PASS  css/css-page/page-name-orthogonal-writing-004-print.html
 PASS  css/css-page/page-name-propagated-001-print.html
 FAIL  css/css-page/page-name-propagated-002-print.html  # page count mismatch: test=1 ref=3 (CSS page property not implemented)
-FAIL  css/css-page/page-name-propagated-003-print.html  # fulgur-aijf: small pixel diff (142/891662) from abs no longer reserving in-flow space; surrounding content shifts by sub-pixel amounts
+PASS  css/css-page/page-name-propagated-003-print.html
 PASS  css/css-page/page-name-propagated-004-print.html
 PASS  css/css-page/page-name-propagated-005-print.html
 FAIL  css/css-page/page-name-propagated-006-print.html  # page count mismatch: test=1 ref=2 (CSS page property not implemented)

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -111,24 +111,32 @@ pub mod net {
 /// Parse HTML and return a fully resolved document (styles + layout computed).
 ///
 /// We pass the content width as the viewport width so Taffy wraps text
-/// at the right column. The viewport height is set very large so that
-/// Taffy lays out the full document without clipping — our own pagination
-/// algorithm handles page breaks.
+/// at the right column. The viewport height is forwarded to stylo so that
+/// `vh` units and viewport-height media queries resolve consistently with
+/// `Engine::render_html`'s `parse_html_with_local_resources` path; this
+/// helper used to drop the height into a 10000px placeholder, which broke
+/// `100vh`-anchored fixtures.
 ///
 /// **Layout parity with `Engine::render_html`**: in addition to stylo + Taffy
 /// resolution this also runs [`relayout_position_fixed`], so unit tests
 /// that build documents through this helper observe the same fixed-position
-/// sizing the renderer produces. The `viewport_height` argument is now used
-/// (previously ignored) as the relayout pass's available height; pass the
-/// same value the renderer would use (`Config::content_height` in CSS px)
-/// for an exact match.
+/// sizing the renderer produces. Pass the same viewport dimensions the
+/// renderer would use (`Config::content_width` / `Config::content_height`
+/// in CSS px) for an exact match.
 pub fn parse_and_layout(
     html: &str,
     viewport_width: f32,
     viewport_height: f32,
     font_data: &[Arc<Vec<u8>>],
 ) -> HtmlDocument {
-    let mut doc = parse(html, viewport_width, font_data);
+    let mut doc = parse_inner(
+        html,
+        viewport_width,
+        viewport_height as u32,
+        font_data,
+        None,
+        None,
+    );
     resolve(&mut doc);
     relayout_position_fixed(&mut doc, viewport_width, viewport_height);
     doc

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -2058,6 +2058,64 @@ pub(crate) fn apply_link_media_rewrites(doc: &mut HtmlDocument, rewrites: &[Link
 mod tests {
     use super::*;
 
+    /// `relayout_position_fixed` must reshape every `position: fixed`
+    /// subtree against the supplied viewport, not against the nearest
+    /// positioned ancestor (the size that Taffy assigned during the
+    /// first pass through `stylo_taffy::convert::map_position` flattens
+    /// Fixed → Absolute). We construct a fixed div nested inside a
+    /// 50px-wide abs ancestor with text wider than 50px, run the
+    /// relayout, and assert the fixed element's `final_layout.size.width`
+    /// expanded past the parent's 50px constraint — which only happens
+    /// if Taffy was re-invoked with viewport-sized available space.
+    #[test]
+    fn relayout_position_fixed_reshapes_against_viewport() {
+        let html = r#"<!doctype html>
+<html><body style="margin:0">
+<div id="abs" style="position:absolute; width:50px">
+  <div id="fix" style="position:fixed">This text needs more than fifty pixels</div>
+</div>
+</body></html>"#;
+        let mut doc = parse(html, 600.0, &[]);
+        resolve(&mut doc);
+
+        // Locate the fixed div before relayout to capture its size.
+        fn find_by_id(doc: &HtmlDocument, id: &str) -> Option<usize> {
+            fn walk(doc: &HtmlDocument, node_id: usize, target: &str) -> Option<usize> {
+                let n = doc.get_node(node_id)?;
+                if let Some(elem) = n.element_data()
+                    && elem.attr(blitz_dom::LocalName::from("id")) == Some(target)
+                {
+                    return Some(node_id);
+                }
+                for &c in &n.children {
+                    if let Some(found) = walk(doc, c, target) {
+                        return Some(found);
+                    }
+                }
+                None
+            }
+            walk(doc, doc.root_element().id, id)
+        }
+        let fix_id = find_by_id(&doc, "fix").expect("fixed div id=fix");
+        let pre_width = doc.get_node(fix_id).unwrap().final_layout.size.width;
+        // Sanity: first pass constrained the fixed element to the
+        // abs ancestor's 50px box, so the long text wraps to multiple
+        // lines and the box stays narrow.
+        assert!(
+            pre_width <= 50.5,
+            "first-pass width should be capped at the abs's 50px; got {pre_width}"
+        );
+
+        // Now run the second pass with a 600 × 800 viewport and recheck.
+        relayout_position_fixed(&mut doc, 600.0, 800.0);
+        let post_width = doc.get_node(fix_id).unwrap().final_layout.size.width;
+        assert!(
+            post_width > 50.5,
+            "viewport relayout should widen the fixed box past the 50px parent; \
+             got {post_width} (pre was {pre_width})"
+        );
+    }
+
     #[test]
     fn parse_html_with_local_resources_orders_imports_before_parent() {
         // CSS cascade: `@import "child.css"` in parent.css must be

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -388,10 +388,19 @@ pub fn relayout_position_fixed(doc: &mut HtmlDocument, viewport_w_px: f32, viewp
         // Use raw children, not layout_children — layout_children may already
         // be invalidated by the time the second-pass relayout runs, and we
         // want every styled fixed element regardless of whether the first
-        // pass touched it.
+        // pass touched it. `::before` / `::after` pseudo-elements live in
+        // `node.before` / `node.after`, *not* in `node.children`, so we
+        // must visit them explicitly or a `::before { position: fixed; ... }`
+        // would keep the stale first-pass layout.
+        if let Some(before_id) = node.before {
+            collect_position_fixed_ids(doc, before_id, out, depth + 1);
+        }
         let children = node.children.clone();
         for child_id in children {
             collect_position_fixed_ids(doc, child_id, out, depth + 1);
+        }
+        if let Some(after_id) = node.after {
+            collect_position_fixed_ids(doc, after_id, out, depth + 1);
         }
     }
 }

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -320,6 +320,82 @@ pub fn resolve(doc: &mut HtmlDocument) {
     doc.resolve(0.0);
 }
 
+/// Re-run Taffy layout on every `position: fixed` subtree using the page area
+/// as available space. CSS 2.1 §10.1.5 specifies the initial containing block
+/// (viewport) as the CB for `position: fixed`, but `stylo_taffy::convert`
+/// flattens `Position::Fixed` to `Position::Absolute` (see crate
+/// `stylo_taffy/src/convert.rs:215`), so the main `doc.resolve(0.0)` pass
+/// lays each fixed element out against its nearest positioned ancestor
+/// instead. The result is a fixed element shrink-to-fit-clipped to the
+/// ancestor's narrow box, which surfaces as wrap differences in
+/// `css/css-page/fixedpos-*` reftests.
+///
+/// This second pass walks the DOM, collects every `position: fixed` node id,
+/// and calls `taffy::compute_root_layout` on each subtree as if it were a
+/// document root, with `available_space` set to the page area in CSS px.
+/// Taffy's caching keys on `(node_id, inputs)`, so the new inputs (different
+/// available space than the first pass used) bypass the cache and overwrite
+/// `unrounded_layout`. We then `round_layout` to populate `final_layout`.
+///
+/// The position math (which page bottom, which CB origin) is still resolved
+/// by `convert::positioned::build_absolute_*_children` against the
+/// viewport-anchored CB, so this pass only needs to fix the *size*.
+///
+/// Page-repetition of fixed content (Chrome's "should repeat on every page"
+/// behavior in WPT fixedpos-* tests) is intentionally **not** done here —
+/// that's a paginate-time concern owned by `crate::paginate`.
+pub fn relayout_position_fixed(doc: &mut HtmlDocument, viewport_w_px: f32, viewport_h_px: f32) {
+    use ::style::properties::longhands::position::computed_value::T as Pos;
+    use std::ops::DerefMut;
+
+    let mut fixed_ids: Vec<usize> = Vec::new();
+    let root_id = doc.root_element().id;
+    collect_position_fixed_ids(doc, root_id, &mut fixed_ids, 0);
+    if fixed_ids.is_empty() {
+        return;
+    }
+
+    let avail = taffy::Size {
+        width: taffy::AvailableSpace::Definite(viewport_w_px),
+        height: taffy::AvailableSpace::Definite(viewport_h_px),
+    };
+
+    let base = doc.deref_mut();
+    for id in fixed_ids {
+        let nid = taffy::NodeId::from(id);
+        taffy::compute_root_layout(base, nid, avail);
+        taffy::round_layout(base, nid);
+    }
+
+    fn collect_position_fixed_ids(
+        doc: &HtmlDocument,
+        node_id: usize,
+        out: &mut Vec<usize>,
+        depth: usize,
+    ) {
+        if depth >= crate::MAX_DOM_DEPTH {
+            return;
+        }
+        let Some(node) = doc.get_node(node_id) else {
+            return;
+        };
+        let is_fixed = node
+            .primary_styles()
+            .is_some_and(|s| matches!(s.get_box().clone_position(), Pos::Fixed));
+        if is_fixed {
+            out.push(node_id);
+        }
+        // Use raw children, not layout_children — layout_children may already
+        // be invalidated by the time the second-pass relayout runs, and we
+        // want every styled fixed element regardless of whether the first
+        // pass touched it.
+        let children = node.children.clone();
+        for child_id in children {
+            collect_position_fixed_ids(doc, child_id, out, depth + 1);
+        }
+    }
+}
+
 /// Walk the DOM for inline `<style>` elements and fold every stylesheet's
 /// GCPM context into one. This is the inline-HTML counterpart of the
 /// link-loaded context returned by [`parse_html_with_local_resources`].

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -114,14 +114,23 @@ pub mod net {
 /// at the right column. The viewport height is set very large so that
 /// Taffy lays out the full document without clipping — our own pagination
 /// algorithm handles page breaks.
+///
+/// **Layout parity with `Engine::render_html`**: in addition to stylo + Taffy
+/// resolution this also runs [`relayout_position_fixed`], so unit tests
+/// that build documents through this helper observe the same fixed-position
+/// sizing the renderer produces. The `viewport_height` argument is now used
+/// (previously ignored) as the relayout pass's available height; pass the
+/// same value the renderer would use (`Config::content_height` in CSS px)
+/// for an exact match.
 pub fn parse_and_layout(
     html: &str,
     viewport_width: f32,
-    _viewport_height: f32,
+    viewport_height: f32,
     font_data: &[Arc<Vec<u8>>],
 ) -> HtmlDocument {
     let mut doc = parse(html, viewport_width, font_data);
     resolve(&mut doc);
+    relayout_position_fixed(&mut doc, viewport_width, viewport_height);
     doc
 }
 

--- a/crates/fulgur/src/convert/list_item.rs
+++ b/crates/fulgur/src/convert/list_item.rs
@@ -530,6 +530,7 @@ mod tests {
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
             link_cache: Default::default(),
+            viewport_size_px: None,
         };
         let tree = dom_to_pageable(&doc, &mut ctx);
         assert!(
@@ -555,6 +556,7 @@ mod tests {
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
             link_cache: Default::default(),
+            viewport_size_px: None,
         };
         let tree = dom_to_pageable(&doc, &mut ctx);
         // Empty <li> with no AssetBundle fonts: marker may not render if no
@@ -580,6 +582,7 @@ mod tests {
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
             link_cache: Default::default(),
+            viewport_size_px: None,
         };
         let tree = dom_to_pageable(&doc, &mut ctx);
         assert!(

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -123,6 +123,17 @@ pub struct ConvertContext<'a> {
     /// the emitted PDF (LinkCollector dedupes by `Arc::ptr_eq`). A single
     /// long-lived cache guarantees pointer identity across the whole tree.
     pub(crate) link_cache: LinkCache,
+    /// Initial CB approximation: page area dimensions in CSS px.
+    /// `position: fixed` resolves its containing block against the viewport
+    /// (CSS 2.1 §10.1.5), but Blitz lays the body out with height = sum of
+    /// in-flow children — which is `0` when every direct child is
+    /// out-of-flow (the fixedpos-* WPT family). Without this fallback,
+    /// `bottom: 0` against body would resolve to `0 - child_h = -child_h`
+    /// and the fixed element snaps to the top of the page instead of the
+    /// bottom. `None` (the test harness default) falls back to the body's
+    /// Taffy size, preserving the historical behavior for unit tests that
+    /// don't run through `Engine::render_html`.
+    pub viewport_size_px: Option<(f32, f32)>,
 }
 
 impl ConvertContext<'_> {
@@ -810,6 +821,7 @@ mod tests {
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
             link_cache: Default::default(),
+            viewport_size_px: None,
         };
         let root = dom_to_pageable(&doc, &mut ctx);
 
@@ -858,6 +870,7 @@ mod tests {
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
             link_cache: Default::default(),
+            viewport_size_px: None,
         };
         let root = dom_to_pageable(&doc, &mut ctx);
 
@@ -922,6 +935,7 @@ mod tests {
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
             link_cache: Default::default(),
+            viewport_size_px: None,
         };
         let root = dom_to_pageable(&doc, &mut ctx);
 
@@ -989,6 +1003,7 @@ mod tests {
                 column_styles: $crate::column_css::ColumnStyleTable::new(),
                 multicol_geometry: $crate::multicol_layout::MulticolGeometryTable::new(),
                 link_cache: Default::default(),
+                viewport_size_px: None,
             }
         }};
     }

--- a/crates/fulgur/src/convert/positioned.rs
+++ b/crates/fulgur/src/convert/positioned.rs
@@ -726,3 +726,144 @@ pub(super) fn try_build_absolute_pseudo_image(
     };
     pseudo::build_pseudo_image(pseudo, basis_w_pt, basis_h_pt, assets)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn body_node_id(doc: &BaseDocument) -> usize {
+        let root = doc.root_element();
+        for &child_id in &root.children {
+            if let Some(node) = doc.get_node(child_id)
+                && let Some(elem) = node.element_data()
+                && elem.name.local.as_ref() == "body"
+            {
+                return child_id;
+            }
+        }
+        panic!("body not found");
+    }
+
+    /// Body has no in-flow content — its Taffy size collapses to zero.
+    /// With `viewport_size_px = Some`, both axes should fall back to the
+    /// supplied dimensions (CSS 2.1 §10.1.5 initial CB approximation).
+    #[test]
+    fn body_zero_size_with_viewport_uses_viewport_dimensions() {
+        let html = r#"<html><body style="margin:0">
+            <div style="position:absolute; bottom:0">x</div>
+        </body></html>"#;
+        let mut doc = crate::blitz_adapter::parse(html, 600.0, &[]);
+        crate::blitz_adapter::resolve(&mut doc);
+        let body_id = body_node_id(&doc);
+        let body = doc.get_node(body_id).unwrap();
+
+        let cb = resolve_cb_for_absolute(&doc, body, false, Some((600.0, 800.0)))
+            .expect("body fallback");
+        assert!(
+            cb.padding_box_size.0 > 0.0,
+            "width should be non-zero (body width is content width or viewport)",
+        );
+        assert!(
+            cb.padding_box_size.1 >= 800.0 - 0.01,
+            "height should fall back to viewport ({}); got {}",
+            800.0,
+            cb.padding_box_size.1
+        );
+    }
+
+    /// Body has no in-flow content but `viewport_size_px = None` — the
+    /// viewport branch is skipped, padding box stays at the (zero) Taffy
+    /// size. Confirms the `None` arm is wired and doesn't NaN/panic.
+    #[test]
+    fn body_zero_size_without_viewport_keeps_zero() {
+        let html = r#"<html><body style="margin:0">
+            <div style="position:absolute; bottom:0">x</div>
+        </body></html>"#;
+        let mut doc = crate::blitz_adapter::parse(html, 600.0, &[]);
+        crate::blitz_adapter::resolve(&mut doc);
+        let body_id = body_node_id(&doc);
+        let body = doc.get_node(body_id).unwrap();
+
+        let cb = resolve_cb_for_absolute(&doc, body, false, None).expect("body fallback");
+        assert!(
+            cb.padding_box_size.1 < 1.0,
+            "height stays at body's Taffy size when viewport_size_px is None; got {}",
+            cb.padding_box_size.1
+        );
+    }
+
+    /// Body has explicit non-zero height via in-flow content. Even when a
+    /// viewport size is supplied, the live padding box should win — the
+    /// fallback only fires when the live value is zero.
+    #[test]
+    fn body_non_zero_size_keeps_taffy_height() {
+        let html = r#"<html><body style="margin:0">
+            <p style="height:200px">filler</p>
+            <div style="position:absolute; bottom:0">x</div>
+        </body></html>"#;
+        let mut doc = crate::blitz_adapter::parse(html, 600.0, &[]);
+        crate::blitz_adapter::resolve(&mut doc);
+        let body_id = body_node_id(&doc);
+        let body = doc.get_node(body_id).unwrap();
+
+        let cb = resolve_cb_for_absolute(&doc, body, false, Some((600.0, 800.0)))
+            .expect("body fallback");
+        assert!(
+            cb.padding_box_size.1 < 800.0,
+            "live body height (~200) must win over viewport (800); got {}",
+            cb.padding_box_size.1
+        );
+        assert!(
+            cb.padding_box_size.1 >= 199.0,
+            "live body height should be at least the in-flow content height; got {}",
+            cb.padding_box_size.1
+        );
+    }
+
+    /// `is_fixed = true` walks past intermediate positioned ancestors and
+    /// resolves to body (initial CB approximation), regardless of how
+    /// deeply the fixed element is nested. Verifies the loop seed change
+    /// still finds body when `parent` itself is positioned.
+    #[test]
+    fn fixed_walks_past_positioned_ancestor_to_body() {
+        let html = r#"<html><body style="margin:0">
+            <div id="abs" style="position:absolute">
+                <div style="position:fixed; bottom:0">x</div>
+            </div>
+        </body></html>"#;
+        let mut doc = crate::blitz_adapter::parse(html, 600.0, &[]);
+        crate::blitz_adapter::resolve(&mut doc);
+        // Find the abs container — its `parent` arg simulates the fixed
+        // child's CB resolution starting from the abs ancestor.
+        let abs_id = {
+            let mut found = None;
+            fn walk(doc: &BaseDocument, id: usize, out: &mut Option<usize>) {
+                if let Some(n) = doc.get_node(id) {
+                    if let Some(elem) = n.element_data()
+                        && elem.attr(blitz_dom::LocalName::from("id")) == Some("abs")
+                    {
+                        *out = Some(id);
+                        return;
+                    }
+                    for &c in &n.children {
+                        walk(doc, c, out);
+                        if out.is_some() {
+                            return;
+                        }
+                    }
+                }
+            }
+            walk(&doc, doc.root_element().id, &mut found);
+            found.expect("abs node")
+        };
+        let abs = doc.get_node(abs_id).unwrap();
+
+        let cb =
+            resolve_cb_for_absolute(&doc, abs, true, Some((600.0, 800.0))).expect("body fallback");
+        // With viewport fallback active the height is the viewport's;
+        // without it the body's (zero) Taffy size would persist. Either
+        // way the function must not return None — that's the regression
+        // we're guarding.
+        assert!(cb.padding_box_size.1 > 0.0);
+    }
+}

--- a/crates/fulgur/src/convert/positioned.rs
+++ b/crates/fulgur/src/convert/positioned.rs
@@ -260,10 +260,21 @@ fn cb_padding_box(node: &Node) -> ((f32, f32), (f32, f32)) {
 /// parent chains, matching the defensive bounds applied elsewhere in
 /// `convert.rs` (`debug_print_tree`, `collect_positioned_children`,
 /// `resolve_enclosing_anchor`).
-fn resolve_cb_for_absolute(doc: &BaseDocument, parent: &Node, is_fixed: bool) -> Option<AbsCb> {
-    let mut offset_x = parent.final_layout.location.x;
-    let mut offset_y = parent.final_layout.location.y;
-    let mut cur_id = parent.parent;
+fn resolve_cb_for_absolute(
+    doc: &BaseDocument,
+    parent: &Node,
+    is_fixed: bool,
+    viewport_size_px: Option<(f32, f32)>,
+) -> Option<AbsCb> {
+    // Walk starts at `parent` itself (offset = 0, 0) so that abs/fixed
+    // children of `<body>` resolve against body. Without this seed, the
+    // loop began at `parent.parent` and never visited body when the abs
+    // descendant's direct parent IS body — leaving body_fallback unset
+    // and falling through to Taffy's `final_layout.location`, which is
+    // (0, 0) for a body whose Taffy height collapsed to zero.
+    let mut offset_x = 0.0_f32;
+    let mut offset_y = 0.0_f32;
+    let mut cur_id = Some(parent.id);
     let mut body_fallback: Option<AbsCb> = None;
     let mut depth: usize = 0;
 
@@ -286,7 +297,23 @@ fn resolve_cb_for_absolute(doc: &BaseDocument, parent: &Node, is_fixed: bool) ->
         }
         if let Some(elem) = cur.element_data() {
             if elem.name.local.as_ref() == "body" {
-                let (padding_box_size, border_top_left) = cb_padding_box(cur);
+                let (mut padding_box_size, border_top_left) = cb_padding_box(cur);
+                // Initial CB approximation: when body's Taffy size collapses
+                // to zero (no in-flow children, e.g. fixedpos-* family) but
+                // the engine knows the page area, swap in the viewport
+                // dimensions per CSS 2.1 §10.1.5 / §10.6.4 — the CB for
+                // `position: fixed` is the viewport, and a body-anchored
+                // `position: absolute` with no positioned ancestor uses the
+                // initial CB. We keep the body's actual padding box when it
+                // is non-zero so explicit `body { height: ... }` still wins.
+                if let Some((vw, vh)) = viewport_size_px {
+                    if padding_box_size.0 <= 0.0 {
+                        padding_box_size.0 = vw;
+                    }
+                    if padding_box_size.1 <= 0.0 {
+                        padding_box_size.1 = vh;
+                    }
+                }
                 body_fallback = Some(AbsCb {
                     padding_box_size,
                     border_top_left,
@@ -375,9 +402,13 @@ pub(super) fn build_absolute_pseudo_children(
         //     pseudos whose `final_layout.size` is `(0, 0)` (Taffy gives
         //     a wrong location for `right` / `bottom` in that case).
         let cb = if is_position_fixed(pseudo) {
-            *cb_fixed.get_or_insert_with(|| resolve_cb_for_absolute(doc, node, true))
+            *cb_fixed.get_or_insert_with(|| {
+                resolve_cb_for_absolute(doc, node, true, ctx.viewport_size_px)
+            })
         } else if parent_is_static {
-            *cb_absolute.get_or_insert_with(|| resolve_cb_for_absolute(doc, node, false))
+            *cb_absolute.get_or_insert_with(|| {
+                resolve_cb_for_absolute(doc, node, false, ctx.viewport_size_px)
+            })
         } else {
             let (padding_box_size, border_top_left) = cb_padding_box(node);
             Some(AbsCb {
@@ -526,9 +557,13 @@ pub(super) fn build_absolute_non_pseudo_children(
         }
 
         let cb = if is_position_fixed(child_node) {
-            *cb_fixed.get_or_insert_with(|| resolve_cb_for_absolute(doc, node, true))
+            *cb_fixed.get_or_insert_with(|| {
+                resolve_cb_for_absolute(doc, node, true, ctx.viewport_size_px)
+            })
         } else if parent_is_static {
-            *cb_absolute.get_or_insert_with(|| resolve_cb_for_absolute(doc, node, false))
+            *cb_absolute.get_or_insert_with(|| {
+                resolve_cb_for_absolute(doc, node, false, ctx.viewport_size_px)
+            })
         } else {
             let (padding_box_size, border_top_left) = cb_padding_box(node);
             Some(AbsCb {

--- a/crates/fulgur/src/convert/pseudo.rs
+++ b/crates/fulgur/src/convert/pseudo.rs
@@ -673,6 +673,7 @@ mod tests {
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
             link_cache: Default::default(),
+            viewport_size_px: None,
         };
         let tree = dom_to_pageable(&doc, &mut ctx);
 
@@ -722,6 +723,7 @@ mod tests {
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
             link_cache: Default::default(),
+            viewport_size_px: None,
         };
         let tree = dom_to_pageable(&doc, &mut ctx);
 
@@ -796,6 +798,7 @@ mod tests {
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
             link_cache: Default::default(),
+            viewport_size_px: None,
         };
         let tree = dom_to_pageable(&doc, &mut ctx);
         let mut images = Vec::new();
@@ -854,6 +857,7 @@ mod tests {
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
             link_cache: Default::default(),
+            viewport_size_px: None,
         };
         let tree = dom_to_pageable(&doc, &mut ctx);
         let mut images = Vec::new();
@@ -903,6 +907,7 @@ mod tests {
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
             link_cache: Default::default(),
+            viewport_size_px: None,
         };
         let tree = dom_to_pageable(&doc, &mut ctx);
         let mut images = Vec::new();

--- a/crates/fulgur/src/convert/replaced.rs
+++ b/crates/fulgur/src/convert/replaced.rs
@@ -336,6 +336,7 @@ mod tests {
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
             link_cache: Default::default(),
+            viewport_size_px: None,
         };
         let tree = dom_to_pageable(&doc, &mut ctx);
 
@@ -369,6 +370,7 @@ mod tests {
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
             link_cache: Default::default(),
+            viewport_size_px: None,
         };
         let tree = dom_to_pageable(&doc, &mut ctx);
 
@@ -405,6 +407,7 @@ mod tests {
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
             link_cache: Default::default(),
+            viewport_size_px: None,
         };
         let tree = dom_to_pageable(&doc, &mut ctx);
 

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -308,6 +308,16 @@ impl Engine {
         crate::blitz_adapter::apply_passes(&mut doc, &passes, &ctx);
 
         crate::blitz_adapter::resolve(&mut doc);
+        // Mirror the production pipeline so structural tests of the
+        // Pageable tree see the same layout as `render_html` produces.
+        // Without this, position:fixed subtrees keep their first-pass
+        // (Absolute-flattened) sizes and any test asserting fixed
+        // geometry would diverge from what the renderer outputs.
+        crate::blitz_adapter::relayout_position_fixed(
+            &mut doc,
+            crate::convert::pt_to_px(self.config.content_width()),
+            crate::convert::pt_to_px(self.config.content_height()),
+        );
         let column_styles = crate::blitz_adapter::extract_column_style_table(&doc);
         let multicol_geometry = crate::multicol_layout::run_pass(doc.deref_mut(), &column_styles);
 

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -170,6 +170,19 @@ impl Engine {
         }
 
         crate::blitz_adapter::resolve(&mut doc);
+        // Second layout pass: re-run Taffy on every `position: fixed` subtree
+        // with the page area as available space. Without this, stylo_taffy
+        // collapses Fixed → Absolute and lays each fixed element out against
+        // its nearest positioned ancestor, producing wrong sizes whenever the
+        // fixed element is nested inside a shrink-to-fit abs (fixedpos-002 et
+        // al.). The position math itself is corrected later inside
+        // `convert::positioned::build_absolute_*_children` via the body cb_h
+        // viewport fallback in `resolve_cb_for_absolute`.
+        crate::blitz_adapter::relayout_position_fixed(
+            &mut doc,
+            crate::convert::pt_to_px(self.config.content_width()),
+            crate::convert::pt_to_px(self.config.content_height()),
+        );
 
         // Harvest Phase A `column-*` properties (column-fill, column-rule-*)
         // that stylo 0.8.0 gates behind its gecko engine. The side-table is
@@ -217,6 +230,10 @@ impl Engine {
             column_styles,
             multicol_geometry,
             link_cache: Default::default(),
+            viewport_size_px: Some((
+                crate::convert::pt_to_px(self.config.content_width()),
+                crate::convert::pt_to_px(self.config.content_height()),
+            )),
         };
         let root = crate::convert::dom_to_pageable(&doc, &mut convert_ctx);
 
@@ -305,6 +322,10 @@ impl Engine {
             column_styles,
             multicol_geometry,
             link_cache: Default::default(),
+            viewport_size_px: Some((
+                crate::convert::pt_to_px(self.config.content_width()),
+                crate::convert::pt_to_px(self.config.content_height()),
+            )),
         };
         crate::convert::dom_to_pageable(&doc, &mut convert_ctx)
     }

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -4473,6 +4473,7 @@ mod tests {
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
             link_cache: Default::default(),
+            viewport_size_px: None,
         };
         let pageable = convert::dom_to_pageable(&doc, &mut ctx);
         let pages = crate::paginate::paginate(pageable, 400.0, 600.0);
@@ -4525,6 +4526,7 @@ mod tests {
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
             link_cache: Default::default(),
+            viewport_size_px: None,
         };
         let pageable = convert::dom_to_pageable(&doc, &mut ctx);
         let pages = crate::paginate::paginate(pageable, 400.0, 600.0);
@@ -4571,6 +4573,7 @@ mod tests {
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
             link_cache: Default::default(),
+            viewport_size_px: None,
         };
         let pageable = convert::dom_to_pageable(&doc, &mut ctx);
         let pages = crate::paginate::paginate(pageable, 400.0, 600.0);

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -1777,6 +1777,7 @@ mod link_collect_tests {
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
             link_cache: Default::default(),
+            viewport_size_px: None,
         };
         let pageable = convert::dom_to_pageable(&doc, &mut ctx);
         let pages = crate::paginate::paginate(pageable, 400.0, 600.0);

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -540,6 +540,7 @@ pub fn render_to_pdf_with_gcpm(
                     column_styles: crate::column_css::ColumnStyleTable::new(),
                     multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
                     link_cache: Default::default(),
+                    viewport_size_px: None,
                 };
                 let pageable = crate::convert::dom_to_pageable(&render_doc, &mut dummy_ctx);
                 render_cache.insert(cache_key.clone(), pageable);

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -496,25 +496,76 @@ fn repeating_linear_gradient_with_hint_renders_via_engine() {
 }
 
 #[test]
-fn position_fixed_inside_absolute_relayouts_against_viewport() {
-    // Regression for fulgur-tbxs (WPT fixedpos-002): when `position: fixed` is
-    // nested inside a shrink-to-fit `position: absolute` ancestor, the first
-    // Taffy pass collapses Fixed → Absolute and sizes the fixed element
-    // against the abs's narrow box. Without `relayout_position_fixed`, the
-    // text "Hello" wraps to multiple lines because the fixed box inherits
-    // ~30px from `width:30px`. The second-pass relayout rebuilds the fixed
-    // subtree against the page area, so the fixed element ends up wide
-    // enough to fit "Hello" on a single line. We assert via PDF byte length
-    // because the smoke crate doesn't pull in pdftocairo for raster diff —
-    // a relayouted PDF reliably comes out a few hundred bytes lighter than
-    // the wrapped-multiline alternative when content is identical.
+fn position_absolute_pseudo_at_body_resolves_initial_cb() {
+    // Exercises `build_absolute_pseudo_children`'s body-anchored path —
+    // ::before is `position: absolute` with no positioned ancestor, so
+    // CB resolution walks to body and (with the fulgur-tbxs viewport
+    // fallback) takes the page area as the padding box. Verifies the
+    // pseudo path's `cb_absolute.get_or_insert_with(...)` arm is
+    // exercised by an end-to-end render and not just by unit tests.
     let html = r#"<html><body style="margin:0">
-<div style="position:absolute; width:30px; height:300vh">
-  outer
-  <div style="position:fixed; bottom:0">Hello</div>
-</div>
+<style>body::before { content: "x"; position: absolute; bottom: 0; }</style>
+<p>filler</p>
 </body></html>"#;
     let pdf = Engine::builder().build().render_html(html).expect("render");
     assert!(!pdf.is_empty());
     assert!(pdf.starts_with(b"%PDF"));
+}
+
+#[test]
+fn position_fixed_inside_absolute_relayouts_against_viewport() {
+    // Regression for fulgur-tbxs (WPT fixedpos-002): when `position: fixed`
+    // is nested inside a shrink-to-fit `position: absolute` ancestor, the
+    // first Taffy pass collapses Fixed → Absolute and sizes the fixed
+    // element against the abs's narrow box. The %PDF byte check only
+    // proves engine completion; the structural assertion is the real
+    // regression guard — we walk the Pageable tree, find every
+    // out-of-flow `ParagraphPageable`, and assert the fixed text laid
+    // itself out as a single line. Without `relayout_position_fixed`,
+    // Parley shapes the long sentence at the abs's ~37.5pt width and
+    // produces multiple wrapped lines; with the relayout, the fixed
+    // subtree is reshaped against the page area and the sentence fits
+    // on one line.
+    use fulgur::pageable::{BlockPageable, Pageable, PositionedChild};
+    use fulgur::paragraph::ParagraphPageable;
+
+    let html = r#"<html><body style="margin:0">
+<div style="position:absolute; width:50px; height:300vh">
+  outer
+  <div style="position:fixed; bottom:0">This text is much wider than fifty pixels</div>
+</div>
+</body></html>"#;
+    let engine = Engine::builder().build();
+    let pdf = engine.render_html(html).expect("render");
+    assert!(pdf.starts_with(b"%PDF"));
+
+    fn max_oof_paragraph_lines(node: &dyn Pageable, own_oof: bool) -> usize {
+        let any = node.as_any();
+        if own_oof && let Some(p) = any.downcast_ref::<ParagraphPageable>() {
+            return p.lines.len();
+        }
+        if let Some(block) = any.downcast_ref::<BlockPageable>() {
+            let mut max = 0;
+            for PositionedChild {
+                child, out_of_flow, ..
+            } in &block.children
+            {
+                let n = max_oof_paragraph_lines(child.as_ref(), *out_of_flow);
+                if n > max {
+                    max = n;
+                }
+            }
+            return max;
+        }
+        0
+    }
+
+    let tree = engine.build_pageable_for_testing_no_gcpm(html);
+    let lines = max_oof_paragraph_lines(tree.as_ref(), false);
+    assert_eq!(
+        lines, 1,
+        "expected the inner position:fixed paragraph to be relayouted \
+         wide enough to hold the sentence on a single line; got {lines} lines, \
+         meaning it kept the 37.5pt parent-abs width and Parley wrapped"
+    );
 }

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -494,3 +494,27 @@ fn repeating_linear_gradient_with_hint_renders_via_engine() {
     let pdf = Engine::builder().build().render_html(html).expect("render");
     assert!(!pdf.is_empty());
 }
+
+#[test]
+fn position_fixed_inside_absolute_relayouts_against_viewport() {
+    // Regression for fulgur-tbxs (WPT fixedpos-002): when `position: fixed` is
+    // nested inside a shrink-to-fit `position: absolute` ancestor, the first
+    // Taffy pass collapses Fixed → Absolute and sizes the fixed element
+    // against the abs's narrow box. Without `relayout_position_fixed`, the
+    // text "Hello" wraps to multiple lines because the fixed box inherits
+    // ~30px from `width:30px`. The second-pass relayout rebuilds the fixed
+    // subtree against the page area, so the fixed element ends up wide
+    // enough to fit "Hello" on a single line. We assert via PDF byte length
+    // because the smoke crate doesn't pull in pdftocairo for raster diff —
+    // a relayouted PDF reliably comes out a few hundred bytes lighter than
+    // the wrapped-multiline alternative when content is identical.
+    let html = r#"<html><body style="margin:0">
+<div style="position:absolute; width:30px; height:300vh">
+  outer
+  <div style="position:fixed; bottom:0">Hello</div>
+</div>
+</body></html>"#;
+    let pdf = Engine::builder().build().render_html(html).expect("render");
+    assert!(!pdf.is_empty());
+    assert!(pdf.starts_with(b"%PDF"));
+}


### PR DESCRIPTION
## 概要

stylo_taffy の `convert.rs:215` が `stylo::Position::Fixed` を `taffy::Position::Absolute` に丸めているため、Blitz のメイン resolve は `position:fixed` を最寄りの positioned ancestor に対する abs と同等にレイアウトしてしまう。fixed が shrink-to-fit な abs にネストされたとき、本来 viewport を CB として shrink-to-fit するべき幅が ancestor の狭い箱に閉じ込められ、`fixedpos-002-print.html` の "This should repeat on every page." が複数行に折り返す。これを直す。

## 設計

二段構成。

1. **`relayout_position_fixed` (`blitz_adapter.rs`)** — `doc.resolve(0.0)` の後に DOM を walk して `position:fixed` の node id を集め、各 subtree について `taffy::compute_root_layout(doc, id, viewport_avail)` を再呼び出し。Taffy の `compute_cached_layout` は inputs（=available_space）を含めて keying するので、最初の pass と異なる available_space で呼ぶとキャッシュをバイパスして再計算してくれる。続く `round_layout` で `final_layout` まで上書き。
2. **`resolve_cb_for_absolute` の二点修正 (`convert/positioned.rs`)** — 位置算出は引き続きこの関数を通る。
   - ループ開始位置を `parent.parent` から `parent` 自身へ変更し、abs/fixed の直接の親が body のケースでも body fallback を拾えるようにした。
   - body の Taffy size が 0（fixedpos-* family のように in-flow 子なし）のとき、`ConvertContext.viewport_size_px`（engine が `content_width` / `content_height` を CSS px で渡す）に差し替えるようにした。これで `bottom: 0` が `-child_height` ではなく page area の下端に解決される。

ページごとの fixed 複製（fixedpos-005/006/010 が要求する "should repeat on every page"）は **paginate-time の責務**として今回は対象外。

## 検証

```text
cargo fmt --check                        ok
cargo clippy --all-targets               warning なし
cargo test -p fulgur                     失敗 0
cargo test -p fulgur-vrt                 失敗 0
cargo test -p fulgur-cli                 失敗 0
FULGUR_WPT_REQUIRED=1 cargo test -p fulgur-wpt --release
```

新規 smoke test: `crates/fulgur/tests/render_smoke.rs` に `position_fixed_inside_absolute_relayouts_against_viewport` を追加し、relayout 経路を engine 越しに踏むようにした（codecov の patch coverage 対策）。

## WPT delta

| Phase | 主branch | このブランチ | Δ |
|---|---|---|---|
| css-page | regressions=17, promotions=0 | regressions=17, promotions=3 | **+3 / 0** |
| smoke | 0 / 0 | 0 / 0 | unchanged |
| bugs | 0 / 0 | 0 / 0 | unchanged |
| opacity-visibility | 0 / 0 | 0 / 0 | unchanged |
| multicol-1〜3 | regressions 3+1+1 | 同左 | unchanged |

新たに PASS:

- `css/css-page/fixedpos-002-print.html` (target)
- `css/css-page/fixedpos-008-print.html`
- `css/css-page/page-name-propagated-003-print.html` (PR #260 / fulgur-aijf で残っていた regression を回収)

純減ゼロ（既存 17 件の `page-name-*` regressions はそのまま; これらは別 issue）。

## 性能補足

`relayout_position_fixed` は `position:fixed` が DOM に存在しないときは早期 return。存在しても通常文書では fixed は header/footer の 1〜2 個程度で各 subtree も小さいため、render 時間への寄与は無視できる範囲のはず。ベンチが必要になるケースが見つかれば、`BaseDocument` を `LayoutPartialTree` ラッパーで包んで 1pass 内で `compute_child_layout` の `available_space` を override する案に切り替え可能（forward boilerplate のメンテコストとのトレードオフ）。今回は最小実装で ship し、必要になってから最適化する方針。

fulgur-tbxs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering for fixed-position content by re-running layout against the page viewport and adding a viewport-size fallback, resolving three CSS page test failures.

* **Tests**
  * Added end-to-end regression tests for fixed/absolute positioning and body/pseudo-element edge cases; updated unit tests to include viewport-size context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->