### PR TITLE
ci: run on all pull_request events (drop main-only filter)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## 概要

`.github/workflows/ci.yml` の `on.pull_request.branches: [main]` フィルタを撤去し、ベースブランチが main 以外の stacked PR でも CI（cargo test / clippy / fmt / coverage / WPT）が走るようにします。

## 背景

現在オープンな stacked PR (#263, #265, #266, #267, #268) では cargo test 等の主要 CI ジョブが起動しておらず、CodeRabbit / Cloudflare Pages / CLA / PR Labeler だけが動いている状態でした。原因は `pull_request.branches: [main]` フィルタにより、ベースが main でない PR がトリガー対象から除外されていたためです。

## 変更内容

- \`pull_request:\` の \`branches\` フィルタを削除 → 全 PR で CI 起動
- \`push:\` 側の \`branches: [main]\` は維持し、ブランチ push の二重起動を回避

## 動作確認

- このPR自身で CI が走ること（base=main なので filter 撤去前後どちらでも走るが、編集後の挙動を踏むことになる）
- マージ後、stacked PR (#266 等) を同期して CI が走ることを確認

## Test plan

- [ ] このPRで CI 全ジョブが SUCCESS
- [ ] マージ後、#266 等を rebase / synchronize して cargo test 等が起動することを確認

Refs: fulgur-m6ty
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
