### PR TITLE
feat(render_v2): Phase 4 PR 3-6 — Pageable migration stack (paragraph → block → table/list-item → transform/multicol → GCPM margin box → overflow clip)

### DIFF
--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -210,13 +210,14 @@ fn extract_drawables_from_pageable(
     pageable: &dyn crate::pageable::Pageable,
     out: &mut crate::drawables::Drawables,
 ) {
-    use crate::drawables::{ImageEntry, SvgEntry};
+    use crate::drawables::{ImageEntry, ParagraphEntry, SvgEntry};
     use crate::image::ImagePageable;
     use crate::pageable::{
         BlockPageable, BookmarkMarkerWrapperPageable, CounterOpWrapperPageable, ListItemPageable,
         MulticolRulePageable, RunningElementWrapperPageable, StringSetWrapperPageable,
         TablePageable, TransformWrapperPageable,
     };
+    use crate::paragraph::ParagraphPageable;
     use crate::svg::SvgPageable;
 
     let any = pageable.as_any();
@@ -254,9 +255,38 @@ fn extract_drawables_from_pageable(
         }
         return;
     }
-    // Block / List / Table / wrappers — recurse into children. PR 4+
-    // will record their own draw payload (BlockEntry, etc.); for PR 2
-    // we only walk past them to reach the leaves.
+    // Paragraph leaf — record the shaped lines verbatim. The lines
+    // already carry per-glyph positions, link spans, decoration spans,
+    // and inline-image / inline-box items, so no re-shaping at render
+    // time. Inline content (LineItem::InlineBox) embeds whole Pageable
+    // subtrees that need their own draw payload — recurse so wrapper
+    // markers / nested blocks land in the appropriate `Drawables` map.
+    if let Some(para) = any.downcast_ref::<ParagraphPageable>() {
+        if let Some(node_id) = para.node_id {
+            out.paragraphs.insert(
+                node_id,
+                ParagraphEntry {
+                    lines: para.lines.clone(),
+                    opacity: para.opacity,
+                    visible: para.visible,
+                    id: para.id.clone(),
+                },
+            );
+        }
+        // Recurse into inline-box content. Each `LineItem::InlineBox`
+        // holds a `Box<dyn Pageable>` (typically a `BlockPageable` for
+        // `<span>`-style inline blocks) so its descendants can register
+        // their own payloads.
+        for line in &para.lines {
+            for item in &line.items {
+                if let crate::paragraph::LineItem::InlineBox(ib) = item {
+                    extract_drawables_from_pageable(ib.content.as_ref(), out);
+                }
+            }
+        }
+        return;
+    }
+    // Block / List / Table / wrappers — recurse into children.
     if let Some(block) = any.downcast_ref::<BlockPageable>() {
         for pc in &block.children {
             extract_drawables_from_pageable(pc.child.as_ref(), out);
@@ -300,15 +330,15 @@ fn extract_drawables_from_pageable(
     // PR #301 Devin: MulticolRulePageable is a wrapper carrying a
     // `child: Box<dyn Pageable>` produced by `maybe_wrap_multicol_rule`
     // around any multicol container. Without this arm, images / SVGs
-    // nested inside a multicol container fall through to "Other" and
-    // never enter `Drawables.images` / `.svgs`. Multicol's own
-    // column-rule painting still lands in PR 6 (`drawables.multicol_rules`).
+    // / paragraphs nested inside a multicol container fall through to
+    // "Other" and never enter `Drawables`. Multicol's own column-rule
+    // painting still lands in PR 6 (`drawables.multicol_rules`).
     if let Some(w) = any.downcast_ref::<MulticolRulePageable>() {
         extract_drawables_from_pageable(w.child.as_ref(), out);
     }
-    // Other types (Spacer, ParagraphPageable, marker-only Pageables)
-    // have no PR 2 payload — markers and Spacers stay no-op in v2;
-    // Paragraph / Multicol-rule paint land in PR 3 / 6.
+    // Other types (Spacer, marker-only Pageables) have no PR 3
+    // payload — markers and Spacers stay no-op in v2; Multicol-rule
+    // paint lands in PR 6.
 }
 
 #[cfg(test)]

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -200,7 +200,35 @@ pub fn dom_to_drawables(
     let mut drawables = crate::drawables::Drawables::new();
     extract_drawables_from_pageable(root_pageable.as_ref(), &mut drawables);
     drawables.bookmark_anchors = extract_bookmark_anchors(doc, &bookmark_snapshot, ctx.assets);
+    drawables.body_offset_pt = extract_body_offset_pt(doc);
     drawables
+}
+
+/// Phase 4 PR 5: walk the DOM looking for `<body>` and return its
+/// `(location.x, location.y)` in pt. The fragmenter records body's
+/// own fragment at `(body_x, 0)` (body-content-area relative) and
+/// slicing depends on that frame; the html → body offset that CSS
+/// margin collapsing puts onto `body.location` lives separately so
+/// `render_v2` can add it to per-fragment draw positions.
+fn extract_body_offset_pt(doc: &HtmlDocument) -> (f32, f32) {
+    use std::ops::Deref;
+    let base = doc.deref();
+    let root = doc.root_element();
+    let Some(root_node) = base.get_node(root.id) else {
+        return (0.0, 0.0);
+    };
+    for &child_id in &root_node.children {
+        let Some(child) = base.get_node(child_id) else {
+            continue;
+        };
+        if let blitz_dom::NodeData::Element(elem) = &child.data
+            && elem.name.local.as_ref() == "body"
+        {
+            let (x, y, _, _) = layout_in_pt(&child.final_layout);
+            return (x, y);
+        }
+    }
+    (0.0, 0.0)
 }
 
 /// Walk a Pageable tree and populate each `Drawables` map by
@@ -210,7 +238,9 @@ fn extract_drawables_from_pageable(
     pageable: &dyn crate::pageable::Pageable,
     out: &mut crate::drawables::Drawables,
 ) {
-    use crate::drawables::{BlockEntry, ImageEntry, ParagraphEntry, SvgEntry};
+    use crate::drawables::{
+        BlockEntry, ImageEntry, ListItemEntry, ParagraphEntry, SvgEntry, TableEntry,
+    };
     use crate::image::ImagePageable;
     use crate::pageable::{
         BlockPageable, BookmarkMarkerWrapperPageable, CounterOpWrapperPageable, ListItemPageable,
@@ -307,6 +337,20 @@ fn extract_drawables_from_pageable(
         return;
     }
     if let Some(table) = any.downcast_ref::<TablePageable>() {
+        if let Some(node_id) = table.node_id {
+            out.tables.insert(
+                node_id,
+                TableEntry {
+                    style: table.style.clone(),
+                    opacity: table.opacity,
+                    visible: table.visible,
+                    id: table.id.clone(),
+                    layout_size: table.layout_size,
+                    width: table.width,
+                    cached_height: table.cached_height,
+                },
+            );
+        }
         for pc in &table.header_cells {
             extract_drawables_from_pageable(pc.child.as_ref(), out);
         }
@@ -316,6 +360,17 @@ fn extract_drawables_from_pageable(
         return;
     }
     if let Some(list_item) = any.downcast_ref::<ListItemPageable>() {
+        if let Some(node_id) = list_item.node_id {
+            out.list_items.insert(
+                node_id,
+                ListItemEntry {
+                    marker: list_item.marker.clone(),
+                    marker_line_height: list_item.marker_line_height,
+                    opacity: list_item.opacity,
+                    visible: list_item.visible,
+                },
+            );
+        }
         extract_drawables_from_pageable(list_item.body.as_ref(), out);
         return;
     }

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -239,7 +239,8 @@ fn extract_drawables_from_pageable(
     out: &mut crate::drawables::Drawables,
 ) {
     use crate::drawables::{
-        BlockEntry, ImageEntry, ListItemEntry, ParagraphEntry, SvgEntry, TableEntry,
+        BlockEntry, ImageEntry, ListItemEntry, MulticolRuleEntry, ParagraphEntry, SvgEntry,
+        TableEntry, TransformEntry,
     };
     use crate::image::ImagePageable;
     use crate::pageable::{
@@ -375,8 +376,40 @@ fn extract_drawables_from_pageable(
         return;
     }
     // Wrappers delegate.
+    //
+    // Transform wrapper: record `TransformEntry` keyed by the inner's
+    // `node_id` (the wrapper has no node_id of its own — it inherits
+    // from inner). After recursing, every NodeId added by the inner
+    // subtree is captured into the entry's `descendants` list so the
+    // render dispatcher can paint them all inside one
+    // `push_transform / pop` group, mirroring v1's
+    // `TransformWrapperPageable::draw`.
     if let Some(w) = any.downcast_ref::<TransformWrapperPageable>() {
+        let before_block = collect_drawables_node_ids(out);
         extract_drawables_from_pageable(w.inner.as_ref(), out);
+        if let Some(inner_id) = w.inner.node_id() {
+            let after_block = collect_drawables_node_ids(out);
+            // Exclude `inner_id` from `descendants` — it's the key the
+            // entry is filed under, and it is dispatched as the
+            // transform parent (`draw_under_transform` calls
+            // `dispatch_fragment(node_id, ..)` for it before iterating
+            // descendants). Without this filter, the render loop's
+            // skip set would contain `inner_id` itself and the parent
+            // node would never paint.
+            let descendants: Vec<usize> = after_block
+                .difference(&before_block)
+                .copied()
+                .filter(|&id| id != inner_id)
+                .collect();
+            out.transforms.insert(
+                inner_id,
+                TransformEntry {
+                    matrix: w.matrix,
+                    origin: w.origin,
+                    descendants,
+                },
+            );
+        }
         return;
     }
     if let Some(w) = any.downcast_ref::<BookmarkMarkerWrapperPageable>() {
@@ -395,18 +428,44 @@ fn extract_drawables_from_pageable(
         extract_drawables_from_pageable(w.child.as_ref(), out);
         return;
     }
-    // PR #301 Devin: MulticolRulePageable is a wrapper carrying a
-    // `child: Box<dyn Pageable>` produced by `maybe_wrap_multicol_rule`
-    // around any multicol container. Without this arm, images / SVGs
-    // / paragraphs nested inside a multicol container fall through to
-    // "Other" and never enter `Drawables`. Multicol's own column-rule
-    // painting still lands in PR 6 (`drawables.multicol_rules`).
+    // MulticolRulePageable: record `MulticolRuleEntry` keyed by the
+    // multicol container (child) node_id, then recurse so the
+    // container's own block / paragraph / image payload land in their
+    // respective maps. Render-side post-pass paints rules per page
+    // using the container's fragments to partition `groups`.
     if let Some(w) = any.downcast_ref::<MulticolRulePageable>() {
+        if let Some(child_id) = w.child.node_id() {
+            out.multicol_rules.insert(
+                child_id,
+                MulticolRuleEntry {
+                    rule: w.rule,
+                    groups: w.groups.clone(),
+                },
+            );
+        }
         extract_drawables_from_pageable(w.child.as_ref(), out);
     }
-    // Other types (Spacer, marker-only Pageables) have no PR 3
-    // payload — markers and Spacers stay no-op in v2; Multicol-rule
-    // paint lands in PR 6.
+    // Other types (Spacer, marker-only Pageables) have no per-NodeId
+    // payload — Spacer is invisible, and the four marker wrappers
+    // (Bookmark / StringSet / Running / CounterOp) drive their effects
+    // through fragmenter geometry rather than per-marker entries.
+}
+
+/// Snapshot the union of `NodeId` keys currently present in `out`'s
+/// per-NodeId maps. Used by `extract_drawables_from_pageable`'s
+/// transform arm to compute `descendants = after - before` so the
+/// transform can list every node added by walking its inner subtree.
+fn collect_drawables_node_ids(
+    out: &crate::drawables::Drawables,
+) -> std::collections::BTreeSet<usize> {
+    let mut ids = std::collections::BTreeSet::new();
+    ids.extend(out.block_styles.keys().copied());
+    ids.extend(out.paragraphs.keys().copied());
+    ids.extend(out.images.keys().copied());
+    ids.extend(out.svgs.keys().copied());
+    ids.extend(out.tables.keys().copied());
+    ids.extend(out.list_items.keys().copied());
+    ids
 }
 
 #[cfg(test)]

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -319,9 +319,8 @@ fn extract_drawables_from_pageable(
     // Paragraph leaf — record the shaped lines verbatim. The lines
     // already carry per-glyph positions, link spans, decoration spans,
     // and inline-image / inline-box items, so no re-shaping at render
-    // time. Inline content (LineItem::InlineBox) embeds whole Pageable
-    // subtrees that need their own draw payload — recurse so wrapper
-    // markers / nested blocks land in the appropriate `Drawables` map.
+    // time. Inline content (LineItem::InlineBox) is intentionally NOT
+    // recursed into — see the comment inside the arm for rationale.
     if let Some(para) = any.downcast_ref::<ParagraphPageable>() {
         if let Some(node_id) = para.node_id {
             out.paragraphs.insert(

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -347,6 +347,7 @@ fn extract_drawables_from_pageable(
     // Block / List / Table / wrappers — recurse into children. Block
     // also records its own paint payload (PR 4).
     if let Some(block) = any.downcast_ref::<BlockPageable>() {
+        let clipping = block.style.has_overflow_clip();
         if let Some(node_id) = block.node_id {
             out.block_styles.insert(
                 node_id,
@@ -356,11 +357,39 @@ fn extract_drawables_from_pageable(
                     visible: block.visible,
                     id: block.id.clone(),
                     layout_size: block.layout_size.or(block.cached_size),
+                    clip_descendants: Vec::new(),
                 },
             );
         }
+        // Snapshot the per-NodeId map keys before recursing so we can
+        // identify which descendants belong inside this block's
+        // `push_clip / pop` scope when the block carries
+        // `overflow: hidden | clip`. Mirrors the
+        // `TransformWrapperPageable` arm exactly.
+        let before = clipping.then(|| collect_drawables_node_ids(out));
         for pc in &block.children {
             extract_drawables_from_pageable(pc.child.as_ref(), out);
+        }
+        if let (Some(before), Some(node_id)) = (before, block.node_id) {
+            let after = collect_drawables_node_ids(out);
+            // Strict descendants only — exclude the wrapper's own key
+            // because the dispatcher emits its bg / border / shadow
+            // OUTSIDE the clip (matching v1's
+            // `BlockPageable::draw` ordering at
+            // `pageable.rs:1796-1827`). Inner content sharing the
+            // wrapper's `node_id` (inline-root paragraph, replaced
+            // image / svg from `convert::replaced` /
+            // `convert::inline_root`) is dispatched as part of the
+            // wrapper's own painting path, not via descendant
+            // iteration.
+            let descendants: Vec<usize> = after
+                .difference(&before)
+                .copied()
+                .filter(|&id| id != node_id)
+                .collect();
+            if let Some(entry) = out.block_styles.get_mut(&node_id) {
+                entry.clip_descendants = descendants;
+            }
         }
         return;
     }

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -215,7 +215,16 @@ fn find_body_id_in_dom(doc: &HtmlDocument) -> Option<usize> {
     let root = doc.root_element();
     let root_node = base.get_node(root.id)?;
     for &child_id in &root_node.children {
-        let child = base.get_node(child_id)?;
+        // `?` would early-return `None` if any sibling lookup fails,
+        // hiding `<body>` past an unfindable `<head>` etc. — `let Some
+        // ... else { continue; }` matches the sibling helpers
+        // (`extract_body_offset_pt`, `pagination_layout::find_body_id`)
+        // and keeps continuation-page `<body>` background paint alive
+        // when one of the html root's earlier children can't be looked
+        // up (PR #305 Devin).
+        let Some(child) = base.get_node(child_id) else {
+            continue;
+        };
         if let blitz_dom::NodeData::Element(elem) = &child.data
             && elem.name.local.as_ref() == "body"
         {

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -334,17 +334,15 @@ fn extract_drawables_from_pageable(
                 },
             );
         }
-        // Recurse into inline-box content. Each `LineItem::InlineBox`
-        // holds a `Box<dyn Pageable>` (typically a `BlockPageable` for
-        // `<span>`-style inline blocks) so its descendants can register
-        // their own payloads.
-        for line in &para.lines {
-            for item in &line.items {
-                if let crate::paragraph::LineItem::InlineBox(ib) = item {
-                    extract_drawables_from_pageable(ib.content.as_ref(), out);
-                }
-            }
-        }
+        // Inline-box content (e.g. inline `<svg>`, inline-block
+        // `<span>`) is painted via `paragraph::draw_shaped_lines`
+        // which calls `ib.content.draw(...)` directly (line ~820 of
+        // paragraph.rs). Recursing here and registering the inner
+        // content in `block_styles` / `svgs` / `images` would
+        // double-paint at render time — once via the paragraph's
+        // inline call, once via the v2 dispatcher's per-NodeId loop.
+        // Skip recursion entirely so inline content stays a v1-style
+        // draw rooted in the paragraph's own dispatch.
         return;
     }
     // Block / List / Table / wrappers — recurse into children. Block

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -210,7 +210,7 @@ fn extract_drawables_from_pageable(
     pageable: &dyn crate::pageable::Pageable,
     out: &mut crate::drawables::Drawables,
 ) {
-    use crate::drawables::{ImageEntry, ParagraphEntry, SvgEntry};
+    use crate::drawables::{BlockEntry, ImageEntry, ParagraphEntry, SvgEntry};
     use crate::image::ImagePageable;
     use crate::pageable::{
         BlockPageable, BookmarkMarkerWrapperPageable, CounterOpWrapperPageable, ListItemPageable,
@@ -286,8 +286,21 @@ fn extract_drawables_from_pageable(
         }
         return;
     }
-    // Block / List / Table / wrappers — recurse into children.
+    // Block / List / Table / wrappers — recurse into children. Block
+    // also records its own paint payload (PR 4).
     if let Some(block) = any.downcast_ref::<BlockPageable>() {
+        if let Some(node_id) = block.node_id {
+            out.block_styles.insert(
+                node_id,
+                BlockEntry {
+                    style: block.style.clone(),
+                    opacity: block.opacity,
+                    visible: block.visible,
+                    id: block.id.clone(),
+                    layout_size: block.layout_size.or(block.cached_size),
+                },
+            );
+        }
         for pc in &block.children {
             extract_drawables_from_pageable(pc.child.as_ref(), out);
         }

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -201,6 +201,7 @@ pub fn dom_to_drawables(
     extract_drawables_from_pageable(root_pageable.as_ref(), &mut drawables);
     drawables.bookmark_anchors = extract_bookmark_anchors(doc, &bookmark_snapshot, ctx.assets);
     drawables.body_offset_pt = extract_body_offset_pt(doc);
+    drawables.root_id = Some(doc.root_element().id);
     drawables
 }
 

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -202,7 +202,27 @@ pub fn dom_to_drawables(
     drawables.bookmark_anchors = extract_bookmark_anchors(doc, &bookmark_snapshot, ctx.assets);
     drawables.body_offset_pt = extract_body_offset_pt(doc);
     drawables.root_id = Some(doc.root_element().id);
+    drawables.body_id = find_body_id_in_dom(doc);
     drawables
+}
+
+/// Locate the `<body>` element id by walking the html root's children.
+/// Mirrors `pagination_layout::find_body_id` but operates on the
+/// `HtmlDocument` API (the latter is private to that module).
+fn find_body_id_in_dom(doc: &HtmlDocument) -> Option<usize> {
+    use std::ops::Deref;
+    let base = doc.deref();
+    let root = doc.root_element();
+    let root_node = base.get_node(root.id)?;
+    for &child_id in &root_node.children {
+        let child = base.get_node(child_id)?;
+        if let blitz_dom::NodeData::Element(elem) = &child.data
+            && elem.name.local.as_ref() == "body"
+        {
+            return Some(child_id);
+        }
+    }
+    None
 }
 
 /// Phase 4 PR 5: walk the DOM looking for `<body>` and return its

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -348,6 +348,12 @@ fn extract_drawables_from_pageable(
     // also records its own paint payload (PR 4).
     if let Some(block) = any.downcast_ref::<BlockPageable>() {
         let clipping = block.style.has_overflow_clip();
+        // Track an opacity scope only when the block has fractional
+        // opacity AND does NOT also clip — the clip path arm already
+        // wraps descendants in `draw_with_opacity` (see
+        // `draw_under_clip`), so the dual case is covered there and
+        // recording it here would double-track.
+        let opacity_scope = !clipping && block.opacity < 1.0;
         if let Some(node_id) = block.node_id {
             out.block_styles.insert(
                 node_id,
@@ -358,15 +364,17 @@ fn extract_drawables_from_pageable(
                     id: block.id.clone(),
                     layout_size: block.layout_size.or(block.cached_size),
                     clip_descendants: Vec::new(),
+                    opacity_descendants: Vec::new(),
                 },
             );
         }
         // Snapshot the per-NodeId map keys before recursing so we can
         // identify which descendants belong inside this block's
         // `push_clip / pop` scope when the block carries
-        // `overflow: hidden | clip`. Mirrors the
+        // `overflow: hidden | clip`, OR inside its `draw_with_opacity`
+        // group when the block carries fractional opacity. Mirrors the
         // `TransformWrapperPageable` arm exactly.
-        let before = clipping.then(|| collect_drawables_node_ids(out));
+        let before = (clipping || opacity_scope).then(|| collect_drawables_node_ids(out));
         for pc in &block.children {
             extract_drawables_from_pageable(pc.child.as_ref(), out);
         }
@@ -388,7 +396,11 @@ fn extract_drawables_from_pageable(
                 .filter(|&id| id != node_id)
                 .collect();
             if let Some(entry) = out.block_styles.get_mut(&node_id) {
-                entry.clip_descendants = descendants;
+                if clipping {
+                    entry.clip_descendants = descendants;
+                } else {
+                    entry.opacity_descendants = descendants;
+                }
             }
         }
         return;

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -205,6 +205,17 @@ pub struct Drawables {
     /// in geometry but absolute on Drawables avoids touching the
     /// fragmenter contract.
     pub body_offset_pt: (f32, f32),
+    /// NodeId of the `<html>` root element when present.
+    ///
+    /// v1 paints html's own `background` BEFORE recursing into body
+    /// via `BlockPageable::draw`'s recursive children walk. v2's flat
+    /// dispatch never visits html — the fragmenter only records body
+    /// and its descendants in `geometry` — so `render_v2` paints html
+    /// as a pre-pass at the page's top-left margin using
+    /// `block_styles[root_id].layout_size` as the rect dimensions.
+    /// That mirrors v1's `total_width / total_height` derivation in
+    /// `BlockPageable::draw` (`pageable.rs:1771-1778`).
+    pub root_id: Option<NodeId>,
     pub block_styles: BTreeMap<NodeId, BlockEntry>,
     pub paragraphs: BTreeMap<NodeId, ParagraphEntry>,
     pub images: BTreeMap<NodeId, ImageEntry>,

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -49,6 +49,18 @@ pub struct BlockEntry {
     /// back to the fragment's width/height (CSS px → pt) at render
     /// time when absent.
     pub layout_size: Option<crate::pageable::Size>,
+    /// Strict descendant `NodeId`s that must paint INSIDE this block's
+    /// `push_clip_path` / `pop` group. Populated by
+    /// `extract_drawables_from_pageable` only when
+    /// `style.has_overflow_clip()` is true — non-clipping blocks leave
+    /// this empty so the dispatcher's main loop handles them with the
+    /// regular shared-node_id pattern.
+    ///
+    /// Mirrors the `TransformEntry.descendants` shape: render time
+    /// emits bg / border / shadow first (outside the clip, matching v1
+    /// `BlockPageable::draw` at `pageable.rs:1796-1827`), then pushes
+    /// the clip path, dispatches each descendant fragment, and pops.
+    pub clip_descendants: Vec<NodeId>,
 }
 
 /// Paragraph draw payload for v2. Holds the shaped lines that

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -216,6 +216,18 @@ pub struct Drawables {
     /// That mirrors v1's `total_width / total_height` derivation in
     /// `BlockPageable::draw` (`pageable.rs:1771-1778`).
     pub root_id: Option<NodeId>,
+    /// NodeId of the `<body>` element when present.
+    ///
+    /// v1 paints body's `background` on EVERY page because each
+    /// page's sliced root pageable still calls body's draw method.
+    /// v2's main dispatch sees body via the fragmenter's single
+    /// fragment on page 0 only, so multi-page documents would lose
+    /// body's bg fill on continuation pages. `render_v2` mirrors v1
+    /// by painting body as a pre-pass on every page (using
+    /// `block_styles[body_id].layout_size` for the rect dimensions
+    /// and `body_offset_pt` for the margin offset), then skipping
+    /// body in the main dispatch loop to avoid double-painting.
+    pub body_id: Option<NodeId>,
     pub block_styles: BTreeMap<NodeId, BlockEntry>,
     pub paragraphs: BTreeMap<NodeId, ParagraphEntry>,
     pub images: BTreeMap<NodeId, ImageEntry>,

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -61,6 +61,20 @@ pub struct BlockEntry {
     /// `BlockPageable::draw` at `pageable.rs:1796-1827`), then pushes
     /// the clip path, dispatches each descendant fragment, and pops.
     pub clip_descendants: Vec<NodeId>,
+    /// Strict descendant `NodeId`s that must paint INSIDE this block's
+    /// `draw_with_opacity` group. Populated by
+    /// `extract_drawables_from_pageable` only when `opacity < 1.0`
+    /// AND the block does NOT have overflow clip (clip's
+    /// `draw_under_clip` already wraps its descendants in
+    /// `draw_with_opacity` so the dual case is covered there).
+    ///
+    /// Mirrors v1's `BlockPageable::draw` ordering: opacity wraps
+    /// EVERYTHING — bg/border/shadow + descendants — so a
+    /// `<div style="opacity:0.4"><svg>..</svg></div>` produces a
+    /// single transparency group. v2's flat dispatch without this
+    /// scope tracking would emit the svg outside the parent's
+    /// opacity wrap, dropping the parent's opacity from the svg.
+    pub opacity_descendants: Vec<NodeId>,
 }
 
 /// Paragraph draw payload for v2. Holds the shaped lines that

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -140,13 +140,35 @@ impl std::fmt::Debug for ListItemEntry {
     }
 }
 
-/// PR 6 target: column-rule paint spec + per-column-group geometry.
-#[derive(Debug, Clone, Default)]
-pub struct MulticolRuleEntry;
+/// Multicol column-rule paint spec + per-column-group geometry.
+/// Mirrors the fields `MulticolRulePageable` carries — render at the
+/// container's location after children paint, partitioning `groups`
+/// per page based on the container's fragment cumulative heights.
+#[derive(Debug, Clone)]
+pub struct MulticolRuleEntry {
+    pub rule: crate::column_css::ColumnRuleSpec,
+    pub groups: Vec<crate::multicol_layout::ColumnGroupGeometry>,
+}
 
-/// PR 6 target: CSS transform matrix + origin.
-#[derive(Debug, Clone, Default)]
-pub struct TransformEntry;
+/// CSS transform matrix + origin for a node (and its descendants).
+///
+/// Mirrors `TransformWrapperPageable`. v1 pushes the surface transform
+/// before drawing `inner.draw(...)` and pops after; v2's flat dispatch
+/// emulates this by recording every descendant `node_id` of the wrapper
+/// at convert time so the render loop can dispatch the wrapper's own
+/// payload + every descendant inside one push/pop pair.
+#[derive(Debug, Clone)]
+pub struct TransformEntry {
+    pub matrix: crate::pageable::Affine2D,
+    pub origin: crate::pageable::Point2,
+    /// Every `NodeId` whose fragment must paint inside this transform's
+    /// `push_transform`/`pop` group. Includes the wrapper's own
+    /// `node_id` (shared with the inner Pageable) and every descendant
+    /// recursively. Stored as a `Vec` for deterministic iteration —
+    /// order matches the depth-first walk produced by
+    /// `extract_drawables_from_pageable`.
+    pub descendants: Vec<NodeId>,
+}
 
 /// Bookmark anchor (level + label) keyed by source node. First-fragment-only
 /// emission is enforced at render time by reading `geometry.fragments[0]`.

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -161,12 +161,14 @@ pub struct MulticolRuleEntry {
 pub struct TransformEntry {
     pub matrix: crate::pageable::Affine2D,
     pub origin: crate::pageable::Point2,
-    /// Every `NodeId` whose fragment must paint inside this transform's
-    /// `push_transform`/`pop` group. Includes the wrapper's own
-    /// `node_id` (shared with the inner Pageable) and every descendant
-    /// recursively. Stored as a `Vec` for deterministic iteration —
-    /// order matches the depth-first walk produced by
-    /// `extract_drawables_from_pageable`.
+    /// Every strict descendant `NodeId` whose fragment must paint
+    /// inside this transform's `push_transform`/`pop` group. Does NOT
+    /// include the wrapper's own `node_id` (the entry's key) — the
+    /// render loop dispatches the wrapper node separately before
+    /// iterating descendants (see
+    /// `render::draw_under_transform`). Stored as a `Vec` for
+    /// deterministic iteration — order matches the depth-first walk
+    /// produced by `extract_drawables_from_pageable`.
     pub descendants: Vec<NodeId>,
 }
 

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -40,10 +40,30 @@ pub type NodeId = usize;
 #[derive(Debug, Clone, Default)]
 pub struct BlockEntry;
 
-/// PR 3 target: per-node shaped lines (`Vec<ShapedLine>`) reused from
-/// the existing `paragraph::draw_shaped_lines` path.
-#[derive(Debug, Clone, Default)]
-pub struct ParagraphEntry;
+/// Paragraph draw payload for v2. Holds the shaped lines that
+/// `paragraph::draw_shaped_lines` consumes verbatim — no re-shaping
+/// at render time. Mirrors the per-paragraph fields from
+/// `ParagraphPageable` that survive draw.
+#[derive(Clone)]
+pub struct ParagraphEntry {
+    pub lines: Vec<crate::paragraph::ShapedLine>,
+    pub opacity: f32,
+    pub visible: bool,
+    /// Anchor id (`id="..."` on the inline root) — drives
+    /// `DestinationRegistry` for `href="#..."` resolution.
+    pub id: Option<std::sync::Arc<String>>,
+}
+
+impl std::fmt::Debug for ParagraphEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ParagraphEntry")
+            .field("lines", &self.lines.len())
+            .field("opacity", &self.opacity)
+            .field("visible", &self.visible)
+            .field("id", &self.id)
+            .finish()
+    }
+}
 
 /// Image draw payload for v2. Mirrors the fields `ImagePageable` holds.
 #[derive(Debug, Clone)]

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -97,14 +97,48 @@ pub struct SvgEntry {
     pub visible: bool,
 }
 
-/// PR 5 target: table layout state — header cell ids, body cell offsets,
-/// header height. Per-page slicing happens at render time.
-#[derive(Debug, Clone, Default)]
-pub struct TableEntry;
+/// Table draw payload for v2. Holds the border-box paint state
+/// (background / borders / shadow) applied to the table's outer
+/// frame. Cell content (`<th>` / `<td>`) lives as separate
+/// `BlockEntry` / `ParagraphEntry` keyed by the cell's own NodeId
+/// and paints through the standard per-NodeId dispatch.
+///
+/// Multi-page header repetition (`<thead>` cloned on continuation
+/// pages) is **not** modelled in PR 5; single-page tables byte-eq
+/// already, multi-page tables follow in a later PR alongside the
+/// per-block clip work.
+#[derive(Debug, Clone)]
+pub struct TableEntry {
+    pub style: crate::pageable::BlockStyle,
+    pub opacity: f32,
+    pub visible: bool,
+    pub id: Option<std::sync::Arc<String>>,
+    pub layout_size: Option<crate::pageable::Size>,
+    pub width: f32,
+    pub cached_height: f32,
+}
 
-/// PR 5 target: list item marker + body wrapper data.
-#[derive(Debug, Clone, Default)]
-pub struct ListItemEntry;
+/// List-item marker payload for v2. The body block paints itself
+/// through `BlockEntry`; `ListItemEntry` only carries the marker
+/// (text / image / svg / none) and the line-height needed to
+/// vertically centre image markers.
+#[derive(Clone)]
+pub struct ListItemEntry {
+    pub marker: crate::pageable::ListItemMarker,
+    pub marker_line_height: f32,
+    pub opacity: f32,
+    pub visible: bool,
+}
+
+impl std::fmt::Debug for ListItemEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ListItemEntry")
+            .field("marker_line_height", &self.marker_line_height)
+            .field("opacity", &self.opacity)
+            .field("visible", &self.visible)
+            .finish()
+    }
+}
 
 /// PR 6 target: column-rule paint spec + per-column-group geometry.
 #[derive(Debug, Clone, Default)]
@@ -137,6 +171,16 @@ pub struct LinkSpanEntry;
 /// fill each map by migrating one Pageable type at a time.
 #[derive(Debug, Default, Clone)]
 pub struct Drawables {
+    /// `body_layout.location.x/y` in pt. Captures the html → body
+    /// offset that CSS margin collapsing folds onto the body element.
+    /// `render_v2` adds this to every per-fragment `(x, y)` so v2 paint
+    /// matches v1's `html → body @ pc=(body.x, body.y)` chain exactly.
+    /// Pre-Phase-4 the fragmenter intentionally records body's own
+    /// fragment at `y=0` in body-content-area-relative coordinates and
+    /// downstream slicing logic depends on that — keeping it relative
+    /// in geometry but absolute on Drawables avoids touching the
+    /// fragmenter contract.
+    pub body_offset_pt: (f32, f32),
     pub block_styles: BTreeMap<NodeId, BlockEntry>,
     pub paragraphs: BTreeMap<NodeId, ParagraphEntry>,
     pub images: BTreeMap<NodeId, ImageEntry>,
@@ -157,6 +201,11 @@ impl Drawables {
     /// `true` when no draw payload has been registered for any node.
     /// PR 1 always returns `true` because the convert side has not
     /// migrated yet.
+    ///
+    /// `body_offset_pt` is intentionally excluded — it is a global
+    /// coordinate offset (e.g. `body { margin: 8px }`), not a per-node
+    /// draw payload, so an empty `<body>` with default browser margins
+    /// should still report `true`.
     pub fn is_empty(&self) -> bool {
         self.block_styles.is_empty()
             && self.paragraphs.is_empty()

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -35,10 +35,21 @@ pub type NodeId = usize;
 // the `Drawables` struct compiles before any draw migration starts; the
 // shadow harness can already exercise the pipeline plumbing.
 
-/// PR 4 target: per-node block-level paint state (background layers,
-/// borders, box-shadow, opacity, overflow clip).
-#[derive(Debug, Clone, Default)]
-pub struct BlockEntry;
+/// Block draw payload for v2. Mirrors the fields `BlockPageable`
+/// holds for paint dispatch — backgrounds, borders, box-shadow,
+/// overflow clip, opacity, and the anchor id used by
+/// `DestinationRegistry`.
+#[derive(Debug, Clone)]
+pub struct BlockEntry {
+    pub style: crate::pageable::BlockStyle,
+    pub opacity: f32,
+    pub visible: bool,
+    pub id: Option<std::sync::Arc<String>>,
+    /// Taffy-computed border-box size (pt). Preferred when set; falls
+    /// back to the fragment's width/height (CSS px → pt) at render
+    /// time when absent.
+    pub layout_size: Option<crate::pageable::Size>,
+}
 
 /// Paragraph draw payload for v2. Holds the shaped lines that
 /// `paragraph::draw_shaped_lines` consumes verbatim — no re-shaping

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -368,6 +368,10 @@ impl Engine {
                     &convert_ctx.pagination_geometry,
                     &drawables,
                     &gcpm,
+                    &running_store,
+                    fonts,
+                    &string_set_for_render,
+                    &counter_ops_for_render,
                 )
             }
         }

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -1611,7 +1611,7 @@ fn draw_border_line(
     }
 }
 
-fn draw_block_border(
+pub(crate) fn draw_block_border(
     canvas: &mut Canvas<'_, '_>,
     style: &BlockStyle,
     x: f32,

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -1455,7 +1455,7 @@ fn apply_border_style(
 }
 
 /// Helper to draw a simple line segment with a given stroke.
-fn stroke_line(
+pub(crate) fn stroke_line(
     canvas: &mut Canvas<'_, '_>,
     x1: f32,
     y1: f32,
@@ -1509,7 +1509,7 @@ pub(crate) fn alpha_to_opacity(alpha: u8) -> krilla::num::NormalizedF32 {
 }
 
 /// Create a stroke with a specific color and width, inheriting opacity from base.
-fn colored_stroke(
+pub(crate) fn colored_stroke(
     color: &[u8; 4],
     width: f32,
     opacity: krilla::num::NormalizedF32,

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -840,7 +840,30 @@ fn record_subtree_descendants(
     let Some(parent) = doc.get_node(parent_id) else {
         return;
     };
-    for &child_id in &parent.children {
+    // Prefer Blitz's `layout_children` over the raw DOM `children` when
+    // it's been computed: when a block container has mixed
+    // block-level and inline-level children, Stylo synthesizes
+    // anonymous block wrappers around inline-level siblings (CSS 2.1
+    // §9.2.1.1). Those wrappers are real `Node` instances with their
+    // own `node_id` and Taffy layout, but they live ONLY in
+    // `layout_children` — the original `children` list still points
+    // at the underlying inline elements (e.g. a `<span
+    // display:inline-block>`).
+    //
+    // Without this preference v2 silently drops the inline-level
+    // span: extract assigns the inner paragraph's `node_id` to the
+    // anonymous wrapper (because Blitz's `is_inline_root()` flag sits
+    // on the wrapper), but the fragmenter — walking `children` —
+    // never visits the wrapper, so geometry has no fragment for that
+    // node_id and `dispatch_fragment` skips the paragraph entirely.
+    // (fulgur-bq6i: review_card_inline_block.html lost its
+    // "OK Approved" rounded badge for this exact reason.)
+    let layout_children_borrow = parent.layout_children.borrow();
+    let walk_children: &[usize] = layout_children_borrow
+        .as_deref()
+        .filter(|v| !v.is_empty())
+        .unwrap_or(&parent.children);
+    for &child_id in walk_children {
         let Some(child) = doc.get_node(child_id) else {
             continue;
         };

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -388,10 +388,40 @@ impl<'a> PaginationLayoutTree<'a> {
                 height: body_layout.size.height,
             });
 
+        // Prefer body's `layout_children` — same rationale as
+        // `record_subtree_descendants`. When a block container has
+        // mixed block-level and inline-level children, Stylo
+        // synthesizes anonymous block wrappers around the inline-
+        // level siblings (CSS 2.1 §9.2.1.1). Those wrappers carry
+        // their own `node_id` and Taffy layout, but they live ONLY
+        // in `layout_children` — `children` still points at the
+        // underlying inline elements (e.g. a body containing
+        // `<label>` followed by `<fieldset>` followed by
+        // `<select><option>...</option></select>` produces an
+        // anonymous block wrapping the `<select>` siblings, visible
+        // only in `layout_children`).
+        //
+        // Without this preference v2 silently drops the inline-level
+        // group's paint: extract assigns the inner paragraph's
+        // `node_id` to the synthesized wrapper, but the body iteration
+        // walks raw `children` and never visits the wrapper, so
+        // geometry has no fragment for that node_id and
+        // `dispatch_fragment` skips the paragraph entirely
+        // (fulgur-bq6i: examples/wasm-demo lost label / legend / option
+        // text content for this exact reason).
         let children = self
             .doc
             .get_node(body_id)
-            .map(|n| n.children.clone())
+            .map(|n| {
+                let layout_borrow = n.layout_children.borrow();
+                if let Some(lc) = layout_borrow.as_deref()
+                    && !lc.is_empty()
+                {
+                    lc.to_vec()
+                } else {
+                    n.children.clone()
+                }
+            })
             .unwrap_or_default();
 
         let mut page_index: u32 = 0;

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -735,9 +735,18 @@ impl<'a> PaginationLayoutTree<'a> {
                 cursor_y = 0.0;
             }
 
+            // Phase 4 PR 5 fix: include `layout.location.x` so the
+            // child's left margin / padding offset within body is
+            // captured. Pre-Phase-4 the fragmenter only fed
+            // `slice_for_page` which doesn't read `frag.x`, so
+            // `body_x` alone happened to be enough; the new
+            // geometry-driven render path now consults `frag.x` for
+            // every Block / Image / Paragraph and reverts to v2
+            // drawing at x=0 without this. Matches the descendant
+            // fragment shape on the line below.
             let frag = Fragment {
                 page_index,
-                x: body_x,
+                x: body_x + layout.location.x,
                 y: cursor_y,
                 width: child_w,
                 height: child_h,
@@ -838,7 +847,23 @@ fn record_subtree_descendants(
         let layout = child.final_layout;
         let h = layout.size.height;
         let w = layout.size.width;
+        // Phase 4 PR 5: zero-size containers (`<tbody>`, `<tr>`,
+        // anonymous boxes) carry no paint payload but DO host visible
+        // descendants (e.g. table cells) that v2 needs in geometry.
+        // Skipping them entirely leaves cells out of `geometry`; the
+        // dispatcher then never finds the cell node_ids and v2 emits
+        // a blank table. Recurse without recording when h/w are
+        // both zero so the descendant cells still register.
         if h <= 0.0 && w <= 0.0 {
+            record_subtree_descendants(
+                geometry,
+                doc,
+                child_id,
+                page_index,
+                parent_page_y + layout.location.y,
+                parent_x_in_body + layout.location.x,
+                depth + 1,
+            );
             continue;
         }
         let child_x = parent_x_in_body + layout.location.x;

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -169,7 +169,24 @@ fn draw_v2_page(
 ) {
     use crate::convert::px_to_pt;
 
+    // Pre-compute the set of node_ids that fall under any transform's
+    // `descendants` list. They are skipped in the main iteration and
+    // drawn instead inside the transform's `push_transform / pop` group
+    // below — mirroring v1's `TransformWrapperPageable::draw` which
+    // calls `inner.draw(...)` while the surface transform is active.
+    let mut transformed_descendants: std::collections::BTreeSet<usize> =
+        std::collections::BTreeSet::new();
+    for tx in drawables.transforms.values() {
+        transformed_descendants.extend(tx.descendants.iter().copied());
+    }
+
     for (&node_id, geom) in geometry {
+        if transformed_descendants.contains(&node_id) {
+            // Drawn inside an ancestor transform group elsewhere in
+            // this loop. Skipping prevents double-painting.
+            continue;
+        }
+
         // Bookmark anchor: emit on the page where the node's *first*
         // fragment lands, mirroring `BookmarkMarkerWrapperPageable`'s
         // `is_first_page_for` slice semantics.
@@ -190,94 +207,314 @@ fn draw_v2_page(
             let x_pt = margin_left_pt + px_to_pt(frag.x);
             let y_pt = margin_top_pt + px_to_pt(frag.y);
 
-            if let Some(table) = drawables.tables.get(&node_id) {
-                draw_table_v2(canvas, table, x_pt, y_pt, frag);
-                continue;
-            }
-            // ListItem case: marker + body block + inline-root
-            // paragraph (when present) all share one opacity group,
-            // mirroring v1's `ListItemPageable::draw` which wraps
-            // `marker` and `self.body.draw(...)` in a single
-            // `draw_with_opacity(self.opacity, ...)` (`pageable.rs:3336`).
-            //
-            // The body BlockPageable is intentionally built with
-            // `opacity: 1.0` (`convert/list_item.rs:56-58`) so v1
-            // produces ONE compositing group. The inline-root paragraph
-            // (when the body holds text content) lands at the same
-            // node_id via `convert::inline_root`. v2 must compose all
-            // three inside one group — separate `draw_with_opacity`
-            // calls would emit multiple `q .. Q` pairs and break byte-eq.
-            //
-            // `continue;` after this arm so the standalone block /
-            // image / svg / paragraph dispatch below does NOT fire for
-            // the same node_id (everything that v1 paints under the
-            // list item already painted inside the group above).
-            if let Some(li) = drawables.list_items.get(&node_id) {
-                let block_for_li = drawables.block_styles.get(&node_id);
-                let para_for_li = drawables.paragraphs.get(&node_id);
-                draw_list_item_with_block(
+            if let Some(tx) = drawables.transforms.get(&node_id) {
+                draw_under_transform(
                     canvas,
-                    li,
-                    block_for_li,
-                    para_for_li,
+                    tx,
+                    node_id,
+                    geom,
+                    frag,
                     x_pt,
                     y_pt,
-                    frag,
-                    &geom.fragments,
+                    geometry,
+                    drawables,
+                    margin_left_pt,
+                    margin_top_pt,
                     page_index,
                 );
-                continue;
+            } else {
+                dispatch_fragment(
+                    canvas, node_id, geom, frag, x_pt, y_pt, drawables, page_index,
+                );
             }
-            // Block + inner content (paragraph / image / svg) sharing
-            // the same node_id: v1's `BlockPageable::draw`
-            // (`pageable.rs:1771`) wraps bg/border AND the children
-            // draw inside ONE `draw_with_opacity(self.opacity, ...)`
-            // group. The inline-root paragraph + replaced-image /
-            // replaced-svg patterns from `convert::inline_root` /
-            // `convert::replaced` deliberately leave the inner draw
-            // payload at `opacity: 1.0` because the wrapping block
-            // carries the real opacity.
-            //
-            // Mirror v1 by combining all four paints into one group at
-            // dispatch time and `continue;`-ing past the standalone
-            // arms. Same pattern as `draw_list_item_with_block`.
-            if let Some(block) = drawables.block_styles.get(&node_id) {
-                let para_for_block = drawables.paragraphs.get(&node_id);
-                let img_for_block = drawables.images.get(&node_id);
-                let svg_for_block = drawables.svgs.get(&node_id);
-                if para_for_block.is_some() || img_for_block.is_some() || svg_for_block.is_some() {
-                    draw_block_with_inner_content(
-                        canvas,
-                        block,
-                        para_for_block,
-                        img_for_block,
-                        svg_for_block,
-                        x_pt,
-                        y_pt,
-                        frag,
-                        &geom.fragments,
-                        page_index,
-                    );
-                    continue;
-                }
-                draw_block_v2(canvas, block, x_pt, y_pt, frag);
-            }
-            if let Some(img) = drawables.images.get(&node_id) {
-                draw_image_v2(canvas, img, x_pt, y_pt);
-                continue;
-            }
-            if let Some(svg) = drawables.svgs.get(&node_id) {
-                draw_svg_v2(canvas, svg, x_pt, y_pt);
-                continue;
-            }
-            if let Some(para) = drawables.paragraphs.get(&node_id) {
-                draw_paragraph_v2(canvas, para, x_pt, y_pt, &geom.fragments, page_index);
-                continue;
-            }
-            // Other types (tables / list_items / ...) land in
-            // subsequent PRs.
         }
     }
+
+    // Post-pass: paint multicol column rules between columns. v1's
+    // `MulticolRulePageable::draw` runs this AFTER `child.draw(...)`
+    // so the rule lines paint on top of the column contents. The
+    // post-pass placement mirrors that ordering — every per-NodeId
+    // payload is already drawn by the main loop above.
+    for (&container_id, entry) in &drawables.multicol_rules {
+        let Some(container_geom) = geometry.get(&container_id) else {
+            continue;
+        };
+        paint_multicol_rule_for_page(
+            canvas,
+            entry,
+            container_geom,
+            margin_left_pt,
+            margin_top_pt,
+            page_index,
+        );
+    }
+}
+
+/// Per-fragment leaf-draw dispatch shared by the main loop and the
+/// transform special-case. Walks `node_id`'s payload maps and emits
+/// the appropriate per-type draw — exactly the same logic as before
+/// the transform refactor, just hoisted into a function so
+/// `draw_under_transform` can re-use it for descendants.
+#[allow(clippy::too_many_arguments)]
+fn dispatch_fragment(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    node_id: usize,
+    geom: &crate::pagination_layout::PaginationGeometry,
+    frag: &crate::pagination_layout::Fragment,
+    x_pt: f32,
+    y_pt: f32,
+    drawables: &Drawables,
+    page_index: u32,
+) {
+    if let Some(table) = drawables.tables.get(&node_id) {
+        draw_table_v2(canvas, table, x_pt, y_pt, frag);
+        return;
+    }
+    // ListItem case: marker + body block + inline-root paragraph
+    // share a single opacity group. See `draw_list_item_with_block`
+    // for the v1 mirror.
+    if let Some(li) = drawables.list_items.get(&node_id) {
+        let block_for_li = drawables.block_styles.get(&node_id);
+        let para_for_li = drawables.paragraphs.get(&node_id);
+        draw_list_item_with_block(
+            canvas,
+            li,
+            block_for_li,
+            para_for_li,
+            x_pt,
+            y_pt,
+            frag,
+            &geom.fragments,
+            page_index,
+        );
+        return;
+    }
+    // Block + inner content (paragraph / image / svg) sharing the
+    // same node_id: combine into one `draw_with_opacity` group. See
+    // `draw_block_with_inner_content` for the v1 mirror.
+    if let Some(block) = drawables.block_styles.get(&node_id) {
+        let para_for_block = drawables.paragraphs.get(&node_id);
+        let img_for_block = drawables.images.get(&node_id);
+        let svg_for_block = drawables.svgs.get(&node_id);
+        if para_for_block.is_some() || img_for_block.is_some() || svg_for_block.is_some() {
+            draw_block_with_inner_content(
+                canvas,
+                block,
+                para_for_block,
+                img_for_block,
+                svg_for_block,
+                x_pt,
+                y_pt,
+                frag,
+                &geom.fragments,
+                page_index,
+            );
+            return;
+        }
+        draw_block_v2(canvas, block, x_pt, y_pt, frag);
+    }
+    if let Some(img) = drawables.images.get(&node_id) {
+        draw_image_v2(canvas, img, x_pt, y_pt);
+        return;
+    }
+    if let Some(svg) = drawables.svgs.get(&node_id) {
+        draw_svg_v2(canvas, svg, x_pt, y_pt);
+        return;
+    }
+    if let Some(para) = drawables.paragraphs.get(&node_id) {
+        draw_paragraph_v2(canvas, para, x_pt, y_pt, &geom.fragments, page_index);
+    }
+}
+
+/// Push the transform onto the surface + link collector, dispatch the
+/// wrapper node's own payload and every descendant fragment that lands
+/// on `page_index`, then pop. Mirrors v1's
+/// `TransformWrapperPageable::draw`:
+///
+/// ```text
+/// canvas.surface.push_transform(matrix);
+/// inner.draw(canvas, x, y, ...);
+/// canvas.surface.pop();
+/// ```
+///
+/// The link collector also receives the transform so `/Link`
+/// annotation rects are mapped into device space — same call sequence
+/// v1 uses (`pageable.rs:2716-2724`).
+#[allow(clippy::too_many_arguments)]
+fn draw_under_transform(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    tx: &crate::drawables::TransformEntry,
+    node_id: usize,
+    geom: &crate::pagination_layout::PaginationGeometry,
+    frag: &crate::pagination_layout::Fragment,
+    x_pt: f32,
+    y_pt: f32,
+    geometry: &crate::pagination_layout::PaginationGeometryTable,
+    drawables: &Drawables,
+    margin_left_pt: f32,
+    margin_top_pt: f32,
+    page_index: u32,
+) {
+    use crate::convert::px_to_pt;
+
+    // `effective_matrix` mirrors `TransformWrapperPageable::effective_matrix`:
+    //   T(x + ox, y + oy) · M · T(-(x + ox), -(y + oy))
+    let ox = x_pt + tx.origin.x;
+    let oy = y_pt + tx.origin.y;
+    use crate::pageable::Affine2D;
+    let full = Affine2D::translation(ox, oy) * tx.matrix * Affine2D::translation(-ox, -oy);
+
+    if let Some(lc) = canvas.link_collector.as_deref_mut() {
+        lc.push_transform(full);
+    }
+    canvas.surface.push_transform(&full.to_krilla());
+
+    // Dispatch the wrapper's own payload first (the `inner` Pageable
+    // shares this `node_id`) — matches v1's `inner.draw(canvas, x, y, ...)`.
+    dispatch_fragment(
+        canvas, node_id, geom, frag, x_pt, y_pt, drawables, page_index,
+    );
+
+    // Then dispatch every strict descendant on this page. Each
+    // descendant's fragment has its own (x, y) in untransformed local
+    // coordinates — the surface transform applies on top, mirroring v1
+    // where `inner.draw(...)` recurses through children with their
+    // pre-transform layout.
+    for &desc_id in &tx.descendants {
+        let Some(desc_geom) = geometry.get(&desc_id) else {
+            continue;
+        };
+        for desc_frag in &desc_geom.fragments {
+            if desc_frag.page_index != page_index {
+                continue;
+            }
+            let desc_x = margin_left_pt + px_to_pt(desc_frag.x);
+            let desc_y = margin_top_pt + px_to_pt(desc_frag.y);
+            dispatch_fragment(
+                canvas, desc_id, desc_geom, desc_frag, desc_x, desc_y, drawables, page_index,
+            );
+        }
+    }
+
+    canvas.surface.pop();
+    if let Some(lc) = canvas.link_collector.as_deref_mut() {
+        lc.pop_transform();
+    }
+}
+
+/// Paint multicol column-rule lines on `page_index` for one
+/// `MulticolRuleEntry`. Partitions `entry.groups` by accumulating the
+/// container's per-page heights — mirrors
+/// `MulticolRulePageable::slice_for_page` + `draw` so each page only
+/// emits the rule segments that fit on it.
+fn paint_multicol_rule_for_page(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    entry: &crate::drawables::MulticolRuleEntry,
+    container_geom: &crate::pagination_layout::PaginationGeometry,
+    margin_left_pt: f32,
+    margin_top_pt: f32,
+    page_index: u32,
+) {
+    use crate::convert::px_to_pt;
+    use crate::pageable::stroke_line;
+
+    let Some(stroke) = build_multicol_stroke(&entry.rule) else {
+        return;
+    };
+
+    let target_pos = container_geom
+        .fragments
+        .iter()
+        .position(|f| f.page_index == page_index);
+    let Some(target_pos) = target_pos else {
+        return;
+    };
+    let target_frag = &container_geom.fragments[target_pos];
+
+    let consumed: f32 = px_to_pt(
+        container_geom.fragments[..target_pos]
+            .iter()
+            .map(|f| f.height)
+            .sum::<f32>(),
+    );
+    let cutoff = px_to_pt(target_frag.height);
+
+    let x_base = margin_left_pt + px_to_pt(target_frag.x);
+    let y_base = margin_top_pt + px_to_pt(target_frag.y);
+
+    for group in &entry.groups {
+        if group.n < 2 || group.col_heights.len() != group.n as usize {
+            continue;
+        }
+        let group_top = group.y_offset - consumed;
+        let max_h = group
+            .col_heights
+            .iter()
+            .copied()
+            .fold(0.0_f32, |acc, h| acc.max(h));
+        let group_bottom = group_top + max_h;
+        if group_bottom <= 0.0 || group_top >= cutoff {
+            continue;
+        }
+        let visible_top = group_top.max(0.0);
+        let y_top = y_base + visible_top;
+        for i in 0..(group.n as usize - 1) {
+            let h_left = group.col_heights[i]
+                .min(cutoff - group_top.max(0.0))
+                .max(0.0);
+            let h_right = group.col_heights[i + 1]
+                .min(cutoff - group_top.max(0.0))
+                .max(0.0);
+            if h_left <= 0.0 || h_right <= 0.0 {
+                continue;
+            }
+            let rule_x = x_base
+                + group.x_offset
+                + (i as f32 + 1.0) * group.col_w
+                + i as f32 * group.gap
+                + group.gap / 2.0;
+            let y_bot = y_top + h_left.min(h_right);
+            stroke_line(canvas, rule_x, y_top, rule_x, y_bot, stroke.clone());
+        }
+    }
+    canvas.surface.set_stroke(None);
+}
+
+/// Build the krilla stroke for the configured rule spec, mirroring
+/// `MulticolRulePageable::build_stroke`. Returns `None` when the rule
+/// is invisible (style `None` or non-positive width).
+fn build_multicol_stroke(
+    rule: &crate::column_css::ColumnRuleSpec,
+) -> Option<krilla::paint::Stroke> {
+    use crate::column_css::ColumnRuleStyle;
+    use crate::pageable::{alpha_to_opacity, colored_stroke};
+
+    if rule.width <= 0.0 || rule.style == ColumnRuleStyle::None {
+        return None;
+    }
+    let opacity = alpha_to_opacity(rule.color[3]);
+    let base = colored_stroke(&rule.color, rule.width, opacity);
+    let w = rule.width;
+    let stroke = match rule.style {
+        ColumnRuleStyle::None => return None,
+        ColumnRuleStyle::Solid => base,
+        ColumnRuleStyle::Dashed => krilla::paint::Stroke {
+            dash: Some(krilla::paint::StrokeDash {
+                array: vec![w * 3.0, w * 2.0],
+                offset: 0.0,
+            }),
+            ..base
+        },
+        ColumnRuleStyle::Dotted => krilla::paint::Stroke {
+            line_cap: krilla::paint::LineCap::Round,
+            dash: Some(krilla::paint::StrokeDash {
+                array: vec![0.0, w * 2.0],
+                offset: 0.0,
+            }),
+            ..base
+        },
+    };
+    Some(stroke)
 }
 
 /// v2 image draw. Mirrors `image::ImagePageable::draw` but operates on

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -420,7 +420,24 @@ fn draw_v2_page(
     // so the rule lines paint on top of the column contents. The
     // post-pass placement mirrors that ordering — every per-NodeId
     // payload is already drawn by the main loop above.
+    //
+    // Skip multicol containers that live inside a transform (whether
+    // they ARE a transform key or are a descendant of one): in v1
+    // `MulticolRulePageable::draw` runs from inside
+    // `TransformWrapperPageable::draw`'s `push_transform / pop` group,
+    // so the rule lines paint under the composed matrix. The transform
+    // version is dispatched from `draw_under_transform`'s tail
+    // (`paint_transform_scoped_multicol_rules`) so the composed
+    // transform stays active. Painting them here unconditionally would
+    // emit the rules twice — once in page coords (wrong) and once
+    // inside the transform (correct) — and visually misalign the
+    // page-coord copy. (PR #305 follow-up Devin)
     for (&container_id, entry) in &drawables.multicol_rules {
+        if transformed_descendants.contains(&container_id)
+            || drawables.transforms.contains_key(&container_id)
+        {
+            continue;
+        }
         let Some(container_geom) = geometry.get(&container_id) else {
             continue;
         };
@@ -663,6 +680,45 @@ fn draw_under_transform(
                 );
             }
         }
+    }
+
+    // Paint multicol column rules for any multicol container in this
+    // transform's direct scope. Mirrors v1's
+    // `MulticolRulePageable::draw` running inside
+    // `TransformWrapperPageable::draw`'s `push_transform / pop` group
+    // (`pageable.rs:2714-2725 → 3088`) so the rule lines render under
+    // the composed matrix instead of in page coordinates.
+    //
+    // Direct scope = `tx.descendants` (or the transform key itself,
+    // covered when `node_id` is also a multicol container) MINUS any
+    // descendant that lives inside a NESTED transform — those are
+    // painted by the inner `draw_under_transform` recursion to compose
+    // both matrices. Without this filter, a multicol container nested
+    // two transforms deep would paint its rules in the outer
+    // transform's space, missing the inner matrix.
+    // (PR #305 follow-up Devin)
+    let nested_tx_desc: std::collections::BTreeSet<usize> = tx
+        .descendants
+        .iter()
+        .filter_map(|id| drawables.transforms.get(id))
+        .flat_map(|inner| inner.descendants.iter().copied())
+        .collect();
+    for (&container_id, entry) in &drawables.multicol_rules {
+        let in_my_scope = container_id == node_id || tx.descendants.contains(&container_id);
+        if !in_my_scope || nested_tx_desc.contains(&container_id) {
+            continue;
+        }
+        let Some(container_geom) = geometry.get(&container_id) else {
+            continue;
+        };
+        paint_multicol_rule_for_page(
+            canvas,
+            entry,
+            container_geom,
+            margin_left_pt,
+            margin_top_pt,
+            page_index,
+        );
     }
 
     canvas.surface.pop();

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -268,10 +268,24 @@ fn draw_v2_page(
     // descendants paint inside the clip's `push_clip_path / pop` group;
     // skipping them here prevents the main loop from also dispatching
     // them outside the clip.
+    //
+    // Body is excluded from this collection: the fragmenter records
+    // body with exactly one fragment at `page_index = 0`
+    // (`pagination_layout.rs:380-384`), so `draw_under_clip(body)`
+    // only fires on page 0. If we kept body in `clipped_descendants`,
+    // every descendant would still be skipped via the
+    // `clipped_descendants.contains(&node_id)` guard on page 1+ but
+    // nobody would dispatch them — silently blanking all content
+    // after page 1 on `<body style="overflow:hidden|auto|scroll">`
+    // (PR #310 follow-up Devin). Skipping body here means body-level
+    // overflow clip is not applied in v2, matching the pre-PR
+    // behavior; body clipping in a paged context is unusual and the
+    // pre-pass at `paint_root_block_v2` already handles body's own
+    // bg / border on continuation pages.
     let mut clipped_descendants: std::collections::BTreeSet<usize> =
         std::collections::BTreeSet::new();
-    for block in drawables.block_styles.values() {
-        if block.style.has_overflow_clip() {
+    for (&node_id, block) in &drawables.block_styles {
+        if block.style.has_overflow_clip() && Some(node_id) != drawables.body_id {
             clipped_descendants.extend(block.clip_descendants.iter().copied());
         }
     }
@@ -364,8 +378,20 @@ fn draw_v2_page(
             // so a `<div style="overflow:hidden;width:50px">long
             // text</div>` still needs the text clipped at the 50px
             // box even with no separate descendant NodeIds.
+            // Body is intentionally excluded from `draw_under_clip`:
+            // body has only a page-0 fragment so the clip would only
+            // wrap page-0 content, but body's `clip_descendants`
+            // include every block in the document. Descendants on
+            // page 1+ are dispatched by the main loop via
+            // `dispatch_fragment` (they're omitted from
+            // `clipped_descendants` above). Without this skip, body's
+            // page-0 clip would also re-dispatch every descendant
+            // already painted by the main loop, causing a double
+            // paint. See the `clipped_descendants` collection block
+            // for the rest of the body-overflow rationale.
             if let Some(block) = drawables.block_styles.get(&node_id)
                 && block.style.has_overflow_clip()
+                && Some(node_id) != drawables.body_id
             {
                 draw_under_clip(
                     canvas,

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -181,15 +181,19 @@ fn draw_v2_page(
     }
 
     for (&node_id, geom) in geometry {
-        if transformed_descendants.contains(&node_id) {
-            // Drawn inside an ancestor transform group elsewhere in
-            // this loop. Skipping prevents double-painting.
-            continue;
-        }
-
         // Bookmark anchor: emit on the page where the node's *first*
         // fragment lands, mirroring `BookmarkMarkerWrapperPageable`'s
-        // `is_first_page_for` slice semantics.
+        // `is_first_page_for` slice semantics. Run BEFORE the
+        // `transformed_descendants` skip so headings nested inside a
+        // transformed ancestor (e.g. `<div style="transform:..."><h1>`)
+        // still register in the PDF outline. v1 invokes
+        // `BookmarkMarkerWrapperPageable::draw` recursively from inside
+        // `TransformWrapperPageable::draw`, so the bookmark is recorded
+        // regardless of transform membership; we mirror that by
+        // unconditionally calling `record` here using the untransformed
+        // y position. (v1 emits at the same untransformed y for the
+        // outline destination — `collect_ids` does push the transform
+        // for `/Link` rects but the bookmark itself is keyed by raw y.)
         if let Some(first_frag) = geom.fragments.first()
             && first_frag.page_index == page_index
             && let Some(anchor) = drawables.bookmark_anchors.get(&node_id)
@@ -197,6 +201,13 @@ fn draw_v2_page(
         {
             let y_pt = margin_top_pt + px_to_pt(first_frag.y);
             c.record(anchor.level, anchor.label.clone(), y_pt);
+        }
+
+        if transformed_descendants.contains(&node_id) {
+            // Drawn inside an ancestor transform group elsewhere in
+            // this loop. Skipping prevents double-painting. Bookmark
+            // anchor recording above already ran unconditionally.
+            continue;
         }
 
         // Per-fragment leaf draws.
@@ -458,13 +469,21 @@ fn paint_multicol_rule_for_page(
         }
         let visible_top = group_top.max(0.0);
         let y_top = y_base + visible_top;
+        // Mirror `MulticolRulePageable::slice_for_page`
+        // (`pageable.rs:3221-3223`): subtract the portion of each
+        // column already painted on prior pages BEFORE clamping to
+        // the visible strip on this page. Without this, a column rule
+        // segment whose group straddles a page boundary extends past
+        // the actual visible column content.
+        let consumed_above = (visible_top - group_top).max(0.0);
+        let visible_h = (group_bottom.min(cutoff) - visible_top).max(0.0);
         for i in 0..(group.n as usize - 1) {
-            let h_left = group.col_heights[i]
-                .min(cutoff - group_top.max(0.0))
-                .max(0.0);
-            let h_right = group.col_heights[i + 1]
-                .min(cutoff - group_top.max(0.0))
-                .max(0.0);
+            let h_left = (group.col_heights[i] - consumed_above)
+                .max(0.0)
+                .min(visible_h);
+            let h_right = (group.col_heights[i + 1] - consumed_above)
+                .max(0.0)
+                .min(visible_h);
             if h_left <= 0.0 || h_right <= 0.0 {
                 continue;
             }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -749,7 +749,30 @@ fn draw_under_clip(
         }
 
         // Strict descendants — each at its own fragment's coords.
+        //
+        // Transform-aware dispatch: a descendant that has its own
+        // `TransformEntry` must enter `draw_under_transform` so the
+        // surface transform composes correctly. The main loop skips
+        // these nodes via `clipped_descendants.contains(...)` BEFORE
+        // it reaches the per-fragment transform check, so without the
+        // recursion below v2 silently drops transforms inside an
+        // `overflow: hidden` ancestor (`<div style="overflow:hidden">
+        // <div style="transform:..."/></div>` — PR #310 Devin).
+        //
+        // Pre-skip the strict descendants of those transforms so they
+        // are not dispatched twice — once via `draw_under_transform`
+        // (which iterates `tx.descendants`) and once via the loop
+        // body's `dispatch_fragment`.
+        let transform_skip: std::collections::BTreeSet<usize> = block
+            .clip_descendants
+            .iter()
+            .filter_map(|id| drawables.transforms.get(id))
+            .flat_map(|tx| tx.descendants.iter().copied())
+            .collect();
         for &desc_id in &block.clip_descendants {
+            if transform_skip.contains(&desc_id) {
+                continue;
+            }
             let Some(desc_geom) = geometry.get(&desc_id) else {
                 continue;
             };
@@ -759,9 +782,27 @@ fn draw_under_clip(
                 }
                 let desc_x = margin_left_pt + px_to_pt(desc_frag.x);
                 let desc_y = margin_top_pt + px_to_pt(desc_frag.y);
-                dispatch_fragment(
-                    canvas, desc_id, desc_geom, desc_frag, desc_x, desc_y, drawables, page_index,
-                );
+                if let Some(desc_tx) = drawables.transforms.get(&desc_id) {
+                    draw_under_transform(
+                        canvas,
+                        desc_tx,
+                        desc_id,
+                        desc_geom,
+                        desc_frag,
+                        desc_x,
+                        desc_y,
+                        geometry,
+                        drawables,
+                        margin_left_pt,
+                        margin_top_pt,
+                        page_index,
+                    );
+                } else {
+                    dispatch_fragment(
+                        canvas, desc_id, desc_geom, desc_frag, desc_x, desc_y, drawables,
+                        page_index,
+                    );
+                }
             }
         }
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -289,6 +289,19 @@ fn draw_v2_page(
             clipped_descendants.extend(block.clip_descendants.iter().copied());
         }
     }
+    // Mirrors `clipped_descendants` for blocks that wrap their
+    // descendants in a `draw_with_opacity` group (fractional opacity,
+    // no clip — see `BlockEntry.opacity_descendants` and
+    // `draw_under_opacity`). Without skipping these in the main loop
+    // they'd be dispatched twice: once at full opacity here, once
+    // again under the parent's opacity wrap.
+    let mut opacity_wrapped_descendants: std::collections::BTreeSet<usize> =
+        std::collections::BTreeSet::new();
+    for block in drawables.block_styles.values() {
+        if !block.opacity_descendants.is_empty() {
+            opacity_wrapped_descendants.extend(block.opacity_descendants.iter().copied());
+        }
+    }
 
     for (&node_id, geom) in geometry {
         // Bookmark anchor: emit on the page where the node's *first*
@@ -322,6 +335,14 @@ fn draw_v2_page(
         if clipped_descendants.contains(&node_id) {
             // Drawn inside an ancestor `overflow: hidden|clip` block's
             // `push_clip_path / pop` group elsewhere in this loop.
+            continue;
+        }
+        if opacity_wrapped_descendants.contains(&node_id) {
+            // Drawn inside an ancestor `draw_with_opacity` group via
+            // `draw_under_opacity` elsewhere in this loop. Mirrors the
+            // `clipped_descendants` skip — without it, the descendant
+            // paints once at full opacity here and once under the
+            // parent's opacity wrap. (fulgur-gdb9)
             continue;
         }
         // Skip the html root: its bg / border / shadow are painted
@@ -394,6 +415,35 @@ fn draw_v2_page(
                 && Some(node_id) != drawables.body_id
             {
                 draw_under_clip(
+                    canvas,
+                    block,
+                    node_id,
+                    geom,
+                    frag,
+                    x_pt,
+                    y_pt,
+                    geometry,
+                    drawables,
+                    margin_left_pt,
+                    margin_top_pt,
+                    page_index,
+                );
+                continue;
+            }
+            // Fractional-opacity block with descendants: wrap own
+            // paint + descendant fragments in a single
+            // `draw_with_opacity` group. Mirrors v1's
+            // `BlockPageable::draw` recursion under
+            // `draw_with_opacity(self.opacity, ..)`. Without this,
+            // `<div opacity:0.4><svg>..</svg></div>` paints the svg
+            // outside the parent's opacity wrap, dropping the parent's
+            // opacity from the svg. (fulgur-gdb9)
+            if let Some(block) = drawables
+                .block_styles
+                .get(&node_id)
+                .filter(|b| !b.opacity_descendants.is_empty())
+            {
+                draw_under_opacity(
                     canvas,
                     block,
                     node_id,
@@ -619,8 +669,23 @@ fn draw_under_transform(
         .filter(|b| b.style.has_overflow_clip())
         .flat_map(|b| b.clip_descendants.iter().copied())
         .collect();
+    // Symmetric pre-skip for opacity-scoped descendants. When an
+    // opacity block sits inside this transform, `draw_under_opacity`
+    // (called below) iterates its own `opacity_descendants` to paint
+    // them inside the opacity wrap; iterating those nodes again here
+    // via `dispatch_fragment` would emit a second draw outside the
+    // opacity group. Mirrors `clip_skip`. (fulgur-gdb9)
+    let opacity_skip: std::collections::BTreeSet<usize> = tx
+        .descendants
+        .iter()
+        .filter_map(|id| drawables.block_styles.get(id))
+        .flat_map(|b| b.opacity_descendants.iter().copied())
+        .collect();
     for &desc_id in &tx.descendants {
-        if nested_skip.contains(&desc_id) || clip_skip.contains(&desc_id) {
+        if nested_skip.contains(&desc_id)
+            || clip_skip.contains(&desc_id)
+            || opacity_skip.contains(&desc_id)
+        {
             continue;
         }
         let Some(desc_geom) = geometry.get(&desc_id) else {
@@ -661,6 +726,32 @@ fn draw_under_transform(
                 // overflow content past the clip boundary
                 // (PR #309 follow-up Devin).
                 draw_under_clip(
+                    canvas,
+                    desc_block,
+                    desc_id,
+                    desc_geom,
+                    desc_frag,
+                    desc_x,
+                    desc_y,
+                    geometry,
+                    drawables,
+                    margin_left_pt,
+                    margin_top_pt,
+                    page_index,
+                );
+            } else if let Some(desc_block) = drawables
+                .block_styles
+                .get(&desc_id)
+                .filter(|b| !b.opacity_descendants.is_empty())
+            {
+                // Opacity-scoped descendant inside this transform.
+                // Without this branch, transforms wrapping an opacity
+                // block would dispatch the descendant's own paint via
+                // `dispatch_fragment` but skip the opacity wrap of
+                // the descendant's children, dropping the descendant
+                // block's opacity from its sub-children.
+                // (fulgur-gdb9)
+                draw_under_opacity(
                     canvas,
                     desc_block,
                     desc_id,
@@ -905,8 +996,22 @@ fn draw_under_clip(
             .filter(|b| b.style.has_overflow_clip())
             .flat_map(|b| b.clip_descendants.iter().copied())
             .collect();
+        // Symmetric pre-skip for opacity-scoped descendants nested
+        // inside this clip. Mirrors `nested_clip_skip` — without it,
+        // an opacity descendant's sub-children would be dispatched by
+        // the loop AND by `draw_under_opacity` below, double-painting
+        // them. (fulgur-gdb9)
+        let nested_opacity_skip: std::collections::BTreeSet<usize> = block
+            .clip_descendants
+            .iter()
+            .filter_map(|id| drawables.block_styles.get(id))
+            .flat_map(|b| b.opacity_descendants.iter().copied())
+            .collect();
         for &desc_id in &block.clip_descendants {
-            if transform_skip.contains(&desc_id) || nested_clip_skip.contains(&desc_id) {
+            if transform_skip.contains(&desc_id)
+                || nested_clip_skip.contains(&desc_id)
+                || nested_opacity_skip.contains(&desc_id)
+            {
                 continue;
             }
             let Some(desc_geom) = geometry.get(&desc_id) else {
@@ -961,6 +1066,28 @@ fn draw_under_clip(
                         margin_top_pt,
                         page_index,
                     );
+                } else if let Some(desc_block) = drawables
+                    .block_styles
+                    .get(&desc_id)
+                    .filter(|b| !b.opacity_descendants.is_empty())
+                {
+                    // Nested opacity-scoped block — recurse so its
+                    // descendants paint inside its `draw_with_opacity`
+                    // wrap. (fulgur-gdb9)
+                    draw_under_opacity(
+                        canvas,
+                        desc_block,
+                        desc_id,
+                        desc_geom,
+                        desc_frag,
+                        desc_x,
+                        desc_y,
+                        geometry,
+                        drawables,
+                        margin_left_pt,
+                        margin_top_pt,
+                        page_index,
+                    );
                 } else {
                     dispatch_fragment(
                         canvas, desc_id, desc_geom, desc_frag, desc_x, desc_y, drawables,
@@ -972,6 +1099,246 @@ fn draw_under_clip(
 
         if clip_pushed {
             canvas.surface.pop();
+        }
+    });
+}
+
+/// Wrap the block's `dispatch_fragment` + every strict descendant in a
+/// single `draw_with_opacity` group. Used for blocks that have
+/// fractional opacity but no overflow clip (the clip arm,
+/// `draw_under_clip`, already handles its own opacity wrap).
+///
+/// Mirrors v1's `BlockPageable::draw` (`pageable.rs:1770-1828`):
+///
+/// ```text
+/// draw_with_opacity(canvas, self.opacity, |c| {
+///     bg + border + shadow at (x, y, total_w, total_h);
+///     for pc in self.children { pc.child.draw(c, x + pc.x, y + pc.y, ..); }
+/// });
+/// ```
+///
+/// v1 emits a single transparency-group XObject for the entire
+/// subtree. v2's flat dispatch without scope tracking would emit the
+/// block's own paint inside opacity but every descendant outside,
+/// dropping the parent's opacity on those descendants. Mirrors
+/// `draw_under_clip` minus the `push_clip_path` / `pop` calls and the
+/// list-item marker arm (a list-item with opacity uses
+/// `draw_list_item_with_block`, not this path, since list-item
+/// markers are owned by `ListItemEntry` rather than `BlockEntry`).
+#[allow(clippy::too_many_arguments)]
+fn draw_under_opacity(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    block: &crate::drawables::BlockEntry,
+    node_id: usize,
+    geom: &crate::pagination_layout::PaginationGeometry,
+    frag: &crate::pagination_layout::Fragment,
+    x_pt: f32,
+    y_pt: f32,
+    geometry: &crate::pagination_layout::PaginationGeometryTable,
+    drawables: &Drawables,
+    margin_left_pt: f32,
+    margin_top_pt: f32,
+    page_index: u32,
+) {
+    use crate::convert::px_to_pt;
+    use crate::pageable::draw_with_opacity;
+
+    draw_with_opacity(canvas, block.opacity, |canvas| {
+        // Block's own paint + shared-node_id inner content. We can
+        // re-use `dispatch_fragment` because it already handles the
+        // shared-node_id case via `draw_block_with_inner_content`,
+        // which itself opens a `draw_with_opacity(block.opacity, ..)`
+        // wrap. That nested wrap is harmless: krilla composes nested
+        // opacity groups by multiplication (0.4 × 1.0 = 0.4, since the
+        // inner block-with-inner-content uses the SAME opacity),
+        // matching the v1 chain `draw_with_opacity(0.4) → child draws`
+        // where the child happens to also be a block at full opacity.
+        //
+        // For pure-block-with-descendants (the case we're fixing —
+        // `<div opacity:0.4><svg>..</svg></div>`), `dispatch_fragment`
+        // calls `draw_block_v2` which wraps own paint in
+        // `draw_with_opacity(0.4)`. The outer wrap here multiplies to
+        // 0.16 — wrong! Inline the block's own paint without the inner
+        // opacity wrap to avoid this.
+        if drawables.list_items.contains_key(&node_id) {
+            // Inside an opacity-scoped block path we never reach a
+            // list-item: list-items dispatch through their own
+            // `draw_list_item_with_block` which composes the marker +
+            // body block + paragraph in one opacity group. If a
+            // list-item carries opacity, it would not have entered
+            // `draw_under_opacity` because list-item's opacity comes
+            // from `ListItemEntry`, not `BlockEntry`. Defensive guard
+            // only — should be unreachable.
+            dispatch_fragment(
+                canvas, node_id, geom, frag, x_pt, y_pt, drawables, page_index,
+            );
+        } else {
+            // Block bg / border / shadow without the inner opacity
+            // wrap. The shared-node_id (`paragraph` / `image` / `svg`
+            // at the same node_id) inner content paints at the
+            // content-box top-left; mirrors
+            // `draw_block_with_inner_content`'s body but without its
+            // own `draw_with_opacity` since the outer wrap already
+            // covers it.
+            let para_for_block = drawables.paragraphs.get(&node_id);
+            let img_for_block = drawables.images.get(&node_id);
+            let svg_for_block = drawables.svgs.get(&node_id);
+            let total_width = block
+                .layout_size
+                .map(|s| s.width)
+                .unwrap_or_else(|| px_to_pt(frag.width));
+            let total_height = block
+                .layout_size
+                .map(|s| s.height)
+                .unwrap_or_else(|| px_to_pt(frag.height));
+            if block.visible {
+                crate::background::draw_box_shadows(
+                    canvas,
+                    &block.style,
+                    x_pt,
+                    y_pt,
+                    total_width,
+                    total_height,
+                );
+                crate::background::draw_background(
+                    canvas,
+                    &block.style,
+                    x_pt,
+                    y_pt,
+                    total_width,
+                    total_height,
+                );
+                crate::pageable::draw_block_border(
+                    canvas,
+                    &block.style,
+                    x_pt,
+                    y_pt,
+                    total_width,
+                    total_height,
+                );
+            }
+            let inner_inset = block.style.content_inset();
+            let inner_x = x_pt + inner_inset.0;
+            let inner_y = y_pt + inner_inset.1;
+            if let Some(p) = para_for_block {
+                draw_paragraph_inner_paint(
+                    canvas,
+                    p,
+                    inner_x,
+                    inner_y,
+                    &geom.fragments,
+                    page_index,
+                );
+            }
+            if let Some(i) = img_for_block {
+                draw_image_inner_paint(canvas, i, inner_x, inner_y);
+            }
+            if let Some(s) = svg_for_block {
+                draw_svg_inner_paint(canvas, s, inner_x, inner_y);
+            }
+        }
+
+        // Descendants — same dispatch tree as `draw_under_clip` minus
+        // the nested-clip recursion (an opacity-scoped block by
+        // construction has `clipping == false`, so its descendants
+        // can still individually have clip / transform / opacity, and
+        // those need their own scope helpers).
+        let transform_skip: std::collections::BTreeSet<usize> = block
+            .opacity_descendants
+            .iter()
+            .filter_map(|id| drawables.transforms.get(id))
+            .flat_map(|tx| tx.descendants.iter().copied())
+            .collect();
+        let nested_clip_skip: std::collections::BTreeSet<usize> = block
+            .opacity_descendants
+            .iter()
+            .filter_map(|id| drawables.block_styles.get(id))
+            .filter(|b| b.style.has_overflow_clip())
+            .flat_map(|b| b.clip_descendants.iter().copied())
+            .collect();
+        let nested_opacity_skip: std::collections::BTreeSet<usize> = block
+            .opacity_descendants
+            .iter()
+            .filter_map(|id| drawables.block_styles.get(id))
+            .flat_map(|b| b.opacity_descendants.iter().copied())
+            .collect();
+        for &desc_id in &block.opacity_descendants {
+            if transform_skip.contains(&desc_id)
+                || nested_clip_skip.contains(&desc_id)
+                || nested_opacity_skip.contains(&desc_id)
+            {
+                continue;
+            }
+            let Some(desc_geom) = geometry.get(&desc_id) else {
+                continue;
+            };
+            for desc_frag in &desc_geom.fragments {
+                if desc_frag.page_index != page_index {
+                    continue;
+                }
+                let desc_x = margin_left_pt + px_to_pt(desc_frag.x);
+                let desc_y = margin_top_pt + px_to_pt(desc_frag.y);
+                if let Some(desc_tx) = drawables.transforms.get(&desc_id) {
+                    draw_under_transform(
+                        canvas,
+                        desc_tx,
+                        desc_id,
+                        desc_geom,
+                        desc_frag,
+                        desc_x,
+                        desc_y,
+                        geometry,
+                        drawables,
+                        margin_left_pt,
+                        margin_top_pt,
+                        page_index,
+                    );
+                } else if let Some(desc_block) = drawables
+                    .block_styles
+                    .get(&desc_id)
+                    .filter(|b| b.style.has_overflow_clip())
+                    .filter(|_| Some(desc_id) != drawables.body_id)
+                {
+                    draw_under_clip(
+                        canvas,
+                        desc_block,
+                        desc_id,
+                        desc_geom,
+                        desc_frag,
+                        desc_x,
+                        desc_y,
+                        geometry,
+                        drawables,
+                        margin_left_pt,
+                        margin_top_pt,
+                        page_index,
+                    );
+                } else if let Some(desc_block) = drawables
+                    .block_styles
+                    .get(&desc_id)
+                    .filter(|b| !b.opacity_descendants.is_empty())
+                {
+                    draw_under_opacity(
+                        canvas,
+                        desc_block,
+                        desc_id,
+                        desc_geom,
+                        desc_frag,
+                        desc_x,
+                        desc_y,
+                        geometry,
+                        drawables,
+                        margin_left_pt,
+                        margin_top_pt,
+                        page_index,
+                    );
+                } else {
+                    dispatch_fragment(
+                        canvas, desc_id, desc_geom, desc_frag, desc_x, desc_y, drawables,
+                        page_index,
+                    );
+                }
+            }
         }
     });
 }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -1390,7 +1390,7 @@ pub(crate) struct MarginBoxRenderer<'a> {
     pub running_states: Vec<BTreeMap<String, crate::pagination_layout::PageRunningState>>,
     pub counter_states: Vec<BTreeMap<String, i32>>,
     pub measure_cache: MeasureCache,
-    pub height_cache: HashMap<(String, u32), f32>,
+    pub height_cache: HashMap<(String, u32, u32), f32>,
     pub render_cache: RenderCache,
 }
 
@@ -1571,7 +1571,18 @@ impl<'a> MarginBoxRenderer<'a> {
                 Some(Edge::Right) => resolved_margin.right,
                 _ => continue,
             };
-            let hc_key = (html.clone(), width_key(fixed_width));
+            // Include `page_size.height` in the key so a `@page :first`
+            // (or other matched-page selector) that overrides the page
+            // SIZE — not just margins — gets a fresh measurement on
+            // the second page. Mirrors `measure_cache`'s key (which
+            // already records `page_size.height`); without this, two
+            // pages with the same fixed margin width but different
+            // page heights would share a stale entry. (PR #309 Devin)
+            let hc_key = (
+                html.clone(),
+                width_key(fixed_width),
+                width_key(page_size.height),
+            );
             self.height_cache.entry(hc_key).or_insert_with(|| {
                 let measure_html = format!(
                     "<html><head><style>{}</style></head><body style=\"margin:0;padding:0;\"><div>{}</div></body></html>",
@@ -1609,7 +1620,11 @@ impl<'a> MarginBoxRenderer<'a> {
                     resolved_margin.right
                 };
                 self.height_cache
-                    .get(&(html.clone(), width_key(fixed_width)))
+                    .get(&(
+                        html.clone(),
+                        width_key(fixed_width),
+                        width_key(page_size.height),
+                    ))
                     .copied()
             };
             if let Some(s) = size {

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -353,9 +353,19 @@ fn draw_v2_page(
             // dispatch self's inner content + every strict descendant
             // INSIDE the clip, then pop. Same shape as
             // `draw_under_transform` but with `push_clip_path`.
+            //
+            // No `!clip_descendants.is_empty()` guard: shared-node_id
+            // inner content (inline-root paragraph from
+            // `convert::inline_root`, replaced image / svg from
+            // `convert::replaced`) lands at the same `node_id` as the
+            // wrapper and so produces an empty `clip_descendants`. v1
+            // pushes the clip unconditionally when
+            // `has_overflow_clip()` is true (`pageable.rs:1808-1826`),
+            // so a `<div style="overflow:hidden;width:50px">long
+            // text</div>` still needs the text clipped at the 50px
+            // box even with no separate descendant NodeIds.
             if let Some(block) = drawables.block_styles.get(&node_id)
                 && block.style.has_overflow_clip()
-                && !block.clip_descendants.is_empty()
             {
                 draw_under_clip(
                     canvas,

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -194,15 +194,39 @@ fn draw_v2_page(
                 draw_table_v2(canvas, table, x_pt, y_pt, frag);
                 continue;
             }
-            // ListItem marker draws before block frame. v1's
-            // `ListItemPageable::draw` calls `self.body.draw(...)` so
-            // the body block's background / border paint underneath the
-            // marker (`pageable.rs:3362`). `<li>` and its body
-            // BlockPageable share the same node_id (`convert/list_item.rs:81`),
-            // so `block_styles[node_id]` carries the body block style;
-            // dropping `continue;` lets the dispatch fall through to it.
+            // ListItem case: marker + body block + inline-root
+            // paragraph (when present) all share one opacity group,
+            // mirroring v1's `ListItemPageable::draw` which wraps
+            // `marker` and `self.body.draw(...)` in a single
+            // `draw_with_opacity(self.opacity, ...)` (`pageable.rs:3336`).
+            //
+            // The body BlockPageable is intentionally built with
+            // `opacity: 1.0` (`convert/list_item.rs:56-58`) so v1
+            // produces ONE compositing group. The inline-root paragraph
+            // (when the body holds text content) lands at the same
+            // node_id via `convert::inline_root`. v2 must compose all
+            // three inside one group — separate `draw_with_opacity`
+            // calls would emit multiple `q .. Q` pairs and break byte-eq.
+            //
+            // `continue;` after this arm so the standalone block /
+            // image / svg / paragraph dispatch below does NOT fire for
+            // the same node_id (everything that v1 paints under the
+            // list item already painted inside the group above).
             if let Some(li) = drawables.list_items.get(&node_id) {
-                draw_list_item_v2(canvas, li, x_pt, y_pt);
+                let block_for_li = drawables.block_styles.get(&node_id);
+                let para_for_li = drawables.paragraphs.get(&node_id);
+                draw_list_item_with_block(
+                    canvas,
+                    li,
+                    block_for_li,
+                    para_for_li,
+                    x_pt,
+                    y_pt,
+                    frag,
+                    &geom.fragments,
+                    page_index,
+                );
+                continue;
             }
             // Block backgrounds/borders draw FIRST so subsequent inner
             // content (paragraph / image / svg sharing the same node_id —
@@ -318,42 +342,35 @@ fn draw_block_v2(
     use crate::pageable::draw_with_opacity;
 
     draw_with_opacity(canvas, entry.opacity, |canvas| {
-        let total_width = entry
-            .layout_size
-            .map(|s| s.width)
-            .unwrap_or_else(|| crate::convert::px_to_pt(frag.width));
-        let total_height = entry
-            .layout_size
-            .map(|s| s.height)
-            .unwrap_or_else(|| crate::convert::px_to_pt(frag.height));
-
-        if entry.visible {
-            crate::background::draw_box_shadows(
-                canvas,
-                &entry.style,
-                x,
-                y,
-                total_width,
-                total_height,
-            );
-            crate::background::draw_background(
-                canvas,
-                &entry.style,
-                x,
-                y,
-                total_width,
-                total_height,
-            );
-            crate::pageable::draw_block_border(
-                canvas,
-                &entry.style,
-                x,
-                y,
-                total_width,
-                total_height,
-            );
-        }
+        draw_block_inner_paint(canvas, entry, x, y, frag);
     });
+}
+
+/// Block bg / border / shadow paint without the outer `draw_with_opacity`
+/// wrap. Used by `draw_list_item_with_block` so the list-item's marker
+/// and body block share a single opacity group (matches v1's
+/// `ListItemPageable::draw` byte output exactly).
+fn draw_block_inner_paint(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    entry: &crate::drawables::BlockEntry,
+    x: f32,
+    y: f32,
+    frag: &crate::pagination_layout::Fragment,
+) {
+    let total_width = entry
+        .layout_size
+        .map(|s| s.width)
+        .unwrap_or_else(|| crate::convert::px_to_pt(frag.width));
+    let total_height = entry
+        .layout_size
+        .map(|s| s.height)
+        .unwrap_or_else(|| crate::convert::px_to_pt(frag.height));
+
+    if entry.visible {
+        crate::background::draw_box_shadows(canvas, &entry.style, x, y, total_width, total_height);
+        crate::background::draw_background(canvas, &entry.style, x, y, total_width, total_height);
+        crate::pageable::draw_block_border(canvas, &entry.style, x, y, total_width, total_height);
+    }
 }
 
 /// v2 table draw. Mirrors `TablePageable::draw`'s outer-frame
@@ -413,22 +430,58 @@ fn draw_table_v2(
     });
 }
 
-/// v2 list-item draw. Paints the marker (text glyphs / image / svg)
-/// at a negative-x offset relative to the list item's body anchor —
-/// mirrors `ListItemPageable::draw`. The body block paints itself
-/// through its own `BlockEntry` dispatch on the next iteration.
-fn draw_list_item_v2(
+/// v2 list-item combined draw. Mirrors v1's `ListItemPageable::draw`
+/// (`pageable.rs:3336`) which wraps the marker plus everything painted
+/// by `self.body.draw(...)` in a single `draw_with_opacity(self.opacity, ...)`
+/// group.
+///
+/// The `<li>` and its body BlockPageable share the same node_id
+/// (`convert/list_item.rs:81`); the body is built with `opacity: 1.0`
+/// on purpose. When the body holds inline content, the inline-root
+/// paragraph also lands at the same node_id (see `convert::inline_root`).
+/// Painting marker + block frame + paragraph glyphs in one compositing
+/// group is what keeps `<li style="opacity:..">` byte-identical with
+/// v1 — separate `draw_with_opacity` calls would emit multiple `q .. Q`
+/// pairs and diverge.
+#[allow(clippy::too_many_arguments)]
+fn draw_list_item_with_block(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    list_item: &crate::drawables::ListItemEntry,
+    block: Option<&crate::drawables::BlockEntry>,
+    paragraph: Option<&crate::drawables::ParagraphEntry>,
+    x: f32,
+    y: f32,
+    frag: &crate::pagination_layout::Fragment,
+    fragments: &[crate::pagination_layout::Fragment],
+    page_index: u32,
+) {
+    use crate::pageable::draw_with_opacity;
+
+    draw_with_opacity(canvas, list_item.opacity, |canvas| {
+        if list_item.visible {
+            draw_list_item_marker(canvas, list_item, x, y);
+        }
+        if let Some(b) = block {
+            draw_block_inner_paint(canvas, b, x, y, frag);
+        }
+        if let Some(p) = paragraph {
+            draw_paragraph_inner_paint(canvas, p, x, y, fragments, page_index);
+        }
+    });
+}
+
+/// List-item marker paint without opacity wrapper or visibility gate
+/// — caller (`draw_list_item_with_block`) handles both so the marker
+/// and the body block share one compositing group.
+fn draw_list_item_marker(
     canvas: &mut crate::pageable::Canvas<'_, '_>,
     entry: &crate::drawables::ListItemEntry,
     x: f32,
     y: f32,
 ) {
-    use crate::pageable::{ImageMarker, ListItemMarker, draw_with_opacity};
+    use crate::pageable::{ImageMarker, ListItemMarker};
 
-    if !entry.visible {
-        return;
-    }
-    draw_with_opacity(canvas, entry.opacity, |canvas| match &entry.marker {
+    match &entry.marker {
         ListItemMarker::Text { lines, width } if !lines.is_empty() => {
             crate::paragraph::draw_shaped_lines(canvas, lines, x - *width, y);
         }
@@ -449,7 +502,7 @@ fn draw_list_item_v2(
             }
         }
         _ => {}
-    });
+    }
 }
 
 /// v2 paragraph draw. Mirrors `paragraph::ParagraphPageable::draw`:
@@ -467,15 +520,32 @@ fn draw_paragraph_v2(
     page_index: u32,
 ) {
     use crate::pageable::draw_with_opacity;
+    draw_with_opacity(canvas, entry.opacity, |canvas| {
+        draw_paragraph_inner_paint(canvas, entry, x, y, fragments, page_index);
+    });
+}
+
+/// Paragraph paint without the outer `draw_with_opacity` wrap. Used
+/// by `draw_list_item_with_block` so a list-item containing inline
+/// content (the body block holds an inline-root paragraph at the same
+/// node_id) can compose marker + block paint + glyph runs into a
+/// single opacity group, matching v1's
+/// `ListItemPageable::draw → body.draw → paragraph.draw` chain.
+fn draw_paragraph_inner_paint(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    entry: &crate::drawables::ParagraphEntry,
+    x: f32,
+    y: f32,
+    fragments: &[crate::pagination_layout::Fragment],
+    page_index: u32,
+) {
     if !entry.visible {
         return;
     }
     let Some(slice) = paragraph_lines_for_page(&entry.lines, fragments, page_index) else {
         return;
     };
-    draw_with_opacity(canvas, entry.opacity, |canvas| {
-        crate::paragraph::draw_shaped_lines(canvas, &slice, x, y);
-    });
+    crate::paragraph::draw_shaped_lines(canvas, &slice, x, y);
 }
 
 /// Phase 4 PR 3 follow-up (PR #302 Devin): mirror

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -744,16 +744,31 @@ fn draw_block_with_inner_content(
 ) {
     use crate::pageable::draw_with_opacity;
 
+    // Inner content (inline-root paragraph from `convert::inline_root`
+    // or replaced image / svg from `convert::replaced`) is positioned
+    // at the block's content-box top-left, not its border-box top-left.
+    // v1 expresses this via `PositionedChild { x: content_inset.x, y:
+    // content_inset.y, .. }` so `BlockPageable::draw` recurses into the
+    // child at `(x + ix, y + iy)`. v2 has no `PositionedChild` here —
+    // the inner payload shares the block's `node_id` and would
+    // otherwise paint at the block's border-box origin, dropping
+    // `padding + border` worth of offset for every inline-root or
+    // replaced element. Mirror v1 by reading the inset from the
+    // BlockStyle and adding it before recursing.
+    let (ix, iy) = block.style.content_inset();
+    let inner_x = x + ix;
+    let inner_y = y + iy;
+
     draw_with_opacity(canvas, block.opacity, |canvas| {
         draw_block_inner_paint(canvas, block, x, y, frag);
         if let Some(p) = paragraph {
-            draw_paragraph_inner_paint(canvas, p, x, y, fragments, page_index);
+            draw_paragraph_inner_paint(canvas, p, inner_x, inner_y, fragments, page_index);
         }
         if let Some(i) = image {
-            draw_image_inner_paint(canvas, i, x, y);
+            draw_image_inner_paint(canvas, i, inner_x, inner_y);
         }
         if let Some(s) = svg {
-            draw_svg_inner_paint(canvas, s, x, y);
+            draw_svg_inner_paint(canvas, s, inner_x, inner_y);
         }
     });
 }
@@ -785,6 +800,14 @@ fn draw_list_item_with_block(
 ) {
     use crate::pageable::draw_with_opacity;
 
+    // Same content-box offset trick as `draw_block_with_inner_content`
+    // — when the body block carries `padding` / `border`, the
+    // inline-root paragraph that shares the list item's node_id has to
+    // paint at the body block's content-box top-left.
+    let inset = block.map(|b| b.style.content_inset()).unwrap_or((0.0, 0.0));
+    let inner_x = x + inset.0;
+    let inner_y = y + inset.1;
+
     draw_with_opacity(canvas, list_item.opacity, |canvas| {
         if list_item.visible {
             draw_list_item_marker(canvas, list_item, x, y);
@@ -793,7 +816,7 @@ fn draw_list_item_with_block(
             draw_block_inner_paint(canvas, b, x, y, frag);
         }
         if let Some(p) = paragraph {
-            draw_paragraph_inner_paint(canvas, p, x, y, fragments, page_index);
+            draw_paragraph_inner_paint(canvas, p, inner_x, inner_y, fragments, page_index);
         }
     });
 }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -1367,7 +1367,7 @@ fn parse_datetime(s: &str) -> Option<krilla::metadata::DateTime> {
 /// Cached max-content width and render Pageable for margin boxes.
 /// Measure cache: (html, page_height as bits) → max-content width.
 /// Render cache: (html, final_width as bits, final_height as bits) → Pageable.
-type MeasureCache = HashMap<(String, u32), f32>;
+type MeasureCache = HashMap<(String, u32, u32), f32>;
 type RenderCache = HashMap<(String, u32, u32), Box<dyn Pageable>>;
 
 fn width_key(w: f32) -> u32 {
@@ -1535,7 +1535,20 @@ impl<'a> MarginBoxRenderer<'a> {
             if !pos.edge().is_some_and(|e| e.is_horizontal()) {
                 continue;
             }
-            let measure_key = (html.clone(), width_key(page_size.height));
+            // Cache key includes `content_width` because `@page :first` /
+            // `:left` / `:right` can override margins per page, changing
+            // the available viewport width that Blitz lays the
+            // `display: inline-block` measure document at. Pre-Phase-4
+            // v1 had a single global `content_width` so two-tuple keys
+            // were complete; the v2 port made `content_width` a
+            // per-page parameter and a stale cache entry could
+            // misalign margin boxes on pages with overridden margins
+            // (PR #309 Devin).
+            let measure_key = (
+                html.clone(),
+                width_key(page_size.height),
+                width_key(content_width),
+            );
             self.measure_cache.entry(measure_key).or_insert_with(|| {
                 let measure_html = format!(
                     "<html><head><style>{}</style></head><body style=\"margin:0;padding:0;\"><div style=\"display:inline-block\">{}</div></body></html>",
@@ -1583,7 +1596,11 @@ impl<'a> MarginBoxRenderer<'a> {
             };
             let size = if edge.is_horizontal() {
                 self.measure_cache
-                    .get(&(html.clone(), width_key(page_size.height)))
+                    .get(&(
+                        html.clone(),
+                        width_key(page_size.height),
+                        width_key(content_width),
+                    ))
                     .copied()
             } else {
                 let fixed_width = if edge == Edge::Left {

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -285,7 +285,18 @@ fn draw_v2_page(
     let mut clipped_descendants: std::collections::BTreeSet<usize> =
         std::collections::BTreeSet::new();
     for (&node_id, block) in &drawables.block_styles {
-        if block.style.has_overflow_clip() && Some(node_id) != drawables.body_id {
+        // Exclude body AND root: both are skipped by the main
+        // dispatch loop (body's only fragment lives on page 0, root
+        // is never recorded in `geometry` and is painted via
+        // `paint_root_block_v2`). Including either would silently
+        // blank descendants on pages 1+ because `draw_under_clip`
+        // never fires for them but the skip set still hides their
+        // descendants from the regular per-fragment dispatch.
+        // (PR #312 follow-up Devin: root exclusion symmetry.)
+        if block.style.has_overflow_clip()
+            && Some(node_id) != drawables.body_id
+            && Some(node_id) != drawables.root_id
+        {
             clipped_descendants.extend(block.clip_descendants.iter().copied());
         }
     }
@@ -296,19 +307,25 @@ fn draw_v2_page(
     // they'd be dispatched twice: once at full opacity here, once
     // again under the parent's opacity wrap.
     //
-    // Body is excluded for the same reason as `clipped_descendants`:
-    // the fragmenter records body with exactly one fragment at
-    // `page_index = 0`, so `draw_under_opacity(body)` only fires on
-    // page 0. Keeping body's descendants in this set would silently
-    // blank all content on pages 1+ (descendants get skipped by the
-    // `opacity_wrapped_descendants.contains(...)` guard but no-one
-    // dispatches them — same `body { opacity: 0.5 }` pitfall the
-    // clip path documents at the `clipped_descendants` collection
-    // (PR #314 follow-up Devin Review).
+    // Body and root are excluded for the same reason
+    // `clipped_descendants` excludes them: the fragmenter records
+    // body with exactly one fragment at `page_index = 0` (so
+    // `draw_under_opacity(body)` only fires on page 0), and root
+    // is never recorded in `geometry` at all (it's painted via
+    // the `paint_root_block_v2` pre-pass). Keeping either's
+    // descendants in this set would silently blank all content on
+    // pages 1+ because descendants get skipped by the guard but
+    // no-one dispatches them — `html { opacity: 0.5 }` would
+    // silently blank the whole document, and `body { opacity:
+    // 0.5 }` would silently blank pages 1+. (PR #314 + PR #312
+    // follow-up Devin Reviews.)
     let mut opacity_wrapped_descendants: std::collections::BTreeSet<usize> =
         std::collections::BTreeSet::new();
     for (&node_id, block) in &drawables.block_styles {
-        if !block.opacity_descendants.is_empty() && Some(node_id) != drawables.body_id {
+        if !block.opacity_descendants.is_empty()
+            && Some(node_id) != drawables.body_id
+            && Some(node_id) != drawables.root_id
+        {
             opacity_wrapped_descendants.extend(block.opacity_descendants.iter().copied());
         }
     }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -38,14 +38,25 @@ pub fn render_v2(
 
     // Pre-pass: register `id` anchors for `href="#..."` resolution.
     // PR 3 records paragraph ids; PR 4 adds block ids. List-item ids
-    // arrive in PR 5.
+    // arrive in PR 5. A node may appear in both `paragraphs` and
+    // `block_styles` (shared node_id case — see `convert::replaced` /
+    // `convert::inline_root`); paragraph wins so the chain mirrors the
+    // priority v1 establishes via the Pageable tree walk.
     let mut dest_registry = crate::pageable::DestinationRegistry::new();
     for (&node_id, geom) in geometry {
         let Some(first_frag) = geom.fragments.first() else {
             continue;
         };
-        if let Some(para) = drawables.paragraphs.get(&node_id)
-            && let Some(id) = &para.id
+        let para_id = drawables
+            .paragraphs
+            .get(&node_id)
+            .and_then(|p| p.id.as_ref());
+        let block_id = drawables
+            .block_styles
+            .get(&node_id)
+            .and_then(|b| b.id.as_ref());
+        let id = para_id.or(block_id);
+        if let Some(id) = id
             && !id.is_empty()
         {
             let page_idx = first_frag.page_index as usize;

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -35,6 +35,40 @@ pub fn render_v2(
     };
 
     let page_count = crate::pagination_layout::implied_page_count(geometry).max(1) as usize;
+
+    // Pre-pass: register `id` anchors for `href="#..."` resolution.
+    // PR 3 covers paragraph anchors (the only id-bearing type in
+    // Drawables this PR). PR 4+ will add block / list-item anchors
+    // when their entry types arrive.
+    let mut dest_registry = crate::pageable::DestinationRegistry::new();
+    for (&node_id, geom) in geometry {
+        let Some(first_frag) = geom.fragments.first() else {
+            continue;
+        };
+        if let Some(para) = drawables.paragraphs.get(&node_id)
+            && let Some(id) = &para.id
+        {
+            let page_idx = first_frag.page_index as usize;
+            dest_registry.set_current_page(page_idx);
+            // The fragment is in body content-area-relative CSS px;
+            // resolve the page-specific margin so destination y_pt is
+            // page-absolute (matches v1's `collect_ids` semantics).
+            let page_num = page_idx + 1;
+            let (_resolved_size, resolved_margin, _resolved_landscape) =
+                crate::gcpm::page_settings::resolve_page_settings(
+                    &gcpm.page_settings,
+                    page_num,
+                    page_count,
+                    config,
+                );
+            let x_pt = resolved_margin.left + crate::convert::px_to_pt(first_frag.x);
+            let y_pt = resolved_margin.top + crate::convert::px_to_pt(first_frag.y);
+            dest_registry.record(id.as_str(), x_pt, y_pt);
+        }
+    }
+
+    let mut link_collector = crate::pageable::LinkCollector::new();
+
     for page_idx in 0..page_count {
         let page_num = page_idx + 1;
         // Pass the full `gcpm.page_settings` (including selector
@@ -58,12 +92,13 @@ pub fn render_v2(
         if let Some(c) = bookmark_collector.as_mut() {
             c.set_current_page(page_idx);
         }
+        link_collector.set_current_page(page_idx);
         {
             let mut surface = page.surface();
             let mut canvas = crate::pageable::Canvas {
                 surface: &mut surface,
                 bookmark_collector: bookmark_collector.as_mut(),
-                link_collector: None,
+                link_collector: Some(&mut link_collector),
             };
             draw_v2_page(
                 &mut canvas,
@@ -74,6 +109,8 @@ pub fn render_v2(
                 drawables,
             );
         }
+        let per_page = link_collector.take_page(page_idx);
+        crate::link::emit_link_annotations(&mut page, &per_page, &dest_registry);
     }
 
     if let Some(c) = bookmark_collector {
@@ -140,8 +177,12 @@ fn draw_v2_page(
                 draw_svg_v2(canvas, svg, x_pt, y_pt);
                 continue;
             }
-            // Other types (block_styles / paragraphs / tables / ...)
-            // land in subsequent PRs.
+            if let Some(para) = drawables.paragraphs.get(&node_id) {
+                draw_paragraph_v2(canvas, para, x_pt, y_pt);
+                continue;
+            }
+            // Other types (block_styles / tables / ...) land in
+            // subsequent PRs.
         }
     }
 }
@@ -210,6 +251,27 @@ fn draw_svg_v2(
             .surface
             .draw_svg(&entry.tree, size, SvgSettings::default());
         canvas.surface.pop();
+    });
+}
+
+/// v2 paragraph draw. Mirrors `paragraph::ParagraphPageable::draw`:
+/// honour `visible`, wrap with `draw_with_opacity`, then call the
+/// existing `paragraph::draw_shaped_lines` which already handles glyph
+/// runs / inline images / inline boxes / link rect emission /
+/// decoration spans. Reusing the helper keeps the per-glyph PDF output
+/// byte-identical between v1 and v2.
+fn draw_paragraph_v2(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    entry: &crate::drawables::ParagraphEntry,
+    x: f32,
+    y: f32,
+) {
+    use crate::pageable::draw_with_opacity;
+    if !entry.visible {
+        return;
+    }
+    draw_with_opacity(canvas, entry.opacity, |canvas| {
+        crate::paragraph::draw_shaped_lines(canvas, &entry.lines, x, y);
     });
 }
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -449,7 +449,25 @@ fn draw_under_transform(
     // inner transform would be silently dropped, breaking
     // `<div style="transform:rotate"><div style="transform:scale">`
     // (PR #305 Devin).
+    //
+    // Pre-skip the strict descendants of any nested transform so they
+    // are not dispatched twice — the nested `draw_under_transform`
+    // already iterates `desc_tx.descendants` and paints them under
+    // the composed matrix; iterating them again here via
+    // `dispatch_fragment` would emit a SECOND draw under the outer
+    // transform only (missing the inner matrix). Bug confirmed by
+    // PR #305 follow-up Devin trace for
+    // `<div transform:A><div transform:B><p>text</p></div></div>`.
+    let nested_skip: std::collections::BTreeSet<usize> = tx
+        .descendants
+        .iter()
+        .filter_map(|id| drawables.transforms.get(id))
+        .flat_map(|inner_tx| inner_tx.descendants.iter().copied())
+        .collect();
     for &desc_id in &tx.descendants {
+        if nested_skip.contains(&desc_id) {
+            continue;
+        }
         let Some(desc_geom) = geometry.get(&desc_id) else {
             continue;
         };

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -588,8 +588,22 @@ fn draw_under_transform(
         .filter_map(|id| drawables.transforms.get(id))
         .flat_map(|inner_tx| inner_tx.descendants.iter().copied())
         .collect();
+    // Symmetric pre-skip for `overflow:hidden` descendants. When a
+    // clip block sits inside this transform, `draw_under_clip` (called
+    // below) iterates its own `clip_descendants` to paint them inside
+    // the clip; iterating those nodes again here via
+    // `dispatch_fragment` would double-paint them outside the clip.
+    // Mirrors the symmetric handling in `draw_under_clip`'s descendant
+    // loop (PR #309 follow-up Devin).
+    let clip_skip: std::collections::BTreeSet<usize> = tx
+        .descendants
+        .iter()
+        .filter_map(|id| drawables.block_styles.get(id))
+        .filter(|b| b.style.has_overflow_clip())
+        .flat_map(|b| b.clip_descendants.iter().copied())
+        .collect();
     for &desc_id in &tx.descendants {
-        if nested_skip.contains(&desc_id) {
+        if nested_skip.contains(&desc_id) || clip_skip.contains(&desc_id) {
             continue;
         }
         let Some(desc_geom) = geometry.get(&desc_id) else {
@@ -605,6 +619,33 @@ fn draw_under_transform(
                 draw_under_transform(
                     canvas,
                     desc_tx,
+                    desc_id,
+                    desc_geom,
+                    desc_frag,
+                    desc_x,
+                    desc_y,
+                    geometry,
+                    drawables,
+                    margin_left_pt,
+                    margin_top_pt,
+                    page_index,
+                );
+            } else if let Some(desc_block) = drawables
+                .block_styles
+                .get(&desc_id)
+                .filter(|b| b.style.has_overflow_clip())
+                .filter(|_| Some(desc_id) != drawables.body_id)
+            {
+                // Descendant carries `overflow:hidden|clip` — push its
+                // clip path the same way the main loop does. Without
+                // this, transforms wrapping a clipping block would
+                // emit the inner block's bg/border via
+                // `dispatch_fragment` but never push the clip, leaking
+                // overflow content past the clip boundary
+                // (PR #309 follow-up Devin).
+                draw_under_clip(
+                    canvas,
+                    desc_block,
                     desc_id,
                     desc_geom,
                     desc_frag,
@@ -795,8 +836,21 @@ fn draw_under_clip(
             .filter_map(|id| drawables.transforms.get(id))
             .flat_map(|tx| tx.descendants.iter().copied())
             .collect();
+        // Symmetric pre-skip for nested `overflow:hidden` descendants.
+        // The recursive `draw_under_clip` call below paints the inner
+        // clip's children inside its push/pop group; iterating the
+        // outer's `clip_descendants` for those same nodes here would
+        // re-dispatch them outside the inner clip
+        // (PR #309 follow-up Devin).
+        let nested_clip_skip: std::collections::BTreeSet<usize> = block
+            .clip_descendants
+            .iter()
+            .filter_map(|id| drawables.block_styles.get(id))
+            .filter(|b| b.style.has_overflow_clip())
+            .flat_map(|b| b.clip_descendants.iter().copied())
+            .collect();
         for &desc_id in &block.clip_descendants {
-            if transform_skip.contains(&desc_id) {
+            if transform_skip.contains(&desc_id) || nested_clip_skip.contains(&desc_id) {
                 continue;
             }
             let Some(desc_geom) = geometry.get(&desc_id) else {
@@ -812,6 +866,34 @@ fn draw_under_clip(
                     draw_under_transform(
                         canvas,
                         desc_tx,
+                        desc_id,
+                        desc_geom,
+                        desc_frag,
+                        desc_x,
+                        desc_y,
+                        geometry,
+                        drawables,
+                        margin_left_pt,
+                        margin_top_pt,
+                        page_index,
+                    );
+                } else if let Some(desc_block) = drawables
+                    .block_styles
+                    .get(&desc_id)
+                    .filter(|b| b.style.has_overflow_clip())
+                    .filter(|_| Some(desc_id) != drawables.body_id)
+                {
+                    // Nested `overflow:hidden|clip` block — recurse so
+                    // its own clip path is pushed. Without this, a
+                    // `<div style="overflow:hidden"><div style="
+                    // overflow:hidden;width:30px"><p>text</p></div>
+                    // </div>` paints the inner block's bg/border via
+                    // `dispatch_fragment` but never pushes the inner
+                    // clip, losing the inner boundary
+                    // (PR #309 follow-up Devin).
+                    draw_under_clip(
+                        canvas,
+                        desc_block,
                         desc_id,
                         desc_geom,
                         desc_frag,

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -295,10 +295,20 @@ fn draw_v2_page(
     // `draw_under_opacity`). Without skipping these in the main loop
     // they'd be dispatched twice: once at full opacity here, once
     // again under the parent's opacity wrap.
+    //
+    // Body is excluded for the same reason as `clipped_descendants`:
+    // the fragmenter records body with exactly one fragment at
+    // `page_index = 0`, so `draw_under_opacity(body)` only fires on
+    // page 0. Keeping body's descendants in this set would silently
+    // blank all content on pages 1+ (descendants get skipped by the
+    // `opacity_wrapped_descendants.contains(...)` guard but no-one
+    // dispatches them — same `body { opacity: 0.5 }` pitfall the
+    // clip path documents at the `clipped_descendants` collection
+    // (PR #314 follow-up Devin Review).
     let mut opacity_wrapped_descendants: std::collections::BTreeSet<usize> =
         std::collections::BTreeSet::new();
-    for block in drawables.block_styles.values() {
-        if !block.opacity_descendants.is_empty() {
+    for (&node_id, block) in &drawables.block_styles {
+        if !block.opacity_descendants.is_empty() && Some(node_id) != drawables.body_id {
             opacity_wrapped_descendants.extend(block.opacity_descendants.iter().copied());
         }
     }
@@ -438,10 +448,21 @@ fn draw_v2_page(
             // `<div opacity:0.4><svg>..</svg></div>` paints the svg
             // outside the parent's opacity wrap, dropping the parent's
             // opacity from the svg. (fulgur-gdb9)
+            //
+            // Body is excluded for the same reason as the clip arm
+            // above: body has only a page-0 fragment so a
+            // `draw_under_opacity(body)` would only wrap page-0
+            // content while the `opacity_wrapped_descendants` skip
+            // (collected above) excludes body explicitly so the main
+            // loop dispatches body's descendants on pages 1+
+            // normally. Without this exclusion `body { opacity: 0.5 }`
+            // would silently blank pages 1+. (PR #314 follow-up Devin
+            // Review)
             if let Some(block) = drawables
                 .block_styles
                 .get(&node_id)
                 .filter(|b| !b.opacity_descendants.is_empty())
+                .filter(|_| Some(node_id) != drawables.body_id)
             {
                 draw_under_opacity(
                     canvas,
@@ -1196,9 +1217,25 @@ fn draw_under_opacity(
                 .layout_size
                 .map(|s| s.width)
                 .unwrap_or_else(|| px_to_pt(frag.width));
+            // Mirror `draw_block_inner_paint`'s `is_split` height fix.
+            // When this opacity-scoped block spans multiple pages
+            // (one fragment per page slice), use `frag.height` so each
+            // slice paints its per-page bg / border height instead of
+            // the full layout height — without this the bg / border
+            // overflows the page bottom on earlier slices and double-
+            // paints on continuation pages, exactly the bug the
+            // `draw_block_inner_paint` fix addresses for non-opacity
+            // blocks (PR #316). (PR #314 follow-up Devin Review)
+            let is_split = geom.fragments.len() > 1;
             let total_height = block
                 .layout_size
-                .map(|s| s.height)
+                .map(|s| {
+                    if is_split && frag.height > 0.0 {
+                        px_to_pt(frag.height)
+                    } else {
+                        s.height
+                    }
+                })
                 .unwrap_or_else(|| px_to_pt(frag.height));
             if block.visible {
                 crate::background::draw_box_shadows(

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -55,10 +55,7 @@ pub fn render_v2(
             .block_styles
             .get(&node_id)
             .and_then(|b| b.id.as_ref());
-        let table_id = drawables
-            .tables
-            .get(&node_id)
-            .and_then(|t| t.id.as_ref());
+        let table_id = drawables.tables.get(&node_id).and_then(|t| t.id.as_ref());
         let id = para_id.or(block_id).or(table_id);
         if let Some(id) = id
             && !id.is_empty()

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -20,11 +20,16 @@ use std::sync::Arc;
 /// Page settings (size, margins, landscape, GCPM `@page` overrides)
 /// resolve identically to the v1 path so byte equality is achievable
 /// once the draw migration completes.
+#[allow(clippy::too_many_arguments)]
 pub fn render_v2(
     config: &Config,
     geometry: &crate::pagination_layout::PaginationGeometryTable,
     drawables: &Drawables,
     gcpm: &GcpmContext,
+    running_store: &RunningElementStore,
+    font_data: &[Arc<Vec<u8>>],
+    string_set_by_node: &HashMap<usize, Vec<(String, String)>>,
+    counter_ops_by_node: &BTreeMap<usize, Vec<crate::gcpm::CounterOp>>,
 ) -> Result<Vec<u8>> {
     let mut document = krilla::Document::new();
 
@@ -87,6 +92,20 @@ pub fn render_v2(
 
     let mut link_collector = crate::pageable::LinkCollector::new();
 
+    // Build the GCPM margin-box renderer once. Reused across pages so
+    // measure / layout / render caches survive between pages and the
+    // pre-computed `string_set_states` / `counter_states` /
+    // `running_states` are paid for once.
+    let mut margin_box_renderer = MarginBoxRenderer::new(
+        gcpm,
+        running_store,
+        font_data,
+        geometry,
+        string_set_by_node,
+        counter_ops_by_node,
+        page_count,
+    );
+
     for page_idx in 0..page_count {
         let page_num = page_idx + 1;
         // Pass the full `gcpm.page_settings` (including selector
@@ -113,6 +132,31 @@ pub fn render_v2(
         link_collector.set_current_page(page_idx);
         {
             let mut surface = page.surface();
+            // Margin box pre-pass first (mirrors v1's
+            // `render_to_pdf_with_gcpm` per-page ordering — header /
+            // footer / corner content paint before body content). v1
+            // gives margin boxes their own collector-less canvas
+            // because running elements promoted into a margin box
+            // shouldn't re-record bookmarks every page; we mirror that
+            // here.
+            {
+                let mut margin_canvas = crate::pageable::Canvas {
+                    surface: &mut surface,
+                    bookmark_collector: None,
+                    link_collector: None,
+                };
+                let page_content_width =
+                    page_size.width - resolved_margin.left - resolved_margin.right;
+                margin_box_renderer.render_page(
+                    &mut margin_canvas,
+                    page_idx,
+                    page_num,
+                    page_count,
+                    page_size,
+                    resolved_margin,
+                    page_content_width,
+                );
+            }
             let mut canvas = crate::pageable::Canvas {
                 surface: &mut surface,
                 bookmark_collector: bookmark_collector.as_mut(),
@@ -1330,6 +1374,285 @@ fn width_key(w: f32) -> u32 {
     w.to_bits()
 }
 
+/// Per-page state and caches required to render `@page` margin boxes
+/// (`@top-center`, `@bottom-center`, `@left-middle`, etc.). Built once
+/// per render and reused across pages so measure / layout passes for
+/// repeated content (e.g. a page-number footer) hit the cache.
+///
+/// Used by both `render_to_pdf_with_gcpm` (v1 path) and `render_v2`
+/// (Phase 4 v2 path) — both call `render_page` per page.
+pub(crate) struct MarginBoxRenderer<'a> {
+    pub gcpm: &'a GcpmContext,
+    pub running_store: &'a RunningElementStore,
+    pub font_data: &'a [Arc<Vec<u8>>],
+    pub margin_css: String,
+    pub string_set_states: Vec<BTreeMap<String, crate::pagination_layout::StringSetPageState>>,
+    pub running_states: Vec<BTreeMap<String, crate::pagination_layout::PageRunningState>>,
+    pub counter_states: Vec<BTreeMap<String, i32>>,
+    pub measure_cache: MeasureCache,
+    pub height_cache: HashMap<(String, u32), f32>,
+    pub render_cache: RenderCache,
+}
+
+impl<'a> MarginBoxRenderer<'a> {
+    /// Build a renderer from raw inputs. `string_set_by_node` /
+    /// `counter_ops_by_node` are the per-node maps drained out of
+    /// `ConvertContext` before `dom_to_pageable` consumed them.
+    pub(crate) fn new(
+        gcpm: &'a GcpmContext,
+        running_store: &'a RunningElementStore,
+        font_data: &'a [Arc<Vec<u8>>],
+        pagination_geometry: &crate::pagination_layout::PaginationGeometryTable,
+        string_set_by_node: &HashMap<usize, Vec<(String, String)>>,
+        counter_ops_by_node: &BTreeMap<usize, Vec<crate::gcpm::CounterOp>>,
+        total_pages: usize,
+    ) -> Self {
+        let string_set_states = if gcpm.string_set_mappings.is_empty() {
+            vec![BTreeMap::new(); total_pages]
+        } else {
+            let by_node_btree: BTreeMap<usize, Vec<(String, String)>> = string_set_by_node
+                .iter()
+                .map(|(k, v)| (*k, v.clone()))
+                .collect();
+            crate::pagination_layout::collect_string_set_states(pagination_geometry, &by_node_btree)
+        };
+        let running_states = if gcpm.running_mappings.is_empty() {
+            vec![BTreeMap::new(); total_pages]
+        } else {
+            crate::pagination_layout::collect_running_element_states(
+                pagination_geometry,
+                running_store,
+            )
+        };
+        let counter_states =
+            if gcpm.counter_mappings.is_empty() && gcpm.content_counter_mappings.is_empty() {
+                vec![BTreeMap::new(); total_pages]
+            } else {
+                crate::pagination_layout::collect_counter_states(
+                    pagination_geometry,
+                    counter_ops_by_node,
+                )
+            };
+        Self {
+            gcpm,
+            running_store,
+            font_data,
+            margin_css: strip_display_none(&gcpm.cleaned_css),
+            string_set_states,
+            running_states,
+            counter_states,
+            measure_cache: HashMap::new(),
+            height_cache: HashMap::new(),
+            render_cache: HashMap::new(),
+        }
+    }
+
+    /// Render every margin box that applies to `page_idx` onto
+    /// `canvas`. Mirrors the per-page block from
+    /// `render_to_pdf_with_gcpm`'s pre-Phase-4 implementation:
+    ///
+    /// 1. Filter `gcpm.margin_boxes` by `@page` selector matching
+    ///    (`:first` / `:left` / `:right`), preferring more-specific
+    ///    selectors over the default.
+    /// 2. Resolve each box's HTML content (substituting `counter()` /
+    ///    `element()` / `string()` from per-page state).
+    /// 3. Measure max-content width (top/bottom) or height (left/right).
+    /// 4. Distribute boxes along each edge with `compute_edge_layout`.
+    /// 5. Render each box at its final rect via Blitz parse + layout +
+    ///    `dom_to_pageable`, then `pageable.draw(canvas, rect)`.
+    ///
+    /// `content_width` is the page content area width in pt — used as
+    /// the available width during measure passes for top/bottom boxes.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn render_page(
+        &mut self,
+        canvas: &mut Canvas<'_, '_>,
+        page_idx: usize,
+        page_num: usize,
+        total_pages: usize,
+        page_size: crate::config::PageSize,
+        resolved_margin: crate::config::Margin,
+        content_width: f32,
+    ) {
+        // Resolve effective boxes: pick the most specific matching rule
+        // per position. Pseudo-class selectors (`:first`, `:left`,
+        // `:right`) override the default `@page` rule.
+        let mut effective_boxes: BTreeMap<MarginBoxPosition, &crate::gcpm::MarginBoxRule> =
+            BTreeMap::new();
+        for margin_box in &self.gcpm.margin_boxes {
+            let matches = match &margin_box.page_selector {
+                None => true,
+                Some(sel) => match sel.as_str() {
+                    ":first" => page_num == 1,
+                    ":left" => page_num % 2 == 0,
+                    ":right" => page_num % 2 != 0,
+                    _ => true,
+                },
+            };
+            if !matches {
+                continue;
+            }
+            let should_replace = effective_boxes
+                .get(&margin_box.position)
+                .map(|existing| {
+                    existing.page_selector.is_none() && margin_box.page_selector.is_some()
+                })
+                .unwrap_or(true);
+            if should_replace {
+                effective_boxes.insert(margin_box.position, margin_box);
+            }
+        }
+
+        // Resolve HTML for each effective box.
+        let mut resolved_htmls: BTreeMap<MarginBoxPosition, String> = BTreeMap::new();
+        for (&pos, rule) in &effective_boxes {
+            let content_html = resolve_content_to_html(
+                &rule.content,
+                self.running_store,
+                &self.running_states,
+                &self.string_set_states[page_idx],
+                page_num,
+                total_pages,
+                page_idx,
+                &self.counter_states[page_idx],
+            );
+            if !content_html.is_empty() {
+                let html = if rule.declarations.is_empty() {
+                    content_html
+                } else {
+                    format!(
+                        "<div style=\"{}\">{}</div>",
+                        escape_attr(&rule.declarations),
+                        content_html
+                    )
+                };
+                resolved_htmls.insert(pos, html);
+            }
+        }
+
+        // Stage 1a: measure max-content width for top / bottom boxes.
+        for (&pos, html) in &resolved_htmls {
+            if !pos.edge().is_some_and(|e| e.is_horizontal()) {
+                continue;
+            }
+            let measure_key = (html.clone(), width_key(page_size.height));
+            self.measure_cache.entry(measure_key).or_insert_with(|| {
+                let measure_html = format!(
+                    "<html><head><style>{}</style></head><body style=\"margin:0;padding:0;\"><div style=\"display:inline-block\">{}</div></body></html>",
+                    self.margin_css, html
+                );
+                let measure_doc = crate::blitz_adapter::parse_and_layout(
+                    &measure_html,
+                    crate::convert::pt_to_px(content_width),
+                    crate::convert::pt_to_px(page_size.height),
+                    self.font_data,
+                );
+                get_body_child_dimension(&measure_doc, true)
+            });
+        }
+
+        // Stage 1b: measure max-content height for left / right boxes.
+        for (&pos, html) in &resolved_htmls {
+            let fixed_width = match pos.edge() {
+                Some(Edge::Left) => resolved_margin.left,
+                Some(Edge::Right) => resolved_margin.right,
+                _ => continue,
+            };
+            let hc_key = (html.clone(), width_key(fixed_width));
+            self.height_cache.entry(hc_key).or_insert_with(|| {
+                let measure_html = format!(
+                    "<html><head><style>{}</style></head><body style=\"margin:0;padding:0;\"><div>{}</div></body></html>",
+                    self.margin_css, html
+                );
+                let measure_doc = crate::blitz_adapter::parse_and_layout(
+                    &measure_html,
+                    crate::convert::pt_to_px(fixed_width),
+                    crate::convert::pt_to_px(page_size.height),
+                    self.font_data,
+                );
+                get_body_child_dimension(&measure_doc, false)
+            });
+        }
+
+        // Stage 2: distribute each edge's boxes against the page rect.
+        let mut edge_defined: BTreeMap<Edge, BTreeMap<MarginBoxPosition, f32>> = BTreeMap::new();
+        for (&pos, html) in &resolved_htmls {
+            let edge = match pos.edge() {
+                Some(e) => e,
+                None => continue,
+            };
+            let size = if edge.is_horizontal() {
+                self.measure_cache
+                    .get(&(html.clone(), width_key(page_size.height)))
+                    .copied()
+            } else {
+                let fixed_width = if edge == Edge::Left {
+                    resolved_margin.left
+                } else {
+                    resolved_margin.right
+                };
+                self.height_cache
+                    .get(&(html.clone(), width_key(fixed_width)))
+                    .copied()
+            };
+            if let Some(s) = size {
+                edge_defined.entry(edge).or_default().insert(pos, s);
+            }
+        }
+        let mut all_rects: HashMap<MarginBoxPosition, MarginBoxRect> = HashMap::new();
+        for (edge, defined) in &edge_defined {
+            all_rects.extend(compute_edge_layout(
+                *edge,
+                defined,
+                page_size,
+                resolved_margin,
+            ));
+        }
+
+        // Stage 3: render at the confirmed rect.
+        for (&pos, html) in &resolved_htmls {
+            let rect = all_rects
+                .get(&pos)
+                .copied()
+                .unwrap_or_else(|| pos.bounding_rect(page_size, resolved_margin));
+
+            let cache_key = (html.clone(), width_key(rect.width), width_key(rect.height));
+            if !self.render_cache.contains_key(&cache_key) {
+                let render_html = format!(
+                    "<html><head><style>{}</style></head><body style=\"margin:0;padding:0;\">{}</body></html>",
+                    self.margin_css, html
+                );
+                let render_doc = crate::blitz_adapter::parse_and_layout(
+                    &render_html,
+                    crate::convert::pt_to_px(rect.width),
+                    crate::convert::pt_to_px(rect.height),
+                    self.font_data,
+                );
+                let dummy_store = RunningElementStore::new();
+                let mut dummy_ctx = crate::convert::ConvertContext {
+                    running_store: &dummy_store,
+                    assets: None,
+                    font_cache: HashMap::new(),
+                    string_set_by_node: HashMap::new(),
+                    counter_ops_by_node: HashMap::new(),
+                    bookmark_by_node: HashMap::new(),
+                    column_styles: crate::column_css::ColumnStyleTable::new(),
+                    multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
+                    pagination_geometry: crate::pagination_layout::PaginationGeometryTable::new(),
+                    link_cache: Default::default(),
+                    viewport_size_px: None,
+                };
+                let pageable = crate::convert::dom_to_pageable(&render_doc, &mut dummy_ctx);
+                self.render_cache.insert(cache_key.clone(), pageable);
+            }
+
+            if let Some(pageable) = self.render_cache.get(&cache_key) {
+                pageable.draw(canvas, rect.x, rect.y, rect.width, rect.height);
+            }
+        }
+    }
+}
+
 /// Get a layout dimension of the first non-zero child of `<body>` in a Blitz document.
 /// When `use_width` is true, returns max-content width; otherwise returns height.
 ///
@@ -1402,7 +1725,7 @@ pub fn render_to_pdf_with_gcpm(
     } else {
         init_size
     };
-    let content_width = init_size.width - init_margin.left - init_margin.right;
+    let _content_width = init_size.width - init_margin.left - init_margin.right;
     let _content_height = init_size.height - init_margin.top - init_margin.bottom;
 
     // body-content page split is geometry-driven: the fragmenter
@@ -1415,39 +1738,19 @@ pub fn render_to_pdf_with_gcpm(
     drop(root);
     let total_pages = pages.len();
 
-    // Per-page state collected directly from the fragmenter geometry
-    // (no Pageable tree walk required).
-    let string_set_states = if gcpm.string_set_mappings.is_empty() {
-        vec![BTreeMap::new(); total_pages]
-    } else {
-        let by_node_btree: BTreeMap<usize, Vec<(String, String)>> = string_set_by_node
-            .iter()
-            .map(|(k, v)| (*k, v.clone()))
-            .collect();
-        crate::pagination_layout::collect_string_set_states(pagination_geometry, &by_node_btree)
-    };
-    let running_states = if gcpm.running_mappings.is_empty() {
-        vec![BTreeMap::new(); total_pages]
-    } else {
-        crate::pagination_layout::collect_running_element_states(pagination_geometry, running_store)
-    };
-    let counter_states = if gcpm.counter_mappings.is_empty()
-        && gcpm.content_counter_mappings.is_empty()
-    {
-        vec![BTreeMap::new(); total_pages]
-    } else {
-        crate::pagination_layout::collect_counter_states(pagination_geometry, counter_ops_by_node)
-    };
-
-    // Build margin-box CSS: strip display:none rules that the parser
-    // injected for running elements (they need to be visible in margin boxes).
-    let margin_css = strip_display_none(&gcpm.cleaned_css);
-
-    // Caches: measure (html → max-content width), height ((html, layout_width) → max-content height),
-    // render (html+width → Pageable)
-    let mut measure_cache: MeasureCache = HashMap::new();
-    let mut height_cache: HashMap<(String, u32), f32> = HashMap::new();
-    let mut render_cache: RenderCache = HashMap::new();
+    // Per-page state + caches required for `@page` margin box rendering.
+    // Both v1 and `render_v2` (Phase 4) use the same renderer so that the
+    // margin box pipeline ports byte-eq from the v1 path without
+    // re-implementing it.
+    let mut margin_box_renderer = MarginBoxRenderer::new(
+        gcpm,
+        running_store,
+        font_data,
+        pagination_geometry,
+        string_set_by_node,
+        counter_ops_by_node,
+        total_pages,
+    );
 
     let mut document = krilla::Document::new();
 
@@ -1537,189 +1840,21 @@ pub fn render_to_pdf_with_gcpm(
             link_collector: None,
         };
 
-        // Resolve margin boxes: for each position, pick the most specific
-        // matching rule. Pseudo-class selectors (:first, :left, :right) override
-        // the default @page rule for the same position.
-        let mut effective_boxes: BTreeMap<MarginBoxPosition, &crate::gcpm::MarginBoxRule> =
-            BTreeMap::new();
-        for margin_box in &gcpm.margin_boxes {
-            let matches = match &margin_box.page_selector {
-                None => true,
-                Some(sel) => match sel.as_str() {
-                    ":first" => page_num == 1,
-                    ":left" => page_num % 2 == 0,
-                    ":right" => page_num % 2 != 0,
-                    _ => true,
-                },
-            };
-            if !matches {
-                continue;
-            }
-            // More specific selector (Some) overrides less specific (None)
-            let should_replace = effective_boxes
-                .get(&margin_box.position)
-                .map(|existing| {
-                    existing.page_selector.is_none() && margin_box.page_selector.is_some()
-                })
-                .unwrap_or(true);
-            if should_replace {
-                effective_boxes.insert(margin_box.position, margin_box);
-            }
-        }
-
-        // Collect resolved HTML for each effective box, wrapping in a div
-        // with the margin box's own declarations (font-size, color, margin, etc.)
-        let mut resolved_htmls: BTreeMap<MarginBoxPosition, String> = BTreeMap::new();
-        for (&pos, rule) in &effective_boxes {
-            let content_html = resolve_content_to_html(
-                &rule.content,
-                running_store,
-                &running_states,
-                &string_set_states[page_idx],
-                page_num,
-                total_pages,
-                page_idx,
-                &counter_states[page_idx],
-            );
-            if !content_html.is_empty() {
-                let html = if rule.declarations.is_empty() {
-                    content_html
-                } else {
-                    format!(
-                        "<div style=\"{}\">{}</div>",
-                        escape_attr(&rule.declarations),
-                        content_html
-                    )
-                };
-                resolved_htmls.insert(pos, html);
-            }
-        }
-
-        // Stage 1a: Measure max-content width for top/bottom boxes.
-        // Uses inline-block wrapper so Blitz computes shrink-to-fit width.
-        for (&pos, html) in &resolved_htmls {
-            if !pos.edge().is_some_and(|e| e.is_horizontal()) {
-                continue;
-            }
-            let measure_key = (html.clone(), width_key(page_size.height));
-            measure_cache.entry(measure_key).or_insert_with(|| {
-                let measure_html = format!(
-                    "<html><head><style>{}</style></head><body style=\"margin:0;padding:0;\"><div style=\"display:inline-block\">{}</div></body></html>",
-                    margin_css, html
-                );
-                let measure_doc = crate::blitz_adapter::parse_and_layout(
-                    &measure_html,
-                    crate::convert::pt_to_px(content_width),
-                    crate::convert::pt_to_px(page_size.height),
-                    font_data,
-                );
-                get_body_child_dimension(&measure_doc, true)
-            });
-        }
-
-        // Stage 1b: Measure max-content height for left/right boxes.
-        // Layout at fixed margin width, then read the resulting height.
-        for (&pos, html) in &resolved_htmls {
-            let fixed_width = match pos.edge() {
-                Some(Edge::Left) => resolved_margin.left,
-                Some(Edge::Right) => resolved_margin.right,
-                _ => continue,
-            };
-            let hc_key = (html.clone(), width_key(fixed_width));
-            height_cache.entry(hc_key).or_insert_with(|| {
-                let measure_html = format!(
-                    "<html><head><style>{}</style></head><body style=\"margin:0;padding:0;\"><div>{}</div></body></html>",
-                    margin_css, html
-                );
-                let measure_doc = crate::blitz_adapter::parse_and_layout(
-                    &measure_html,
-                    crate::convert::pt_to_px(fixed_width),
-                    crate::convert::pt_to_px(page_size.height),
-                    font_data,
-                );
-                get_body_child_dimension(&measure_doc, false)
-            });
-        }
-
-        // Stage 2: Group by edge and compute layout
-        let mut edge_defined: BTreeMap<Edge, BTreeMap<MarginBoxPosition, f32>> = BTreeMap::new();
-
-        for (&pos, html) in &resolved_htmls {
-            let edge = match pos.edge() {
-                Some(e) => e,
-                None => continue, // corners
-            };
-            let size = if edge.is_horizontal() {
-                measure_cache
-                    .get(&(html.clone(), width_key(page_size.height)))
-                    .copied()
-            } else {
-                let fixed_width = if edge == Edge::Left {
-                    resolved_margin.left
-                } else {
-                    resolved_margin.right
-                };
-                height_cache
-                    .get(&(html.clone(), width_key(fixed_width)))
-                    .copied()
-            };
-            if let Some(s) = size {
-                edge_defined.entry(edge).or_default().insert(pos, s);
-            }
-        }
-
-        let mut all_rects: HashMap<MarginBoxPosition, MarginBoxRect> = HashMap::new();
-        for (edge, defined) in &edge_defined {
-            all_rects.extend(compute_edge_layout(
-                *edge,
-                defined,
-                page_size,
-                resolved_margin,
-            ));
-        }
-
-        // Stage 3: Render at confirmed width and draw.
-        // Pageable is created (or fetched from cache) at the final rect width.
-        for (&pos, html) in &resolved_htmls {
-            let rect = all_rects
-                .get(&pos)
-                .copied()
-                .unwrap_or_else(|| pos.bounding_rect(page_size, resolved_margin));
-
-            let cache_key = (html.clone(), width_key(rect.width), width_key(rect.height));
-            if !render_cache.contains_key(&cache_key) {
-                let render_html = format!(
-                    "<html><head><style>{}</style></head><body style=\"margin:0;padding:0;\">{}</body></html>",
-                    margin_css, html
-                );
-                let render_doc = crate::blitz_adapter::parse_and_layout(
-                    &render_html,
-                    crate::convert::pt_to_px(rect.width),
-                    crate::convert::pt_to_px(rect.height),
-                    font_data,
-                );
-                let dummy_store = RunningElementStore::new();
-                let mut dummy_ctx = crate::convert::ConvertContext {
-                    running_store: &dummy_store,
-                    assets: None,
-                    font_cache: HashMap::new(),
-                    string_set_by_node: HashMap::new(),
-                    counter_ops_by_node: HashMap::new(),
-                    bookmark_by_node: HashMap::new(),
-                    column_styles: crate::column_css::ColumnStyleTable::new(),
-                    multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
-                    pagination_geometry: crate::pagination_layout::PaginationGeometryTable::new(),
-                    link_cache: Default::default(),
-                    viewport_size_px: None,
-                };
-                let pageable = crate::convert::dom_to_pageable(&render_doc, &mut dummy_ctx);
-                render_cache.insert(cache_key.clone(), pageable);
-            }
-
-            if let Some(pageable) = render_cache.get(&cache_key) {
-                pageable.draw(&mut canvas, rect.x, rect.y, rect.width, rect.height);
-            }
-        }
+        // Margin boxes (`@top-center`, `@bottom-center`, etc.) — see
+        // `MarginBoxRenderer::render_page` for the multi-stage measure /
+        // layout / render pipeline. v1 uses the same renderer the v2
+        // path uses so both share the same per-page state caches and
+        // produce byte-equivalent margin-box output.
+        let page_content_width = page_size.width - resolved_margin.left - resolved_margin.right;
+        margin_box_renderer.render_page(
+            &mut canvas,
+            page_idx,
+            page_num,
+            total_pages,
+            page_size,
+            resolved_margin,
+            page_content_width,
+        );
 
         // Draw body content with resolved per-page margin. Reuse `canvas`
         // by overwriting it so the previous (collector-less) Canvas's

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -118,16 +118,19 @@ pub fn render_v2(
                 bookmark_collector: bookmark_collector.as_mut(),
                 link_collector: Some(&mut link_collector),
             };
-            // Root `<html>` background pre-pass. v1's
-            // `BlockPageable::draw` for the html element paints its
-            // own bg/border/shadow BEFORE recursing into body — but
-            // v2's `geometry` table only carries body + descendants,
-            // so the dispatcher would otherwise skip html entirely.
-            // Paint at `(margin.left, margin.top)` with html's own
-            // `layout_size` (mirrors v1's
-            // `total_width = self.layout_size.or(cached_size)...`).
-            // Done on every page so multi-page docs with `html { background: ... }`
-            // pick up the fill on each page.
+            // Root `<html>` + `<body>` background pre-pass. v1's
+            // `BlockPageable::draw` for these elements paints
+            // bg/border/shadow on EVERY page because each page's
+            // sliced root pageable still calls them. v2's main
+            // dispatch sees them via the fragmenter's single fragment
+            // on page 0 only — multi-page docs would lose those fills
+            // on continuation pages. Paint each here at its own offset
+            // (`(margin.left, margin.top)` for html, plus
+            // `body_offset_pt` for body) using `layout_size` from the
+            // entry — mirrors v1's
+            // `total_width = self.layout_size.or(cached_size)...`
+            // derivation. The main dispatch loop skips both `root_id`
+            // and `body_id` to avoid double-painting on page 0.
             if let Some(root_id) = drawables.root_id
                 && let Some(root_block) = drawables.block_styles.get(&root_id)
             {
@@ -136,6 +139,23 @@ pub fn render_v2(
                     root_block,
                     resolved_margin.left,
                     resolved_margin.top,
+                );
+            }
+            // body's bg pre-pass runs on continuation pages only.
+            // Page 0 already paints body via the main dispatch loop
+            // (the fragmenter records body's fragment on page 0, with
+            // `layout_size` covering body's full height — clipped to
+            // page area at PDF render time, mirroring v1 exactly).
+            // Without this guard, page 0 would double-paint body's bg.
+            if page_idx > 0
+                && let Some(body_id) = drawables.body_id
+                && let Some(body_block) = drawables.block_styles.get(&body_id)
+            {
+                paint_root_block_v2(
+                    &mut canvas,
+                    body_block,
+                    resolved_margin.left + drawables.body_offset_pt.0,
+                    resolved_margin.top + drawables.body_offset_pt.1,
                 );
             }
             // `frag.x` is html-relative (fragmenter folds body's x
@@ -227,6 +247,16 @@ fn draw_v2_page(
             // Drawn inside an ancestor transform group elsewhere in
             // this loop. Skipping prevents double-painting. Bookmark
             // anchor recording above already ran unconditionally.
+            continue;
+        }
+        // Skip the html root: its bg / border / shadow are painted
+        // per-page in the pre-pass (`paint_root_block_v2`) above.
+        // Body intentionally is NOT skipped here — page 0 needs the
+        // main dispatch to paint body normally (so inline-root
+        // children at body's node_id keep flowing through
+        // `draw_block_with_inner_content`); page 1+ relies on the
+        // body branch of the pre-pass.
+        if Some(node_id) == drawables.root_id {
             continue;
         }
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -522,6 +522,13 @@ fn dispatch_fragment(
         draw_table_v2(canvas, table, x_pt, y_pt, frag);
         return;
     }
+    // True when this block / list-item / paragraph spans multiple
+    // pages (the fragmenter recorded one fragment per page slice).
+    // Passed down so `draw_block_inner_paint` can use the per-page
+    // slice height (`frag.height`) instead of `layout_size.height`
+    // — without it, every slice paints the FULL block, which
+    // doubled the callout in `examples/break-inside` (fulgur-bq6i).
+    let is_split = geom.fragments.len() > 1;
     // ListItem case: marker + body block + inline-root paragraph
     // share a single opacity group. See `draw_list_item_with_block`
     // for the v1 mirror.
@@ -538,6 +545,7 @@ fn dispatch_fragment(
             frag,
             &geom.fragments,
             page_index,
+            is_split,
         );
         return;
     }
@@ -560,10 +568,11 @@ fn dispatch_fragment(
                 frag,
                 &geom.fragments,
                 page_index,
+                is_split,
             );
             return;
         }
-        draw_block_v2(canvas, block, x_pt, y_pt, frag);
+        draw_block_v2(canvas, block, x_pt, y_pt, frag, is_split);
     }
     if let Some(img) = drawables.images.get(&node_id) {
         draw_image_v2(canvas, img, x_pt, y_pt);
@@ -1574,11 +1583,12 @@ fn draw_block_v2(
     x: f32,
     y: f32,
     frag: &crate::pagination_layout::Fragment,
+    is_split: bool,
 ) {
     use crate::pageable::draw_with_opacity;
 
     draw_with_opacity(canvas, entry.opacity, |canvas| {
-        draw_block_inner_paint(canvas, entry, x, y, frag);
+        draw_block_inner_paint(canvas, entry, x, y, frag, is_split);
     });
 }
 
@@ -1645,14 +1655,39 @@ fn draw_block_inner_paint(
     x: f32,
     y: f32,
     frag: &crate::pagination_layout::Fragment,
+    is_split: bool,
 ) {
     let total_width = entry
         .layout_size
         .map(|s| s.width)
         .unwrap_or_else(|| crate::convert::px_to_pt(frag.width));
+    // For split blocks (one fragment per page), `frag.height` reports
+    // the per-page slice height. `entry.layout_size.height` always
+    // carries Taffy's full block height, so painting bg / border with
+    // `layout_size` would draw the FULL block on every slice — visible
+    // as a callout-box overflowing page bottom on page 1 AND repeating
+    // full-size on page 2 (fulgur-bq6i: `examples/break-inside`).
+    //
+    // Mirror v1: `BlockPageable::slice_for_page` returns a sliced
+    // pageable whose `layout_size.height` already equals the slice
+    // height, so v1's draw uses the slice-correct height naturally.
+    // v2 has a single `BlockEntry` per node_id holding the full
+    // layout, so we recover the slice-correct height from
+    // `frag.height` only when the dispatcher tells us this is a
+    // split fragment (`is_split = geom.fragments.len() > 1`). Using
+    // a multi-fragment signal — not a `frag_h < layout_h` comparison
+    // — avoids spurious flips for single-page blocks where the two
+    // values may differ by 1 ULP after CSS-px → pt conversion
+    // rounding.
     let total_height = entry
         .layout_size
-        .map(|s| s.height)
+        .map(|s| {
+            if is_split && frag.height > 0.0 {
+                crate::convert::px_to_pt(frag.height)
+            } else {
+                s.height
+            }
+        })
         .unwrap_or_else(|| crate::convert::px_to_pt(frag.height));
 
     if entry.visible {
@@ -1743,6 +1778,7 @@ fn draw_block_with_inner_content(
     frag: &crate::pagination_layout::Fragment,
     fragments: &[crate::pagination_layout::Fragment],
     page_index: u32,
+    is_split: bool,
 ) {
     use crate::pageable::draw_with_opacity;
 
@@ -1762,7 +1798,7 @@ fn draw_block_with_inner_content(
     let inner_y = y + iy;
 
     draw_with_opacity(canvas, block.opacity, |canvas| {
-        draw_block_inner_paint(canvas, block, x, y, frag);
+        draw_block_inner_paint(canvas, block, x, y, frag, is_split);
         if let Some(p) = paragraph {
             draw_paragraph_inner_paint(canvas, p, inner_x, inner_y, fragments, page_index);
         }
@@ -1799,6 +1835,7 @@ fn draw_list_item_with_block(
     frag: &crate::pagination_layout::Fragment,
     fragments: &[crate::pagination_layout::Fragment],
     page_index: u32,
+    is_split: bool,
 ) {
     use crate::pageable::draw_with_opacity;
 
@@ -1815,7 +1852,7 @@ fn draw_list_item_with_block(
             draw_list_item_marker(canvas, list_item, x, y);
         }
         if let Some(b) = block {
-            draw_block_inner_paint(canvas, b, x, y, frag);
+            draw_block_inner_paint(canvas, b, x, y, frag, is_split);
         }
         if let Some(p) = paragraph {
             draw_paragraph_inner_paint(canvas, p, inner_x, inner_y, fragments, page_index);

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -661,7 +661,30 @@ fn draw_under_clip(
     let svg_for_block = drawables.svgs.get(&node_id);
     let inner_inset = block.style.content_inset();
 
-    draw_with_opacity(canvas, block.opacity, |canvas| {
+    // When this node is a list-item with overflow clip, mirror v1's
+    // `ListItemPageable::draw` ordering: outer opacity uses
+    // `list_item.opacity` (the body BlockPageable inside is built with
+    // default opacity=1.0 in `convert::list_item::build_list_item_body`,
+    // so `block.opacity` here would silently drop CSS opacity), and
+    // the marker draws before `push_clip_path` (markers sit at negative
+    // x outside the body box, so they must not be clipped). Without
+    // this, `<li style="overflow:hidden">` loses its marker entirely
+    // and any opacity set on the `<li>` is ignored. (PR #310 Devin)
+    let list_item = drawables.list_items.get(&node_id);
+    let opacity = list_item.map_or(block.opacity, |li| li.opacity);
+
+    draw_with_opacity(canvas, opacity, |canvas| {
+        // List-item marker paints first, OUTSIDE the clip — v1's
+        // `ListItemPageable::draw` emits the marker before delegating
+        // to `body.draw` (which paints bg / border / shadow). Markers
+        // sit at negative x relative to (x_pt, y_pt), so they must
+        // also stay outside the clip path pushed below.
+        if let Some(li) = list_item
+            && li.visible
+        {
+            draw_list_item_marker(canvas, li, x_pt, y_pt);
+        }
+
         // bg / border / shadow outside the clip — same as
         // `draw_block_inner_paint` but inlined so the opacity wrap
         // covers the entire clipped region too.

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -118,6 +118,26 @@ pub fn render_v2(
                 bookmark_collector: bookmark_collector.as_mut(),
                 link_collector: Some(&mut link_collector),
             };
+            // Root `<html>` background pre-pass. v1's
+            // `BlockPageable::draw` for the html element paints its
+            // own bg/border/shadow BEFORE recursing into body — but
+            // v2's `geometry` table only carries body + descendants,
+            // so the dispatcher would otherwise skip html entirely.
+            // Paint at `(margin.left, margin.top)` with html's own
+            // `layout_size` (mirrors v1's
+            // `total_width = self.layout_size.or(cached_size)...`).
+            // Done on every page so multi-page docs with `html { background: ... }`
+            // pick up the fill on each page.
+            if let Some(root_id) = drawables.root_id
+                && let Some(root_block) = drawables.block_styles.get(&root_id)
+            {
+                paint_root_block_v2(
+                    &mut canvas,
+                    root_block,
+                    resolved_margin.left,
+                    resolved_margin.top,
+                );
+            }
             // `frag.x` is html-relative (fragmenter folds body's x
             // offset in); `frag.y` is body-content-area-relative — so
             // only y receives `body_offset_pt`.
@@ -649,6 +669,59 @@ fn draw_block_v2(
 
     draw_with_opacity(canvas, entry.opacity, |canvas| {
         draw_block_inner_paint(canvas, entry, x, y, frag);
+    });
+}
+
+/// v2 root-element (`<html>`) background pre-pass. The fragmenter's
+/// `geometry` table only carries body + descendants, so the standard
+/// per-(node_id, fragment) dispatch never visits html. Mirror v1's
+/// `BlockPageable::draw` for the html root by painting bg / border /
+/// shadow at `(margin.left, margin.top)` with html's own
+/// `layout_size` (which equals body's outer height including
+/// collapsed margins, matching v1's `total_height` derivation).
+///
+/// Called once per page from `render_v2`; intentionally bypasses the
+/// `body_offset_pt.y` adjustment that the main dispatch loop applies,
+/// because html's bg paints at the page's margin top, not at body's
+/// content origin.
+fn paint_root_block_v2(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    entry: &crate::drawables::BlockEntry,
+    margin_left_pt: f32,
+    margin_top_pt: f32,
+) {
+    use crate::pageable::draw_with_opacity;
+    let Some(size) = entry.layout_size else {
+        return;
+    };
+
+    draw_with_opacity(canvas, entry.opacity, |canvas| {
+        if entry.visible {
+            crate::background::draw_box_shadows(
+                canvas,
+                &entry.style,
+                margin_left_pt,
+                margin_top_pt,
+                size.width,
+                size.height,
+            );
+            crate::background::draw_background(
+                canvas,
+                &entry.style,
+                margin_left_pt,
+                margin_top_pt,
+                size.width,
+                size.height,
+            );
+            crate::pageable::draw_block_border(
+                canvas,
+                &entry.style,
+                margin_left_pt,
+                margin_top_pt,
+                size.width,
+                size.height,
+            );
+        }
     });
 }
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -263,6 +263,18 @@ fn draw_v2_page(
     for tx in drawables.transforms.values() {
         transformed_descendants.extend(tx.descendants.iter().copied());
     }
+    // Same shape as `transformed_descendants` but keyed by an ancestor
+    // block whose `style.has_overflow_clip()` is true. Strict
+    // descendants paint inside the clip's `push_clip_path / pop` group;
+    // skipping them here prevents the main loop from also dispatching
+    // them outside the clip.
+    let mut clipped_descendants: std::collections::BTreeSet<usize> =
+        std::collections::BTreeSet::new();
+    for block in drawables.block_styles.values() {
+        if block.style.has_overflow_clip() {
+            clipped_descendants.extend(block.clip_descendants.iter().copied());
+        }
+    }
 
     for (&node_id, geom) in geometry {
         // Bookmark anchor: emit on the page where the node's *first*
@@ -291,6 +303,11 @@ fn draw_v2_page(
             // Drawn inside an ancestor transform group elsewhere in
             // this loop. Skipping prevents double-painting. Bookmark
             // anchor recording above already ran unconditionally.
+            continue;
+        }
+        if clipped_descendants.contains(&node_id) {
+            // Drawn inside an ancestor `overflow: hidden|clip` block's
+            // `push_clip_path / pop` group elsewhere in this loop.
             continue;
         }
         // Skip the html root: its bg / border / shadow are painted
@@ -327,11 +344,38 @@ fn draw_v2_page(
                     margin_top_pt,
                     page_index,
                 );
-            } else {
-                dispatch_fragment(
-                    canvas, node_id, geom, frag, x_pt, y_pt, drawables, page_index,
-                );
+                continue;
             }
+            // `overflow: hidden | clip` block: bg / border / shadow
+            // paint OUTSIDE the clip (matching v1's
+            // `BlockPageable::draw` ordering at
+            // `pageable.rs:1796-1827`), then push the clip path,
+            // dispatch self's inner content + every strict descendant
+            // INSIDE the clip, then pop. Same shape as
+            // `draw_under_transform` but with `push_clip_path`.
+            if let Some(block) = drawables.block_styles.get(&node_id)
+                && block.style.has_overflow_clip()
+                && !block.clip_descendants.is_empty()
+            {
+                draw_under_clip(
+                    canvas,
+                    block,
+                    node_id,
+                    geom,
+                    frag,
+                    x_pt,
+                    y_pt,
+                    geometry,
+                    drawables,
+                    margin_left_pt,
+                    margin_top_pt,
+                    page_index,
+                );
+                continue;
+            }
+            dispatch_fragment(
+                canvas, node_id, geom, frag, x_pt, y_pt, drawables, page_index,
+            );
         }
     }
 
@@ -548,6 +592,150 @@ fn draw_under_transform(
     if let Some(lc) = canvas.link_collector.as_deref_mut() {
         lc.pop_transform();
     }
+}
+
+/// Push the block's overflow-clip path onto the surface, dispatch the
+/// wrapper's own bg / border / shadow + every descendant fragment that
+/// lands on `page_index`, then pop. Mirrors v1's `BlockPageable::draw`
+/// (`pageable.rs:1796-1827`):
+///
+/// ```text
+/// // bg/border/shadow paint OUTSIDE the clip
+/// draw_with_opacity(canvas, opacity, |c| {
+///     bg + border + shadow at (x, y, total_w, total_h);
+///     if let Some(clip) = compute_overflow_clip_path(...) {
+///         c.surface.push_clip_path(&clip, FillRule::default());
+///         for child in children { child.draw(c, x + child.x, y + child.y, ..); }
+///         c.surface.pop();
+///     }
+/// });
+/// ```
+///
+/// In v2 the wrapper's own inner content (paragraph / image / svg
+/// sharing the same `node_id`) is dispatched as part of the clipped
+/// region, then strict descendants iterate inside the clip. The block
+/// dispatcher's "shared node_id" combined helper
+/// (`draw_block_with_inner_content`) already handles the outer
+/// opacity wrap when used; here we replicate that ordering manually
+/// — bg/border outside clip, inner content + descendants inside clip,
+/// all wrapped in one opacity group.
+#[allow(clippy::too_many_arguments)]
+fn draw_under_clip(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    block: &crate::drawables::BlockEntry,
+    node_id: usize,
+    geom: &crate::pagination_layout::PaginationGeometry,
+    frag: &crate::pagination_layout::Fragment,
+    x_pt: f32,
+    y_pt: f32,
+    geometry: &crate::pagination_layout::PaginationGeometryTable,
+    drawables: &Drawables,
+    margin_left_pt: f32,
+    margin_top_pt: f32,
+    page_index: u32,
+) {
+    use crate::convert::px_to_pt;
+    use crate::pageable::draw_with_opacity;
+
+    let total_width = block
+        .layout_size
+        .map(|s| s.width)
+        .unwrap_or_else(|| px_to_pt(frag.width));
+    let total_height = block
+        .layout_size
+        .map(|s| s.height)
+        .unwrap_or_else(|| px_to_pt(frag.height));
+
+    let para_for_block = drawables.paragraphs.get(&node_id);
+    let img_for_block = drawables.images.get(&node_id);
+    let svg_for_block = drawables.svgs.get(&node_id);
+    let inner_inset = block.style.content_inset();
+
+    draw_with_opacity(canvas, block.opacity, |canvas| {
+        // bg / border / shadow outside the clip — same as
+        // `draw_block_inner_paint` but inlined so the opacity wrap
+        // covers the entire clipped region too.
+        if block.visible {
+            crate::background::draw_box_shadows(
+                canvas,
+                &block.style,
+                x_pt,
+                y_pt,
+                total_width,
+                total_height,
+            );
+            crate::background::draw_background(
+                canvas,
+                &block.style,
+                x_pt,
+                y_pt,
+                total_width,
+                total_height,
+            );
+            crate::pageable::draw_block_border(
+                canvas,
+                &block.style,
+                x_pt,
+                y_pt,
+                total_width,
+                total_height,
+            );
+        }
+
+        // Push clip — fall through to inner content + descendants if
+        // `compute_overflow_clip_path` returns `None` (style somehow
+        // changed since extract decided this block clips).
+        let clip_pushed = if let Some(clip_path) = crate::pageable::compute_overflow_clip_path(
+            &block.style,
+            x_pt,
+            y_pt,
+            total_width,
+            total_height,
+        ) {
+            canvas
+                .surface
+                .push_clip_path(&clip_path, &krilla::paint::FillRule::default());
+            true
+        } else {
+            false
+        };
+
+        // Inner content sharing `node_id` (inline-root paragraph,
+        // replaced image / svg) paints at the content-box top-left,
+        // not the border-box. Mirrors `draw_block_with_inner_content`.
+        let inner_x = x_pt + inner_inset.0;
+        let inner_y = y_pt + inner_inset.1;
+        if let Some(p) = para_for_block {
+            draw_paragraph_inner_paint(canvas, p, inner_x, inner_y, &geom.fragments, page_index);
+        }
+        if let Some(i) = img_for_block {
+            draw_image_inner_paint(canvas, i, inner_x, inner_y);
+        }
+        if let Some(s) = svg_for_block {
+            draw_svg_inner_paint(canvas, s, inner_x, inner_y);
+        }
+
+        // Strict descendants — each at its own fragment's coords.
+        for &desc_id in &block.clip_descendants {
+            let Some(desc_geom) = geometry.get(&desc_id) else {
+                continue;
+            };
+            for desc_frag in &desc_geom.fragments {
+                if desc_frag.page_index != page_index {
+                    continue;
+                }
+                let desc_x = margin_left_pt + px_to_pt(desc_frag.x);
+                let desc_y = margin_top_pt + px_to_pt(desc_frag.y);
+                dispatch_fragment(
+                    canvas, desc_id, desc_geom, desc_frag, desc_x, desc_y, drawables, page_index,
+                );
+            }
+        }
+
+        if clip_pushed {
+            canvas.surface.pop();
+        }
+    });
 }
 
 /// Paint multicol column-rule lines on `page_index` for one

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -47,6 +47,7 @@ pub fn render_v2(
         };
         if let Some(para) = drawables.paragraphs.get(&node_id)
             && let Some(id) = &para.id
+            && !id.is_empty()
         {
             let page_idx = first_frag.page_index as usize;
             dest_registry.set_current_page(page_idx);
@@ -178,7 +179,7 @@ fn draw_v2_page(
                 continue;
             }
             if let Some(para) = drawables.paragraphs.get(&node_id) {
-                draw_paragraph_v2(canvas, para, x_pt, y_pt);
+                draw_paragraph_v2(canvas, para, x_pt, y_pt, &geom.fragments, page_index);
                 continue;
             }
             // Other types (block_styles / tables / ...) land in
@@ -265,14 +266,92 @@ fn draw_paragraph_v2(
     entry: &crate::drawables::ParagraphEntry,
     x: f32,
     y: f32,
+    fragments: &[crate::pagination_layout::Fragment],
+    page_index: u32,
 ) {
     use crate::pageable::draw_with_opacity;
     if !entry.visible {
         return;
     }
+    let Some(slice) = paragraph_lines_for_page(&entry.lines, fragments, page_index) else {
+        return;
+    };
     draw_with_opacity(canvas, entry.opacity, |canvas| {
-        crate::paragraph::draw_shaped_lines(canvas, &entry.lines, x, y);
+        crate::paragraph::draw_shaped_lines(canvas, &slice, x, y);
     });
+}
+
+/// Phase 4 PR 3 follow-up (PR #302 Devin): mirror
+/// `ParagraphPageable::slice_for_page` so multi-page paragraphs only
+/// emit the lines belonging to the requested page.
+///
+/// Single-fragment fast path: clone every line. Multi-fragment case:
+/// recover line range from cumulative fragment heights (CSS px → pt
+/// before comparing) and rebase line baselines / inline-image
+/// `computed_y` by the consumed amount so the slice is fragment-local.
+fn paragraph_lines_for_page(
+    all_lines: &[crate::paragraph::ShapedLine],
+    fragments: &[crate::pagination_layout::Fragment],
+    page_index: u32,
+) -> Option<Vec<crate::paragraph::ShapedLine>> {
+    let target_pos = fragments.iter().position(|f| f.page_index == page_index)?;
+
+    if fragments.len() == 1 && target_pos == 0 {
+        return Some(all_lines.to_vec());
+    }
+
+    let target_h = crate::convert::px_to_pt(fragments[target_pos].height);
+    let consumed: f32 = crate::convert::px_to_pt(
+        fragments[..target_pos]
+            .iter()
+            .map(|f| f.height)
+            .sum::<f32>(),
+    );
+
+    let eps = 0.01_f32;
+    let mut line_top: f32 = 0.0;
+    let mut start_idx = 0usize;
+    while start_idx < all_lines.len() {
+        let next_top = line_top + all_lines[start_idx].height;
+        if next_top > consumed + eps {
+            break;
+        }
+        line_top = next_top;
+        start_idx += 1;
+    }
+
+    let mut end_idx = start_idx;
+    let mut accum = 0.0_f32;
+    while end_idx < all_lines.len() {
+        let line_h = all_lines[end_idx].height;
+        if accum + line_h > target_h + eps {
+            break;
+        }
+        accum += line_h;
+        end_idx += 1;
+    }
+
+    if end_idx <= start_idx {
+        return None;
+    }
+
+    let sliced: Vec<crate::paragraph::ShapedLine> = all_lines[start_idx..end_idx]
+        .iter()
+        .cloned()
+        .map(|mut line| {
+            // Rebase paragraph-absolute coords (baseline + inline
+            // image `computed_y`) to fragment-local. Mirror
+            // `ParagraphPageable::slice_for_page` exactly.
+            line.baseline -= consumed;
+            for item in &mut line.items {
+                if let crate::paragraph::LineItem::Image(img) = item {
+                    img.computed_y -= consumed;
+                }
+            }
+            line
+        })
+        .collect();
+    Some(sliced)
 }
 
 /// Render a Pageable tree to PDF bytes using fragmenter geometry to

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -37,9 +37,8 @@ pub fn render_v2(
     let page_count = crate::pagination_layout::implied_page_count(geometry).max(1) as usize;
 
     // Pre-pass: register `id` anchors for `href="#..."` resolution.
-    // PR 3 covers paragraph anchors (the only id-bearing type in
-    // Drawables this PR). PR 4+ will add block / list-item anchors
-    // when their entry types arrive.
+    // PR 3 records paragraph ids; PR 4 adds block ids. List-item ids
+    // arrive in PR 5.
     let mut dest_registry = crate::pageable::DestinationRegistry::new();
     for (&node_id, geom) in geometry {
         let Some(first_frag) = geom.fragments.first() else {
@@ -170,6 +169,14 @@ fn draw_v2_page(
             let x_pt = margin_left_pt + px_to_pt(frag.x);
             let y_pt = margin_top_pt + px_to_pt(frag.y);
 
+            // Block backgrounds/borders draw FIRST so subsequent inner
+            // content (paragraph / image / svg sharing the same node_id —
+            // see `convert::replaced` and `convert::inline_root`)
+            // overlays on top. No `continue;`: the dispatch falls through
+            // to the inner-content checks below.
+            if let Some(block) = drawables.block_styles.get(&node_id) {
+                draw_block_v2(canvas, block, x_pt, y_pt, frag);
+            }
             if let Some(img) = drawables.images.get(&node_id) {
                 draw_image_v2(canvas, img, x_pt, y_pt);
                 continue;
@@ -182,7 +189,7 @@ fn draw_v2_page(
                 draw_paragraph_v2(canvas, para, x_pt, y_pt, &geom.fragments, page_index);
                 continue;
             }
-            // Other types (block_styles / tables / ...) land in
+            // Other types (tables / list_items / ...) land in
             // subsequent PRs.
         }
     }
@@ -252,6 +259,65 @@ fn draw_svg_v2(
             .surface
             .draw_svg(&entry.tree, size, SvgSettings::default());
         canvas.surface.pop();
+    });
+}
+
+/// v2 block draw. Mirrors `BlockPageable::draw`'s background / border /
+/// box-shadow emission. Children paint themselves via their own
+/// per-NodeId dispatch in `draw_v2_page`, so this fn does **not**
+/// recurse into block children.
+///
+/// Overflow clip (`overflow: hidden`) is intentionally not pushed
+/// here — the v1 recursive draw scope owns push/pop while the v2 flat
+/// dispatch does not have a natural "end of children" point. Phase 4
+/// PR 5+ will add a per-block clip scope by tracking child-exit
+/// fragments. Documents that rely on `overflow: hidden` won't
+/// byte-eq until then; the inline test cases avoid that property.
+fn draw_block_v2(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    entry: &crate::drawables::BlockEntry,
+    x: f32,
+    y: f32,
+    frag: &crate::pagination_layout::Fragment,
+) {
+    use crate::pageable::draw_with_opacity;
+
+    draw_with_opacity(canvas, entry.opacity, |canvas| {
+        let total_width = entry
+            .layout_size
+            .map(|s| s.width)
+            .unwrap_or_else(|| crate::convert::px_to_pt(frag.width));
+        let total_height = entry
+            .layout_size
+            .map(|s| s.height)
+            .unwrap_or_else(|| crate::convert::px_to_pt(frag.height));
+
+        if entry.visible {
+            crate::background::draw_box_shadows(
+                canvas,
+                &entry.style,
+                x,
+                y,
+                total_width,
+                total_height,
+            );
+            crate::background::draw_background(
+                canvas,
+                &entry.style,
+                x,
+                y,
+                total_width,
+                total_height,
+            );
+            crate::pageable::draw_block_border(
+                canvas,
+                &entry.style,
+                x,
+                y,
+                total_width,
+                total_height,
+            );
+        }
     });
 }
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -895,9 +895,26 @@ fn draw_under_clip(
         .layout_size
         .map(|s| s.width)
         .unwrap_or_else(|| px_to_pt(frag.width));
+    // Mirror `draw_block_inner_paint` / `draw_under_opacity`'s
+    // `is_split` height fix. When this `overflow: hidden | clip`
+    // block spans multiple pages (one fragment per page slice), use
+    // `frag.height` so each slice paints its per-page bg / border /
+    // shadow at the slice height — and pushes a clip rectangle of
+    // the slice height too. Without this the bg / border overflows
+    // the page bottom on earlier slices, double-paints on
+    // continuation pages, AND the clip rect on continuation pages
+    // covers content that should be cut off.
+    // (PR #313 follow-up Devin Review — completes the PR #316 fix.)
+    let is_split = geom.fragments.len() > 1;
     let total_height = block
         .layout_size
-        .map(|s| s.height)
+        .map(|s| {
+            if is_split && frag.height > 0.0 {
+                px_to_pt(frag.height)
+            } else {
+                s.height
+            }
+        })
         .unwrap_or_else(|| px_to_pt(frag.height));
 
     let para_for_block = drawables.paragraphs.get(&node_id);

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -55,7 +55,11 @@ pub fn render_v2(
             .block_styles
             .get(&node_id)
             .and_then(|b| b.id.as_ref());
-        let id = para_id.or(block_id);
+        let table_id = drawables
+            .tables
+            .get(&node_id)
+            .and_then(|t| t.id.as_ref());
+        let id = para_id.or(block_id).or(table_id);
         if let Some(id) = id
             && !id.is_empty()
         {
@@ -72,8 +76,14 @@ pub fn render_v2(
                     page_count,
                     config,
                 );
+            // `frag.x` is html-relative (already includes body's x
+            // offset from the fragmenter); only y needs `body_offset_pt`
+            // applied because fragments are body-content-area-relative
+            // along the y axis.
             let x_pt = resolved_margin.left + crate::convert::px_to_pt(first_frag.x);
-            let y_pt = resolved_margin.top + crate::convert::px_to_pt(first_frag.y);
+            let y_pt = resolved_margin.top
+                + drawables.body_offset_pt.1
+                + crate::convert::px_to_pt(first_frag.y);
             dest_registry.record(id.as_str(), x_pt, y_pt);
         }
     }
@@ -111,11 +121,14 @@ pub fn render_v2(
                 bookmark_collector: bookmark_collector.as_mut(),
                 link_collector: Some(&mut link_collector),
             };
+            // `frag.x` is html-relative (fragmenter folds body's x
+            // offset in); `frag.y` is body-content-area-relative — so
+            // only y receives `body_offset_pt`.
             draw_v2_page(
                 &mut canvas,
                 page_idx as u32,
                 resolved_margin.left,
-                resolved_margin.top,
+                resolved_margin.top + drawables.body_offset_pt.1,
                 geometry,
                 drawables,
             );
@@ -180,6 +193,20 @@ fn draw_v2_page(
             let x_pt = margin_left_pt + px_to_pt(frag.x);
             let y_pt = margin_top_pt + px_to_pt(frag.y);
 
+            if let Some(table) = drawables.tables.get(&node_id) {
+                draw_table_v2(canvas, table, x_pt, y_pt, frag);
+                continue;
+            }
+            // ListItem marker draws before block frame. v1's
+            // `ListItemPageable::draw` calls `self.body.draw(...)` so
+            // the body block's background / border paint underneath the
+            // marker (`pageable.rs:3362`). `<li>` and its body
+            // BlockPageable share the same node_id (`convert/list_item.rs:81`),
+            // so `block_styles[node_id]` carries the body block style;
+            // dropping `continue;` lets the dispatch fall through to it.
+            if let Some(li) = drawables.list_items.get(&node_id) {
+                draw_list_item_v2(canvas, li, x_pt, y_pt);
+            }
             // Block backgrounds/borders draw FIRST so subsequent inner
             // content (paragraph / image / svg sharing the same node_id —
             // see `convert::replaced` and `convert::inline_root`)
@@ -329,6 +356,102 @@ fn draw_block_v2(
                 total_height,
             );
         }
+    });
+}
+
+/// v2 table draw. Mirrors `TablePageable::draw`'s outer-frame
+/// background / border / shadow emission. Cell paint (each `<th>` /
+/// `<td>` is a `BlockPageable` with its own NodeId in geometry) lands
+/// through the standard per-NodeId dispatch.
+///
+/// Same overflow-clip caveat as `draw_block_v2`: clip is not pushed
+/// here because flat dispatch lacks a natural close point. Multi-page
+/// table header repetition is also deferred to a later PR — single-
+/// page tables byte-eq today.
+fn draw_table_v2(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    entry: &crate::drawables::TableEntry,
+    x: f32,
+    y: f32,
+    frag: &crate::pagination_layout::Fragment,
+) {
+    use crate::pageable::draw_with_opacity;
+
+    draw_with_opacity(canvas, entry.opacity, |canvas| {
+        let total_width = entry.layout_size.map(|s| s.width).unwrap_or(entry.width);
+        let total_height = entry.layout_size.map(|s| s.height).unwrap_or_else(|| {
+            let from_frag = crate::convert::px_to_pt(frag.height);
+            if from_frag > 0.0 {
+                from_frag
+            } else {
+                entry.cached_height
+            }
+        });
+        if entry.visible {
+            crate::background::draw_box_shadows(
+                canvas,
+                &entry.style,
+                x,
+                y,
+                total_width,
+                total_height,
+            );
+            crate::background::draw_background(
+                canvas,
+                &entry.style,
+                x,
+                y,
+                total_width,
+                total_height,
+            );
+            crate::pageable::draw_block_border(
+                canvas,
+                &entry.style,
+                x,
+                y,
+                total_width,
+                total_height,
+            );
+        }
+    });
+}
+
+/// v2 list-item draw. Paints the marker (text glyphs / image / svg)
+/// at a negative-x offset relative to the list item's body anchor —
+/// mirrors `ListItemPageable::draw`. The body block paints itself
+/// through its own `BlockEntry` dispatch on the next iteration.
+fn draw_list_item_v2(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    entry: &crate::drawables::ListItemEntry,
+    x: f32,
+    y: f32,
+) {
+    use crate::pageable::{ImageMarker, ListItemMarker, draw_with_opacity};
+
+    if !entry.visible {
+        return;
+    }
+    draw_with_opacity(canvas, entry.opacity, |canvas| match &entry.marker {
+        ListItemMarker::Text { lines, width } if !lines.is_empty() => {
+            crate::paragraph::draw_shaped_lines(canvas, lines, x - *width, y);
+        }
+        ListItemMarker::Image {
+            marker,
+            width,
+            height,
+        } => {
+            let marker_x = x - *width;
+            let marker_y = y + (entry.marker_line_height - *height) / 2.0;
+            match marker {
+                ImageMarker::Raster(img) => {
+                    img.draw(canvas, marker_x, marker_y, *width, *height);
+                }
+                ImageMarker::Svg(svg) => {
+                    svg.draw(canvas, marker_x, marker_y, *width, *height);
+                }
+            }
+        }
+        _ => {}
     });
 }
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -228,12 +228,38 @@ fn draw_v2_page(
                 );
                 continue;
             }
-            // Block backgrounds/borders draw FIRST so subsequent inner
-            // content (paragraph / image / svg sharing the same node_id —
-            // see `convert::replaced` and `convert::inline_root`)
-            // overlays on top. No `continue;`: the dispatch falls through
-            // to the inner-content checks below.
+            // Block + inner content (paragraph / image / svg) sharing
+            // the same node_id: v1's `BlockPageable::draw`
+            // (`pageable.rs:1771`) wraps bg/border AND the children
+            // draw inside ONE `draw_with_opacity(self.opacity, ...)`
+            // group. The inline-root paragraph + replaced-image /
+            // replaced-svg patterns from `convert::inline_root` /
+            // `convert::replaced` deliberately leave the inner draw
+            // payload at `opacity: 1.0` because the wrapping block
+            // carries the real opacity.
+            //
+            // Mirror v1 by combining all four paints into one group at
+            // dispatch time and `continue;`-ing past the standalone
+            // arms. Same pattern as `draw_list_item_with_block`.
             if let Some(block) = drawables.block_styles.get(&node_id) {
+                let para_for_block = drawables.paragraphs.get(&node_id);
+                let img_for_block = drawables.images.get(&node_id);
+                let svg_for_block = drawables.svgs.get(&node_id);
+                if para_for_block.is_some() || img_for_block.is_some() || svg_for_block.is_some() {
+                    draw_block_with_inner_content(
+                        canvas,
+                        block,
+                        para_for_block,
+                        img_for_block,
+                        svg_for_block,
+                        x_pt,
+                        y_pt,
+                        frag,
+                        &geom.fragments,
+                        page_index,
+                    );
+                    continue;
+                }
                 draw_block_v2(canvas, block, x_pt, y_pt, frag);
             }
             if let Some(img) = drawables.images.get(&node_id) {
@@ -265,22 +291,35 @@ fn draw_image_v2(
     y: f32,
 ) {
     use crate::pageable::draw_with_opacity;
+    draw_with_opacity(canvas, entry.opacity, |canvas| {
+        draw_image_inner_paint(canvas, entry, x, y);
+    });
+}
 
+/// Image paint without `draw_with_opacity` wrapper. Used by
+/// `draw_block_with_inner_content` so a `<img>` whose wrapping inline-root
+/// `BlockPageable` shares its node_id (`convert::replaced`) composes
+/// with the block bg/border under one opacity group, mirroring v1's
+/// `BlockPageable::draw` (`pageable.rs:1771`).
+fn draw_image_inner_paint(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    entry: &crate::drawables::ImageEntry,
+    x: f32,
+    y: f32,
+) {
     if !entry.visible {
         return;
     }
-    draw_with_opacity(canvas, entry.opacity, |canvas| {
-        let Some(image) = decode_image_for_v2(entry) else {
-            return;
-        };
-        let Some(size) = krilla::geom::Size::from_wh(entry.width, entry.height) else {
-            return;
-        };
-        let transform = krilla::geom::Transform::from_translate(x, y);
-        canvas.surface.push_transform(&transform);
-        canvas.surface.draw_image(image, size);
-        canvas.surface.pop();
-    });
+    let Some(image) = decode_image_for_v2(entry) else {
+        return;
+    };
+    let Some(size) = krilla::geom::Size::from_wh(entry.width, entry.height) else {
+        return;
+    };
+    let transform = krilla::geom::Transform::from_translate(x, y);
+    canvas.surface.push_transform(&transform);
+    canvas.surface.draw_image(image, size);
+    canvas.surface.pop();
 }
 
 fn decode_image_for_v2(entry: &crate::drawables::ImageEntry) -> Option<krilla::image::Image> {
@@ -303,22 +342,33 @@ fn draw_svg_v2(
     y: f32,
 ) {
     use crate::pageable::draw_with_opacity;
-    use krilla_svg::{SurfaceExt, SvgSettings};
+    draw_with_opacity(canvas, entry.opacity, |canvas| {
+        draw_svg_inner_paint(canvas, entry, x, y);
+    });
+}
 
+/// SVG paint without `draw_with_opacity` wrapper. See
+/// `draw_image_inner_paint` for the rationale (inline-root `<svg>`
+/// shares node_id with the wrapping block).
+fn draw_svg_inner_paint(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    entry: &crate::drawables::SvgEntry,
+    x: f32,
+    y: f32,
+) {
+    use krilla_svg::{SurfaceExt, SvgSettings};
     if !entry.visible {
         return;
     }
-    draw_with_opacity(canvas, entry.opacity, |canvas| {
-        let Some(size) = krilla::geom::Size::from_wh(entry.width, entry.height) else {
-            return;
-        };
-        let transform = krilla::geom::Transform::from_translate(x, y);
-        canvas.surface.push_transform(&transform);
-        let _ = canvas
-            .surface
-            .draw_svg(&entry.tree, size, SvgSettings::default());
-        canvas.surface.pop();
-    });
+    let Some(size) = krilla::geom::Size::from_wh(entry.width, entry.height) else {
+        return;
+    };
+    let transform = krilla::geom::Transform::from_translate(x, y);
+    canvas.surface.push_transform(&transform);
+    let _ = canvas
+        .surface
+        .draw_svg(&entry.tree, size, SvgSettings::default());
+    canvas.surface.pop();
 }
 
 /// v2 block draw. Mirrors `BlockPageable::draw`'s background / border /
@@ -426,6 +476,47 @@ fn draw_table_v2(
                 total_width,
                 total_height,
             );
+        }
+    });
+}
+
+/// v2 block + inner content combined draw. Mirrors v1's
+/// `BlockPageable::draw` (`pageable.rs:1771`) which wraps bg/border
+/// **and** the children draw inside ONE
+/// `draw_with_opacity(self.opacity, ...)` group.
+///
+/// The shared-node_id patterns from `convert::inline_root` (block
+/// wraps an inline-root paragraph) and `convert::replaced` (block
+/// wraps `<img>` / `<svg>`) deliberately leave the inner draw payload
+/// at `opacity: 1.0` — the wrapping block carries the real opacity.
+/// Composing them all under a single `draw_with_opacity(block.opacity, ...)`
+/// keeps the v1 `q .. Q` framing intact so byte-eq holds for
+/// `<p style="opacity:0.5; background:red">text</p>` and friends.
+#[allow(clippy::too_many_arguments)]
+fn draw_block_with_inner_content(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    block: &crate::drawables::BlockEntry,
+    paragraph: Option<&crate::drawables::ParagraphEntry>,
+    image: Option<&crate::drawables::ImageEntry>,
+    svg: Option<&crate::drawables::SvgEntry>,
+    x: f32,
+    y: f32,
+    frag: &crate::pagination_layout::Fragment,
+    fragments: &[crate::pagination_layout::Fragment],
+    page_index: u32,
+) {
+    use crate::pageable::draw_with_opacity;
+
+    draw_with_opacity(canvas, block.opacity, |canvas| {
+        draw_block_inner_paint(canvas, block, x, y, frag);
+        if let Some(p) = paragraph {
+            draw_paragraph_inner_paint(canvas, p, x, y, fragments, page_index);
+        }
+        if let Some(i) = image {
+            draw_image_inner_paint(canvas, i, x, y);
+        }
+        if let Some(s) = svg {
+            draw_svg_inner_paint(canvas, s, x, y);
         }
     });
 }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -441,6 +441,14 @@ fn draw_under_transform(
     // coordinates — the surface transform applies on top, mirroring v1
     // where `inner.draw(...)` recurses through children with their
     // pre-transform layout.
+    //
+    // Descendants that have their OWN `TransformEntry` recurse into
+    // `draw_under_transform` so their matrix composes with the outer
+    // push (matches v1's nested `TransformWrapperPageable::draw` call
+    // chain at `pageable.rs:2714-2725`). Without this recursion the
+    // inner transform would be silently dropped, breaking
+    // `<div style="transform:rotate"><div style="transform:scale">`
+    // (PR #305 Devin).
     for &desc_id in &tx.descendants {
         let Some(desc_geom) = geometry.get(&desc_id) else {
             continue;
@@ -451,9 +459,26 @@ fn draw_under_transform(
             }
             let desc_x = margin_left_pt + px_to_pt(desc_frag.x);
             let desc_y = margin_top_pt + px_to_pt(desc_frag.y);
-            dispatch_fragment(
-                canvas, desc_id, desc_geom, desc_frag, desc_x, desc_y, drawables, page_index,
-            );
+            if let Some(desc_tx) = drawables.transforms.get(&desc_id) {
+                draw_under_transform(
+                    canvas,
+                    desc_tx,
+                    desc_id,
+                    desc_geom,
+                    desc_frag,
+                    desc_x,
+                    desc_y,
+                    geometry,
+                    drawables,
+                    margin_left_pt,
+                    margin_top_pt,
+                    page_index,
+                );
+            } else {
+                dispatch_fragment(
+                    canvas, desc_id, desc_geom, desc_frag, desc_x, desc_y, drawables, page_index,
+                );
+            }
         }
     }
 

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -247,3 +247,54 @@ fn render_path_byte_equality() {
     // visible signal — the test passes regardless.
     let _ = diffs;
 }
+
+/// Inline byte-equality cases. These exist alongside the on-disk
+/// fixtures because PR 3's Paragraph migration only unlocks byte-eq
+/// for documents with **purely paragraph content under a margin:0
+/// body** — no Block backgrounds, no inline-block, no Table. The
+/// existing VRT / examples fixtures all have richer content that
+/// requires later PRs (Block, Table, Multicol, Transform). Inline
+/// cases let each PR demonstrate productive byte-eq advancement
+/// without seeding VRT goldens that lock in incomplete v2 output.
+///
+/// Each case asserts unconditionally — they are the unit-of-progress
+/// for the migration. PR N adds cases that PR N's migration covers.
+#[test]
+fn inline_byte_equality_cases() {
+    // PR 3 (Paragraph + inline content) coverage.
+    let pr3_cases: &[(&str, &str)] = &[
+        (
+            "minimal body text",
+            "<!DOCTYPE html><html><head><style>body{margin:0;padding:0}</style></head><body>hello world</body></html>",
+        ),
+        (
+            "two paragraphs",
+            "<!DOCTYPE html><html><head><style>body{margin:0;padding:0}p{margin:0}</style></head><body><p>first paragraph</p><p>second paragraph here</p></body></html>",
+        ),
+        (
+            "paragraph with anchor link",
+            r#"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}p{margin:0}</style></head><body><p>before <a href="https://example.com">link</a> after</p></body></html>"#,
+        ),
+        (
+            "paragraph with internal anchor",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}p{margin:0}</style></head><body><p id="top">heading line</p><p><a href="#top">jump</a></p></body></html>"##,
+        ),
+    ];
+
+    for (label, html) in pr3_cases {
+        let engine = Engine::builder().build();
+        let v1 = engine
+            .render_html(html)
+            .unwrap_or_else(|e| panic!("v1 render `{label}`: {e}"));
+        let v2 = engine
+            .render_html_v2(html)
+            .unwrap_or_else(|e| panic!("v2 render `{label}`: {e}"));
+        assert_eq!(
+            v1,
+            v2,
+            "inline case `{label}` is not byte-identical (v1={}B v2={}B)",
+            v1.len(),
+            v2.len(),
+        );
+    }
+}

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -675,3 +675,52 @@ fn known_divergent_fixtures_stay_within_f32_ulp_bound() {
         );
     }
 }
+
+/// Bounded-divergence regression for `vrt://bugs/grid-row-promote-background.html`
+/// (fulgur-bq6i). v1 paints an off-page card slice at a different
+/// numeric y than v2 because of a `BlockPageable::slice_for_page`
+/// quirk: when an ancestor (`.grid`) has no fragment on the current
+/// page but its descendants do, `self_page_y` falls back to 0 and
+/// the child's `new_y` is computed against that fallback while the
+/// ancestor's own `pc.y` (body-relative) is also added by the draw
+/// chain — producing y = 1681pt vs v2's correct 868.94pt. Both are
+/// off-page (page bottom is 822pt); only the numeric Tm operand
+/// differs and the renderer clips both via the page MediaBox.
+///
+/// See the "Known-divergent v1 quirk" comment block in
+/// `render_path_parity.toml` for the full chain.
+///
+/// Resolution: defer to PR 8 v1 deletion. This test asserts the
+/// divergence stays within the v1-quirk-only bound; if some future
+/// change grows it past that, this fires.
+#[test]
+fn grid_row_promote_v1_quirk_stays_within_quirk_bound() {
+    use fulgur::Engine;
+
+    let root = repo_root();
+    let html_path = root.join("crates/fulgur-vrt/fixtures/bugs/grid-row-promote-background.html");
+    let html = std::fs::read_to_string(&html_path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", html_path.display()));
+
+    let engine = Engine::builder().build();
+    let v1 = engine
+        .render_html(&html)
+        .unwrap_or_else(|e| panic!("v1 render: {e}"));
+    let v2 = engine
+        .render_html_v2(&html)
+        .unwrap_or_else(|e| panic!("v2 render: {e}"));
+
+    // Empirically the diff is 15 bytes — single off-page slice y plus
+    // matching border-edge y. ≤32 leaves margin for xref re-flow
+    // without masking real layout regressions.
+    let len_diff = (v1.len() as isize - v2.len() as isize).unsigned_abs();
+    assert!(
+        len_diff <= 32,
+        "grid-row-promote: byte-length divergence ballooned \
+         (v1={}B v2={}B, |diff|={len_diff}B). Expected ≤32B for the \
+         v1 slice-y quirk. A larger diff means real visible layout \
+         has changed — investigate before raising the bound.",
+        v1.len(),
+        v2.len(),
+    );
+}

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -541,6 +541,19 @@ fn inline_byte_equality_cases() {
             "nested overflow:hidden blocks",
             r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.outer{width:120px;height:80px;overflow:hidden;background:#cef}.inner{width:60px;height:40px;overflow:hidden;background:#fce}.leaf{width:200px;height:20px;background:#ffd}</style></head><body><div class="outer"><div class="inner"><div class="leaf"></div></div></div></body></html>"##,
         ),
+        // PR #305 follow-up Devin: a multicol container with
+        // `column-rule` nested inside a `transform` ancestor used to
+        // paint its rule lines in untransformed page coordinates,
+        // because the post-pass at `draw_v2_page` ran outside any
+        // transform `push/pop` group. v1 emits rules from inside
+        // `TransformWrapperPageable::draw → MulticolRulePageable::draw`
+        // (`pageable.rs:2714-2725 → 3088`). The fix dispatches
+        // transform-scoped multicol rules from inside
+        // `draw_under_transform` and skips them in the post-pass.
+        (
+            "multicol with column-rule inside transform",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.tx{transform:translate(8px,4px)}.cols{column-count:2;column-rule:1pt solid #888;column-gap:12pt;height:80pt}.cell{height:30pt;background:#cef;margin-bottom:6pt}</style></head><body><div class="tx"><div class="cols"><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div></div></body></html>"##,
+        ),
     ];
 
     // Bookmark-inside-transform regression (PR #305 Devin): a heading

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -310,6 +310,15 @@ fn inline_byte_equality_cases() {
             "paragraph with background (shared node_id)",
             "<!DOCTYPE html><html><head><style>body{margin:0;padding:0}p{margin:0;background:#fce}</style></head><body><p>hello</p></body></html>",
         ),
+        // Regression for PR #303 Devin (block id anchors): `<a href="#x">`
+        // targeting `<div id="x">` must resolve in v2 the same way it
+        // does in v1 (`BlockPageable::collect_ids`). v1 emits a
+        // `/Link → /Dest` mapping; v2 must register block ids in the
+        // pre-pass `DestinationRegistry`.
+        (
+            "anchor link to block id",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}div{width:80px;height:40px}#target{background:#cef}p{margin:0}</style></head><body><div id="target"></div><p><a href="#target">jump</a></p></body></html>"##,
+        ),
     ];
 
     let cases = pr3_cases.iter().chain(pr4_cases.iter());

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -486,6 +486,25 @@ fn inline_byte_equality_cases() {
             "overflow hidden block with shared-node_id inline text",
             r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.box{width:50px;height:30px;overflow:hidden;background:#cef;font-size:8pt;line-height:1.2;white-space:nowrap}</style></head><body><div class="box">long overflowing text content</div></body></html>"##,
         ),
+        // PR #310 follow-up Devin: `<li style="overflow:hidden">` must
+        // (a) draw its marker (markers sit outside the body box at
+        // negative x, so `draw_under_clip` must emit the marker before
+        // pushing the clip path), and (b) honour `list_item.opacity`,
+        // not `block.opacity` — `convert::list_item::build_list_item_body`
+        // builds the body block with default opacity=1.0 because v1's
+        // `ListItemPageable::draw` carries the opacity at the outer
+        // wrap. Using `block.opacity` here silently drops any CSS
+        // opacity set on the `<li>`.
+        //
+        // The `<li>` wraps a sized `<div>` block child so the body
+        // BlockPageable's `cached_size.height` carries a non-zero
+        // value through to render — `convert::list_item::build_list_item_body`'s
+        // non-inline-root branch (line 508) doesn't set `layout_size`,
+        // and an empty body would collapse the bg paint to height=0.
+        (
+            "list item with overflow:hidden and opacity",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}ul{margin:0;padding:0 0 0 24px}li{background:#cef;overflow:hidden;opacity:0.5}.inner{height:30px;background:#fce}</style></head><body><ul><li><div class="inner"></div></li></ul></body></html>"##,
+        ),
     ];
 
     // Bookmark-inside-transform regression (PR #305 Devin): a heading

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -321,7 +321,29 @@ fn inline_byte_equality_cases() {
         ),
     ];
 
-    let cases = pr3_cases.iter().chain(pr4_cases.iter());
+    // PR 5 (Table + ListItem) extends `Drawables` with `tables` and
+    // `list_items` and adds `body_offset_pt` propagation so html→body
+    // collapsed margin reaches v2 children. Inline cases for the new
+    // types are deferred to PR 6 — table cells contain paragraphs
+    // whose text shaping resolves through inline_root, and inline-box
+    // wiring still has gaps that flake the byte-eq comparison on
+    // these specific configurations. The on-disk allowlist coverage
+    // (10 new fixtures) demonstrates the productive byte-eq advance.
+    //
+    // Regression for PR #304 Devin (list-item shared node_id): `<li>`
+    // and its body block share the same node_id — `list_items[id]`
+    // and `block_styles[id]` co-exist. The marker dispatch must NOT
+    // `continue;` past the block check or `<li style="background:...">`
+    // silently drops the body block paint in v2.
+    let pr5_cases: &[(&str, &str)] = &[(
+        "list item with body block background (shared node_id)",
+        r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}ul{margin:0;padding:0;list-style:none}li{background:#fdf;height:40px}</style></head><body><ul><li></li></ul></body></html>"##,
+    )];
+
+    let cases = pr3_cases
+        .iter()
+        .chain(pr4_cases.iter())
+        .chain(pr5_cases.iter());
     for (label, html) in cases {
         let engine = Engine::builder().build();
         let v1 = engine

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -281,7 +281,30 @@ fn inline_byte_equality_cases() {
         ),
     ];
 
-    for (label, html) in pr3_cases {
+    // PR 4 (Block migration) coverage — backgrounds, borders,
+    // border-radius, box-shadow at the block frame. Body is set to
+    // margin:0 so the v2 frame anchor matches v1's block.draw call.
+    let pr4_cases: &[(&str, &str)] = &[
+        (
+            "solid block with background color",
+            "<!DOCTYPE html><html><head><style>body{margin:0;padding:0}div{width:100px;height:80px;background:#e53935}</style></head><body><div></div></body></html>",
+        ),
+        (
+            "block with solid border",
+            "<!DOCTYPE html><html><head><style>body{margin:0;padding:0}div{width:80px;height:80px;border:4px solid #444}</style></head><body><div></div></body></html>",
+        ),
+        (
+            "block with border-radius",
+            "<!DOCTYPE html><html><head><style>body{margin:0;padding:0}div{width:80px;height:80px;background:#bdf;border-radius:12px}</style></head><body><div></div></body></html>",
+        ),
+        (
+            "two stacked blocks",
+            "<!DOCTYPE html><html><head><style>body{margin:0;padding:0}div{width:80px;height:60px}.a{background:#fcd}.b{background:#cdf}</style></head><body><div class=\"a\"></div><div class=\"b\"></div></body></html>",
+        ),
+    ];
+
+    let cases = pr3_cases.iter().chain(pr4_cases.iter());
+    for (label, html) in cases {
         let engine = Engine::builder().build();
         let v1 = engine
             .render_html(html)

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -390,6 +390,18 @@ fn inline_byte_equality_cases() {
             "nested transforms (rotate around translate)",
             r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.outer{width:120px;height:80px;background:#cef;transform:translate(10px,5px)}.inner{width:60px;height:40px;background:#fce;transform:rotate(10deg)}</style></head><body><div class="outer"><div class="inner"></div></div></body></html>"##,
         ),
+        // PR #305 follow-up Devin: nested transforms with a
+        // non-transform descendant inside the inner transform caused
+        // double-draw — `draw_under_transform` for the OUTER iterated
+        // its full `descendants` list (which includes the inner's own
+        // descendants), so the deeply nested node was painted once
+        // under outer*inner (correct, via the inner recursion) and a
+        // second time under outer only (wrong). Regression: a styled
+        // grandchild block inside two stacked transforms.
+        (
+            "triple nested transform descendant double-draw",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.outer{width:200px;height:120px;background:#cef;transform:translate(8px,4px)}.inner{width:120px;height:80px;background:#fce;transform:rotate(5deg)}.leaf{width:40px;height:20px;background:#ffd}</style></head><body><div class="outer"><div class="inner"><div class="leaf"></div></div></div></body></html>"##,
+        ),
         // PR 6 follow-up: shared-node_id inner content (inline-root
         // paragraph from `convert::inline_root`, replaced image/svg
         // from `convert::replaced`) must paint at the wrapping block's

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -400,6 +400,18 @@ fn inline_byte_equality_cases() {
             "bordered paragraph with background (shared node_id)",
             r##"<!DOCTYPE html><html><head><style>body{margin:0}p{margin:0;border:3px solid #444;background:#fce}</style></head><body><p>hello</p></body></html>"##,
         ),
+        // PR 6 follow-up (fulgur-9y1a) — html root element's
+        // background was silently dropped because the fragmenter's
+        // `geometry` only records body + descendants, never html. v2
+        // now paints html's bg as a pre-pass at `(margin.left,
+        // margin.top)` with `block_styles[root_id].layout_size`.
+        // Without that pre-pass v2 lost 13 bytes per gradient-hint
+        // fixture (six fixtures regressed simultaneously, all sharing
+        // `html, body { background: white }`).
+        (
+            "html background distinct from body background",
+            r##"<!DOCTYPE html><html><head><style>html, body { margin:0; padding:0; background:white; } .g { width:120px; height:80px; margin:24px; background:red; }</style></head><body><div class="g"></div></body></html>"##,
+        ),
     ];
 
     // Bookmark-inside-transform regression (PR #305 Devin): a heading

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -378,6 +378,18 @@ fn inline_byte_equality_cases() {
             "block with transform rotate around center",
             r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.box{width:80px;height:60px;background:#fce;transform:rotate(15deg);transform-origin:center}</style></head><body><div class="box"></div></body></html>"##,
         ),
+        // PR #305 Devin: nested transforms — inner transform was
+        // silently dropped because `draw_under_transform` dispatched
+        // descendants via `dispatch_fragment` which never checks
+        // `drawables.transforms`. v1's nested
+        // `TransformWrapperPageable::draw` recursively pushes both
+        // matrices; v2 must do the same by recursing into
+        // `draw_under_transform` when a descendant has its own
+        // `TransformEntry`.
+        (
+            "nested transforms (rotate around translate)",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.outer{width:120px;height:80px;background:#cef;transform:translate(10px,5px)}.inner{width:60px;height:40px;background:#fce;transform:rotate(10deg)}</style></head><body><div class="outer"><div class="inner"></div></div></body></html>"##,
+        ),
         // PR 6 follow-up: shared-node_id inner content (inline-root
         // paragraph from `convert::inline_root`, replaced image/svg
         // from `convert::replaced`) must paint at the wrapping block's

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -301,6 +301,15 @@ fn inline_byte_equality_cases() {
             "two stacked blocks",
             "<!DOCTYPE html><html><head><style>body{margin:0;padding:0}div{width:80px;height:60px}.a{background:#fcd}.b{background:#cdf}</style></head><body><div class=\"a\"></div><div class=\"b\"></div></body></html>",
         ),
+        // Regression for PR #303 Devin: convert wraps an inline-root
+        // paragraph in a BlockPageable that shares the same node_id, so
+        // both `block_styles[id]` and `paragraphs[id]` are populated. The
+        // block dispatch must not `continue` past the paragraph check —
+        // background draws first, glyph runs draw on top.
+        (
+            "paragraph with background (shared node_id)",
+            "<!DOCTYPE html><html><head><style>body{margin:0;padding:0}p{margin:0;background:#fce}</style></head><body><p>hello</p></body></html>",
+        ),
     ];
 
     let cases = pr3_cases.iter().chain(pr4_cases.iter());

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -450,6 +450,18 @@ fn inline_byte_equality_cases() {
             "body with inline svg margin",
             r##"<!DOCTYPE html><html><head><style>html,body{margin:0;padding:0}</style></head><body><svg width="40" height="40" xmlns="http://www.w3.org/2000/svg" style="margin:20px"><rect x="0" y="0" width="40" height="40" fill="#fa0"/></svg></body></html>"##,
         ),
+        // PR 6 follow-up (fulgur-rtza) — GCPM `@page` margin box
+        // rendering ported to `render_v2` via the shared
+        // `MarginBoxRenderer`. Without the port, v2 silently dropped
+        // `@top-center` / `@bottom-center` / counter() / element() /
+        // string() content on every page. v1's `render_to_pdf_with_gcpm`
+        // per-page measure / layout / render pipeline now lives in
+        // `MarginBoxRenderer::render_page`; both paths share the same
+        // implementation and per-page state caches.
+        (
+            "page counter in @bottom-center",
+            r##"<!DOCTYPE html><html><head><style>@page { @bottom-center { content: counter(page) " / " counter(pages); font-size: 8pt; } } body { margin: 0; padding: 0; } .item { height: 720px; }</style></head><body><div class="item">first</div><div class="item">second</div></body></html>"##,
+        ),
     ];
 
     // Bookmark-inside-transform regression (PR #305 Devin): a heading

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -610,3 +610,68 @@ fn inline_byte_equality_cases() {
         );
     }
 }
+
+/// Bounded-divergence regression for the 3 fixtures known to suffer
+/// from f32 chain non-associativity between v1 and v2 (fulgur-g7a1).
+///
+/// These fixtures cannot be byte-eq without deliberately degrading v2's
+/// accuracy (see the "Known-divergent" comment block in
+/// `render_path_parity.toml`). They are intentionally not allowlisted,
+/// but we still want a regression catch: if some future change grows
+/// the divergence past pure 1 ULP rounding, the divergence pattern
+/// will change shape and this test will catch it.
+///
+/// Empirically, each fixture currently differs in exactly one Tm
+/// operand by 1 ULP, which makes the v2 PDF ≤ 4 bytes longer than v1
+/// (one extra digit in the ASCII-formatted f32). The xref / ID table
+/// shift is constant. We assert |len_diff| ≤ 8 to leave margin for
+/// xref re-flow without masking real regressions.
+///
+/// PR 8 (fulgur-9t3z.5) deletes the v1 path; this test becomes moot
+/// then and should be removed alongside the parity harness itself.
+#[test]
+fn known_divergent_fixtures_stay_within_f32_ulp_bound() {
+    use fulgur::Engine;
+
+    // FONTCONFIG_FILE pinning is required for box-shadow's text
+    // rendering. Skip silently when missing — matches the convention
+    // used by `render_path_byte_equality`.
+    if std::env::var_os("FONTCONFIG_FILE").is_none() {
+        eprintln!("known_divergent_fixtures: FONTCONFIG_FILE unset — skipping (CI sets this)");
+        return;
+    }
+
+    let root = repo_root();
+    let cases: &[&str] = &["multicol", "multicol-span-all", "box-shadow"];
+
+    for name in cases {
+        let dir = root.join("examples").join(name);
+        let html_path = dir.join("index.html");
+        let html = std::fs::read_to_string(&html_path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", html_path.display()));
+
+        let engine = Engine::builder()
+            .page_size(fulgur::config::PageSize::A4)
+            .base_path(dir.clone())
+            .build();
+        let v1 = engine
+            .render_html(&html)
+            .unwrap_or_else(|e| panic!("v1 render {name}: {e}"));
+        let v2 = engine
+            .render_html_v2(&html)
+            .unwrap_or_else(|e| panic!("v2 render {name}: {e}"));
+
+        // |len_diff| must stay small. f32 ULP changing a Tm operand
+        // adds at most 1 character (e.g. "537.4429" → "537.44293"),
+        // and the xref/ID shift cascades a small constant. Anything
+        // bigger means real layout has changed.
+        let len_diff = (v1.len() as isize - v2.len() as isize).unsigned_abs();
+        assert!(
+            len_diff <= 8,
+            "{name}: byte-length divergence ballooned (v1={}B v2={}B, |diff|={len_diff}B). \
+             Expected ≤8B for f32 ULP-only divergence + xref shift.",
+            v1.len(),
+            v2.len(),
+        );
+    }
+}

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -402,6 +402,17 @@ fn inline_byte_equality_cases() {
         ),
     ];
 
+    // Bookmark-inside-transform regression (PR #305 Devin): a heading
+    // nested under a `transform`-wrapped ancestor must still record a
+    // bookmark anchor in the PDF outline. v1 invokes
+    // `BookmarkMarkerWrapperPageable::draw` recursively from inside
+    // `TransformWrapperPageable::draw`; v2 records the anchor BEFORE
+    // the `transformed_descendants` skip in the dispatcher.
+    let bookmark_in_transform = (
+        "bookmark anchor inside transformed ancestor",
+        r##"<!DOCTYPE html><html><head><style>body{margin:0}div{transform:rotate(5deg)}h1{margin:0;font-size:14px}</style></head><body><div><h1>Heading</h1></div></body></html>"##,
+    );
+
     let cases = pr3_cases
         .iter()
         .chain(pr4_cases.iter())
@@ -409,6 +420,27 @@ fn inline_byte_equality_cases() {
         .chain(pr6_cases.iter());
     for (label, html) in cases {
         let engine = Engine::builder().build();
+        let v1 = engine
+            .render_html(html)
+            .unwrap_or_else(|e| panic!("v1 render `{label}`: {e}"));
+        let v2 = engine
+            .render_html_v2(html)
+            .unwrap_or_else(|e| panic!("v2 render `{label}`: {e}"));
+        assert_eq!(
+            v1,
+            v2,
+            "inline case `{label}` is not byte-identical (v1={}B v2={}B)",
+            v1.len(),
+            v2.len(),
+        );
+    }
+
+    // Bookmark anchors require `bookmarks(true)` on the engine —
+    // separate render so the assertion can target the
+    // bookmark-inside-transform case explicitly.
+    {
+        let (label, html) = bookmark_in_transform;
+        let engine = Engine::builder().bookmarks(true).build();
         let v1 = engine
             .render_html(html)
             .unwrap_or_else(|e| panic!("v1 render `{label}`: {e}"));

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -462,6 +462,18 @@ fn inline_byte_equality_cases() {
             "page counter in @bottom-center",
             r##"<!DOCTYPE html><html><head><style>@page { @bottom-center { content: counter(page) " / " counter(pages); font-size: 8pt; } } body { margin: 0; padding: 0; } .item { height: 720px; }</style></head><body><div class="item">first</div><div class="item">second</div></body></html>"##,
         ),
+        // PR 6 follow-up (overflow clip scope tracking, fulgur-ekz7) —
+        // v1 `BlockPageable::draw` (`pageable.rs:1796-1827`) paints
+        // bg / border / shadow OUTSIDE the clip, then pushes the
+        // overflow clip path, draws children INSIDE, then pops. v2 now
+        // tracks `BlockEntry.clip_descendants` and replays the same
+        // ordering via `draw_under_clip`. Without this fix, overflow
+        // children that overshoot the parent's box paint past the
+        // clip boundary.
+        (
+            "overflow hidden block with overflowing child",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.outer{width:80px;height:60px;overflow:hidden;background:#cef}.inner{width:200px;height:200px;background:#fce;margin:-20px}</style></head><body><div class="outer"><div class="inner"></div></div></body></html>"##,
+        ),
     ];
 
     // Bookmark-inside-transform regression (PR #305 Devin): a heading

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -335,10 +335,21 @@ fn inline_byte_equality_cases() {
     // and `block_styles[id]` co-exist. The marker dispatch must NOT
     // `continue;` past the block check or `<li style="background:...">`
     // silently drops the body block paint in v2.
-    let pr5_cases: &[(&str, &str)] = &[(
-        "list item with body block background (shared node_id)",
-        r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}ul{margin:0;padding:0;list-style:none}li{background:#fdf;height:40px}</style></head><body><ul><li></li></ul></body></html>"##,
-    )];
+    let pr5_cases: &[(&str, &str)] = &[
+        (
+            "list item with body block background (shared node_id)",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}ul{margin:0;padding:0;list-style:none}li{background:#fdf;height:40px}</style></head><body><ul><li></li></ul></body></html>"##,
+        ),
+        // Regression for PR #304 follow-up Devin (list-item opacity
+        // grouping): v1's `ListItemPageable::draw` wraps marker + body
+        // block in a SINGLE `draw_with_opacity` group. v2 must produce
+        // the same single q/Q wrapper or the PDF stream diverges when
+        // `<li style="opacity:0.5">`.
+        (
+            "list item with opacity and body block background",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}ul{margin:0;padding:0;list-style:none}li{background:#cef;height:40px;opacity:0.5}</style></head><body><ul><li></li></ul></body></html>"##,
+        ),
+    ];
 
     let cases = pr3_cases
         .iter()

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -486,6 +486,17 @@ fn inline_byte_equality_cases() {
             "overflow hidden block with shared-node_id inline text",
             r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.box{width:50px;height:30px;overflow:hidden;background:#cef;font-size:8pt;line-height:1.2;white-space:nowrap}</style></head><body><div class="box">long overflowing text content</div></body></html>"##,
         ),
+        // PR #310 follow-up Devin: a transform nested inside an
+        // `overflow:hidden` block was silently dropped because the
+        // main loop pre-skips `clipped_descendants` BEFORE the
+        // per-fragment transform check. `draw_under_clip` now
+        // dispatches transform-key descendants via
+        // `draw_under_transform` (and pre-skips their own descendants
+        // so they are not painted twice).
+        (
+            "transform inside overflow:hidden ancestor",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.outer{width:120px;height:80px;overflow:hidden;background:#cef}.inner{width:60px;height:40px;background:#fce;transform:rotate(10deg)}</style></head><body><div class="outer"><div class="inner"></div></div></body></html>"##,
+        ),
         // PR #310 follow-up Devin: `<li style="overflow:hidden">` must
         // (a) draw its marker (markers sit outside the body box at
         // negative x, so `draw_under_clip` must emit the marker before

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -474,6 +474,18 @@ fn inline_byte_equality_cases() {
             "overflow hidden block with overflowing child",
             r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.outer{width:80px;height:60px;overflow:hidden;background:#cef}.inner{width:200px;height:200px;background:#fce;margin:-20px}</style></head><body><div class="outer"><div class="inner"></div></div></body></html>"##,
         ),
+        // PR #310 Devin: overflow:hidden block with shared-node_id
+        // inner content only (inline-root paragraph at the same
+        // `node_id`) — no separate descendant NodeIds. v1 pushes the
+        // clip unconditionally when `has_overflow_clip()` is true, so
+        // `<div style="overflow:hidden;width:50px">long overflowing
+        // text</div>` clips the long text at the 50px boundary. v2's
+        // dispatcher must do the same regardless of whether
+        // `clip_descendants` is empty.
+        (
+            "overflow hidden block with shared-node_id inline text",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.box{width:50px;height:30px;overflow:hidden;background:#cef;font-size:8pt;line-height:1.2;white-space:nowrap}</style></head><body><div class="box">long overflowing text content</div></body></html>"##,
+        ),
     ];
 
     // Bookmark-inside-transform regression (PR #305 Devin): a heading

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -362,10 +362,29 @@ fn inline_byte_equality_cases() {
         ),
     ];
 
+    // PR 6 (Transform + MulticolRule + marker wrappers verification)
+    // exercises the new `Drawables.transforms` and
+    // `Drawables.multicol_rules` maps. Transform tests cover the
+    // shared-node_id case (block + transform same id) and the strict
+    // descendant case (block wraps a child with its own id). Multicol
+    // rule painting requires a `column-rule` style, which the example
+    // fixtures don't currently use, so we add minimal cases here.
+    let pr6_cases: &[(&str, &str)] = &[
+        (
+            "block with transform translate (shared node_id)",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.box{width:80px;height:60px;background:#cef;transform:translate(10px,5px)}</style></head><body><div class="box"></div></body></html>"##,
+        ),
+        (
+            "block with transform rotate around center",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.box{width:80px;height:60px;background:#fce;transform:rotate(15deg);transform-origin:center}</style></head><body><div class="box"></div></body></html>"##,
+        ),
+    ];
+
     let cases = pr3_cases
         .iter()
         .chain(pr4_cases.iter())
-        .chain(pr5_cases.iter());
+        .chain(pr5_cases.iter())
+        .chain(pr6_cases.iter());
     for (label, html) in cases {
         let engine = Engine::builder().build();
         let v1 = engine

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -319,6 +319,17 @@ fn inline_byte_equality_cases() {
             "anchor link to block id",
             r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}div{width:80px;height:40px}#target{background:#cef}p{margin:0}</style></head><body><div id="target"></div><p><a href="#target">jump</a></p></body></html>"##,
         ),
+        // Regression for PR #303 follow-up Devin: shared node_id
+        // (block + paragraph from `convert::inline_root`) with
+        // `opacity < 1.0` must compose under ONE
+        // `draw_with_opacity(block.opacity, ...)` group, mirroring v1's
+        // `BlockPageable::draw` which wraps bg/border + child draws in
+        // a single group. Separate wrappers paint the bg at 50% but
+        // glyphs at 100% — visually wrong AND byte-divergent.
+        (
+            "paragraph with opacity and background (shared node_id)",
+            "<!DOCTYPE html><html><head><style>body{margin:0;padding:0}p{margin:0;background:#cef;opacity:0.5}</style></head><body><p>hello</p></body></html>",
+        ),
     ];
 
     // PR 5 (Table + ListItem) extends `Drawables` with `tables` and

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -378,6 +378,28 @@ fn inline_byte_equality_cases() {
             "block with transform rotate around center",
             r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.box{width:80px;height:60px;background:#fce;transform:rotate(15deg);transform-origin:center}</style></head><body><div class="box"></div></body></html>"##,
         ),
+        // PR 6 follow-up: shared-node_id inner content (inline-root
+        // paragraph from `convert::inline_root`, replaced image/svg
+        // from `convert::replaced`) must paint at the wrapping block's
+        // *content-box* top-left, not its border-box top-left, when
+        // the block carries `padding` or `border`. v1 expresses this
+        // via `PositionedChild { x: content_inset.x, y:
+        // content_inset.y }`; v2 mirrors it by adding
+        // `block.style.content_inset()` inside
+        // `draw_block_with_inner_content` (and
+        // `draw_list_item_with_block`). Without that offset, every
+        // text run inside a padded block landed `padding+border`
+        // worth of px high-and-left of where it should — the bug that
+        // kept `examples/transform`'s `.box { padding: 6px }` 11
+        // bytes short.
+        (
+            "padded paragraph with background (shared node_id)",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0}p{margin:0;padding:6px;background:#cef}</style></head><body><p>hello</p></body></html>"##,
+        ),
+        (
+            "bordered paragraph with background (shared node_id)",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0}p{margin:0;border:3px solid #444;background:#fce}</style></head><body><p>hello</p></body></html>"##,
+        ),
     ];
 
     let cases = pr3_cases

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -436,6 +436,20 @@ fn inline_byte_equality_cases() {
             "html background distinct from body background",
             r##"<!DOCTYPE html><html><head><style>html, body { margin:0; padding:0; background:white; } .g { width:120px; height:80px; margin:24px; background:red; }</style></head><body><div class="g"></div></body></html>"##,
         ),
+        // PR 6 follow-up (fulgur-9y1a) — `extract_drawables_from_pageable`
+        // recurses into the Pageable tree to populate per-NodeId draw
+        // payloads. `LineItem::InlineBox` carries inner content (e.g.
+        // an inline `<svg>`) that `paragraph::draw_shaped_lines`
+        // paints via `ib.content.draw(...)` directly. Recursing into
+        // that content registered it again in `svgs` / `block_styles`
+        // and the v2 dispatcher then double-painted at the fragment's
+        // own coordinates (e.g. `body + svg_margin` for
+        // `<svg style="margin:Npx">`). Drop the recurse so inline-box
+        // content stays a pure paragraph-rooted draw.
+        (
+            "body with inline svg margin",
+            r##"<!DOCTYPE html><html><head><style>html,body{margin:0;padding:0}</style></head><body><svg width="40" height="40" xmlns="http://www.w3.org/2000/svg" style="margin:20px"><rect x="0" y="0" width="40" height="40" fill="#fa0"/></svg></body></html>"##,
+        ),
     ];
 
     // Bookmark-inside-transform regression (PR #305 Devin): a heading

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -516,6 +516,31 @@ fn inline_byte_equality_cases() {
             "list item with overflow:hidden and opacity",
             r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}ul{margin:0;padding:0 0 0 24px}li{background:#cef;overflow:hidden;opacity:0.5}.inner{height:30px;background:#fce}</style></head><body><ul><li><div class="inner"></div></li></ul></body></html>"##,
         ),
+        // PR #309 follow-up Devin: an `overflow:hidden` block nested
+        // inside a `transform` ancestor was silently losing its clip.
+        // `draw_under_transform` dispatched the inner block via
+        // `dispatch_fragment` (which only paints bg/border/shadow) and
+        // never pushed the clip path. Same shape as the
+        // PR #310 transform-inside-clip fix but mirrored — clip inside
+        // transform also needs to enter `draw_under_clip`.
+        (
+            "overflow:hidden inside transform ancestor",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.outer{width:140px;height:80px;background:#cef;transform:translate(8px,4px)}.inner{width:60px;height:40px;background:#fce;overflow:hidden}.leaf{width:120px;height:20px;background:#ffd}</style></head><body><div class="outer"><div class="inner"><div class="leaf"></div></div></div></body></html>"##,
+        ),
+        // PR #309 follow-up Devin: nested `overflow:hidden` blocks
+        // (`<div style="overflow:hidden"><div style="overflow:hidden">
+        // ...`) lost the inner clip because `draw_under_clip`'s
+        // descendant loop only checked for transforms, never for
+        // nested clips. The inner block's bg/border landed via
+        // `dispatch_fragment` but no inner push_clip_path fired, so
+        // overflowing content escaped the inner boundary. Fix:
+        // descendant dispatch recursively calls `draw_under_clip` for
+        // nested clip blocks (with a `nested_clip_skip` to avoid
+        // double-paint).
+        (
+            "nested overflow:hidden blocks",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.outer{width:120px;height:80px;overflow:hidden;background:#cef}.inner{width:60px;height:40px;overflow:hidden;background:#fce}.leaf{width:200px;height:20px;background:#ffd}</style></head><body><div class="outer"><div class="inner"><div class="leaf"></div></div></div></body></html>"##,
+        ),
     ];
 
     // Bookmark-inside-transform regression (PR #305 Devin): a heading

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -143,6 +143,16 @@ allowlist = [
     # `vrt://layout/review_card_inline_block.html` and any future
     # mixed-block-and-inline content.
     "vrt://layout/review_card_inline_block.html",
+    # PR follow-up (per-slice block height, fulgur-bq6i:break-inside) —
+    # split blocks (one fragment per page) were painting the FULL
+    # `layout_size.height` on every slice, so a `break-inside: avoid`
+    # callout that doesn't fit on page 1 painted overflowing-the-page-
+    # bottom on page 1 AND repeated full-size on page 2. v2 now passes
+    # `is_split = geom.fragments.len() > 1` from `dispatch_fragment` to
+    # `draw_block_inner_paint`, which uses `frag.height` per slice when
+    # split — mirroring v1's `BlockPageable::slice_for_page` which
+    # adjusts `layout_size.height` per sliced pageable.
+    "examples://break-inside",
 ]
 
 # Known-divergent fixtures (fulgur-g7a1, 2026-04-30)

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -229,3 +229,29 @@ allowlist = [
 #
 # Resolution: defer to PR 8 v1 deletion. Fixing v1 in flight would
 # touch `slice_for_page` for a quirk that disappears with the path.
+
+# Known-divergent: v2 renders content v1 silently drops (fulgur-bq6i:wasm-demo)
+# ----------------------------------------------------------------------
+# `examples/wasm-demo` is intentionally NOT allowlisted because v2's
+# `fragment_pagination_root` now walks `body.layout_children` (when
+# present) for the same reason `record_subtree_descendants` does:
+# Stylo synthesizes anonymous block wrappers around inline-level
+# siblings of block-level body children, and those wrappers carry
+# the inline content's `node_id`.
+#
+# After the body-level layout_children fix, v2 picks up
+# `<label>` / `<legend>` / `<select>` / `<option>` / `<input>` /
+# `<button>` paint that v1 silently drops because v1's body
+# iteration only saw the raw children list (which omits the
+# anonymous wrappers Stylo creates for the form-element row).
+#
+# Net delta: v2 is 53 bytes longer than v1 on this fixture because
+# v2 also paints the `<button id="render" disabled>Loading WASM…
+# </button>` text that v1 omits. v2 is the more visually correct
+# output — Phase 4's whole point is that the geometry-driven path
+# fixes coverage gaps in the Pageable path, and this is one such
+# gap that becomes the canonical behavior after PR 8 v1 deletion.
+#
+# Resolution: defer to PR 8 v1 deletion. Once the v1 path is gone,
+# the parity test compares v2 vs v2 (trivially byte-eq). For users
+# rendering form-heavy HTML to PDF, this is a v2 improvement.

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -67,4 +67,18 @@ allowlist = [
     "vrt://paint/repeating-linear-gradient.html",
     "vrt://paint/repeating-linear-gradient-hint.html",
     "vrt://paint/repeating-radial-gradient.html",
+    # PR 6 follow-up (skip InlineBox.content recurse, fulgur-9y1a) —
+    # inline-block / inline-flex / inline-grid / inline-svg content is
+    # painted via `paragraph::draw_shaped_lines` calling
+    # `ib.content.draw(...)`. extract was recursing into
+    # `InlineBox.content` and registering the inner Pageable in
+    # `block_styles` / `svgs` / etc., so v2 dispatch double-painted
+    # everything inside an inline box. Six layout fixtures lit up at
+    # once after dropping the recurse.
+    "vrt://layout/inline-block-basic.html",
+    "vrt://layout/inline-block-nested.html",
+    "vrt://layout/inline-block-overflow-hidden.html",
+    "vrt://layout/inline-flex-smoke.html",
+    "vrt://layout/inline-grid-smoke.html",
+    "vrt://svg/shapes.html",
 ]

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -95,4 +95,15 @@ allowlist = [
     "vrt://bugs/cover-page-break-after.html",
     "examples://header-footer",
     "examples://header-footer-split",
+    # PR 6 follow-up (overflow clip scope tracking, fulgur-ekz7) —
+    # `overflow: hidden | clip` blocks now record their strict
+    # descendants in `BlockEntry.clip_descendants`. v2 dispatcher
+    # paints bg / border / shadow OUTSIDE the clip, pushes the clip
+    # path, dispatches inner content + descendants INSIDE the clip,
+    # then pops — mirroring v1's `BlockPageable::draw` ordering
+    # (`pageable.rs:1796-1827`). Both VRT overflow-hidden fixtures and
+    # the examples/overflow-hidden demo lit up.
+    "vrt://layout/overflow-hidden.html",
+    "vrt://layout/overflow-hidden-rounded.html",
+    "examples://overflow-hidden",
 ]

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -29,4 +29,18 @@ allowlist = [
     "vrt://layout/flex-row.html",
     "vrt://layout/grid-simple.html",
     "vrt://layout/multicol-2.html",
+    # PR 5 (Table + ListItem + html→body offset fix) — adds the
+    # `body_y` propagation that lets the html → body collapsed-margin
+    # offset reach v2 children. Most pure-block paint / gradient
+    # fixtures fall in once that's in place.
+    "vrt://basic/solid-box.html",
+    "vrt://paint/background-gradient.html",
+    "vrt://paint/gradient-repeat-round.html",
+    "vrt://paint/gradient-repeat-x-with-position.html",
+    "vrt://paint/gradient-size-no-repeat-center.html",
+    "vrt://paint/gradient-to-top-right-tile-aspect.html",
+    "vrt://paint/opacity.html",
+    "vrt://paint/radial-gradient-no-repeat-corner.html",
+    "vrt://paint/radial-gradient-repeat-round.html",
+    "vrt://paint/radial-gradient-tiled.html",
 ]

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -120,6 +120,17 @@ allowlist = [
     "examples://pseudo-content-url",
     "examples://text-align",
     "examples://text-decoration",
+    # PR follow-up (cross-node_id opacity grouping, fulgur-gdb9) —
+    # `<div style="opacity:0.4"><svg>..</svg></div>` was painting the
+    # svg outside the parent's `draw_with_opacity` wrap because v2's
+    # flat dispatch had no way to nest descendants under a parent's
+    # opacity group. `BlockEntry.opacity_descendants` + new
+    # `draw_under_opacity` mirror the existing
+    # `clip_descendants` / `draw_under_clip` shape so opacity wraps
+    # everything (own paint + descendants), matching v1's
+    # `BlockPageable::draw` recursion under
+    # `draw_with_opacity(self.opacity, ..)`.
+    "examples://svg",
 ]
 
 # Known-divergent fixtures (fulgur-g7a1, 2026-04-30)

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -54,4 +54,17 @@ allowlist = [
     "examples://border-radius",
     "examples://table-header",
     "examples://transform",
+    # PR 6 follow-up (root `<html>` bg pre-pass, fulgur-9y1a) — html
+    # element's own `background` was silently dropped because the
+    # fragmenter's `geometry` only carries body + descendants. v2 now
+    # paints html's bg explicitly at `(margin.left, margin.top)` with
+    # `block_styles[root_id].layout_size` before the main loop runs.
+    # Six paint fixtures with `html, body { background: white }` lit up
+    # at once.
+    "vrt://paint/linear-gradient-hint-30pct.html",
+    "vrt://paint/linear-gradient-hint-70pct.html",
+    "vrt://paint/radial-gradient-hint.html",
+    "vrt://paint/repeating-linear-gradient.html",
+    "vrt://paint/repeating-linear-gradient-hint.html",
+    "vrt://paint/repeating-radial-gradient.html",
 ]

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -196,3 +196,36 @@ allowlist = [
 # Resolution: defer to PR 8 v1 deletion. Once v1 is gone, the parity
 # test compares v2 vs v2 (trivially byte-eq) and these fixtures need
 # no special handling.
+
+# Known-divergent v1 quirk: off-page slice y (fulgur-bq6i:grid-row-promote)
+# ----------------------------------------------------------------------
+# `vrt://bugs/grid-row-promote-background.html` is intentionally NOT
+# allowlisted because v1 emits an off-page card slice at a different
+# numeric y than v2. The visual output is identical (both clipped by
+# the page MediaBox) — only the numeric Tm operand differs.
+#
+# Root cause: a v1 quirk in `BlockPageable::slice_for_page` when an
+# ancestor (here `.grid`) has NO fragment on the current page but its
+# descendants (cards) do. The ancestor's `self_page_y` falls back to
+# `0.0`, and the child's slice computes
+# `new_y = px_to_pt(child_frag.y - 0)` treating body-content-relative
+# `child_frag.y` as parent-relative. The Pageable draw chain then
+# double-adds the ancestor's `pc.y` (from convert) AND the child's
+# new_y (which is also body-relative), producing y = 1681pt — far
+# off the page bottom.
+#
+#   v1: body.draw(y=56.69) → grid.draw(y=56.69 + 812 = 868.69) →
+#       card_1_slice.draw(y=868.69 + 812.25 = 1680.94pt)
+#   v2: dispatch_fragment uses frag.y_page_local =
+#       56.69 + px_to_pt(1083) = 868.94pt
+#
+# v2 is correct (page-local from fragmenter); v1's value is the sum
+# of two body-relative offsets due to the slice-coord bug.
+#
+# Both renders emit the slice off-page (anywhere past 822pt is past
+# the page bottom for an A4 with 20mm margin). The slice gets clipped
+# by the MediaBox so neither is visible; the difference is purely in
+# the numeric operand the renderer emits before the clip.
+#
+# Resolution: defer to PR 8 v1 deletion. Fixing v1 in flight would
+# touch `slice_for_page` for a quirk that disappears with the path.

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -107,3 +107,45 @@ allowlist = [
     "vrt://layout/overflow-hidden-rounded.html",
     "examples://overflow-hidden",
 ]
+
+# Known-divergent fixtures (fulgur-g7a1, 2026-04-30)
+# ----------------------------------------------------------------------
+# These produce 1 ULP differences in numeric `Tm` operands and CANNOT
+# be made byte-equivalent without deliberately degrading v2's accuracy
+# to match v1's per-step rounding pattern. They are intentionally NOT
+# allowlisted, and will become moot when PR 8 (fulgur-9t3z.5) deletes
+# the v1 path entirely.
+#
+# Root cause: f32 addition non-associativity between v1 and v2 chains.
+#
+# - v1 (`BlockPageable::draw`): each `PositionedChild.y` is set during
+#   convert as `px_to_pt(taffy_loc.y)` (per-level f32 conversion), and
+#   the draw chain accumulates `y + pc0.y + pc1.y + ...` in pt — every
+#   intermediate sum gets rounded.
+# - v2 (`dispatch_fragment`): `Fragment.y` is the cumulative absolute
+#   y in CSS px from the fragmenter, converted in a single
+#   `margin_top_pt + px_to_pt(frag.y)` step at draw time — only one
+#   rounding occurs.
+#
+# Empirical example (examples/box-shadow, page 0, node_id=34):
+#
+#   v1: ((56.692913 + 132.750) + 70.500) = 189.442917 + 70.500
+#       = 259.942932 (bits=4381f8b2)
+#   v2: 56.692913 + 203.250 = 259.942902 (bits=4381f8b1)
+#   true: 259.94291305...
+#
+# v2 is closer to the true mathematical result; v1's chain accumulates
+# intermediate rounding error. Making v2 byte-eq with v1 means
+# replicating v1's two-step rounding — pure regression in accuracy
+# for transitional benefit only.
+#
+# Affected fixtures (3) — diff is exactly one Tm operand off by 1 ULP:
+# - examples/multicol      (v1 hex b2f88743 / v2 hex b1f88743)
+# - examples/multicol-span-all  (v1 b2789543 / v2 b1789543)
+# - examples/box-shadow    (v1 585c0644 / v2 595c0644 — note reversed
+#                           direction confirming order-of-operations,
+#                           not a unidirectional offset)
+#
+# Resolution: defer to PR 8 v1 deletion. Once v1 is gone, the parity
+# test compares v2 vs v2 (trivially byte-eq) and these fixtures need
+# no special handling.

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -21,6 +21,12 @@
 # fixture roots in `render_path_parity.rs::FIXTURE_ROOTS`.
 
 allowlist = [
-    # PR 2 will add: vrt://basic/solid-box, vrt://basic/borders,
-    # examples://image, etc.
+    # PR 4 (Block migration) — block backgrounds / borders / radius
+    # unlock fixtures that are pure-block content with margin:0 body
+    # (no inline-block, no overflow:hidden, no images, no text).
+    "vrt://basic/border-radius.html",
+    "vrt://basic/borders.html",
+    "vrt://layout/flex-row.html",
+    "vrt://layout/grid-simple.html",
+    "vrt://layout/multicol-2.html",
 ]

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -131,6 +131,18 @@ allowlist = [
     # `BlockPageable::draw` recursion under
     # `draw_with_opacity(self.opacity, ..)`.
     "examples://svg",
+    # PR follow-up (anonymous-block layout walk, fulgur-bq6i:review_card)
+    # — Stylo synthesizes anonymous block wrappers around inline-level
+    # siblings of block-level siblings (CSS 2.1 §9.2.1.1). Those
+    # wrappers carry their own `node_id` and live in
+    # `Node.layout_children` but NOT in `Node.children`. The fragmenter's
+    # `record_subtree_descendants` walked `children`, missing the
+    # synthesized anonymous block, so geometry never recorded its
+    # fragment and v2 dispatch silently dropped its inline-root
+    # paragraph. Switching to `layout_children` (when `Some`) lights up
+    # `vrt://layout/review_card_inline_block.html` and any future
+    # mixed-block-and-inline content.
+    "vrt://layout/review_card_inline_block.html",
 ]
 
 # Known-divergent fixtures (fulgur-g7a1, 2026-04-30)

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -81,4 +81,18 @@ allowlist = [
     "vrt://layout/inline-flex-smoke.html",
     "vrt://layout/inline-grid-smoke.html",
     "vrt://svg/shapes.html",
+    # PR 6 follow-up (GCPM @page margin box port to render_v2,
+    # fulgur-rtza). v1's `render_to_pdf_with_gcpm` per-page margin box
+    # measure / layout / render pipeline was extracted into
+    # `MarginBoxRenderer` and called from `render_v2`. Both paths now
+    # share the same caches and produce byte-equivalent margin-box
+    # output, lighting up the GCPM family + cover-page-break-after +
+    # examples/header-footer{,-split}.
+    "vrt://gcpm/counter-page-numbers.html",
+    "vrt://gcpm/page-selector.html",
+    "vrt://gcpm/running-element.html",
+    "vrt://gcpm/string-set.html",
+    "vrt://bugs/cover-page-break-after.html",
+    "examples://header-footer",
+    "examples://header-footer-split",
 ]

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -43,4 +43,15 @@ allowlist = [
     "vrt://paint/radial-gradient-no-repeat-corner.html",
     "vrt://paint/radial-gradient-repeat-round.html",
     "vrt://paint/radial-gradient-tiled.html",
+    # PR 6 (Transform + MulticolRule + content-inset fix) — transform
+    # plumbing unlocks the `examples/transform` fixture, and the
+    # shared-node_id content-box offset (`block.style.content_inset()`
+    # added inside `draw_block_with_inner_content`) closes the
+    # `padding`/`border` shift that was keeping basic painted block
+    # fixtures off the allowlist.
+    "vrt://basic/box-shadow.html",
+    "examples://bookmark",
+    "examples://border-radius",
+    "examples://table-header",
+    "examples://transform",
 ]

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -106,6 +106,20 @@ allowlist = [
     "vrt://layout/overflow-hidden.html",
     "vrt://layout/overflow-hidden-rounded.html",
     "examples://overflow-hidden",
+    # Phase 4 stack merge enrollment — fixtures that became
+    # byte-identical incidentally (mostly through the GCPM port,
+    # InlineBox no-recurse fix, and content-inset / clip / transform
+    # work) but had not yet been allowlisted. Enrolling them locks
+    # in v1/v2 parity and progresses PR 7 (default flip) coverage.
+    "vrt://gcpm/bookmark-outline.html",
+    "vrt://gcpm/link-annotations.html",
+    "examples://image",
+    "examples://link-media",
+    "examples://link-stylesheet",
+    "examples://list-style-image",
+    "examples://pseudo-content-url",
+    "examples://text-align",
+    "examples://text-decoration",
 ]
 
 # Known-divergent fixtures (fulgur-g7a1, 2026-04-30)

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -846,3 +846,16 @@ fn render_v2_smoke_list_item_image_marker() {
     let pdf = engine.render_html_v2(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
+
+#[test]
+fn render_v2_smoke_multicol_rule_inside_transform() {
+    // Regression for PR #305 follow-up Devin: a multicol container
+    // with `column-rule` nested inside a `transform` ancestor needs
+    // the rule lines painted from inside `draw_under_transform`'s
+    // `push_transform / pop` group, not the page-level post-pass.
+    // Otherwise the rules render in untransformed page coordinates.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.tx{transform:translate(8px,4px)}.cols{column-count:2;column-rule:1pt solid #888;column-gap:12pt;height:80pt}.cell{height:30pt;background:#cef;margin-bottom:6pt}</style></head><body><div class="tx"><div class="cols"><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -753,3 +753,29 @@ fn render_v2_smoke_list_item_overflow_clip_with_opacity() {
     let pdf = engine.render_html_v2(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
+
+#[test]
+fn render_v2_smoke_overflow_clip_inside_transform() {
+    // Regression for PR #309 follow-up Devin: an `overflow:hidden`
+    // descendant of a `transform` ancestor must enter
+    // `draw_under_clip` so its clip path is pushed. Previously the
+    // descendant's bg/border landed via `dispatch_fragment` but no
+    // clip path fired, leaking content past the boundary.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0}.outer{width:140px;height:80px;background:#cef;transform:translate(8px,4px)}.inner{width:60px;height:40px;background:#fce;overflow:hidden}.leaf{width:120px;height:20px;background:#ffd}</style></head><body><div class="outer"><div class="inner"><div class="leaf"></div></div></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn render_v2_smoke_nested_overflow_clip_blocks() {
+    // Regression for PR #309 follow-up Devin: nested
+    // `overflow:hidden` blocks must each push their own clip path.
+    // Previously the inner block's bg/border landed via
+    // `dispatch_fragment` and no inner clip fired, losing the inner
+    // boundary while overflowing content escaped through it.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0}.outer{width:120px;height:80px;overflow:hidden;background:#cef}.inner{width:60px;height:40px;overflow:hidden;background:#fce}.leaf{width:200px;height:20px;background:#ffd}</style></head><body><div class="outer"><div class="inner"><div class="leaf"></div></div></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -697,15 +697,12 @@ fn render_v2_smoke_bookmarks_under_transform() {
 }
 
 #[test]
-fn render_v2_smoke_triple_nested_transform_descendants() {
-    // Exercises the `nested_skip` pre-collection in
-    // `draw_under_transform` added in PR #305 follow-up Devin: the
-    // outer transform's `descendants` includes the inner transform's
-    // own descendants (e.g. a styled grandchild block), so the
-    // outer's iteration must skip them or they get painted twice —
-    // once correctly under outer*inner via the recursion, and once
-    // wrongly under outer only.
-    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0}.outer{width:200px;height:120px;background:#cef;transform:translate(8px,4px)}.inner{width:120px;height:80px;background:#fce;transform:rotate(5deg)}.leaf{width:40px;height:20px;background:#ffd}</style></head><body><div class="outer"><div class="inner"><div class="leaf"></div></div></div></body></html>"##;
+fn render_v2_smoke_transform_inside_overflow_clip() {
+    // Exercises `draw_under_clip`'s transform-aware descendant
+    // dispatch added in PR #310 Devin fix: a `transform` nested
+    // inside `overflow:hidden` was dropped because the main loop
+    // pre-skips `clipped_descendants` before the transform check.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0}.outer{width:120px;height:80px;overflow:hidden;background:#cef}.inner{width:60px;height:40px;background:#fce;transform:rotate(10deg)}</style></head><body><div class="outer"><div class="inner"></div></div></body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
     let pdf = engine.render_html_v2(html).expect("v2 render");
     assert!(!pdf.is_empty());

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -1148,3 +1148,62 @@ fn render_v2_smoke_split_overflow_clip_block_uses_per_slice_height() {
         "expected multi-page output for split-overflow-clip test, got {page_count}",
     );
 }
+
+#[test]
+fn render_v2_smoke_html_opacity_multi_page_content_survives() {
+    // Regression for PR #312 follow-up Devin Review: the
+    // `<html>` root element with fractional opacity must NOT
+    // silently blank the entire document.
+    //
+    // Root is never recorded in `geometry` (it's painted via
+    // `paint_root_block_v2` as a pre-pass). When `html { opacity:
+    // 0.5 }` is set, `extract_drawables_from_pageable` populates
+    // root's `BlockEntry.opacity_descendants` with body + all body
+    // descendants. Without the root exclusion in the
+    // `opacity_wrapped_descendants` collection, those descendants
+    // were added to the skip set and dropped from the main loop —
+    // but `draw_under_opacity(root)` never fires either (root is
+    // skipped at line 348), so the entire page content silently
+    // blanked.
+    //
+    // Same defense as the body exclusion (PR #314 follow-up).
+    let html = r##"<!DOCTYPE html><html style="opacity:0.5"><head><style>
+        body{margin:0;padding:0;font-size:10pt}
+        .filler{height:800pt;background:#eef}
+        .tail{height:120pt;background:#cef;margin-top:12pt}
+    </style></head><body>
+        <div class="filler"></div>
+        <div class="tail">tail content on page 2</div>
+    </body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+    // Multi-page sanity.
+    let pdf_str = String::from_utf8_lossy(&pdf);
+    let page_count = pdf_str.matches("/Type /Page\n").count();
+    assert!(
+        page_count >= 2,
+        "expected multi-page output for html-opacity test, got {page_count}",
+    );
+    // Compare against no-opacity baseline. Without the root
+    // exclusion fix, `html { opacity: 0.5 }` silently dropped all
+    // body content and the PDF shrunk to roughly the empty-page
+    // size. Require ≥85% of baseline (small overhead for the
+    // root-level transparency-group XObject).
+    let html_baseline = r##"<!DOCTYPE html><html><head><style>
+        body{margin:0;padding:0;font-size:10pt}
+        .filler{height:800pt;background:#eef}
+        .tail{height:120pt;background:#cef;margin-top:12pt}
+    </style></head><body>
+        <div class="filler"></div>
+        <div class="tail">tail content on page 2</div>
+    </body></html>"##;
+    let pdf_baseline = engine.render_html_v2(html_baseline).expect("v2 render");
+    assert!(
+        pdf.len() * 100 >= pdf_baseline.len() * 85,
+        "with-html-opacity PDF lost too much content vs baseline \
+         (with={}B baseline={}B); did root exclusion regress?",
+        pdf.len(),
+        pdf_baseline.len(),
+    );
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -709,6 +709,38 @@ fn render_v2_smoke_transform_inside_overflow_clip() {
 }
 
 #[test]
+fn render_v2_smoke_body_overflow_hidden_multi_page_content_survives() {
+    // Regression for PR #310 follow-up Devin: `<body style="overflow:
+    // hidden|auto|scroll">` previously blanked every descendant on
+    // page 1+. The fragmenter records body with a single fragment at
+    // `page_index=0`, so `draw_under_clip(body)` would only fire on
+    // page 0; the main loop's `clipped_descendants.contains` guard
+    // then ate every body descendant on every page, leaving page 1+
+    // with only the body bg pre-pass and nothing else.
+    //
+    // Render with `body{overflow:hidden}` AND with a tall enough
+    // child to force multi-page output, and assert the v2 PDF size
+    // stays close to the no-overflow render (within 5%). If the bug
+    // returns, page 1's content stream collapses and the PDF shrinks
+    // dramatically.
+    let with_clip = r##"<!DOCTYPE html><html><head><style>html,body{margin:0;padding:0;background:#fff}body{overflow:hidden}.tall{height:1500px;background:#cef}</style></head><body><div class="tall"></div></body></html>"##;
+    let without_clip = r##"<!DOCTYPE html><html><head><style>html,body{margin:0;padding:0;background:#fff}.tall{height:1500px;background:#cef}</style></head><body><div class="tall"></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf_clip = engine.render_html_v2(with_clip).expect("v2 render w/ clip");
+    let pdf_plain = engine
+        .render_html_v2(without_clip)
+        .expect("v2 render w/o clip");
+    let ratio = pdf_clip.len() as f32 / pdf_plain.len() as f32;
+    assert!(
+        ratio > 0.95 && ratio < 1.05,
+        "body overflow:hidden v2 size ({} B) diverges too much from baseline ({} B); \
+         likely indicates page 1+ content was dropped by the clipped_descendants pre-skip",
+        pdf_clip.len(),
+        pdf_plain.len(),
+    );
+}
+
+#[test]
 fn render_v2_smoke_list_item_overflow_clip_with_opacity() {
     // Exercises `draw_under_clip`'s list_items branch added in PR #310
     // Devin fix: when the clipped block's NodeId also has a

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -859,3 +859,47 @@ fn render_v2_smoke_multicol_rule_inside_transform() {
     let pdf = engine.render_html_v2(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
+
+#[test]
+fn render_v2_smoke_opacity_descendants_block_with_svg() {
+    // Regression for fulgur-gdb9: a fractional-opacity block wrapping
+    // a child element of a different node_id (the canonical
+    // `<div opacity:0.4><svg>..</svg></div>` shape) must paint the
+    // svg INSIDE the parent's `draw_with_opacity` group. Without
+    // `BlockEntry.opacity_descendants` + `draw_under_opacity`, v2's
+    // flat dispatch paints svg at full opacity and double-emits the
+    // transparency group. This smoke exercises the new
+    // `draw_under_opacity` arm in `dispatch_fragment`'s precedence
+    // chain.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.faded{opacity:0.4}</style></head><body><div class="faded"><svg xmlns="http://www.w3.org/2000/svg" width="40" height="40"><rect width="40" height="40" fill="#1a6faa"/></svg></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn render_v2_smoke_opacity_inside_overflow_clip() {
+    // Composition: a clipping ancestor with an opacity-scoped
+    // descendant. Exercises the new `nested_opacity_skip` set inside
+    // `draw_under_clip`'s descendant loop and the `draw_under_opacity`
+    // arm in the recursive descend. Without the skip, the inner
+    // opacity block's strict descendants would dispatch twice (once
+    // by the clip's main loop iteration, once under the opacity
+    // wrap).
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.clip{overflow:hidden;width:120pt;height:80pt}.faded{opacity:0.5}</style></head><body><div class="clip"><div class="faded"><svg xmlns="http://www.w3.org/2000/svg" width="60" height="60"><circle cx="30" cy="30" r="25" fill="#e74c3c"/></svg></div></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn render_v2_smoke_opacity_inside_transform() {
+    // Composition: a transformed ancestor with an opacity-scoped
+    // descendant. Exercises the new `opacity_skip` set inside
+    // `draw_under_transform`'s descendant loop and the
+    // `draw_under_opacity` arm in the recursive descend.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.tx{transform:rotate(5deg)}.faded{opacity:0.6}</style></head><body><div class="tx"><div class="faded"><svg xmlns="http://www.w3.org/2000/svg" width="40" height="40"><rect width="40" height="40" fill="#27ae60"/></svg></div></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -937,3 +937,40 @@ fn render_v2_smoke_anonymous_block_inline_level_sibling() {
         pdf_no_badge.len(),
     );
 }
+
+#[test]
+fn render_v2_smoke_split_block_uses_per_slice_height() {
+    // Regression for fulgur-bq6i:break-inside — when a block spans
+    // multiple pages (the fragmenter records one fragment per page
+    // slice), `draw_block_inner_paint` must paint each slice at its
+    // per-page `frag.height` rather than the block's full
+    // `layout_size.height`. Without this, the block's bg / border
+    // paints full-size on every slice, leaking past the page bottom on
+    // earlier slices and double-painting on the continuation page.
+    //
+    // Construct a body that overflows page 1 with a tall styled box
+    // straddling the page break. The styled box has a colored bg so a
+    // full-height repaint on page 2 (the bug) would emit an
+    // unmistakably oversized rect — verifiable via PDF size: split
+    // version stays close to single-page version + per-slice paints,
+    // not 2× the block-area worth of bg fills.
+    let html = r##"<!DOCTYPE html><html><head><style>
+        body{margin:0;padding:0;font-size:10pt}
+        .filler{height:600pt;background:#eef}
+        .box{height:300pt;background:#cef;border:2pt solid #44a}
+    </style></head><body>
+        <div class="filler"></div>
+        <div class="box"></div>
+    </body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+    // Sanity: must produce a multi-page PDF (the box straddles page
+    // bottom).
+    let pdf_str = String::from_utf8_lossy(&pdf);
+    let page_count = pdf_str.matches("/Type /Page\n").count();
+    assert!(
+        page_count >= 2,
+        "expected multi-page output for split block, got {page_count}",
+    );
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -1111,3 +1111,40 @@ fn render_v2_smoke_split_opacity_block_uses_per_slice_height() {
         "expected multi-page output for split-opacity test, got {page_count}",
     );
 }
+
+#[test]
+fn render_v2_smoke_split_overflow_clip_block_uses_per_slice_height() {
+    // Regression for PR #313 follow-up Devin Review: an
+    // `overflow: hidden` block that spans multiple pages must
+    // paint its bg / border / shadow at the per-page slice height
+    // (`frag.height`) and push a clip rectangle of the slice
+    // height too — not at the full `layout_size.height`.
+    //
+    // PR #316 added `is_split` height handling to
+    // `draw_block_inner_paint`; PR #314 follow-up added it to
+    // `draw_under_opacity`; this test guards `draw_under_clip`
+    // (the third parallel paint path). Without the fix, the
+    // overflow:hidden block overflows the page bottom on earlier
+    // slices AND the clip rectangle on continuation pages covers
+    // content that should be cut off.
+    let html = r##"<!DOCTYPE html><html><head><style>
+        body{margin:0;padding:0;font-size:10pt}
+        .filler{height:600pt;background:#eef}
+        .clip{overflow:hidden;height:300pt;background:#cef;border:2pt solid #44a;margin-top:12pt}
+        .clip > .inner{height:60pt;background:#fef;margin:6pt}
+    </style></head><body>
+        <div class="filler"></div>
+        <div class="clip"><div class="inner">clipped content</div></div>
+    </body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+    // Multi-page sanity (filler 600pt + clip 300pt + 12pt margin
+    // = 912pt > A4 ~842pt content height).
+    let pdf_str = String::from_utf8_lossy(&pdf);
+    let page_count = pdf_str.matches("/Type /Page\n").count();
+    assert!(
+        page_count >= 2,
+        "expected multi-page output for split-overflow-clip test, got {page_count}",
+    );
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -1009,3 +1009,105 @@ fn render_v2_smoke_body_layout_children_for_form_siblings() {
         pdf_no_inline.len(),
     );
 }
+
+#[test]
+fn render_v2_smoke_body_opacity_multi_page_content_survives() {
+    // Regression for PR #314 follow-up Devin Review:
+    // `body { opacity: 0.5 }` with content that spans multiple
+    // pages must NOT silently blank pages 1+. The `body` element
+    // gets exactly one fragment at `page_index = 0`
+    // (`pagination_layout.rs:380-384`), so
+    // `draw_under_opacity(body)` only fires on page 0. If body's
+    // descendants are added to `opacity_wrapped_descendants`
+    // unconditionally, they get skipped on pages 1+ by the
+    // `opacity_wrapped_descendants.contains(...)` guard but no-one
+    // dispatches them — silently blanking everything after page 1.
+    //
+    // Body is now excluded from `opacity_wrapped_descendants` (and
+    // from the `draw_under_opacity` dispatch arm) for the same
+    // reason `clipped_descendants` excludes it (PR #310 Devin).
+    let html = r##"<!DOCTYPE html><html><head><style>
+        body{margin:0;padding:0;opacity:0.5;font-size:10pt}
+        .filler{height:800pt;background:#eef}
+        .tail{height:120pt;background:#cef;margin-top:12pt}
+    </style></head><body>
+        <div class="filler"></div>
+        <div class="tail">tail content on page 2</div>
+    </body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+    // Sanity: must be multi-page (filler 800pt + tail 132pt > A4
+    // content height of ~842pt).
+    let pdf_str = String::from_utf8_lossy(&pdf);
+    let page_count = pdf_str.matches("/Type /Page\n").count();
+    assert!(
+        page_count >= 2,
+        "expected multi-page output for body-opacity test, got {page_count}",
+    );
+    // Compare to a no-opacity baseline. Without the body exclusion
+    // fix, body's descendants on page 2 silently disappear and the
+    // PDF shrinks compared to the no-opacity version. The opacity-
+    // group XObject adds a small constant; the test simply asserts
+    // the with-opacity PDF retains MOST of the no-opacity content
+    // (i.e. didn't lose page 2 entirely).
+    let html_baseline = r##"<!DOCTYPE html><html><head><style>
+        body{margin:0;padding:0;font-size:10pt}
+        .filler{height:800pt;background:#eef}
+        .tail{height:120pt;background:#cef;margin-top:12pt}
+    </style></head><body>
+        <div class="filler"></div>
+        <div class="tail">tail content on page 2</div>
+    </body></html>"##;
+    let pdf_baseline = engine.render_html_v2(html_baseline).expect("v2 render");
+    // Allow some room for the opacity group XObject overhead but
+    // require at least 90% of the baseline content survives. A real
+    // regression (silent page-2 blanking) drops the size by far more
+    // than 10%.
+    assert!(
+        pdf.len() * 100 >= pdf_baseline.len() * 90,
+        "with-opacity PDF lost too much content vs baseline \
+         (with={}B baseline={}B); did body exclusion regress?",
+        pdf.len(),
+        pdf_baseline.len(),
+    );
+}
+
+#[test]
+fn render_v2_smoke_split_opacity_block_uses_per_slice_height() {
+    // Regression for PR #314 follow-up Devin Review: a fractional-
+    // opacity block with descendants that ALSO spans multiple pages
+    // (split slice) must paint each per-page slice at its
+    // `frag.height`, not the full `layout_size.height`. v2's
+    // `draw_under_opacity` inlines the bg / border / shadow paint;
+    // without the `is_split` height fix that
+    // `draw_block_inner_paint` got in PR #316, the inlined paint
+    // overflows the page bottom on earlier slices and double-paints
+    // on continuation pages.
+    //
+    // Construct a body with a tall opacity-wrapped block (containing
+    // a same-node_id-different SVG descendant so the opacity arm
+    // fires) that straddles the page boundary.
+    let html = r##"<!DOCTYPE html><html><head><style>
+        body{margin:0;padding:0;font-size:10pt}
+        .filler{height:600pt;background:#eef}
+        .opaque{opacity:0.5;height:300pt;background:#cef;border:2pt solid #44a;margin-top:12pt}
+    </style></head><body>
+        <div class="filler"></div>
+        <div class="opaque">
+            <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40">
+                <rect width="40" height="40" fill="#1a6faa"/>
+            </svg>
+        </div>
+    </body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+    // Multi-page sanity.
+    let pdf_str = String::from_utf8_lossy(&pdf);
+    let page_count = pdf_str.matches("/Type /Page\n").count();
+    assert!(
+        page_count >= 2,
+        "expected multi-page output for split-opacity test, got {page_count}",
+    );
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -710,3 +710,70 @@ fn render_v2_smoke_triple_nested_transform_descendants() {
     let pdf = engine.render_html_v2(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
+
+#[test]
+fn render_v2_smoke_multicol_dashed_and_dotted_column_rule() {
+    // Exercises the `ColumnRuleStyle::Dashed` and `Dotted` arms of
+    // `build_multicol_stroke` (`render.rs:613-627` from PR #305).
+    // Solid is already covered by the `multicol-2` VRT fixture but
+    // dashed/dotted patterns weren't on any byte-eq path.
+    let html_dashed = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:8pt}.cols{column-count:2;column-rule:1pt dashed #888;column-gap:12pt;height:80pt}.cell{height:30pt;background:#cef;margin-bottom:6pt}</style></head><body><div class="cols"><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div></body></html>"##;
+    let html_dotted = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:8pt}.cols{column-count:2;column-rule:1pt dotted #888;column-gap:12pt;height:80pt}.cell{height:30pt;background:#cef;margin-bottom:6pt}</style></head><body><div class="cols"><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf_dashed = engine.render_html_v2(html_dashed).expect("dashed render");
+    let pdf_dotted = engine.render_html_v2(html_dotted).expect("dotted render");
+    assert!(!pdf_dashed.is_empty());
+    assert!(!pdf_dotted.is_empty());
+}
+
+#[test]
+fn render_v2_smoke_paragraph_multi_fragment_slice() {
+    // Exercises `paragraph_lines_for_page` (`render.rs:1075-1138`
+    // from PR #305): a paragraph that splits across multiple pages
+    // requires the slice / rebase logic. Most fixtures keep
+    // paragraphs on one page, so this branch needs an explicit
+    // multi-page paragraph.
+    let mut paragraph_text = String::new();
+    for i in 0..400 {
+        use std::fmt::Write;
+        write!(&mut paragraph_text, "Sentence {i} with some words. ").unwrap();
+    }
+    let html = format!(
+        r##"<!DOCTYPE html><html><head><style>html,body{{margin:0;padding:0}}p{{margin:0;font-size:14pt;line-height:1.4}}</style></head><body><p>{paragraph_text}</p></body></html>"##
+    );
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(&html).expect("v2 render");
+    assert!(!pdf.is_empty());
+    // Multi-page sanity check: multiple `Type /Page` entries (one per
+    // page object) — without slicing, only the first fragment would
+    // emit any glyphs.
+    let pdf_str = String::from_utf8_lossy(&pdf);
+    let page_count = pdf_str.matches("/Type /Page\n").count();
+    assert!(
+        page_count >= 2,
+        "expected multi-page output, got {page_count} pages"
+    );
+}
+
+#[test]
+fn render_v2_smoke_list_item_image_marker() {
+    // Exercises `draw_list_item_marker`'s `ListItemMarker::Image` arm
+    // (`render.rs:1004-1019` from PR #305): a `<li>` rendered with a
+    // raster `list-style-image` so the marker takes the
+    // `ImageMarker::Raster` branch instead of the text/glyph default.
+    let png_data: Vec<u8> = vec![
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90,
+        0x77, 0x53, 0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0xF8,
+        0xCF, 0xC0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00, 0xC9, 0xFE, 0x92, 0xEF, 0x00, 0x00, 0x00,
+        0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+    ];
+    let mut bundle = AssetBundle::default();
+    bundle.add_css(r#"li { list-style-image: url("bullet.png"); }"#);
+    bundle.add_image("bullet.png", png_data);
+    let html =
+        r##"<!doctype html><html><body><ul><li>Item 1</li><li>Item 2</li></ul></body></html>"##;
+    let engine = Engine::builder().assets(bundle).build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -903,3 +903,37 @@ fn render_v2_smoke_opacity_inside_transform() {
     let pdf = engine.render_html_v2(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
+
+#[test]
+fn render_v2_smoke_anonymous_block_inline_level_sibling() {
+    // Regression for fulgur-bq6i (review_card_inline_block):
+    // a block container with mixed block-level and inline-level
+    // children triggers Stylo's anonymous-block synthesis (CSS 2.1
+    // §9.2.1.1). The anonymous wrapper has its own `node_id` and
+    // appears in `Node.layout_children` but NOT in `Node.children`.
+    // The fragmenter's `record_subtree_descendants` previously
+    // walked `children`, missing the wrapper and silently dropping
+    // the inline-level child's paint. Now `layout_children` is
+    // preferred when `Some`.
+    //
+    // Without the fix, the BADGE span content (background + text)
+    // never paints in v2 because its wrapping inline-root
+    // paragraph's `node_id` lacks a geometry entry, so
+    // `dispatch_fragment` skips it. The size-comparison sanity
+    // check below catches a regression where the anonymous-block
+    // walk gets dropped: with-badge PDF must be measurably larger
+    // than no-badge PDF.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.card{padding:8pt}.label{display:inline-block;background:#cef;padding:2pt 6pt}</style></head><body><div class="card"><div>block child</div><span class="label">BADGE</span></div></body></html>"##;
+    let html_no_badge = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.card{padding:8pt}</style></head><body><div class="card"><div>block child</div></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    let pdf_no_badge = engine.render_html_v2(html_no_badge).expect("v2 render");
+    assert!(!pdf.is_empty());
+    assert!(
+        pdf.len() > pdf_no_badge.len(),
+        "expected BADGE rendering to produce more bytes than no-badge \
+         baseline (got {} vs {}); did anonymous-block walk regress?",
+        pdf.len(),
+        pdf_no_badge.len(),
+    );
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -626,3 +626,72 @@ fn position_fixed_repeats_on_every_page() {
         "page 2 should also contain FXFXFX (per-page repetition for position:fixed)"
     );
 }
+
+// ── Phase 4 v2 render path smoke tests (fulgur-9t3z) ─────────────────
+//
+// Exercise the v2 dispatcher (`render_v2`) so the patch-coverage gate
+// sees the new draw helpers added in PR 6 (`draw_under_transform`,
+// `draw_under_clip`, `draw_under_opacity`, `paint_multicol_rule_for_page`,
+// `paint_root_block_v2`, `MarginBoxRenderer`). These run end-to-end
+// through `Engine::render_html_v2` and assert only that the bytes
+// come back non-empty — byte-eq with v1 is already covered by the
+// `render_path_parity` shadow harness.
+
+#[test]
+fn render_v2_smoke_transform_translate() {
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0}.box{width:80px;height:60px;background:#cef;transform:translate(10px,5px)}</style></head><body><div class="box"></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn render_v2_smoke_nested_transforms() {
+    // Exercises the `draw_under_transform` recursion path added in
+    // PR #305 Devin fix: outer rotate wraps an inner translate, both
+    // matrices must compose.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0}.outer{width:120px;height:80px;background:#cef;transform:rotate(10deg)}.inner{width:60px;height:40px;background:#fce;transform:translate(8px,4px)}</style></head><body><div class="outer"><div class="inner"></div></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn render_v2_smoke_multicol_with_column_rule() {
+    // Exercises `paint_multicol_rule_for_page` — most fixtures don't
+    // declare `column-rule` so this path needs an explicit smoke test.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:8pt}.cols{column-count:2;column-rule:1pt solid #888;column-gap:12pt;height:80pt}.cell{height:30pt;background:#cef;margin-bottom:6pt}</style></head><body><div class="cols"><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn render_v2_smoke_html_body_bg_multi_page() {
+    // Exercises `paint_root_block_v2` for both `<html>` (pre-pass on
+    // every page) and `<body>` (pre-pass on continuation pages).
+    let html = r##"<!DOCTYPE html><html><head><style>html,body{margin:0;background:#fafafa}.tall{height:1500px;background:#cef}</style></head><body><div class="tall"></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn render_v2_smoke_block_with_inline_root_padding() {
+    // Exercises `draw_block_with_inner_content` content-inset path —
+    // the `padding: 6px` shift fix that landed in PR 6.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0}p{margin:0;padding:6px;background:#cef}</style></head><body><p>hello</p></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn render_v2_smoke_bookmarks_under_transform() {
+    // Exercises the bookmark-anchor pre-skip path (`record(...)` runs
+    // before `transformed_descendants` skip) added in PR 6 Devin fix.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0}div{transform:rotate(5deg)}h1{margin:0;font-size:14px}</style></head><body><div><h1>Heading</h1></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().bookmarks(true).build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -710,3 +710,17 @@ fn render_v2_smoke_triple_nested_transform_descendants() {
     let pdf = engine.render_html_v2(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
+
+#[test]
+fn render_v2_smoke_list_item_overflow_clip_with_opacity() {
+    // Exercises `draw_under_clip`'s list_items branch added in PR #310
+    // Devin fix: when the clipped block's NodeId also has a
+    // `ListItemEntry`, the outer opacity wrap must use
+    // `list_item.opacity` (the body block carries default opacity=1.0
+    // from `convert::list_item::build_list_item_body`) and the marker
+    // must paint before `push_clip_path`.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}ul{margin:0;padding:0 0 0 24px}li{background:#cef;overflow:hidden;opacity:0.5}.inner{height:30px;background:#fce}</style></head><body><ul><li><div class="inner"></div></li></ul></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -695,3 +695,18 @@ fn render_v2_smoke_bookmarks_under_transform() {
     let pdf = engine.render_html_v2(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
+
+#[test]
+fn render_v2_smoke_triple_nested_transform_descendants() {
+    // Exercises the `nested_skip` pre-collection in
+    // `draw_under_transform` added in PR #305 follow-up Devin: the
+    // outer transform's `descendants` includes the inner transform's
+    // own descendants (e.g. a styled grandchild block), so the
+    // outer's iteration must skip them or they get painted twice —
+    // once correctly under outer*inner via the recursion, and once
+    // wrongly under outer only.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0}.outer{width:200px;height:120px;background:#cef;transform:translate(8px,4px)}.inner{width:120px;height:80px;background:#fce;transform:rotate(5deg)}.leaf{width:40px;height:20px;background:#ffd}</style></head><body><div class="outer"><div class="inner"><div class="leaf"></div></div></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -974,3 +974,38 @@ fn render_v2_smoke_split_block_uses_per_slice_height() {
         "expected multi-page output for split block, got {page_count}",
     );
 }
+
+#[test]
+fn render_v2_smoke_body_layout_children_for_form_siblings() {
+    // Regression for fulgur-bq6i:wasm-demo — body with mixed
+    // block-level and inline-level children triggers Stylo's
+    // anonymous-block synthesis at the BODY level (CSS 2.1
+    // §9.2.1.1). The synthesized wrapper appears in
+    // `body.layout_children` but NOT in `body.children`, so the
+    // fragmenter's `fragment_pagination_root` (now preferring
+    // `layout_children` when non-empty) must visit it for v2 to
+    // see the inline-level group's paint.
+    //
+    // Without this fix, a body containing
+    // `<h1>title</h1><label>field: <input></label>` paints only
+    // the h1; the label + input row gets dropped because its
+    // anonymous wrapper isn't visited.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:8pt;font-size:10pt}label{margin-right:8pt}input{padding:2pt;border:1pt solid #888;width:120pt}</style></head><body><h1>Form sample</h1><label>Name:</label><input type="text" value="hello"></body></html>"##;
+    let html_no_inline = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:8pt;font-size:10pt}</style></head><body><h1>Form sample</h1></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    let pdf_no_inline = engine.render_html_v2(html_no_inline).expect("v2 render");
+    assert!(!pdf.is_empty());
+    // Sanity: body with inline-level form siblings produces a
+    // larger PDF than h1-only baseline. Without the body-level
+    // layout_children walk, the label + input row is dropped and
+    // the two sizes converge.
+    assert!(
+        pdf.len() > pdf_no_inline.len(),
+        "expected form-row rendering to produce more bytes than \
+         h1-only baseline (got {} vs {}); did body layout_children \
+         walk regress?",
+        pdf.len(),
+        pdf_no_inline.len(),
+    );
+}


### PR DESCRIPTION
## 概要

Phase 4 (fulgur-9t3z) PR 3 を起点に、PR 4-6 とその follow-up を全部 stack マージで取り込んだ集大成 PR。Pageable trait 削除に向けた v2 (geometry + Drawables) render 経路の中核実装が揃い、shadow harness (`render_path_parity.toml`) で 59 fixture 中 51 が v1/v2 byte-identical、その全件が allowlist 登録済み (= 残 8 件のみ未対応)。

beads: fulgur-9t3z (epic) / fulgur-ccjx (PR 3 起点) / fulgur-ekz7 (overflow clip) / fulgur-rtza (GCPM margin box) / fulgur-9y1a (residual fixes)

## 取り込み済み stacked PRs

| PR | スコープ | head |
|---|---|---|
| #303 | Block migration (BlockEntry: bg/border/shadow/clip/opacity) | feat/phase4-pr4-block |
| #304 | Table + ListItem migration | feat/phase4-pr5-table-listitem |
| #305 | Transform + MulticolRule | feat/phase4-pr6-transform-multicol |
| #307 | residual cleanup | feat/phase4-pr6-residual |
| #308 | InlineBox no-recurse (double-paint fix) | feat/phase4-pr6-residual-2 |
| #309 | GCPM `@page` margin box port (fulgur-rtza) | feat/phase4-pr6-gcpm-margin-box |
| #310 | overflow:hidden / opacity scope tracking (fulgur-ekz7) | feat/phase4-pr6-overflow-clip |

各 PR の Devin / CodeRabbit findings は本 PR head で fix 済 (詳細は個別 commit message を参照)。最新 follow-up は `565cb2b` (multicol column-rule を transform scope 内で paint)。

## v1/v2 parity 進捗

| 観点 | 現値 |
|---|---|
| on-disk fixtures (`crates/fulgur-vrt/manifest.toml` + `examples/`) | 59 |
| v2 byte-identical | 51 |
| `render_path_parity.toml` allowlist | 51 |
| inline byte-eq cases (`inline_byte_equality_cases`) | 23 |

`FONTCONFIG_FILE=examples/.fontconfig/fonts.conf cargo test -p fulgur --test render_path_parity` で allowlist 全件パス。

### 残 8 fixtures (PR 7 default flip 前に解消が必要)

| label | v1 / v2 (B) | 差 |
|---|---|---|
| vrt://layout/review_card_inline_block.html | 21616 / 20492 | -1124 |
| vrt://bugs/grid-row-promote-background.html | 2732 / 2717 | -15 |
| examples://box-shadow | 32726 / 32726 | 0 (内容差) |
| examples://break-inside | 66628 / 66632 | +4 |
| examples://multicol | 36481 / 36482 | +1 |
| examples://multicol-span-all | 50333 / 50333 | 0 (内容差) |
| examples://svg | 39438 / 39361 | -77 |
| examples://wasm-demo | 43093 / 40763 | -2330 |

## render_v2 dispatcher の主な追加

- `Drawables` 拡張: `block_styles` / `tables` / `list_items` / `transforms` / `multicol_rules` / `paragraphs` / `images` / `svgs` / `bookmark_anchors` / `body_id` / `body_offset_pt`
- `BlockEntry.clip_descendants` で overflow:hidden の strict descendants を pre-collect、`draw_under_clip` で `push_clip / pop` 群内に dispatch
- `TransformEntry.descendants` 同形、`draw_under_transform` で `push_transform / pop` 群内に dispatch
- 双方向の nested 対応: clip-inside-transform / transform-inside-clip / nested clip / nested transform を全て pre-skip + 再帰 dispatch
- `MarginBoxRenderer` を v1/v2 で共有 (GCPM `@page` margin box を v2 でも byte-identical に paint)
- list-item marker は `draw_under_clip` 内でも `push_clip_path` の前に paint (markers が body 負 x 域に居る前提)
- root `<html>` / `<body>` の bg pre-pass: 継続ページで body bg を確実に paint
- `body{overflow:hidden}` は v2 では silently drop (pre-PR 挙動と一致)。fragmenter は body fragment を page 0 のみ記録するため、clip_descendants が page 1+ で feasible でない

## codecov

- target 91.70% に対して PR head 単独でカバー補強済み (`render_smoke.rs` に lib smoke 多数追加: nested transforms, transform inside overflow:hidden, list_item overflow clip + opacity, body overflow:hidden continuation, multicol rule inside transform, paragraph multi-fragment slice, image marker, dashed/dotted column-rule など)
- ローカル `cargo llvm-cov nextest --workspace --exclude fulgur-vrt` 計測で render.rs 94.30% / convert/mod.rs 98.35% (combined patch ~95.46%)

## Verification

- `cargo build -p fulgur` — 0 warning
- `cargo clippy -p fulgur --all-targets` — 0 warning
- `cargo fmt --check` — 整形済み
- `cargo test -p fulgur --lib` — 847 pass
- `cargo test -p fulgur --test render_path_parity` — 両 test pass (allowlist 51 件)
- `cargo test -p fulgur --test render_smoke` — 44 pass
- `cargo test -p fulgur-vrt` — regression なし

## 次

- 残 8 divergent fixtures の調査 + 修正 (上表)
- PR 7 (default flip): `Engine::render_html` を v2 経路に切り替え
- PR 8: `Pageable` trait + 17 impl 削除 (epic fulgur-9t3z 完了)

## Stacking

base = `feat/pageable-replacement` (PR #290)。本 PR が `feat/pageable-replacement` にマージされた後、PR #290 が main にマージされる予定。