### PR TITLE
fix(pagination_layout): admit multicol with column-span:all to recursion gate (fulgur-916y)

### DIFF
--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -648,10 +648,26 @@ impl<'a> PaginationLayoutTree<'a> {
             // recursion for them — Pageable's `ColumnGroupPageable`
             // handles their split internally and emits whole when the
             // multicol box itself fits the strip.
+            //
+            // fulgur-916y: multicol containers with a `column-span:
+            // all` direct child get an exception — the span subtree
+            // is laid out by Taffy as a full-width block flowing
+            // between the column groups, so block-flow recursion via
+            // `fragment_block_subtree` can split it across pages
+            // when it overflows. Containers without span:all stay
+            // atomic.
             let is_multicol = child_node.is_some_and(crate::blitz_adapter::is_multicol_container);
+            let multicol_has_span_all = is_multicol
+                && child_node.is_some_and(|n| {
+                    n.children.iter().any(|&id| {
+                        self.doc
+                            .get_node(id)
+                            .is_some_and(crate::blitz_adapter::has_column_span_all)
+                    })
+                });
             let available_strip = (self.page_height_px - cursor_y).max(0.0);
             let needs_recursion = has_splittable_children
-                && !is_multicol
+                && (!is_multicol || multicol_has_span_all)
                 && (has_forced_break_below(self.doc, child_id, self.column_styles, 0)
                     || would_split_block_subtree(
                         self.doc,
@@ -2568,6 +2584,56 @@ mod tests {
                  to cursor-advance)",
             );
         }
+    }
+
+    /// fulgur-916y: a multicol container with a `column-span: all`
+    /// child whose subtree exceeds one page must split across pages
+    /// in the partition path. Pre-fix, the multicol gate
+    /// (`!is_multicol`) blocked recursion, so the whole multicol
+    /// container ended up as a single fragment regardless of
+    /// overflow — fragmenter reported 1 page. Post-fix, the gate
+    /// admits multicol containers that have a span:all child, so
+    /// `fragment_block_subtree` recurses into the span subtree and
+    /// splits it across pages via the regular block-flow logic.
+    ///
+    /// Pins `implied_page_count(geometry) >= 2` for the
+    /// `multicol_span_all` integration fixture's HTML rendered with
+    /// the fragmenter's strip height set small enough that the
+    /// span:all section overflows page 0.
+    #[test]
+    fn fragment_pagination_root_recurses_into_multicol_with_span_all() {
+        let mut long = String::new();
+        for _ in 0..40 {
+            long.push_str(
+                "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. \
+                 Sed do eiusmod tempor incididunt ut labore et dolore magna \
+                 aliqua. Ut enim ad minim veniam, quis nostrud exercitation.</p>",
+            );
+        }
+        let html = format!(
+            r#"<!doctype html><html><head><style>
+                body {{ margin: 10pt; font-size: 10pt; }}
+                .mc {{ column-count: 2; column-gap: 10pt; }}
+                .span {{ column-span: all; }}
+            </style></head><body>
+              <div class="mc">
+                <p>before column content.</p>
+                <section class="span">{long}</section>
+                <p>after column content.</p>
+              </div>
+            </body></html>"#,
+            long = long
+        );
+
+        // 600 viewport, 400 page strip (small enough to overflow).
+        let mut doc = parse(&html, 600.0);
+        let table = blitz_adapter::extract_column_style_table(&doc);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 400.0, &table);
+        let pages = super::implied_page_count(&geom);
+        assert!(
+            pages >= 2,
+            "expected multicol with span:all overflow to split into >=2 pages, got {pages}",
+        );
     }
 
     /// Devin Review on PR #285 (fulgur-a36m Phase 3.1.5b):


### PR DESCRIPTION
## サマリー

multicol container 内で \`column-span: all\` の subtree が 1 ページを越えるとき、partition 経路ではフラグメンターが multicol を atomic 扱いするため \`pages = 1\` になっていました。本 PR で multicol container に column-span:all 直接子が居るケースだけ recursion gate を通すよう変更し、span:all subtree が block-flow split で正しくページ跨ぎ可能になります。

## 修正

\`fragment_pagination_root\` および \`fragment_block_subtree\` の \`needs_recursion\` ゲートで multicol を一律除外していたのを、column-span:all 子持ちのケースだけ通す形に変更:

```
let multicol_has_span_all = is_multicol
    && child_node.is_some_and(|n| {
        n.children.iter().any(|&id| {
            doc.get_node(id).is_some_and(blitz_adapter::has_column_span_all)
        })
    });
let needs_recursion = has_splittable_children
    && (!is_multicol || multicol_has_span_all)
    && (forced_break_below || would_split_block_subtree(...));
```

recursion に入ると \`fragment_block_subtree\` が multicol の直下 children を Taffy の \`layout.location.y\` で配置 (fulgur-kv0r 修正済み)。span:all section は full-width block として Taffy が配置済みなので、block-flow recursion がそのまま split を発火させます。column-flow 子要素 (\`Segment::ColumnGroup\`) は深い span:all 子を持たないため、それぞれ atomic に emit されます。

column-span:all を持たない multicol は従来通り atomic — \`ColumnGroupPageable\` の column balance を block-flow logic で破壊しないように保護。

## テスト

新 unit test \`fragment_pagination_root_recurses_into_multicol_with_span_all\`: \`multicol_span_all\` integration fixture の HTML を 400px page strip でフラグメントし、\`implied_page_count(geometry) >= 2\` を pin。pre-fix では 1 でした。

## 検証

- \`cargo test -p fulgur --lib\`: **898 pass** (+1 新規)
- \`cargo test -p fulgur\`: full integration pass
- \`cargo test -p fulgur-vrt\`: **33/33** byte-exact
- \`cargo test -p fulgur-cli --test examples_determinism\`: **11/11** byte-exact
- \`cargo clippy -p fulgur\`: clean
- \`cargo fmt --check\`: clean

## Phase 3.3 unblock

\`fulgur-g9e3.3\` の前提 3 件のうち 2 件目を解消:

- ✅ \`fulgur-kv0r\` (grid/flex parallel-sibling): PR #292
- ✅ **\`fulgur-916y\` (this PR)**: column-span:all recursion gate
- ⏳ \`fulgur-frmj\`: SVG / radial-gradient byte drift (最後の前提)

## Test plan

- [x] cargo test -p fulgur --lib (898 pass)
- [x] cargo test -p fulgur (integration)
- [x] cargo test -p fulgur-vrt (33/33 byte-exact)
- [x] cargo test -p fulgur-cli --test examples_determinism (11/11 byte-exact)
- [x] cargo clippy -p fulgur (clean)
- [x] cargo fmt --check (clean)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
