### PR TITLE
feat(pagination_layout): bookmark entry parity assertion (fulgur-s67g Phase 2.4)

### DIFF
--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -270,6 +270,14 @@ impl Engine {
                 .iter()
                 .map(|(k, v)| (*k, v.clone()))
                 .collect();
+        // fulgur-s67g Phase 2.4: same pattern for bookmark_by_node —
+        // ConvertContext drains it via `.remove()` while wrapping
+        // content with `BookmarkMarkerWrapperPageable`.
+        let bookmark_by_node_for_parity: BTreeMap<usize, crate::blitz_adapter::BookmarkInfo> =
+            bookmark_by_node
+                .iter()
+                .map(|(k, v)| (*k, v.clone()))
+                .collect();
 
         let mut convert_ctx = ConvertContext {
             running_store: &running_store,
@@ -301,6 +309,7 @@ impl Engine {
                 &convert_ctx.pagination_geometry,
                 &string_set_by_node_for_parity,
                 &counter_ops_by_node_for_parity,
+                &bookmark_by_node_for_parity,
             )
         }
     }

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -929,6 +929,64 @@ pub fn collect_counter_states(
     result
 }
 
+/// fulgur-s67g Phase 2.4: walk the geometry table and emit
+/// `(page_idx, level, label)` triples for every body child whose
+/// `BookmarkInfo` is registered. Mirrors what
+/// `pageable::BookmarkMarkerPageable::record_if_collecting`
+/// records during draw, except the spike works off the
+/// `PaginationGeometryTable` directly without traversing the
+/// Pageable tree.
+///
+/// Source order is `BTreeMap<NodeId, _>` iteration — same
+/// approximation as [`collect_string_set_states`] and
+/// [`collect_counter_states`]. A node that registers a bookmark
+/// emits one triple on the page where its first fragment lands
+/// (subsequent split fragments do not re-emit, matching
+/// `BookmarkMarkerWrapperPageable`'s "marker travels with the
+/// first split fragment" invariant).
+///
+/// `y_pt` is intentionally **not** returned: the spike works in
+/// CSS px / fragment frames while Pageable records absolute PDF
+/// pt at draw time (after applying `config.margin.top` and
+/// per-page running-element offsets). The Phase 2.4 parity
+/// assertion in `render_to_pdf_with_gcpm` compares only
+/// `(page_idx, level, label)` triples, which are sufficient to
+/// detect a regression in the bookmark-to-page mapping. Y-pt
+/// matching is a downstream concern handled by the convert /
+/// render path that will eventually consume this geometry
+/// directly (Phase 4).
+pub fn collect_bookmark_entries(
+    geometry: &PaginationGeometryTable,
+    bookmark_by_node: &BTreeMap<usize, crate::blitz_adapter::BookmarkInfo>,
+) -> Vec<BookmarkPageEntry> {
+    let mut result = Vec::new();
+    for (&node_id, geom) in geometry {
+        let Some(first_frag) = geom.fragments.first() else {
+            continue;
+        };
+        let Some(info) = bookmark_by_node.get(&node_id) else {
+            continue;
+        };
+        result.push(BookmarkPageEntry {
+            page_idx: first_frag.page_index as usize,
+            level: info.level,
+            label: info.label.clone(),
+        });
+    }
+    result
+}
+
+/// Reduced view of `pageable::BookmarkEntry` exposed by
+/// [`collect_bookmark_entries`]. Drops `y_pt` because the spike
+/// does not work in PDF-pt frames; see the function's docstring
+/// for the parity rationale.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BookmarkPageEntry {
+    pub page_idx: usize,
+    pub level: u8,
+    pub label: String,
+}
+
 /// fulgur-jkl5: enumerate `position: fixed` elements and emit one
 /// fragment per page so downstream rendering can repeat them on every
 /// page (Chrome-compatible behaviour for paged media — see WPT

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -207,6 +207,51 @@ fn assert_counter_states_parity(
     }
 }
 
+/// fulgur-s67g Phase 2.4: in debug builds, assert that the spike's
+/// `pagination_layout::collect_bookmark_entries` produces the same
+/// `(page_idx, level, label)` triples Pageable's collector emits at
+/// draw time. `y_pt` is intentionally not compared — see the
+/// docstring on `collect_bookmark_entries` for the rationale.
+fn assert_bookmark_entries_parity(
+    pageable_entries: &[crate::pageable::BookmarkEntry],
+    geometry: &crate::pagination_layout::PaginationGeometryTable,
+    bookmark_by_node: &BTreeMap<usize, crate::blitz_adapter::BookmarkInfo>,
+) {
+    if !cfg!(debug_assertions) || geometry.is_empty() {
+        return;
+    }
+    let pageable_triples: Vec<crate::pagination_layout::BookmarkPageEntry> = pageable_entries
+        .iter()
+        .map(|e| crate::pagination_layout::BookmarkPageEntry {
+            page_idx: e.page_idx,
+            level: e.level,
+            label: e.label.clone(),
+        })
+        .collect();
+    let mut spike_triples =
+        crate::pagination_layout::collect_bookmark_entries(geometry, bookmark_by_node);
+    // Sort both by (page_idx, label) so iteration order from BTreeMap
+    // (NodeId-ordered) matches Pageable's draw-order recording when
+    // the source order happens to disagree on tie-breaks.
+    let mut sorted_pageable = pageable_triples.clone();
+    sorted_pageable.sort_by(|a, b| {
+        a.page_idx
+            .cmp(&b.page_idx)
+            .then(a.level.cmp(&b.level))
+            .then(a.label.cmp(&b.label))
+    });
+    spike_triples.sort_by(|a, b| {
+        a.page_idx
+            .cmp(&b.page_idx)
+            .then(a.level.cmp(&b.level))
+            .then(a.label.cmp(&b.label))
+    });
+    debug_assert_eq!(
+        sorted_pageable, spike_triples,
+        "bookmark entries drift:\n  pageable = {sorted_pageable:#?}\n  spike    = {spike_triples:#?}",
+    );
+}
+
 /// Build krilla Metadata from Config.
 fn build_metadata(config: &Config) -> krilla::metadata::Metadata {
     let mut metadata = krilla::metadata::Metadata::new();
@@ -341,6 +386,7 @@ pub fn render_to_pdf_with_gcpm(
     pagination_geometry: &crate::pagination_layout::PaginationGeometryTable,
     string_set_by_node: &HashMap<usize, Vec<(String, String)>>,
     counter_ops_by_node: &BTreeMap<usize, Vec<crate::gcpm::CounterOp>>,
+    bookmark_by_node: &BTreeMap<usize, crate::blitz_adapter::BookmarkInfo>,
 ) -> Result<Vec<u8>> {
     // Resolve the default (no-selector) CSS @page margin for initial pagination.
     // :first/:left/:right overrides are applied per-page during rendering below.
@@ -733,6 +779,14 @@ pub fn render_to_pdf_with_gcpm(
 
     if let Some(c) = collector {
         let entries = c.into_entries();
+        // fulgur-s67g Phase 2.4: parity-check the spike's
+        // geometry-driven bookmark walk against Pageable's draw-time
+        // collector output. Compares only `(page_idx, level, label)`
+        // — the spike does not work in PDF-pt frames so y_pt parity
+        // is deferred to Phase 4 (convert / render rewrite).
+        if !entries.is_empty() && (content_height - config.content_height()).abs() < 0.001 {
+            assert_bookmark_entries_parity(&entries, pagination_geometry, bookmark_by_node);
+        }
         if !entries.is_empty() {
             document.set_outline(crate::outline::build_outline(&entries));
         }
@@ -1078,6 +1132,7 @@ mod tests {
             &Default::default(),
             &Default::default(),
             &Default::default(),
+            &Default::default(),
         )
         .unwrap();
         assert_pdf_header(&pdf);
@@ -1097,6 +1152,7 @@ mod tests {
             &Default::default(),
             &Default::default(),
             &Default::default(),
+            &Default::default(),
         )
         .unwrap();
         assert_pdf_header(&pdf);
@@ -1113,6 +1169,7 @@ mod tests {
             &GcpmContext::default(),
             &RunningElementStore::new(),
             &[],
+            &Default::default(),
             &Default::default(),
             &Default::default(),
             &Default::default(),
@@ -1139,6 +1196,7 @@ mod tests {
             &gcpm,
             &RunningElementStore::new(),
             &[],
+            &Default::default(),
             &Default::default(),
             &Default::default(),
             &Default::default(),
@@ -1176,6 +1234,7 @@ mod tests {
             &GcpmContext::default(),
             &RunningElementStore::new(),
             &[],
+            &Default::default(),
             &Default::default(),
             &Default::default(),
             &Default::default(),


### PR DESCRIPTION
## 概要

fulgur-z2mg (Pageable replacement epic) Phase 2.4 — bookmark/outline mapping の parity gate。

⚠️ **stack**: epic ← #276 ← **本 PR**

base = `feat/fulgur-s67g-counter-states` (= #276 head)。

## 主な変更

### spike: `pagination_layout::collect_bookmark_entries`

- 新 type `BookmarkPageEntry { page_idx, level, label }` — `pageable::BookmarkEntry` から `y_pt` を落とした reduced view
- `pagination_layout::collect_bookmark_entries(geometry, bookmark_by_node) -> Vec<BookmarkPageEntry>`: geometry 上の各 node が bookmark を持つなら first fragment の page にエントリを emit (Pageable の `BookmarkMarkerWrapperPageable` が first split fragment にマーカー継承するのと同じ invariant)

### `y_pt` を比較しない理由

Pageable は draw 時に絶対 PDF pt 座標 (margin + per-page running offset 適用済) を記録する。spike は CSS px / fragment 相対座標で動いているため pt 単位の数値マッチングは Phase 4 (convert/render 書き換え) まで保留。Phase 2.4 では `(page_idx, level, label)` の triple 一致のみを検証 — bookmark-to-page mapping の regression 検出には十分。

### render: parity assertion

- `render_to_pdf_with_gcpm` に `bookmark_by_node: &BTreeMap<usize, BookmarkInfo>` 追加
- `assert_bookmark_entries_parity` helper で `(page_idx, level, label)` triple を sort してから `debug_assert_eq!` (draw-order vs NodeId-order の tie-break 差を吸収)
- gate: bookmarks 有効 (entries 非空) AND content_height 一致

### engine: bookmark clone for parity

`bookmark_by_node` も `convert::dom_to_pageable` で `.remove()` 経由 drain されるため、parity 用に `BTreeMap` clone (Phase 1.3 / 2.3 と同じパターン)

## 検証

| | |
|---|---|
| fulgur lib unit tests | **881 pass** |
| examples_determinism | **11/11 pass** |
| VRT byte-wise | **33/33 pass** |
| production build | **0 warnings**, clippy clean |

## 関連

- Epic: fulgur-z2mg
- Phase: fulgur-s67g (Phase 2)
- 直前 PR: #276 (Phase 2.3 counter parity)

## 次の作業

Phase 2.5 (nested break - table-row / flex-item / multicol-internal) または `@page` resolution の spike 取り込み (parity gate の content_height skip 解除) で Phase 2 の残りを片付ける段階に。