### PR TITLE
feat(render_v2): Phase 4 PR 5 — Table / ListItem + body offset propagation (fulgur-9t3z.2)

### DIFF
--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -200,7 +200,35 @@ pub fn dom_to_drawables(
     let mut drawables = crate::drawables::Drawables::new();
     extract_drawables_from_pageable(root_pageable.as_ref(), &mut drawables);
     drawables.bookmark_anchors = extract_bookmark_anchors(doc, &bookmark_snapshot, ctx.assets);
+    drawables.body_offset_pt = extract_body_offset_pt(doc);
     drawables
+}
+
+/// Phase 4 PR 5: walk the DOM looking for `<body>` and return its
+/// `(location.x, location.y)` in pt. The fragmenter records body's
+/// own fragment at `(body_x, 0)` (body-content-area relative) and
+/// slicing depends on that frame; the html → body offset that CSS
+/// margin collapsing puts onto `body.location` lives separately so
+/// `render_v2` can add it to per-fragment draw positions.
+fn extract_body_offset_pt(doc: &HtmlDocument) -> (f32, f32) {
+    use std::ops::Deref;
+    let base = doc.deref();
+    let root = doc.root_element();
+    let Some(root_node) = base.get_node(root.id) else {
+        return (0.0, 0.0);
+    };
+    for &child_id in &root_node.children {
+        let Some(child) = base.get_node(child_id) else {
+            continue;
+        };
+        if let blitz_dom::NodeData::Element(elem) = &child.data
+            && elem.name.local.as_ref() == "body"
+        {
+            let (x, y, _, _) = layout_in_pt(&child.final_layout);
+            return (x, y);
+        }
+    }
+    (0.0, 0.0)
 }
 
 /// Walk a Pageable tree and populate each `Drawables` map by
@@ -210,7 +238,9 @@ fn extract_drawables_from_pageable(
     pageable: &dyn crate::pageable::Pageable,
     out: &mut crate::drawables::Drawables,
 ) {
-    use crate::drawables::{BlockEntry, ImageEntry, ParagraphEntry, SvgEntry};
+    use crate::drawables::{
+        BlockEntry, ImageEntry, ListItemEntry, ParagraphEntry, SvgEntry, TableEntry,
+    };
     use crate::image::ImagePageable;
     use crate::pageable::{
         BlockPageable, BookmarkMarkerWrapperPageable, CounterOpWrapperPageable, ListItemPageable,
@@ -307,6 +337,20 @@ fn extract_drawables_from_pageable(
         return;
     }
     if let Some(table) = any.downcast_ref::<TablePageable>() {
+        if let Some(node_id) = table.node_id {
+            out.tables.insert(
+                node_id,
+                TableEntry {
+                    style: table.style.clone(),
+                    opacity: table.opacity,
+                    visible: table.visible,
+                    id: table.id.clone(),
+                    layout_size: table.layout_size,
+                    width: table.width,
+                    cached_height: table.cached_height,
+                },
+            );
+        }
         for pc in &table.header_cells {
             extract_drawables_from_pageable(pc.child.as_ref(), out);
         }
@@ -316,6 +360,17 @@ fn extract_drawables_from_pageable(
         return;
     }
     if let Some(list_item) = any.downcast_ref::<ListItemPageable>() {
+        if let Some(node_id) = list_item.node_id {
+            out.list_items.insert(
+                node_id,
+                ListItemEntry {
+                    marker: list_item.marker.clone(),
+                    marker_line_height: list_item.marker_line_height,
+                    opacity: list_item.opacity,
+                    visible: list_item.visible,
+                },
+            );
+        }
         extract_drawables_from_pageable(list_item.body.as_ref(), out);
         return;
     }

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -97,14 +97,48 @@ pub struct SvgEntry {
     pub visible: bool,
 }
 
-/// PR 5 target: table layout state — header cell ids, body cell offsets,
-/// header height. Per-page slicing happens at render time.
-#[derive(Debug, Clone, Default)]
-pub struct TableEntry;
+/// Table draw payload for v2. Holds the border-box paint state
+/// (background / borders / shadow) applied to the table's outer
+/// frame. Cell content (`<th>` / `<td>`) lives as separate
+/// `BlockEntry` / `ParagraphEntry` keyed by the cell's own NodeId
+/// and paints through the standard per-NodeId dispatch.
+///
+/// Multi-page header repetition (`<thead>` cloned on continuation
+/// pages) is **not** modelled in PR 5; single-page tables byte-eq
+/// already, multi-page tables follow in a later PR alongside the
+/// per-block clip work.
+#[derive(Debug, Clone)]
+pub struct TableEntry {
+    pub style: crate::pageable::BlockStyle,
+    pub opacity: f32,
+    pub visible: bool,
+    pub id: Option<std::sync::Arc<String>>,
+    pub layout_size: Option<crate::pageable::Size>,
+    pub width: f32,
+    pub cached_height: f32,
+}
 
-/// PR 5 target: list item marker + body wrapper data.
-#[derive(Debug, Clone, Default)]
-pub struct ListItemEntry;
+/// List-item marker payload for v2. The body block paints itself
+/// through `BlockEntry`; `ListItemEntry` only carries the marker
+/// (text / image / svg / none) and the line-height needed to
+/// vertically centre image markers.
+#[derive(Clone)]
+pub struct ListItemEntry {
+    pub marker: crate::pageable::ListItemMarker,
+    pub marker_line_height: f32,
+    pub opacity: f32,
+    pub visible: bool,
+}
+
+impl std::fmt::Debug for ListItemEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ListItemEntry")
+            .field("marker_line_height", &self.marker_line_height)
+            .field("opacity", &self.opacity)
+            .field("visible", &self.visible)
+            .finish()
+    }
+}
 
 /// PR 6 target: column-rule paint spec + per-column-group geometry.
 #[derive(Debug, Clone, Default)]
@@ -137,6 +171,16 @@ pub struct LinkSpanEntry;
 /// fill each map by migrating one Pageable type at a time.
 #[derive(Debug, Default, Clone)]
 pub struct Drawables {
+    /// `body_layout.location.x/y` in pt. Captures the html → body
+    /// offset that CSS margin collapsing folds onto the body element.
+    /// `render_v2` adds this to every per-fragment `(x, y)` so v2 paint
+    /// matches v1's `html → body @ pc=(body.x, body.y)` chain exactly.
+    /// Pre-Phase-4 the fragmenter intentionally records body's own
+    /// fragment at `y=0` in body-content-area-relative coordinates and
+    /// downstream slicing logic depends on that — keeping it relative
+    /// in geometry but absolute on Drawables avoids touching the
+    /// fragmenter contract.
+    pub body_offset_pt: (f32, f32),
     pub block_styles: BTreeMap<NodeId, BlockEntry>,
     pub paragraphs: BTreeMap<NodeId, ParagraphEntry>,
     pub images: BTreeMap<NodeId, ImageEntry>,
@@ -157,6 +201,11 @@ impl Drawables {
     /// `true` when no draw payload has been registered for any node.
     /// PR 1 always returns `true` because the convert side has not
     /// migrated yet.
+    ///
+    /// `body_offset_pt` is intentionally excluded — it is a global
+    /// coordinate offset (e.g. `body { margin: 8px }`), not a per-node
+    /// draw payload, so an empty `<body>` with default browser margins
+    /// should still report `true`.
     pub fn is_empty(&self) -> bool {
         self.block_styles.is_empty()
             && self.paragraphs.is_empty()

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -735,9 +735,18 @@ impl<'a> PaginationLayoutTree<'a> {
                 cursor_y = 0.0;
             }
 
+            // Phase 4 PR 5 fix: include `layout.location.x` so the
+            // child's left margin / padding offset within body is
+            // captured. Pre-Phase-4 the fragmenter only fed
+            // `slice_for_page` which doesn't read `frag.x`, so
+            // `body_x` alone happened to be enough; the new
+            // geometry-driven render path now consults `frag.x` for
+            // every Block / Image / Paragraph and reverts to v2
+            // drawing at x=0 without this. Matches the descendant
+            // fragment shape on the line below.
             let frag = Fragment {
                 page_index,
-                x: body_x,
+                x: body_x + layout.location.x,
                 y: cursor_y,
                 width: child_w,
                 height: child_h,
@@ -838,7 +847,23 @@ fn record_subtree_descendants(
         let layout = child.final_layout;
         let h = layout.size.height;
         let w = layout.size.width;
+        // Phase 4 PR 5: zero-size containers (`<tbody>`, `<tr>`,
+        // anonymous boxes) carry no paint payload but DO host visible
+        // descendants (e.g. table cells) that v2 needs in geometry.
+        // Skipping them entirely leaves cells out of `geometry`; the
+        // dispatcher then never finds the cell node_ids and v2 emits
+        // a blank table. Recurse without recording when h/w are
+        // both zero so the descendant cells still register.
         if h <= 0.0 && w <= 0.0 {
+            record_subtree_descendants(
+                geometry,
+                doc,
+                child_id,
+                page_index,
+                parent_page_y + layout.location.y,
+                parent_x_in_body + layout.location.x,
+                depth + 1,
+            );
             continue;
         }
         let child_x = parent_x_in_body + layout.location.x;

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -194,15 +194,39 @@ fn draw_v2_page(
                 draw_table_v2(canvas, table, x_pt, y_pt, frag);
                 continue;
             }
-            // ListItem marker draws before block frame. v1's
-            // `ListItemPageable::draw` calls `self.body.draw(...)` so
-            // the body block's background / border paint underneath the
-            // marker (`pageable.rs:3362`). `<li>` and its body
-            // BlockPageable share the same node_id (`convert/list_item.rs:81`),
-            // so `block_styles[node_id]` carries the body block style;
-            // dropping `continue;` lets the dispatch fall through to it.
+            // ListItem case: marker + body block + inline-root
+            // paragraph (when present) all share one opacity group,
+            // mirroring v1's `ListItemPageable::draw` which wraps
+            // `marker` and `self.body.draw(...)` in a single
+            // `draw_with_opacity(self.opacity, ...)` (`pageable.rs:3336`).
+            //
+            // The body BlockPageable is intentionally built with
+            // `opacity: 1.0` (`convert/list_item.rs:56-58`) so v1
+            // produces ONE compositing group. The inline-root paragraph
+            // (when the body holds text content) lands at the same
+            // node_id via `convert::inline_root`. v2 must compose all
+            // three inside one group — separate `draw_with_opacity`
+            // calls would emit multiple `q .. Q` pairs and break byte-eq.
+            //
+            // `continue;` after this arm so the standalone block /
+            // image / svg / paragraph dispatch below does NOT fire for
+            // the same node_id (everything that v1 paints under the
+            // list item already painted inside the group above).
             if let Some(li) = drawables.list_items.get(&node_id) {
-                draw_list_item_v2(canvas, li, x_pt, y_pt);
+                let block_for_li = drawables.block_styles.get(&node_id);
+                let para_for_li = drawables.paragraphs.get(&node_id);
+                draw_list_item_with_block(
+                    canvas,
+                    li,
+                    block_for_li,
+                    para_for_li,
+                    x_pt,
+                    y_pt,
+                    frag,
+                    &geom.fragments,
+                    page_index,
+                );
+                continue;
             }
             // Block backgrounds/borders draw FIRST so subsequent inner
             // content (paragraph / image / svg sharing the same node_id —
@@ -318,42 +342,35 @@ fn draw_block_v2(
     use crate::pageable::draw_with_opacity;
 
     draw_with_opacity(canvas, entry.opacity, |canvas| {
-        let total_width = entry
-            .layout_size
-            .map(|s| s.width)
-            .unwrap_or_else(|| crate::convert::px_to_pt(frag.width));
-        let total_height = entry
-            .layout_size
-            .map(|s| s.height)
-            .unwrap_or_else(|| crate::convert::px_to_pt(frag.height));
-
-        if entry.visible {
-            crate::background::draw_box_shadows(
-                canvas,
-                &entry.style,
-                x,
-                y,
-                total_width,
-                total_height,
-            );
-            crate::background::draw_background(
-                canvas,
-                &entry.style,
-                x,
-                y,
-                total_width,
-                total_height,
-            );
-            crate::pageable::draw_block_border(
-                canvas,
-                &entry.style,
-                x,
-                y,
-                total_width,
-                total_height,
-            );
-        }
+        draw_block_inner_paint(canvas, entry, x, y, frag);
     });
+}
+
+/// Block bg / border / shadow paint without the outer `draw_with_opacity`
+/// wrap. Used by `draw_list_item_with_block` so the list-item's marker
+/// and body block share a single opacity group (matches v1's
+/// `ListItemPageable::draw` byte output exactly).
+fn draw_block_inner_paint(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    entry: &crate::drawables::BlockEntry,
+    x: f32,
+    y: f32,
+    frag: &crate::pagination_layout::Fragment,
+) {
+    let total_width = entry
+        .layout_size
+        .map(|s| s.width)
+        .unwrap_or_else(|| crate::convert::px_to_pt(frag.width));
+    let total_height = entry
+        .layout_size
+        .map(|s| s.height)
+        .unwrap_or_else(|| crate::convert::px_to_pt(frag.height));
+
+    if entry.visible {
+        crate::background::draw_box_shadows(canvas, &entry.style, x, y, total_width, total_height);
+        crate::background::draw_background(canvas, &entry.style, x, y, total_width, total_height);
+        crate::pageable::draw_block_border(canvas, &entry.style, x, y, total_width, total_height);
+    }
 }
 
 /// v2 table draw. Mirrors `TablePageable::draw`'s outer-frame
@@ -413,22 +430,58 @@ fn draw_table_v2(
     });
 }
 
-/// v2 list-item draw. Paints the marker (text glyphs / image / svg)
-/// at a negative-x offset relative to the list item's body anchor —
-/// mirrors `ListItemPageable::draw`. The body block paints itself
-/// through its own `BlockEntry` dispatch on the next iteration.
-fn draw_list_item_v2(
+/// v2 list-item combined draw. Mirrors v1's `ListItemPageable::draw`
+/// (`pageable.rs:3336`) which wraps the marker plus everything painted
+/// by `self.body.draw(...)` in a single `draw_with_opacity(self.opacity, ...)`
+/// group.
+///
+/// The `<li>` and its body BlockPageable share the same node_id
+/// (`convert/list_item.rs:81`); the body is built with `opacity: 1.0`
+/// on purpose. When the body holds inline content, the inline-root
+/// paragraph also lands at the same node_id (see `convert::inline_root`).
+/// Painting marker + block frame + paragraph glyphs in one compositing
+/// group is what keeps `<li style="opacity:..">` byte-identical with
+/// v1 — separate `draw_with_opacity` calls would emit multiple `q .. Q`
+/// pairs and diverge.
+#[allow(clippy::too_many_arguments)]
+fn draw_list_item_with_block(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    list_item: &crate::drawables::ListItemEntry,
+    block: Option<&crate::drawables::BlockEntry>,
+    paragraph: Option<&crate::drawables::ParagraphEntry>,
+    x: f32,
+    y: f32,
+    frag: &crate::pagination_layout::Fragment,
+    fragments: &[crate::pagination_layout::Fragment],
+    page_index: u32,
+) {
+    use crate::pageable::draw_with_opacity;
+
+    draw_with_opacity(canvas, list_item.opacity, |canvas| {
+        if list_item.visible {
+            draw_list_item_marker(canvas, list_item, x, y);
+        }
+        if let Some(b) = block {
+            draw_block_inner_paint(canvas, b, x, y, frag);
+        }
+        if let Some(p) = paragraph {
+            draw_paragraph_inner_paint(canvas, p, x, y, fragments, page_index);
+        }
+    });
+}
+
+/// List-item marker paint without opacity wrapper or visibility gate
+/// — caller (`draw_list_item_with_block`) handles both so the marker
+/// and the body block share one compositing group.
+fn draw_list_item_marker(
     canvas: &mut crate::pageable::Canvas<'_, '_>,
     entry: &crate::drawables::ListItemEntry,
     x: f32,
     y: f32,
 ) {
-    use crate::pageable::{ImageMarker, ListItemMarker, draw_with_opacity};
+    use crate::pageable::{ImageMarker, ListItemMarker};
 
-    if !entry.visible {
-        return;
-    }
-    draw_with_opacity(canvas, entry.opacity, |canvas| match &entry.marker {
+    match &entry.marker {
         ListItemMarker::Text { lines, width } if !lines.is_empty() => {
             crate::paragraph::draw_shaped_lines(canvas, lines, x - *width, y);
         }
@@ -449,7 +502,7 @@ fn draw_list_item_v2(
             }
         }
         _ => {}
-    });
+    }
 }
 
 /// v2 paragraph draw. Mirrors `paragraph::ParagraphPageable::draw`:
@@ -467,15 +520,32 @@ fn draw_paragraph_v2(
     page_index: u32,
 ) {
     use crate::pageable::draw_with_opacity;
+    draw_with_opacity(canvas, entry.opacity, |canvas| {
+        draw_paragraph_inner_paint(canvas, entry, x, y, fragments, page_index);
+    });
+}
+
+/// Paragraph paint without the outer `draw_with_opacity` wrap. Used
+/// by `draw_list_item_with_block` so a list-item containing inline
+/// content (the body block holds an inline-root paragraph at the same
+/// node_id) can compose marker + block paint + glyph runs into a
+/// single opacity group, matching v1's
+/// `ListItemPageable::draw → body.draw → paragraph.draw` chain.
+fn draw_paragraph_inner_paint(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    entry: &crate::drawables::ParagraphEntry,
+    x: f32,
+    y: f32,
+    fragments: &[crate::pagination_layout::Fragment],
+    page_index: u32,
+) {
     if !entry.visible {
         return;
     }
     let Some(slice) = paragraph_lines_for_page(&entry.lines, fragments, page_index) else {
         return;
     };
-    draw_with_opacity(canvas, entry.opacity, |canvas| {
-        crate::paragraph::draw_shaped_lines(canvas, &slice, x, y);
-    });
+    crate::paragraph::draw_shaped_lines(canvas, &slice, x, y);
 }
 
 /// Phase 4 PR 3 follow-up (PR #302 Devin): mirror

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -55,10 +55,7 @@ pub fn render_v2(
             .block_styles
             .get(&node_id)
             .and_then(|b| b.id.as_ref());
-        let table_id = drawables
-            .tables
-            .get(&node_id)
-            .and_then(|t| t.id.as_ref());
+        let table_id = drawables.tables.get(&node_id).and_then(|t| t.id.as_ref());
         let id = para_id.or(block_id).or(table_id);
         if let Some(id) = id
             && !id.is_empty()

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -55,7 +55,11 @@ pub fn render_v2(
             .block_styles
             .get(&node_id)
             .and_then(|b| b.id.as_ref());
-        let id = para_id.or(block_id);
+        let table_id = drawables
+            .tables
+            .get(&node_id)
+            .and_then(|t| t.id.as_ref());
+        let id = para_id.or(block_id).or(table_id);
         if let Some(id) = id
             && !id.is_empty()
         {
@@ -72,8 +76,14 @@ pub fn render_v2(
                     page_count,
                     config,
                 );
+            // `frag.x` is html-relative (already includes body's x
+            // offset from the fragmenter); only y needs `body_offset_pt`
+            // applied because fragments are body-content-area-relative
+            // along the y axis.
             let x_pt = resolved_margin.left + crate::convert::px_to_pt(first_frag.x);
-            let y_pt = resolved_margin.top + crate::convert::px_to_pt(first_frag.y);
+            let y_pt = resolved_margin.top
+                + drawables.body_offset_pt.1
+                + crate::convert::px_to_pt(first_frag.y);
             dest_registry.record(id.as_str(), x_pt, y_pt);
         }
     }
@@ -111,11 +121,14 @@ pub fn render_v2(
                 bookmark_collector: bookmark_collector.as_mut(),
                 link_collector: Some(&mut link_collector),
             };
+            // `frag.x` is html-relative (fragmenter folds body's x
+            // offset in); `frag.y` is body-content-area-relative — so
+            // only y receives `body_offset_pt`.
             draw_v2_page(
                 &mut canvas,
                 page_idx as u32,
                 resolved_margin.left,
-                resolved_margin.top,
+                resolved_margin.top + drawables.body_offset_pt.1,
                 geometry,
                 drawables,
             );
@@ -180,6 +193,20 @@ fn draw_v2_page(
             let x_pt = margin_left_pt + px_to_pt(frag.x);
             let y_pt = margin_top_pt + px_to_pt(frag.y);
 
+            if let Some(table) = drawables.tables.get(&node_id) {
+                draw_table_v2(canvas, table, x_pt, y_pt, frag);
+                continue;
+            }
+            // ListItem marker draws before block frame. v1's
+            // `ListItemPageable::draw` calls `self.body.draw(...)` so
+            // the body block's background / border paint underneath the
+            // marker (`pageable.rs:3362`). `<li>` and its body
+            // BlockPageable share the same node_id (`convert/list_item.rs:81`),
+            // so `block_styles[node_id]` carries the body block style;
+            // dropping `continue;` lets the dispatch fall through to it.
+            if let Some(li) = drawables.list_items.get(&node_id) {
+                draw_list_item_v2(canvas, li, x_pt, y_pt);
+            }
             // Block backgrounds/borders draw FIRST so subsequent inner
             // content (paragraph / image / svg sharing the same node_id —
             // see `convert::replaced` and `convert::inline_root`)
@@ -329,6 +356,102 @@ fn draw_block_v2(
                 total_height,
             );
         }
+    });
+}
+
+/// v2 table draw. Mirrors `TablePageable::draw`'s outer-frame
+/// background / border / shadow emission. Cell paint (each `<th>` /
+/// `<td>` is a `BlockPageable` with its own NodeId in geometry) lands
+/// through the standard per-NodeId dispatch.
+///
+/// Same overflow-clip caveat as `draw_block_v2`: clip is not pushed
+/// here because flat dispatch lacks a natural close point. Multi-page
+/// table header repetition is also deferred to a later PR — single-
+/// page tables byte-eq today.
+fn draw_table_v2(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    entry: &crate::drawables::TableEntry,
+    x: f32,
+    y: f32,
+    frag: &crate::pagination_layout::Fragment,
+) {
+    use crate::pageable::draw_with_opacity;
+
+    draw_with_opacity(canvas, entry.opacity, |canvas| {
+        let total_width = entry.layout_size.map(|s| s.width).unwrap_or(entry.width);
+        let total_height = entry.layout_size.map(|s| s.height).unwrap_or_else(|| {
+            let from_frag = crate::convert::px_to_pt(frag.height);
+            if from_frag > 0.0 {
+                from_frag
+            } else {
+                entry.cached_height
+            }
+        });
+        if entry.visible {
+            crate::background::draw_box_shadows(
+                canvas,
+                &entry.style,
+                x,
+                y,
+                total_width,
+                total_height,
+            );
+            crate::background::draw_background(
+                canvas,
+                &entry.style,
+                x,
+                y,
+                total_width,
+                total_height,
+            );
+            crate::pageable::draw_block_border(
+                canvas,
+                &entry.style,
+                x,
+                y,
+                total_width,
+                total_height,
+            );
+        }
+    });
+}
+
+/// v2 list-item draw. Paints the marker (text glyphs / image / svg)
+/// at a negative-x offset relative to the list item's body anchor —
+/// mirrors `ListItemPageable::draw`. The body block paints itself
+/// through its own `BlockEntry` dispatch on the next iteration.
+fn draw_list_item_v2(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    entry: &crate::drawables::ListItemEntry,
+    x: f32,
+    y: f32,
+) {
+    use crate::pageable::{ImageMarker, ListItemMarker, draw_with_opacity};
+
+    if !entry.visible {
+        return;
+    }
+    draw_with_opacity(canvas, entry.opacity, |canvas| match &entry.marker {
+        ListItemMarker::Text { lines, width } if !lines.is_empty() => {
+            crate::paragraph::draw_shaped_lines(canvas, lines, x - *width, y);
+        }
+        ListItemMarker::Image {
+            marker,
+            width,
+            height,
+        } => {
+            let marker_x = x - *width;
+            let marker_y = y + (entry.marker_line_height - *height) / 2.0;
+            match marker {
+                ImageMarker::Raster(img) => {
+                    img.draw(canvas, marker_x, marker_y, *width, *height);
+                }
+                ImageMarker::Svg(svg) => {
+                    svg.draw(canvas, marker_x, marker_y, *width, *height);
+                }
+            }
+        }
+        _ => {}
     });
 }
 

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -321,7 +321,29 @@ fn inline_byte_equality_cases() {
         ),
     ];
 
-    let cases = pr3_cases.iter().chain(pr4_cases.iter());
+    // PR 5 (Table + ListItem) extends `Drawables` with `tables` and
+    // `list_items` and adds `body_offset_pt` propagation so html→body
+    // collapsed margin reaches v2 children. Inline cases for the new
+    // types are deferred to PR 6 — table cells contain paragraphs
+    // whose text shaping resolves through inline_root, and inline-box
+    // wiring still has gaps that flake the byte-eq comparison on
+    // these specific configurations. The on-disk allowlist coverage
+    // (10 new fixtures) demonstrates the productive byte-eq advance.
+    //
+    // Regression for PR #304 Devin (list-item shared node_id): `<li>`
+    // and its body block share the same node_id — `list_items[id]`
+    // and `block_styles[id]` co-exist. The marker dispatch must NOT
+    // `continue;` past the block check or `<li style="background:...">`
+    // silently drops the body block paint in v2.
+    let pr5_cases: &[(&str, &str)] = &[(
+        "list item with body block background (shared node_id)",
+        r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}ul{margin:0;padding:0;list-style:none}li{background:#fdf;height:40px}</style></head><body><ul><li></li></ul></body></html>"##,
+    )];
+
+    let cases = pr3_cases
+        .iter()
+        .chain(pr4_cases.iter())
+        .chain(pr5_cases.iter());
     for (label, html) in cases {
         let engine = Engine::builder().build();
         let v1 = engine

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -335,10 +335,21 @@ fn inline_byte_equality_cases() {
     // and `block_styles[id]` co-exist. The marker dispatch must NOT
     // `continue;` past the block check or `<li style="background:...">`
     // silently drops the body block paint in v2.
-    let pr5_cases: &[(&str, &str)] = &[(
-        "list item with body block background (shared node_id)",
-        r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}ul{margin:0;padding:0;list-style:none}li{background:#fdf;height:40px}</style></head><body><ul><li></li></ul></body></html>"##,
-    )];
+    let pr5_cases: &[(&str, &str)] = &[
+        (
+            "list item with body block background (shared node_id)",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}ul{margin:0;padding:0;list-style:none}li{background:#fdf;height:40px}</style></head><body><ul><li></li></ul></body></html>"##,
+        ),
+        // Regression for PR #304 follow-up Devin (list-item opacity
+        // grouping): v1's `ListItemPageable::draw` wraps marker + body
+        // block in a SINGLE `draw_with_opacity` group. v2 must produce
+        // the same single q/Q wrapper or the PDF stream diverges when
+        // `<li style="opacity:0.5">`.
+        (
+            "list item with opacity and body block background",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}ul{margin:0;padding:0;list-style:none}li{background:#cef;height:40px;opacity:0.5}</style></head><body><ul><li></li></ul></body></html>"##,
+        ),
+    ];
 
     let cases = pr3_cases
         .iter()

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -29,4 +29,18 @@ allowlist = [
     "vrt://layout/flex-row.html",
     "vrt://layout/grid-simple.html",
     "vrt://layout/multicol-2.html",
+    # PR 5 (Table + ListItem + html→body offset fix) — adds the
+    # `body_y` propagation that lets the html → body collapsed-margin
+    # offset reach v2 children. Most pure-block paint / gradient
+    # fixtures fall in once that's in place.
+    "vrt://basic/solid-box.html",
+    "vrt://paint/background-gradient.html",
+    "vrt://paint/gradient-repeat-round.html",
+    "vrt://paint/gradient-repeat-x-with-position.html",
+    "vrt://paint/gradient-size-no-repeat-center.html",
+    "vrt://paint/gradient-to-top-right-tile-aspect.html",
+    "vrt://paint/opacity.html",
+    "vrt://paint/radial-gradient-no-repeat-corner.html",
+    "vrt://paint/radial-gradient-repeat-round.html",
+    "vrt://paint/radial-gradient-tiled.html",
 ]


### PR DESCRIPTION
## 概要

Phase 4 (fulgur-9t3z) PR 5: Table と ListItem を Drawables に migrate + body offset 伝播の修正。**PR #303 の上に stack**。

beads: fulgur-9t3z.2

## byte-eq 進捗: **5 / 59 → 15 / 59** (+10)

新たに pass する fixture:
- \`vrt://basic/solid-box.html\` (body offset fix で unlock)
- \`vrt://paint/background-gradient.html\` 〜 \`radial-gradient-tiled.html\` (9 件、すべて gradient/opacity 系)

## 追加

### TableEntry
\`style: BlockStyle\`, \`opacity\`, \`visible\`, \`id\`, \`layout_size\`, \`width\`, \`cached_height\`。table の outer frame 用 (cells は各 cell の BlockEntry が描画)。

### ListItemEntry
\`marker: ListItemMarker\` (Text/Image/None), \`marker_line_height\`, \`opacity\`, \`visible\`。body は別 NodeId として Block dispatch に任せる。

### Drawables.body_offset_pt: (f32, f32)
新フィールド。\`<body>.final_layout.location\` を保持し、\`render_v2\` が per-fragment (x, y) に加算する。html → body の collapsed margin offset を v2 に伝える。fragmenter の geometry は body-content-area-relative のままで slicing semantics を破壊しない。

### Fragmenter fix: zero-size container recursion
\`record_subtree_descendants\` が \`h <= 0.0 && w <= 0.0\` の child を完全 skip していた。これで anonymous \`<tbody>\` / \`<tr>\` 配下の \`<td>\` cells が geometry から消えていた。recurse のみ行い fragment は record しない形に変更。cells (非ゼロサイズ) は正しく登録される。

## render_v2 dispatcher

| arm | 役割 |
|---|---|
| \`draw_table_v2\` | table border-box の background / border / shadow |
| \`draw_list_item_v2\` | marker (text/image/svg) を負 x 位置に描画 |

## 制約

- inline test に table / list は **追加しない** (cell 内 paragraph と inline-box 配線で byte-eq に揺らぎ。PR 6 で対処)
- multi-page table の header repetition は未対応 (single-page table は v1 と同等)
- overflow:hidden の clip path は引き続き未対応 (PR 4 と同じ)

## 検証

- \`cargo build -p fulgur\`: 0 warning
- \`cargo clippy --workspace --tests\`: 0 warning
- \`cargo test -p fulgur\`: 全 green
- \`cargo test -p fulgur-vrt -p fulgur-cli\`: regression なし
- shadow harness: \`v2 byte-identical 15 / 59 fixtures (allowlist 15)\`

## Stacking

base = \`feat/phase4-pr4-block\` (PR #303)。マージ順: #300 → #301 → #302 → #303 → this。

## 次: PR 6 (Transform + Multicol + marker wrappers)

CSS transform stack、column-rule paint、4 marker wrappers の完了。allowlist が 56/56 に近づく見込み。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
