### PR TITLE
feat(render_v2): Phase 4 PR 2 — Image / SVG / Bookmark draw migration (fulgur-w9bs)

### DIFF
--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -305,6 +305,7 @@ fn extract_drawables_from_pageable(
     // column-rule painting still lands in PR 6 (`drawables.multicol_rules`).
     if let Some(w) = any.downcast_ref::<MulticolRulePageable>() {
         extract_drawables_from_pageable(w.child.as_ref(), out);
+        return;
     }
     // Other types (Spacer, ParagraphPageable, marker-only Pageables)
     // have no PR 2 payload — markers and Spacers stay no-op in v2;

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -305,7 +305,6 @@ fn extract_drawables_from_pageable(
     // column-rule painting still lands in PR 6 (`drawables.multicol_rules`).
     if let Some(w) = any.downcast_ref::<MulticolRulePageable>() {
         extract_drawables_from_pageable(w.child.as_ref(), out);
-        return;
     }
     // Other types (Spacer, ParagraphPageable, marker-only Pageables)
     // have no PR 2 payload — markers and Spacers stay no-op in v2;

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -188,11 +188,18 @@ pub fn dom_to_drawables(
     doc: &HtmlDocument,
     ctx: &mut ConvertContext<'_>,
 ) -> crate::drawables::Drawables {
+    // Snapshot bookmark map *before* `dom_to_pageable` runs:
+    // `convert_node` drains `ctx.bookmark_by_node` via `.remove(&node_id)`
+    // for every node it visits, so by the time we'd read back from
+    // `ctx.bookmark_by_node` below it would be empty (PR #301 Devin
+    // review). The clone is small (one `BookmarkInfo` per heading);
+    // the v1 path already accepts the same allocation cost via
+    // `bookmark_by_node_for_parity` in `engine.rs`.
+    let bookmark_snapshot = ctx.bookmark_by_node.clone();
     let root_pageable = dom_to_pageable(doc, ctx);
     let mut drawables = crate::drawables::Drawables::new();
     extract_drawables_from_pageable(root_pageable.as_ref(), &mut drawables);
-    let bookmark_anchors_drained = extract_bookmark_anchors(doc, &ctx.bookmark_by_node, ctx.assets);
-    drawables.bookmark_anchors = bookmark_anchors_drained;
+    drawables.bookmark_anchors = extract_bookmark_anchors(doc, &bookmark_snapshot, ctx.assets);
     drawables
 }
 
@@ -207,8 +214,8 @@ fn extract_drawables_from_pageable(
     use crate::image::ImagePageable;
     use crate::pageable::{
         BlockPageable, BookmarkMarkerWrapperPageable, CounterOpWrapperPageable, ListItemPageable,
-        RunningElementWrapperPageable, StringSetWrapperPageable, TablePageable,
-        TransformWrapperPageable,
+        MulticolRulePageable, RunningElementWrapperPageable, StringSetWrapperPageable,
+        TablePageable, TransformWrapperPageable,
     };
     use crate::svg::SvgPageable;
 
@@ -288,10 +295,20 @@ fn extract_drawables_from_pageable(
     }
     if let Some(w) = any.downcast_ref::<CounterOpWrapperPageable>() {
         extract_drawables_from_pageable(w.child.as_ref(), out);
+        return;
     }
-    // Other types (Spacer, ParagraphPageable, MulticolRulePageable,
-    // marker-only Pageables) have no PR 2 payload — markers and
-    // Spacers stay no-op in v2; Paragraph / Multicol land in PR 3 / 6.
+    // PR #301 Devin: MulticolRulePageable is a wrapper carrying a
+    // `child: Box<dyn Pageable>` produced by `maybe_wrap_multicol_rule`
+    // around any multicol container. Without this arm, images / SVGs
+    // nested inside a multicol container fall through to "Other" and
+    // never enter `Drawables.images` / `.svgs`. Multicol's own
+    // column-rule painting still lands in PR 6 (`drawables.multicol_rules`).
+    if let Some(w) = any.downcast_ref::<MulticolRulePageable>() {
+        extract_drawables_from_pageable(w.child.as_ref(), out);
+    }
+    // Other types (Spacer, ParagraphPageable, marker-only Pageables)
+    // have no PR 2 payload — markers and Spacers stay no-op in v2;
+    // Paragraph / Multicol-rule paint land in PR 3 / 6.
 }
 
 #[cfg(test)]
@@ -364,6 +381,53 @@ mod extract_drawables_tests {
         let mut out = Drawables::new();
         extract_drawables_from_pageable(&wrapped, &mut out);
         assert!(out.images.contains_key(&99));
+    }
+
+    /// Regression: `MulticolRulePageable` is a wrapper too. Images
+    /// nested inside a multicol container reach `drawables.images`
+    /// only if the extractor descends into its `child` (PR #301
+    /// Devin). Without the dedicated arm the wrapper falls through
+    /// to "Other" and the image is silently dropped.
+    #[test]
+    fn descends_into_multicol_rule_wrapper_to_reach_image() {
+        use crate::column_css::ColumnRuleSpec;
+        use crate::pageable::MulticolRulePageable;
+
+        let img = ImagePageable::new(Arc::new(vec![0u8; 4]), ImageFormat::Png, 10.0, 10.0)
+            .with_node_id(Some(123));
+        let wrapped =
+            MulticolRulePageable::new(Box::new(img), ColumnRuleSpec::default(), Vec::new());
+        let mut out = Drawables::new();
+        extract_drawables_from_pageable(&wrapped, &mut out);
+        assert!(
+            out.images.contains_key(&123),
+            "MulticolRulePageable's child must be visited by the extractor"
+        );
+    }
+
+    /// Regression: `dom_to_drawables` must snapshot `ctx.bookmark_by_node`
+    /// **before** calling `dom_to_pageable`. `convert_node` drains the
+    /// map via `.remove(&node_id)` for every visited node, so a naive
+    /// post-call read sees an empty map (PR #301 Devin). End-to-end
+    /// test through `Engine::render_html_v2` with `bookmarks(true)`:
+    /// the rendered PDF must contain `/Outlines` even though the v2
+    /// path is the one that builds the outline.
+    #[test]
+    fn dom_to_drawables_preserves_bookmark_anchors_for_outline() {
+        use crate::config::PageSize;
+        use crate::engine::Engine;
+
+        let html = "<!DOCTYPE html><html><head><style>body{margin:0;padding:0}</style></head><body><h1>Heading</h1></body></html>";
+        let engine = Engine::builder()
+            .page_size(PageSize::A4)
+            .bookmarks(true)
+            .build();
+        let pdf = engine.render_html_v2(html).expect("render v2");
+        let pdf_str = String::from_utf8_lossy(&pdf);
+        assert!(
+            pdf_str.contains("/Outlines"),
+            "bookmark anchors must reach the v2 outline pipeline; PDF missing /Outlines"
+        );
     }
 }
 

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -173,17 +173,221 @@ pub fn dom_to_pageable(doc: &HtmlDocument, ctx: &mut ConvertContext<'_>) -> Box<
     convert_node(doc.deref(), root.id, ctx, 0)
 }
 
-/// Phase 4 PR 1 skeleton (fulgur-9t3z): convert a resolved Blitz document
-/// into a `Drawables` struct holding per-NodeId draw payload.
+/// Phase 4 (fulgur-9t3z): convert a resolved Blitz document into a
+/// `Drawables` struct holding per-NodeId draw payload.
 ///
-/// Returns an empty `Drawables` until subsequent PRs migrate each
-/// Pageable type's data extraction. The `_doc` / `_ctx` arguments are
-/// kept on the signature so PR 2+ does not need to re-thread them.
+/// **Migration scaffolding (PRs 2-6)**: this implementation runs
+/// `dom_to_pageable` internally and walks the resulting tree to
+/// extract each per-type payload into its `Drawables` map. The
+/// Pageable tree is dropped before return — wasteful but lets each
+/// subsequent PR migrate one Pageable type at a time without
+/// duplicating convert logic. PR 8 (after Pageable deletion) will
+/// replace this body with a native DOM walk that doesn't allocate
+/// the intermediate Pageable tree.
 pub fn dom_to_drawables(
-    _doc: &HtmlDocument,
-    _ctx: &mut ConvertContext<'_>,
+    doc: &HtmlDocument,
+    ctx: &mut ConvertContext<'_>,
 ) -> crate::drawables::Drawables {
-    crate::drawables::Drawables::new()
+    let root_pageable = dom_to_pageable(doc, ctx);
+    let mut drawables = crate::drawables::Drawables::new();
+    extract_drawables_from_pageable(root_pageable.as_ref(), &mut drawables);
+    let bookmark_anchors_drained = extract_bookmark_anchors(doc, &ctx.bookmark_by_node, ctx.assets);
+    drawables.bookmark_anchors = bookmark_anchors_drained;
+    drawables
+}
+
+/// Walk a Pageable tree and populate each `Drawables` map by
+/// downcasting concrete types. PR 2 covers `ImagePageable` and
+/// `SvgPageable`; subsequent PRs add the rest.
+fn extract_drawables_from_pageable(
+    pageable: &dyn crate::pageable::Pageable,
+    out: &mut crate::drawables::Drawables,
+) {
+    use crate::drawables::{ImageEntry, SvgEntry};
+    use crate::image::ImagePageable;
+    use crate::pageable::{
+        BlockPageable, BookmarkMarkerWrapperPageable, CounterOpWrapperPageable, ListItemPageable,
+        RunningElementWrapperPageable, StringSetWrapperPageable, TablePageable,
+        TransformWrapperPageable,
+    };
+    use crate::svg::SvgPageable;
+
+    let any = pageable.as_any();
+
+    // Image leaf — record per-NodeId payload.
+    if let Some(img) = any.downcast_ref::<ImagePageable>() {
+        if let Some(node_id) = img.node_id {
+            out.images.insert(
+                node_id,
+                ImageEntry {
+                    image_data: img.image_data.clone(),
+                    format: img.format,
+                    width: img.width,
+                    height: img.height,
+                    opacity: img.opacity,
+                    visible: img.visible,
+                },
+            );
+        }
+        return;
+    }
+    // SVG leaf — record per-NodeId payload.
+    if let Some(svg) = any.downcast_ref::<SvgPageable>() {
+        if let Some(node_id) = svg.node_id {
+            out.svgs.insert(
+                node_id,
+                SvgEntry {
+                    tree: svg.tree.clone(),
+                    width: svg.width,
+                    height: svg.height,
+                    opacity: svg.opacity,
+                    visible: svg.visible,
+                },
+            );
+        }
+        return;
+    }
+    // Block / List / Table / wrappers — recurse into children. PR 4+
+    // will record their own draw payload (BlockEntry, etc.); for PR 2
+    // we only walk past them to reach the leaves.
+    if let Some(block) = any.downcast_ref::<BlockPageable>() {
+        for pc in &block.children {
+            extract_drawables_from_pageable(pc.child.as_ref(), out);
+        }
+        return;
+    }
+    if let Some(table) = any.downcast_ref::<TablePageable>() {
+        for pc in &table.header_cells {
+            extract_drawables_from_pageable(pc.child.as_ref(), out);
+        }
+        for pc in &table.body_cells {
+            extract_drawables_from_pageable(pc.child.as_ref(), out);
+        }
+        return;
+    }
+    if let Some(list_item) = any.downcast_ref::<ListItemPageable>() {
+        extract_drawables_from_pageable(list_item.body.as_ref(), out);
+        return;
+    }
+    // Wrappers delegate.
+    if let Some(w) = any.downcast_ref::<TransformWrapperPageable>() {
+        extract_drawables_from_pageable(w.inner.as_ref(), out);
+        return;
+    }
+    if let Some(w) = any.downcast_ref::<BookmarkMarkerWrapperPageable>() {
+        extract_drawables_from_pageable(w.child.as_ref(), out);
+        return;
+    }
+    if let Some(w) = any.downcast_ref::<StringSetWrapperPageable>() {
+        extract_drawables_from_pageable(w.child.as_ref(), out);
+        return;
+    }
+    if let Some(w) = any.downcast_ref::<RunningElementWrapperPageable>() {
+        extract_drawables_from_pageable(w.child.as_ref(), out);
+        return;
+    }
+    if let Some(w) = any.downcast_ref::<CounterOpWrapperPageable>() {
+        extract_drawables_from_pageable(w.child.as_ref(), out);
+    }
+    // Other types (Spacer, ParagraphPageable, MulticolRulePageable,
+    // marker-only Pageables) have no PR 2 payload — markers and
+    // Spacers stay no-op in v2; Paragraph / Multicol land in PR 3 / 6.
+}
+
+#[cfg(test)]
+mod extract_drawables_tests {
+    use super::*;
+    use crate::drawables::Drawables;
+    use crate::image::{ImageFormat, ImagePageable};
+    use crate::pageable::{
+        BlockPageable, BookmarkMarkerPageable, BookmarkMarkerWrapperPageable, PositionedChild,
+    };
+    use crate::svg::SvgPageable;
+    use std::sync::Arc;
+    use usvg::{Options, Tree};
+
+    /// Build a Pageable tree containing one block-level `ImagePageable`,
+    /// run the extractor, and verify the image lands in
+    /// `drawables.images` keyed by its `node_id`.
+    #[test]
+    fn extracts_block_level_image_into_drawables() {
+        let img = ImagePageable::new(Arc::new(vec![0u8; 4]), ImageFormat::Png, 50.0, 30.0)
+            .with_node_id(Some(42));
+        let block = BlockPageable::with_positioned_children(vec![PositionedChild::in_flow(
+            Box::new(img),
+            0.0,
+            0.0,
+        )]);
+        let mut out = Drawables::new();
+        extract_drawables_from_pageable(&block, &mut out);
+
+        let entry = out.images.get(&42).expect("image entry recorded");
+        assert_eq!(entry.width, 50.0);
+        assert_eq!(entry.height, 30.0);
+        assert!(entry.visible);
+    }
+
+    /// Same shape for SVG.
+    #[test]
+    fn extracts_block_level_svg_into_drawables() {
+        let tree = Arc::new(
+            Tree::from_str(
+                "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'></svg>",
+                &Options::default(),
+            )
+            .expect("parse svg"),
+        );
+        let svg = SvgPageable::new(tree, 80.0, 60.0).with_node_id(Some(7));
+        let block = BlockPageable::with_positioned_children(vec![PositionedChild::in_flow(
+            Box::new(svg),
+            0.0,
+            0.0,
+        )]);
+        let mut out = Drawables::new();
+        extract_drawables_from_pageable(&block, &mut out);
+
+        let entry = out.svgs.get(&7).expect("svg entry recorded");
+        assert_eq!(entry.width, 80.0);
+        assert_eq!(entry.height, 60.0);
+    }
+
+    /// Marker wrappers must be transparent — the extractor descends
+    /// into `child` and finds the image inside.
+    #[test]
+    fn descends_into_bookmark_wrapper_to_reach_image() {
+        let img = ImagePageable::new(Arc::new(vec![0u8; 4]), ImageFormat::Png, 10.0, 10.0)
+            .with_node_id(Some(99));
+        let wrapped = BookmarkMarkerWrapperPageable::new(
+            BookmarkMarkerPageable::new(1, "X".into()),
+            Box::new(img),
+        );
+        let mut out = Drawables::new();
+        extract_drawables_from_pageable(&wrapped, &mut out);
+        assert!(out.images.contains_key(&99));
+    }
+}
+
+/// Build the bookmark anchor map. The `bookmark_by_node` map on
+/// `ConvertContext` is populated upstream (`engine.rs` runs
+/// `BookmarkPass` before `dom_to_pageable`); we only project it into
+/// the `Drawables` shape. The `_doc` / `_assets` arguments are
+/// reserved for future enrichment (PR 6+).
+fn extract_bookmark_anchors(
+    _doc: &HtmlDocument,
+    bookmark_by_node: &std::collections::HashMap<usize, crate::blitz_adapter::BookmarkInfo>,
+    _assets: Option<&crate::asset::AssetBundle>,
+) -> std::collections::BTreeMap<usize, crate::drawables::BookmarkAnchorEntry> {
+    let mut out = std::collections::BTreeMap::new();
+    for (&node_id, info) in bookmark_by_node {
+        out.insert(
+            node_id,
+            crate::drawables::BookmarkAnchorEntry {
+                level: info.level,
+                label: info.label.clone(),
+            },
+        );
+    }
+    out
 }
 
 fn debug_print_tree(doc: &BaseDocument, node_id: usize, depth: usize) {

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -45,13 +45,26 @@ pub struct BlockEntry;
 #[derive(Debug, Clone, Default)]
 pub struct ParagraphEntry;
 
-/// PR 2 target: image bytes + format + intrinsic size.
-#[derive(Debug, Clone, Default)]
-pub struct ImageEntry;
+/// Image draw payload for v2. Mirrors the fields `ImagePageable` holds.
+#[derive(Debug, Clone)]
+pub struct ImageEntry {
+    pub image_data: std::sync::Arc<Vec<u8>>,
+    pub format: crate::image::ImageFormat,
+    pub width: f32,
+    pub height: f32,
+    pub opacity: f32,
+    pub visible: bool,
+}
 
-/// PR 2 target: parsed SVG tree.
-#[derive(Debug, Clone, Default)]
-pub struct SvgEntry;
+/// SVG draw payload for v2. Mirrors the fields `SvgPageable` holds.
+#[derive(Debug, Clone)]
+pub struct SvgEntry {
+    pub tree: std::sync::Arc<usvg::Tree>,
+    pub width: f32,
+    pub height: f32,
+    pub opacity: f32,
+    pub visible: bool,
+}
 
 /// PR 5 target: table layout state — header cell ids, body cell offsets,
 /// header height. Per-page slicing happens at render time.
@@ -70,11 +83,13 @@ pub struct MulticolRuleEntry;
 #[derive(Debug, Clone, Default)]
 pub struct TransformEntry;
 
-/// PR 2 target: bookmark anchor (level + label) keyed by source node.
-/// First-fragment-only emission is enforced at render time via
-/// `geometry`.
-#[derive(Debug, Clone, Default)]
-pub struct BookmarkAnchorEntry;
+/// Bookmark anchor (level + label) keyed by source node. First-fragment-only
+/// emission is enforced at render time by reading `geometry.fragments[0]`.
+#[derive(Debug, Clone)]
+pub struct BookmarkAnchorEntry {
+    pub level: u8,
+    pub label: String,
+}
 
 /// PR 3 target: link span (target + alt text) covering one or more
 /// glyph runs in a paragraph. `Vec<(NodeId, LinkSpan)>` lets a single

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -26,20 +26,21 @@ pub fn render_v2(
     drawables: &Drawables,
     gcpm: &GcpmContext,
 ) -> Result<Vec<u8>> {
-    let _ = drawables; // PR 1: every draw map is empty
-
     let mut document = krilla::Document::new();
+
+    let mut bookmark_collector = if config.bookmarks {
+        Some(crate::pageable::BookmarkCollector::new())
+    } else {
+        None
+    };
 
     let page_count = crate::pagination_layout::implied_page_count(geometry).max(1) as usize;
     for page_idx in 0..page_count {
         let page_num = page_idx + 1;
         // Pass the full `gcpm.page_settings` (including selector
         // rules: `:first`, `:left`, `:right`) so per-page overrides
-        // fire identically to the v1 GCPM path. Filtering to
-        // `page_selector.is_none()` here would silently drop those
-        // overrides and bake the wrong `MediaBox` dimensions even on
-        // PR 1's blank pages (Devin review on PR #300).
-        let (resolved_size, _resolved_margin, resolved_landscape) =
+        // fire identically to the v1 GCPM path.
+        let (resolved_size, resolved_margin, resolved_landscape) =
             crate::gcpm::page_settings::resolve_page_settings(
                 &gcpm.page_settings,
                 page_num,
@@ -53,16 +54,163 @@ pub fn render_v2(
         };
         let settings = krilla::page::PageSettings::from_wh(page_size.width, page_size.height)
             .ok_or_else(|| Error::PdfGeneration("Invalid page dimensions".into()))?;
-        let _page = document.start_page_with(settings);
-        // PR 2+: walk geometry.fragments_on_page(page_idx) and dispatch
-        // (node_id, fragment) → draw_node(canvas, ..) here. PR 1 emits
-        // an empty page.
+        let mut page = document.start_page_with(settings);
+        if let Some(c) = bookmark_collector.as_mut() {
+            c.set_current_page(page_idx);
+        }
+        {
+            let mut surface = page.surface();
+            let mut canvas = crate::pageable::Canvas {
+                surface: &mut surface,
+                bookmark_collector: bookmark_collector.as_mut(),
+                link_collector: None,
+            };
+            draw_v2_page(
+                &mut canvas,
+                page_idx as u32,
+                resolved_margin.left,
+                resolved_margin.top,
+                geometry,
+                drawables,
+            );
+        }
+    }
+
+    if let Some(c) = bookmark_collector {
+        let entries = c.into_entries();
+        if !entries.is_empty() {
+            document.set_outline(crate::outline::build_outline(&entries));
+        }
     }
 
     document.set_metadata(build_metadata(config));
     document
         .finish()
         .map_err(|e| Error::PdfGeneration(format!("{e:?}")))
+}
+
+/// Phase 4 v2 per-page draw dispatcher. Walks every `(node_id,
+/// fragment)` pair whose fragment is on `page_index` and routes each
+/// to a per-type draw function sourced from `drawables`.
+///
+/// Iteration is by `BTreeMap<NodeId, _>` order which is approximately
+/// document order (Blitz allocates NodeIds during parse). That keeps
+/// stacking order — backgrounds before foregrounds, parents before
+/// children — consistent with the v1 traversal.
+///
+/// PR 2 covers `Drawables.images`, `.svgs`, and `.bookmark_anchors`
+/// (first-fragment-only). Subsequent PRs add match arms for the
+/// other maps.
+fn draw_v2_page(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    page_index: u32,
+    margin_left_pt: f32,
+    margin_top_pt: f32,
+    geometry: &crate::pagination_layout::PaginationGeometryTable,
+    drawables: &Drawables,
+) {
+    use crate::convert::px_to_pt;
+
+    for (&node_id, geom) in geometry {
+        // Bookmark anchor: emit on the page where the node's *first*
+        // fragment lands, mirroring `BookmarkMarkerWrapperPageable`'s
+        // `is_first_page_for` slice semantics.
+        if let Some(first_frag) = geom.fragments.first()
+            && first_frag.page_index == page_index
+            && let Some(anchor) = drawables.bookmark_anchors.get(&node_id)
+            && let Some(c) = canvas.bookmark_collector.as_deref_mut()
+        {
+            let y_pt = margin_top_pt + px_to_pt(first_frag.y);
+            c.record(anchor.level, anchor.label.clone(), y_pt);
+        }
+
+        // Per-fragment leaf draws.
+        for frag in &geom.fragments {
+            if frag.page_index != page_index {
+                continue;
+            }
+            let x_pt = margin_left_pt + px_to_pt(frag.x);
+            let y_pt = margin_top_pt + px_to_pt(frag.y);
+
+            if let Some(img) = drawables.images.get(&node_id) {
+                draw_image_v2(canvas, img, x_pt, y_pt);
+                continue;
+            }
+            if let Some(svg) = drawables.svgs.get(&node_id) {
+                draw_svg_v2(canvas, svg, x_pt, y_pt);
+                continue;
+            }
+            // Other types (block_styles / paragraphs / tables / ...)
+            // land in subsequent PRs.
+        }
+    }
+}
+
+/// v2 image draw. Mirrors `image::ImagePageable::draw` but operates on
+/// the side-channel `ImageEntry` data; the `width`/`height` are the
+/// CSS-resolved size in pt that fulgur stores on the original
+/// `ImagePageable`.
+fn draw_image_v2(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    entry: &crate::drawables::ImageEntry,
+    x: f32,
+    y: f32,
+) {
+    use crate::pageable::draw_with_opacity;
+
+    if !entry.visible {
+        return;
+    }
+    draw_with_opacity(canvas, entry.opacity, |canvas| {
+        let Some(image) = decode_image_for_v2(entry) else {
+            return;
+        };
+        let Some(size) = krilla::geom::Size::from_wh(entry.width, entry.height) else {
+            return;
+        };
+        let transform = krilla::geom::Transform::from_translate(x, y);
+        canvas.surface.push_transform(&transform);
+        canvas.surface.draw_image(image, size);
+        canvas.surface.pop();
+    });
+}
+
+fn decode_image_for_v2(entry: &crate::drawables::ImageEntry) -> Option<krilla::image::Image> {
+    use crate::image::ImageFormat;
+    use krilla::image::Image;
+    let data: krilla::Data = entry.image_data.clone().into();
+    let image_result = match entry.format {
+        ImageFormat::Png => Image::from_png(data, true),
+        ImageFormat::Jpeg => Image::from_jpeg(data, true),
+        ImageFormat::Gif => Image::from_gif(data, true),
+    };
+    image_result.ok()
+}
+
+/// v2 SVG draw. Mirrors `svg::SvgPageable::draw`.
+fn draw_svg_v2(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    entry: &crate::drawables::SvgEntry,
+    x: f32,
+    y: f32,
+) {
+    use crate::pageable::draw_with_opacity;
+    use krilla_svg::{SurfaceExt, SvgSettings};
+
+    if !entry.visible {
+        return;
+    }
+    draw_with_opacity(canvas, entry.opacity, |canvas| {
+        let Some(size) = krilla::geom::Size::from_wh(entry.width, entry.height) else {
+            return;
+        };
+        let transform = krilla::geom::Transform::from_translate(x, y);
+        canvas.surface.push_transform(&transform);
+        let _ = canvas
+            .surface
+            .draw_svg(&entry.tree, size, SvgSettings::default());
+        canvas.surface.pop();
+    });
 }
 
 /// Render a Pageable tree to PDF bytes using fragmenter geometry to

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -225,6 +225,12 @@ fn render_path_byte_equality() {
         allowlist.len(),
     );
 
+    if std::env::var_os("FULGUR_PARITY_VERBOSE").is_some() {
+        for (label, v1l, v2l) in &diffs {
+            eprintln!("  diff {label}: v1={v1l}B v2={v2l}B");
+        }
+    }
+
     if !allowlist_failures.is_empty() {
         let detail = allowlist_failures
             .iter()


### PR DESCRIPTION
## 概要

Phase 4 (fulgur-9t3z) PR 2: Image / SVG / Bookmark anchor の v2 draw migration。**PR #300 の上に stack**。

beads: fulgur-w9bs

## 追加

### 実 entry types (placeholder → real)

| Entry | Fields |
|---|---|
| \`ImageEntry\` | \`image_data: Arc<Vec<u8>>\`, \`format: ImageFormat\`, \`width\`, \`height\`, \`opacity\`, \`visible\` |
| \`SvgEntry\` | \`tree: Arc<usvg::Tree>\`, \`width\`, \`height\`, \`opacity\`, \`visible\` |
| \`BookmarkAnchorEntry\` | \`level: u8\`, \`label: String\` |

### convert::dom_to_drawables

- \`dom_to_pageable\` を internally call → 結果の Pageable tree を walk して payload 抽出
- transitional scaffolding (PR 8 で native DOM walk に置換)
- 4 wrapper types (Bookmark/StringSet/Running/CounterOp) は delegate のみ — child まで降下
- \`bookmark_by_node\` (engine.rs で BookmarkPass が populate) を BookmarkAnchorEntry に projection

### render_v2 dispatcher

\`for (node_id, frag) in geometry → drawables.images.get(node_id) ? draw_image_v2 : drawables.svgs.get(node_id) ? draw_svg_v2 : ...\`。bookmark anchor は first-fragment-only で BookmarkCollector に record。

### Unit tests

- \`extract_drawables_tests::extracts_block_level_image_into_drawables\`
- \`extract_drawables_tests::extracts_block_level_svg_into_drawables\`
- \`extract_drawables_tests::descends_into_bookmark_wrapper_to_reach_image\`

## 注意: allowlist は空のまま

実 HTML の \`<img>\` / inline \`<svg>\` は \`ParagraphPageable\` の \`LineItem::Image\` として **inline 包含** される。standalone な \`ImagePageable\` は実 fixture には現れない (\`display:block\` でも convert は inline-root → Paragraph のラップを行うパターンが多い)。

このため PR 2 単独では byte-eq fixture が増えない。**PR 3 (Paragraph migration)** が paragraph 内の inline image を line-internal で draw して初めて byte-eq が伸びる。

PR 2 の deliverable は **infrastructure + dispatcher + 単体検証** に focus し、allowlist 拡張は PR 3 に任せる。

## 検証

- \`cargo build -p fulgur\`: 0 warning
- \`cargo clippy --workspace --tests\`: 0 warning
- \`cargo test -p fulgur --lib\`: 842 pass (840 prior + 2 PR 1 parity + 3 new)
- VRT / examples_determinism: regression なし
- shadow harness: \`v2 byte-identical 0 / 59\` (PR 3 で改善見込み)

## Stacking note

base = \`feat/phase4-pr1-skeleton\` (= PR #300)。PR #300 が main にマージされたら、本 PR の base を \`feat/pageable-replacement\` に rebase してマージ。

## Test plan

- [x] cargo build / clippy / test pass
- [x] shadow harness reports unchanged 0 / 59
- [x] unit tests cover extraction logic for standalone Image/Svg/Bookmark wrapper
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
