### PR TITLE
Fix clone_children to preserve fixed positioning flag

### DIFF
--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -1611,34 +1611,14 @@ fn split_children_for_within(
 /// Clone a slice of PositionedChild, optionally shifting y coordinates.
 /// When `y_offset` is 0.0, children are cloned as-is.
 /// A negative `y_offset` shifts children upward (subtracts from y).
+///
+/// Delegates to `clone_pc_with_offset` so the in-flow / out-of-flow / fixed
+/// branches stay in lockstep — a fixed child cloned through here keeps its
+/// viewport-relative y, just like in the split paths above.
 fn clone_children(children: &[PositionedChild], y_offset: f32) -> Vec<PositionedChild> {
-    // In-flow children are clamped at 0.0 so parallel siblings (grid/flex
-    // children sharing the same y as a split-causing child) don't end up at
-    // negative y on the second fragment, which would push their
-    // background+border above the page top and silently drop them
-    // (fulgur-86fo).
-    //
-    // Out-of-flow children (CSS 2.1 §10.6.4 abs/fixed) preserve negative y
-    // so a tall abs element anchored at its CB's top:0 naturally extends
-    // above the second fragment's page area; Krilla clips outside the page,
-    // producing the correct slice on each page (fulgur-aijf).
     children
         .iter()
-        .map(|pc| {
-            let shifted = pc.y - y_offset;
-            let y = if pc.out_of_flow {
-                shifted
-            } else {
-                shifted.max(0.0)
-            };
-            PositionedChild {
-                child: pc.child.clone_box(),
-                x: pc.x,
-                y,
-                out_of_flow: pc.out_of_flow,
-                is_fixed: false,
-            }
-        })
+        .map(|pc| clone_pc_with_offset(pc, y_offset))
         .collect()
 }
 
@@ -4173,6 +4153,37 @@ mod tests {
         // Verify out-of-flow replicated with no clamp on negative.
         let second_oof = second.iter().find(|p| p.out_of_flow).unwrap();
         assert_eq!(second_oof.y, -70.0);
+    }
+
+    /// fulgur-jkl5 follow-up (Devin / CodeRabbit on PR #263): `clone_children`
+    /// is the bulk-cloning helper used by `TablePageable::split` etc., and
+    /// it must mirror `clone_pc_with_offset`'s three-way branch — in-flow
+    /// clamps at 0, out-of-flow keeps negative y, and **fixed** children
+    /// preserve their original viewport-relative y. Previously this
+    /// function hardcoded `is_fixed: false` and treated fixed children as
+    /// out-of-flow, which would silently lose the flag if any caller ever
+    /// passed fixed children through it.
+    #[test]
+    fn clone_children_preserves_in_flow_out_of_flow_and_fixed() {
+        let children = vec![
+            PositionedChild::in_flow(make_spacer(10.0), 0.0, 50.0),
+            PositionedChild::out_of_flow(make_spacer(99.0), 0.0, 0.0),
+            PositionedChild::fixed(make_spacer(5.0), 0.0, 10.0),
+        ];
+        let cloned = clone_children(&children, 80.0);
+        assert_eq!(cloned.len(), 3);
+        // In-flow: y - offset = 50 - 80 = -30 → clamped to 0.
+        assert_eq!(cloned[0].y, 0.0);
+        assert!(!cloned[0].out_of_flow);
+        assert!(!cloned[0].is_fixed);
+        // Out-of-flow: y - offset = 0 - 80 = -80, no clamp.
+        assert_eq!(cloned[1].y, -80.0);
+        assert!(cloned[1].out_of_flow);
+        assert!(!cloned[1].is_fixed);
+        // Fixed: y stays at 10 regardless of offset.
+        assert_eq!(cloned[2].y, 10.0);
+        assert!(cloned[2].out_of_flow);
+        assert!(cloned[2].is_fixed);
     }
 
     #[test]

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -603,7 +603,7 @@ fn fragment_inline_root(
 /// `fragment_pagination_root` itself.
 pub fn collect_string_set_states(
     geometry: &PaginationGeometryTable,
-    string_set_by_node: &std::collections::HashMap<usize, Vec<(String, String)>>,
+    string_set_by_node: &BTreeMap<usize, Vec<(String, String)>>,
 ) -> Vec<BTreeMap<String, crate::paginate::StringSetPageState>> {
     let max_page = geometry
         .values()
@@ -948,23 +948,22 @@ mod tests {
     use std::ops::DerefMut;
     use std::sync::Arc;
 
-    fn parse(html: &str, viewport_w: f32, viewport_h: u32) -> blitz_html::HtmlDocument {
+    /// Parse helper for the spike's tests.
+    ///
+    /// We deliberately don't accept a viewport height: `blitz_adapter::parse`
+    /// uses a hardcoded viewport_h internally, and the spike's strip slicing
+    /// is driven by the `page_height_px` argument to `run_pass` rather than
+    /// by the viewport. The fixtures pass viewport_w only.
+    fn parse(html: &str, viewport_w: f32) -> blitz_html::HtmlDocument {
         let fonts: Vec<Arc<Vec<u8>>> = Vec::new();
         let mut doc = blitz_adapter::parse(html, viewport_w, &fonts);
-        // Mimic the engine pipeline: parse() leaves viewport_h hardcoded,
-        // so we re-parse via parse_inner equivalents only when we need a
-        // specific page height. For the spike we read final_layout that
-        // resolve() produces, so the value passed to parse_inner is
-        // mostly irrelevant — our `page_height_px` arg is what controls
-        // strip slicing.
-        let _ = viewport_h;
         blitz_adapter::resolve(&mut doc);
         doc
     }
 
     #[test]
     fn empty_document_emits_no_fragments() {
-        let mut doc = parse("<html><body></body></html>", 600.0, 800);
+        let mut doc = parse("<html><body></body></html>", 600.0);
         let table = run_pass(&mut doc, 800.0);
         assert!(
             table.is_empty(),
@@ -979,7 +978,7 @@ mod tests {
         // synthesized body contains no children, so the pass emits no
         // fragments — which is the behaviour Pageable produces for the
         // same input.
-        let mut doc = parse("<html></html>", 600.0, 800);
+        let mut doc = parse("<html></html>", 600.0);
         let tree = PaginationLayoutTree::new(&mut doc, 800.0);
         assert!(tree.body_id.is_some(), "html5ever should synthesize a body");
         let table = run_pass(&mut doc, 800.0);
@@ -997,7 +996,7 @@ mod tests {
               <div style="height: 200px"></div>
             </body></html>
         "#;
-        let mut doc = parse(html, 600.0, 1000);
+        let mut doc = parse(html, 600.0);
         let table = run_pass(&mut doc, 800.0);
         assert_eq!(table.len(), 3, "expected 3 entries, got {}", table.len());
         for (id, geom) in &table {
@@ -1021,7 +1020,7 @@ mod tests {
               <div style="height: 400px"></div>
             </body></html>
         "#;
-        let mut doc = parse(html, 600.0, 1000);
+        let mut doc = parse(html, 600.0);
         let table = run_pass(&mut doc, 800.0);
         assert_eq!(table.len(), 2);
         let pages: Vec<u32> = table.values().map(|g| g.fragments[0].page_index).collect();
@@ -1039,7 +1038,6 @@ mod tests {
     #[test]
     fn string_set_state_carries_across_pages() {
         use crate::paginate::StringSetPageState;
-        use std::collections::HashMap;
 
         // Three nodes: A on page 0, B on page 0, C on page 1.
         // A sets header="a", B sets header="b" (so first/last on page 0
@@ -1067,7 +1065,7 @@ mod tests {
             height: 50.0,
         });
 
-        let mut markers: HashMap<usize, Vec<(String, String)>> = HashMap::new();
+        let mut markers: BTreeMap<usize, Vec<(String, String)>> = BTreeMap::new();
         markers.insert(10, vec![("header".into(), "a".into())]);
         markers.insert(20, vec![("header".into(), "b".into())]);
 
@@ -1101,7 +1099,6 @@ mod tests {
         // A node spans two pages (inline-aware split). Markers fire
         // only on the first appearance.
         use crate::paginate::StringSetPageState;
-        use std::collections::HashMap;
 
         let mut geom = PaginationGeometryTable::new();
         geom.entry(42).or_default().fragments.push(Fragment {
@@ -1119,7 +1116,7 @@ mod tests {
             height: 200.0,
         });
 
-        let mut markers: HashMap<usize, Vec<(String, String)>> = HashMap::new();
+        let mut markers: BTreeMap<usize, Vec<(String, String)>> = BTreeMap::new();
         markers.insert(42, vec![("title".into(), "intro".into())]);
 
         let states = super::collect_string_set_states(&geom, &markers);
@@ -1146,7 +1143,7 @@ mod tests {
     fn string_set_states_empty_geometry_returns_one_empty_page() {
         // Mirrors Pageable's "always at least one page" convention.
         let geom = PaginationGeometryTable::new();
-        let markers = std::collections::HashMap::new();
+        let markers = BTreeMap::new();
         let states = super::collect_string_set_states(&geom, &markers);
         assert_eq!(states.len(), 1);
         assert!(states[0].is_empty());
@@ -1164,7 +1161,7 @@ mod tests {
                           width: 100px; height: 50px"></div>
             </body></html>
         "#;
-        let mut doc = parse(html, 600.0, 1000);
+        let mut doc = parse(html, 600.0);
 
         let mut geom = super::run_pass(doc.deref_mut(), 800.0);
         let pages_before = super::implied_page_count(&geom);
@@ -1214,7 +1211,7 @@ mod tests {
                           width: 50px; height: 30px"></div>
             </body></html>
         "#;
-        let mut doc = parse(html, 600.0, 1000);
+        let mut doc = parse(html, 600.0);
         let mut geom = PaginationGeometryTable::new();
         super::append_position_fixed_fragments(&mut geom, doc.deref_mut(), 0);
         assert_eq!(geom.len(), 1);
@@ -1252,7 +1249,7 @@ mod tests {
               <div style="height: 1000px"></div>
             </body></html>
         "#;
-        let mut doc = parse(html, 600.0, 1500);
+        let mut doc = parse(html, 600.0);
         let table = run_pass(&mut doc, 800.0);
         assert_eq!(table.len(), 1);
         let geom = table.values().next().unwrap();
@@ -1285,16 +1282,11 @@ mod compare_with_pageable {
 
     /// Compute the spike's page count from a geometry table.
     ///
-    /// Convention: empty table → 1 page (matches Pageable's "always at
-    /// least one page" guarantee for empty bodies).
+    /// Thin wrapper over [`super::implied_page_count`] so the comparison
+    /// harness and the production-facing helper can never drift apart on
+    /// the "empty → 1" convention.
     fn spike_page_count(table: &super::PaginationGeometryTable) -> u32 {
-        table
-            .values()
-            .flat_map(|g| g.fragments.iter())
-            .map(|f| f.page_index)
-            .max()
-            .map(|m| m + 1)
-            .unwrap_or(1)
+        super::implied_page_count(table)
     }
 
     /// Run the engine's testing helper to build a `Pageable` for `html`,

--- a/docs/plans/2026-04-28-pagination-layout-spike.md
+++ b/docs/plans/2026-04-28-pagination-layout-spike.md
@@ -50,9 +50,13 @@ and `pagination_layout::run_pass` (spike side). Page counts:
 | two 50vh divs sum to 100vh | 2 | 2 | ✓ |
 | one 1028px div (just over content) | 1 | 1 | ✓ |
 | nested 100% height with no parent height | 1 | 1 | ✓ |
-| long paragraph wraps into multiple pages (initial) | 2 | **1** | ✗ |
 | long paragraph wraps into multiple pages (after p55h) | 2 | **2** | ✓ |
 | small lead block + oversized block | 2 | 2 | ✓ |
+
+(Historical baseline, pre-p55h: the long-paragraph fixture used to
+disagree as `Pageable=2 / spike=1` because the block-only spike treated
+a tall paragraph as a single oversized fragment. Listed here for
+posterity but not counted in the table above.)
 
 10/10 agree after fulgur-p55h landed the Parley line-box probe in
 `fragment_inline_root`. The original disagreement (block-only spike


### PR DESCRIPTION
## Summary

Refactor `clone_children` to delegate to `clone_pc_with_offset`, ensuring that fixed-positioned children preserve their `is_fixed` flag and viewport-relative y-coordinates during cloning. Previously, the function hardcoded `is_fixed: false`, which would silently lose the flag if any caller passed fixed children through it.

## Changes

- **pageable.rs**: Replace inline cloning logic in `clone_children` with a call to `clone_pc_with_offset` to maintain consistency with the three-way branch (in-flow clamps at 0, out-of-flow preserves negative y, fixed preserves viewport-relative y)
- **pageable.rs**: Add comprehensive test `clone_children_preserves_in_flow_out_of_flow_and_fixed` to verify all three positioning modes are handled correctly
- **pagination_layout.rs**: Change `string_set_by_node` parameter type from `HashMap` to `BTreeMap` for consistency and determinism
- **pagination_layout.rs**: Simplify test helper `parse()` by removing unused `viewport_h` parameter and clarifying that page height is controlled by `page_height_px` argument to `run_pass`
- **pagination_layout.rs**: Replace inline page count calculation in `spike_page_count` with call to `implied_page_count` helper to prevent drift
- **docs**: Update comparison table to remove historical baseline (pre-p55h long-paragraph fixture) and clarify that all 10/10 tests now agree

## Test plan

- Added unit test `clone_children_preserves_in_flow_out_of_flow_and_fixed` that verifies in-flow children clamp at 0, out-of-flow children preserve negative y, and fixed children preserve their original y and `is_fixed` flag
- Existing pagination layout tests updated to use simplified `parse()` signature
- `cargo test -p fulgur` passes all tests

https://claude.ai/code/session_01SvEi53oBkZA1NRe1BMeafZ
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
