### PR TITLE
chore(convert): carry pagination_geometry on ConvertContext (fulgur-cj6u Phase 1.1)

### DIFF
--- a/crates/fulgur/src/convert/list_item.rs
+++ b/crates/fulgur/src/convert/list_item.rs
@@ -533,6 +533,7 @@ mod tests {
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
+            pagination_geometry: ::std::collections::BTreeMap::new(),
             link_cache: Default::default(),
             viewport_size_px: None,
         };
@@ -559,6 +560,7 @@ mod tests {
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
+            pagination_geometry: ::std::collections::BTreeMap::new(),
             link_cache: Default::default(),
             viewport_size_px: None,
         };
@@ -585,6 +587,7 @@ mod tests {
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
+            pagination_geometry: ::std::collections::BTreeMap::new(),
             link_cache: Default::default(),
             viewport_size_px: None,
         };

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -114,6 +114,16 @@ pub struct ConvertContext<'a> {
     /// Keyed by container `usize` NodeId — same convention as
     /// `column_styles`.
     pub multicol_geometry: crate::multicol_layout::MulticolGeometryTable,
+    /// fulgur-cj6u Phase 1.1: per-body-child page-fragment geometry
+    /// recorded by [`crate::pagination_layout::run_pass_with_break_styles`].
+    /// Currently captured but not yet consumed — the next phase
+    /// (parity assertion) reads `implied_page_count` from this table
+    /// and compares it to `paginate(...).len()` to catch divergence
+    /// between the spike fragmenter and Pageable's split decisions.
+    /// Empty when the document had no body or no in-flow children.
+    /// Keyed by source `usize` NodeId — same convention as
+    /// `column_styles` and `multicol_geometry`.
+    pub pagination_geometry: crate::pagination_layout::PaginationGeometryTable,
     /// Anchor (`<a href>`) resolution cache shared across the entire
     /// conversion. Lifted out of `extract_paragraph` because inline-box
     /// extraction recurses through `convert_node → extract_paragraph`, and a
@@ -823,6 +833,7 @@ mod tests {
             bookmark_by_node,
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
+            pagination_geometry: ::std::collections::BTreeMap::new(),
             link_cache: Default::default(),
             viewport_size_px: None,
         };
@@ -872,6 +883,7 @@ mod tests {
             bookmark_by_node,
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
+            pagination_geometry: ::std::collections::BTreeMap::new(),
             link_cache: Default::default(),
             viewport_size_px: None,
         };
@@ -937,6 +949,7 @@ mod tests {
             bookmark_by_node,
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
+            pagination_geometry: ::std::collections::BTreeMap::new(),
             link_cache: Default::default(),
             viewport_size_px: None,
         };
@@ -1005,6 +1018,7 @@ mod tests {
                 bookmark_by_node: ::std::collections::HashMap::new(),
                 column_styles: $crate::column_css::ColumnStyleTable::new(),
                 multicol_geometry: $crate::multicol_layout::MulticolGeometryTable::new(),
+                pagination_geometry: ::std::collections::BTreeMap::new(),
                 link_cache: Default::default(),
                 viewport_size_px: None,
             }

--- a/crates/fulgur/src/convert/pseudo.rs
+++ b/crates/fulgur/src/convert/pseudo.rs
@@ -674,6 +674,7 @@ mod tests {
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
+            pagination_geometry: ::std::collections::BTreeMap::new(),
             link_cache: Default::default(),
             viewport_size_px: None,
         };
@@ -724,6 +725,7 @@ mod tests {
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
+            pagination_geometry: ::std::collections::BTreeMap::new(),
             link_cache: Default::default(),
             viewport_size_px: None,
         };
@@ -799,6 +801,7 @@ mod tests {
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
+            pagination_geometry: ::std::collections::BTreeMap::new(),
             link_cache: Default::default(),
             viewport_size_px: None,
         };
@@ -858,6 +861,7 @@ mod tests {
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
+            pagination_geometry: ::std::collections::BTreeMap::new(),
             link_cache: Default::default(),
             viewport_size_px: None,
         };
@@ -908,6 +912,7 @@ mod tests {
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
+            pagination_geometry: ::std::collections::BTreeMap::new(),
             link_cache: Default::default(),
             viewport_size_px: None,
         };

--- a/crates/fulgur/src/convert/replaced.rs
+++ b/crates/fulgur/src/convert/replaced.rs
@@ -337,6 +337,7 @@ mod tests {
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
+            pagination_geometry: ::std::collections::BTreeMap::new(),
             link_cache: Default::default(),
             viewport_size_px: None,
         };
@@ -371,6 +372,7 @@ mod tests {
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
+            pagination_geometry: ::std::collections::BTreeMap::new(),
             link_cache: Default::default(),
             viewport_size_px: None,
         };
@@ -408,6 +410,7 @@ mod tests {
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
+            pagination_geometry: ::std::collections::BTreeMap::new(),
             link_cache: Default::default(),
             viewport_size_px: None,
         };

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -201,20 +201,12 @@ impl Engine {
 
         // Run the pagination_layout fragmenter (fulgur-4cbc). Walks
         // body's children's existing `final_layout` (populated by
-        // `resolve()` and `multicol_layout::run_pass`) and records
-        // per-node page fragments in a `PaginationGeometryTable`. The
-        // returned table is currently *observational only* — no convert
-        // / render path consumes it yet, but routing the call through
-        // the production code path:
-        //
-        // - replaces the previous `#![allow(dead_code)]` blanket
-        //   permission with a single drop-the-result call site so
-        //   `cargo build` / `cargo clippy` warn truthfully when an item
-        //   becomes orphaned,
-        // - gives follow-up work (counter / string-set replacement,
-        //   per-page fixed repetition redesign, etc.) a stable hand-off
-        //   point: capture the table on `ConvertContext` instead of
-        //   dropping it.
+        // `resolve()` and `multicol_layout::run_pass`) and produces a
+        // per-node `PaginationGeometryTable`. fulgur-cj6u Phase 1.1
+        // captures the result on `ConvertContext` so future consumers
+        // — parity assertion, counter / string-set replacement,
+        // per-page fixed repetition redesign — can read it without
+        // re-walking layout.
         //
         // Side-effect safety: `run_pass_with_break_styles` is a
         // read-only walk of `final_layout` via
@@ -227,7 +219,7 @@ impl Engine {
         // `pagination_layout.rs` module docs). VRT /
         // examples_determinism / WPT all stay byte-identical with
         // this call inserted.
-        let _pagination_geometry = crate::pagination_layout::run_pass_with_break_styles(
+        let pagination_geometry = crate::pagination_layout::run_pass_with_break_styles(
             doc.deref_mut(),
             crate::convert::pt_to_px(self.config.content_height()),
             &column_styles,
@@ -263,6 +255,7 @@ impl Engine {
             bookmark_by_node,
             column_styles,
             multicol_geometry,
+            pagination_geometry,
             link_cache: Default::default(),
             viewport_size_px: Some((
                 crate::convert::pt_to_px(self.config.content_width()),
@@ -354,6 +347,13 @@ impl Engine {
         );
         let column_styles = crate::blitz_adapter::extract_column_style_table(&doc);
         let multicol_geometry = crate::multicol_layout::run_pass(doc.deref_mut(), &column_styles);
+        // fulgur-cj6u Phase 1.1: capture pagination geometry on
+        // ConvertContext for parity with the production path.
+        let pagination_geometry = crate::pagination_layout::run_pass_with_break_styles(
+            doc.deref_mut(),
+            crate::convert::pt_to_px(self.config.content_height()),
+            &column_styles,
+        );
 
         let running_store = crate::gcpm::running::RunningElementStore::new();
         let mut convert_ctx = ConvertContext {
@@ -365,6 +365,7 @@ impl Engine {
             bookmark_by_node: HashMap::new(),
             column_styles,
             multicol_geometry,
+            pagination_geometry,
             link_cache: Default::default(),
             viewport_size_px: Some((
                 crate::convert::pt_to_px(self.config.content_width()),

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -4572,6 +4572,7 @@ mod tests {
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
+            pagination_geometry: ::std::collections::BTreeMap::new(),
             link_cache: Default::default(),
             viewport_size_px: None,
         };
@@ -4625,6 +4626,7 @@ mod tests {
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
+            pagination_geometry: ::std::collections::BTreeMap::new(),
             link_cache: Default::default(),
             viewport_size_px: None,
         };
@@ -4672,6 +4674,7 @@ mod tests {
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
+            pagination_geometry: ::std::collections::BTreeMap::new(),
             link_cache: Default::default(),
             viewport_size_px: None,
         };

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -1776,6 +1776,7 @@ mod link_collect_tests {
             bookmark_by_node: HashMap::new(),
             column_styles: crate::column_css::ColumnStyleTable::new(),
             multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
+            pagination_geometry: ::std::collections::BTreeMap::new(),
             link_cache: Default::default(),
             viewport_size_px: None,
         };

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -539,6 +539,7 @@ pub fn render_to_pdf_with_gcpm(
                     bookmark_by_node: HashMap::new(),
                     column_styles: crate::column_css::ColumnStyleTable::new(),
                     multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
+                    pagination_geometry: crate::pagination_layout::PaginationGeometryTable::new(),
                     link_cache: Default::default(),
                     viewport_size_px: None,
                 };


### PR DESCRIPTION
## 概要

fulgur-z2mg (Pageable replacement epic) Phase 1.1。

`pagination_layout::run_pass_with_break_styles` の戻り値 `PaginationGeometryTable` を engine.rs で drop していたのを `ConvertContext` のフィールドとして carry する。consumer はまだ読まない — Phase 1.2 (page count parity assertion) でこの table を読んで `paginate(...).len()` と比較する。

⚠️ **stack 順序**: `feat/pageable-replacement` (epic) ← #263 ← #265 ← **本 PR**

base = `feat/fulgur-4cbc-pagination-wire` (= #265 head)。#265 が epic branch に merge された後に本 PR の base を `feat/pageable-replacement` に retarget。

## 変更内容

- `ConvertContext::pagination_geometry: PaginationGeometryTable` フィールド追加 (既存の `multicol_geometry` / `column_styles` と同列)
- `Engine::render_html`: `let _pagination_geometry = ...` → `pagination_geometry` を保持して ConvertContext に渡す
- `Engine::build_pageable_for_testing_no_gcpm`: `run_pass_with_break_styles` を追加して test path も同じ context shape (Phase 1.2 で parity assertion を test 側にも入れるため)
- `convert/`, `pageable.rs`, `paragraph.rs`, `render.rs` の test / unit ConvertContext 構築は `pagination_geometry: BTreeMap::new()` で初期化 (既存 `multicol_geometry` と同じ defaults pattern)

## 検証

- fulgur lib unit tests: **877 pass** (#265 と同数 — Phase 1.1 自体は production behaviour 不変)
- examples_determinism: **11/11 pass** (byte-identical PDFs)
- VRT byte-wise: **33/33 pass**
- production build: **0 warnings**
- clippy clean

## レビュー観点

- ConvertContext の field 追加位置 (`multicol_geometry` の直後にした、文書も同じパターン)
- 全 test 用 default `BTreeMap::new()` で空テーブル (既存パターン踏襲)
- `build_pageable_for_testing_no_gcpm` も spike を呼ぶ — テストハーネスの観測 surface が production と一致

## 次の作業

- Phase 1.2: `pagination_layout::implied_page_count(&geometry)` を un-gate し、render path で `paginate(...).len()` との parity を `debug_assert!` する PR
- 本 PR が merge されたら Phase 1.2 を本 PR の上に stack

## 関連

- Epic: fulgur-z2mg (Pageable replacement)
- Phase: fulgur-cj6u
- 直前 PR: #265 (engine wire + spike-only API gate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal pagination geometry tracking by updating the conversion context to store pagination state computed during the pagination step.

* **Tests**
  * Updated test infrastructure across multiple modules to initialize pagination geometry state, ensuring compatibility with the updated conversion context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->