### PR TITLE
test(list_marker): add coverage for inject and find_marker_font

### DIFF
--- a/crates/fulgur/src/convert/list_marker.rs
+++ b/crates/fulgur/src/convert/list_marker.rs
@@ -523,19 +523,14 @@ mod tests {
             .downcast_ref::<ParagraphPageable>()
             .unwrap();
         assert_eq!(para.lines[0].items.len(), 2, "marker prepended");
-        if let LineItem::Image(m) = &para.lines[0].items[0] {
-            assert!((m.width - 12.0).abs() < 0.01, "first item is the marker");
-        } else {
-            panic!("first item should be the injected marker image");
-        }
-        if let LineItem::Image(orig) = &para.lines[0].items[1] {
-            assert!(
-                (orig.x_offset - (5.0 + 12.0)).abs() < 0.01,
-                "existing item x_offset shifted by marker width"
-            );
-        } else {
-            panic!("second item should be the original image");
-        }
+        assert!(
+            matches!(&para.lines[0].items[0], LineItem::Image(m) if (m.width - 12.0).abs() < 0.01),
+            "first item should be the injected marker image of width 12"
+        );
+        assert!(
+            matches!(&para.lines[0].items[1], LineItem::Image(orig) if (orig.x_offset - (5.0 + 12.0)).abs() < 0.01),
+            "existing item x_offset should be shifted by marker width"
+        );
     }
 
     #[test]

--- a/crates/fulgur/src/convert/list_marker.rs
+++ b/crates/fulgur/src/convert/list_marker.rs
@@ -424,3 +424,183 @@ pub(super) fn inject_inside_marker_item_into_children(
 
     false
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::image::ImageFormat;
+
+    fn img_marker(width: f32) -> LineItem {
+        LineItem::Image(InlineImage {
+            data: Arc::new(vec![]),
+            format: ImageFormat::Png,
+            width,
+            height: 10.0,
+            x_offset: 0.0,
+            vertical_align: VerticalAlign::Baseline,
+            opacity: 1.0,
+            visible: true,
+            computed_y: 0.0,
+            link: None,
+        })
+    }
+
+    fn pc(child: Box<dyn Pageable>) -> PositionedChild {
+        PositionedChild::in_flow(child, 0.0, 0.0)
+    }
+
+    // ── inject_inside_marker_item_into_children ───────────────────────────────
+
+    #[test]
+    fn inject_empty_children_returns_false() {
+        let mut children: Vec<PositionedChild> = vec![];
+        assert!(!inject_inside_marker_item_into_children(
+            &mut children,
+            img_marker(10.0)
+        ));
+    }
+
+    #[test]
+    fn inject_no_paragraph_descendant_returns_false() {
+        let spacer = Box::new(SpacerPageable::new(20.0));
+        let mut children = vec![pc(spacer)];
+        assert!(!inject_inside_marker_item_into_children(
+            &mut children,
+            img_marker(10.0)
+        ));
+    }
+
+    #[test]
+    fn inject_into_empty_paragraph_creates_single_line_with_marker() {
+        let mut children = vec![pc(Box::new(ParagraphPageable::new(vec![])))];
+        assert!(inject_inside_marker_item_into_children(
+            &mut children,
+            img_marker(8.0)
+        ));
+        let para = children[0]
+            .child
+            .as_any()
+            .downcast_ref::<ParagraphPageable>()
+            .unwrap();
+        assert_eq!(para.lines.len(), 1, "should create one line");
+        assert_eq!(para.lines[0].items.len(), 1, "line should hold the marker");
+        // height comes from img.height (10.0)
+        assert!(
+            (para.lines[0].height - 10.0).abs() < 0.01,
+            "line height = img height"
+        );
+    }
+
+    #[test]
+    fn inject_into_paragraph_with_existing_items_prepends_and_shifts() {
+        let existing = InlineImage {
+            data: Arc::new(vec![]),
+            format: ImageFormat::Png,
+            width: 20.0,
+            height: 10.0,
+            x_offset: 5.0,
+            vertical_align: VerticalAlign::Baseline,
+            opacity: 1.0,
+            visible: true,
+            computed_y: 0.0,
+            link: None,
+        };
+        let line = ShapedLine {
+            height: 10.0,
+            baseline: 8.0,
+            items: vec![LineItem::Image(existing)],
+        };
+        let mut children = vec![pc(Box::new(ParagraphPageable::new(vec![line])))];
+
+        // Marker width = 12.0. Existing item's x_offset (5.0) must grow by 12.
+        assert!(inject_inside_marker_item_into_children(
+            &mut children,
+            img_marker(12.0)
+        ));
+        let para = children[0]
+            .child
+            .as_any()
+            .downcast_ref::<ParagraphPageable>()
+            .unwrap();
+        assert_eq!(para.lines[0].items.len(), 2, "marker prepended");
+        if let LineItem::Image(m) = &para.lines[0].items[0] {
+            assert!((m.width - 12.0).abs() < 0.01, "first item is the marker");
+        } else {
+            panic!("first item should be the injected marker image");
+        }
+        if let LineItem::Image(orig) = &para.lines[0].items[1] {
+            assert!(
+                (orig.x_offset - (5.0 + 12.0)).abs() < 0.01,
+                "existing item x_offset shifted by marker width"
+            );
+        } else {
+            panic!("second item should be the original image");
+        }
+    }
+
+    #[test]
+    fn inject_into_paragraph_nested_in_block_recurses() {
+        // BlockPageable whose only child is a ParagraphPageable.
+        let line = ShapedLine {
+            height: 12.0,
+            baseline: 9.0,
+            items: vec![],
+        };
+        let para = Box::new(ParagraphPageable::new(vec![line]));
+        let block = Box::new(BlockPageable::with_positioned_children(vec![pc(para)]));
+        let mut children = vec![pc(block)];
+
+        assert!(inject_inside_marker_item_into_children(
+            &mut children,
+            img_marker(6.0)
+        ));
+        let block = children[0]
+            .child
+            .as_any()
+            .downcast_ref::<BlockPageable>()
+            .unwrap();
+        let para = block.children[0]
+            .child
+            .as_any()
+            .downcast_ref::<ParagraphPageable>()
+            .unwrap();
+        assert_eq!(
+            para.lines[0].items.len(),
+            1,
+            "marker injected into nested paragraph"
+        );
+    }
+
+    #[test]
+    fn inject_block_without_paragraph_returns_false() {
+        let spacer = Box::new(SpacerPageable::new(10.0));
+        let block = Box::new(BlockPageable::with_positioned_children(vec![pc(spacer)]));
+        let mut children = vec![pc(block)];
+        assert!(!inject_inside_marker_item_into_children(
+            &mut children,
+            img_marker(5.0)
+        ));
+    }
+
+    // ── find_marker_font ─────────────────────────────────────────────────────
+
+    #[test]
+    fn find_marker_font_no_assets_empty_children_returns_none() {
+        let marker = crate::blitz_adapter::Marker::Char('\u{2022}');
+        let children: Vec<PositionedChild> = vec![];
+        assert!(find_marker_font(&marker, None, &children).is_none());
+    }
+
+    #[test]
+    fn find_marker_font_paragraph_with_image_items_only_returns_none() {
+        // Image items contain no font data → fallback search finds nothing.
+        let line = ShapedLine {
+            height: 10.0,
+            baseline: 8.0,
+            items: vec![img_marker(5.0)],
+        };
+        let children = vec![pc(Box::new(ParagraphPageable::new(vec![line])))];
+        let marker = crate::blitz_adapter::Marker::Char('\u{2022}');
+        assert!(find_marker_font(&marker, None, &children).is_none());
+    }
+}


### PR DESCRIPTION
## 対象モジュール

`crates/fulgur/src/convert/list_marker.rs`

## カバレッジ変化

| 指標 | 変更前 | 変更後 |
|------|--------|--------|
| Regions | 59.00% (196/478 missed) | 75.19% (161/649 missed) |
| Lines | 63.46% (110/301 missed) | 78.98% (91/433 missed) |

## 追加したテスト (8件)

### `inject_inside_marker_item_into_children` に関するテスト

| テスト名 | 確認する分岐 |
|---------|------------|
| `inject_empty_children_returns_false` | children が空の場合 → false を返す |
| `inject_no_paragraph_descendant_returns_false` | ParagraphPageable を含まない子 (SpacerPageable) → false |
| `inject_into_empty_paragraph_creates_single_line_with_marker` | lines が空の ParagraphPageable → 新規行を生成してマーカーを挿入 |
| `inject_into_paragraph_with_existing_items_prepends_and_shifts` | lines に既存アイテムがある場合 → marker_width 分だけ x_offset をシフトしてマーカーを先頭に挿入 |
| `inject_into_paragraph_nested_in_block_recurses` | BlockPageable の子に ParagraphPageable がある場合 → 再帰して true を返す |
| `inject_block_without_paragraph_returns_false` | Paragraph 子孫を持たない BlockPageable → false |

### `find_marker_font` に関するテスト

| テスト名 | 確認する分岐 |
|---------|------------|
| `find_marker_font_no_assets_empty_children_returns_none` | AssetBundle なし・children 空 → None |
| `find_marker_font_paragraph_with_image_items_only_returns_none` | ParagraphPageable の items が Image のみ (テキストランなし) → None |

## 意図的に対象外としたブランチ

| 関数 | 除外理由 |
|------|---------|
| `resolve_list_style_image_asset` / `resolve_list_marker` / `resolve_inside_image_marker` | `node.primary_styles()` 等 Blitz DOM ノードへの依存が深く、DOM を起動せずに単体でテストできない |
| `extract_marker_lines` | Parley レイアウトデータが必要。Blitz の parse+resolve なしには構築できない |
| `shape_marker_with_skrifa` | 実際のフォントバイナリ (skrifa が解析できるもの) が必要。システムフォントの有無に依存するため CI の再現性が保証できない |
| `find_marker_font` の成功パス | `ShapedGlyphRun.font_data` が skrifa でパース可能な有効なフォントバイナリを必要とするため除外 |

https://claude.ai/code/session_01LsMHG9afCtbQ4D3x12TrrU

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsMHG9afCtbQ4D3x12TrrU)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded automated test coverage for marker injection and font-detection behavior. Verifies handling of empty content, absence of text, nested paragraphs, and image-only scenarios. Confirms injected marker images create correct shaped lines, preserve line height, and adjust neighboring image offsets as expected. Ensures font-fallback logic behaves correctly when no text runs are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->