### PR TITLE
feat(pageable): partition helper core + slice_for_page for plain types (fulgur-r6we Phase 3.2.a)

### DIFF
--- a/crates/fulgur/src/image.rs
+++ b/crates/fulgur/src/image.rs
@@ -74,6 +74,9 @@ pub struct ImagePageable {
     pub height: f32,
     pub opacity: f32,
     pub visible: bool,
+    /// fulgur-r6we (Phase 3.2.a): DOM NodeId for `slice_for_page`
+    /// geometry lookup. See `BlockPageable::node_id`.
+    pub node_id: Option<usize>,
 }
 
 impl ImagePageable {
@@ -85,7 +88,13 @@ impl ImagePageable {
             height,
             opacity: 1.0,
             visible: true,
+            node_id: None,
         }
+    }
+
+    pub fn with_node_id(mut self, node_id: Option<usize>) -> Self {
+        self.node_id = node_id;
+        self
     }
 
     /// Decode image dimensions (width, height) from header bytes.
@@ -220,6 +229,28 @@ impl Pageable for ImagePageable {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn node_id(&self) -> Option<usize> {
+        self.node_id
+    }
+
+    fn slice_for_page(
+        &self,
+        page_index: u32,
+        geometry: &crate::pagination_layout::PaginationGeometryTable,
+    ) -> Option<Box<dyn Pageable>> {
+        let node_id = self.node_id?;
+        let frag = crate::pageable::fragment_on_page(geometry, node_id, page_index)?;
+        Some(Box::new(ImagePageable {
+            image_data: Arc::clone(&self.image_data),
+            format: self.format,
+            width: frag.width,
+            height: frag.height,
+            opacity: self.opacity,
+            visible: self.visible,
+            node_id: self.node_id,
+        }))
     }
 }
 

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -596,6 +596,68 @@ pub trait Pageable: Send + Sync {
     fn has_forced_break_below(&self) -> bool {
         false
     }
+
+    /// fulgur-r6we (Phase 3.2.a): the DOM `usize` NodeId this
+    /// Pageable represents, if any. Used by `slice_for_page` to look
+    /// up the matching `Fragment` in `PaginationGeometryTable` (which
+    /// is keyed by NodeId). Wrappers delegate to their inner
+    /// Pageable's `node_id` (markers do not have their own NodeId —
+    /// they piggyback on the host element's geometry entry).
+    ///
+    /// Default `None` for impls that have no DOM correspondence
+    /// (synthetic Pageables built by tests, etc.). Plain types
+    /// (`BlockPageable`, `ParagraphPageable`, `SpacerPageable`,
+    /// `ImagePageable`) override to return their stored `node_id`.
+    fn node_id(&self) -> Option<usize> {
+        None
+    }
+
+    /// fulgur-r6we (Phase 3.2.a): extract the slice of `self` that
+    /// falls on `page_index` according to `geometry`. Returns `None`
+    /// when no fragment of `self` (or its descendants) is on that
+    /// page.
+    ///
+    /// `geometry.y` is page-local in fragmenter output (see
+    /// `fragment_pagination_root` and `fragment_block_subtree` —
+    /// `cursor_y` resets at each page break, and
+    /// `record_subtree_descendants` propagates that page-local cursor
+    /// through the subtree). Implementations therefore read
+    /// `fragment.y` directly without a body→page rebase.
+    ///
+    /// Default: `unimplemented!()` — every concrete impl that
+    /// participates in `partition_pageable_by_geometry` must override.
+    /// Phase 3.2.a covers the plain types (`BlockPageable`,
+    /// `ParagraphPageable`, `SpacerPageable`, `ImagePageable`); Phase
+    /// 3.2.b covers wrappers and special split impls.
+    fn slice_for_page(
+        &self,
+        _page_index: u32,
+        _geometry: &crate::pagination_layout::PaginationGeometryTable,
+    ) -> Option<Box<dyn Pageable>> {
+        unimplemented!(
+            "slice_for_page not implemented for {} — Phase 3.2.b will fill this in",
+            std::any::type_name::<Self>(),
+        )
+    }
+}
+
+/// fulgur-r6we (Phase 3.2.a): helper for `slice_for_page` impls. Look
+/// up the fragment of `node_id` on `page_index`, returning `None`
+/// when the node is absent from geometry or has no fragment on that
+/// page. Geometry can record multiple fragments for one node when the
+/// node spans pages — we pick the first match (mid-element split is
+/// not yet exposed via `slice_for_page`; that's part of Phase 3.2.b /
+/// 3.2.c).
+pub(crate) fn fragment_on_page(
+    geometry: &crate::pagination_layout::PaginationGeometryTable,
+    node_id: usize,
+    page_index: u32,
+) -> Option<&crate::pagination_layout::Fragment> {
+    geometry
+        .get(&node_id)?
+        .fragments
+        .iter()
+        .find(|f| f.page_index == page_index)
 }
 
 impl Clone for Box<dyn Pageable> {
@@ -1053,6 +1115,14 @@ pub struct BlockPageable {
     /// for internal `href="#..."` links. `Arc<String>` so split fragments
     /// can share without cloning the string.
     pub id: Option<Arc<String>>,
+    /// fulgur-r6we (Phase 3.2.a): DOM `usize` NodeId. Lets
+    /// `slice_for_page` look up the matching `Fragment` in
+    /// `PaginationGeometryTable`, which is keyed by NodeId. Default
+    /// `None` for legacy / test-only constructions; convert.rs sets it
+    /// for production-built BlockPageables. Split fragments share the
+    /// originating node's id (both halves represent the same DOM
+    /// element on different pages).
+    pub node_id: Option<usize>,
     /// Last `avail_height` received by `wrap()`. `find_split_point` uses this
     /// to detect "content taller than any possible page" and fall back to a
     /// normal split rather than honour `break-inside: avoid` to the point of
@@ -1087,6 +1157,7 @@ impl BlockPageable {
             opacity: 1.0,
             visible: true,
             id: None,
+            node_id: None,
             page_height: 0.0,
         }
     }
@@ -1101,6 +1172,7 @@ impl BlockPageable {
             opacity: 1.0,
             visible: true,
             id: None,
+            node_id: None,
             page_height: 0.0,
         }
     }
@@ -1127,6 +1199,15 @@ impl BlockPageable {
 
     pub fn with_id(mut self, id: Option<Arc<String>>) -> Self {
         self.id = id;
+        self
+    }
+
+    /// fulgur-r6we (Phase 3.2.a): set the DOM NodeId. Used by
+    /// `slice_for_page` to look up the block's `Fragment` in
+    /// `PaginationGeometryTable`. Plumbed from `convert::convert_node`
+    /// — see `crates/fulgur/src/convert/`.
+    pub fn with_node_id(mut self, node_id: Option<usize>) -> Self {
+        self.node_id = node_id;
         self
     }
 
@@ -2092,7 +2173,8 @@ impl Pageable for BlockPageable {
                     .with_style(self.style.clone())
                     .with_opacity(self.opacity)
                     .with_visible(self.visible)
-                    .with_id(self.id.clone());
+                    .with_id(self.id.clone())
+                    .with_node_id(self.node_id);
                 first_block.cached_size = Some(Size {
                     width: total_width,
                     height: first_height,
@@ -2103,7 +2185,8 @@ impl Pageable for BlockPageable {
                     .with_style(self.style.clone())
                     .with_opacity(self.opacity)
                     .with_visible(self.visible)
-                    .with_id(self.id.clone());
+                    .with_id(self.id.clone())
+                    .with_node_id(self.node_id);
                 second_block.cached_size = Some(Size {
                     width: total_width,
                     height: (total_height - first_height).max(0.0),
@@ -2136,7 +2219,8 @@ impl Pageable for BlockPageable {
                     .with_style(self.style.clone())
                     .with_opacity(self.opacity)
                     .with_visible(self.visible)
-                    .with_id(self.id.clone());
+                    .with_id(self.id.clone())
+                    .with_node_id(self.node_id);
                 first_block.cached_size = Some(Size {
                     width: total_width,
                     height: split_y,
@@ -2147,7 +2231,8 @@ impl Pageable for BlockPageable {
                     .with_style(self.style.clone())
                     .with_opacity(self.opacity)
                     .with_visible(self.visible)
-                    .with_id(self.id.clone());
+                    .with_id(self.id.clone())
+                    .with_node_id(self.node_id);
                 second_block.cached_size = Some(Size {
                     width: total_width,
                     height: (total_height - split_y).max(0.0),
@@ -2210,7 +2295,8 @@ impl Pageable for BlockPageable {
                     .with_style(me.style.clone())
                     .with_opacity(me.opacity)
                     .with_visible(me.visible)
-                    .with_id(me.id.clone());
+                    .with_id(me.id.clone())
+                    .with_node_id(me.node_id);
                 first_block.cached_size = Some(Size {
                     width: total_width,
                     height: first_height,
@@ -2221,7 +2307,8 @@ impl Pageable for BlockPageable {
                     .with_style(me.style)
                     .with_opacity(me.opacity)
                     .with_visible(me.visible)
-                    .with_id(me.id);
+                    .with_id(me.id)
+                    .with_node_id(me.node_id);
                 second_block.cached_size = Some(Size {
                     width: total_width,
                     height: (total_height - first_height).max(0.0),
@@ -2259,7 +2346,8 @@ impl Pageable for BlockPageable {
                     .with_style(me.style.clone())
                     .with_opacity(me.opacity)
                     .with_visible(me.visible)
-                    .with_id(me.id.clone());
+                    .with_id(me.id.clone())
+                    .with_node_id(me.node_id);
                 first_block.cached_size = Some(Size {
                     width: total_width,
                     height: split_y,
@@ -2270,7 +2358,8 @@ impl Pageable for BlockPageable {
                     .with_style(me.style)
                     .with_opacity(me.opacity)
                     .with_visible(me.visible)
-                    .with_id(me.id);
+                    .with_id(me.id)
+                    .with_node_id(me.node_id);
                 second_block.cached_size = Some(Size {
                     width: total_width,
                     height: (total_height - split_y).max(0.0),
@@ -2402,6 +2491,73 @@ impl Pageable for BlockPageable {
                 || pc.child.has_forced_break_below()
         })
     }
+
+    fn node_id(&self) -> Option<usize> {
+        self.node_id
+    }
+
+    fn slice_for_page(
+        &self,
+        page_index: u32,
+        geometry: &crate::pagination_layout::PaginationGeometryTable,
+    ) -> Option<Box<dyn Pageable>> {
+        // No NodeId → no geometry lookup possible. Synthetic Pageables
+        // built by tests fall in this branch; production-built blocks
+        // always have node_id set by `convert::*`.
+        let node_id = self.node_id?;
+        let self_frag = fragment_on_page(geometry, node_id, page_index)?;
+        let self_page_y = self_frag.y;
+        let frag_w = self_frag.width;
+        let frag_h = self_frag.height;
+
+        // Recursively slice each child. `child.fragment.y - self.fragment.y`
+        // gives the child's parent-relative y on this page, which equals the
+        // original `pc.y` when the child stays on the same page as the parent
+        // (Taffy's `layout.location.y` is parent-relative, and
+        // `record_subtree_descendants` propagates `parent_page_y +
+        // layout.location.y`). On a forced break, `cursor_y` resets and the
+        // gap is discarded — so the rebased y differs from `pc.y` and is the
+        // value we want.
+        let mut sliced_children: Vec<PositionedChild> = Vec::with_capacity(self.children.len());
+        for pc in &self.children {
+            let Some(sliced) = pc.child.slice_for_page(page_index, geometry) else {
+                continue;
+            };
+            let new_y = match pc.child.node_id() {
+                Some(child_node_id) => {
+                    match fragment_on_page(geometry, child_node_id, page_index) {
+                        Some(child_frag) => child_frag.y - self_page_y,
+                        None => pc.y,
+                    }
+                }
+                None => pc.y,
+            };
+            sliced_children.push(PositionedChild {
+                child: sliced,
+                x: pc.x,
+                y: new_y,
+                out_of_flow: pc.out_of_flow,
+                is_fixed: pc.is_fixed,
+            });
+        }
+
+        let mut block = BlockPageable::with_positioned_children(sliced_children)
+            .with_pagination(self.pagination)
+            .with_style(self.style.clone())
+            .with_opacity(self.opacity)
+            .with_visible(self.visible)
+            .with_id(self.id.clone())
+            .with_node_id(self.node_id);
+        block.cached_size = Some(Size {
+            width: frag_w,
+            height: frag_h,
+        });
+        block.layout_size = Some(Size {
+            width: frag_w,
+            height: frag_h,
+        });
+        Some(Box::new(block))
+    }
 }
 
 // ─── SpacerPageable ──────────────────────────────────────
@@ -2410,11 +2566,22 @@ impl Pageable for BlockPageable {
 #[derive(Clone)]
 pub struct SpacerPageable {
     pub height: Pt,
+    /// fulgur-r6we (Phase 3.2.a): DOM NodeId for `slice_for_page`
+    /// geometry lookup. See `BlockPageable::node_id`.
+    pub node_id: Option<usize>,
 }
 
 impl SpacerPageable {
     pub fn new(height: Pt) -> Self {
-        Self { height }
+        Self {
+            height,
+            node_id: None,
+        }
+    }
+
+    pub fn with_node_id(mut self, node_id: Option<usize>) -> Self {
+        self.node_id = node_id;
+        self
     }
 }
 
@@ -2448,6 +2615,27 @@ impl Pageable for SpacerPageable {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn node_id(&self) -> Option<usize> {
+        self.node_id
+    }
+
+    fn slice_for_page(
+        &self,
+        page_index: u32,
+        geometry: &crate::pagination_layout::PaginationGeometryTable,
+    ) -> Option<Box<dyn Pageable>> {
+        let node_id = self.node_id?;
+        let frag = fragment_on_page(geometry, node_id, page_index)?;
+        // Spacer adopts the fragment's height — when fragmenter spans
+        // a Spacer across pages it would split the height, but the
+        // current fragmenter emits a single fragment per Spacer (no
+        // mid-element split for atomic Pageables).
+        Some(Box::new(SpacerPageable {
+            height: frag.height,
+            node_id: self.node_id,
+        }))
     }
 }
 

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -1860,6 +1860,49 @@ pub fn implied_page_count(geometry: &PaginationGeometryTable) -> u32 {
         .unwrap_or(1)
 }
 
+/// fulgur-r6we (Phase 3.2.a): build the per-page Pageable list from a
+/// root Pageable + fragmenter geometry. Phase 3.2 replaces
+/// [`crate::paginate::paginate`]'s split-driven page decomposition
+/// with this geometry-driven pass: the fragmenter has already decided
+/// where the page breaks fall, this helper just slices the Pageable
+/// tree to match.
+///
+/// Returns one `Box<dyn Pageable>` per page (`implied_page_count(geometry)`
+/// total). Pages whose subtree slice is empty (every node returned
+/// `None` from `slice_for_page`) get an empty `BlockPageable` placeholder
+/// so page count is preserved — this matches `paginate()`'s output for
+/// rendered pages with no in-flow content.
+///
+/// Phase 3.2.a only supports plain Pageable types (`BlockPageable` /
+/// `ParagraphPageable` / `SpacerPageable` / `ImagePageable`). Wrapper
+/// types (`CounterOpWrapperPageable`, `BookmarkMarkerWrapperPageable`,
+/// etc.) and special-split impls (`TablePageable`, `ListItemPageable`)
+/// will reach `unimplemented!()` in their `slice_for_page` until Phase
+/// 3.2.b implements them.
+///
+/// `#[allow(dead_code)]` is temporary: this function's only callers in
+/// PR 1 are unit tests under `mod tests`. Phase 3.2.c (`fulgur-4ltp`)
+/// wires it into `render.rs::render_to_pdf` / `render_to_pdf_with_gcpm`
+/// in place of `paginate()`, at which point the attribute is removed.
+#[allow(dead_code)]
+pub fn partition_pageable_by_geometry(
+    root: &dyn crate::pageable::Pageable,
+    geometry: &PaginationGeometryTable,
+) -> Vec<Box<dyn crate::pageable::Pageable>> {
+    let page_count = implied_page_count(geometry);
+    (0..page_count)
+        .map(|p| {
+            root.slice_for_page(p, geometry)
+                .unwrap_or_else(empty_page_placeholder)
+        })
+        .collect()
+}
+
+#[allow(dead_code)]
+fn empty_page_placeholder() -> Box<dyn crate::pageable::Pageable> {
+    Box::new(crate::pageable::BlockPageable::new(Vec::new()))
+}
+
 /// Locate the `<body>` element id by walking the html root's children.
 ///
 /// Prefers the first child whose tag name is `body`. Falls back to
@@ -2471,6 +2514,271 @@ mod tests {
             height: 1.0,
         });
         assert_eq!(super::implied_page_count(&geom), 3);
+    }
+
+    // ─── partition_pageable_by_geometry (fulgur-r6we Phase 3.2.a) ───
+    //
+    // Tests for the new geometry-driven Pageable slicing helper. PR 1
+    // covers plain Pageable types; manual fixture construction lets us
+    // unit-test slicing semantics without depending on convert.rs +
+    // fragmenter integration (Phase 3.2.c will exercise that via
+    // examples_determinism / VRT byte-equality gates).
+
+    use crate::pageable::{BlockPageable, Pageable, PositionedChild, SpacerPageable};
+
+    /// Build a 2-child block that spans two pages: a (h=100) on page 0,
+    /// b (h=100) on page 1 after a forced break (gap discarded).
+    /// Mirrors the geometry that `fragment_block_subtree` records for
+    /// the parent + children.
+    fn two_page_block_fixture() -> (Box<dyn Pageable>, PaginationGeometryTable) {
+        const ROOT_ID: usize = 100;
+        const A_ID: usize = 101;
+        const B_ID: usize = 102;
+
+        let a = Box::new(SpacerPageable::new(100.0).with_node_id(Some(A_ID)));
+        let b = Box::new(SpacerPageable::new(100.0).with_node_id(Some(B_ID)));
+        let root = BlockPageable::with_positioned_children(vec![
+            PositionedChild::in_flow(a, 0.0, 0.0),
+            PositionedChild::in_flow(b, 0.0, 120.0),
+        ])
+        .with_node_id(Some(ROOT_ID));
+
+        let mut geom = PaginationGeometryTable::new();
+        // root: spans page 0 (covers a + 20px gap = 120) and page 1
+        // (covers b alone = 100, gap discarded by forced break).
+        geom.entry(ROOT_ID).or_default().fragments.extend([
+            Fragment {
+                page_index: 0,
+                x: 0.0,
+                y: 0.0,
+                width: 200.0,
+                height: 120.0,
+            },
+            Fragment {
+                page_index: 1,
+                x: 0.0,
+                y: 0.0,
+                width: 200.0,
+                height: 100.0,
+            },
+        ]);
+        // a: page 0 only, at root's top.
+        geom.entry(A_ID).or_default().fragments.push(Fragment {
+            page_index: 0,
+            x: 0.0,
+            y: 0.0,
+            width: 200.0,
+            height: 100.0,
+        });
+        // b: page 1 only, at page-local y=0 (forced break discarded gap).
+        geom.entry(B_ID).or_default().fragments.push(Fragment {
+            page_index: 1,
+            x: 0.0,
+            y: 0.0,
+            width: 200.0,
+            height: 100.0,
+        });
+
+        (Box::new(root), geom)
+    }
+
+    #[test]
+    fn partition_emits_one_pageable_per_page() {
+        let (root, geom) = two_page_block_fixture();
+        let pages = super::partition_pageable_by_geometry(root.as_ref(), &geom);
+        assert_eq!(pages.len(), 2, "two-page geometry → two Pageable slices");
+    }
+
+    #[test]
+    fn block_slice_for_page_keeps_only_page_local_children() {
+        let (root, geom) = two_page_block_fixture();
+        let pages = super::partition_pageable_by_geometry(root.as_ref(), &geom);
+
+        let page0 = pages[0]
+            .as_any()
+            .downcast_ref::<BlockPageable>()
+            .expect("page 0 is a BlockPageable");
+        assert_eq!(page0.children.len(), 1, "page 0 keeps only A");
+        assert!(
+            (page0.children[0].y - 0.0).abs() < 0.01,
+            "A's pc.y on page 0 is 0 (root top), got {}",
+            page0.children[0].y,
+        );
+
+        let page1 = pages[1]
+            .as_any()
+            .downcast_ref::<BlockPageable>()
+            .expect("page 1 is a BlockPageable");
+        assert_eq!(page1.children.len(), 1, "page 1 keeps only B");
+        assert!(
+            (page1.children[0].y - 0.0).abs() < 0.01,
+            "B's pc.y on page 1 is 0 (root top after forced break, gap discarded), got {}",
+            page1.children[0].y,
+        );
+    }
+
+    #[test]
+    fn block_slice_for_page_returns_none_when_no_fragment_on_page() {
+        const ROOT_ID: usize = 200;
+        let root = BlockPageable::new(Vec::new()).with_node_id(Some(ROOT_ID));
+        let mut geom = PaginationGeometryTable::new();
+        geom.entry(ROOT_ID).or_default().fragments.push(Fragment {
+            page_index: 0,
+            x: 0.0,
+            y: 0.0,
+            width: 100.0,
+            height: 50.0,
+        });
+        // page 1 absent from geometry → slice returns None.
+        assert!(root.slice_for_page(1, &geom).is_none());
+        // page 0 → Some.
+        assert!(root.slice_for_page(0, &geom).is_some());
+    }
+
+    #[test]
+    fn partition_returns_empty_block_placeholder_for_pages_without_fragments() {
+        // Geometry has 3 pages but root only on pages 0 and 2 → page 1
+        // gets an empty block placeholder so page count is preserved.
+        const ROOT_ID: usize = 300;
+        let root = BlockPageable::new(Vec::new()).with_node_id(Some(ROOT_ID));
+        let mut geom = PaginationGeometryTable::new();
+        geom.entry(ROOT_ID).or_default().fragments.extend([
+            Fragment {
+                page_index: 0,
+                x: 0.0,
+                y: 0.0,
+                width: 100.0,
+                height: 50.0,
+            },
+            Fragment {
+                page_index: 2,
+                x: 0.0,
+                y: 0.0,
+                width: 100.0,
+                height: 50.0,
+            },
+        ]);
+        let pages = super::partition_pageable_by_geometry(&root, &geom);
+        assert_eq!(pages.len(), 3, "page_count = max_page_index + 1 = 3");
+        // Page 1 is the placeholder — empty BlockPageable.
+        let page1 = pages[1]
+            .as_any()
+            .downcast_ref::<BlockPageable>()
+            .expect("placeholder is BlockPageable");
+        assert!(page1.children.is_empty(), "placeholder has no children");
+    }
+
+    #[test]
+    fn spacer_slice_adopts_fragment_height() {
+        // Verify that SpacerPageable picks up the fragmenter-decided
+        // height from geometry (relevant when the fragmenter shrinks
+        // an oversized spacer to fit a strip — Phase 3.2.b will start
+        // exercising this path; PR 1 just records the contract).
+        const SPACER_ID: usize = 400;
+        let spacer = SpacerPageable::new(100.0).with_node_id(Some(SPACER_ID));
+        let mut geom = PaginationGeometryTable::new();
+        geom.entry(SPACER_ID).or_default().fragments.push(Fragment {
+            page_index: 0,
+            x: 0.0,
+            y: 0.0,
+            width: 200.0,
+            height: 60.0,
+        });
+        let sliced = spacer
+            .slice_for_page(0, &geom)
+            .expect("page 0 has fragment");
+        let sliced_spacer = sliced
+            .as_any()
+            .downcast_ref::<SpacerPageable>()
+            .expect("sliced is a SpacerPageable");
+        assert!(
+            (sliced_spacer.height - 60.0).abs() < 0.01,
+            "sliced spacer adopts fragment height (60), got {}",
+            sliced_spacer.height,
+        );
+    }
+
+    #[test]
+    fn slice_for_page_returns_none_when_node_id_absent() {
+        // Pageable without node_id (synthetic / test-only construction)
+        // returns None — there's no way to look up its geometry entry.
+        let spacer = SpacerPageable::new(50.0); // node_id = None
+        let geom = PaginationGeometryTable::new();
+        assert!(spacer.slice_for_page(0, &geom).is_none());
+    }
+
+    /// fulgur-r6we (Phase 3.2.a): a 4-line paragraph split across two
+    /// pages — first 2 lines on page 0, last 2 on page 1. The
+    /// fragmenter records two `Fragment`s on the paragraph's NodeId
+    /// with heights summing to total paragraph height; `slice_for_page`
+    /// must recover each line range from those heights and rebase the
+    /// second fragment's `line.baseline` (paragraph-absolute) by
+    /// subtracting `consumed` (sum of earlier fragment heights).
+    #[test]
+    fn paragraph_slice_for_page_recovers_line_range_and_rebases_baseline() {
+        use crate::paragraph::{ParagraphPageable, ShapedLine};
+
+        const PARA_ID: usize = 500;
+
+        // 4 lines, 75pt each. baseline at 60pt of each line (paragraph-absolute).
+        let line = |idx: usize| ShapedLine {
+            height: 75.0,
+            baseline: 60.0 + idx as f32 * 75.0,
+            items: Vec::new(),
+        };
+        let para = ParagraphPageable::new(vec![line(0), line(1), line(2), line(3)])
+            .with_node_id(Some(PARA_ID));
+
+        // Two-page geometry: 150pt + 150pt (2 lines per page).
+        let mut geom = PaginationGeometryTable::new();
+        geom.entry(PARA_ID).or_default().fragments.extend([
+            Fragment {
+                page_index: 0,
+                x: 0.0,
+                y: 0.0,
+                width: 200.0,
+                height: 150.0,
+            },
+            Fragment {
+                page_index: 1,
+                x: 0.0,
+                y: 0.0,
+                width: 200.0,
+                height: 150.0,
+            },
+        ]);
+
+        let page0 = para
+            .slice_for_page(0, &geom)
+            .expect("page 0 fragment present")
+            .as_any()
+            .downcast_ref::<ParagraphPageable>()
+            .cloned()
+            .expect("page 0 slice is a ParagraphPageable");
+        assert_eq!(page0.lines.len(), 2, "page 0 keeps lines 0-1");
+        // Baselines unchanged on page 0 (consumed = 0).
+        assert!((page0.lines[0].baseline - 60.0).abs() < 0.01);
+        assert!((page0.lines[1].baseline - 135.0).abs() < 0.01);
+
+        let page1 = para
+            .slice_for_page(1, &geom)
+            .expect("page 1 fragment present")
+            .as_any()
+            .downcast_ref::<ParagraphPageable>()
+            .cloned()
+            .expect("page 1 slice is a ParagraphPageable");
+        assert_eq!(page1.lines.len(), 2, "page 1 keeps lines 2-3");
+        // Baselines on page 1 rebased by consumed=150: line 2 was at 210, now 60.
+        assert!(
+            (page1.lines[0].baseline - 60.0).abs() < 0.01,
+            "line 2 baseline rebased: 210 - 150 = 60, got {}",
+            page1.lines[0].baseline,
+        );
+        assert!(
+            (page1.lines[1].baseline - 135.0).abs() < 0.01,
+            "line 3 baseline rebased: 285 - 150 = 135, got {}",
+            page1.lines[1].baseline,
+        );
     }
 
     /// fulgur-s67g Phase 2.1: a 3-line paragraph that overflows the

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -341,6 +341,9 @@ pub struct ParagraphPageable {
     /// links targeting headings (`<h1 id=..>`) and similar inline-root
     /// elements that do not gain a `BlockPageable` wrapper.
     pub id: Option<Arc<String>>,
+    /// fulgur-r6we (Phase 3.2.a): DOM NodeId for `slice_for_page`
+    /// geometry lookup. See `BlockPageable::node_id`.
+    pub node_id: Option<usize>,
 }
 
 impl ParagraphPageable {
@@ -353,12 +356,18 @@ impl ParagraphPageable {
             opacity: 1.0,
             visible: true,
             id: None,
+            node_id: None,
         }
     }
 
     /// Attach an `id` anchor to this paragraph. Chain after `new()`.
     pub fn with_id(mut self, id: Option<Arc<String>>) -> Self {
         self.id = id;
+        self
+    }
+
+    pub fn with_node_id(mut self, node_id: Option<usize>) -> Self {
+        self.node_id = node_id;
         self
     }
 }
@@ -986,6 +995,7 @@ impl Pageable for ParagraphPageable {
         first.opacity = self.opacity;
         first.visible = self.visible;
         first.id = self.id.clone();
+        first.node_id = self.node_id;
 
         // Rebase second fragment: baseline is absolute from paragraph top,
         // so subtract the consumed height to make it relative to the new fragment.
@@ -1016,6 +1026,7 @@ impl Pageable for ParagraphPageable {
         // it lands on a later page — we just carry the id so ordering quirks
         // don't drop anchors.
         second.id = self.id.clone();
+        second.node_id = self.node_id;
 
         Some((Box::new(first), Box::new(second)))
     }
@@ -1081,6 +1092,89 @@ impl Pageable for ParagraphPageable {
             }
             line_top += line.height;
         }
+    }
+
+    fn node_id(&self) -> Option<usize> {
+        self.node_id
+    }
+
+    fn slice_for_page(
+        &self,
+        page_index: u32,
+        geometry: &crate::pagination_layout::PaginationGeometryTable,
+    ) -> Option<Box<dyn Pageable>> {
+        // fulgur-r6we (Phase 3.2.a): paragraph slicing maps each
+        // page's `Fragment` back to a contiguous run of `self.lines`.
+        //
+        // The fragmenter (`fragment_inline_root` at
+        // `pagination_layout.rs:1424`) pre-computes per-page line
+        // ranges and emits one `Fragment` per page with `height =
+        // last_line_bottom - first_line_top`. To recover the line
+        // range from a fragment alone we sum line heights within the
+        // paragraph, advancing past lines that belong to earlier
+        // pages until we reach the target page's fragment, then
+        // take lines whose cumulative height fits the fragment.
+        //
+        // Tolerance `0.01` absorbs `f32` rounding when summing
+        // line.height values.
+        let node_id = self.node_id?;
+        let frags = &geometry.get(&node_id)?.fragments;
+        let target_pos = frags.iter().position(|f| f.page_index == page_index)?;
+        let target_h = frags[target_pos].height;
+        let consumed: f32 = frags[..target_pos].iter().map(|f| f.height).sum();
+
+        let eps = 0.01_f32;
+        let mut line_top: f32 = 0.0;
+        let mut start_idx = 0usize;
+        while start_idx < self.lines.len() {
+            let next_top = line_top + self.lines[start_idx].height;
+            if next_top > consumed + eps {
+                break;
+            }
+            line_top = next_top;
+            start_idx += 1;
+        }
+
+        let mut end_idx = start_idx;
+        let mut accum = 0.0_f32;
+        while end_idx < self.lines.len() {
+            let line_h = self.lines[end_idx].height;
+            if accum + line_h > target_h + eps {
+                break;
+            }
+            accum += line_h;
+            end_idx += 1;
+        }
+
+        if end_idx <= start_idx {
+            return None;
+        }
+
+        let sliced_lines: Vec<ShapedLine> = self.lines[start_idx..end_idx]
+            .iter()
+            .cloned()
+            .map(|mut line| {
+                // Mirror existing `split()` rebase: baseline and
+                // inline-image `computed_y` are paragraph-absolute,
+                // shift by `consumed` so they become local to the
+                // sliced fragment.
+                line.baseline -= consumed;
+                for item in &mut line.items {
+                    if let LineItem::Image(img) = item {
+                        img.computed_y -= consumed;
+                    }
+                }
+                line
+            })
+            .collect();
+
+        let mut sliced = ParagraphPageable::new(sliced_lines);
+        sliced.opacity = self.opacity;
+        sliced.visible = self.visible;
+        sliced.pagination = self.pagination;
+        sliced.id = self.id.clone();
+        sliced.node_id = self.node_id;
+        Some(Box::new(sliced))
     }
 }
 

--- a/docs/plans/2026-04-29-phase3-2-stacked-design.md
+++ b/docs/plans/2026-04-29-phase3-2-stacked-design.md
@@ -1,0 +1,143 @@
+# Phase 3.2 stacked PR design — fulgur-g9e3.2
+
+> Parent: `docs/plans/2026-04-29-phase3-paginate-deletion.md` §3.2
+> Predecessor branch: `feat/fulgur-7hf5-in-place-split` (PR #286 / Phase 3.1.5c)
+> Successor: Phase 3.3 (`Pageable::split` 削除 / fulgur-g9e3.3)
+
+## ゴール
+
+`render.rs` の `paginate(root, w, h)` 呼び出しを fragmenter geometry を使った per-page Pageable 抽出に置き換える。Phase 3.2 を 3 本の stacked PR に分割して段階的にマージする。
+
+## 共通: 新 trait method `slice_for_page`
+
+```rust
+trait Pageable {
+    /// Extract the slice of self that falls on `page_index` according
+    /// to `geometry`. Returns `None` when no fragment of self (or its
+    /// descendants) is on that page. Implementations recurse into
+    /// children. `geometry.y` is already page-local in fragmenter
+    /// output (see `fragment_pagination_root` / `fragment_block_subtree`),
+    /// so implementations read fragment.y directly without a body→page
+    /// y conversion.
+    fn slice_for_page(
+        &self,
+        page_index: u32,
+        geometry: &PaginationGeometryTable,
+    ) -> Option<Box<dyn Pageable>>;
+}
+```
+
+PR 1 では `default impl { unimplemented!() }` で追加し plain 系のみ実装。PR 2 で残りを埋める。Phase 3.3 で `split` / `find_split_point` / `clone_box` (役目を終える) と一緒に整理する。
+
+後方互換は不要 — paginate() 経路は PR 3 で除却するため、PR 1/2 段階で `slice_for_page` と `split` が並存していてよい (default `unimplemented!` は PR 3 で削除されると同時に required = 実装網羅、と段階を踏める)。
+
+## PR 1 (g9e3.2.a): helper core + plain Pageable
+
+### 実装範囲
+
+- `Pageable::slice_for_page` を required method として trait 定義に追加 (default = `unimplemented!()`)
+- impl: `BlockPageable`, `ParagraphPageable`, `SpacerPageable`, `ImagePageable`
+- 新 helper `partition_pageable_by_geometry(root: &dyn Pageable, geometry: &PaginationGeometryTable) -> Vec<Box<dyn Pageable>>`
+  - `implied_page_count(geometry)` で page 数決定
+  - 各 page p について `root.slice_for_page(p, geometry)` を呼ぶ
+  - `None` の page は empty placeholder Pageable で埋める (page count は維持)
+- `render.rs` には触らない (paginate() は健在)
+
+### Pageable per-impl 実装ノート
+
+- `BlockPageable::slice_for_page`:
+  - `self.id` で `geometry.get(node_id)` し、`page_index` 一致の fragment があるか確認
+  - 一致 fragment の `(x, y, w, h)` で新 BlockPageable を組む (cached_size = (w, h))
+  - children を順に `slice_for_page` 再帰、`Some` のみ in-place で残す
+  - fragment が無く全 children も None → 自身も None
+- `ParagraphPageable::slice_for_page`:
+  - geometry 上に複数 fragment があれば line range で分けるが、Phase 2.1 (widow/orphan) でフラグメント済み — fragment ごとに line subset を割り当て
+  - 1 fragment に含まれる line を `lines[range]` で抽出して新 Paragraph を組む
+- `SpacerPageable` / `ImagePageable`: 自身の fragment が page_index に存在 → clone (geometry の y で位置調整)、無ければ None
+
+### 受け入れ条件
+
+- `cargo test -p fulgur --lib` 全 pass (新 unit test 含む)
+- 新規 unit test: plain Block の 2-page split / Paragraph の line split / 単一 page fixture / 0-fragment subtree → None
+- clippy / fmt clean
+
+### リスク
+
+- 既存 26 impl のうち plain 系 4 種を実装、残り 22 種は `unimplemented!()` のまま — production 経路 (paginate()) は健在なので問題ないが、`slice_for_page` を呼ぶ test code を実行すると panic する。test gate は plain 系のみに留める。
+
+## PR 2 (g9e3.2.b): wrapper / 特殊型対応
+
+### 実装範囲
+
+#### Wrapper 系 (first-half marker semantics)
+
+- `CounterOpWrapper`, `StringSetWrapper`, `BookmarkWrapper`, `RunningElementWrapper`:
+  - wrapped 子の `slice_for_page(page_index, geometry)` を呼ぶ
+  - 子が `Some(sliced_child)` を返した場合:
+    - 自身が emit される最小 page_index を geometry から求める (wrapped 子の geometry entries から min(page_index))
+    - `page_index == min_page` → marker 込みで wrapper 再構築
+    - それ以外 → wrapper 外して `sliced_child` を直接返す (透過)
+  - 子が `None` → `None`
+
+#### Out-of-flow 系
+
+- `FixedPosPageable`: `position: fixed` は全 page に複製。`slice_for_page` は wrapped 子の任意 page slice を返す (geometry に依存せず always Some、ただし子が空なら None)
+- `ColumnGroupPageable`: column 単位の split は Phase 2.5 で fragmenter 側に移行済み — 各 column を `slice_for_page` 再帰すれば良い
+
+#### 特殊 split 系
+
+- `TablePageable`: header rows を全 page に repeat。slice_for_page では header を always 含め、body rows を geometry でフィルタ
+- `ListItemPageable`: marker は first page のみ (CounterOpWrapper と同じ semantics)
+- `RepeatRowsPageable`: header と同じ repeat semantics
+
+### 受け入れ条件
+
+- `cargo test -p fulgur --lib` 全 pass
+- 新規 unit test:
+  - counter increment が first page にのみ出る (CounterOpWrapper)
+  - bookmark anchor が first page にのみ出る (BookmarkWrapper)
+  - fixed pos が全 page に複製される (FixedPosPageable)
+  - table header が全 page に repeat される (TablePageable)
+  - column group の column 単位 slice (ColumnGroupPageable)
+- 全 26 impl が `slice_for_page` を実装 (`unimplemented!()` 残無し)
+
+### リスク
+
+- `propagate_page_height` の `break-inside: avoid` フォールバック判定が partition 側で必要か不要か — Phase 3.1 (fulgur-g9e3.1) で fragmenter 側に移行済みなら不要。実装中に確認、必要なら helper 内で reproduce
+- `clone_pc_with_offset` の y_offset 計算が `slice_for_page` で再現必要 — geometry y は page-local なので不要のはずだが、fixed pos / out-of-flow の anchor 計算は要確認
+
+## PR 3 (g9e3.2.c): render.rs 切り替え
+
+### 実装範囲
+
+- `render.rs::render_to_pdf` (line 25) の `paginate()` 呼び出しを `partition_pageable_by_geometry` に置換
+- `render.rs::render_to_pdf_with_gcpm` (line 441) も同様
+- `propagate_page_height` の dead code (Phase 3.1 で fragmenter 側に移行済みのフォールバック) を削除
+- `paginate()` の caller が render.rs から完全に消えたことを確認 (test 経由の caller は Phase 3.3 で整理)
+
+### 受け入れ条件
+
+- `cargo test -p fulgur` 全 pass (lib + integration)
+- `cargo test -p fulgur-vrt` 33 fixtures byte-equal
+- `cargo test -p fulgur-cli --test examples_determinism` 11 fixtures byte-equal
+- `cargo test -p fulgur-wpt` regression 数が Phase 2.6 baseline と同じ
+- `cargo clippy -p fulgur` clean
+- `cargo fmt --check` clean
+- `render.rs` 内に `paginate(` 文字列が残っていない
+
+### リスク
+
+- byte-equal が崩れた場合、原因は (a) wrapper marker 順序 (b) page-local y 変換 (c) fixed pos の page 複製 のいずれか。byte diff を pdftocairo で画像化して目視確認 → 該当の `slice_for_page` 実装を直す
+
+## サブタスク依存
+
+```text
+g9e3.2.a (PR 1) → g9e3.2.b (PR 2) → g9e3.2.c (PR 3)
+```
+
+PR 1 は `feat/fulgur-7hf5-in-place-split` (PR #286) を base に。PR #286 がマージされ次第、後続 PR は順次 rebase。
+
+## 不確実性 / 要検討
+
+- `Pageable::slice_for_page` を required method にすると 26 impl すべてで `unimplemented!()` を書く必要があり、PR 1 の diff が膨らむ。代案: trait method を `Option<Box<dyn Pageable>>` を返す default 付き method にし、plain 系のみ override (default は `None`) → ただし PR 2 の漏れに気付きにくい。required の方が PR 2 の網羅判定が楽 (compile error)
+- helper の test fixture は `pagination_layout::tests::parse` パターンを再利用できるか — fragmenter geometry の build まで test 内でやればよい


### PR DESCRIPTION
## サマリー

Phase 3.2 (`paginate()` を fragmenter geometry-driven な per-page Pageable 抽出に置き換える) を 3 本の stacked PR に分割しました。本 PR は **PR 1 of 3** で、helper の core と plain Pageable 型 (`BlockPageable` / `ParagraphPageable` / `SpacerPageable` / `ImagePageable`) の `slice_for_page` 実装を追加します。

`render.rs` には触らず、production 経路は `paginate()` のままです。新 helper は unit test でのみ exercise されます。

## 主な変更

### Pageable trait

- `node_id() -> Option<usize>` accessor (default `None`、plain types が override)
- `slice_for_page(page_index, geometry) -> Option<Box<dyn Pageable>>` (default `unimplemented!()`、PR 2 で wrapper / 特殊型を埋める)

### plain types に `node_id: Option<usize>` フィールド + `with_node_id(...)` builder

- `BlockPageable` / `ParagraphPageable` / `SpacerPageable` / `ImagePageable`
- `split()` も両 half に node_id を伝播

### slice_for_page 実装

- **BlockPageable**: 自身の fragment を look up、子を再帰 slice、`pc.y` を `child_frag.y - self_frag.y` に rebase (page-local 座標)
- **ParagraphPageable**: per-page Fragment height から line range を復元、`line.baseline` と inline-image `computed_y` を `consumed` (前 page までの fragment height 合計) で rebase。既存 `split()` と同じ semantics
- **Spacer / Image**: leaf — fragment dimensions で clone

### 新 helper

- `fragment_on_page(geometry, node_id, page_index)` — per-page Fragment lookup
- `partition_pageable_by_geometry(root, geometry) -> Vec<Box<dyn Pageable>>` — `0..implied_page_count(geometry)` を iterate、空 page には empty BlockPageable placeholder。\`#[allow(dead_code)]\` は Phase 3.2.c で render.rs に wire する時に外す

### y 座標の page-local 性

\`fragment_pagination_root\` と \`fragment_block_subtree\` は page break 時に \`cursor_y\` をリセットし、その page-local な \`cursor_y\` で fragment を emit します。\`record_subtree_descendants\` は \`parent_page_y + layout.location.y\` で descendant に伝播するので、descendant の fragment.y も page-local です。したがって \`slice_for_page\` は body→page rebase せずに \`Fragment.y\` を直接読めます。

## 追加テスト

- \`partition_emits_one_pageable_per_page\`
- \`block_slice_for_page_keeps_only_page_local_children\` — 強制改ページ + 20px gap → 新 page で y=0 (gap 破棄)
- \`block_slice_for_page_returns_none_when_no_fragment_on_page\`
- \`partition_returns_empty_block_placeholder_for_pages_without_fragments\`
- \`spacer_slice_adopts_fragment_height\`
- \`slice_for_page_returns_none_when_node_id_absent\`
- \`paragraph_slice_for_page_recovers_line_range_and_rebases_baseline\` — 4-line para 2+2 split、baseline rebase 検証

## 検証

- \`cargo test -p fulgur --lib\`: **892 pass** (+8 新規)
- \`cargo test -p fulgur\`: full integration pass
- \`cargo test -p fulgur-vrt\` (byte-exact): pass
- \`cargo test -p fulgur-cli --test examples_determinism\` (byte-exact): **11 pass**
- \`cargo clippy -p fulgur\`: clean
- \`cargo fmt --check\`: clean

## Stacking

3.1.5c (PR #286) がマージされたため base は \`feat/pageable-replacement\`。

- 3.2.a (\`fulgur-r6we\`, this PR): partition helper core + plain types
- 3.2.b (\`fulgur-3vwx\`, next): wrappers + special-split impls
- 3.2.c (\`fulgur-4ltp\`): render.rs paginate() → partition_pageable_by_geometry

Design: \`docs/plans/2026-04-29-phase3-2-stacked-design.md\`

## Test plan

- [x] cargo test -p fulgur --lib
- [x] cargo test -p fulgur (integration)
- [x] cargo test -p fulgur-vrt (byte-exact)
- [x] cargo test -p fulgur-cli --test examples_determinism
- [x] cargo clippy -p fulgur
- [x] cargo fmt --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
