### PR TITLE
feat(pagination_layout): forced-break-below recursion + break-* in fragment_block_subtree (fulgur-a36m Phase 3.1.5b)

### DIFF
--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -987,31 +987,31 @@ fn fragment_block_subtree(
             Some(crate::pageable::BreakAfter::Page)
         );
 
-        // Honour `break-before: page`. Leading collapse: only fires
-        // when some content has already been placed on this page —
-        // gated by `cursor_y > page_start_y` (mirrors body-level's
-        // `cursor_y > 0.0` since body's implicit page_start is 0).
-        if break_before_page && cursor_y > page_start_y {
-            geometry
-                .entry(parent_id)
-                .or_default()
-                .fragments
-                .push(Fragment {
-                    page_index,
-                    x: parent_x_in_body,
-                    y: page_start_y,
-                    width: parent_w,
-                    height: cursor_y - page_start_y,
-                });
-            page_index += 1;
-            cursor_y = 0.0;
-            page_start_y = 0.0;
-        }
-
         if child_h <= 0.0 {
             // Phase 2.3 fix: zero-height **element** nodes still
             // need to enter geometry so their counter / string-set
             // / bookmark markers participate in the parity walks.
+            //
+            // Zero-height children skip the inter-child gap (matching
+            // `fragment_pagination_root`'s zero-height branch where
+            // `continue` happens before the gap calc), so break-before
+            // can fire here without first folding gap into cursor_y.
+            if break_before_page && cursor_y > page_start_y {
+                geometry
+                    .entry(parent_id)
+                    .or_default()
+                    .fragments
+                    .push(Fragment {
+                        page_index,
+                        x: parent_x_in_body,
+                        y: page_start_y,
+                        width: parent_w,
+                        height: cursor_y - page_start_y,
+                    });
+                page_index += 1;
+                cursor_y = 0.0;
+                page_start_y = 0.0;
+            }
             if child.element_data().is_some() {
                 geometry
                     .entry(child_id)
@@ -1049,9 +1049,35 @@ fn fragment_block_subtree(
 
         // Inter-child gap (collapsed margins, padding) in parent
         // coordinates — same convention as `fragment_pagination_root`.
+        // The gap MUST be folded into `cursor_y` before the break-before
+        // check so a forced break properly discards the gap (cursor_y
+        // is reset to 0 on the new page). Doing break-before first
+        // would re-apply the gap on the new page, placing the child at
+        // y=gap instead of y=0 (Devin Review on PR #285).
         let this_top_in_parent = layout.location.y;
         let gap = (this_top_in_parent - prev_bottom_in_parent).max(0.0);
         cursor_y += gap;
+
+        // Honour `break-before: page`. Leading collapse: only fires
+        // when some content has already been placed on this page —
+        // gated by `cursor_y > page_start_y` (mirrors body-level's
+        // `cursor_y > 0.0` since body's implicit page_start is 0).
+        if break_before_page && cursor_y > page_start_y {
+            geometry
+                .entry(parent_id)
+                .or_default()
+                .fragments
+                .push(Fragment {
+                    page_index,
+                    x: parent_x_in_body,
+                    y: page_start_y,
+                    width: parent_w,
+                    height: cursor_y - page_start_y,
+                });
+            page_index += 1;
+            cursor_y = 0.0;
+            page_start_y = 0.0;
+        }
 
         // Child does not fit in the remaining strip → cut a page.
         if cursor_y > page_start_y && cursor_y + child_h > page_height_px {
@@ -2246,6 +2272,58 @@ mod tests {
         for (id, direct) in &direct_geom {
             let taffy = taffy_geom.get(id).expect("same node id in both passes");
             assert_eq!(direct.fragments, taffy.fragments, "node {id}");
+        }
+    }
+
+    /// Devin Review on PR #285 (fulgur-a36m Phase 3.1.5b):
+    /// `fragment_block_subtree` had `break-before: page` firing BEFORE
+    /// the inter-child gap was folded into `cursor_y`, so the gap was
+    /// re-applied AFTER the break-before reset — placing the child at
+    /// `y=gap` on the new page instead of `y=0`. The body-level
+    /// `fragment_pagination_root` had the correct ordering. This test
+    /// pins B's y-coordinate on the new page and would catch the
+    /// pre-fix value (gap≈20, was 26.6 in CSS px after Stylo's pt→px).
+    ///
+    /// Setup: outer wrapper triggers recursion via
+    /// `has_forced_break_below`. Inside, A (h=100) at y=0 and B
+    /// (h=100) at y=120 with `break-before: page`. The `margin-top:
+    /// 20px` on B creates a 20px gap that the bug would leak through.
+    #[test]
+    fn fragment_block_subtree_break_before_after_gap_places_child_at_y_zero() {
+        let html = r#"
+            <html><body style="margin: 0; padding: 0">
+              <div id="outer" style="margin: 0; padding: 0">
+                <div id="a" style="height: 100px; margin: 0"></div>
+                <div id="b" style="margin-top: 20px; break-before: page; height: 100px"></div>
+              </div>
+            </body></html>
+        "#;
+        let mut doc = parse(html, 600.0);
+        let table = blitz_adapter::extract_column_style_table(&doc);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 800.0, &table);
+
+        // Find every fragment with height ≈ 100 on page 1; B is the
+        // only such fragment (outer's page-1 fragment height is the
+        // total parent strip, which equals 100 after the fix because
+        // only B sits on page 1; outer's page-0 fragment carries
+        // A + gap = 120; A is on page 0).
+        let b_on_page1: Vec<&Fragment> = geom
+            .values()
+            .flat_map(|g| g.fragments.iter())
+            .filter(|f| f.page_index == 1 && (f.height - 100.0).abs() < 0.5)
+            .collect();
+        assert!(
+            !b_on_page1.is_empty(),
+            "expected B fragment on page 1, geom={geom:?}"
+        );
+        for f in &b_on_page1 {
+            assert!(
+                f.y.abs() < 0.5,
+                "B should land at y=0 on the new page (forced break discards \
+                 the inter-child gap), but got y={} (gap leaked through \
+                 break-before — see Devin Review on PR #285). frag={f:?}",
+                f.y,
+            );
         }
     }
 

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -647,37 +647,48 @@ impl<'a> PaginationLayoutTree<'a> {
             // to splitting too (matches Pageable's
             // `total_height > page_height` override at
             // `pageable.rs:1165`).
-            if child_h > self.page_height_px {
-                let has_splittable_children = self
-                    .doc
-                    .get_node(child_id)
-                    .is_some_and(|n| !n.children.is_empty());
-                if has_splittable_children {
-                    let child_x_in_body = body_x + layout.location.x;
-                    let (new_page, new_cursor) = fragment_block_subtree(
-                        &mut self.geometry,
-                        self.doc,
-                        child_id,
-                        child_w,
-                        child_x_in_body,
-                        page_index,
-                        cursor_y,
-                        self.page_height_px,
-                        0,
-                    );
-                    page_index = new_page;
-                    cursor_y = new_cursor;
-                    emitted += 1;
-                    prev_bottom_y_in_body = this_top_in_body + child_h;
-                    if matches!(
-                        break_props.break_after,
-                        Some(crate::pageable::BreakAfter::Page)
-                    ) {
-                        page_index += 1;
-                        cursor_y = 0.0;
-                    }
-                    continue;
+            // fulgur-a36m (Phase 3.1.5b): also recurse when the
+            // body-direct child fits the strip but its DOM subtree
+            // declares a forced break (e.g. body has `<ul>` whose
+            // `<li class="icon">` carries `break-before: page`).
+            // Without recursion, the nested break would be emitted
+            // inside the body child's whole fragment with no page
+            // boundary, mismatching Pageable's
+            // `BlockPageable::find_split_point` `has_forced_break_below`
+            // path (`pageable.rs:1196-1203`).
+            let has_splittable_children = self
+                .doc
+                .get_node(child_id)
+                .is_some_and(|n| !n.children.is_empty());
+            let needs_recursion = has_splittable_children
+                && (child_h > self.page_height_px
+                    || has_forced_break_below(self.doc, child_id, self.column_styles, 0));
+            if needs_recursion {
+                let child_x_in_body = body_x + layout.location.x;
+                let (new_page, new_cursor) = fragment_block_subtree(
+                    &mut self.geometry,
+                    self.doc,
+                    self.column_styles,
+                    child_id,
+                    child_w,
+                    child_x_in_body,
+                    page_index,
+                    cursor_y,
+                    self.page_height_px,
+                    0,
+                );
+                page_index = new_page;
+                cursor_y = new_cursor;
+                emitted += 1;
+                prev_bottom_y_in_body = this_top_in_body + child_h;
+                if matches!(
+                    break_props.break_after,
+                    Some(crate::pageable::BreakAfter::Page)
+                ) {
+                    page_index += 1;
+                    cursor_y = 0.0;
                 }
+                continue;
             }
 
             let frag = Fragment {
@@ -813,6 +824,43 @@ fn record_subtree_descendants(
     }
 }
 
+/// fulgur-a36m (Phase 3.1.5b): true if any descendant of `node_id`
+/// declares `break-before: page` or `break-after: page` in
+/// `column_styles`. Walks the entire DOM subtree, bails at
+/// [`crate::MAX_DOM_DEPTH`].
+///
+/// Mirrors `BlockPageable::has_forced_break_below()` from `pageable.rs`,
+/// but works on Blitz nodes via the column-style side-table rather
+/// than the converted Pageable tree. Used by `fragment_pagination_root`
+/// and `fragment_block_subtree` to decide whether a body-direct (or
+/// nested) child needs to be entered for break recursion even when it
+/// fits the current page strip whole.
+fn has_forced_break_below(
+    doc: &BaseDocument,
+    node_id: usize,
+    column_styles: Option<&crate::column_css::ColumnStyleTable>,
+    depth: usize,
+) -> bool {
+    if depth >= crate::MAX_DOM_DEPTH {
+        return false;
+    }
+    let Some(node) = doc.get_node(node_id) else {
+        return false;
+    };
+    for &child_id in &node.children {
+        if let Some(props) = column_styles.and_then(|t| t.get(&child_id))
+            && (matches!(props.break_before, Some(crate::pageable::BreakBefore::Page))
+                || matches!(props.break_after, Some(crate::pageable::BreakAfter::Page)))
+        {
+            return true;
+        }
+        if has_forced_break_below(doc, child_id, column_styles, depth + 1) {
+            return true;
+        }
+    }
+    false
+}
+
 /// fulgur-g9e3.1: split a block element across pages by walking its DOM
 /// children and emitting per-page fragments for both the block itself
 /// and its children.
@@ -832,13 +880,15 @@ fn record_subtree_descendants(
 /// counter / string-set / bookmark ops attached to elements that fit
 /// on a single page span within the parent.
 ///
-/// Forced breaks (`break-before` / `break-after` / nested
-/// `has_forced_break_below`) are intentionally **not** handled here —
-/// that's `fulgur-a9qf` (Phase 3.1.5). Children flagged with break-*
-/// fall through the same overflow check the rest of the children take
-/// and may land slightly differently from Pageable in those cases; the
-/// `forced_break_skipped` gate in `render.rs` keeps parity assertions
-/// quiet on those tests until 3.1.5 lands.
+/// fulgur-a36m (Phase 3.1.5b): also honours `break-before: page` /
+/// `break-after: page` on direct children, and recurses into children
+/// whose subtrees declare a forced break (`has_forced_break_below`)
+/// so deeper nested breaks land on the right page.
+///
+/// In-place mid-element split (`cursor_y + child_h > page_h` with
+/// `child_h <= page_h` and a CSS-set parent height that diverges from
+/// children sum) still falls back to the pre-3.1 push-to-next-page
+/// behaviour — that's `fulgur-7hf5` (Phase 3.1.5c).
 ///
 /// Skips OOF / running / whitespace-text children, same convention as
 /// `fragment_pagination_root`. Bails at [`crate::MAX_DOM_DEPTH`] —
@@ -852,6 +902,7 @@ fn record_subtree_descendants(
 fn fragment_block_subtree(
     geometry: &mut PaginationGeometryTable,
     doc: &BaseDocument,
+    column_styles: Option<&crate::column_css::ColumnStyleTable>,
     parent_id: usize,
     parent_w: f32,
     parent_x_in_body: f32,
@@ -920,6 +971,43 @@ fn fragment_block_subtree(
         } else {
             parent_w
         };
+
+        // fulgur-a36m: read break-* props for this child once. Both
+        // the zero-height and non-zero paths honour them.
+        let break_props = column_styles
+            .and_then(|t| t.get(&child_id))
+            .copied()
+            .unwrap_or_default();
+        let break_before_page = matches!(
+            break_props.break_before,
+            Some(crate::pageable::BreakBefore::Page)
+        );
+        let break_after_page = matches!(
+            break_props.break_after,
+            Some(crate::pageable::BreakAfter::Page)
+        );
+
+        // Honour `break-before: page`. Leading collapse: only fires
+        // when some content has already been placed on this page —
+        // gated by `cursor_y > page_start_y` (mirrors body-level's
+        // `cursor_y > 0.0` since body's implicit page_start is 0).
+        if break_before_page && cursor_y > page_start_y {
+            geometry
+                .entry(parent_id)
+                .or_default()
+                .fragments
+                .push(Fragment {
+                    page_index,
+                    x: parent_x_in_body,
+                    y: page_start_y,
+                    width: parent_w,
+                    height: cursor_y - page_start_y,
+                });
+            page_index += 1;
+            cursor_y = 0.0;
+            page_start_y = 0.0;
+        }
+
         if child_h <= 0.0 {
             // Phase 2.3 fix: zero-height **element** nodes still
             // need to enter geometry so their counter / string-set
@@ -936,6 +1024,25 @@ fn fragment_block_subtree(
                         width: child_w,
                         height: 0.0,
                     });
+            }
+            // Honour `break-after: page` for zero-height elements
+            // too — same fulgur-p3uf (Phase 3.1.5a) fix as
+            // `fragment_pagination_root`'s zero-height branch.
+            if break_after_page {
+                geometry
+                    .entry(parent_id)
+                    .or_default()
+                    .fragments
+                    .push(Fragment {
+                        page_index,
+                        x: parent_x_in_body,
+                        y: page_start_y,
+                        width: parent_w,
+                        height: cursor_y - page_start_y,
+                    });
+                page_index += 1;
+                cursor_y = 0.0;
+                page_start_y = 0.0;
             }
             continue;
         }
@@ -968,43 +1075,64 @@ fn fragment_block_subtree(
 
         let child_x_in_body = parent_x_in_body + layout.location.x;
 
-        // Child is itself oversized → recurse to split among its
-        // grandchildren (same overflow→split rule we used to enter
-        // this function).
-        if child_h > page_height_px {
-            let has_splittable_children = !child.children.is_empty();
-            if has_splittable_children {
-                let (np, nc) = fragment_block_subtree(
-                    geometry,
-                    doc,
-                    child_id,
-                    child_w,
-                    child_x_in_body,
-                    page_index,
-                    cursor_y,
-                    page_height_px,
-                    depth + 1,
-                );
-                page_index = np;
-                cursor_y = nc;
-                // The recursion may have moved us off `page_start_y`'s
-                // page; restart the parent fragment on whatever page
-                // we're on now.
-                if page_index != page_in || nc < page_start_y {
-                    page_start_y = 0.0;
-                }
-                prev_bottom_in_parent = this_top_in_parent + child_h;
-                continue;
+        // Child needs recursion when:
+        //   - itself oversized (Phase 3.1, mirrors
+        //     `find_split_point`'s overflow→split path), OR
+        //   - subtree contains a forced break (Phase 3.1.5b,
+        //     mirrors `find_split_point`'s `has_forced_break_below`
+        //     check at `pageable.rs:1196-1203`).
+        let needs_recursion = !child.children.is_empty()
+            && (child_h > page_height_px
+                || has_forced_break_below(doc, child_id, column_styles, 0));
+        if needs_recursion {
+            let pre_recursion_page = page_index;
+            let (np, nc) = fragment_block_subtree(
+                geometry,
+                doc,
+                column_styles,
+                child_id,
+                child_w,
+                child_x_in_body,
+                page_index,
+                cursor_y,
+                page_height_px,
+                depth + 1,
+            );
+            page_index = np;
+            cursor_y = nc;
+            // If the recursion crossed a boundary, the parent's
+            // current-page fragment must restart at y=0 on the new
+            // page. Defensive `nc < page_start_y` guards against
+            // backward cursor returns (impossible in normal flow).
+            if page_index != pre_recursion_page || nc < page_start_y {
+                page_start_y = 0.0;
             }
-            // Atomic oversized leaf — fall through to whole-emit; it
-            // will simply spill below the page strip on its starting
-            // page. Pageable's same-shaped fallback at
-            // `pageable.rs:1252` (`in_flow_count == 1` → NoSplit) lands
-            // here too.
+            prev_bottom_in_parent = this_top_in_parent + child_h;
+            // Honour `break-after: page` after recursion.
+            if break_after_page {
+                geometry
+                    .entry(parent_id)
+                    .or_default()
+                    .fragments
+                    .push(Fragment {
+                        page_index,
+                        x: parent_x_in_body,
+                        y: page_start_y,
+                        width: parent_w,
+                        height: cursor_y - page_start_y,
+                    });
+                page_index += 1;
+                cursor_y = 0.0;
+                page_start_y = 0.0;
+            }
+            continue;
         }
 
-        // Child fits (or is atomic-oversized-fallback). Emit its
-        // fragment and recurse into its descendants on the same page.
+        // Child fits the strip (or is an atomic oversized leaf that
+        // simply overflows below the page bottom — Pageable's same
+        // fallback at `pageable.rs:1252`, `in_flow_count == 1 →
+        // NoSplit`). Emit its fragment and recurse into descendants
+        // on the same page.
         geometry
             .entry(child_id)
             .or_default()
@@ -1027,6 +1155,25 @@ fn fragment_block_subtree(
         );
         cursor_y += child_h;
         prev_bottom_in_parent = this_top_in_parent + child_h;
+
+        // Honour `break-after: page` after the child fragment lands
+        // (and the descendant walk records same-page entries).
+        if break_after_page {
+            geometry
+                .entry(parent_id)
+                .or_default()
+                .fragments
+                .push(Fragment {
+                    page_index,
+                    x: parent_x_in_body,
+                    y: page_start_y,
+                    width: parent_w,
+                    height: cursor_y - page_start_y,
+                });
+            page_index += 1;
+            cursor_y = 0.0;
+            page_start_y = 0.0;
+        }
     }
 
     // Close the parent's fragment for the final page span. Always


### PR DESCRIPTION
## Summary

Phase 3.1.5b (\`fulgur-a36m\`): nested forced break (例: `<ul>` body-direct child の `<li class="icon">` に `break-before: page`) を fragmenter 側でも検出するように。

## 背景

Pageable の \`BlockPageable::find_split_point\` (\`pageable.rs:1196-1203\`) は \`has_forced_break_below()\` で子孫の forced break を検出して split に降りる。fragmenter は body-direct child しか走査していなかったため、深い階層の break-before/after が無視されていた。

該当する failing test:
- \`tests/pseudo_only_break_before.rs::pseudo_only_list_item_honours_break_before_page\`

paginate=2 fragmenter=1 で \`forced_break_skipped\` gate でマスクされていた。

## 主な変更 (`crates/fulgur/src/pagination_layout.rs`)

1. **新ヘルパ \`has_forced_break_below(doc, node_id, column_styles, depth)\`**: DOM subtree を再帰 walk し、いずれかの descendant が `break-before: page` / `break-after: page` を持つか調べる。Pageable の \`BlockPageable::has_forced_break_below()\` を Blitz nodes + column-style side-table で再実装。`MAX_DOM_DEPTH` で bail。
2. **\`fragment_block_subtree\` 拡張**: \`column_styles\` パラメータ追加、各直接 child の `break-before` / `break-after` を honour (zero-height / non-zero 両経路)、再帰条件に nested forced break を追加。`cursor > page_start_y` ガードで CSS leading-collapse を mirror。
3. **\`fragment_pagination_root\` body-direct loop**: forced-break-below 検出 gate を追加、Phase 3.1 の truly-oversized gate と統合。

## 動作確認

\`tests/pseudo_only_break_before.rs\` 全4 test の paginate vs fragmenter (instrumented):

| Test | before | after |
|---|---|---|
| `bare_img_*` (Phase 3.1.5a で fix 済) | 2 / 2 | 2 / 2 |
| `pseudo_only_inline_root_*` (Phase 3.1.5a で fix 済) | 2 / 2 | 2 / 2 |
| `pseudo_only_list_item_*` (本 PR スコープ) | **2 / 1** | **2 / 2** ✓ |
| `empty_leaf_div_*` (元々 pass) | 2 / 2 | 2 / 2 |

## 残スコープ (3.1.5c / `fulgur-7hf5`)

- in-place mid-element split (`cursor + child_h > page_h` で `child_h <= page_h`)
- \`forced_break_skipped\` helper の完全削除
- \`pageable_count > fragmenter_count\` 早期 return の削除

## Test plan

- [x] \`cargo test -p fulgur\`: 1111 pass / 0 fail
- [x] \`cargo test -p fulgur-vrt\` (byte-exact): 31 pass
- [x] \`cargo test -p fulgur-cli --test examples_determinism\` (byte-exact): 11 pass
- [x] \`cargo test -p fulgur-wpt\`: 85 pass / 0 fail
- [x] \`cargo clippy -p fulgur\`: clean
- [x] \`cargo fmt --check\`: clean

## 関連

- 親 epic: \`fulgur-z2mg\` (Pageable replacement)
- Phase 3 epic: \`fulgur-g9e3\` (paginate.rs deletion)
- 親 task: \`fulgur-a9qf\` (Phase 3.1.5)
- 前段 PR: #283 (Phase 3.1) / #284 (Phase 3.1.5a) — both merged into \`feat/pageable-replacement\`
- 後段: \`fulgur-7hf5\` (Phase 3.1.5c)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
