### PR TITLE
docs(engine): correct stale pagination_layout call-site comment

### DIFF
--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -199,17 +199,14 @@ impl Engine {
         // and docs/plans/2026-04-21-fulgur-v7a-column-rule.md.
         let multicol_geometry = crate::multicol_layout::run_pass(doc.deref_mut(), &column_styles);
 
-        // Run the pagination_layout Taffy hook (fulgur-4cbc). Drives
-        // `compute_root_layout` against the body to populate a per-node
-        // `PaginationGeometryTable`. The returned table is currently
-        // *observational only* — no convert / render path consumes it
-        // yet, but routing the call through production code path:
+        // Run the pagination_layout fragmenter (fulgur-4cbc). Walks
+        // body's children's existing `final_layout` (populated by
+        // `resolve()` and `multicol_layout::run_pass`) and records
+        // per-node page fragments in a `PaginationGeometryTable`. The
+        // returned table is currently *observational only* — no convert
+        // / render path consumes it yet, but routing the call through
+        // the production code path:
         //
-        // - keeps the spike's `LayoutPartialTree` wrapper exercised by
-        //   every `Engine::render_html` invocation rather than only by
-        //   in-crate unit tests, so a regression in the wrapper surfaces
-        //   in real workloads instead of waiting for someone to flip a
-        //   feature flag,
         // - replaces the previous `#![allow(dead_code)]` blanket
         //   permission with a single drop-the-result call site so
         //   `cargo build` / `cargo clippy` warn truthfully when an item
@@ -219,14 +216,17 @@ impl Engine {
         //   point: capture the table on `ConvertContext` instead of
         //   dropping it.
         //
-        // Side-effect safety: `run_pass_with_break_styles` invokes
-        // `taffy::compute_root_layout(&mut tree, body_id, MaxContent)`
-        // which hits Blitz's existing cache (the original
-        // `resolve()` already laid body out at the same available
-        // space), and the wrapper restores body's `location` after
-        // the call so downstream `convert::dom_to_pageable` sees the
-        // same coordinates Blitz produced. VRT / examples_determinism
-        // / WPT all stay byte-identical with this call inserted.
+        // Side-effect safety: `run_pass_with_break_styles` is a
+        // read-only walk of `final_layout` via
+        // `fragment_pagination_root` — it does not re-drive Taffy or
+        // mutate any node's layout. The wrapper's `LayoutPartialTree`
+        // / `RoundTree` / `CacheTree` / `TraversePartialTree` impls
+        // are kept compile-time live as scaffolding for a future
+        // per-strip-constrained variant and are exercised at runtime
+        // only by the test-gated `drive_taffy_root_layout` (see
+        // `pagination_layout.rs` module docs). VRT /
+        // examples_determinism / WPT all stay byte-identical with
+        // this call inserted.
         let _pagination_geometry = crate::pagination_layout::run_pass_with_break_styles(
             doc.deref_mut(),
             crate::convert::pt_to_px(self.config.content_height()),


### PR DESCRIPTION
## Summary

`crates/fulgur/src/engine.rs:202-229` のコメントブロックが、PR #272 で行った direct-walk への移行に追従できておらず、3 点の事実誤認が残っていた。Devin Review (#265 の `discussion_r3153995848`) で指摘された内容をそのまま修正。

修正前 (誤):

1. 「`compute_root_layout` against the body」を駆動 → 実際は `fragment_pagination_root` を直接呼ぶ direct walk
2. 「wrapper exercised by every `Engine::render_html` invocation」 → production は wrapper を通らない (test-only `drive_taffy_root_layout` のみ)
3. 「wrapper restores body's `location`」 → 起こっていない (read-only walk)

修正後はコメント側を `pagination_layout.rs` モジュール docs と揃え、`run_pass_with_break_styles` が `final_layout` の read-only walk であること、wrapper trait impls は scaffolding として compile-time に生存し runtime 実行は test-gated path のみであることを明記。

## Changes

- `crates/fulgur/src/engine.rs:202-229` のコメントブロックを書き換え (本体ロジックは無変更)

## Test plan

- [x] `cargo build -p fulgur` clean
- [x] `cargo fmt --check` clean
- 本体コードの変更なし、コメントのみのため動作・出力に影響なし

## 関連

- Stacks on top of #272 (merged)
- Original review comment: https://github.com/fulgur-rs/fulgur/pull/265#discussion_r3153995848

https://claude.ai/code/session_011vawryoZCWzx1C54t6F7V3

---
_Generated by [Claude Code](https://claude.ai/code/session_011vawryoZCWzx1C54t6F7V3)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
