### PR TITLE
feat(render): string-set state parity assertion (fulgur-cj6u Phase 1.3)

### DIFF
--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -246,6 +246,17 @@ impl Engine {
             map
         };
 
+        // fulgur-cj6u Phase 1.3: keep a copy of the string-set map for
+        // post-convert parity comparison. `convert::dom_to_pageable`
+        // drains the map via `.remove(&node_id)` as it wraps content
+        // with `StringSetWrapperPageable`, so by render time the
+        // version on `ConvertContext` is empty. The clone is small
+        // (one `Vec<(String, String)>` per node that declares
+        // `string-set`) and only used by the debug parity assertion
+        // — `cfg!(debug_assertions)` short-circuits the comparison
+        // in release.
+        let string_set_by_node_for_parity = string_set_by_node.clone();
+
         let mut convert_ctx = ConvertContext {
             running_store: &running_store,
             assets: self.assets.as_ref(),
@@ -274,6 +285,7 @@ impl Engine {
                 &running_store,
                 fonts,
                 &convert_ctx.pagination_geometry,
+                &string_set_by_node_for_parity,
             )
         }
     }

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -619,11 +619,11 @@ fn fragment_inline_root(
 /// `string-set` state across pages, mirroring
 /// [`crate::paginate::collect_string_set_states`].
 ///
-/// Currently exercised only by in-crate unit tests (no production
-/// consumer yet). The function is kept as the spike's documented
-/// extension point — when a future PR replaces Pageable's string-set
-/// walk, this gates off `#[cfg(test)]` and joins the public surface.
-#[cfg(test)]
+/// Used by fulgur-cj6u Phase 1.3 as the spike-side input to a
+/// per-page state parity assertion against `paginate`'s walk in
+/// `render_to_pdf_with_gcpm`. Drift between the two outputs is the
+/// regression signal that catches geometry-vs-Pageable divergence
+/// for `string-set` resolution.
 ///
 /// For each page index 0..max_page:
 ///

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -138,6 +138,45 @@ fn assert_pageable_spike_parity(
     );
 }
 
+/// fulgur-cj6u Phase 1.3: in debug builds, assert that the spike's
+/// `pagination_layout::collect_string_set_states` produces the same
+/// per-page `(start, first, last)` shape Pageable's tree walk does.
+/// Same skip semantics as `assert_pageable_spike_parity`: empty
+/// geometry → spike pass not run; release builds compile to a no-op.
+///
+/// `string_set_by_node` is the engine-side `HashMap`; the spike
+/// wants a `BTreeMap` (deterministic iteration), so we materialise
+/// one once for the comparison. The conversion is debug-only via
+/// `cfg!(debug_assertions)`.
+fn assert_string_set_states_parity(
+    pageable_states: &[BTreeMap<String, crate::paginate::StringSetPageState>],
+    geometry: &crate::pagination_layout::PaginationGeometryTable,
+    string_set_by_node: &HashMap<usize, Vec<(String, String)>>,
+) {
+    if !cfg!(debug_assertions) || geometry.is_empty() {
+        return;
+    }
+    let by_node_btree: BTreeMap<usize, Vec<(String, String)>> = string_set_by_node
+        .iter()
+        .map(|(k, v)| (*k, v.clone()))
+        .collect();
+    let spike_states =
+        crate::pagination_layout::collect_string_set_states(geometry, &by_node_btree);
+    debug_assert_eq!(
+        pageable_states.len(),
+        spike_states.len(),
+        "string-set state vec length drift: pageable={} spike={}",
+        pageable_states.len(),
+        spike_states.len(),
+    );
+    for (idx, (pg, sp)) in pageable_states.iter().zip(spike_states.iter()).enumerate() {
+        debug_assert_eq!(
+            pg, sp,
+            "string-set state drift on page {idx}:\n  pageable = {pg:#?}\n  spike    = {sp:#?}",
+        );
+    }
+}
+
 /// Build krilla Metadata from Config.
 fn build_metadata(config: &Config) -> krilla::metadata::Metadata {
     let mut metadata = krilla::metadata::Metadata::new();
@@ -269,6 +308,7 @@ pub fn render_to_pdf_with_gcpm(
     running_store: &RunningElementStore,
     font_data: &[Arc<Vec<u8>>],
     pagination_geometry: &crate::pagination_layout::PaginationGeometryTable,
+    string_set_by_node: &HashMap<usize, Vec<(String, String)>>,
 ) -> Result<Vec<u8>> {
     // Resolve the default (no-selector) CSS @page margin for initial pagination.
     // :first/:left/:right overrides are applied per-page during rendering below.
@@ -316,6 +356,21 @@ pub fn render_to_pdf_with_gcpm(
     } else {
         crate::paginate::collect_string_set_states(&pages)
     };
+    // fulgur-cj6u Phase 1.3: parity-check the spike's geometry-table-
+    // driven `collect_string_set_states` against Pageable's tree walk.
+    // Same activation gates as the page-count parity (Phase 1.2):
+    // skipped when @page rules differ or running elements are
+    // present, because both shift the body view between the two paths.
+    if !gcpm.string_set_mappings.is_empty()
+        && (content_height - config.content_height()).abs() < 0.001
+        && gcpm.running_mappings.is_empty()
+    {
+        assert_string_set_states_parity(
+            &string_set_states,
+            pagination_geometry,
+            string_set_by_node,
+        );
+    }
     let running_states = if gcpm.running_mappings.is_empty() {
         vec![BTreeMap::new(); pages.len()]
     } else {
@@ -985,6 +1040,7 @@ mod tests {
             &RunningElementStore::new(),
             &[],
             &Default::default(),
+            &Default::default(),
         )
         .unwrap();
         assert_pdf_header(&pdf);
@@ -1002,6 +1058,7 @@ mod tests {
             &RunningElementStore::new(),
             &[],
             &Default::default(),
+            &Default::default(),
         )
         .unwrap();
         assert_pdf_header(&pdf);
@@ -1018,6 +1075,7 @@ mod tests {
             &GcpmContext::default(),
             &RunningElementStore::new(),
             &[],
+            &Default::default(),
             &Default::default(),
         )
         .unwrap();
@@ -1042,6 +1100,7 @@ mod tests {
             &gcpm,
             &RunningElementStore::new(),
             &[],
+            &Default::default(),
             &Default::default(),
         )
         .unwrap();
@@ -1077,6 +1136,7 @@ mod tests {
             &GcpmContext::default(),
             &RunningElementStore::new(),
             &[],
+            &Default::default(),
             &Default::default(),
         )
         .unwrap();


### PR DESCRIPTION
## 概要

fulgur-z2mg (Pageable replacement epic) Phase 1.3 — Phase 1 完了。

`pagination_layout::collect_string_set_states` を un-gate して `render_to_pdf_with_gcpm` 内で `paginate::collect_string_set_states` の出力と per-page 並走比較する debug assertion を追加。string-set state でも Pageable と spike の乖離を CI で検知できる。

⚠️ **stack**: `feat/pageable-replacement` ← #263 ← #265 ← #266 ← #267 ← **本 PR**

base = `feat/fulgur-cj6u-page-count-parity` (= #267 head)。

## 変更内容

### 1. `pagination_layout::collect_string_set_states` を un-gate

`#[cfg(test)]` 削除。production API に。Phase 1.3 の用途を docstring に明示。

### 2. `render_to_pdf_with_gcpm` に `string_set_by_node` 追加

新パラメータ `&HashMap<usize, Vec<(String, String)>>`。engine.rs は **clone** して渡す — `convert::dom_to_pageable` が ConvertContext.string_set_by_node を `.remove()` で破壊するため、render 時には残っていない。clone size は string-set を declare している node の数だけなので軽い。

### 3. `assert_string_set_states_parity` helper

per-page `debug_assert_eq!` で `pageable_states` と spike `collect_string_set_states(geometry, string_set_by_node)` を比較。empty geometry は skip。release では `cfg!(debug_assertions)` 経由で no-op。

### 4. Activation gate (Phase 1.2 と同じ)

```text
!gcpm.string_set_mappings.is_empty()
&& (content_height - config.content_height()).abs() < 0.001
&& gcpm.running_mappings.is_empty()
```

string-set declare されていない document は元々 `vec![BTreeMap::new(); pages.len()]` を返す short-circuit があるので比較対象外。

## 検証

| | |
|---|---|
| fulgur lib unit tests | **877 pass** |
| examples_determinism | **11/11 pass** (string-set を使う example で drift なし → spike と Pageable が同じ output を出している) |
| VRT byte-wise | **33/33 pass** |
| production build | **0 warnings**, clippy clean |

## Phase 1 完了

これで Phase 1 (geometry consumer integration) が完結。spike は:

- 1.1: 各 render で `run_pass_with_break_styles` を呼んで geometry を `ConvertContext` に carry
- 1.2: `paginate(...).len() == implied_page_count(geometry)` を debug_assert
- 1.3: `paginate::collect_string_set_states(&pages) == pagination_layout::collect_string_set_states(&geometry, &string_set_by_node)` を debug_assert

すべて gate 条件下では 100% 一致。drift 検出 = regression、これが Phase 2 (feature gap closure) を駆動する CI signal になる。

## 次の作業

Phase 2.1 (widow/orphan in `fragment_inline_root`) または Phase 2.2 (running element awareness) のどちらかを次の stacked PR で。

## 関連

- Epic: fulgur-z2mg
- Phase: fulgur-cj6u (Phase 1) — 本 PR で完了予定
- 直前 PR: #267 (Phase 1.2 page count parity)