### PR TITLE
feat(pagination_layout): running element awareness + gap-aware cursor (fulgur-s67g Phase 2.2)

### DIFF
--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -208,7 +208,7 @@ impl Engine {
         // per-page fixed repetition redesign — can read it without
         // re-walking layout.
         //
-        // Side-effect safety: `run_pass_with_break_styles` is a
+        // Side-effect safety: `run_pass_with_break_and_running` is a
         // read-only walk of `final_layout` via
         // `fragment_pagination_root` — it does not re-drive Taffy or
         // mutate any node's layout. The wrapper's `LayoutPartialTree`
@@ -219,10 +219,16 @@ impl Engine {
         // `pagination_layout.rs` module docs). VRT /
         // examples_determinism / WPT all stay byte-identical with
         // this call inserted.
-        let pagination_geometry = crate::pagination_layout::run_pass_with_break_styles(
+        //
+        // fulgur-s67g Phase 2.2: thread `running_store` so the
+        // fragmenter skips `position: running()` named children. They
+        // belong in `@page` margin boxes, not body flow, so including
+        // their height would over-count and diverge from Pageable.
+        let pagination_geometry = crate::pagination_layout::run_pass_with_break_and_running(
             doc.deref_mut(),
             crate::convert::pt_to_px(self.config.content_height()),
             &column_styles,
+            &running_store,
         );
 
         // --- Convert DOM to Pageable and render ---

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -131,6 +131,15 @@ pub struct PaginationLayoutTree<'a> {
     /// extraction. `None` means "no break properties set anywhere",
     /// which the fragmenter treats as all-`Auto`.
     pub(crate) column_styles: Option<&'a crate::column_css::ColumnStyleTable>,
+    /// fulgur-s67g Phase 2.2: `position: running()` element instances
+    /// registered by [`crate::blitz_adapter::RunningElementPass`].
+    /// `fragment_pagination_root` consults this store to skip running-
+    /// named children — they are placed into `@page` margin boxes per
+    /// page, not into the body's flow, so they must not contribute to
+    /// the body cursor or page-fragment geometry. `None` (the default
+    /// for unit-test entry points) means "no running mappings"; the
+    /// fragmenter treats every body child as in-flow.
+    pub(crate) running_store: Option<&'a crate::gcpm::running::RunningElementStore>,
 }
 
 /// One-shot entry: run the block-level fragmenter for `doc` against a
@@ -156,7 +165,7 @@ pub struct PaginationLayoutTree<'a> {
 /// `ColumnStyleTable` are honoured.
 #[cfg(test)]
 pub fn run_pass(doc: &mut BaseDocument, page_height_px: f32) -> PaginationGeometryTable {
-    run_pass_with_break_styles_inner(doc, page_height_px, None)
+    run_pass_inner(doc, page_height_px, None, None)
 }
 
 /// fulgur-k0g0 variant: thread the document's `break-before` /
@@ -170,16 +179,38 @@ pub fn run_pass_with_break_styles<'a>(
     page_height_px: f32,
     column_styles: &'a crate::column_css::ColumnStyleTable,
 ) -> PaginationGeometryTable {
-    run_pass_with_break_styles_inner(doc, page_height_px, Some(column_styles))
+    run_pass_inner(doc, page_height_px, Some(column_styles), None)
 }
 
-fn run_pass_with_break_styles_inner<'a>(
+/// fulgur-s67g Phase 2.2 variant: extends
+/// [`run_pass_with_break_styles`] with awareness of `position:
+/// running()` element instances. Running children are skipped during
+/// the body walk so they do not contribute to body cursor or page
+/// fragments — Pageable handles their per-page placement via
+/// [`crate::paginate::collect_running_element_states`].
+pub fn run_pass_with_break_and_running<'a>(
+    doc: &'a mut BaseDocument,
+    page_height_px: f32,
+    column_styles: &'a crate::column_css::ColumnStyleTable,
+    running_store: &'a crate::gcpm::running::RunningElementStore,
+) -> PaginationGeometryTable {
+    run_pass_inner(
+        doc,
+        page_height_px,
+        Some(column_styles),
+        Some(running_store),
+    )
+}
+
+fn run_pass_inner<'a>(
     doc: &'a mut BaseDocument,
     page_height_px: f32,
     column_styles: Option<&'a crate::column_css::ColumnStyleTable>,
+    running_store: Option<&'a crate::gcpm::running::RunningElementStore>,
 ) -> PaginationGeometryTable {
     let mut tree = PaginationLayoutTree::new(doc, page_height_px);
     tree.column_styles = column_styles;
+    tree.running_store = running_store;
     if tree.body_id.is_some() && page_height_px > 0.0 {
         // Read body's children's existing `final_layout` (populated by
         // Blitz's `resolve()` and `multicol_layout::run_pass`) and
@@ -212,6 +243,7 @@ impl<'a> PaginationLayoutTree<'a> {
             geometry: BTreeMap::new(),
             body_id,
             column_styles: None,
+            running_store: None,
         }
     }
 
@@ -369,6 +401,19 @@ impl<'a> PaginationLayoutTree<'a> {
                     continue;
                 }
             }
+            // fulgur-s67g Phase 2.2: skip `position: running()` named
+            // children. They are removed from body flow and placed
+            // into `@page` margin boxes per page; including them in
+            // the body cursor would over-count height and diverge
+            // from Pageable's view (which sees them as
+            // `RunningElementWrapperPageable` markers with zero
+            // contribution to body height).
+            if self
+                .running_store
+                .is_some_and(|s| s.instance_for_node(child_id).is_some())
+            {
+                continue;
+            }
             let layout = child.final_layout;
             let child_h = layout.size.height;
             let child_w = if layout.size.width > 0.0 {
@@ -430,6 +475,23 @@ impl<'a> PaginationLayoutTree<'a> {
                 collect_inline_line_metrics(child)
             };
             if line_metrics.len() > 1 {
+                // fulgur-s67g Phase 2.2: if the paragraph cannot fit
+                // the remaining space on the current page strip but
+                // would fit (or at least start fresh) on a new page,
+                // advance the page boundary before calling
+                // `fragment_inline_root`. Mirrors Pageable's
+                // `BlockPageable::split` falling back to `AtIndex`
+                // (split before the child) when
+                // `ParagraphPageable::split` cannot honour widow /
+                // orphan and returns `None`.
+                let para_total_h = line_metrics
+                    .last()
+                    .map(|l| l.1 - line_metrics[0].0)
+                    .unwrap_or(child_h);
+                if cursor_y > 0.0 && cursor_y + para_total_h > self.page_height_px {
+                    page_index += 1;
+                    cursor_y = 0.0;
+                }
                 let para_x = layout.location.x;
                 let (new_page_index, new_cursor_y, frag_count) = fragment_inline_root(
                     &mut self.geometry,

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -331,23 +331,17 @@ pub fn render_to_pdf_with_gcpm(
     // Pass 1: paginate body content
     let pages = paginate(root, content_width, content_height);
     // fulgur-cj6u Phase 1.2: cross-check the spike fragmenter agrees
-    // with Pageable on the page count. Skipped when:
+    // with Pageable on the page count. Skipped when `@page` rules
+    // changed `content_height` away from `config.content_height()` —
+    // the spike was driven with the unresolved config-level value,
+    // so a strict equality would produce a false positive (later
+    // Phase 2 work moves `@page` size resolution into the spike).
     //
-    // - `@page` rules changed `content_height` away from
-    //   `config.content_height()`. The spike was driven with the
-    //   unresolved config-level value, so a strict equality would
-    //   produce a false positive (Phase 2 moves `@page` size
-    //   resolution into the spike).
-    // - The document declares running elements (`position: running()`).
-    //   Stylo / Blitz do not natively understand the GCPM `running()`
-    //   value, so the spike's body walk still sees those nodes as
-    //   in-flow and counts their height; Pageable strips them into
-    //   `RunningElementWrapperPageable` before pagination. Phase 2.2
-    //   adds running-element awareness to the spike — until then the
-    //   two views diverge for these documents and the assertion is
-    //   uninformative.
-    if (content_height - config.content_height()).abs() < 0.001 && gcpm.running_mappings.is_empty()
-    {
+    // fulgur-s67g Phase 2.2 (running elements) ungated the
+    // `gcpm.running_mappings.is_empty()` skip: the spike now
+    // consults `RunningElementStore` and skips `position: running()`
+    // named children, matching Pageable's body view.
+    if (content_height - config.content_height()).abs() < 0.001 {
         assert_pageable_spike_parity(&pages, pagination_geometry);
     }
     let total_pages = pages.len();
@@ -358,12 +352,12 @@ pub fn render_to_pdf_with_gcpm(
     };
     // fulgur-cj6u Phase 1.3: parity-check the spike's geometry-table-
     // driven `collect_string_set_states` against Pageable's tree walk.
-    // Same activation gates as the page-count parity (Phase 1.2):
-    // skipped when @page rules differ or running elements are
-    // present, because both shift the body view between the two paths.
+    // Same activation gate as the page-count parity (Phase 1.2):
+    // skipped when @page rules shift `content_height` away from the
+    // config value. fulgur-s67g Phase 2.2 ungated the
+    // running-elements skip on this assertion too.
     if !gcpm.string_set_mappings.is_empty()
         && (content_height - config.content_height()).abs() < 0.001
-        && gcpm.running_mappings.is_empty()
     {
         assert_string_set_states_parity(
             &string_set_states,


### PR DESCRIPTION
## 概要

fulgur-z2mg (Pageable replacement epic) Phase 2.2。spike が `position: running()` 要素を認識し、parity gate (Phase 1.2 / 1.3) の running_mappings skip を ungate できる状態に。

⚠️ **stack**: epic ← #266 ← #267 ← #268 ← #270 ← **本 PR**

base = `feat/fulgur-s67g-widow-orphan` (= #270 head)。

## 主な変更

### 1. Running element skip

- `PaginationLayoutTree::running_store: Option<&RunningElementStore>` 追加
- 新エントリ `run_pass_with_break_and_running` を engine から呼ぶ
- `fragment_pagination_root` で `running_store.instance_for_node(child_id).is_some()` の child を skip

### 2. Gap-aware cursor (実は重要だったのはこっち)

旧 spike は `final_layout.size.height` を素朴に累積していた。Pageable は `final_layout.location.y` 空間で動いており、子要素間の margin / padding gap を自然に含む。spike 側で `prev_bottom_in_body` を track して `child.location.y - prev_bottom` を gap として cursor に加算するように修正。

これが実は header-footer の `paginate=2 spike=1` drift の主犯だった (running 要素は元々 display:none → 高さ 0 で skip されていた)。

### 3. Inline-aware page-defer

paragraph が remaining-space に収まらず widow/orphan で split もできない場合、現在の cursor で oversize emit する代わりに先に page を進めるロジックを main loop に追加。Pageable の `BlockPageable::split` が `ParagraphPageable::split → None` 時に `AtIndex` (子の前で break) にフォールバックする挙動と一致。

### 4. Parity gate ungate

`assert_pageable_spike_parity` (Phase 1.2) と `assert_string_set_states_parity` (Phase 1.3) の両方で `gcpm.running_mappings.is_empty()` 条件を削除。spike が running 要素を skip するようになったので、running 要素を持つ document も parity 検証対象に。`@page` 経由の content_height シフト skip は残置 (Phase 2 残作業)。

## 検証

| | |
|---|---|
| fulgur lib unit tests | **881 pass** (Phase 2.1 と同数 — Phase 2.2 は parity gate で検証されるので追加 unit test なし) |
| examples_determinism | **11/11 pass** — header-footer / header-footer-split を含めて全 PASS |
| VRT byte-wise | **33/33 pass** |
| production build | **0 warnings**, clippy clean |

## 開発中の発見

最初は running element skip だけ実装したが parity drift は解消せず (`paginate=2 spike=1` のまま)。debug print で body height = 1008px / page strip = 971px / spike が報告する pages = 1 を観測。

実際には spike は `cursor_y += child_h` 方式で 1008 まで届かず、子間の gap (~150px 累積) を見逃して body の真の終端 = 859 までしか cursor が伸びていなかった。

修正後: gap を含めて 1008 に到達 → 最後の paragraph で cursor 969 → +40 = 1009 > 971 で正しく page break が発生 → spike も 2 pages を報告。

開発手法的には parity gate (Phase 1.2 / 1.3) が "spike が間違っている" ことを CI で示してくれたおかげで、debug print で原因を特定できた。

## 関連

- Epic: fulgur-z2mg
- Phase: fulgur-s67g (Phase 2)
- 直前 PR: #270 (Phase 2.1 widow/orphan)

## 次の作業

Phase 2.3 (counter / target-counter cross-page resolution) または Phase 2.4 (bookmark/outline mapping)、あるいは @page resolution を spike に取り込む先行作業 (parity gate の content_height skip も取り除く) のどれか。