### PR TITLE
feat(render): Phase 4 PR 1 — Drawables skeleton + render_v2 + shadow harness (fulgur-s9qd)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,6 +1138,7 @@ dependencies = [
  "taffy",
  "tempfile",
  "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
  "usvg",
  "woff2-patched",
 ]
@@ -1177,7 +1178,7 @@ dependencies = [
  "serde",
  "tempfile",
  "tokio",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -3922,6 +3923,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
@@ -3929,10 +3945,19 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.2",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -3950,7 +3975,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -4633,6 +4658,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"

--- a/crates/fulgur/Cargo.toml
+++ b/crates/fulgur/Cargo.toml
@@ -49,3 +49,4 @@ getrandom = { version = "0.4", default-features = false, features = ["wasm_js"] 
 [dev-dependencies]
 tempfile = "3.27.0"
 image = { version = "0.25", default-features = false, features = ["png"] }
+toml = "0.9"

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -305,6 +305,7 @@ fn extract_drawables_from_pageable(
     // column-rule painting still lands in PR 6 (`drawables.multicol_rules`).
     if let Some(w) = any.downcast_ref::<MulticolRulePageable>() {
         extract_drawables_from_pageable(w.child.as_ref(), out);
+        return;
     }
     // Other types (Spacer, ParagraphPageable, marker-only Pageables)
     // have no PR 2 payload — markers and Spacers stay no-op in v2;

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -173,6 +173,19 @@ pub fn dom_to_pageable(doc: &HtmlDocument, ctx: &mut ConvertContext<'_>) -> Box<
     convert_node(doc.deref(), root.id, ctx, 0)
 }
 
+/// Phase 4 PR 1 skeleton (fulgur-9t3z): convert a resolved Blitz document
+/// into a `Drawables` struct holding per-NodeId draw payload.
+///
+/// Returns an empty `Drawables` until subsequent PRs migrate each
+/// Pageable type's data extraction. The `_doc` / `_ctx` arguments are
+/// kept on the signature so PR 2+ does not need to re-thread them.
+pub fn dom_to_drawables(
+    _doc: &HtmlDocument,
+    _ctx: &mut ConvertContext<'_>,
+) -> crate::drawables::Drawables {
+    crate::drawables::Drawables::new()
+}
+
 fn debug_print_tree(doc: &BaseDocument, node_id: usize, depth: usize) {
     if depth >= MAX_DOM_DEPTH {
         eprintln!("{}... (max depth reached)", "  ".repeat(depth));

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -305,7 +305,6 @@ fn extract_drawables_from_pageable(
     // column-rule painting still lands in PR 6 (`drawables.multicol_rules`).
     if let Some(w) = any.downcast_ref::<MulticolRulePageable>() {
         extract_drawables_from_pageable(w.child.as_ref(), out);
-        return;
     }
     // Other types (Spacer, ParagraphPageable, marker-only Pageables)
     // have no PR 2 payload — markers and Spacers stay no-op in v2;

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -188,11 +188,18 @@ pub fn dom_to_drawables(
     doc: &HtmlDocument,
     ctx: &mut ConvertContext<'_>,
 ) -> crate::drawables::Drawables {
+    // Snapshot bookmark map *before* `dom_to_pageable` runs:
+    // `convert_node` drains `ctx.bookmark_by_node` via `.remove(&node_id)`
+    // for every node it visits, so by the time we'd read back from
+    // `ctx.bookmark_by_node` below it would be empty (PR #301 Devin
+    // review). The clone is small (one `BookmarkInfo` per heading);
+    // the v1 path already accepts the same allocation cost via
+    // `bookmark_by_node_for_parity` in `engine.rs`.
+    let bookmark_snapshot = ctx.bookmark_by_node.clone();
     let root_pageable = dom_to_pageable(doc, ctx);
     let mut drawables = crate::drawables::Drawables::new();
     extract_drawables_from_pageable(root_pageable.as_ref(), &mut drawables);
-    let bookmark_anchors_drained = extract_bookmark_anchors(doc, &ctx.bookmark_by_node, ctx.assets);
-    drawables.bookmark_anchors = bookmark_anchors_drained;
+    drawables.bookmark_anchors = extract_bookmark_anchors(doc, &bookmark_snapshot, ctx.assets);
     drawables
 }
 
@@ -207,8 +214,8 @@ fn extract_drawables_from_pageable(
     use crate::image::ImagePageable;
     use crate::pageable::{
         BlockPageable, BookmarkMarkerWrapperPageable, CounterOpWrapperPageable, ListItemPageable,
-        RunningElementWrapperPageable, StringSetWrapperPageable, TablePageable,
-        TransformWrapperPageable,
+        MulticolRulePageable, RunningElementWrapperPageable, StringSetWrapperPageable,
+        TablePageable, TransformWrapperPageable,
     };
     use crate::svg::SvgPageable;
 
@@ -288,10 +295,20 @@ fn extract_drawables_from_pageable(
     }
     if let Some(w) = any.downcast_ref::<CounterOpWrapperPageable>() {
         extract_drawables_from_pageable(w.child.as_ref(), out);
+        return;
     }
-    // Other types (Spacer, ParagraphPageable, MulticolRulePageable,
-    // marker-only Pageables) have no PR 2 payload — markers and
-    // Spacers stay no-op in v2; Paragraph / Multicol land in PR 3 / 6.
+    // PR #301 Devin: MulticolRulePageable is a wrapper carrying a
+    // `child: Box<dyn Pageable>` produced by `maybe_wrap_multicol_rule`
+    // around any multicol container. Without this arm, images / SVGs
+    // nested inside a multicol container fall through to "Other" and
+    // never enter `Drawables.images` / `.svgs`. Multicol's own
+    // column-rule painting still lands in PR 6 (`drawables.multicol_rules`).
+    if let Some(w) = any.downcast_ref::<MulticolRulePageable>() {
+        extract_drawables_from_pageable(w.child.as_ref(), out);
+    }
+    // Other types (Spacer, ParagraphPageable, marker-only Pageables)
+    // have no PR 2 payload — markers and Spacers stay no-op in v2;
+    // Paragraph / Multicol-rule paint land in PR 3 / 6.
 }
 
 #[cfg(test)]
@@ -364,6 +381,53 @@ mod extract_drawables_tests {
         let mut out = Drawables::new();
         extract_drawables_from_pageable(&wrapped, &mut out);
         assert!(out.images.contains_key(&99));
+    }
+
+    /// Regression: `MulticolRulePageable` is a wrapper too. Images
+    /// nested inside a multicol container reach `drawables.images`
+    /// only if the extractor descends into its `child` (PR #301
+    /// Devin). Without the dedicated arm the wrapper falls through
+    /// to "Other" and the image is silently dropped.
+    #[test]
+    fn descends_into_multicol_rule_wrapper_to_reach_image() {
+        use crate::column_css::ColumnRuleSpec;
+        use crate::pageable::MulticolRulePageable;
+
+        let img = ImagePageable::new(Arc::new(vec![0u8; 4]), ImageFormat::Png, 10.0, 10.0)
+            .with_node_id(Some(123));
+        let wrapped =
+            MulticolRulePageable::new(Box::new(img), ColumnRuleSpec::default(), Vec::new());
+        let mut out = Drawables::new();
+        extract_drawables_from_pageable(&wrapped, &mut out);
+        assert!(
+            out.images.contains_key(&123),
+            "MulticolRulePageable's child must be visited by the extractor"
+        );
+    }
+
+    /// Regression: `dom_to_drawables` must snapshot `ctx.bookmark_by_node`
+    /// **before** calling `dom_to_pageable`. `convert_node` drains the
+    /// map via `.remove(&node_id)` for every visited node, so a naive
+    /// post-call read sees an empty map (PR #301 Devin). End-to-end
+    /// test through `Engine::render_html_v2` with `bookmarks(true)`:
+    /// the rendered PDF must contain `/Outlines` even though the v2
+    /// path is the one that builds the outline.
+    #[test]
+    fn dom_to_drawables_preserves_bookmark_anchors_for_outline() {
+        use crate::config::PageSize;
+        use crate::engine::Engine;
+
+        let html = "<!DOCTYPE html><html><head><style>body{margin:0;padding:0}</style></head><body><h1>Heading</h1></body></html>";
+        let engine = Engine::builder()
+            .page_size(PageSize::A4)
+            .bookmarks(true)
+            .build();
+        let pdf = engine.render_html_v2(html).expect("render v2");
+        let pdf_str = String::from_utf8_lossy(&pdf);
+        assert!(
+            pdf_str.contains("/Outlines"),
+            "bookmark anchors must reach the v2 outline pipeline; PDF missing /Outlines"
+        );
     }
 }
 

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -173,17 +173,221 @@ pub fn dom_to_pageable(doc: &HtmlDocument, ctx: &mut ConvertContext<'_>) -> Box<
     convert_node(doc.deref(), root.id, ctx, 0)
 }
 
-/// Phase 4 PR 1 skeleton (fulgur-9t3z): convert a resolved Blitz document
-/// into a `Drawables` struct holding per-NodeId draw payload.
+/// Phase 4 (fulgur-9t3z): convert a resolved Blitz document into a
+/// `Drawables` struct holding per-NodeId draw payload.
 ///
-/// Returns an empty `Drawables` until subsequent PRs migrate each
-/// Pageable type's data extraction. The `_doc` / `_ctx` arguments are
-/// kept on the signature so PR 2+ does not need to re-thread them.
+/// **Migration scaffolding (PRs 2-6)**: this implementation runs
+/// `dom_to_pageable` internally and walks the resulting tree to
+/// extract each per-type payload into its `Drawables` map. The
+/// Pageable tree is dropped before return — wasteful but lets each
+/// subsequent PR migrate one Pageable type at a time without
+/// duplicating convert logic. PR 8 (after Pageable deletion) will
+/// replace this body with a native DOM walk that doesn't allocate
+/// the intermediate Pageable tree.
 pub fn dom_to_drawables(
-    _doc: &HtmlDocument,
-    _ctx: &mut ConvertContext<'_>,
+    doc: &HtmlDocument,
+    ctx: &mut ConvertContext<'_>,
 ) -> crate::drawables::Drawables {
-    crate::drawables::Drawables::new()
+    let root_pageable = dom_to_pageable(doc, ctx);
+    let mut drawables = crate::drawables::Drawables::new();
+    extract_drawables_from_pageable(root_pageable.as_ref(), &mut drawables);
+    let bookmark_anchors_drained = extract_bookmark_anchors(doc, &ctx.bookmark_by_node, ctx.assets);
+    drawables.bookmark_anchors = bookmark_anchors_drained;
+    drawables
+}
+
+/// Walk a Pageable tree and populate each `Drawables` map by
+/// downcasting concrete types. PR 2 covers `ImagePageable` and
+/// `SvgPageable`; subsequent PRs add the rest.
+fn extract_drawables_from_pageable(
+    pageable: &dyn crate::pageable::Pageable,
+    out: &mut crate::drawables::Drawables,
+) {
+    use crate::drawables::{ImageEntry, SvgEntry};
+    use crate::image::ImagePageable;
+    use crate::pageable::{
+        BlockPageable, BookmarkMarkerWrapperPageable, CounterOpWrapperPageable, ListItemPageable,
+        RunningElementWrapperPageable, StringSetWrapperPageable, TablePageable,
+        TransformWrapperPageable,
+    };
+    use crate::svg::SvgPageable;
+
+    let any = pageable.as_any();
+
+    // Image leaf — record per-NodeId payload.
+    if let Some(img) = any.downcast_ref::<ImagePageable>() {
+        if let Some(node_id) = img.node_id {
+            out.images.insert(
+                node_id,
+                ImageEntry {
+                    image_data: img.image_data.clone(),
+                    format: img.format,
+                    width: img.width,
+                    height: img.height,
+                    opacity: img.opacity,
+                    visible: img.visible,
+                },
+            );
+        }
+        return;
+    }
+    // SVG leaf — record per-NodeId payload.
+    if let Some(svg) = any.downcast_ref::<SvgPageable>() {
+        if let Some(node_id) = svg.node_id {
+            out.svgs.insert(
+                node_id,
+                SvgEntry {
+                    tree: svg.tree.clone(),
+                    width: svg.width,
+                    height: svg.height,
+                    opacity: svg.opacity,
+                    visible: svg.visible,
+                },
+            );
+        }
+        return;
+    }
+    // Block / List / Table / wrappers — recurse into children. PR 4+
+    // will record their own draw payload (BlockEntry, etc.); for PR 2
+    // we only walk past them to reach the leaves.
+    if let Some(block) = any.downcast_ref::<BlockPageable>() {
+        for pc in &block.children {
+            extract_drawables_from_pageable(pc.child.as_ref(), out);
+        }
+        return;
+    }
+    if let Some(table) = any.downcast_ref::<TablePageable>() {
+        for pc in &table.header_cells {
+            extract_drawables_from_pageable(pc.child.as_ref(), out);
+        }
+        for pc in &table.body_cells {
+            extract_drawables_from_pageable(pc.child.as_ref(), out);
+        }
+        return;
+    }
+    if let Some(list_item) = any.downcast_ref::<ListItemPageable>() {
+        extract_drawables_from_pageable(list_item.body.as_ref(), out);
+        return;
+    }
+    // Wrappers delegate.
+    if let Some(w) = any.downcast_ref::<TransformWrapperPageable>() {
+        extract_drawables_from_pageable(w.inner.as_ref(), out);
+        return;
+    }
+    if let Some(w) = any.downcast_ref::<BookmarkMarkerWrapperPageable>() {
+        extract_drawables_from_pageable(w.child.as_ref(), out);
+        return;
+    }
+    if let Some(w) = any.downcast_ref::<StringSetWrapperPageable>() {
+        extract_drawables_from_pageable(w.child.as_ref(), out);
+        return;
+    }
+    if let Some(w) = any.downcast_ref::<RunningElementWrapperPageable>() {
+        extract_drawables_from_pageable(w.child.as_ref(), out);
+        return;
+    }
+    if let Some(w) = any.downcast_ref::<CounterOpWrapperPageable>() {
+        extract_drawables_from_pageable(w.child.as_ref(), out);
+    }
+    // Other types (Spacer, ParagraphPageable, MulticolRulePageable,
+    // marker-only Pageables) have no PR 2 payload — markers and
+    // Spacers stay no-op in v2; Paragraph / Multicol land in PR 3 / 6.
+}
+
+#[cfg(test)]
+mod extract_drawables_tests {
+    use super::*;
+    use crate::drawables::Drawables;
+    use crate::image::{ImageFormat, ImagePageable};
+    use crate::pageable::{
+        BlockPageable, BookmarkMarkerPageable, BookmarkMarkerWrapperPageable, PositionedChild,
+    };
+    use crate::svg::SvgPageable;
+    use std::sync::Arc;
+    use usvg::{Options, Tree};
+
+    /// Build a Pageable tree containing one block-level `ImagePageable`,
+    /// run the extractor, and verify the image lands in
+    /// `drawables.images` keyed by its `node_id`.
+    #[test]
+    fn extracts_block_level_image_into_drawables() {
+        let img = ImagePageable::new(Arc::new(vec![0u8; 4]), ImageFormat::Png, 50.0, 30.0)
+            .with_node_id(Some(42));
+        let block = BlockPageable::with_positioned_children(vec![PositionedChild::in_flow(
+            Box::new(img),
+            0.0,
+            0.0,
+        )]);
+        let mut out = Drawables::new();
+        extract_drawables_from_pageable(&block, &mut out);
+
+        let entry = out.images.get(&42).expect("image entry recorded");
+        assert_eq!(entry.width, 50.0);
+        assert_eq!(entry.height, 30.0);
+        assert!(entry.visible);
+    }
+
+    /// Same shape for SVG.
+    #[test]
+    fn extracts_block_level_svg_into_drawables() {
+        let tree = Arc::new(
+            Tree::from_str(
+                "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'></svg>",
+                &Options::default(),
+            )
+            .expect("parse svg"),
+        );
+        let svg = SvgPageable::new(tree, 80.0, 60.0).with_node_id(Some(7));
+        let block = BlockPageable::with_positioned_children(vec![PositionedChild::in_flow(
+            Box::new(svg),
+            0.0,
+            0.0,
+        )]);
+        let mut out = Drawables::new();
+        extract_drawables_from_pageable(&block, &mut out);
+
+        let entry = out.svgs.get(&7).expect("svg entry recorded");
+        assert_eq!(entry.width, 80.0);
+        assert_eq!(entry.height, 60.0);
+    }
+
+    /// Marker wrappers must be transparent — the extractor descends
+    /// into `child` and finds the image inside.
+    #[test]
+    fn descends_into_bookmark_wrapper_to_reach_image() {
+        let img = ImagePageable::new(Arc::new(vec![0u8; 4]), ImageFormat::Png, 10.0, 10.0)
+            .with_node_id(Some(99));
+        let wrapped = BookmarkMarkerWrapperPageable::new(
+            BookmarkMarkerPageable::new(1, "X".into()),
+            Box::new(img),
+        );
+        let mut out = Drawables::new();
+        extract_drawables_from_pageable(&wrapped, &mut out);
+        assert!(out.images.contains_key(&99));
+    }
+}
+
+/// Build the bookmark anchor map. The `bookmark_by_node` map on
+/// `ConvertContext` is populated upstream (`engine.rs` runs
+/// `BookmarkPass` before `dom_to_pageable`); we only project it into
+/// the `Drawables` shape. The `_doc` / `_assets` arguments are
+/// reserved for future enrichment (PR 6+).
+fn extract_bookmark_anchors(
+    _doc: &HtmlDocument,
+    bookmark_by_node: &std::collections::HashMap<usize, crate::blitz_adapter::BookmarkInfo>,
+    _assets: Option<&crate::asset::AssetBundle>,
+) -> std::collections::BTreeMap<usize, crate::drawables::BookmarkAnchorEntry> {
+    let mut out = std::collections::BTreeMap::new();
+    for (&node_id, info) in bookmark_by_node {
+        out.insert(
+            node_id,
+            crate::drawables::BookmarkAnchorEntry {
+                level: info.level,
+                label: info.label.clone(),
+            },
+        );
+    }
+    out
 }
 
 fn debug_print_tree(doc: &BaseDocument, node_id: usize, depth: usize) {

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -45,13 +45,26 @@ pub struct BlockEntry;
 #[derive(Debug, Clone, Default)]
 pub struct ParagraphEntry;
 
-/// PR 2 target: image bytes + format + intrinsic size.
-#[derive(Debug, Clone, Default)]
-pub struct ImageEntry;
+/// Image draw payload for v2. Mirrors the fields `ImagePageable` holds.
+#[derive(Debug, Clone)]
+pub struct ImageEntry {
+    pub image_data: std::sync::Arc<Vec<u8>>,
+    pub format: crate::image::ImageFormat,
+    pub width: f32,
+    pub height: f32,
+    pub opacity: f32,
+    pub visible: bool,
+}
 
-/// PR 2 target: parsed SVG tree.
-#[derive(Debug, Clone, Default)]
-pub struct SvgEntry;
+/// SVG draw payload for v2. Mirrors the fields `SvgPageable` holds.
+#[derive(Debug, Clone)]
+pub struct SvgEntry {
+    pub tree: std::sync::Arc<usvg::Tree>,
+    pub width: f32,
+    pub height: f32,
+    pub opacity: f32,
+    pub visible: bool,
+}
 
 /// PR 5 target: table layout state — header cell ids, body cell offsets,
 /// header height. Per-page slicing happens at render time.
@@ -70,11 +83,13 @@ pub struct MulticolRuleEntry;
 #[derive(Debug, Clone, Default)]
 pub struct TransformEntry;
 
-/// PR 2 target: bookmark anchor (level + label) keyed by source node.
-/// First-fragment-only emission is enforced at render time via
-/// `geometry`.
-#[derive(Debug, Clone, Default)]
-pub struct BookmarkAnchorEntry;
+/// Bookmark anchor (level + label) keyed by source node. First-fragment-only
+/// emission is enforced at render time by reading `geometry.fragments[0]`.
+#[derive(Debug, Clone)]
+pub struct BookmarkAnchorEntry {
+    pub level: u8,
+    pub label: String,
+}
 
 /// PR 3 target: link span (target + alt text) covering one or more
 /// glyph runs in a paragraph. `Vec<(NodeId, LinkSpan)>` lets a single

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -1,0 +1,146 @@
+//! Phase 4 (fulgur-9t3z): node-keyed side-channel maps that replace the
+//! `Pageable` trait + 17 impls.
+//!
+//! `Drawables` is the data shape that `convert::dom_to_drawables` produces
+//! and `render::render_v2` consumes. Each map holds per-NodeId state for
+//! one draw concern (background, paragraph, image, etc.). The render path
+//! walks `pagination_layout::PaginationGeometryTable` per page and looks
+//! up the node's data in the appropriate map — no trait dispatch, no
+//! central `DrawOp` enum.
+//!
+//! See `docs/plans/2026-04-30-phase4-design.md` for the full design.
+//!
+//! ## PR sequence note
+//!
+//! This struct is introduced in PR 1 with empty placeholder fields. Each
+//! subsequent PR replaces one placeholder with the real data type:
+//!
+//! - PR 2: `images`, `svgs`, plus the five marker types collapse into
+//!   `bookmark_anchors` (the rest are deleted from the draw path).
+//! - PR 3: `paragraphs`.
+//! - PR 4: `block_styles`.
+//! - PR 5: `tables`, `list_items`.
+//! - PR 6: `transforms`, `multicol_rules`, plus marker wrappers vanish.
+
+use std::collections::BTreeMap;
+
+/// Blitz DOM node id, keyed throughout `Drawables`. Same shape as
+/// `pagination_layout::PaginationGeometryTable`'s key.
+pub type NodeId = usize;
+
+// ── Placeholder entry types ──────────────────────────────────────────
+//
+// Each PR in the Phase 4 sequence replaces one of these with the real
+// per-node data extracted from convert. The placeholder is empty so that
+// the `Drawables` struct compiles before any draw migration starts; the
+// shadow harness can already exercise the pipeline plumbing.
+
+/// PR 4 target: per-node block-level paint state (background layers,
+/// borders, box-shadow, opacity, overflow clip).
+#[derive(Debug, Clone, Default)]
+pub struct BlockEntry;
+
+/// PR 3 target: per-node shaped lines (`Vec<ShapedLine>`) reused from
+/// the existing `paragraph::draw_shaped_lines` path.
+#[derive(Debug, Clone, Default)]
+pub struct ParagraphEntry;
+
+/// PR 2 target: image bytes + format + intrinsic size.
+#[derive(Debug, Clone, Default)]
+pub struct ImageEntry;
+
+/// PR 2 target: parsed SVG tree.
+#[derive(Debug, Clone, Default)]
+pub struct SvgEntry;
+
+/// PR 5 target: table layout state — header cell ids, body cell offsets,
+/// header height. Per-page slicing happens at render time.
+#[derive(Debug, Clone, Default)]
+pub struct TableEntry;
+
+/// PR 5 target: list item marker + body wrapper data.
+#[derive(Debug, Clone, Default)]
+pub struct ListItemEntry;
+
+/// PR 6 target: column-rule paint spec + per-column-group geometry.
+#[derive(Debug, Clone, Default)]
+pub struct MulticolRuleEntry;
+
+/// PR 6 target: CSS transform matrix + origin.
+#[derive(Debug, Clone, Default)]
+pub struct TransformEntry;
+
+/// PR 2 target: bookmark anchor (level + label) keyed by source node.
+/// First-fragment-only emission is enforced at render time via
+/// `geometry`.
+#[derive(Debug, Clone, Default)]
+pub struct BookmarkAnchorEntry;
+
+/// PR 3 target: link span (target + alt text) covering one or more
+/// glyph runs in a paragraph. `Vec<(NodeId, LinkSpan)>` lets a single
+/// node carry multiple spans.
+#[derive(Debug, Clone, Default)]
+pub struct LinkSpanEntry;
+
+// ── Drawables ─────────────────────────────────────────────────────────
+
+/// Node-keyed side-channel maps consumed by `render::render_v2`.
+///
+/// Phase 4 PR 1 ships this with all maps empty — the v2 render path
+/// walks geometry but emits no content for any node. Subsequent PRs
+/// fill each map by migrating one Pageable type at a time.
+#[derive(Debug, Default, Clone)]
+pub struct Drawables {
+    pub block_styles: BTreeMap<NodeId, BlockEntry>,
+    pub paragraphs: BTreeMap<NodeId, ParagraphEntry>,
+    pub images: BTreeMap<NodeId, ImageEntry>,
+    pub svgs: BTreeMap<NodeId, SvgEntry>,
+    pub tables: BTreeMap<NodeId, TableEntry>,
+    pub list_items: BTreeMap<NodeId, ListItemEntry>,
+    pub multicol_rules: BTreeMap<NodeId, MulticolRuleEntry>,
+    pub transforms: BTreeMap<NodeId, TransformEntry>,
+    pub bookmark_anchors: BTreeMap<NodeId, BookmarkAnchorEntry>,
+    pub link_spans: Vec<(NodeId, LinkSpanEntry)>,
+}
+
+impl Drawables {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// `true` when no draw payload has been registered for any node.
+    /// PR 1 always returns `true` because the convert side has not
+    /// migrated yet.
+    pub fn is_empty(&self) -> bool {
+        self.block_styles.is_empty()
+            && self.paragraphs.is_empty()
+            && self.images.is_empty()
+            && self.svgs.is_empty()
+            && self.tables.is_empty()
+            && self.list_items.is_empty()
+            && self.multicol_rules.is_empty()
+            && self.transforms.is_empty()
+            && self.bookmark_anchors.is_empty()
+            && self.link_spans.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drawables_default_is_empty() {
+        let d = Drawables::default();
+        assert!(d.is_empty());
+        assert_eq!(d.block_styles.len(), 0);
+        assert_eq!(d.link_spans.len(), 0);
+    }
+
+    #[test]
+    fn drawables_new_matches_default() {
+        let a = Drawables::new();
+        let b = Drawables::default();
+        assert_eq!(a.is_empty(), b.is_empty());
+    }
+}

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -7,6 +7,17 @@ use std::collections::{BTreeMap, HashMap};
 use std::ops::DerefMut;
 use std::path::{Path, PathBuf};
 
+/// Phase 4 PR 1 (fulgur-9t3z): selects which render pipeline produces
+/// the PDF. `V1` is the existing `Pageable` tree path; `V2` is the new
+/// geometry-driven `Drawables` path that replaces it. Both paths share
+/// upstream parse / Stylo / fragmenter work; they diverge only after
+/// `ConvertContext` has been populated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RenderPath {
+    V1,
+    V2,
+}
+
 /// Reusable PDF generation engine.
 pub struct Engine {
     config: Config,
@@ -45,6 +56,25 @@ impl Engine {
     /// a 2-pass rendering pipeline is used: pass 1 paginates body content, pass 2
     /// renders each page with resolved margin boxes.
     pub fn render_html(&self, html: &str) -> Result<Vec<u8>> {
+        self.render_html_via_path(html, RenderPath::V1)
+    }
+
+    /// Phase 4 PR 1 (fulgur-9t3z): render HTML through the parallel
+    /// `render_v2` path. Hidden from public docs while migration is in
+    /// progress; the shadow harness in
+    /// `crates/fulgur/tests/render_path_parity.rs` exercises it
+    /// alongside `render_html` and asserts byte equality on the
+    /// fixtures listed in `render_path_parity.toml`.
+    ///
+    /// PR 1 emits blank pages because every map in `Drawables` is empty;
+    /// later PRs migrate one Pageable type at a time and the byte-eq
+    /// allowlist grows.
+    #[doc(hidden)]
+    pub fn render_html_v2(&self, html: &str) -> Result<Vec<u8>> {
+        self.render_html_via_path(html, RenderPath::V2)
+    }
+
+    fn render_html_via_path(&self, html: &str, path: RenderPath) -> Result<Vec<u8>> {
         let html = crate::blitz_adapter::rewrite_marker_content_url_in_html(html);
 
         let combined_css = self
@@ -308,21 +338,38 @@ impl Engine {
                 crate::convert::pt_to_px(self.config.content_height()),
             )),
         };
-        let root = crate::convert::dom_to_pageable(&doc, &mut convert_ctx);
 
-        if gcpm.is_empty() {
-            crate::render::render_to_pdf(root, &self.config, &convert_ctx.pagination_geometry)
-        } else {
-            crate::render::render_to_pdf_with_gcpm(
-                root,
-                &self.config,
-                &gcpm,
-                &running_store,
-                fonts,
-                &convert_ctx.pagination_geometry,
-                &string_set_for_render,
-                &counter_ops_for_render,
-            )
+        match path {
+            RenderPath::V1 => {
+                let root = crate::convert::dom_to_pageable(&doc, &mut convert_ctx);
+                if gcpm.is_empty() {
+                    crate::render::render_to_pdf(
+                        root,
+                        &self.config,
+                        &convert_ctx.pagination_geometry,
+                    )
+                } else {
+                    crate::render::render_to_pdf_with_gcpm(
+                        root,
+                        &self.config,
+                        &gcpm,
+                        &running_store,
+                        fonts,
+                        &convert_ctx.pagination_geometry,
+                        &string_set_for_render,
+                        &counter_ops_for_render,
+                    )
+                }
+            }
+            RenderPath::V2 => {
+                let drawables = crate::convert::dom_to_drawables(&doc, &mut convert_ctx);
+                crate::render::render_v2(
+                    &self.config,
+                    &convert_ctx.pagination_geometry,
+                    &drawables,
+                    &gcpm,
+                )
+            }
         }
     }
 

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -8,6 +8,7 @@ pub mod blitz_adapter;
 pub(crate) mod column_css;
 pub mod config;
 pub mod convert;
+pub(crate) mod drawables;
 pub mod engine;
 pub mod error;
 pub mod gcpm;

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -26,20 +26,21 @@ pub fn render_v2(
     drawables: &Drawables,
     gcpm: &GcpmContext,
 ) -> Result<Vec<u8>> {
-    let _ = drawables; // PR 1: every draw map is empty
-
     let mut document = krilla::Document::new();
+
+    let mut bookmark_collector = if config.bookmarks {
+        Some(crate::pageable::BookmarkCollector::new())
+    } else {
+        None
+    };
 
     let page_count = crate::pagination_layout::implied_page_count(geometry).max(1) as usize;
     for page_idx in 0..page_count {
         let page_num = page_idx + 1;
         // Pass the full `gcpm.page_settings` (including selector
         // rules: `:first`, `:left`, `:right`) so per-page overrides
-        // fire identically to the v1 GCPM path. Filtering to
-        // `page_selector.is_none()` here would silently drop those
-        // overrides and bake the wrong `MediaBox` dimensions even on
-        // PR 1's blank pages (Devin review on PR #300).
-        let (resolved_size, _resolved_margin, resolved_landscape) =
+        // fire identically to the v1 GCPM path.
+        let (resolved_size, resolved_margin, resolved_landscape) =
             crate::gcpm::page_settings::resolve_page_settings(
                 &gcpm.page_settings,
                 page_num,
@@ -53,16 +54,163 @@ pub fn render_v2(
         };
         let settings = krilla::page::PageSettings::from_wh(page_size.width, page_size.height)
             .ok_or_else(|| Error::PdfGeneration("Invalid page dimensions".into()))?;
-        let _page = document.start_page_with(settings);
-        // PR 2+: walk geometry.fragments_on_page(page_idx) and dispatch
-        // (node_id, fragment) → draw_node(canvas, ..) here. PR 1 emits
-        // an empty page.
+        let mut page = document.start_page_with(settings);
+        if let Some(c) = bookmark_collector.as_mut() {
+            c.set_current_page(page_idx);
+        }
+        {
+            let mut surface = page.surface();
+            let mut canvas = crate::pageable::Canvas {
+                surface: &mut surface,
+                bookmark_collector: bookmark_collector.as_mut(),
+                link_collector: None,
+            };
+            draw_v2_page(
+                &mut canvas,
+                page_idx as u32,
+                resolved_margin.left,
+                resolved_margin.top,
+                geometry,
+                drawables,
+            );
+        }
+    }
+
+    if let Some(c) = bookmark_collector {
+        let entries = c.into_entries();
+        if !entries.is_empty() {
+            document.set_outline(crate::outline::build_outline(&entries));
+        }
     }
 
     document.set_metadata(build_metadata(config));
     document
         .finish()
         .map_err(|e| Error::PdfGeneration(format!("{e:?}")))
+}
+
+/// Phase 4 v2 per-page draw dispatcher. Walks every `(node_id,
+/// fragment)` pair whose fragment is on `page_index` and routes each
+/// to a per-type draw function sourced from `drawables`.
+///
+/// Iteration is by `BTreeMap<NodeId, _>` order which is approximately
+/// document order (Blitz allocates NodeIds during parse). That keeps
+/// stacking order — backgrounds before foregrounds, parents before
+/// children — consistent with the v1 traversal.
+///
+/// PR 2 covers `Drawables.images`, `.svgs`, and `.bookmark_anchors`
+/// (first-fragment-only). Subsequent PRs add match arms for the
+/// other maps.
+fn draw_v2_page(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    page_index: u32,
+    margin_left_pt: f32,
+    margin_top_pt: f32,
+    geometry: &crate::pagination_layout::PaginationGeometryTable,
+    drawables: &Drawables,
+) {
+    use crate::convert::px_to_pt;
+
+    for (&node_id, geom) in geometry {
+        // Bookmark anchor: emit on the page where the node's *first*
+        // fragment lands, mirroring `BookmarkMarkerWrapperPageable`'s
+        // `is_first_page_for` slice semantics.
+        if let Some(first_frag) = geom.fragments.first()
+            && first_frag.page_index == page_index
+            && let Some(anchor) = drawables.bookmark_anchors.get(&node_id)
+            && let Some(c) = canvas.bookmark_collector.as_deref_mut()
+        {
+            let y_pt = margin_top_pt + px_to_pt(first_frag.y);
+            c.record(anchor.level, anchor.label.clone(), y_pt);
+        }
+
+        // Per-fragment leaf draws.
+        for frag in &geom.fragments {
+            if frag.page_index != page_index {
+                continue;
+            }
+            let x_pt = margin_left_pt + px_to_pt(frag.x);
+            let y_pt = margin_top_pt + px_to_pt(frag.y);
+
+            if let Some(img) = drawables.images.get(&node_id) {
+                draw_image_v2(canvas, img, x_pt, y_pt);
+                continue;
+            }
+            if let Some(svg) = drawables.svgs.get(&node_id) {
+                draw_svg_v2(canvas, svg, x_pt, y_pt);
+                continue;
+            }
+            // Other types (block_styles / paragraphs / tables / ...)
+            // land in subsequent PRs.
+        }
+    }
+}
+
+/// v2 image draw. Mirrors `image::ImagePageable::draw` but operates on
+/// the side-channel `ImageEntry` data; the `width`/`height` are the
+/// CSS-resolved size in pt that fulgur stores on the original
+/// `ImagePageable`.
+fn draw_image_v2(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    entry: &crate::drawables::ImageEntry,
+    x: f32,
+    y: f32,
+) {
+    use crate::pageable::draw_with_opacity;
+
+    if !entry.visible {
+        return;
+    }
+    draw_with_opacity(canvas, entry.opacity, |canvas| {
+        let Some(image) = decode_image_for_v2(entry) else {
+            return;
+        };
+        let Some(size) = krilla::geom::Size::from_wh(entry.width, entry.height) else {
+            return;
+        };
+        let transform = krilla::geom::Transform::from_translate(x, y);
+        canvas.surface.push_transform(&transform);
+        canvas.surface.draw_image(image, size);
+        canvas.surface.pop();
+    });
+}
+
+fn decode_image_for_v2(entry: &crate::drawables::ImageEntry) -> Option<krilla::image::Image> {
+    use crate::image::ImageFormat;
+    use krilla::image::Image;
+    let data: krilla::Data = entry.image_data.clone().into();
+    let image_result = match entry.format {
+        ImageFormat::Png => Image::from_png(data, true),
+        ImageFormat::Jpeg => Image::from_jpeg(data, true),
+        ImageFormat::Gif => Image::from_gif(data, true),
+    };
+    image_result.ok()
+}
+
+/// v2 SVG draw. Mirrors `svg::SvgPageable::draw`.
+fn draw_svg_v2(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    entry: &crate::drawables::SvgEntry,
+    x: f32,
+    y: f32,
+) {
+    use crate::pageable::draw_with_opacity;
+    use krilla_svg::{SurfaceExt, SvgSettings};
+
+    if !entry.visible {
+        return;
+    }
+    draw_with_opacity(canvas, entry.opacity, |canvas| {
+        let Some(size) = krilla::geom::Size::from_wh(entry.width, entry.height) else {
+            return;
+        };
+        let transform = krilla::geom::Transform::from_translate(x, y);
+        canvas.surface.push_transform(&transform);
+        let _ = canvas
+            .surface
+            .draw_svg(&entry.tree, size, SvgSettings::default());
+        canvas.surface.pop();
+    });
 }
 
 /// Render a Pageable tree to PDF bytes using fragmenter geometry to

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -1,4 +1,5 @@
 use crate::config::Config;
+use crate::drawables::Drawables;
 use crate::error::{Error, Result};
 use crate::gcpm::GcpmContext;
 use crate::gcpm::counter::resolve_content_to_html;
@@ -7,6 +8,62 @@ use crate::gcpm::running::RunningElementStore;
 use crate::pageable::{Canvas, Pageable};
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
+
+/// Phase 4 PR 1 (fulgur-9t3z): geometry-driven render skeleton.
+///
+/// Walks `geometry` per page, dispatches each (node_id, fragment) to
+/// per-type draw functions sourced from `drawables`. PR 1 emits blank
+/// pages because every map in `Drawables` is empty; subsequent PRs
+/// migrate one Pageable type at a time and the dispatcher grows
+/// match arms.
+///
+/// Page settings (size, margins, landscape, GCPM `@page` overrides)
+/// resolve identically to the v1 path so byte equality is achievable
+/// once the draw migration completes.
+pub fn render_v2(
+    config: &Config,
+    geometry: &crate::pagination_layout::PaginationGeometryTable,
+    drawables: &Drawables,
+    gcpm: &GcpmContext,
+) -> Result<Vec<u8>> {
+    let _ = drawables; // PR 1: every draw map is empty
+
+    let mut document = krilla::Document::new();
+
+    let default_page_rules: Vec<_> = gcpm
+        .page_settings
+        .iter()
+        .filter(|r| r.page_selector.is_none())
+        .cloned()
+        .collect();
+    let page_count = crate::pagination_layout::implied_page_count(geometry).max(1);
+    for page_idx in 0..page_count as usize {
+        let page_num = page_idx + 1;
+        let (resolved_size, _resolved_margin, resolved_landscape) =
+            crate::gcpm::page_settings::resolve_page_settings(
+                &default_page_rules,
+                page_num,
+                page_count as usize,
+                config,
+            );
+        let page_size = if resolved_landscape {
+            resolved_size.landscape()
+        } else {
+            resolved_size
+        };
+        let settings = krilla::page::PageSettings::from_wh(page_size.width, page_size.height)
+            .ok_or_else(|| Error::PdfGeneration("Invalid page dimensions".into()))?;
+        let _page = document.start_page_with(settings);
+        // PR 2+: walk geometry.fragments_on_page(page_idx) and dispatch
+        // (node_id, fragment) → draw_node(canvas, ..) here. PR 1 emits
+        // an empty page.
+    }
+
+    document.set_metadata(build_metadata(config));
+    document
+        .finish()
+        .map_err(|e| Error::PdfGeneration(format!("{e:?}")))
+}
 
 /// Render a Pageable tree to PDF bytes using fragmenter geometry to
 /// split pages.

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -30,20 +30,20 @@ pub fn render_v2(
 
     let mut document = krilla::Document::new();
 
-    let default_page_rules: Vec<_> = gcpm
-        .page_settings
-        .iter()
-        .filter(|r| r.page_selector.is_none())
-        .cloned()
-        .collect();
-    let page_count = crate::pagination_layout::implied_page_count(geometry).max(1);
-    for page_idx in 0..page_count as usize {
+    let page_count = crate::pagination_layout::implied_page_count(geometry).max(1) as usize;
+    for page_idx in 0..page_count {
         let page_num = page_idx + 1;
+        // Pass the full `gcpm.page_settings` (including selector
+        // rules: `:first`, `:left`, `:right`) so per-page overrides
+        // fire identically to the v1 GCPM path. Filtering to
+        // `page_selector.is_none()` here would silently drop those
+        // overrides and bake the wrong `MediaBox` dimensions even on
+        // PR 1's blank pages (Devin review on PR #300).
         let (resolved_size, _resolved_margin, resolved_landscape) =
             crate::gcpm::page_settings::resolve_page_settings(
-                &default_page_rules,
+                &gcpm.page_settings,
                 page_num,
-                page_count as usize,
+                page_count,
                 config,
             );
         let page_size = if resolved_landscape {

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -225,6 +225,12 @@ fn render_path_byte_equality() {
         allowlist.len(),
     );
 
+    if std::env::var_os("FULGUR_PARITY_VERBOSE").is_some() {
+        for (label, v1l, v2l) in &diffs {
+            eprintln!("  diff {label}: v1={v1l}B v2={v2l}B");
+        }
+    }
+
     if !allowlist_failures.is_empty() {
         let detail = allowlist_failures
             .iter()

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -1,0 +1,243 @@
+//! Phase 4 shadow harness (fulgur-9t3z).
+//!
+//! Drives every fixture through both `Engine::render_html` (v1, the
+//! current `Pageable` trait path) and `Engine::render_html_v2` (v2,
+//! the geometry + `Drawables` path). For fixtures listed in
+//! `render_path_parity.toml`'s `allowlist`, asserts byte equality.
+//!
+//! PR 1 ships an empty allowlist — every fixture is rendered through
+//! both paths to validate that v2 doesn't crash, and the harness
+//! reports a coverage line ("v2 byte-identical: N / TOTAL"). PR 2 onward
+//! adds fixtures to the allowlist as Pageable types migrate, and the
+//! `assert_eq!` arm fires when a previously-passing fixture regresses.
+//!
+//! When the allowlist reaches the full 56-fixture set, PR 7 flips
+//! `Engine::render_html` to call the v2 path by default and PR 8
+//! deletes v1.
+
+use fulgur::config::PageSize;
+use fulgur::engine::Engine;
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+const ALLOWLIST_TOML: &str = include_str!("render_path_parity.toml");
+
+/// Repository root, resolved from the fulgur crate's manifest dir.
+fn repo_root() -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest
+        .parent()
+        .and_then(Path::parent)
+        .expect("fulgur crate should be nested under <repo>/crates")
+        .to_path_buf()
+}
+
+/// Resolve every fixture currently exercised by VRT (incl. GCPM) and
+/// `fulgur-cli`'s examples_determinism integration.
+fn collect_fixtures() -> Vec<FixtureSpec> {
+    let mut out = Vec::new();
+    let root = repo_root();
+
+    // VRT fixtures — read manifest.toml and resolve each row's path
+    // against `crates/fulgur-vrt/fixtures/`. The VRT manifest knows
+    // about per-fixture margin / page-size / bookmark overrides; we
+    // re-apply them so rendered PDFs match the VRT runner's settings
+    // exactly.
+    let vrt_manifest = root.join("crates/fulgur-vrt/manifest.toml");
+    let vrt_root = root.join("crates/fulgur-vrt/fixtures");
+    let vrt_text = std::fs::read_to_string(&vrt_manifest).expect("read VRT manifest");
+    let vrt_parsed: VrtManifest = toml::from_str(&vrt_text).expect("parse VRT manifest");
+    for row in &vrt_parsed.fixture {
+        let html_path = vrt_root.join(&row.path);
+        out.push(FixtureSpec {
+            label: format!("vrt://{}", row.path),
+            html_path,
+            page_size: row
+                .page_size
+                .clone()
+                .unwrap_or_else(|| vrt_parsed.defaults.page_size.clone()),
+            margin_pt: row.margin_pt,
+            bookmarks: row.bookmarks.unwrap_or(false),
+            base_path: None,
+        });
+    }
+
+    // examples/ fixtures — every directory under `examples/` that has
+    // an `index.html` is rendered with default config. Mirrors the
+    // `fulgur-cli` examples_determinism harness.
+    let examples_root = root.join("examples");
+    if let Ok(entries) = std::fs::read_dir(&examples_root) {
+        let mut dirs: Vec<PathBuf> = entries
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+            .map(|e| e.path())
+            .filter(|p| p.join("index.html").exists())
+            .collect();
+        dirs.sort();
+        for dir in dirs {
+            let name = dir
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("")
+                .to_string();
+            out.push(FixtureSpec {
+                label: format!("examples://{name}"),
+                html_path: dir.join("index.html"),
+                page_size: "A4".into(),
+                margin_pt: None,
+                bookmarks: false,
+                base_path: Some(dir.clone()),
+            });
+        }
+    }
+
+    out
+}
+
+/// Render a single fixture via the requested path; returns the PDF
+/// bytes.
+fn render(fx: &FixtureSpec, path: RenderPath) -> Vec<u8> {
+    let html = std::fs::read_to_string(&fx.html_path)
+        .unwrap_or_else(|e| panic!("read fixture {}: {e}", fx.html_path.display()));
+
+    let mut builder = Engine::builder().page_size(page_size_from_name(&fx.page_size));
+    if let Some(mpt) = fx.margin_pt {
+        builder = builder.margin(fulgur::config::Margin::uniform(mpt));
+    }
+    if fx.bookmarks {
+        builder = builder.bookmarks(true);
+    }
+    if let Some(base) = &fx.base_path {
+        builder = builder.base_path(base.clone());
+    }
+    let engine = builder.build();
+
+    match path {
+        RenderPath::V1 => engine
+            .render_html(&html)
+            .unwrap_or_else(|e| panic!("v1 render {}: {e}", fx.label)),
+        RenderPath::V2 => engine
+            .render_html_v2(&html)
+            .unwrap_or_else(|e| panic!("v2 render {}: {e}", fx.label)),
+    }
+}
+
+fn page_size_from_name(name: &str) -> PageSize {
+    match name.to_ascii_uppercase().as_str() {
+        "A4" => PageSize::A4,
+        "A3" => PageSize::A3,
+        "LETTER" => PageSize::LETTER,
+        _ => PageSize::A4,
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum RenderPath {
+    V1,
+    V2,
+}
+
+#[derive(Debug, Clone)]
+struct FixtureSpec {
+    /// Human-readable identifier (e.g. `vrt://basic/borders.html`).
+    label: String,
+    html_path: PathBuf,
+    page_size: String,
+    margin_pt: Option<f32>,
+    bookmarks: bool,
+    /// Forwarded to `Engine::builder().base_path(..)` so relative
+    /// `<link rel=stylesheet href=...>` references resolve. Required
+    /// for the GCPM and `examples/` fixtures.
+    base_path: Option<PathBuf>,
+}
+
+#[derive(serde::Deserialize)]
+struct AllowlistFile {
+    #[serde(default)]
+    allowlist: Vec<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct VrtManifest {
+    defaults: VrtDefaults,
+    #[serde(default)]
+    fixture: Vec<VrtFixture>,
+}
+
+#[derive(serde::Deserialize)]
+struct VrtDefaults {
+    page_size: String,
+}
+
+#[derive(serde::Deserialize)]
+struct VrtFixture {
+    path: String,
+    page_size: Option<String>,
+    margin_pt: Option<f32>,
+    bookmarks: Option<bool>,
+}
+
+fn load_allowlist() -> BTreeSet<String> {
+    let parsed: AllowlistFile =
+        toml::from_str(ALLOWLIST_TOML).expect("parse render_path_parity.toml");
+    parsed.allowlist.into_iter().collect()
+}
+
+#[test]
+fn render_path_byte_equality() {
+    let fixtures = collect_fixtures();
+    assert!(
+        !fixtures.is_empty(),
+        "no fixtures collected — repository layout changed?"
+    );
+
+    let allowlist = load_allowlist();
+    let mut byte_eq_count = 0usize;
+    let mut diffs: Vec<(String, usize, usize)> = Vec::new();
+    let mut allowlist_failures: Vec<(String, usize, usize)> = Vec::new();
+
+    // Restrict noisy fixtures: GCPM/font fixtures rely on
+    // `FONTCONFIG_FILE` for determinism. Don't fail the test if it
+    // isn't set; just skip the byte-eq comparison so PR 1 can run
+    // green in environments without the pinned fontconfig.
+    let fontconfig_set = std::env::var_os("FONTCONFIG_FILE").is_some();
+
+    for fx in &fixtures {
+        let v1 = render(fx, RenderPath::V1);
+        let v2 = render(fx, RenderPath::V2);
+
+        let eq = v1 == v2;
+        if eq {
+            byte_eq_count += 1;
+        } else {
+            diffs.push((fx.label.clone(), v1.len(), v2.len()));
+        }
+
+        if allowlist.contains(&fx.label) && !eq && fontconfig_set {
+            allowlist_failures.push((fx.label.clone(), v1.len(), v2.len()));
+        }
+    }
+
+    eprintln!(
+        "render_path_parity: v2 byte-identical {} / {} fixtures (allowlist {})",
+        byte_eq_count,
+        fixtures.len(),
+        allowlist.len(),
+    );
+
+    if !allowlist_failures.is_empty() {
+        let detail = allowlist_failures
+            .iter()
+            .map(|(label, v1l, v2l)| format!("  {label}: v1={v1l}B v2={v2l}B"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        panic!(
+            "{} allowlisted fixture(s) regressed in v2:\n{detail}",
+            allowlist_failures.len()
+        );
+    }
+
+    // PR 1: allowlist is empty by design. The line above is the only
+    // visible signal — the test passes regardless.
+    let _ = diffs;
+}

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -1,0 +1,26 @@
+# Phase 4 (fulgur-9t3z) shadow harness allowlist.
+#
+# Each fixture path listed here MUST produce byte-identical PDFs when
+# rendered via `Engine::render_html` (v1 = Pageable trait path) and
+# `Engine::render_html_v2` (v2 = geometry + Drawables path).
+#
+# As Phase 4 progresses, each PR migrates one Pageable type and adds the
+# fixtures it covers to this allowlist. PR 7 (default flip) requires
+# this file to cover every fixture in:
+#
+# - `crates/fulgur-vrt/manifest.toml` (currently 39 fixtures)
+# - `crates/fulgur-cli/tests/examples_determinism.rs` (currently 11)
+# - GCPM fixtures under `crates/fulgur-vrt/fixtures/gcpm/` (already
+#   covered by the VRT manifest above)
+#
+# PR 1 ships with an empty allowlist — the harness still runs both
+# paths against every fixture and reports coverage, but no byte-eq
+# assertions fire.
+
+# Format: TOML array of relative paths. Paths are resolved against the
+# fixture roots in `render_path_parity.rs::FIXTURE_ROOTS`.
+
+allowlist = [
+    # PR 2 will add: vrt://basic/solid-box, vrt://basic/borders,
+    # examples://image, etc.
+]


### PR DESCRIPTION
## 概要

Phase 4 (fulgur-9t3z) PR 1: parallel render path のスケルトン + shadow harness。production の挙動変更なし。

beads: fulgur-s9qd

## 追加

### Drawables 型 (\`crates/fulgur/src/drawables.rs\`)

Phase 4 の中核 IR。\`BTreeMap<NodeId, T>\` を 10 種類持つ struct。各 entry type は **placeholder unit struct**:

| Field | Phase 4 PR で fill |
|---|---|
| \`block_styles\` | PR 4 |
| \`paragraphs\` | PR 3 |
| \`images\` / \`svgs\` | PR 2 |
| \`tables\` / \`list_items\` | PR 5 |
| \`multicol_rules\` / \`transforms\` | PR 6 |
| \`bookmark_anchors\` | PR 2 |
| \`link_spans\` | PR 3 |

### convert / render skeleton

- \`convert::dom_to_drawables(doc, ctx) -> Drawables\` (空 map を返す)
- \`render::render_v2(config, geometry, drawables, gcpm) -> Result<Vec<u8>>\` (geometry の page 数 + GCPM \`@page\` resolution は正しく適用、ただし draw dispatch は no-op)

### Engine refactor

\`render_html\` を \`render_html_via_path(html, RenderPath::V1)\` に delegate。\`#[doc(hidden)] render_html_v2\` を \`V2\` で同 fn 呼び出し。upstream pipeline (parse / Stylo / fragmenter / GCPM passes) は v1/v2 共通、\`ConvertContext\` 構築後に分岐。

### Shadow harness

- \`crates/fulgur/tests/render_path_parity.rs\` — VRT 39 + GCPM 6 + examples 11 = 計 **59 fixture** を v1 と v2 両方で render し byte-eq 比較
- \`crates/fulgur/tests/render_path_parity.toml\` — allowlist (PR 1 では空)
- \`FONTCONFIG_FILE\` 未設定環境では byte-eq assertion を skip (font determinism 依存のため)
- 出力例: \`render_path_parity: v2 byte-identical 0 / 59 fixtures (allowlist 0)\`

## 検証

- \`cargo build -p fulgur\`: 0 warning
- \`cargo clippy --workspace --tests\`: 0 warning
- \`cargo test -p fulgur --lib\`: 840 pass
- \`cargo test -p fulgur --test render_path_parity\`: 0/59 byte-identical (期待通り)、allowlist 0 件、test pass
- \`cargo test -p fulgur-vrt -p fulgur-cli\`: 既存全 byte-eq pass (regression なし)

## Open question 解決状況

Phase 4 design doc (PR #299) で挙げた 4 つの open question:
1. ✅ \`Drawables\` は新 struct (\`ConvertContext\` extension ではない) — convert の **output**
2. ✅ GCPM context は \`Drawables\` の中ではなく \`render_v2\` の引数で別管理
3. ✅ Shadow harness は \`crates/fulgur/tests/render_path_parity.rs\`、2.5s で完了するため nextest gate 不要
4. ⏳ PR 6 の Transform/Multicol/wrapper 順序は PR 6 着手時に再決定

## 次: PR 2

Spacer / Image / SVG + 5 marker types を \`Drawables\` に migrate。allowlist に該当 fixture を追加。

## Test plan

- [x] \`cargo build -p fulgur\` 0 warning
- [x] \`cargo clippy --workspace --tests\` 0 warning
- [x] \`cargo test -p fulgur --lib\` 840 pass
- [x] \`cargo test -p fulgur --test render_path_parity\` pass (0/59 expected)
- [x] \`cargo test -p fulgur-vrt -p fulgur-cli\` 既存全 byte-eq pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
