### PR TITLE
ci(wpt-nightly): set GH_REPO so aggregate job can call gh without checkout

### DIFF
--- a/.github/workflows/wpt-nightly.yml
+++ b/.github/workflows/wpt-nightly.yml
@@ -94,6 +94,7 @@ jobs:
       - name: Aggregate and file issues
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## 概要

`WPT nightly` workflow の `regressions / aggregate` job が exit 1 で fail していた問題を修正する。

失敗 run: https://github.com/fulgur-rs/fulgur/actions/runs/25035866322

## 原因

`regressions-aggregate` job には `actions/checkout` ステップが無いため、`gh` CLI が repo を git 経由で判定できず `failed to run git: fatal: not a git repository` を吐いていた。

スクリプトは `set -euo pipefail` 配下で動いており、for ループ内の以下の行で:

```bash
existing=$(gh issue list --state open --search "..." --json number --jq '.[0].number // empty')
```

コマンド置換が失敗 → set -e が発火 → exit 1。結果として既存の regression issue (#142, #201) への comment 投稿も行われていなかった。

## 修正

`env` ブロックに `GH_REPO: \${{ github.repository }}` を追加。`gh` CLI は `GH_REPO` env を尊重して git lookup をスキップするため、checkout 無しで動作する。

`actions/checkout` を追加する代替案より軽量 (このジョブは artifact をダウンロードして集計するだけで、リポジトリのコードは不要)。

## Test plan

- [ ] 次回 nightly schedule run (02:00 UTC) で `regressions / aggregate` job が成功すること
- [ ] regression が検出された場合、既存 issue へのコメント or 新規 issue 作成が機能すること
- [ ] `workflow_dispatch` で手動実行して動作確認 (任意)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration.

---

**Note:** This release contains only internal infrastructure updates with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->