### PR TITLE
spike(pagination_layout): block-only Taffy-hooked fragmenter (fulgur-4cbc)

### DIFF
--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -333,6 +333,14 @@ impl<'a> PaginationLayoutTree<'a> {
         let mut page_index: u32 = 0;
         let mut cursor_y: f32 = 0.0;
         let mut emitted = 0usize;
+        // Tracks the bottom edge of the previously emitted in-flow child
+        // in body-content-box coordinates. Used to pick up inter-child
+        // gaps (collapsed margins, padding) that Blitz baked into each
+        // child's `final_layout.location.y` but the cursor-only walk
+        // would otherwise miss. Pageable accumulates `pc.y + child_h`
+        // from `final_layout.location.y` during convert, so margin gaps
+        // are present in the Pageable side; the spike must match.
+        let mut prev_bottom_y_in_body: f32 = 0.0;
 
         for child_id in children {
             let Some(child) = self.doc.get_node(child_id) else {
@@ -345,6 +353,22 @@ impl<'a> PaginationLayoutTree<'a> {
             {
                 continue;
             }
+            // CSS 2.1 §10.6.4: out-of-flow elements (`position: absolute`
+            // / `position: fixed`) do not contribute to their containing
+            // block's normal-flow height. Pageable routes them through
+            // `PositionedChild { out_of_flow: true }` and they never
+            // advance pagination cursors; the spike must match or the
+            // fulgur-cj6u Phase 1.2 parity assertion fires on documents
+            // with abs/fixed body-direct children.
+            {
+                use ::style::properties::longhands::position::computed_value::T as Pos;
+                let is_out_of_flow = child.primary_styles().is_some_and(|s| {
+                    matches!(s.get_box().clone_position(), Pos::Absolute | Pos::Fixed)
+                });
+                if is_out_of_flow {
+                    continue;
+                }
+            }
             let layout = child.final_layout;
             let child_h = layout.size.height;
             let child_w = if layout.size.width > 0.0 {
@@ -355,6 +379,15 @@ impl<'a> PaginationLayoutTree<'a> {
             if child_h <= 0.0 {
                 continue;
             }
+
+            // Pick up the inter-child gap in body coordinates (collapsed
+            // top/bottom margins, body padding before the first child)
+            // before any break / overflow logic so the cursor reflects
+            // Blitz's flow positions. `max(0.0)` guards against negative
+            // gaps from sibling overlap (rare with default UA styles).
+            let this_top_in_body = layout.location.y;
+            let gap = (this_top_in_body - prev_bottom_y_in_body).max(0.0);
+            cursor_y += gap;
 
             // fulgur-k0g0: read break-before / break-after / break-inside
             // for this child from the column-style side-table (shared with
@@ -411,6 +444,7 @@ impl<'a> PaginationLayoutTree<'a> {
                 page_index = new_page_index;
                 cursor_y = new_cursor_y;
                 emitted += frag_count;
+                prev_bottom_y_in_body = this_top_in_body + child_h;
                 if matches!(
                     break_props.break_after,
                     Some(crate::pageable::BreakAfter::Page)
@@ -448,6 +482,7 @@ impl<'a> PaginationLayoutTree<'a> {
 
             cursor_y += child_h;
             emitted += 1;
+            prev_bottom_y_in_body = this_top_in_body + child_h;
 
             // `break-after: page` forces a page boundary after the
             // child. A trailing break on the last in-flow child does


### PR DESCRIPTION
Add a sibling of multicol_layout that wraps BaseDocument as a Taffy
LayoutPartialTree and records what page-fragment geometry the body's
direct block children would produce against a given page strip height.

The current pass is measurement-only — it walks final_layout populated
by Blitz's first-pass resolve() and does not yet call
taffy::compute_root_layout. The full LayoutPartialTree / RoundTree /
CacheTree / TraversePartialTree wiring is in place so the next
iteration can swap the walk for a real Taffy intercept (analog of
multicol_layout::compute_multicol_layout) without changing the public
surface.

Scope (block-only):
- Iterates body's direct children only; nested layout is reused as-is.
- No break-before / break-after / break-inside, no widow/orphan.
- No out-of-flow handling (position:fixed already owned by
  blitz_adapter::relayout_position_fixed).
- A child taller than a page is emitted whole on its starting page
  (oversized fragment). True mid-element split needs inline / break
  point support that is out of scope here.

The module is wired into lib.rs as `pub(crate)` and not yet called
from engine.rs; #![allow(dead_code)] documents the spike status. Five
unit tests cover empty doc, html-only synthesized body, three-blocks-
fit-one-page, two-blocks-with-page-break, and the oversize-block case.

Existing 857 lib tests stay green (862 total with the new ones).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Fixed-positioned elements now correctly repeat across multiple pages in paginated documents
* **Tests**
  * Added regression test for multi-page fixed element positioning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
