### PR TITLE
ci: free disk space before heavy Rust builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,16 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: false
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -73,6 +83,17 @@ jobs:
             cache-key: windows-latest-fulgur
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Free disk space (Linux)
+        if: runner.os == 'Linux'
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: false
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -158,6 +179,16 @@ jobs:
     name: Visual Regression Tests
     runs-on: ubuntu-latest
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: false
       - uses: actions/checkout@v6
       - name: Install poppler-utils
         run: sudo apt-get update && sudo apt-get install -y poppler-utils mold
@@ -223,6 +254,16 @@ jobs:
             test: wpt_lists
             filter: wpt_list_smoke
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: false
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -271,6 +312,16 @@ jobs:
     # 検証は release-python.yml / release-ruby.yml の責務。
     runs-on: ubuntu-latest
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: false
       - uses: actions/checkout@v6
       - uses: oxidize-rb/actions/setup-ruby-and-rust@e5f9a49a7812a078584072f6e3f657ad247c8771  # v1.4.4
         with:


### PR DESCRIPTION
## 概要

GitHub-hosted Ubuntu runner のデフォルト空き容量 (~14 GB) では fulgur の 7 crate workspace のテストビルドで溢れることが分かったため (#279 / #281 で発覚)、`jlumbroso/free-disk-space` を Linux 上で cargo full build を行う全ジョブの冒頭に追加する。

## 背景

PR #279 / #281 の CI で発生した失敗:

\`\`\`text
error: couldn't create a temp dir: No space left on device (os error 28)
  at path \"/home/runner/work/fulgur/fulgur/target/debug/deps/rmetaZytJwW\"
\`\`\`

ubuntu test ジョブの 1 つが落ちるとその影響で matrix の他の OS (windows / ubuntu-arm) もキャンセルされる連鎖を起こし、CI 全体が赤になる。

## 対象ジョブ

Linux で workspace を full build するもの:

- \`lint\` (clippy + fmt)
- \`test\` (matrix — Linux のみ \`runner.os == 'Linux'\` ガード付き)
- \`vrt\` (Visual Regression Tests)
- \`wpt\` (7-phase matrix)
- \`bindings-check\` (Ruby + Rust cdylib)

スキップ: \`markdownlint\`, \`wasm-check\`, \`octocov\` (workspace を link しない)

## free-disk-space の設定

| オプション | 値 | 理由 |
|---|---|---|
| \`tool-cache\` | false | Rust toolchain がここに居る |
| \`android\` | true | 約 14 GB |
| \`dotnet\` | true | 約 2 GB |
| \`haskell\` | true | 約 5.4 GB |
| \`docker-images\` | true | 約 3 GB |
| \`large-packages\` | false | apt 操作が遅い (+2 分) 割に効果薄 |
| \`swap-storage\` | false | swap は build に使っていない |

合計: ~30 GB 確保 (実空き容量は 50-60 GB に拡大)。各ジョブのオーバーヘッド: ~30-60 秒。

## 検証

このPR自体のCI runで効果確認 (test ジョブが green になり、ディスク容量警告が消えること)。

## Action 固定

\`v1.3.1\` の commit SHA \`54081f138730dfa15788a46383842cd2f914a1be\` を使用。タグだけより安全。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved continuous integration infrastructure stability and performance through enhanced disk space management. Automated cleanup procedures now execute systematically across multiple build workflows, strategically removing unnecessary system components from build environments to maximize available disk resources. These infrastructure enhancements reduce disk-related build failures, strengthen pipeline reliability, and significantly accelerate build execution times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
