### PR TITLE
refactor: rename spike → fragmenter (fulgur-q0vb / Phase 3.0)

### DIFF
--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -119,7 +119,7 @@ pub struct ConvertContext<'a> {
     /// Currently captured but not yet consumed — the next phase
     /// (parity assertion) reads `implied_page_count` from this table
     /// and compares it to `paginate(...).len()` to catch divergence
-    /// between the spike fragmenter and Pageable's split decisions.
+    /// between the fragmenter and Pageable's split decisions.
     /// Empty when the document had no body or no in-flow children.
     /// Keyed by source `usize` NodeId — same convention as
     /// `column_styles` and `multicol_geometry`.

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -227,7 +227,7 @@ impl Engine {
         //
         // fulgur-s67g Phase 2.6 (`@page` size / margin resolution):
         // resolve the page-1 size + margin from `gcpm.page_settings`
-        // before driving the spike, so its strip height matches
+        // before driving the fragmenter, so its strip height matches
         // `render_to_pdf_with_gcpm`'s `content_height` exactly. Both
         // sides use the page-1 result for *all* pages — Pageable
         // does the same in `render.rs:283-291` and does not re-resolve
@@ -235,7 +235,7 @@ impl Engine {
         // This lets the parity gates drop the
         // `(content_height - config.content_height()).abs() < 0.001`
         // skip: documents that override page size / margin via
-        // `@page { size: ...; margin: ...; }` now feed the spike a
+        // `@page { size: ...; margin: ...; }` now feed the fragmenter a
         // matching strip height by construction.
         let default_page_rules: Vec<_> = gcpm
             .page_settings
@@ -297,7 +297,7 @@ impl Engine {
         // release.
         let string_set_by_node_for_parity = string_set_by_node.clone();
         // Counter ops use a `BTreeMap` for the parity assertion to
-        // match the spike's deterministic-iteration signature.
+        // match the fragmenter's deterministic-iteration signature.
         let counter_ops_by_node_for_parity: BTreeMap<usize, Vec<crate::gcpm::CounterOp>> =
             counter_ops_map
                 .iter()

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -36,7 +36,7 @@
 //!
 //! The wrapper is currently exercised against the body subtree only.
 //! Anything nested inside body's direct children continues to use
-//! Blitz's normal layout dispatch, and the spike post-walks
+//! Blitz's normal layout dispatch, and the fragmenter post-walks
 //! `final_layout` rather than re-issuing per-strip
 //! `compute_child_layout` calls. The fulgur-ik6o probe established
 //! that constraining `available_space.height` does not change Taffy's
@@ -59,7 +59,7 @@
 //! and [`implied_page_count`] are gated `#[cfg(test)]` because they
 //! describe extension points (Pageable's string-set walk replacement,
 //! geometry-driven fixed repetition) that have no production consumer
-//! yet. They stay visible to the in-file test module so the spike's
+//! yet. They stay visible to the in-file test module so the fragmenter's
 //! comparison harness can exercise them; future PRs un-gate them when
 //! a real consumer lands.
 
@@ -87,7 +87,7 @@ pub struct Fragment {
 
 /// Per-source-node geometry: every page on which the node has a placement.
 ///
-/// For the block-only spike the vector is normally length 1 (the node
+/// For the block-only fragmenter the vector is normally length 1 (the node
 /// fits on one page). A node taller than the page produces multiple
 /// fragments — but in the current measurement-only implementation we
 /// emit it as a single oversized fragment on the page where its top
@@ -119,7 +119,7 @@ pub struct PaginationLayoutTree<'a> {
     pub(crate) page_height_px: f32,
     pub(crate) geometry: PaginationGeometryTable,
     /// Cached id of the `<body>` element, if any. Used as the
-    /// fragmentation root for the block-only spike. `None` means the
+    /// fragmentation root for the block-only fragmenter. `None` means the
     /// document had no body and the pass becomes a no-op.
     pub(crate) body_id: Option<usize>,
     /// fulgur-k0g0: `break-before` / `break-after` / `break-inside`
@@ -127,7 +127,7 @@ pub struct PaginationLayoutTree<'a> {
     /// [`crate::blitz_adapter::extract_column_style_table`]. The table
     /// is shared with `multicol_layout` (Pageable's
     /// `extract_pagination_from_column_css` reads the same fields), so
-    /// the pagination spike does not maintain its own break-style
+    /// the pagination fragmenter does not maintain its own break-style
     /// extraction. `None` means "no break properties set anywhere",
     /// which the fragmenter treats as all-`Auto`.
     pub(crate) column_styles: Option<&'a crate::column_css::ColumnStyleTable>,
@@ -366,7 +366,7 @@ impl<'a> PaginationLayoutTree<'a> {
         // / string-set / bookmark ops fire only on page 0
         // (`pageable.rs:2829-2840` etc.).
         //
-        // Without this entry the spike's geometry table excludes body
+        // Without this entry the fragmenter's geometry table excludes body
         // entirely; `collect_counter_states` /
         // `collect_string_set_states` / `collect_bookmark_entries`
         // miss body's ops and the parity gates fire on documents like
@@ -403,7 +403,7 @@ impl<'a> PaginationLayoutTree<'a> {
         // child's `final_layout.location.y` but the cursor-only walk
         // would otherwise miss. Pageable accumulates `pc.y + child_h`
         // from `final_layout.location.y` during convert, so margin gaps
-        // are present in the Pageable side; the spike must match.
+        // are present in the Pageable side; the fragmenter must match.
         let mut prev_bottom_y_in_body: f32 = 0.0;
 
         for child_id in children {
@@ -421,7 +421,7 @@ impl<'a> PaginationLayoutTree<'a> {
             // / `position: fixed`) do not contribute to their containing
             // block's normal-flow height. Pageable routes them through
             // `PositionedChild { out_of_flow: true }` and they never
-            // advance pagination cursors; the spike must match or the
+            // advance pagination cursors; the fragmenter must match or the
             // fulgur-cj6u Phase 1.2 parity assertion fires on documents
             // with abs/fixed body-direct children.
             {
@@ -606,7 +606,7 @@ impl<'a> PaginationLayoutTree<'a> {
             // and record per-node fragments for every visible
             // descendant. Pageable's `paginate::collect_*` walks
             // recurse into `BlockPageable`, `ListItemPageable`,
-            // wrapper types, and table cells; the spike side needs
+            // wrapper types, and table cells; the fragmenter side needs
             // matching coverage so bookmark / counter / string-set
             // markers attached to nested DOM elements (e.g. an `h2`
             // inside a wrapper `<div>`) appear in geometry too.
@@ -634,7 +634,7 @@ impl<'a> PaginationLayoutTree<'a> {
 
             // `break-after: page` forces a page boundary after the
             // child. A trailing break on the last in-flow child does
-            // emit an empty trailing page in CSS, but the spike's
+            // emit an empty trailing page in CSS, but the fragmenter's
             // observable signal (page_count) treats this as "advance
             // cursor"; the next iteration's emit-or-skip handles
             // whether the page is materialised.
@@ -669,7 +669,7 @@ impl<'a> PaginationLayoutTree<'a> {
 /// Mid-element split inside a body child (a deeply nested element
 /// crossing the page boundary that the parent itself did not split
 /// at) is **not** modelled here — descendants land on the same page
-/// as their ancestor. This is the spike's "block-level only" gap;
+/// as their ancestor. This is the fragmenter's "block-level only" gap;
 /// closing it requires the full per-strip layout pass that Phase 3
 /// (paginate.rs replacement) introduces.
 fn record_subtree_descendants(
@@ -772,7 +772,7 @@ fn collect_inline_line_metrics(node: &blitz_dom::Node) -> Vec<(f32, f32)> {
 ///
 /// Pageable hard-codes `orphans = widows = 2` via `Pagination::default()`
 /// (`pageable.rs:268-275`). CSS `orphans` / `widows` properties are
-/// not parsed today, so the spike uses the same constants.
+/// not parsed today, so the fragmenter uses the same constants.
 ///
 /// Output:
 ///
@@ -879,7 +879,7 @@ fn fragment_inline_root(
 /// `string-set` state across pages, mirroring
 /// [`crate::paginate::collect_string_set_states`].
 ///
-/// Used by fulgur-cj6u Phase 1.3 as the spike-side input to a
+/// Used by fulgur-cj6u Phase 1.3 as the fragmenter-side input to a
 /// per-page state parity assertion against `paginate`'s walk in
 /// `render_to_pdf_with_gcpm`. Drift between the two outputs is the
 /// regression signal that catches geometry-vs-Pageable divergence
@@ -905,7 +905,7 @@ fn fragment_inline_root(
 /// iteration is by ascending NodeId. For body's direct children that
 /// matches DOM source order, since Blitz allocates ids sequentially
 /// during parse. Nested string-set declarations (markers attached to
-/// a `<span>` inside a `<p>`) are not in the spike's geometry table
+/// a `<span>` inside a `<p>`) are not in the fragmenter's geometry table
 /// today and so are silently dropped — same scope limitation as
 /// `fragment_pagination_root` itself.
 pub fn collect_string_set_states(
@@ -970,12 +970,12 @@ pub fn collect_string_set_states(
 /// applied in the order they appear in the body's children list,
 /// approximated by `BTreeMap<NodeId, _>` iteration. Nested counter
 /// declarations on descendants of body's direct children are not in
-/// the spike's geometry today and are silently dropped — same scope
+/// the fragmenter's geometry today and are silently dropped — same scope
 /// limitation as `fragment_pagination_root` itself.
 ///
 /// Used by fulgur-cj6u Phase 1.x parity gates extension in
 /// `render_to_pdf_with_gcpm`. Drift between Pageable's counter walk
-/// and the spike's geometry-driven walk is the regression signal
+/// and the fragmenter's geometry-driven walk is the regression signal
 /// for counter-correctness on documents with `counter-increment` /
 /// `counter-reset` / `counter-set`.
 pub fn collect_counter_states(
@@ -1030,7 +1030,7 @@ pub fn collect_counter_states(
 /// `(page_idx, level, label)` triples for every body child whose
 /// `BookmarkInfo` is registered. Mirrors what
 /// `pageable::BookmarkMarkerPageable::record_if_collecting`
-/// records during draw, except the spike works off the
+/// records during draw, except the fragmenter works off the
 /// `PaginationGeometryTable` directly without traversing the
 /// Pageable tree.
 ///
@@ -1042,7 +1042,7 @@ pub fn collect_counter_states(
 /// `BookmarkMarkerWrapperPageable`'s "marker travels with the
 /// first split fragment" invariant).
 ///
-/// `y_pt` is intentionally **not** returned: the spike works in
+/// `y_pt` is intentionally **not** returned: the fragmenter works in
 /// CSS px / fragment frames while Pageable records absolute PDF
 /// pt at draw time (after applying `config.margin.top` and
 /// per-page running-element offsets). The Phase 2.4 parity
@@ -1074,7 +1074,7 @@ pub fn collect_bookmark_entries(
 }
 
 /// Reduced view of `pageable::BookmarkEntry` exposed by
-/// [`collect_bookmark_entries`]. Drops `y_pt` because the spike
+/// [`collect_bookmark_entries`]. Drops `y_pt` because the fragmenter
 /// does not work in PDF-pt frames; see the function's docstring
 /// for the parity rationale.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1095,7 +1095,7 @@ pub struct BookmarkPageEntry {
 /// path leaves fixed elements at their viewport-relative coordinates).
 /// The geometry-table approach this function provides is kept under
 /// `#[cfg(test)]` as scaffolding for a future architecture where
-/// convert / render consume the spike's geometry directly. Both paths
+/// convert / render consume the fragmenter's geometry directly. Both paths
 /// produce equivalent observable output today.
 #[cfg(test)]
 ///
@@ -1110,7 +1110,7 @@ pub struct BookmarkPageEntry {
 /// `blitz_adapter::relayout_position_fixed` (added in fulgur-tbxs,
 /// branch `feat/fixedpos-viewport-cb`) having run beforehand** so
 /// that `final_layout` reflects viewport-CB resolution rather than
-/// the inherited (often wrong) abs-position layout. The spike branch
+/// the inherited (often wrong) abs-position layout. The fragmenter branch
 /// does not yet include `relayout_position_fixed`; once both land on
 /// `main` this function picks up the corrected positions automatically.
 ///
@@ -1211,14 +1211,14 @@ fn walk_for_position_fixed(doc: &BaseDocument, node_id: usize, out: &mut Vec<usi
 
 /// fulgur-jkl5: total page count implied by a geometry table.
 ///
-/// Convention matches `compare_with_pageable::spike_page_count`:
+/// Convention matches `compare_with_pageable::fragmenter_page_count`:
 /// returns `max(page_index) + 1` if the table has any fragments, else
 /// `1` (Pageable's "always at least one page" guarantee).
 ///
-/// Used by fulgur-cj6u Phase 1.2 as the spike-side input to a
+/// Used by fulgur-cj6u Phase 1.2 as the fragmenter-side input to a
 /// `paginate(...).len() == implied_page_count(&geometry)` parity
 /// assertion in `render_to_pdf_with_gcpm`. Drift between Pageable's
-/// split decisions and the spike's fragmenter is the regression
+/// split decisions and the fragmenter is the regression
 /// signal Phase 2 work needs to chase.
 pub fn implied_page_count(geometry: &PaginationGeometryTable) -> u32 {
     geometry
@@ -1359,7 +1359,7 @@ impl RoundTree for PaginationLayoutTree<'_> {
     }
 }
 
-/// Custom layout dispatch for the body (the spike's fragmentation root).
+/// Custom layout dispatch for the body (the fragmenter's fragmentation root).
 ///
 /// Mirrors the structure of [`crate::multicol_layout::compute_multicol_layout`]:
 /// the wrapper's `compute_child_layout` fires for body, delegates the
@@ -1369,7 +1369,7 @@ impl RoundTree for PaginationLayoutTree<'_> {
 ///
 /// In the next iteration this is where per-strip available_space
 /// constraint and child-by-child re-layout will live. For the current
-/// spike it's a thin shim that proves the dispatch path works.
+/// fragmenter it's a thin shim that proves the dispatch path works.
 fn compute_pagination_layout(
     tree: &mut PaginationLayoutTree<'_>,
     body_id: NodeId,
@@ -1397,10 +1397,10 @@ mod tests {
     use std::ops::DerefMut;
     use std::sync::Arc;
 
-    /// Parse helper for the spike's tests.
+    /// Parse helper for the fragmenter's tests.
     ///
     /// We deliberately don't accept a viewport height: `blitz_adapter::parse`
-    /// uses a hardcoded viewport_h internally, and the spike's strip slicing
+    /// uses a hardcoded viewport_h internally, and the fragmenter's strip slicing
     /// is driven by the `page_height_px` argument to `run_pass` rather than
     /// by the viewport. The fixtures pass viewport_w only.
     fn parse(html: &str, viewport_w: f32) -> blitz_html::HtmlDocument {
@@ -1867,7 +1867,7 @@ mod tests {
 
     #[test]
     fn taller_than_page_block_emits_single_oversize_fragment() {
-        // 1000px block on a 800px page. Block-only spike emits it whole
+        // 1000px block on a 800px page. Block-only fragmenter emits it whole
         // on the page where its top lands, with the full height — true
         // split is the next iteration's job.
         let html = r#"
@@ -1892,9 +1892,9 @@ mod tests {
 /// Comparison harness: drive the same HTML through `paginate::paginate(...)`
 /// and `pagination_layout::run_pass(...)` and tabulate the per-fixture
 /// page count agreement. The harness is observational — its purpose is to
-/// surface where the two paths agree (so the spike can claim it covers
+/// surface where the two paths agree (so the fragmenter can claim it covers
 /// the simple-block case) and where they diverge (so the next iteration
-/// of the spike has a concrete target list).
+/// of the fragmenter has a concrete target list).
 ///
 /// Lives in the same file as the unit tests so it can use `pub(crate)`
 /// helpers like `crate::convert::pt_to_px` and `crate::paginate::paginate`
@@ -1906,12 +1906,12 @@ mod compare_with_pageable {
     use crate::{Engine, PageSize};
     use std::ops::DerefMut;
 
-    /// Compute the spike's page count from a geometry table.
+    /// Compute the fragmenter's page count from a geometry table.
     ///
     /// Thin wrapper over [`super::implied_page_count`] so the comparison
     /// harness and the production-facing helper can never drift apart on
     /// the "empty → 1" convention.
-    fn spike_page_count(table: &super::PaginationGeometryTable) -> u32 {
+    fn fragmenter_page_count(table: &super::PaginationGeometryTable) -> u32 {
         super::implied_page_count(table)
     }
 
@@ -1927,7 +1927,7 @@ mod compare_with_pageable {
         pages.len()
     }
 
-    /// Run the spike against the same HTML the Pageable side rendered.
+    /// Run the fragmenter against the same HTML the Pageable side rendered.
     /// Re-parses (deterministic) so we get a fresh `BaseDocument` and
     /// can mutate it without unsafe shenanigans. Threads the column-
     /// style side-table so `break-*` properties are honoured.
@@ -1936,7 +1936,7 @@ mod compare_with_pageable {
     /// reachable from production; its result is preserved in
     /// `docs/plans/2026-04-28-pagination-layout-spike.md` follow-up
     /// #2.)
-    fn spike_page_count_for(html: &str) -> u32 {
+    fn fragmenter_page_count_for(html: &str) -> u32 {
         use crate::blitz_adapter;
         let engine = Engine::builder().page_size(PageSize::A4).build();
         let cfg = engine.config();
@@ -1955,13 +1955,13 @@ mod compare_with_pageable {
             pt_to_px(cfg.content_height()),
             &column_styles,
         );
-        spike_page_count(&table)
+        fragmenter_page_count(&table)
     }
 
     /// Each fixture: (label, html, agreement expected?).
     ///
     /// `agreement_expected = false` means we already know Pageable and
-    /// the block-only spike will diverge for this case (e.g. inline text
+    /// the block-only fragmenter will diverge for this case (e.g. inline text
     /// that wraps across pages). The harness still runs both sides and
     /// records the disagreement so the next iteration knows what to fix.
     fn fixtures() -> Vec<(&'static str, &'static str, bool)> {
@@ -2008,10 +2008,10 @@ mod compare_with_pageable {
             ),
             // ── vh / percentage observation fixtures ──────────────────
             //
-            // These probe the cases the block-only spike is *expected* to
+            // These probe the cases the block-only fragmenter is *expected* to
             // disagree with Pageable on. Marking them
             // `expected_agreement = false` documents the divergence; once
-            // the spike grows mid-element splitting, flip these to `true`
+            // the fragmenter grows mid-element splitting, flip these to `true`
             // and use the test as a regression gate.
             (
                 "single 100vh div (taller than content area)",
@@ -2022,7 +2022,7 @@ mod compare_with_pageable {
                 // `BlockPageable::split` returns `Err(unsplit)` for a
                 // body whose only child is a single oversized empty
                 // box (no break point inside, refusing to emit an empty
-                // page first), and the spike's `cursor_y > 0` guard does
+                // page first), and the fragmenter's `cursor_y > 0` guard does
                 // the same on its side. Convergent fallback rather than
                 // shared correctness — flagged here to remember.
                 r#"<html><body>
@@ -2063,7 +2063,7 @@ mod compare_with_pageable {
                 // CSS 2.1 §10.5: percentage height resolves to `auto`
                 // when the containing block has no explicit height. Both
                 // sides should produce a single empty page (the divs
-                // collapse). The spike's measurement walk reads
+                // collapse). The fragmenter's measurement walk reads
                 // final_layout, so it sees the same zero-height boxes
                 // Pageable converts. Expected: both report 1 page.
                 r#"<html><body>
@@ -2075,7 +2075,7 @@ mod compare_with_pageable {
             ),
             (
                 "long paragraph wraps into multiple pages",
-                // fulgur-p55h: the spike now probes Parley's line
+                // fulgur-p55h: the fragmenter now probes Parley's line
                 // metrics (`Layout::lines()` → `LineMetrics`) and
                 // splits inline roots at line boundaries via
                 // `fragment_inline_root`. This fixture flipped from
@@ -2086,7 +2086,7 @@ mod compare_with_pageable {
                 // Lorem ipsum block wraps into ~70 lines at A4 content
                 // width → ~5250 px total, comfortably overflowing 2+
                 // pages. Pageable's `ParagraphPageable::split` (line
-                // boundaries) should split it across pages. The spike's
+                // boundaries) should split it across pages. The fragmenter's
                 // `fragment_pagination_root` sees one block child with
                 // a 5000+ px height and emits it whole → 1 page.
                 r#"<html><body><p style="font-size: 50px; line-height: 1.5">
@@ -2146,16 +2146,16 @@ mod compare_with_pageable {
             ),
             (
                 "break-inside: avoid keeps tall paragraph whole",
-                // Intentional divergence: the spike's
+                // Intentional divergence: the fragmenter's
                 // `fragment_pagination_root` checks `break-inside:
                 // avoid` *before* entering the inline-split branch and
                 // emits the paragraph as a single oversized block →
                 // 1 page. Pageable's `ParagraphPageable::split`
                 // (paragraph.rs:945) does NOT check `break_inside`, so
                 // it splits at line boundaries regardless → 2 pages.
-                // The spike behaviour is correct per CSS Fragmentation
+                // The fragmenter behaviour is correct per CSS Fragmentation
                 // §3.3; Pageable has a latent bug here. Tracking the
-                // Pageable fix is out of scope for this spike — file
+                // Pageable fix is out of scope for this fragmenter — file
                 // separately if it matters.
                 r#"<html><body><p style="font-size: 50px; line-height: 1.5; break-inside: avoid">
                     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
@@ -2179,24 +2179,24 @@ mod compare_with_pageable {
 
         for (label, html, expected_agreement) in &fixtures {
             let pageable_pages = pageable_page_count(html) as u32;
-            let spike_pages = spike_page_count_for(html);
-            let agree = pageable_pages == spike_pages;
+            let fragmenter_pages = fragmenter_page_count_for(html);
+            let agree = pageable_pages == fragmenter_pages;
 
             eprintln!(
-                "[{:>1}] {label:<55} pageable={pageable_pages} spike={spike_pages}",
+                "[{:>1}] {label:<55} pageable={pageable_pages} fragmenter={fragmenter_pages}",
                 if agree { "✓" } else { "✗" },
             );
 
             if agree != *expected_agreement {
                 disagreements.push(format!(
-                    "{label}: pageable={pageable_pages} spike={spike_pages} expected_agreement={expected_agreement}",
+                    "{label}: pageable={pageable_pages} fragmenter={fragmenter_pages} expected_agreement={expected_agreement}",
                 ));
             }
         }
 
         assert!(
             disagreements.is_empty(),
-            "Pageable vs spike disagreement (or unexpected agreement) for:\n  - {}",
+            "Pageable vs fragmenter disagreement (or unexpected agreement) for:\n  - {}",
             disagreements.join("\n  - "),
         );
     }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 /// directly without going through `Engine::render_html`, so no
 /// `pagination_layout::PaginationGeometryTable` is available. The
 /// parity gate lives in [`render_to_pdf_with_gcpm`] which is the
-/// engine-internal entry threaded with the spike's geometry.
+/// engine-internal entry threaded with the fragmenter's geometry.
 pub fn render_to_pdf(root: Box<dyn Pageable>, config: &Config) -> Result<Vec<u8>> {
     let content_width = config.content_width();
     let content_height = config.content_height();
@@ -115,15 +115,15 @@ pub fn render_to_pdf(root: Box<dyn Pageable>, config: &Config) -> Result<Vec<u8>
 /// (widow/orphan, running element / margin-box, counter, table-row
 /// break, …).
 ///
-/// Skipped when `geometry` is empty — the spike pass was either not
+/// Skipped when `geometry` is empty — the fragmenter pass was either not
 /// run or the document had no body / no in-flow children, in which
 /// case Pageable's "always at least one page" convention diverges
-/// from the spike's "no fragments" output and the assertion is
+/// from the fragmenter's "no fragments" output and the assertion is
 /// uninformative. Empty bodies still go through Pageable's single-
 /// empty-page fallback.
 ///
 /// Release builds compile this to a no-op via `cfg!(debug_assertions)`.
-fn assert_pageable_spike_parity(
+fn assert_pageable_fragmenter_parity(
     pages: &[Box<dyn Pageable>],
     geometry: &crate::pagination_layout::PaginationGeometryTable,
 ) {
@@ -131,41 +131,41 @@ fn assert_pageable_spike_parity(
         return;
     }
     let pageable_count = pages.len() as u32;
-    let spike_count = crate::pagination_layout::implied_page_count(geometry);
+    let fragmenter_count = crate::pagination_layout::implied_page_count(geometry);
     // fulgur-s67g Phase 2.6: when Pageable splits an oversized element
     // across pages (mid-element split, e.g. `.huge { break-inside: avoid }`
-    // taller than `@page`), Pageable emits more pages than the spike's
-    // strip-based fragmenter currently models. That gap is Phase 3 work
+    // taller than `@page`), Pageable emits more pages than the fragmenter's
+    // strip-based pass currently models. That gap is Phase 3 work
     // (per-strip layout pass / `fulgur-g9e3`); until then, skip parity
-    // when Pageable > spike. The reverse direction is still a regression.
-    if pageable_count > spike_count {
+    // when Pageable > fragmenter. The reverse direction is still a regression.
+    if pageable_count > fragmenter_count {
         return;
     }
     debug_assert_eq!(
-        pageable_count, spike_count,
-        "page count parity drift: paginate={pageable_count} spike={spike_count}",
+        pageable_count, fragmenter_count,
+        "page count parity drift: paginate={pageable_count} fragmenter={fragmenter_count}",
     );
 }
 
-/// Detect mid-element split: Pageable produces more pages than spike's
-/// `implied_page_count`. See `assert_pageable_spike_parity` for the
+/// Detect mid-element split: Pageable produces more pages than fragmenter's
+/// `implied_page_count`. See `assert_pageable_fragmenter_parity` for the
 /// rationale — this is Phase 3 territory and the dependent parity
 /// assertions can't be meaningfully compared either.
 fn mid_element_split_skipped(
     pageable_pages: usize,
     geometry: &crate::pagination_layout::PaginationGeometryTable,
 ) -> bool {
-    let spike_count = crate::pagination_layout::implied_page_count(geometry) as usize;
-    pageable_pages > spike_count
+    let fragmenter_count = crate::pagination_layout::implied_page_count(geometry) as usize;
+    pageable_pages > fragmenter_count
 }
 
-/// fulgur-cj6u Phase 1.3: in debug builds, assert that the spike's
+/// fulgur-cj6u Phase 1.3: in debug builds, assert that the fragmenter's
 /// `pagination_layout::collect_string_set_states` produces the same
 /// per-page `(start, first, last)` shape Pageable's tree walk does.
-/// Same skip semantics as `assert_pageable_spike_parity`: empty
-/// geometry → spike pass not run; release builds compile to a no-op.
+/// Same skip semantics as `assert_pageable_fragmenter_parity`: empty
+/// geometry → fragmenter pass not run; release builds compile to a no-op.
 ///
-/// `string_set_by_node` is the engine-side `HashMap`; the spike
+/// `string_set_by_node` is the engine-side `HashMap`; the fragmenter
 /// wants a `BTreeMap` (deterministic iteration), so we materialise
 /// one once for the comparison. The conversion is debug-only via
 /// `cfg!(debug_assertions)`.
@@ -184,27 +184,31 @@ fn assert_string_set_states_parity(
         .iter()
         .map(|(k, v)| (*k, v.clone()))
         .collect();
-    let spike_states =
+    let fragmenter_states =
         crate::pagination_layout::collect_string_set_states(geometry, &by_node_btree);
     debug_assert_eq!(
         pageable_states.len(),
-        spike_states.len(),
-        "string-set state vec length drift: pageable={} spike={}",
+        fragmenter_states.len(),
+        "string-set state vec length drift: pageable={} fragmenter={}",
         pageable_states.len(),
-        spike_states.len(),
+        fragmenter_states.len(),
     );
-    for (idx, (pg, sp)) in pageable_states.iter().zip(spike_states.iter()).enumerate() {
+    for (idx, (pg, sp)) in pageable_states
+        .iter()
+        .zip(fragmenter_states.iter())
+        .enumerate()
+    {
         debug_assert_eq!(
             pg, sp,
-            "string-set state drift on page {idx}:\n  pageable = {pg:#?}\n  spike    = {sp:#?}",
+            "string-set state drift on page {idx}:\n  pageable   = {pg:#?}\n  fragmenter = {sp:#?}",
         );
     }
 }
 
-/// fulgur-s67g Phase 2.3: in debug builds, assert that the spike's
+/// fulgur-s67g Phase 2.3: in debug builds, assert that the fragmenter's
 /// `pagination_layout::collect_counter_states` produces the same
 /// per-page counter snapshot Pageable's tree walk does. Same skip
-/// semantics as the other parity helpers: empty geometry → spike pass
+/// semantics as the other parity helpers: empty geometry → fragmenter pass
 /// not run; release builds compile to a no-op.
 fn assert_counter_states_parity(
     pageable_states: &[BTreeMap<String, i32>],
@@ -218,7 +222,7 @@ fn assert_counter_states_parity(
     // (e.g. `<div class="reset"></div>` carrying `counter-set: ..`),
     // so a counter-op node can be absent from `geometry` while
     // Pageable still applies its op during the tree walk. Skip the
-    // assertion in that case — the spike's view is intentionally
+    // assertion in that case — the fragmenter's view is intentionally
     // incomplete here, same scope limitation as the function's
     // docstring already calls out for nested declarations.
     if counter_ops_by_node
@@ -230,24 +234,28 @@ fn assert_counter_states_parity(
     if mid_element_split_skipped(pageable_states.len(), geometry) {
         return;
     }
-    let spike_states =
+    let fragmenter_states =
         crate::pagination_layout::collect_counter_states(geometry, counter_ops_by_node);
     debug_assert_eq!(
         pageable_states.len(),
-        spike_states.len(),
-        "counter state vec length drift: pageable={} spike={}",
+        fragmenter_states.len(),
+        "counter state vec length drift: pageable={} fragmenter={}",
         pageable_states.len(),
-        spike_states.len(),
+        fragmenter_states.len(),
     );
-    for (idx, (pg, sp)) in pageable_states.iter().zip(spike_states.iter()).enumerate() {
+    for (idx, (pg, sp)) in pageable_states
+        .iter()
+        .zip(fragmenter_states.iter())
+        .enumerate()
+    {
         debug_assert_eq!(
             pg, sp,
-            "counter state drift on page {idx}:\n  pageable = {pg:#?}\n  spike    = {sp:#?}",
+            "counter state drift on page {idx}:\n  pageable   = {pg:#?}\n  fragmenter = {sp:#?}",
         );
     }
 }
 
-/// fulgur-s67g Phase 2.4: in debug builds, assert that the spike's
+/// fulgur-s67g Phase 2.4: in debug builds, assert that the fragmenter's
 /// `pagination_layout::collect_bookmark_entries` produces the same
 /// `(page_idx, level, label)` triples Pageable's collector emits at
 /// draw time. `y_pt` is intentionally not compared — see the
@@ -272,7 +280,7 @@ fn assert_bookmark_entries_parity(
             label: e.label.clone(),
         })
         .collect();
-    let mut spike_triples =
+    let mut fragmenter_triples =
         crate::pagination_layout::collect_bookmark_entries(geometry, bookmark_by_node);
     // Sort both by (page_idx, label) so iteration order from BTreeMap
     // (NodeId-ordered) matches Pageable's draw-order recording when
@@ -284,15 +292,15 @@ fn assert_bookmark_entries_parity(
             .then(a.level.cmp(&b.level))
             .then(a.label.cmp(&b.label))
     });
-    spike_triples.sort_by(|a, b| {
+    fragmenter_triples.sort_by(|a, b| {
         a.page_idx
             .cmp(&b.page_idx)
             .then(a.level.cmp(&b.level))
             .then(a.label.cmp(&b.label))
     });
     debug_assert_eq!(
-        sorted_pageable, spike_triples,
-        "bookmark entries drift:\n  pageable = {sorted_pageable:#?}\n  spike    = {spike_triples:#?}",
+        sorted_pageable, fragmenter_triples,
+        "bookmark entries drift:\n  pageable   = {sorted_pageable:#?}\n  fragmenter = {fragmenter_triples:#?}",
     );
 }
 
@@ -453,20 +461,20 @@ pub fn render_to_pdf_with_gcpm(
     // Pass 1: paginate body content
     let pages = paginate(root, content_width, content_height);
     // fulgur-cj6u Phase 1.2 / fulgur-s67g Phase 2.6: cross-check the
-    // spike fragmenter agrees with Pageable on the page count.
+    // fragmenter agrees with Pageable on the page count.
     // Phase 2.6 (`@page` size / margin resolution) makes the engine
-    // pre-resolve page-1 settings before driving the spike, so the
-    // strip height the spike sees matches `content_height` here by
+    // pre-resolve page-1 settings before driving the fragmenter, so the
+    // strip height the fragmenter sees matches `content_height` here by
     // construction — no skip needed for `@page`-modified docs.
     // (Phase 2.2 already ungated the running-elements skip.)
-    assert_pageable_spike_parity(&pages, pagination_geometry);
+    assert_pageable_fragmenter_parity(&pages, pagination_geometry);
     let total_pages = pages.len();
     let string_set_states = if gcpm.string_set_mappings.is_empty() {
         vec![BTreeMap::new(); pages.len()]
     } else {
         crate::paginate::collect_string_set_states(&pages)
     };
-    // fulgur-cj6u Phase 1.3: parity-check the spike's geometry-table-
+    // fulgur-cj6u Phase 1.3: parity-check the fragmenter's geometry-table-
     // driven `collect_string_set_states` against Pageable's tree walk.
     // No activation gate beyond "string-set actually used" — Phase 2.2
     // / 2.6 ungated the running-elements and `@page` skips.
@@ -488,7 +496,7 @@ pub fn render_to_pdf_with_gcpm(
         } else {
             crate::paginate::collect_counter_states(&pages)
         };
-    // fulgur-s67g Phase 2.3: parity-check the spike's geometry-table-
+    // fulgur-s67g Phase 2.3: parity-check the fragmenter's geometry-table-
     // driven `collect_counter_states` against Pageable's tree walk.
     // No activation gate beyond "counter actually used".
     if !gcpm.counter_mappings.is_empty() || !gcpm.content_counter_mappings.is_empty() {
@@ -809,10 +817,10 @@ pub fn render_to_pdf_with_gcpm(
 
     if let Some(c) = collector {
         let entries = c.into_entries();
-        // fulgur-s67g Phase 2.4: parity-check the spike's
+        // fulgur-s67g Phase 2.4: parity-check the fragmenter's
         // geometry-driven bookmark walk against Pageable's draw-time
         // collector output. Compares only `(page_idx, level, label)`
-        // — the spike does not work in PDF-pt frames so y_pt parity
+        // — the fragmenter does not work in PDF-pt frames so y_pt parity
         // is deferred to Phase 4 (convert / render rewrite).
         // Phase 2.6 ungated the `@page`-content-height skip.
         if !entries.is_empty() {

--- a/docs/plans/2026-04-29-phase3-paginate-deletion.md
+++ b/docs/plans/2026-04-29-phase3-paginate-deletion.md
@@ -1,0 +1,193 @@
+# Phase 3: paginate.rs deletion (fragmenter-driven page split) — fulgur-g9e3
+
+> Parent epic: `fulgur-z2mg` (Pageable replacement)
+> Predecessor: `fulgur-s67g` (Phase 2 — feature gap closure, completed 2026-04-29)
+> Successor: `fulgur-9t3z` (Phase 4 — convert + render replacement, delete Pageable type)
+
+## ゴール
+
+`paginate::paginate` および `BlockPageable::split` / `find_split_point` 系の page split 判定を fragmenter (`pagination_layout`) に集約し、`paginate.rs` を削除する。Phase 2 で feature parity が成立したため、fragmenter が page 数 / 各 node の page 配置を一手に決め、Pageable は per-node の draw list 供給源として残る。
+
+## 現状の構造 (Phase 2 完了時点)
+
+### `paginate.rs` (663 行)
+
+公開 API:
+
+```text
+paginate(root, page_width, page_height) -> Vec<Box<dyn Pageable>>
+collect_string_set_states(pages) -> Vec<BTreeMap<String, StringSetPageState>>
+collect_running_element_states(pages) -> Vec<BTreeMap<String, usize>>
+collect_counter_states(pages) -> Vec<BTreeMap<String, i32>>
+```
+
+すべて Pageable tree を再帰 walk して per-page state を組み立てる。**fragmenter 側の同名関数 (`collect_*_states` / `collect_bookmark_entries`) は Phase 1.x / 2.x で実装済み**で、parity assertion が DEBUG ビルドで一致を保証している。
+
+### `Pageable::split` / `split_boxed` (pageable.rs 内、26 impl)
+
+- `BlockPageable::split` / `find_split_point` (1136 行) — メインロジック
+- `ParagraphPageable::split` (line-by-line + widow/orphan)
+- `TablePageable::split_boxed` (header repeat)
+- `RepeatRowsPageable::split_boxed`
+- 各 wrapper (Counter / StringSet / Bookmark / RunningElement / ColumnGroup / FixedPos) の split
+- helper: `clone_pc_with_offset`, `split_children_at_index`, `split_children_for_within`
+
+### `paginate()` の production caller
+
+- `render.rs:25` (`render_to_pdf`)
+- `render.rs:441` (`render_to_pdf_with_gcpm`)
+
+それ以外の caller はすべて test (`pageable.rs::tests`, `paragraph.rs::tests`, `pagination_layout.rs::cmp_test`)。
+
+### fragmenter (`pagination_layout`) の現状能力 (Phase 2.6 時点)
+
+- body の direct children を順次 placement
+- inline root (Parley) は line-by-line split + widow / orphan
+- 子要素が strip より大きい場合 → 現 page に whole emit (mid-element split **未対応**)
+- `break-before: page` / `break-after: page` / `break-inside: avoid` 対応
+- `position: absolute` / `position: fixed` / `position: running()` 除外
+- 子の subtree descendants を再帰記録 (Phase 2.5)
+- `@page` size / margin の page-1 解決 (Phase 2.6)
+
+**残るギャップ:** mid-element split (`fulgur-s67g` Phase 2.6 で skip gate を入れた領域)。`avoid_block_taller_than_page_falls_back_to_split` のような「子 block が strip より大きく、その中の splittable children を切らないとフィットしない」ケース。
+
+## サブタスク分割
+
+### 3.1 fragmenter: mid-element split support (fulgur-g9e3-1)
+
+fragmenter が body 直下の child だけでなく、**ブロック型 child の subtree 内も再帰的に split** できるようにする。Pageable `BlockPageable::find_split_point` 相当のロジックを DOM 駆動で再実装。
+
+#### 仕様
+
+- 子 block が strip に収まらない場合:
+  1. `break-inside: avoid` 指定なら whole placement を試みる (現状通り)
+  2. avoid なし、かつ子の DOM children (table の場合は rows、list の場合は items、汎用 block の場合は flow children) を strip 単位で再帰 split
+  3. inline root の場合は既存の line-by-line split (これは既に対応済み)
+- 子要素単位の fragment を `geometry` に複数 page 分記録する
+- `Fragment.height` は分割された strip の高さ (元の `final_layout.size.height` と異なる)
+
+#### 実装方針
+
+`fragment_pagination_root` の child loop 内で「strip 超え + avoid なし」分岐に新ヘルパ `fragment_block_subtree(child_id, ...)` を呼ぶ。再帰関数で:
+
+- block の children を順に walk
+- 各 grandchild について「収まる / 跨ぐ / 全く収まらない」判定
+- 跨ぐ場合は cursor を strip 終端まで進めた fragment + 次 page 用 fragment を分割記録
+- 全く収まらない (= grandchild も oversized) ならさらに再帰
+
+table / list-item / multicol column / fixed-pos など Pageable 側で特殊 split impl を持つケースは、まずは「whole emit (現状の動作)」でフォールバックし、Phase 4 で個別対応するか別 sub-issue で扱う。
+
+#### 受け入れ条件
+
+- `crates/fulgur/tests/break_inside_avoid.rs::avoid_block_taller_than_page_falls_back_to_split` で `assert_pageable_fragmenter_parity` の skip gate が発火しなくなる (page count が一致)
+- `mid_element_split_skipped` helper が production 経路で用いられなくなる (削除可能になる)
+- 既存の examples_determinism / VRT / WPT すべて pass
+- `cargo test -p fulgur` 全 pass
+
+#### リスク
+
+- table / list / multicol の特殊な split semantics (header repeat、marker 継承) を全て fragmenter 側に再現するのは大きい
+- Phase 3.1 では汎用 block の再帰だけ対応し、特殊型は引き続き Pageable::split で扱う妥協案を取ることも可能 (ただし Phase 3.2 で paginate() を削除するなら fragmenter 側で handle 必須)
+
+### 3.2 fragmenter-driven page split (fulgur-g9e3-2)
+
+`render.rs` の `paginate(root, w, h)` 呼び出しを fragmenter geometry を使った per-page Pageable 抽出に置き換える。
+
+#### 仕様
+
+新 helper `partition_pageable_by_geometry(root, geometry) -> Vec<Box<dyn Pageable>>`:
+
+- fragmenter geometry から `implied_page_count(geometry)` で page 数を決定
+- 各 page p について root を walk し、page p に該当する fragment のみを保持した Pageable を構築
+  - subtree の深さ・wrapper 構造は保持 (counter / bookmark / string-set marker が draw 順を保つため)
+  - fragment の y は page-local coordinate に変換 (geometry の y は body 全体での累積値)
+  - page p に fragment を持たない subtree は除去 (or empty placeholder)
+- 出力は既存 `paginate()` と同じ `Vec<Box<dyn Pageable>>`
+
+`render.rs` 側の変更は minimal:
+
+```rust
+// before
+let pages = paginate(root, content_width, content_height);
+
+// after
+let pages = partition_pageable_by_geometry(root, pagination_geometry);
+```
+
+#### 受け入れ条件
+
+- `render_to_pdf` / `render_to_pdf_with_gcpm` の paginate 呼び出しが消える
+- examples_determinism (11 fixtures) byte-equal
+- VRT 33 fixtures byte-equal
+- WPT regression 数が Phase 2.6 baseline と同じ
+- `cargo test -p fulgur` 全 pass
+
+#### リスク
+
+- Pageable wrapper (CounterOpWrapper 等) が「first half にだけ marker を残す」というセマンティクスを持つ。partition で wrapper 自体を切るときも同じ semantics を再現する必要がある
+- `propagate_page_height` で `break-inside: avoid` のフォールバック判定をしている部分が `partition` 経由でどう reproduce されるか要検討 → 3.1 が完了していれば fragmenter 側ですでに判定済みなので不要
+
+### 3.3 Pageable::split / split_boxed / find_split_point 削除 (fulgur-g9e3-3)
+
+#### 仕様
+
+- `Pageable` trait から `split` / `split_boxed` メソッド削除
+- `BlockPageable::find_split_point` / `split_children_at_index` / `split_children_for_within` / `clone_pc_with_offset` を削除 (clone_pc_with_offset は draw 用に残るかは要確認)
+- 全 `impl Pageable for X` から `split` / `split_boxed` の実装を削除
+- 既存の `tests/` / `#[cfg(test)] mod tests` 内で split を直接呼んでいる test を整理:
+  - `partition_pageable_by_geometry` 経由に書き換え
+  - もしくは fragmenter の挙動をテストする形に移植
+  - test fixture が old API に強く依存しているものは削除
+
+#### 受け入れ条件
+
+- `pageable.rs` から split 関連コードが消えている
+- `cargo test -p fulgur` 全 pass
+- `cargo doc --no-deps` warnings 0
+
+#### リスク
+
+- 削除する split impl の test カバレッジを失わないよう、移植/再書きが必要 (元 test の意図を fragmenter 側に再現)
+
+### 3.4 paginate.rs 削除 (fulgur-g9e3-4)
+
+#### 仕様
+
+- `crates/fulgur/src/paginate.rs` をファイルごと削除
+- `crates/fulgur/src/lib.rs` から `pub mod paginate;` 削除
+- `paginate::collect_string_set_states` / `collect_counter_states` / `collect_running_element_states` / `StringSetPageState` の caller (parity assertion 用に残っていれば) を fragmenter 側 (`pagination_layout::collect_*_states`) 経由に統一
+- 関連 import / re-export を整理
+
+#### 受け入れ条件
+
+- `paginate.rs` が存在しない
+- `cargo build -p fulgur` 0 warning
+- `cargo test -p fulgur` 全 pass
+- examples_determinism / VRT / WPT 全 pass
+
+## サブタスク依存
+
+```text
+3.1 (mid-element split)  →  3.2 (fragmenter-driven page split)  →  3.3 (Pageable::split 削除)  →  3.4 (paginate.rs 削除)
+```
+
+3.2 は 3.1 が完了していないと examples_determinism で diff が出る (mid-element split を含む fixture がある場合)。3.3 / 3.4 は 3.2 完了後に直列で実施可能。
+
+## マージ戦略
+
+各 sub-PR は前の PR を base とした stacked PR で出す (Phase 2 と同じ流れ)。マージ順は 3.1 → 3.2 → 3.3 → 3.4。
+
+## Phase 4 との境界
+
+Phase 4 (`fulgur-9t3z`) は **Pageable type 自体の削除**。Phase 3 完了時点では:
+
+- `Pageable` trait と各 impl は残る (draw 用)
+- fragmenter geometry が page split を駆動する
+- paginate.rs / split メソッドは消えている
+
+Phase 4 は draw も fragmenter geometry 駆動に変え、Pageable trait を削除して convert を直接 PDF emission に繋げる。
+
+## 不確実性 / 要検討
+
+- mid-element split で table / list / multicol の特殊 split をどこまで再現するか — Phase 3.1 開始時に WPT / VRT fixture で実態を測ってから方針決定
+- partition helper の clone semantics — `Box<dyn Pageable>` のため shallow clone 不可。`Pageable::clone_for_page(page_index)` のような新 trait method が必要かもしれない


### PR DESCRIPTION
## 概要

Phase 3 で `paginate.rs` / `Pageable::split` が消え `pagination_layout` が正式実装になるのに合わせ、コード内の「spike」呼称を「fragmenter」に統一する。Phase 3 の 0 番目 (`fulgur-q0vb`)。

## 変更点

- 関数リネーム: `assert_pageable_spike_parity` → `assert_pageable_fragmenter_parity`、`spike_page_count[_for]` → `fragmenter_page_count[_for]`
- 変数リネーム: `spike_count` / `spike_pages` / `spike_states` / `spike_triples` → `fragmenter_*`
- assertion メッセージ: `paginate=… spike=…` → `paginate=… fragmenter=…`
- コメント / docstring の「the spike」「spike pass」等 → 「the fragmenter」「fragmenter pass」
- 設計ドキュメント `docs/plans/2026-04-29-phase3-paginate-deletion.md` を新規追加 (Phase 3 全体の設計書、fragmenter 表記で記述)

## 履歴として残した参照

- `docs/plans/2026-04-28-pagination-layout-spike.md` ファイル名 (元々の検討ドキュメント名なので固定)
- `fulgur-ik6o spike` epic ID 参照 (実験経緯の記録)

## 検証

- 882 fulgur lib tests pass
- 41 integration test binaries all pass
- cargo clippy clean
- cargo fmt clean
- examples_determinism / VRT byte-equal (lib コードのみの rename なので影響なし)

## 位置付け

Phase 3.0 として、`fulgur-962g` (Phase 3.1: mid-element split) の前提。Phase 2.6 (`#279`) を base にした stacked PR。

```text
Phase 2.6 (#279)  →  Phase 3.0 (this PR)  →  Phase 3.1 (mid-element split)  →  3.2 → 3.3 → 3.4
```

## 関連 issue

- `fulgur-q0vb` (Phase 3.0)
- `fulgur-g9e3` (Phase 3 epic)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
