### PR TITLE
feat(render): page count parity assertion (fulgur-cj6u Phase 1.2)

### DIFF
--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -267,7 +267,14 @@ impl Engine {
         if gcpm.is_empty() {
             self.render_pageable(root)
         } else {
-            crate::render::render_to_pdf_with_gcpm(root, &self.config, &gcpm, &running_store, fonts)
+            crate::render::render_to_pdf_with_gcpm(
+                root,
+                &self.config,
+                &gcpm,
+                &running_store,
+                fonts,
+                &convert_ctx.pagination_geometry,
+            )
         }
     }
 

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -793,12 +793,13 @@ fn walk_for_position_fixed(doc: &BaseDocument, node_id: usize, out: &mut Vec<usi
 ///
 /// Convention matches `compare_with_pageable::spike_page_count`:
 /// returns `max(page_index) + 1` if the table has any fragments, else
-/// `1` (Pageable's "always at least one page" guarantee). Exposed as
-/// a helper so callers that need to thread `total_pages` into
-/// [`append_position_fixed_fragments`] can do so without re-computing.
+/// `1` (Pageable's "always at least one page" guarantee).
 ///
-/// Test-only today — paired with [`append_position_fixed_fragments`].
-#[cfg(test)]
+/// Used by fulgur-cj6u Phase 1.2 as the spike-side input to a
+/// `paginate(...).len() == implied_page_count(&geometry)` parity
+/// assertion in `render_to_pdf_with_gcpm`. Drift between Pageable's
+/// split decisions and the spike's fragmenter is the regression
+/// signal Phase 2 work needs to chase.
 pub fn implied_page_count(geometry: &PaginationGeometryTable) -> u32 {
     geometry
         .values()

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -333,6 +333,14 @@ impl<'a> PaginationLayoutTree<'a> {
         let mut page_index: u32 = 0;
         let mut cursor_y: f32 = 0.0;
         let mut emitted = 0usize;
+        // Tracks the bottom edge of the previously emitted in-flow child
+        // in body-content-box coordinates. Used to pick up inter-child
+        // gaps (collapsed margins, padding) that Blitz baked into each
+        // child's `final_layout.location.y` but the cursor-only walk
+        // would otherwise miss. Pageable accumulates `pc.y + child_h`
+        // from `final_layout.location.y` during convert, so margin gaps
+        // are present in the Pageable side; the spike must match.
+        let mut prev_bottom_y_in_body: f32 = 0.0;
 
         for child_id in children {
             let Some(child) = self.doc.get_node(child_id) else {
@@ -345,6 +353,22 @@ impl<'a> PaginationLayoutTree<'a> {
             {
                 continue;
             }
+            // CSS 2.1 §10.6.4: out-of-flow elements (`position: absolute`
+            // / `position: fixed`) do not contribute to their containing
+            // block's normal-flow height. Pageable routes them through
+            // `PositionedChild { out_of_flow: true }` and they never
+            // advance pagination cursors; the spike must match or the
+            // fulgur-cj6u Phase 1.2 parity assertion fires on documents
+            // with abs/fixed body-direct children.
+            {
+                use ::style::properties::longhands::position::computed_value::T as Pos;
+                let is_out_of_flow = child.primary_styles().is_some_and(|s| {
+                    matches!(s.get_box().clone_position(), Pos::Absolute | Pos::Fixed)
+                });
+                if is_out_of_flow {
+                    continue;
+                }
+            }
             let layout = child.final_layout;
             let child_h = layout.size.height;
             let child_w = if layout.size.width > 0.0 {
@@ -355,6 +379,15 @@ impl<'a> PaginationLayoutTree<'a> {
             if child_h <= 0.0 {
                 continue;
             }
+
+            // Pick up the inter-child gap in body coordinates (collapsed
+            // top/bottom margins, body padding before the first child)
+            // before any break / overflow logic so the cursor reflects
+            // Blitz's flow positions. `max(0.0)` guards against negative
+            // gaps from sibling overlap (rare with default UA styles).
+            let this_top_in_body = layout.location.y;
+            let gap = (this_top_in_body - prev_bottom_y_in_body).max(0.0);
+            cursor_y += gap;
 
             // fulgur-k0g0: read break-before / break-after / break-inside
             // for this child from the column-style side-table (shared with
@@ -411,6 +444,7 @@ impl<'a> PaginationLayoutTree<'a> {
                 page_index = new_page_index;
                 cursor_y = new_cursor_y;
                 emitted += frag_count;
+                prev_bottom_y_in_body = this_top_in_body + child_h;
                 if matches!(
                     break_props.break_after,
                     Some(crate::pageable::BreakAfter::Page)
@@ -448,6 +482,7 @@ impl<'a> PaginationLayoutTree<'a> {
 
             cursor_y += child_h;
             emitted += 1;
+            prev_bottom_y_in_body = this_top_in_body + child_h;
 
             // `break-after: page` forces a page boundary after the
             // child. A trailing break on the last in-flow child does

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -10,6 +10,13 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 /// Render a Pageable tree to PDF bytes.
+///
+/// Public entry that does not run the fulgur-cj6u Phase 1.2
+/// page-count parity assertion: the caller built the Pageable
+/// directly without going through `Engine::render_html`, so no
+/// `pagination_layout::PaginationGeometryTable` is available. The
+/// parity gate lives in [`render_to_pdf_with_gcpm`] which is the
+/// engine-internal entry threaded with the spike's geometry.
 pub fn render_to_pdf(root: Box<dyn Pageable>, config: &Config) -> Result<Vec<u8>> {
     let content_width = config.content_width();
     let content_height = config.content_height();
@@ -99,6 +106,36 @@ pub fn render_to_pdf(root: Box<dyn Pageable>, config: &Config) -> Result<Vec<u8>
         .finish()
         .map_err(|e| Error::PdfGeneration(format!("{e:?}")))?;
     Ok(pdf_bytes)
+}
+
+/// fulgur-cj6u Phase 1.2: in debug builds, assert that
+/// `pagination_layout::implied_page_count(geometry)` matches the
+/// Pageable-driven page count from `paginate(...)`. Drift between
+/// the two is the regression signal Phase 2 work needs to chase
+/// (widow/orphan, running element / margin-box, counter, table-row
+/// break, …).
+///
+/// Skipped when `geometry` is empty — the spike pass was either not
+/// run or the document had no body / no in-flow children, in which
+/// case Pageable's "always at least one page" convention diverges
+/// from the spike's "no fragments" output and the assertion is
+/// uninformative. Empty bodies still go through Pageable's single-
+/// empty-page fallback.
+///
+/// Release builds compile this to a no-op via `cfg!(debug_assertions)`.
+fn assert_pageable_spike_parity(
+    pages: &[Box<dyn Pageable>],
+    geometry: &crate::pagination_layout::PaginationGeometryTable,
+) {
+    if !cfg!(debug_assertions) || geometry.is_empty() {
+        return;
+    }
+    let pageable_count = pages.len() as u32;
+    let spike_count = crate::pagination_layout::implied_page_count(geometry);
+    debug_assert_eq!(
+        pageable_count, spike_count,
+        "page count parity drift: paginate={pageable_count} spike={spike_count}",
+    );
 }
 
 /// Build krilla Metadata from Config.
@@ -231,6 +268,7 @@ pub fn render_to_pdf_with_gcpm(
     gcpm: &GcpmContext,
     running_store: &RunningElementStore,
     font_data: &[Arc<Vec<u8>>],
+    pagination_geometry: &crate::pagination_layout::PaginationGeometryTable,
 ) -> Result<Vec<u8>> {
     // Resolve the default (no-selector) CSS @page margin for initial pagination.
     // :first/:left/:right overrides are applied per-page during rendering below.
@@ -252,6 +290,26 @@ pub fn render_to_pdf_with_gcpm(
 
     // Pass 1: paginate body content
     let pages = paginate(root, content_width, content_height);
+    // fulgur-cj6u Phase 1.2: cross-check the spike fragmenter agrees
+    // with Pageable on the page count. Skipped when:
+    //
+    // - `@page` rules changed `content_height` away from
+    //   `config.content_height()`. The spike was driven with the
+    //   unresolved config-level value, so a strict equality would
+    //   produce a false positive (Phase 2 moves `@page` size
+    //   resolution into the spike).
+    // - The document declares running elements (`position: running()`).
+    //   Stylo / Blitz do not natively understand the GCPM `running()`
+    //   value, so the spike's body walk still sees those nodes as
+    //   in-flow and counts their height; Pageable strips them into
+    //   `RunningElementWrapperPageable` before pagination. Phase 2.2
+    //   adds running-element awareness to the spike — until then the
+    //   two views diverge for these documents and the assertion is
+    //   uninformative.
+    if (content_height - config.content_height()).abs() < 0.001 && gcpm.running_mappings.is_empty()
+    {
+        assert_pageable_spike_parity(&pages, pagination_geometry);
+    }
     let total_pages = pages.len();
     let string_set_states = if gcpm.string_set_mappings.is_empty() {
         vec![BTreeMap::new(); pages.len()]
@@ -926,6 +984,7 @@ mod tests {
             &GcpmContext::default(),
             &RunningElementStore::new(),
             &[],
+            &Default::default(),
         )
         .unwrap();
         assert_pdf_header(&pdf);
@@ -942,6 +1001,7 @@ mod tests {
             &GcpmContext::default(),
             &RunningElementStore::new(),
             &[],
+            &Default::default(),
         )
         .unwrap();
         assert_pdf_header(&pdf);
@@ -958,6 +1018,7 @@ mod tests {
             &GcpmContext::default(),
             &RunningElementStore::new(),
             &[],
+            &Default::default(),
         )
         .unwrap();
         assert_pdf_header(&pdf);
@@ -981,6 +1042,7 @@ mod tests {
             &gcpm,
             &RunningElementStore::new(),
             &[],
+            &Default::default(),
         )
         .unwrap();
         assert_pdf_header(&pdf);
@@ -1015,6 +1077,7 @@ mod tests {
             &GcpmContext::default(),
             &RunningElementStore::new(),
             &[],
+            &Default::default(),
         )
         .unwrap();
         assert_pdf_header(&pdf);


### PR DESCRIPTION
## 概要

fulgur-z2mg (Pageable replacement epic) Phase 1.2。

`pagination_layout::implied_page_count(&geometry)` を un-gate し、`render_to_pdf_with_gcpm` 内で `paginate(...).len()` との parity を `debug_assert!` する。Pageable と spike の page split 判定が乖離した瞬間を CI で検知できるようにする regression gate。

⚠️ **stack**: `feat/pageable-replacement` ← #263 ← #265 ← #266 ← **本 PR**

base = `feat/fulgur-cj6u-convert-ctx-geometry` (= #266 head)。

## 変更内容

### 1. `pagination_layout::implied_page_count` を un-gate

`#[cfg(test)]` 削除。production API の一部に。docstring も Phase 1.2 の用途を明示。

### 2. `render_to_pdf_with_gcpm` に geometry を threaded

新パラメータ `pagination_geometry: &PaginationGeometryTable`。engine.rs は `convert_ctx.pagination_geometry` を pass。

### 3. `assert_pageable_spike_parity` helper

`debug_assert_eq!(pages.len(), implied_page_count(&geometry))`。`cfg!(debug_assertions)` で release no-op。empty geometry は skip。

### 4. Activation gate

```text
(content_height - config.content_height()).abs() < 0.001
&& gcpm.running_mappings.is_empty()
```

- 第 1 条件: `@page` 系の size 解決が `config.content_height()` を変えた場合 skip (Phase 2 で spike が `@page` 解決を引き受ける際 ungate)
- 第 2 条件: `position: running()` がある document は spike が running 要素を通常 block として高さに加算するので Pageable と乖離 (Phase 2.2 で running 要素対応を spike に追加した時 ungate)

### 5. 公開 API は touch しない

`render_to_pdf` (公開 2 引数) は変更なし。手動で Pageable を組み立てた呼び出し側には spike geometry が無いので、parity gate は engine-internal の `render_to_pdf_with_gcpm` のみ。

## 検証

| | |
|---|---|
| fulgur lib unit tests | **877 pass** |
| examples_determinism | **11/11 pass** (header-footer / split は gate に引っかかって正しく skip) |
| VRT byte-wise | **33/33 pass** |
| production build | **0 warnings**, clippy clean |

## 開発中の発見

最初は activation gate なしで実装したところ、`header-footer` / `header-footer-split` 例で `paginate=2 spike=1` の drift が発生し examples_determinism が fail。原因は `position: running()` を Stylo / Blitz が認識せず、spike の body walk が running 要素を normal block として高さ加算するため。Phase 2.2 (running element awareness) を spike に入れるまではこの種の document は parity 対象外、ということが具体例で見えた。

## 次の作業

Phase 1 の残り (1.3 string-set algorithm parity) は string-set mappings がある document だけが対象なので、本 PR の上に積むかどうかは Phase 2 着手前に判断。Phase 2 を先に進めるなら Phase 1.3 は skip して直接 widow/orphan 対応 (Phase 2.1) に入る選択肢もある。

## 関連

- Epic: fulgur-z2mg
- Phase: fulgur-cj6u (Phase 1)
- 直前 PR: #266 (Phase 1.1 ConvertContext carry)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced PDF rendering robustness by adding internal validation that detects pagination inconsistencies in debug builds, helping surface potential regressions earlier in development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->