### PR TITLE
feat(pageable): slice_for_page for wrappers and special-split impls (fulgur-3vwx Phase 3.2.b)

### DIFF
--- a/crates/fulgur/src/convert/list_item.rs
+++ b/crates/fulgur/src/convert/list_item.rs
@@ -78,6 +78,7 @@ pub(super) fn try_convert(
             height: 0.0,
             opacity,
             visible,
+            node_id: Some(node_id),
         };
         item.wrap(width, 10000.0);
         return Some(Box::new(item));
@@ -135,6 +136,7 @@ pub(super) fn try_convert(
                 height: 0.0,
                 opacity,
                 visible,
+                node_id: Some(node_id),
             };
             item.wrap(width, 10000.0);
             return Some(Box::new(item));

--- a/crates/fulgur/src/convert/table.rs
+++ b/crates/fulgur/src/convert/table.rs
@@ -69,6 +69,7 @@ fn convert_table(
         opacity,
         visible,
         id: extract_block_id(node),
+        node_id: Some(node.id),
     };
     Box::new(table)
 }

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -660,6 +660,23 @@ pub(crate) fn fragment_on_page(
         .find(|f| f.page_index == page_index)
 }
 
+/// fulgur-3vwx (Phase 3.2.b): "is `page_index` the first page on which
+/// `node_id` has a fragment?" — used by wrapper `slice_for_page` impls
+/// to decide whether to keep the marker (first page) or drop it
+/// (continuation pages). Mirrors `split()`'s first-fragment-only
+/// marker semantics (`BookmarkMarkerWrapperPageable::split`,
+/// `CounterOpWrapperPageable::split`, etc.).
+pub(crate) fn is_first_page_for(
+    geometry: &crate::pagination_layout::PaginationGeometryTable,
+    node_id: usize,
+    page_index: u32,
+) -> bool {
+    geometry
+        .get(&node_id)
+        .and_then(|g| g.fragments.iter().map(|f| f.page_index).min())
+        .is_some_and(|min_page| min_page == page_index)
+}
+
 impl Clone for Box<dyn Pageable> {
     fn clone(&self) -> Self {
         self.clone_box()
@@ -2736,6 +2753,20 @@ impl Pageable for BookmarkMarkerPageable {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
+
+    fn slice_for_page(
+        &self,
+        _page_index: u32,
+        _geometry: &crate::pagination_layout::PaginationGeometryTable,
+    ) -> Option<Box<dyn Pageable>> {
+        // Bare markers have no node_id — they cannot be located in
+        // `geometry`. In production, markers are always wrapped by
+        // their respective `*WrapperPageable` types, which clone the
+        // marker in their own `slice_for_page` (no recursion into the
+        // marker's own slice_for_page). A standalone marker here means
+        // an upstream bug; drop it rather than emit it on every page.
+        None
+    }
 }
 
 // ─── BookmarkMarkerWrapperPageable ──────────────────────────
@@ -2819,6 +2850,33 @@ impl Pageable for BookmarkMarkerWrapperPageable {
     fn has_forced_break_below(&self) -> bool {
         self.child.has_forced_break_below()
     }
+
+    fn node_id(&self) -> Option<usize> {
+        self.child.node_id()
+    }
+
+    fn slice_for_page(
+        &self,
+        page_index: u32,
+        geometry: &crate::pagination_layout::PaginationGeometryTable,
+    ) -> Option<Box<dyn Pageable>> {
+        // First-page-only marker semantics — same as `split()`.
+        // The bookmark anchor must land on the page where the heading
+        // visually starts; continuation pages get the unwrapped child.
+        let sliced_child = self.child.slice_for_page(page_index, geometry)?;
+        let is_first = self
+            .child
+            .node_id()
+            .is_some_and(|id| is_first_page_for(geometry, id, page_index));
+        if is_first {
+            Some(Box::new(BookmarkMarkerWrapperPageable {
+                marker: self.marker.clone(),
+                child: sliced_child,
+            }))
+        } else {
+            Some(sliced_child)
+        }
+    }
 }
 
 // ─── StringSetPageable ──────────────────────────────────
@@ -2865,6 +2923,17 @@ impl Pageable for StringSetPageable {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn slice_for_page(
+        &self,
+        _page_index: u32,
+        _geometry: &crate::pagination_layout::PaginationGeometryTable,
+    ) -> Option<Box<dyn Pageable>> {
+        // See `BookmarkMarkerPageable::slice_for_page` — markers are
+        // always wrapped in production; standalone occurrences are
+        // dropped rather than duplicated across pages.
+        None
     }
 }
 
@@ -2927,6 +2996,17 @@ impl Pageable for RunningElementMarkerPageable {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
+
+    fn slice_for_page(
+        &self,
+        _page_index: u32,
+        _geometry: &crate::pagination_layout::PaginationGeometryTable,
+    ) -> Option<Box<dyn Pageable>> {
+        // See `BookmarkMarkerPageable::slice_for_page` — markers are
+        // always wrapped in production; standalone occurrences are
+        // dropped rather than duplicated across pages.
+        None
+    }
 }
 
 // ─── CounterOpMarkerPageable ──────────────────────────────
@@ -2975,6 +3055,17 @@ impl Pageable for CounterOpMarkerPageable {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn slice_for_page(
+        &self,
+        _page_index: u32,
+        _geometry: &crate::pagination_layout::PaginationGeometryTable,
+    ) -> Option<Box<dyn Pageable>> {
+        // See `BookmarkMarkerPageable::slice_for_page` — markers are
+        // always wrapped in production; standalone occurrences are
+        // dropped rather than duplicated across pages.
+        None
     }
 }
 
@@ -3065,6 +3156,34 @@ impl Pageable for CounterOpWrapperPageable {
 
     fn has_forced_break_below(&self) -> bool {
         self.child.has_forced_break_below()
+    }
+
+    fn node_id(&self) -> Option<usize> {
+        self.child.node_id()
+    }
+
+    fn slice_for_page(
+        &self,
+        page_index: u32,
+        geometry: &crate::pagination_layout::PaginationGeometryTable,
+    ) -> Option<Box<dyn Pageable>> {
+        // First-page-only marker semantics — same as `split()`.
+        // Counter ops must apply on the first page where the wrapped
+        // element appears; continuation pages get the unwrapped child
+        // so `collect_counter_states` doesn't double-count.
+        let sliced_child = self.child.slice_for_page(page_index, geometry)?;
+        let is_first = self
+            .child
+            .node_id()
+            .is_some_and(|id| is_first_page_for(geometry, id, page_index));
+        if is_first {
+            Some(Box::new(CounterOpWrapperPageable {
+                ops: self.ops.clone(),
+                child: sliced_child,
+            }))
+        } else {
+            Some(sliced_child)
+        }
     }
 }
 
@@ -3189,6 +3308,30 @@ impl Pageable for TransformWrapperPageable {
     fn has_forced_break_below(&self) -> bool {
         self.inner.has_forced_break_below()
     }
+
+    fn node_id(&self) -> Option<usize> {
+        self.inner.node_id()
+    }
+
+    fn slice_for_page(
+        &self,
+        page_index: u32,
+        geometry: &crate::pagination_layout::PaginationGeometryTable,
+    ) -> Option<Box<dyn Pageable>> {
+        // Transforms are atomic (`split()` always returns `None`), so
+        // the wrapped subtree appears whole on whichever page the
+        // fragmenter decided. Wrap with the same transform on every
+        // page where `inner.slice_for_page` returns `Some` —
+        // typically only one page since the transform's bounding box
+        // shouldn't be split, but partition is faithful to whatever
+        // fragmenter chose.
+        let sliced_inner = self.inner.slice_for_page(page_index, geometry)?;
+        Some(Box::new(TransformWrapperPageable {
+            inner: sliced_inner,
+            matrix: self.matrix,
+            origin: self.origin,
+        }))
+    }
 }
 
 // ─── StringSetWrapperPageable ──────────────────────────────
@@ -3277,6 +3420,35 @@ impl Pageable for StringSetWrapperPageable {
 
     fn has_forced_break_below(&self) -> bool {
         self.child.has_forced_break_below()
+    }
+
+    fn node_id(&self) -> Option<usize> {
+        self.child.node_id()
+    }
+
+    fn slice_for_page(
+        &self,
+        page_index: u32,
+        geometry: &crate::pagination_layout::PaginationGeometryTable,
+    ) -> Option<Box<dyn Pageable>> {
+        // First-page-only marker semantics — same as `split()`.
+        // String-set values must be resolved on the page where the
+        // wrapped element appears; continuation pages get the
+        // unwrapped child so `collect_string_set_states` doesn't
+        // resolve a value one page too early.
+        let sliced_child = self.child.slice_for_page(page_index, geometry)?;
+        let is_first = self
+            .child
+            .node_id()
+            .is_some_and(|id| is_first_page_for(geometry, id, page_index));
+        if is_first {
+            Some(Box::new(StringSetWrapperPageable {
+                markers: self.markers.clone(),
+                child: sliced_child,
+            }))
+        } else {
+            Some(sliced_child)
+        }
     }
 }
 
@@ -3368,6 +3540,35 @@ impl Pageable for RunningElementWrapperPageable {
 
     fn has_forced_break_below(&self) -> bool {
         self.child.has_forced_break_below()
+    }
+
+    fn node_id(&self) -> Option<usize> {
+        self.child.node_id()
+    }
+
+    fn slice_for_page(
+        &self,
+        page_index: u32,
+        geometry: &crate::pagination_layout::PaginationGeometryTable,
+    ) -> Option<Box<dyn Pageable>> {
+        // First-page-only marker semantics — same as `split()`.
+        // The running-element marker registers an instance on the
+        // page where the source declaration appears so per-page
+        // `@page` margin boxes can resolve `element()` references;
+        // continuation pages get the unwrapped child.
+        let sliced_child = self.child.slice_for_page(page_index, geometry)?;
+        let is_first = self
+            .child
+            .node_id()
+            .is_some_and(|id| is_first_page_for(geometry, id, page_index));
+        if is_first {
+            Some(Box::new(RunningElementWrapperPageable {
+                markers: self.markers.clone(),
+                child: sliced_child,
+            }))
+        } else {
+            Some(sliced_child)
+        }
     }
 }
 
@@ -3606,6 +3807,79 @@ impl Pageable for MulticolRulePageable {
     fn has_forced_break_below(&self) -> bool {
         self.child.has_forced_break_below()
     }
+
+    fn node_id(&self) -> Option<usize> {
+        self.child.node_id()
+    }
+
+    fn slice_for_page(
+        &self,
+        page_index: u32,
+        geometry: &crate::pagination_layout::PaginationGeometryTable,
+    ) -> Option<Box<dyn Pageable>> {
+        // Partition `self.groups` across pages by accumulating the
+        // child's per-page heights as page-local cutoffs. For page p,
+        // the multicol container has consumed `sum(heights[0..p])`
+        // worth of content on prior pages — that's the offset into
+        // `self.groups`'s y-axis we strip off, then the page's own
+        // height becomes the cutoff for which groups still fit on
+        // this page. Mirrors `split()`'s `partition_groups_at_cutoff`
+        // but iterated per page rather than once.
+        let sliced_child = self.child.slice_for_page(page_index, geometry)?;
+        let groups_for_this_page = match self.child.node_id() {
+            Some(id) => {
+                let frags = geometry
+                    .get(&id)
+                    .map(|g| g.fragments.as_slice())
+                    .unwrap_or(&[]);
+                let target_pos = frags.iter().position(|f| f.page_index == page_index);
+                match target_pos {
+                    Some(pos) => {
+                        let consumed: f32 = frags[..pos].iter().map(|f| f.height).sum();
+                        let cutoff = frags[pos].height;
+                        // Shift groups by `-consumed` so y_offset is
+                        // page-local, then partition at `cutoff`.
+                        let shifted: Vec<_> = self
+                            .groups
+                            .iter()
+                            .filter_map(|g| {
+                                let group_top = g.y_offset - consumed;
+                                let max_h = g
+                                    .col_heights
+                                    .iter()
+                                    .copied()
+                                    .fold(0.0_f32, |acc, h| acc.max(h));
+                                let group_bottom = group_top + max_h;
+                                if group_bottom <= 0.0 || group_top >= cutoff {
+                                    None
+                                } else {
+                                    let mut shifted_g = g.clone();
+                                    shifted_g.y_offset = group_top.max(0.0);
+                                    // Clamp col_heights to the visible
+                                    // strip on this page.
+                                    let visible_top = group_top.max(0.0);
+                                    let visible_bot = group_bottom.min(cutoff);
+                                    let visible_h = (visible_bot - visible_top).max(0.0);
+                                    for h in &mut shifted_g.col_heights {
+                                        *h = h.min(visible_h);
+                                    }
+                                    Some(shifted_g)
+                                }
+                            })
+                            .collect();
+                        shifted
+                    }
+                    None => Vec::new(),
+                }
+            }
+            None => self.groups.clone(),
+        };
+        Some(Box::new(MulticolRulePageable {
+            child: sliced_child,
+            rule: self.rule,
+            groups: groups_for_this_page,
+        }))
+    }
 }
 
 /// Partition a `Vec<ColumnGroupGeometry>` across a page boundary at
@@ -3745,6 +4019,10 @@ pub struct ListItemPageable {
     pub opacity: f32,
     /// CSS visibility (false = hidden).
     pub visible: bool,
+    /// fulgur-3vwx (Phase 3.2.b): DOM NodeId for `slice_for_page`
+    /// geometry lookup. See `BlockPageable::node_id`. The `<li>`
+    /// element's NodeId, plumbed through `convert::list_item`.
+    pub node_id: Option<usize>,
 }
 
 impl Pageable for ListItemPageable {
@@ -3777,6 +4055,7 @@ impl Pageable for ListItemPageable {
                 height: 0.0,
                 opacity: self.opacity,
                 visible: self.visible,
+                node_id: self.node_id,
             }),
             Box::new(ListItemPageable {
                 marker: ListItemMarker::None,
@@ -3787,6 +4066,7 @@ impl Pageable for ListItemPageable {
                 height: 0.0,
                 opacity: self.opacity,
                 visible: self.visible,
+                node_id: self.node_id,
             }),
         ))
     }
@@ -3809,6 +4089,7 @@ impl Pageable for ListItemPageable {
                 height: 0.0,
                 opacity: me.opacity,
                 visible: me.visible,
+                node_id: me.node_id,
             }),
             Box::new(ListItemPageable {
                 marker: ListItemMarker::None,
@@ -3819,6 +4100,7 @@ impl Pageable for ListItemPageable {
                 height: 0.0,
                 opacity: me.opacity,
                 visible: me.visible,
+                node_id: me.node_id,
             }),
         ))
     }
@@ -3888,6 +4170,44 @@ impl Pageable for ListItemPageable {
     fn has_forced_break_below(&self) -> bool {
         self.body.has_forced_break_below()
     }
+
+    fn node_id(&self) -> Option<usize> {
+        self.node_id
+    }
+
+    fn slice_for_page(
+        &self,
+        page_index: u32,
+        geometry: &crate::pagination_layout::PaginationGeometryTable,
+    ) -> Option<Box<dyn Pageable>> {
+        // Marker on first page only (matches `split()` setting
+        // `ListItemMarker::None` on the bottom half). Body is sliced
+        // per page via the body's own `slice_for_page`. The list
+        // item's outer fragment determines self_h on this page.
+        let node_id = self.node_id?;
+        let self_frag = fragment_on_page(geometry, node_id, page_index)?;
+        let sliced_body = self.body.slice_for_page(page_index, geometry)?;
+        let is_first = is_first_page_for(geometry, node_id, page_index);
+        Some(Box::new(ListItemPageable {
+            marker: if is_first {
+                self.marker.clone()
+            } else {
+                ListItemMarker::None
+            },
+            marker_line_height: if is_first {
+                self.marker_line_height
+            } else {
+                0.0
+            },
+            body: sliced_body,
+            style: self.style.clone(),
+            width: self.width,
+            height: self_frag.height,
+            opacity: self.opacity,
+            visible: self.visible,
+            node_id: self.node_id,
+        }))
+    }
 }
 
 // ─── TablePageable ─────────────────────────────────────
@@ -3915,6 +4235,9 @@ pub struct TablePageable {
     /// for internal `href="#..."` links. `Arc<String>` so split fragments
     /// can share without cloning the string. Mirrors `BlockPageable::id`.
     pub id: Option<Arc<String>>,
+    /// fulgur-3vwx (Phase 3.2.b): DOM NodeId for `slice_for_page`
+    /// geometry lookup. See `BlockPageable::node_id`.
+    pub node_id: Option<usize>,
 }
 
 impl Pageable for TablePageable {
@@ -4015,6 +4338,7 @@ impl Pageable for TablePageable {
                 opacity: self.opacity,
                 visible: self.visible,
                 id: self.id.clone(),
+                node_id: self.node_id,
             }),
             Box::new(TablePageable {
                 header_cells: second_header,
@@ -4027,6 +4351,7 @@ impl Pageable for TablePageable {
                 opacity: self.opacity,
                 visible: self.visible,
                 id: self.id.clone(),
+                node_id: self.node_id,
             }),
         ))
     }
@@ -4095,6 +4420,7 @@ impl Pageable for TablePageable {
                 opacity: me.opacity,
                 visible: me.visible,
                 id: me.id.clone(),
+                node_id: me.node_id,
             }),
             Box::new(TablePageable {
                 header_cells: me.header_cells,
@@ -4107,6 +4433,7 @@ impl Pageable for TablePageable {
                 opacity: me.opacity,
                 visible: me.visible,
                 id: me.id,
+                node_id: me.node_id,
             }),
         ))
     }
@@ -4214,6 +4541,67 @@ impl Pageable for TablePageable {
                 || pc.child.pagination().break_after == BreakAfter::Page
                 || pc.child.has_forced_break_below()
         })
+    }
+
+    fn node_id(&self) -> Option<usize> {
+        self.node_id
+    }
+
+    fn slice_for_page(
+        &self,
+        page_index: u32,
+        geometry: &crate::pagination_layout::PaginationGeometryTable,
+    ) -> Option<Box<dyn Pageable>> {
+        // Headers repeat on every page where the table appears
+        // (matches `split()` cloning `header_cells` to both halves).
+        // Body cells are filtered to those with a fragment on this
+        // page, then their `pc.y` is rebased so the first kept body
+        // cell sits right after the repeated header (mirrors
+        // `split()`'s `header_height + (pc.y - split_y)` formula).
+        let node_id = self.node_id?;
+        let _self_frag = fragment_on_page(geometry, node_id, page_index)?;
+
+        let kept: Vec<&PositionedChild> = self
+            .body_cells
+            .iter()
+            .filter(|pc| {
+                pc.child
+                    .node_id()
+                    .is_some_and(|id| fragment_on_page(geometry, id, page_index).is_some())
+            })
+            .collect();
+
+        let first_kept_y = kept.iter().map(|pc| pc.y).fold(f32::INFINITY, f32::min);
+        let rebase_delta = if first_kept_y.is_finite() && first_kept_y > self.header_height + 0.01 {
+            first_kept_y - self.header_height
+        } else {
+            0.0
+        };
+
+        let body_cells: Vec<PositionedChild> = kept
+            .iter()
+            .map(|pc| PositionedChild {
+                child: pc.child.clone_box(),
+                x: pc.x,
+                y: pc.y - rebase_delta,
+                out_of_flow: pc.out_of_flow,
+                is_fixed: pc.is_fixed,
+            })
+            .collect();
+
+        Some(Box::new(TablePageable {
+            header_cells: clone_children(&self.header_cells, 0.0),
+            body_cells,
+            header_height: self.header_height,
+            style: self.style.clone(),
+            layout_size: None,
+            width: self.width,
+            cached_height: 0.0,
+            opacity: self.opacity,
+            visible: self.visible,
+            id: self.id.clone(),
+            node_id: self.node_id,
+        }))
     }
 }
 
@@ -4495,6 +4883,7 @@ mod tests {
             height: 100.0,
             opacity: 1.0,
             visible: true,
+            node_id: None,
         };
         let size = item.wrap(200.0, 1000.0);
         assert!((size.height - 100.0).abs() < 0.01);
@@ -4520,6 +4909,7 @@ mod tests {
             height: 300.0,
             opacity: 1.0,
             visible: true,
+            node_id: None,
         };
         item.wrap(200.0, 1000.0);
         let result = item.split(200.0, 250.0);
@@ -4565,6 +4955,7 @@ mod tests {
             height: 300.0,
             opacity: 1.0,
             visible: true,
+            node_id: None,
         };
         item.wrap(200.0, 1000.0);
         let result = item.split(200.0, 250.0);
@@ -4657,6 +5048,7 @@ mod tests {
             opacity: 1.0,
             visible: true,
             id: None,
+            node_id: None,
         };
         table.wrap(200.0, 1000.0);
 
@@ -6063,6 +6455,7 @@ mod forced_break_below_tests {
             height: 10.0,
             opacity: 1.0,
             visible: true,
+            node_id: None,
         };
         assert!(wrapped.has_forced_break_below());
 
@@ -6075,6 +6468,7 @@ mod forced_break_below_tests {
             height: 10.0,
             opacity: 1.0,
             visible: true,
+            node_id: None,
         };
         assert!(!clean.has_forced_break_below());
     }
@@ -6099,6 +6493,7 @@ mod forced_break_below_tests {
             opacity: 1.0,
             visible: true,
             id: None,
+            node_id: None,
         };
         assert!(wrapped.has_forced_break_below());
 
@@ -6119,6 +6514,7 @@ mod forced_break_below_tests {
             opacity: 1.0,
             visible: true,
             id: None,
+            node_id: None,
         };
         assert!(!clean.has_forced_break_below());
     }
@@ -6197,6 +6593,7 @@ mod forced_break_below_tests {
             opacity: 1.0,
             visible: true,
             id: None,
+            node_id: None,
         };
 
         // Table fits in 1000pt but has forced break → must still split.

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -4554,38 +4554,59 @@ impl Pageable for TablePageable {
     ) -> Option<Box<dyn Pageable>> {
         // Headers repeat on every page where the table appears
         // (matches `split()` cloning `header_cells` to both halves).
-        // Body cells are filtered to those with a fragment on this
-        // page, then their `pc.y` is rebased so the first kept body
-        // cell sits right after the repeated header (mirrors
-        // `split()`'s `header_height + (pc.y - split_y)` formula).
+        // Body cells are recursively sliced via `slice_for_page` so a
+        // cell that spans pages internally only contributes its
+        // page-specific content here (Devin Review on PR #288: full
+        // `clone_box()` would leak content from other pages). `pc.y`
+        // is rebased so the first kept body cell sits right after
+        // the repeated header (mirrors `split()`'s `header_height +
+        // (pc.y - split_y)` formula).
         let node_id = self.node_id?;
         let _self_frag = fragment_on_page(geometry, node_id, page_index)?;
 
-        let kept: Vec<&PositionedChild> = self
+        // First pass: recursively slice each body cell and pair the
+        // result with the original `pc.y` (needed for rebase
+        // calculation). Cells whose `slice_for_page` returns `None`
+        // are dropped from this page.
+        let sliced: Vec<(f32, PositionedChild)> = self
             .body_cells
             .iter()
-            .filter(|pc| {
-                pc.child
-                    .node_id()
-                    .is_some_and(|id| fragment_on_page(geometry, id, page_index).is_some())
+            .filter_map(|pc| {
+                let sliced_child = pc.child.slice_for_page(page_index, geometry)?;
+                Some((
+                    pc.y,
+                    PositionedChild {
+                        child: sliced_child,
+                        x: pc.x,
+                        // Placeholder, rebased in the second pass.
+                        y: pc.y,
+                        out_of_flow: pc.out_of_flow,
+                        is_fixed: pc.is_fixed,
+                    },
+                ))
             })
             .collect();
 
-        let first_kept_y = kept.iter().map(|pc| pc.y).fold(f32::INFINITY, f32::min);
+        let first_kept_y = sliced
+            .iter()
+            .map(|(orig_y, _)| *orig_y)
+            .fold(f32::INFINITY, f32::min);
         let rebase_delta = if first_kept_y.is_finite() && first_kept_y > self.header_height + 0.01 {
             first_kept_y - self.header_height
         } else {
             0.0
         };
 
-        let body_cells: Vec<PositionedChild> = kept
-            .iter()
-            .map(|pc| PositionedChild {
-                child: pc.child.clone_box(),
-                x: pc.x,
-                y: pc.y - rebase_delta,
-                out_of_flow: pc.out_of_flow,
-                is_fixed: pc.is_fixed,
+        // Second pass: apply the rebase delta to each sliced cell's
+        // `pc.y`. The first kept body cell ends up at exactly
+        // `header_height` (page 0: rebase_delta = 0; later pages:
+        // shifted up so the first kept cell sits right after the
+        // repeated header).
+        let body_cells: Vec<PositionedChild> = sliced
+            .into_iter()
+            .map(|(_, mut pc)| {
+                pc.y -= rebase_delta;
+                pc
             })
             .collect();
 

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -3860,8 +3860,22 @@ impl Pageable for MulticolRulePageable {
                                     let visible_top = group_top.max(0.0);
                                     let visible_bot = group_bottom.min(cutoff);
                                     let visible_h = (visible_bot - visible_top).max(0.0);
+                                    // Subtract the portion of each
+                                    // column already painted on
+                                    // earlier pages before clamping
+                                    // to `visible_h`. Without this
+                                    // step, a column whose content
+                                    // ended above this page (col_top +
+                                    // col_h ≤ 0) would be clamped to
+                                    // `visible_h` instead of 0, and a
+                                    // partially-visible column would
+                                    // be reported at `visible_h`
+                                    // even when its remainder is
+                                    // shorter (Devin Review on PR
+                                    // #288).
+                                    let consumed_above = (visible_top - group_top).max(0.0);
                                     for h in &mut shifted_g.col_heights {
-                                        *h = h.min(visible_h);
+                                        *h = (*h - consumed_above).max(0.0).min(visible_h);
                                     }
                                     Some(shifted_g)
                                 }

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -2781,6 +2781,120 @@ mod tests {
         );
     }
 
+    // ─── slice_for_page wrapper / special-split tests (fulgur-3vwx Phase 3.2.b) ───
+
+    use crate::gcpm::CounterOp;
+    use crate::pageable::{
+        BookmarkMarkerPageable, BookmarkMarkerWrapperPageable, CounterOpWrapperPageable,
+    };
+
+    /// CounterOpWrapper.slice_for_page keeps the marker on the first page
+    /// where the wrapped child appears, drops it on continuation pages
+    /// (returns the inner child unwrapped). Without this, counter
+    /// operations would be replayed on every page the child spans.
+    #[test]
+    fn counter_op_wrapper_keeps_marker_on_first_page_only() {
+        const ID: usize = 600;
+        let inner = SpacerPageable::new(100.0).with_node_id(Some(ID));
+        let wrapped = CounterOpWrapperPageable::new(
+            vec![CounterOp::Increment {
+                name: "section".into(),
+                value: 1,
+            }],
+            Box::new(inner),
+        );
+        let mut geom = PaginationGeometryTable::new();
+        geom.entry(ID).or_default().fragments.extend([
+            Fragment {
+                page_index: 0,
+                x: 0.0,
+                y: 0.0,
+                width: 100.0,
+                height: 50.0,
+            },
+            Fragment {
+                page_index: 1,
+                x: 0.0,
+                y: 0.0,
+                width: 100.0,
+                height: 50.0,
+            },
+        ]);
+
+        let page0 = wrapped
+            .slice_for_page(0, &geom)
+            .expect("inner has fragment on page 0");
+        assert!(
+            page0
+                .as_any()
+                .downcast_ref::<CounterOpWrapperPageable>()
+                .is_some(),
+            "page 0 keeps the wrapper (counter op fires here)"
+        );
+
+        let page1 = wrapped
+            .slice_for_page(1, &geom)
+            .expect("inner has fragment on page 1");
+        assert!(
+            page1
+                .as_any()
+                .downcast_ref::<CounterOpWrapperPageable>()
+                .is_none(),
+            "page 1 strips the wrapper (counter op already fired)"
+        );
+        assert!(
+            page1.as_any().downcast_ref::<SpacerPageable>().is_some(),
+            "page 1 returns the unwrapped inner Spacer, got {:?}",
+            std::any::type_name_of_val(&*page1)
+        );
+    }
+
+    /// BookmarkMarkerWrapper.slice_for_page applies the same first-page-only
+    /// rule for outline anchors.
+    #[test]
+    fn bookmark_marker_wrapper_keeps_marker_on_first_page_only() {
+        const ID: usize = 601;
+        let inner = SpacerPageable::new(100.0).with_node_id(Some(ID));
+        let wrapped = BookmarkMarkerWrapperPageable::new(
+            BookmarkMarkerPageable::new(1, "Chapter 1".into()),
+            Box::new(inner),
+        );
+        let mut geom = PaginationGeometryTable::new();
+        geom.entry(ID).or_default().fragments.extend([
+            Fragment {
+                page_index: 0,
+                x: 0.0,
+                y: 0.0,
+                width: 100.0,
+                height: 50.0,
+            },
+            Fragment {
+                page_index: 1,
+                x: 0.0,
+                y: 0.0,
+                width: 100.0,
+                height: 50.0,
+            },
+        ]);
+
+        let page0 = wrapped.slice_for_page(0, &geom).unwrap();
+        assert!(
+            page0
+                .as_any()
+                .downcast_ref::<BookmarkMarkerWrapperPageable>()
+                .is_some(),
+            "bookmark anchor lands on first page"
+        );
+        let page1 = wrapped.slice_for_page(1, &geom).unwrap();
+        assert!(
+            page1
+                .as_any()
+                .downcast_ref::<BookmarkMarkerWrapperPageable>()
+                .is_none(),
+            "continuation page has no bookmark anchor"
+        );
+    }
+
     /// fulgur-s67g Phase 2.1: a 3-line paragraph that overflows the
     /// page strip after line 2 cannot split between line 2 and the
     /// final line — the second fragment would have only 1 line, below

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -2849,6 +2849,113 @@ mod tests {
         );
     }
 
+    /// Devin Review on PR #288: `TablePageable::slice_for_page` must
+    /// **recursively** slice body cells (`pc.child.slice_for_page(...)`)
+    /// rather than `clone_box()` them. Otherwise a body cell that
+    /// spans pages internally contributes its full content to every
+    /// page where it appears, breaking the slice contract.
+    ///
+    /// Setup: a single body cell whose child is a `BlockPageable`
+    /// containing A (h=100, page 0) and B (h=100, page 1). On page 1
+    /// the table's body cell must contain ONLY B, not the full A+B.
+    #[test]
+    fn table_slice_for_page_recursively_slices_multi_page_body_cells() {
+        use crate::pageable::TablePageable;
+
+        const TABLE_ID: usize = 700;
+        const CELL_ID: usize = 701;
+        const A_ID: usize = 702;
+        const B_ID: usize = 703;
+
+        let cell_block = BlockPageable::with_positioned_children(vec![
+            PositionedChild::in_flow(
+                Box::new(SpacerPageable::new(100.0).with_node_id(Some(A_ID))),
+                0.0,
+                0.0,
+            ),
+            PositionedChild::in_flow(
+                Box::new(SpacerPageable::new(100.0).with_node_id(Some(B_ID))),
+                0.0,
+                100.0,
+            ),
+        ])
+        .with_node_id(Some(CELL_ID));
+
+        let table = TablePageable {
+            header_cells: Vec::new(),
+            body_cells: vec![PositionedChild::in_flow(Box::new(cell_block), 0.0, 0.0)],
+            header_height: 0.0,
+            style: Default::default(),
+            layout_size: None,
+            width: 200.0,
+            cached_height: 0.0,
+            opacity: 1.0,
+            visible: true,
+            id: None,
+            node_id: Some(TABLE_ID),
+        };
+
+        // Geometry: table + cell span both pages, A only on page 0,
+        // B only on page 1.
+        let mut geom = PaginationGeometryTable::new();
+        for id in [TABLE_ID, CELL_ID] {
+            geom.entry(id).or_default().fragments.extend([
+                Fragment {
+                    page_index: 0,
+                    x: 0.0,
+                    y: 0.0,
+                    width: 200.0,
+                    height: 100.0,
+                },
+                Fragment {
+                    page_index: 1,
+                    x: 0.0,
+                    y: 0.0,
+                    width: 200.0,
+                    height: 100.0,
+                },
+            ]);
+        }
+        geom.entry(A_ID).or_default().fragments.push(Fragment {
+            page_index: 0,
+            x: 0.0,
+            y: 0.0,
+            width: 200.0,
+            height: 100.0,
+        });
+        geom.entry(B_ID).or_default().fragments.push(Fragment {
+            page_index: 1,
+            x: 0.0,
+            y: 0.0,
+            width: 200.0,
+            height: 100.0,
+        });
+
+        let page1 = table
+            .slice_for_page(1, &geom)
+            .expect("table on page 1")
+            .as_any()
+            .downcast_ref::<TablePageable>()
+            .cloned()
+            .expect("page 1 is a TablePageable");
+        assert_eq!(page1.body_cells.len(), 1, "page 1 keeps the cell");
+        let cell_block = page1.body_cells[0]
+            .child
+            .as_any()
+            .downcast_ref::<BlockPageable>()
+            .expect("cell child is a BlockPageable");
+        // Pre-fix: cell_block.children would have BOTH A and B
+        // (clone_box() copies everything). Post-fix: only B is sliced
+        // in for page 1 (A's slice_for_page returns None since A has
+        // no fragment on page 1).
+        assert_eq!(
+            cell_block.children.len(),
+            1,
+            "cell on page 1 keeps only B (slice recurses), got {} children",
+            cell_block.children.len(),
+        );
+    }
+
     /// BookmarkMarkerWrapper.slice_for_page applies the same first-page-only
     /// rule for outline anchors.
     #[test]

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -2956,6 +2956,86 @@ mod tests {
         );
     }
 
+    /// Devin Review on PR #288 (second comment):
+    /// `MulticolRulePageable::slice_for_page` was clamping
+    /// per-column heights to `visible_h` for groups straddling from a
+    /// prior page (`group_top < 0`), without subtracting the
+    /// `consumed_above` portion that was already painted on earlier
+    /// pages. Result: a column whose entire content ended on a prior
+    /// page got `visible_h` (non-zero) instead of 0 on this page,
+    /// causing a stranded rule painted from y=0 to y=visible_h with
+    /// no actual content underneath.
+    ///
+    /// Setup: child has fragments on page 0 (height=20) and page 1
+    /// (height=50). Group at y_offset=0 with col_heights=[10, 30].
+    /// On page 1, group_top = 0 - 20 = -20. Column 0 (h=10) ends at
+    /// -10 (entirely above page) → expect 0. Column 1 (h=30) ends at
+    /// 10 (10pt visible on page 1) → expect 10.
+    #[test]
+    fn multicol_rule_slice_for_page_subtracts_consumed_above_when_straddling() {
+        use crate::multicol_layout::ColumnGroupGeometry;
+        use crate::pageable::MulticolRulePageable;
+
+        const CHILD_ID: usize = 800;
+
+        let child = SpacerPageable::new(70.0).with_node_id(Some(CHILD_ID));
+        let group = ColumnGroupGeometry {
+            y_offset: 0.0,
+            x_offset: 0.0,
+            n: 2,
+            col_w: 100.0,
+            gap: 10.0,
+            col_heights: vec![10.0, 30.0],
+        };
+        let wrapper = MulticolRulePageable {
+            child: Box::new(child),
+            rule: crate::column_css::ColumnRuleSpec {
+                width: 1.0,
+                style: crate::column_css::ColumnRuleStyle::Solid,
+                color: [0, 0, 0, 255],
+            },
+            groups: vec![group],
+        };
+
+        let mut geom = PaginationGeometryTable::new();
+        geom.entry(CHILD_ID).or_default().fragments.extend([
+            Fragment {
+                page_index: 0,
+                x: 0.0,
+                y: 0.0,
+                width: 200.0,
+                height: 20.0,
+            },
+            Fragment {
+                page_index: 1,
+                x: 0.0,
+                y: 0.0,
+                width: 200.0,
+                height: 50.0,
+            },
+        ]);
+
+        let page1 = wrapper
+            .slice_for_page(1, &geom)
+            .expect("child has page 1 fragment")
+            .as_any()
+            .downcast_ref::<MulticolRulePageable>()
+            .cloned()
+            .expect("page 1 slice is a MulticolRulePageable");
+        assert_eq!(page1.groups.len(), 1, "straddling group survives on page 1");
+        let g = &page1.groups[0];
+        assert!(
+            (g.col_heights[0] - 0.0).abs() < 0.01,
+            "column 0 (h=10) was entirely above page 1, expected 0, got {}",
+            g.col_heights[0],
+        );
+        assert!(
+            (g.col_heights[1] - 10.0).abs() < 0.01,
+            "column 1 (h=30) has 10pt remaining on page 1, expected 10, got {}",
+            g.col_heights[1],
+        );
+    }
+
     /// BookmarkMarkerWrapper.slice_for_page applies the same first-page-only
     /// rule for outline anchors.
     #[test]

--- a/crates/fulgur/src/svg.rs
+++ b/crates/fulgur/src/svg.rs
@@ -20,6 +20,9 @@ pub struct SvgPageable {
     pub height: f32,
     pub opacity: f32,
     pub visible: bool,
+    /// fulgur-3vwx (Phase 3.2.b): DOM NodeId for `slice_for_page`
+    /// geometry lookup. See `BlockPageable::node_id`.
+    pub node_id: Option<usize>,
 }
 
 impl SvgPageable {
@@ -30,7 +33,13 @@ impl SvgPageable {
             height,
             opacity: 1.0,
             visible: true,
+            node_id: None,
         }
+    }
+
+    pub fn with_node_id(mut self, node_id: Option<usize>) -> Self {
+        self.node_id = node_id;
+        self
     }
 }
 
@@ -88,6 +97,27 @@ impl Pageable for SvgPageable {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn node_id(&self) -> Option<usize> {
+        self.node_id
+    }
+
+    fn slice_for_page(
+        &self,
+        page_index: u32,
+        geometry: &crate::pagination_layout::PaginationGeometryTable,
+    ) -> Option<Box<dyn Pageable>> {
+        let node_id = self.node_id?;
+        let frag = crate::pageable::fragment_on_page(geometry, node_id, page_index)?;
+        Some(Box::new(SvgPageable {
+            tree: Arc::clone(&self.tree),
+            width: frag.width,
+            height: frag.height,
+            opacity: self.opacity,
+            visible: self.visible,
+            node_id: self.node_id,
+        }))
     }
 }
 


### PR DESCRIPTION
## サマリー

Phase 3.2 stacked PR の **2 of 3**。3.2.a (PR #287) で残した 13 個の Pageable impl の `slice_for_page` を埋めます。本 PR 後、すべての具象 Pageable impl が任意 page index に対して意味のある slice を返すため、`partition_pageable_by_geometry` が完全機能。3.2.c (`fulgur-4ltp`) で `render.rs` に wire 込みます。

`render.rs` は本 PR でも未変更、production 経路は `paginate()` のままです。

## 主な変更

### Wrappers (first-page-only marker semantics)

**`BookmarkMarkerWrapperPageable` / `CounterOpWrapperPageable` / `StringSetWrapperPageable` / `RunningElementWrapperPageable`**:
- 内側 child を再帰 slice
- child が `Some` を返し、かつ `is_first_page_for(child.node_id)` の場合: marker 込みで再 wrap (counter op fire / bookmark anchor / string-set 解決)
- 継続 page では wrapper を剥がして inner を直接返す (透過)。`collect_*_states` が marker を二重適用しない
- `node_id()` は wrapped child に委譲

**`TransformWrapperPageable`**: atomic — `matrix` / `origin` 維持で全 page 再 wrap (`split()` が常に `None` を返すので通常 1 page のみ)。

### 特殊 split impls

- **`ListItemPageable`**: marker は first page のみ (既存 `split()` の `ListItemMarker::None` 設定を踏襲)、body は page ごとに `body.slice_for_page` で slice。`node_id: Option<usize>` フィールド追加 (`convert::list_item` から plumbing)
- **`TablePageable`**: `header_cells` を全 page で repeat (`split()` 同様)。`body_cells` を fragment-on-page でフィルタ、`pc.y` を rebase して repeat header の直後に配置 (既存の `header_height + (pc.y - split_y)` 計算を踏襲)。`node_id` フィールド追加 (`convert::table` の `node.id` から)
- **`MulticolRulePageable`**: page ごとに `self.groups` を partition。fragment height を accumulate して page-local cutoff を作り、既存 `partition_groups_at_cutoff` を per-page 適用。groups は `(visible_top, visible_bot)` で clip + page-local `y_offset` に shift

### Markers (zero-height, no node_id)

`BookmarkMarkerPageable` / `StringSetPageable` / `RunningElementMarkerPageable` / `CounterOpMarkerPageable` — `slice_for_page` は `None`。production では必ず対応 wrapper の中。standalone は upstream bug 扱い (drop が conservative、`Some(clone)` だと毎 page 重複)。

### Misc

- **`SvgPageable`**: `ImagePageable` 同様 leaf — fragment dims で clone。`node_id` フィールド + builder 追加
- `Pageable::node_id()` を全 production impl が override (wrapper は inner に委譲)
- 新 helper `is_first_page_for(geometry, node_id, page_index)` — `geometry[node_id].fragments` の最小 page_index と一致するか

## 追加テスト

- `counter_op_wrapper_keeps_marker_on_first_page_only` — page 0 で wrapper 保持、page 1 で unwrap
- `bookmark_marker_wrapper_keeps_marker_on_first_page_only` — outline anchor 同様
- 既存 8 テスト fixture (`ListItemPageable` / `TablePageable` struct 直書き) を `node_id: None` 追加で更新

## 検証

- `cargo test -p fulgur --lib`: **894 pass** (+2 新規)
- `cargo test -p fulgur`: full integration pass
- `cargo test -p fulgur-vrt` (byte-exact): pass
- `cargo test -p fulgur-cli --test examples_determinism` (byte-exact): **11 pass**
- `cargo clippy -p fulgur`: clean
- `cargo fmt --check`: clean

## Stacking

Based on `feat/fulgur-r6we-partition-helper` (PR #287 / Phase 3.2.a)。

- 3.2.a (`fulgur-r6we`, PR #287): partition helper core + plain types
- **3.2.b (`fulgur-3vwx`, this PR)**: wrappers + special-split impls
- 3.2.c (`fulgur-4ltp`, next): render.rs paginate() → partition_pageable_by_geometry

Design: `docs/plans/2026-04-29-phase3-2-stacked-design.md`

## Test plan

- [x] cargo test -p fulgur --lib
- [x] cargo test -p fulgur (integration)
- [x] cargo test -p fulgur-vrt (byte-exact)
- [x] cargo test -p fulgur-cli --test examples_determinism
- [x] cargo clippy -p fulgur
- [x] cargo fmt --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
