### PR TITLE
fix(pagination_layout): zero-height body-direct child honours break-before/after (fulgur-p3uf Phase 3.1.5a)

### DIFF
--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -468,6 +468,32 @@ impl<'a> PaginationLayoutTree<'a> {
                 // Whitespace-only text nodes are already filtered
                 // above; running and abs/fixed elements are filtered
                 // before this branch.
+                //
+                // fulgur-p3uf (Phase 3.1.5a): honour `break-before`
+                // / `break-after` on zero-height element nodes too.
+                // Bare `<img>` with no explicit dimensions and
+                // pseudo-only `<div>` (rendering only `::before`
+                // content) both arrive here with `child_h == 0` after
+                // Blitz's intrinsic-size collapse, and Pageable
+                // honours their `break-before: page` directive
+                // (`tests/pseudo_only_break_before.rs::bare_img_honours_break_before_page`
+                // and `pseudo_only_inline_root_honours_break_before_page`).
+                // The pre-3.1.5a fragmenter `continue`'d before
+                // reading break properties at all, so the gate
+                // `forced_break_skipped` masked the divergence.
+                let zero_break_props = self
+                    .column_styles
+                    .and_then(|t| t.get(&child_id))
+                    .copied()
+                    .unwrap_or_default();
+                if matches!(
+                    zero_break_props.break_before,
+                    Some(crate::pageable::BreakBefore::Page)
+                ) && cursor_y > 0.0
+                {
+                    page_index += 1;
+                    cursor_y = 0.0;
+                }
                 if child.element_data().is_some() {
                     self.geometry
                         .entry(child_id)
@@ -481,6 +507,13 @@ impl<'a> PaginationLayoutTree<'a> {
                             height: 0.0,
                         });
                     emitted += 1;
+                }
+                if matches!(
+                    zero_break_props.break_after,
+                    Some(crate::pageable::BreakAfter::Page)
+                ) {
+                    page_index += 1;
+                    cursor_y = 0.0;
                 }
                 continue;
             }
@@ -2424,6 +2457,37 @@ mod compare_with_pageable {
                 </style></head><body>
                     <div style="height: 100px"></div>
                     <div class="b" style="height: 100px"></div>
+                </body></html>"#,
+                true,
+            ),
+            (
+                // fulgur-p3uf (Phase 3.1.5a): zero-height body-direct
+                // child with `break-before: page` must still force a
+                // page boundary. Pre-fix the fragmenter `continue`'d
+                // before reading break props for zero-height children,
+                // skipping the directive — same root cause as
+                // `tests/pseudo_only_break_before.rs::bare_img_honours_break_before_page`
+                // / `pseudo_only_inline_root_honours_break_before_page`
+                // but without an AssetBundle, so it fits in this
+                // doc-only fixture set.
+                "zero-height body-direct child honours break-before",
+                r#"<html><head><style>
+                    .first { height: 40px; }
+                    .zero { break-before: page; }
+                </style></head><body>
+                    <div class="first"></div>
+                    <div class="zero"></div>
+                </body></html>"#,
+                true,
+            ),
+            (
+                "zero-height body-direct child honours break-after",
+                r#"<html><head><style>
+                    .first { break-after: page; }
+                    .second { height: 40px; }
+                </style></head><body>
+                    <div class="first"></div>
+                    <div class="second"></div>
                 </body></html>"#,
                 true,
             ),


### PR DESCRIPTION
## Summary

Phase 3.1.5a (`fulgur-p3uf`): `fragment_pagination_root` の zero-height \`continue\` 分岐が break-before/after を読まずに skip していたバグを修正。

## 背景

PR #283 (Phase 3.1) で skip gate を `forced_break_skipped` に rename した時点で、3 件の forced-break 系テストが gate に頼って pass している状態だった。今回はそのうち2件を解消する。

## 根本原因

`fragment_pagination_root` (\`pagination_layout.rs:456\`) の zero-height 経路は break props を読まずに \`continue\` していた。Blitz が intrinsic-size collapse を起こす:
- `<img>` (explicit width/height 無し) → 1×1 PNG natural size が 0 に collapse
- pseudo-only `<div>` (中身は `::before { content: url(...) }` のみ) → 同様に 0

これらは Pageable 側では `BlockPageable::find_split_point` (\`pageable.rs:1170\`) で break-before / break-after が honoured されるため、parity gate \`forced_break_skipped\` で \`paginate=2 fragmenter=1\` の divergence をマスクしていた。

## 主な変更

### `crates/fulgur/src/pagination_layout.rs`

zero-height 経路を以下の順で処理するよう変更:

1. column-style 側 table から break-* props を読む
2. \`break-before: page\` && \`cursor_y > 0\` (CSS leading-collapse 準拠) → page advance
3. zero-height fragment を emit (geometry parity 維持)
4. \`break-after: page\` → page advance

\`compare_with_pageable\` モジュールの \`fixtures()\` に doc-only な regression cover を2件追加:

- "zero-height body-direct child honours break-before"
- "zero-height body-direct child honours break-after"

## 動作確認

instrumented \`[DBG]\` で fragmenter page count を fix 前後で測定:

| Test | before | after |
|---|---|---|
| `bare_img_honours_break_before_page` | paginate=2 fragmenter=1 | paginate=2 fragmenter=2 ✓ |
| `pseudo_only_inline_root_honours_break_before_page` | paginate=2 fragmenter=1 | paginate=2 fragmenter=2 ✓ |
| `pseudo_only_list_item_honours_break_before_page` | paginate=2 fragmenter=1 | paginate=2 fragmenter=1 (3.1.5b 範囲) |

## スコープ外

- nested 要素の forced-break-below 再帰 (`<ul>` 配下 `<li class=\"icon\">` 等) — Phase 3.1.5b (\`fulgur-a36m\`)
- in-place mid-element split + \`forced_break_skipped\` 完全削除 — Phase 3.1.5c (\`fulgur-7hf5\`)

## Test plan

- [x] \`cargo test -p fulgur\`: 1111 pass / 0 fail
- [x] \`cargo test -p fulgur-vrt\` (byte-exact): 31 pass
- [x] \`cargo test -p fulgur-cli --test examples_determinism\` (byte-exact): 11 pass
- [x] \`cargo test -p fulgur-wpt\`: 85 pass / 0 fail
- [x] \`cargo clippy -p fulgur\`: clean
- [x] \`cargo fmt --check\`: clean

## 関連

- 親 epic: \`fulgur-z2mg\` (Pageable replacement, geometry-driven render path)
- Phase 3 epic: \`fulgur-g9e3\` (paginate.rs deletion)
- 親 task: \`fulgur-a9qf\` (Phase 3.1.5)
- 前段 PR: #283 (\`fulgur-g9e3.1\` Phase 3.1 mid-element split)
- 後段: \`fulgur-a36m\` → \`fulgur-7hf5\`

## Stacking

base = \`feat/fulgur-g9e3-1-mid-element-split\` (PR #283)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
