### PR TITLE
Phase 4 PR 6 — Transform + MulticolRule migration

### DIFF
--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -239,7 +239,8 @@ fn extract_drawables_from_pageable(
     out: &mut crate::drawables::Drawables,
 ) {
     use crate::drawables::{
-        BlockEntry, ImageEntry, ListItemEntry, ParagraphEntry, SvgEntry, TableEntry,
+        BlockEntry, ImageEntry, ListItemEntry, MulticolRuleEntry, ParagraphEntry, SvgEntry,
+        TableEntry, TransformEntry,
     };
     use crate::image::ImagePageable;
     use crate::pageable::{
@@ -375,8 +376,40 @@ fn extract_drawables_from_pageable(
         return;
     }
     // Wrappers delegate.
+    //
+    // Transform wrapper: record `TransformEntry` keyed by the inner's
+    // `node_id` (the wrapper has no node_id of its own — it inherits
+    // from inner). After recursing, every NodeId added by the inner
+    // subtree is captured into the entry's `descendants` list so the
+    // render dispatcher can paint them all inside one
+    // `push_transform / pop` group, mirroring v1's
+    // `TransformWrapperPageable::draw`.
     if let Some(w) = any.downcast_ref::<TransformWrapperPageable>() {
+        let before_block = collect_drawables_node_ids(out);
         extract_drawables_from_pageable(w.inner.as_ref(), out);
+        if let Some(inner_id) = w.inner.node_id() {
+            let after_block = collect_drawables_node_ids(out);
+            // Exclude `inner_id` from `descendants` — it's the key the
+            // entry is filed under, and it is dispatched as the
+            // transform parent (`draw_under_transform` calls
+            // `dispatch_fragment(node_id, ..)` for it before iterating
+            // descendants). Without this filter, the render loop's
+            // skip set would contain `inner_id` itself and the parent
+            // node would never paint.
+            let descendants: Vec<usize> = after_block
+                .difference(&before_block)
+                .copied()
+                .filter(|&id| id != inner_id)
+                .collect();
+            out.transforms.insert(
+                inner_id,
+                TransformEntry {
+                    matrix: w.matrix,
+                    origin: w.origin,
+                    descendants,
+                },
+            );
+        }
         return;
     }
     if let Some(w) = any.downcast_ref::<BookmarkMarkerWrapperPageable>() {
@@ -395,18 +428,44 @@ fn extract_drawables_from_pageable(
         extract_drawables_from_pageable(w.child.as_ref(), out);
         return;
     }
-    // PR #301 Devin: MulticolRulePageable is a wrapper carrying a
-    // `child: Box<dyn Pageable>` produced by `maybe_wrap_multicol_rule`
-    // around any multicol container. Without this arm, images / SVGs
-    // / paragraphs nested inside a multicol container fall through to
-    // "Other" and never enter `Drawables`. Multicol's own column-rule
-    // painting still lands in PR 6 (`drawables.multicol_rules`).
+    // MulticolRulePageable: record `MulticolRuleEntry` keyed by the
+    // multicol container (child) node_id, then recurse so the
+    // container's own block / paragraph / image payload land in their
+    // respective maps. Render-side post-pass paints rules per page
+    // using the container's fragments to partition `groups`.
     if let Some(w) = any.downcast_ref::<MulticolRulePageable>() {
+        if let Some(child_id) = w.child.node_id() {
+            out.multicol_rules.insert(
+                child_id,
+                MulticolRuleEntry {
+                    rule: w.rule,
+                    groups: w.groups.clone(),
+                },
+            );
+        }
         extract_drawables_from_pageable(w.child.as_ref(), out);
     }
-    // Other types (Spacer, marker-only Pageables) have no PR 3
-    // payload — markers and Spacers stay no-op in v2; Multicol-rule
-    // paint lands in PR 6.
+    // Other types (Spacer, marker-only Pageables) have no per-NodeId
+    // payload — Spacer is invisible, and the four marker wrappers
+    // (Bookmark / StringSet / Running / CounterOp) drive their effects
+    // through fragmenter geometry rather than per-marker entries.
+}
+
+/// Snapshot the union of `NodeId` keys currently present in `out`'s
+/// per-NodeId maps. Used by `extract_drawables_from_pageable`'s
+/// transform arm to compute `descendants = after - before` so the
+/// transform can list every node added by walking its inner subtree.
+fn collect_drawables_node_ids(
+    out: &crate::drawables::Drawables,
+) -> std::collections::BTreeSet<usize> {
+    let mut ids = std::collections::BTreeSet::new();
+    ids.extend(out.block_styles.keys().copied());
+    ids.extend(out.paragraphs.keys().copied());
+    ids.extend(out.images.keys().copied());
+    ids.extend(out.svgs.keys().copied());
+    ids.extend(out.tables.keys().copied());
+    ids.extend(out.list_items.keys().copied());
+    ids
 }
 
 #[cfg(test)]

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -319,9 +319,8 @@ fn extract_drawables_from_pageable(
     // Paragraph leaf — record the shaped lines verbatim. The lines
     // already carry per-glyph positions, link spans, decoration spans,
     // and inline-image / inline-box items, so no re-shaping at render
-    // time. Inline content (LineItem::InlineBox) embeds whole Pageable
-    // subtrees that need their own draw payload — recurse so wrapper
-    // markers / nested blocks land in the appropriate `Drawables` map.
+    // time. Inline content (LineItem::InlineBox) is intentionally NOT
+    // recursed into — see the comment inside the arm for rationale.
     if let Some(para) = any.downcast_ref::<ParagraphPageable>() {
         if let Some(node_id) = para.node_id {
             out.paragraphs.insert(

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -215,7 +215,16 @@ fn find_body_id_in_dom(doc: &HtmlDocument) -> Option<usize> {
     let root = doc.root_element();
     let root_node = base.get_node(root.id)?;
     for &child_id in &root_node.children {
-        let child = base.get_node(child_id)?;
+        // `?` would early-return `None` if any sibling lookup fails,
+        // hiding `<body>` past an unfindable `<head>` etc. — `let Some
+        // ... else { continue; }` matches the sibling helpers
+        // (`extract_body_offset_pt`, `pagination_layout::find_body_id`)
+        // and keeps continuation-page `<body>` background paint alive
+        // when one of the html root's earlier children can't be looked
+        // up (PR #305 Devin).
+        let Some(child) = base.get_node(child_id) else {
+            continue;
+        };
         if let blitz_dom::NodeData::Element(elem) = &child.data
             && elem.name.local.as_ref() == "body"
         {

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -334,17 +334,15 @@ fn extract_drawables_from_pageable(
                 },
             );
         }
-        // Recurse into inline-box content. Each `LineItem::InlineBox`
-        // holds a `Box<dyn Pageable>` (typically a `BlockPageable` for
-        // `<span>`-style inline blocks) so its descendants can register
-        // their own payloads.
-        for line in &para.lines {
-            for item in &line.items {
-                if let crate::paragraph::LineItem::InlineBox(ib) = item {
-                    extract_drawables_from_pageable(ib.content.as_ref(), out);
-                }
-            }
-        }
+        // Inline-box content (e.g. inline `<svg>`, inline-block
+        // `<span>`) is painted via `paragraph::draw_shaped_lines`
+        // which calls `ib.content.draw(...)` directly (line ~820 of
+        // paragraph.rs). Recursing here and registering the inner
+        // content in `block_styles` / `svgs` / `images` would
+        // double-paint at render time — once via the paragraph's
+        // inline call, once via the v2 dispatcher's per-NodeId loop.
+        // Skip recursion entirely so inline content stays a v1-style
+        // draw rooted in the paragraph's own dispatch.
         return;
     }
     // Block / List / Table / wrappers — recurse into children. Block

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -201,6 +201,7 @@ pub fn dom_to_drawables(
     extract_drawables_from_pageable(root_pageable.as_ref(), &mut drawables);
     drawables.bookmark_anchors = extract_bookmark_anchors(doc, &bookmark_snapshot, ctx.assets);
     drawables.body_offset_pt = extract_body_offset_pt(doc);
+    drawables.root_id = Some(doc.root_element().id);
     drawables
 }
 

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -202,7 +202,27 @@ pub fn dom_to_drawables(
     drawables.bookmark_anchors = extract_bookmark_anchors(doc, &bookmark_snapshot, ctx.assets);
     drawables.body_offset_pt = extract_body_offset_pt(doc);
     drawables.root_id = Some(doc.root_element().id);
+    drawables.body_id = find_body_id_in_dom(doc);
     drawables
+}
+
+/// Locate the `<body>` element id by walking the html root's children.
+/// Mirrors `pagination_layout::find_body_id` but operates on the
+/// `HtmlDocument` API (the latter is private to that module).
+fn find_body_id_in_dom(doc: &HtmlDocument) -> Option<usize> {
+    use std::ops::Deref;
+    let base = doc.deref();
+    let root = doc.root_element();
+    let root_node = base.get_node(root.id)?;
+    for &child_id in &root_node.children {
+        let child = base.get_node(child_id)?;
+        if let blitz_dom::NodeData::Element(elem) = &child.data
+            && elem.name.local.as_ref() == "body"
+        {
+            return Some(child_id);
+        }
+    }
+    None
 }
 
 /// Phase 4 PR 5: walk the DOM looking for `<body>` and return its

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -205,6 +205,17 @@ pub struct Drawables {
     /// in geometry but absolute on Drawables avoids touching the
     /// fragmenter contract.
     pub body_offset_pt: (f32, f32),
+    /// NodeId of the `<html>` root element when present.
+    ///
+    /// v1 paints html's own `background` BEFORE recursing into body
+    /// via `BlockPageable::draw`'s recursive children walk. v2's flat
+    /// dispatch never visits html — the fragmenter only records body
+    /// and its descendants in `geometry` — so `render_v2` paints html
+    /// as a pre-pass at the page's top-left margin using
+    /// `block_styles[root_id].layout_size` as the rect dimensions.
+    /// That mirrors v1's `total_width / total_height` derivation in
+    /// `BlockPageable::draw` (`pageable.rs:1771-1778`).
+    pub root_id: Option<NodeId>,
     pub block_styles: BTreeMap<NodeId, BlockEntry>,
     pub paragraphs: BTreeMap<NodeId, ParagraphEntry>,
     pub images: BTreeMap<NodeId, ImageEntry>,

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -216,6 +216,18 @@ pub struct Drawables {
     /// That mirrors v1's `total_width / total_height` derivation in
     /// `BlockPageable::draw` (`pageable.rs:1771-1778`).
     pub root_id: Option<NodeId>,
+    /// NodeId of the `<body>` element when present.
+    ///
+    /// v1 paints body's `background` on EVERY page because each
+    /// page's sliced root pageable still calls body's draw method.
+    /// v2's main dispatch sees body via the fragmenter's single
+    /// fragment on page 0 only, so multi-page documents would lose
+    /// body's bg fill on continuation pages. `render_v2` mirrors v1
+    /// by painting body as a pre-pass on every page (using
+    /// `block_styles[body_id].layout_size` for the rect dimensions
+    /// and `body_offset_pt` for the margin offset), then skipping
+    /// body in the main dispatch loop to avoid double-painting.
+    pub body_id: Option<NodeId>,
     pub block_styles: BTreeMap<NodeId, BlockEntry>,
     pub paragraphs: BTreeMap<NodeId, ParagraphEntry>,
     pub images: BTreeMap<NodeId, ImageEntry>,

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -140,13 +140,35 @@ impl std::fmt::Debug for ListItemEntry {
     }
 }
 
-/// PR 6 target: column-rule paint spec + per-column-group geometry.
-#[derive(Debug, Clone, Default)]
-pub struct MulticolRuleEntry;
+/// Multicol column-rule paint spec + per-column-group geometry.
+/// Mirrors the fields `MulticolRulePageable` carries — render at the
+/// container's location after children paint, partitioning `groups`
+/// per page based on the container's fragment cumulative heights.
+#[derive(Debug, Clone)]
+pub struct MulticolRuleEntry {
+    pub rule: crate::column_css::ColumnRuleSpec,
+    pub groups: Vec<crate::multicol_layout::ColumnGroupGeometry>,
+}
 
-/// PR 6 target: CSS transform matrix + origin.
-#[derive(Debug, Clone, Default)]
-pub struct TransformEntry;
+/// CSS transform matrix + origin for a node (and its descendants).
+///
+/// Mirrors `TransformWrapperPageable`. v1 pushes the surface transform
+/// before drawing `inner.draw(...)` and pops after; v2's flat dispatch
+/// emulates this by recording every descendant `node_id` of the wrapper
+/// at convert time so the render loop can dispatch the wrapper's own
+/// payload + every descendant inside one push/pop pair.
+#[derive(Debug, Clone)]
+pub struct TransformEntry {
+    pub matrix: crate::pageable::Affine2D,
+    pub origin: crate::pageable::Point2,
+    /// Every `NodeId` whose fragment must paint inside this transform's
+    /// `push_transform`/`pop` group. Includes the wrapper's own
+    /// `node_id` (shared with the inner Pageable) and every descendant
+    /// recursively. Stored as a `Vec` for deterministic iteration —
+    /// order matches the depth-first walk produced by
+    /// `extract_drawables_from_pageable`.
+    pub descendants: Vec<NodeId>,
+}
 
 /// Bookmark anchor (level + label) keyed by source node. First-fragment-only
 /// emission is enforced at render time by reading `geometry.fragments[0]`.

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -161,12 +161,14 @@ pub struct MulticolRuleEntry {
 pub struct TransformEntry {
     pub matrix: crate::pageable::Affine2D,
     pub origin: crate::pageable::Point2,
-    /// Every `NodeId` whose fragment must paint inside this transform's
-    /// `push_transform`/`pop` group. Includes the wrapper's own
-    /// `node_id` (shared with the inner Pageable) and every descendant
-    /// recursively. Stored as a `Vec` for deterministic iteration —
-    /// order matches the depth-first walk produced by
-    /// `extract_drawables_from_pageable`.
+    /// Every strict descendant `NodeId` whose fragment must paint
+    /// inside this transform's `push_transform`/`pop` group. Does NOT
+    /// include the wrapper's own `node_id` (the entry's key) — the
+    /// render loop dispatches the wrapper node separately before
+    /// iterating descendants (see
+    /// `render::draw_under_transform`). Stored as a `Vec` for
+    /// deterministic iteration — order matches the depth-first walk
+    /// produced by `extract_drawables_from_pageable`.
     pub descendants: Vec<NodeId>,
 }
 

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -1455,7 +1455,7 @@ fn apply_border_style(
 }
 
 /// Helper to draw a simple line segment with a given stroke.
-fn stroke_line(
+pub(crate) fn stroke_line(
     canvas: &mut Canvas<'_, '_>,
     x1: f32,
     y1: f32,
@@ -1509,7 +1509,7 @@ pub(crate) fn alpha_to_opacity(alpha: u8) -> krilla::num::NormalizedF32 {
 }
 
 /// Create a stroke with a specific color and width, inheriting opacity from base.
-fn colored_stroke(
+pub(crate) fn colored_stroke(
     color: &[u8; 4],
     width: f32,
     opacity: krilla::num::NormalizedF32,

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -169,7 +169,24 @@ fn draw_v2_page(
 ) {
     use crate::convert::px_to_pt;
 
+    // Pre-compute the set of node_ids that fall under any transform's
+    // `descendants` list. They are skipped in the main iteration and
+    // drawn instead inside the transform's `push_transform / pop` group
+    // below — mirroring v1's `TransformWrapperPageable::draw` which
+    // calls `inner.draw(...)` while the surface transform is active.
+    let mut transformed_descendants: std::collections::BTreeSet<usize> =
+        std::collections::BTreeSet::new();
+    for tx in drawables.transforms.values() {
+        transformed_descendants.extend(tx.descendants.iter().copied());
+    }
+
     for (&node_id, geom) in geometry {
+        if transformed_descendants.contains(&node_id) {
+            // Drawn inside an ancestor transform group elsewhere in
+            // this loop. Skipping prevents double-painting.
+            continue;
+        }
+
         // Bookmark anchor: emit on the page where the node's *first*
         // fragment lands, mirroring `BookmarkMarkerWrapperPageable`'s
         // `is_first_page_for` slice semantics.
@@ -190,94 +207,314 @@ fn draw_v2_page(
             let x_pt = margin_left_pt + px_to_pt(frag.x);
             let y_pt = margin_top_pt + px_to_pt(frag.y);
 
-            if let Some(table) = drawables.tables.get(&node_id) {
-                draw_table_v2(canvas, table, x_pt, y_pt, frag);
-                continue;
-            }
-            // ListItem case: marker + body block + inline-root
-            // paragraph (when present) all share one opacity group,
-            // mirroring v1's `ListItemPageable::draw` which wraps
-            // `marker` and `self.body.draw(...)` in a single
-            // `draw_with_opacity(self.opacity, ...)` (`pageable.rs:3336`).
-            //
-            // The body BlockPageable is intentionally built with
-            // `opacity: 1.0` (`convert/list_item.rs:56-58`) so v1
-            // produces ONE compositing group. The inline-root paragraph
-            // (when the body holds text content) lands at the same
-            // node_id via `convert::inline_root`. v2 must compose all
-            // three inside one group — separate `draw_with_opacity`
-            // calls would emit multiple `q .. Q` pairs and break byte-eq.
-            //
-            // `continue;` after this arm so the standalone block /
-            // image / svg / paragraph dispatch below does NOT fire for
-            // the same node_id (everything that v1 paints under the
-            // list item already painted inside the group above).
-            if let Some(li) = drawables.list_items.get(&node_id) {
-                let block_for_li = drawables.block_styles.get(&node_id);
-                let para_for_li = drawables.paragraphs.get(&node_id);
-                draw_list_item_with_block(
+            if let Some(tx) = drawables.transforms.get(&node_id) {
+                draw_under_transform(
                     canvas,
-                    li,
-                    block_for_li,
-                    para_for_li,
+                    tx,
+                    node_id,
+                    geom,
+                    frag,
                     x_pt,
                     y_pt,
-                    frag,
-                    &geom.fragments,
+                    geometry,
+                    drawables,
+                    margin_left_pt,
+                    margin_top_pt,
                     page_index,
                 );
-                continue;
+            } else {
+                dispatch_fragment(
+                    canvas, node_id, geom, frag, x_pt, y_pt, drawables, page_index,
+                );
             }
-            // Block + inner content (paragraph / image / svg) sharing
-            // the same node_id: v1's `BlockPageable::draw`
-            // (`pageable.rs:1771`) wraps bg/border AND the children
-            // draw inside ONE `draw_with_opacity(self.opacity, ...)`
-            // group. The inline-root paragraph + replaced-image /
-            // replaced-svg patterns from `convert::inline_root` /
-            // `convert::replaced` deliberately leave the inner draw
-            // payload at `opacity: 1.0` because the wrapping block
-            // carries the real opacity.
-            //
-            // Mirror v1 by combining all four paints into one group at
-            // dispatch time and `continue;`-ing past the standalone
-            // arms. Same pattern as `draw_list_item_with_block`.
-            if let Some(block) = drawables.block_styles.get(&node_id) {
-                let para_for_block = drawables.paragraphs.get(&node_id);
-                let img_for_block = drawables.images.get(&node_id);
-                let svg_for_block = drawables.svgs.get(&node_id);
-                if para_for_block.is_some() || img_for_block.is_some() || svg_for_block.is_some() {
-                    draw_block_with_inner_content(
-                        canvas,
-                        block,
-                        para_for_block,
-                        img_for_block,
-                        svg_for_block,
-                        x_pt,
-                        y_pt,
-                        frag,
-                        &geom.fragments,
-                        page_index,
-                    );
-                    continue;
-                }
-                draw_block_v2(canvas, block, x_pt, y_pt, frag);
-            }
-            if let Some(img) = drawables.images.get(&node_id) {
-                draw_image_v2(canvas, img, x_pt, y_pt);
-                continue;
-            }
-            if let Some(svg) = drawables.svgs.get(&node_id) {
-                draw_svg_v2(canvas, svg, x_pt, y_pt);
-                continue;
-            }
-            if let Some(para) = drawables.paragraphs.get(&node_id) {
-                draw_paragraph_v2(canvas, para, x_pt, y_pt, &geom.fragments, page_index);
-                continue;
-            }
-            // Other types (tables / list_items / ...) land in
-            // subsequent PRs.
         }
     }
+
+    // Post-pass: paint multicol column rules between columns. v1's
+    // `MulticolRulePageable::draw` runs this AFTER `child.draw(...)`
+    // so the rule lines paint on top of the column contents. The
+    // post-pass placement mirrors that ordering — every per-NodeId
+    // payload is already drawn by the main loop above.
+    for (&container_id, entry) in &drawables.multicol_rules {
+        let Some(container_geom) = geometry.get(&container_id) else {
+            continue;
+        };
+        paint_multicol_rule_for_page(
+            canvas,
+            entry,
+            container_geom,
+            margin_left_pt,
+            margin_top_pt,
+            page_index,
+        );
+    }
+}
+
+/// Per-fragment leaf-draw dispatch shared by the main loop and the
+/// transform special-case. Walks `node_id`'s payload maps and emits
+/// the appropriate per-type draw — exactly the same logic as before
+/// the transform refactor, just hoisted into a function so
+/// `draw_under_transform` can re-use it for descendants.
+#[allow(clippy::too_many_arguments)]
+fn dispatch_fragment(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    node_id: usize,
+    geom: &crate::pagination_layout::PaginationGeometry,
+    frag: &crate::pagination_layout::Fragment,
+    x_pt: f32,
+    y_pt: f32,
+    drawables: &Drawables,
+    page_index: u32,
+) {
+    if let Some(table) = drawables.tables.get(&node_id) {
+        draw_table_v2(canvas, table, x_pt, y_pt, frag);
+        return;
+    }
+    // ListItem case: marker + body block + inline-root paragraph
+    // share a single opacity group. See `draw_list_item_with_block`
+    // for the v1 mirror.
+    if let Some(li) = drawables.list_items.get(&node_id) {
+        let block_for_li = drawables.block_styles.get(&node_id);
+        let para_for_li = drawables.paragraphs.get(&node_id);
+        draw_list_item_with_block(
+            canvas,
+            li,
+            block_for_li,
+            para_for_li,
+            x_pt,
+            y_pt,
+            frag,
+            &geom.fragments,
+            page_index,
+        );
+        return;
+    }
+    // Block + inner content (paragraph / image / svg) sharing the
+    // same node_id: combine into one `draw_with_opacity` group. See
+    // `draw_block_with_inner_content` for the v1 mirror.
+    if let Some(block) = drawables.block_styles.get(&node_id) {
+        let para_for_block = drawables.paragraphs.get(&node_id);
+        let img_for_block = drawables.images.get(&node_id);
+        let svg_for_block = drawables.svgs.get(&node_id);
+        if para_for_block.is_some() || img_for_block.is_some() || svg_for_block.is_some() {
+            draw_block_with_inner_content(
+                canvas,
+                block,
+                para_for_block,
+                img_for_block,
+                svg_for_block,
+                x_pt,
+                y_pt,
+                frag,
+                &geom.fragments,
+                page_index,
+            );
+            return;
+        }
+        draw_block_v2(canvas, block, x_pt, y_pt, frag);
+    }
+    if let Some(img) = drawables.images.get(&node_id) {
+        draw_image_v2(canvas, img, x_pt, y_pt);
+        return;
+    }
+    if let Some(svg) = drawables.svgs.get(&node_id) {
+        draw_svg_v2(canvas, svg, x_pt, y_pt);
+        return;
+    }
+    if let Some(para) = drawables.paragraphs.get(&node_id) {
+        draw_paragraph_v2(canvas, para, x_pt, y_pt, &geom.fragments, page_index);
+    }
+}
+
+/// Push the transform onto the surface + link collector, dispatch the
+/// wrapper node's own payload and every descendant fragment that lands
+/// on `page_index`, then pop. Mirrors v1's
+/// `TransformWrapperPageable::draw`:
+///
+/// ```text
+/// canvas.surface.push_transform(matrix);
+/// inner.draw(canvas, x, y, ...);
+/// canvas.surface.pop();
+/// ```
+///
+/// The link collector also receives the transform so `/Link`
+/// annotation rects are mapped into device space — same call sequence
+/// v1 uses (`pageable.rs:2716-2724`).
+#[allow(clippy::too_many_arguments)]
+fn draw_under_transform(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    tx: &crate::drawables::TransformEntry,
+    node_id: usize,
+    geom: &crate::pagination_layout::PaginationGeometry,
+    frag: &crate::pagination_layout::Fragment,
+    x_pt: f32,
+    y_pt: f32,
+    geometry: &crate::pagination_layout::PaginationGeometryTable,
+    drawables: &Drawables,
+    margin_left_pt: f32,
+    margin_top_pt: f32,
+    page_index: u32,
+) {
+    use crate::convert::px_to_pt;
+
+    // `effective_matrix` mirrors `TransformWrapperPageable::effective_matrix`:
+    //   T(x + ox, y + oy) · M · T(-(x + ox), -(y + oy))
+    let ox = x_pt + tx.origin.x;
+    let oy = y_pt + tx.origin.y;
+    use crate::pageable::Affine2D;
+    let full = Affine2D::translation(ox, oy) * tx.matrix * Affine2D::translation(-ox, -oy);
+
+    if let Some(lc) = canvas.link_collector.as_deref_mut() {
+        lc.push_transform(full);
+    }
+    canvas.surface.push_transform(&full.to_krilla());
+
+    // Dispatch the wrapper's own payload first (the `inner` Pageable
+    // shares this `node_id`) — matches v1's `inner.draw(canvas, x, y, ...)`.
+    dispatch_fragment(
+        canvas, node_id, geom, frag, x_pt, y_pt, drawables, page_index,
+    );
+
+    // Then dispatch every strict descendant on this page. Each
+    // descendant's fragment has its own (x, y) in untransformed local
+    // coordinates — the surface transform applies on top, mirroring v1
+    // where `inner.draw(...)` recurses through children with their
+    // pre-transform layout.
+    for &desc_id in &tx.descendants {
+        let Some(desc_geom) = geometry.get(&desc_id) else {
+            continue;
+        };
+        for desc_frag in &desc_geom.fragments {
+            if desc_frag.page_index != page_index {
+                continue;
+            }
+            let desc_x = margin_left_pt + px_to_pt(desc_frag.x);
+            let desc_y = margin_top_pt + px_to_pt(desc_frag.y);
+            dispatch_fragment(
+                canvas, desc_id, desc_geom, desc_frag, desc_x, desc_y, drawables, page_index,
+            );
+        }
+    }
+
+    canvas.surface.pop();
+    if let Some(lc) = canvas.link_collector.as_deref_mut() {
+        lc.pop_transform();
+    }
+}
+
+/// Paint multicol column-rule lines on `page_index` for one
+/// `MulticolRuleEntry`. Partitions `entry.groups` by accumulating the
+/// container's per-page heights — mirrors
+/// `MulticolRulePageable::slice_for_page` + `draw` so each page only
+/// emits the rule segments that fit on it.
+fn paint_multicol_rule_for_page(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    entry: &crate::drawables::MulticolRuleEntry,
+    container_geom: &crate::pagination_layout::PaginationGeometry,
+    margin_left_pt: f32,
+    margin_top_pt: f32,
+    page_index: u32,
+) {
+    use crate::convert::px_to_pt;
+    use crate::pageable::stroke_line;
+
+    let Some(stroke) = build_multicol_stroke(&entry.rule) else {
+        return;
+    };
+
+    let target_pos = container_geom
+        .fragments
+        .iter()
+        .position(|f| f.page_index == page_index);
+    let Some(target_pos) = target_pos else {
+        return;
+    };
+    let target_frag = &container_geom.fragments[target_pos];
+
+    let consumed: f32 = px_to_pt(
+        container_geom.fragments[..target_pos]
+            .iter()
+            .map(|f| f.height)
+            .sum::<f32>(),
+    );
+    let cutoff = px_to_pt(target_frag.height);
+
+    let x_base = margin_left_pt + px_to_pt(target_frag.x);
+    let y_base = margin_top_pt + px_to_pt(target_frag.y);
+
+    for group in &entry.groups {
+        if group.n < 2 || group.col_heights.len() != group.n as usize {
+            continue;
+        }
+        let group_top = group.y_offset - consumed;
+        let max_h = group
+            .col_heights
+            .iter()
+            .copied()
+            .fold(0.0_f32, |acc, h| acc.max(h));
+        let group_bottom = group_top + max_h;
+        if group_bottom <= 0.0 || group_top >= cutoff {
+            continue;
+        }
+        let visible_top = group_top.max(0.0);
+        let y_top = y_base + visible_top;
+        for i in 0..(group.n as usize - 1) {
+            let h_left = group.col_heights[i]
+                .min(cutoff - group_top.max(0.0))
+                .max(0.0);
+            let h_right = group.col_heights[i + 1]
+                .min(cutoff - group_top.max(0.0))
+                .max(0.0);
+            if h_left <= 0.0 || h_right <= 0.0 {
+                continue;
+            }
+            let rule_x = x_base
+                + group.x_offset
+                + (i as f32 + 1.0) * group.col_w
+                + i as f32 * group.gap
+                + group.gap / 2.0;
+            let y_bot = y_top + h_left.min(h_right);
+            stroke_line(canvas, rule_x, y_top, rule_x, y_bot, stroke.clone());
+        }
+    }
+    canvas.surface.set_stroke(None);
+}
+
+/// Build the krilla stroke for the configured rule spec, mirroring
+/// `MulticolRulePageable::build_stroke`. Returns `None` when the rule
+/// is invisible (style `None` or non-positive width).
+fn build_multicol_stroke(
+    rule: &crate::column_css::ColumnRuleSpec,
+) -> Option<krilla::paint::Stroke> {
+    use crate::column_css::ColumnRuleStyle;
+    use crate::pageable::{alpha_to_opacity, colored_stroke};
+
+    if rule.width <= 0.0 || rule.style == ColumnRuleStyle::None {
+        return None;
+    }
+    let opacity = alpha_to_opacity(rule.color[3]);
+    let base = colored_stroke(&rule.color, rule.width, opacity);
+    let w = rule.width;
+    let stroke = match rule.style {
+        ColumnRuleStyle::None => return None,
+        ColumnRuleStyle::Solid => base,
+        ColumnRuleStyle::Dashed => krilla::paint::Stroke {
+            dash: Some(krilla::paint::StrokeDash {
+                array: vec![w * 3.0, w * 2.0],
+                offset: 0.0,
+            }),
+            ..base
+        },
+        ColumnRuleStyle::Dotted => krilla::paint::Stroke {
+            line_cap: krilla::paint::LineCap::Round,
+            dash: Some(krilla::paint::StrokeDash {
+                array: vec![0.0, w * 2.0],
+                offset: 0.0,
+            }),
+            ..base
+        },
+    };
+    Some(stroke)
 }
 
 /// v2 image draw. Mirrors `image::ImagePageable::draw` but operates on

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -181,15 +181,19 @@ fn draw_v2_page(
     }
 
     for (&node_id, geom) in geometry {
-        if transformed_descendants.contains(&node_id) {
-            // Drawn inside an ancestor transform group elsewhere in
-            // this loop. Skipping prevents double-painting.
-            continue;
-        }
-
         // Bookmark anchor: emit on the page where the node's *first*
         // fragment lands, mirroring `BookmarkMarkerWrapperPageable`'s
-        // `is_first_page_for` slice semantics.
+        // `is_first_page_for` slice semantics. Run BEFORE the
+        // `transformed_descendants` skip so headings nested inside a
+        // transformed ancestor (e.g. `<div style="transform:..."><h1>`)
+        // still register in the PDF outline. v1 invokes
+        // `BookmarkMarkerWrapperPageable::draw` recursively from inside
+        // `TransformWrapperPageable::draw`, so the bookmark is recorded
+        // regardless of transform membership; we mirror that by
+        // unconditionally calling `record` here using the untransformed
+        // y position. (v1 emits at the same untransformed y for the
+        // outline destination — `collect_ids` does push the transform
+        // for `/Link` rects but the bookmark itself is keyed by raw y.)
         if let Some(first_frag) = geom.fragments.first()
             && first_frag.page_index == page_index
             && let Some(anchor) = drawables.bookmark_anchors.get(&node_id)
@@ -197,6 +201,13 @@ fn draw_v2_page(
         {
             let y_pt = margin_top_pt + px_to_pt(first_frag.y);
             c.record(anchor.level, anchor.label.clone(), y_pt);
+        }
+
+        if transformed_descendants.contains(&node_id) {
+            // Drawn inside an ancestor transform group elsewhere in
+            // this loop. Skipping prevents double-painting. Bookmark
+            // anchor recording above already ran unconditionally.
+            continue;
         }
 
         // Per-fragment leaf draws.
@@ -458,13 +469,21 @@ fn paint_multicol_rule_for_page(
         }
         let visible_top = group_top.max(0.0);
         let y_top = y_base + visible_top;
+        // Mirror `MulticolRulePageable::slice_for_page`
+        // (`pageable.rs:3221-3223`): subtract the portion of each
+        // column already painted on prior pages BEFORE clamping to
+        // the visible strip on this page. Without this, a column rule
+        // segment whose group straddles a page boundary extends past
+        // the actual visible column content.
+        let consumed_above = (visible_top - group_top).max(0.0);
+        let visible_h = (group_bottom.min(cutoff) - visible_top).max(0.0);
         for i in 0..(group.n as usize - 1) {
-            let h_left = group.col_heights[i]
-                .min(cutoff - group_top.max(0.0))
-                .max(0.0);
-            let h_right = group.col_heights[i + 1]
-                .min(cutoff - group_top.max(0.0))
-                .max(0.0);
+            let h_left = (group.col_heights[i] - consumed_above)
+                .max(0.0)
+                .min(visible_h);
+            let h_right = (group.col_heights[i + 1] - consumed_above)
+                .max(0.0)
+                .min(visible_h);
             if h_left <= 0.0 || h_right <= 0.0 {
                 continue;
             }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -744,16 +744,31 @@ fn draw_block_with_inner_content(
 ) {
     use crate::pageable::draw_with_opacity;
 
+    // Inner content (inline-root paragraph from `convert::inline_root`
+    // or replaced image / svg from `convert::replaced`) is positioned
+    // at the block's content-box top-left, not its border-box top-left.
+    // v1 expresses this via `PositionedChild { x: content_inset.x, y:
+    // content_inset.y, .. }` so `BlockPageable::draw` recurses into the
+    // child at `(x + ix, y + iy)`. v2 has no `PositionedChild` here —
+    // the inner payload shares the block's `node_id` and would
+    // otherwise paint at the block's border-box origin, dropping
+    // `padding + border` worth of offset for every inline-root or
+    // replaced element. Mirror v1 by reading the inset from the
+    // BlockStyle and adding it before recursing.
+    let (ix, iy) = block.style.content_inset();
+    let inner_x = x + ix;
+    let inner_y = y + iy;
+
     draw_with_opacity(canvas, block.opacity, |canvas| {
         draw_block_inner_paint(canvas, block, x, y, frag);
         if let Some(p) = paragraph {
-            draw_paragraph_inner_paint(canvas, p, x, y, fragments, page_index);
+            draw_paragraph_inner_paint(canvas, p, inner_x, inner_y, fragments, page_index);
         }
         if let Some(i) = image {
-            draw_image_inner_paint(canvas, i, x, y);
+            draw_image_inner_paint(canvas, i, inner_x, inner_y);
         }
         if let Some(s) = svg {
-            draw_svg_inner_paint(canvas, s, x, y);
+            draw_svg_inner_paint(canvas, s, inner_x, inner_y);
         }
     });
 }
@@ -785,6 +800,14 @@ fn draw_list_item_with_block(
 ) {
     use crate::pageable::draw_with_opacity;
 
+    // Same content-box offset trick as `draw_block_with_inner_content`
+    // — when the body block carries `padding` / `border`, the
+    // inline-root paragraph that shares the list item's node_id has to
+    // paint at the body block's content-box top-left.
+    let inset = block.map(|b| b.style.content_inset()).unwrap_or((0.0, 0.0));
+    let inner_x = x + inset.0;
+    let inner_y = y + inset.1;
+
     draw_with_opacity(canvas, list_item.opacity, |canvas| {
         if list_item.visible {
             draw_list_item_marker(canvas, list_item, x, y);
@@ -793,7 +816,7 @@ fn draw_list_item_with_block(
             draw_block_inner_paint(canvas, b, x, y, frag);
         }
         if let Some(p) = paragraph {
-            draw_paragraph_inner_paint(canvas, p, x, y, fragments, page_index);
+            draw_paragraph_inner_paint(canvas, p, inner_x, inner_y, fragments, page_index);
         }
     });
 }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -449,7 +449,25 @@ fn draw_under_transform(
     // inner transform would be silently dropped, breaking
     // `<div style="transform:rotate"><div style="transform:scale">`
     // (PR #305 Devin).
+    //
+    // Pre-skip the strict descendants of any nested transform so they
+    // are not dispatched twice — the nested `draw_under_transform`
+    // already iterates `desc_tx.descendants` and paints them under
+    // the composed matrix; iterating them again here via
+    // `dispatch_fragment` would emit a SECOND draw under the outer
+    // transform only (missing the inner matrix). Bug confirmed by
+    // PR #305 follow-up Devin trace for
+    // `<div transform:A><div transform:B><p>text</p></div></div>`.
+    let nested_skip: std::collections::BTreeSet<usize> = tx
+        .descendants
+        .iter()
+        .filter_map(|id| drawables.transforms.get(id))
+        .flat_map(|inner_tx| inner_tx.descendants.iter().copied())
+        .collect();
     for &desc_id in &tx.descendants {
+        if nested_skip.contains(&desc_id) {
+            continue;
+        }
         let Some(desc_geom) = geometry.get(&desc_id) else {
             continue;
         };

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -118,16 +118,19 @@ pub fn render_v2(
                 bookmark_collector: bookmark_collector.as_mut(),
                 link_collector: Some(&mut link_collector),
             };
-            // Root `<html>` background pre-pass. v1's
-            // `BlockPageable::draw` for the html element paints its
-            // own bg/border/shadow BEFORE recursing into body — but
-            // v2's `geometry` table only carries body + descendants,
-            // so the dispatcher would otherwise skip html entirely.
-            // Paint at `(margin.left, margin.top)` with html's own
-            // `layout_size` (mirrors v1's
-            // `total_width = self.layout_size.or(cached_size)...`).
-            // Done on every page so multi-page docs with `html { background: ... }`
-            // pick up the fill on each page.
+            // Root `<html>` + `<body>` background pre-pass. v1's
+            // `BlockPageable::draw` for these elements paints
+            // bg/border/shadow on EVERY page because each page's
+            // sliced root pageable still calls them. v2's main
+            // dispatch sees them via the fragmenter's single fragment
+            // on page 0 only — multi-page docs would lose those fills
+            // on continuation pages. Paint each here at its own offset
+            // (`(margin.left, margin.top)` for html, plus
+            // `body_offset_pt` for body) using `layout_size` from the
+            // entry — mirrors v1's
+            // `total_width = self.layout_size.or(cached_size)...`
+            // derivation. The main dispatch loop skips both `root_id`
+            // and `body_id` to avoid double-painting on page 0.
             if let Some(root_id) = drawables.root_id
                 && let Some(root_block) = drawables.block_styles.get(&root_id)
             {
@@ -136,6 +139,23 @@ pub fn render_v2(
                     root_block,
                     resolved_margin.left,
                     resolved_margin.top,
+                );
+            }
+            // body's bg pre-pass runs on continuation pages only.
+            // Page 0 already paints body via the main dispatch loop
+            // (the fragmenter records body's fragment on page 0, with
+            // `layout_size` covering body's full height — clipped to
+            // page area at PDF render time, mirroring v1 exactly).
+            // Without this guard, page 0 would double-paint body's bg.
+            if page_idx > 0
+                && let Some(body_id) = drawables.body_id
+                && let Some(body_block) = drawables.block_styles.get(&body_id)
+            {
+                paint_root_block_v2(
+                    &mut canvas,
+                    body_block,
+                    resolved_margin.left + drawables.body_offset_pt.0,
+                    resolved_margin.top + drawables.body_offset_pt.1,
                 );
             }
             // `frag.x` is html-relative (fragmenter folds body's x
@@ -227,6 +247,16 @@ fn draw_v2_page(
             // Drawn inside an ancestor transform group elsewhere in
             // this loop. Skipping prevents double-painting. Bookmark
             // anchor recording above already ran unconditionally.
+            continue;
+        }
+        // Skip the html root: its bg / border / shadow are painted
+        // per-page in the pre-pass (`paint_root_block_v2`) above.
+        // Body intentionally is NOT skipped here — page 0 needs the
+        // main dispatch to paint body normally (so inline-root
+        // children at body's node_id keep flowing through
+        // `draw_block_with_inner_content`); page 1+ relies on the
+        // body branch of the pre-pass.
+        if Some(node_id) == drawables.root_id {
             continue;
         }
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -118,6 +118,26 @@ pub fn render_v2(
                 bookmark_collector: bookmark_collector.as_mut(),
                 link_collector: Some(&mut link_collector),
             };
+            // Root `<html>` background pre-pass. v1's
+            // `BlockPageable::draw` for the html element paints its
+            // own bg/border/shadow BEFORE recursing into body — but
+            // v2's `geometry` table only carries body + descendants,
+            // so the dispatcher would otherwise skip html entirely.
+            // Paint at `(margin.left, margin.top)` with html's own
+            // `layout_size` (mirrors v1's
+            // `total_width = self.layout_size.or(cached_size)...`).
+            // Done on every page so multi-page docs with `html { background: ... }`
+            // pick up the fill on each page.
+            if let Some(root_id) = drawables.root_id
+                && let Some(root_block) = drawables.block_styles.get(&root_id)
+            {
+                paint_root_block_v2(
+                    &mut canvas,
+                    root_block,
+                    resolved_margin.left,
+                    resolved_margin.top,
+                );
+            }
             // `frag.x` is html-relative (fragmenter folds body's x
             // offset in); `frag.y` is body-content-area-relative — so
             // only y receives `body_offset_pt`.
@@ -649,6 +669,59 @@ fn draw_block_v2(
 
     draw_with_opacity(canvas, entry.opacity, |canvas| {
         draw_block_inner_paint(canvas, entry, x, y, frag);
+    });
+}
+
+/// v2 root-element (`<html>`) background pre-pass. The fragmenter's
+/// `geometry` table only carries body + descendants, so the standard
+/// per-(node_id, fragment) dispatch never visits html. Mirror v1's
+/// `BlockPageable::draw` for the html root by painting bg / border /
+/// shadow at `(margin.left, margin.top)` with html's own
+/// `layout_size` (which equals body's outer height including
+/// collapsed margins, matching v1's `total_height` derivation).
+///
+/// Called once per page from `render_v2`; intentionally bypasses the
+/// `body_offset_pt.y` adjustment that the main dispatch loop applies,
+/// because html's bg paints at the page's margin top, not at body's
+/// content origin.
+fn paint_root_block_v2(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    entry: &crate::drawables::BlockEntry,
+    margin_left_pt: f32,
+    margin_top_pt: f32,
+) {
+    use crate::pageable::draw_with_opacity;
+    let Some(size) = entry.layout_size else {
+        return;
+    };
+
+    draw_with_opacity(canvas, entry.opacity, |canvas| {
+        if entry.visible {
+            crate::background::draw_box_shadows(
+                canvas,
+                &entry.style,
+                margin_left_pt,
+                margin_top_pt,
+                size.width,
+                size.height,
+            );
+            crate::background::draw_background(
+                canvas,
+                &entry.style,
+                margin_left_pt,
+                margin_top_pt,
+                size.width,
+                size.height,
+            );
+            crate::pageable::draw_block_border(
+                canvas,
+                &entry.style,
+                margin_left_pt,
+                margin_top_pt,
+                size.width,
+                size.height,
+            );
+        }
     });
 }
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -441,6 +441,14 @@ fn draw_under_transform(
     // coordinates — the surface transform applies on top, mirroring v1
     // where `inner.draw(...)` recurses through children with their
     // pre-transform layout.
+    //
+    // Descendants that have their OWN `TransformEntry` recurse into
+    // `draw_under_transform` so their matrix composes with the outer
+    // push (matches v1's nested `TransformWrapperPageable::draw` call
+    // chain at `pageable.rs:2714-2725`). Without this recursion the
+    // inner transform would be silently dropped, breaking
+    // `<div style="transform:rotate"><div style="transform:scale">`
+    // (PR #305 Devin).
     for &desc_id in &tx.descendants {
         let Some(desc_geom) = geometry.get(&desc_id) else {
             continue;
@@ -451,9 +459,26 @@ fn draw_under_transform(
             }
             let desc_x = margin_left_pt + px_to_pt(desc_frag.x);
             let desc_y = margin_top_pt + px_to_pt(desc_frag.y);
-            dispatch_fragment(
-                canvas, desc_id, desc_geom, desc_frag, desc_x, desc_y, drawables, page_index,
-            );
+            if let Some(desc_tx) = drawables.transforms.get(&desc_id) {
+                draw_under_transform(
+                    canvas,
+                    desc_tx,
+                    desc_id,
+                    desc_geom,
+                    desc_frag,
+                    desc_x,
+                    desc_y,
+                    geometry,
+                    drawables,
+                    margin_left_pt,
+                    margin_top_pt,
+                    page_index,
+                );
+            } else {
+                dispatch_fragment(
+                    canvas, desc_id, desc_geom, desc_frag, desc_x, desc_y, drawables, page_index,
+                );
+            }
         }
     }
 

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -390,6 +390,18 @@ fn inline_byte_equality_cases() {
             "nested transforms (rotate around translate)",
             r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.outer{width:120px;height:80px;background:#cef;transform:translate(10px,5px)}.inner{width:60px;height:40px;background:#fce;transform:rotate(10deg)}</style></head><body><div class="outer"><div class="inner"></div></div></body></html>"##,
         ),
+        // PR #305 follow-up Devin: nested transforms with a
+        // non-transform descendant inside the inner transform caused
+        // double-draw — `draw_under_transform` for the OUTER iterated
+        // its full `descendants` list (which includes the inner's own
+        // descendants), so the deeply nested node was painted once
+        // under outer*inner (correct, via the inner recursion) and a
+        // second time under outer only (wrong). Regression: a styled
+        // grandchild block inside two stacked transforms.
+        (
+            "triple nested transform descendant double-draw",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.outer{width:200px;height:120px;background:#cef;transform:translate(8px,4px)}.inner{width:120px;height:80px;background:#fce;transform:rotate(5deg)}.leaf{width:40px;height:20px;background:#ffd}</style></head><body><div class="outer"><div class="inner"><div class="leaf"></div></div></div></body></html>"##,
+        ),
         // PR 6 follow-up: shared-node_id inner content (inline-root
         // paragraph from `convert::inline_root`, replaced image/svg
         // from `convert::replaced`) must paint at the wrapping block's

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -400,6 +400,18 @@ fn inline_byte_equality_cases() {
             "bordered paragraph with background (shared node_id)",
             r##"<!DOCTYPE html><html><head><style>body{margin:0}p{margin:0;border:3px solid #444;background:#fce}</style></head><body><p>hello</p></body></html>"##,
         ),
+        // PR 6 follow-up (fulgur-9y1a) — html root element's
+        // background was silently dropped because the fragmenter's
+        // `geometry` only records body + descendants, never html. v2
+        // now paints html's bg as a pre-pass at `(margin.left,
+        // margin.top)` with `block_styles[root_id].layout_size`.
+        // Without that pre-pass v2 lost 13 bytes per gradient-hint
+        // fixture (six fixtures regressed simultaneously, all sharing
+        // `html, body { background: white }`).
+        (
+            "html background distinct from body background",
+            r##"<!DOCTYPE html><html><head><style>html, body { margin:0; padding:0; background:white; } .g { width:120px; height:80px; margin:24px; background:red; }</style></head><body><div class="g"></div></body></html>"##,
+        ),
     ];
 
     // Bookmark-inside-transform regression (PR #305 Devin): a heading

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -378,6 +378,18 @@ fn inline_byte_equality_cases() {
             "block with transform rotate around center",
             r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.box{width:80px;height:60px;background:#fce;transform:rotate(15deg);transform-origin:center}</style></head><body><div class="box"></div></body></html>"##,
         ),
+        // PR #305 Devin: nested transforms — inner transform was
+        // silently dropped because `draw_under_transform` dispatched
+        // descendants via `dispatch_fragment` which never checks
+        // `drawables.transforms`. v1's nested
+        // `TransformWrapperPageable::draw` recursively pushes both
+        // matrices; v2 must do the same by recursing into
+        // `draw_under_transform` when a descendant has its own
+        // `TransformEntry`.
+        (
+            "nested transforms (rotate around translate)",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.outer{width:120px;height:80px;background:#cef;transform:translate(10px,5px)}.inner{width:60px;height:40px;background:#fce;transform:rotate(10deg)}</style></head><body><div class="outer"><div class="inner"></div></div></body></html>"##,
+        ),
         // PR 6 follow-up: shared-node_id inner content (inline-root
         // paragraph from `convert::inline_root`, replaced image/svg
         // from `convert::replaced`) must paint at the wrapping block's

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -402,6 +402,17 @@ fn inline_byte_equality_cases() {
         ),
     ];
 
+    // Bookmark-inside-transform regression (PR #305 Devin): a heading
+    // nested under a `transform`-wrapped ancestor must still record a
+    // bookmark anchor in the PDF outline. v1 invokes
+    // `BookmarkMarkerWrapperPageable::draw` recursively from inside
+    // `TransformWrapperPageable::draw`; v2 records the anchor BEFORE
+    // the `transformed_descendants` skip in the dispatcher.
+    let bookmark_in_transform = (
+        "bookmark anchor inside transformed ancestor",
+        r##"<!DOCTYPE html><html><head><style>body{margin:0}div{transform:rotate(5deg)}h1{margin:0;font-size:14px}</style></head><body><div><h1>Heading</h1></div></body></html>"##,
+    );
+
     let cases = pr3_cases
         .iter()
         .chain(pr4_cases.iter())
@@ -409,6 +420,27 @@ fn inline_byte_equality_cases() {
         .chain(pr6_cases.iter());
     for (label, html) in cases {
         let engine = Engine::builder().build();
+        let v1 = engine
+            .render_html(html)
+            .unwrap_or_else(|e| panic!("v1 render `{label}`: {e}"));
+        let v2 = engine
+            .render_html_v2(html)
+            .unwrap_or_else(|e| panic!("v2 render `{label}`: {e}"));
+        assert_eq!(
+            v1,
+            v2,
+            "inline case `{label}` is not byte-identical (v1={}B v2={}B)",
+            v1.len(),
+            v2.len(),
+        );
+    }
+
+    // Bookmark anchors require `bookmarks(true)` on the engine —
+    // separate render so the assertion can target the
+    // bookmark-inside-transform case explicitly.
+    {
+        let (label, html) = bookmark_in_transform;
+        let engine = Engine::builder().bookmarks(true).build();
         let v1 = engine
             .render_html(html)
             .unwrap_or_else(|e| panic!("v1 render `{label}`: {e}"));

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -362,10 +362,29 @@ fn inline_byte_equality_cases() {
         ),
     ];
 
+    // PR 6 (Transform + MulticolRule + marker wrappers verification)
+    // exercises the new `Drawables.transforms` and
+    // `Drawables.multicol_rules` maps. Transform tests cover the
+    // shared-node_id case (block + transform same id) and the strict
+    // descendant case (block wraps a child with its own id). Multicol
+    // rule painting requires a `column-rule` style, which the example
+    // fixtures don't currently use, so we add minimal cases here.
+    let pr6_cases: &[(&str, &str)] = &[
+        (
+            "block with transform translate (shared node_id)",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.box{width:80px;height:60px;background:#cef;transform:translate(10px,5px)}</style></head><body><div class="box"></div></body></html>"##,
+        ),
+        (
+            "block with transform rotate around center",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.box{width:80px;height:60px;background:#fce;transform:rotate(15deg);transform-origin:center}</style></head><body><div class="box"></div></body></html>"##,
+        ),
+    ];
+
     let cases = pr3_cases
         .iter()
         .chain(pr4_cases.iter())
-        .chain(pr5_cases.iter());
+        .chain(pr5_cases.iter())
+        .chain(pr6_cases.iter());
     for (label, html) in cases {
         let engine = Engine::builder().build();
         let v1 = engine

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -378,6 +378,28 @@ fn inline_byte_equality_cases() {
             "block with transform rotate around center",
             r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.box{width:80px;height:60px;background:#fce;transform:rotate(15deg);transform-origin:center}</style></head><body><div class="box"></div></body></html>"##,
         ),
+        // PR 6 follow-up: shared-node_id inner content (inline-root
+        // paragraph from `convert::inline_root`, replaced image/svg
+        // from `convert::replaced`) must paint at the wrapping block's
+        // *content-box* top-left, not its border-box top-left, when
+        // the block carries `padding` or `border`. v1 expresses this
+        // via `PositionedChild { x: content_inset.x, y:
+        // content_inset.y }`; v2 mirrors it by adding
+        // `block.style.content_inset()` inside
+        // `draw_block_with_inner_content` (and
+        // `draw_list_item_with_block`). Without that offset, every
+        // text run inside a padded block landed `padding+border`
+        // worth of px high-and-left of where it should — the bug that
+        // kept `examples/transform`'s `.box { padding: 6px }` 11
+        // bytes short.
+        (
+            "padded paragraph with background (shared node_id)",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0}p{margin:0;padding:6px;background:#cef}</style></head><body><p>hello</p></body></html>"##,
+        ),
+        (
+            "bordered paragraph with background (shared node_id)",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0}p{margin:0;border:3px solid #444;background:#fce}</style></head><body><p>hello</p></body></html>"##,
+        ),
     ];
 
     let cases = pr3_cases

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -436,6 +436,20 @@ fn inline_byte_equality_cases() {
             "html background distinct from body background",
             r##"<!DOCTYPE html><html><head><style>html, body { margin:0; padding:0; background:white; } .g { width:120px; height:80px; margin:24px; background:red; }</style></head><body><div class="g"></div></body></html>"##,
         ),
+        // PR 6 follow-up (fulgur-9y1a) — `extract_drawables_from_pageable`
+        // recurses into the Pageable tree to populate per-NodeId draw
+        // payloads. `LineItem::InlineBox` carries inner content (e.g.
+        // an inline `<svg>`) that `paragraph::draw_shaped_lines`
+        // paints via `ib.content.draw(...)` directly. Recursing into
+        // that content registered it again in `svgs` / `block_styles`
+        // and the v2 dispatcher then double-painted at the fragment's
+        // own coordinates (e.g. `body + svg_margin` for
+        // `<svg style="margin:Npx">`). Drop the recurse so inline-box
+        // content stays a pure paragraph-rooted draw.
+        (
+            "body with inline svg margin",
+            r##"<!DOCTYPE html><html><head><style>html,body{margin:0;padding:0}</style></head><body><svg width="40" height="40" xmlns="http://www.w3.org/2000/svg" style="margin:20px"><rect x="0" y="0" width="40" height="40" fill="#fa0"/></svg></body></html>"##,
+        ),
     ];
 
     // Bookmark-inside-transform regression (PR #305 Devin): a heading

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -67,4 +67,18 @@ allowlist = [
     "vrt://paint/repeating-linear-gradient.html",
     "vrt://paint/repeating-linear-gradient-hint.html",
     "vrt://paint/repeating-radial-gradient.html",
+    # PR 6 follow-up (skip InlineBox.content recurse, fulgur-9y1a) —
+    # inline-block / inline-flex / inline-grid / inline-svg content is
+    # painted via `paragraph::draw_shaped_lines` calling
+    # `ib.content.draw(...)`. extract was recursing into
+    # `InlineBox.content` and registering the inner Pageable in
+    # `block_styles` / `svgs` / etc., so v2 dispatch double-painted
+    # everything inside an inline box. Six layout fixtures lit up at
+    # once after dropping the recurse.
+    "vrt://layout/inline-block-basic.html",
+    "vrt://layout/inline-block-nested.html",
+    "vrt://layout/inline-block-overflow-hidden.html",
+    "vrt://layout/inline-flex-smoke.html",
+    "vrt://layout/inline-grid-smoke.html",
+    "vrt://svg/shapes.html",
 ]

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -54,4 +54,17 @@ allowlist = [
     "examples://border-radius",
     "examples://table-header",
     "examples://transform",
+    # PR 6 follow-up (root `<html>` bg pre-pass, fulgur-9y1a) — html
+    # element's own `background` was silently dropped because the
+    # fragmenter's `geometry` only carries body + descendants. v2 now
+    # paints html's bg explicitly at `(margin.left, margin.top)` with
+    # `block_styles[root_id].layout_size` before the main loop runs.
+    # Six paint fixtures with `html, body { background: white }` lit up
+    # at once.
+    "vrt://paint/linear-gradient-hint-30pct.html",
+    "vrt://paint/linear-gradient-hint-70pct.html",
+    "vrt://paint/radial-gradient-hint.html",
+    "vrt://paint/repeating-linear-gradient.html",
+    "vrt://paint/repeating-linear-gradient-hint.html",
+    "vrt://paint/repeating-radial-gradient.html",
 ]

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -43,4 +43,15 @@ allowlist = [
     "vrt://paint/radial-gradient-no-repeat-corner.html",
     "vrt://paint/radial-gradient-repeat-round.html",
     "vrt://paint/radial-gradient-tiled.html",
+    # PR 6 (Transform + MulticolRule + content-inset fix) — transform
+    # plumbing unlocks the `examples/transform` fixture, and the
+    # shared-node_id content-box offset (`block.style.content_inset()`
+    # added inside `draw_block_with_inner_content`) closes the
+    # `padding`/`border` shift that was keeping basic painted block
+    # fixtures off the allowlist.
+    "vrt://basic/box-shadow.html",
+    "examples://bookmark",
+    "examples://border-radius",
+    "examples://table-header",
+    "examples://transform",
 ]

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -710,3 +710,70 @@ fn render_v2_smoke_triple_nested_transform_descendants() {
     let pdf = engine.render_html_v2(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
+
+#[test]
+fn render_v2_smoke_multicol_dashed_and_dotted_column_rule() {
+    // Exercises the `ColumnRuleStyle::Dashed` and `Dotted` arms of
+    // `build_multicol_stroke` (`render.rs:613-627` from PR #305).
+    // Solid is already covered by the `multicol-2` VRT fixture but
+    // dashed/dotted patterns weren't on any byte-eq path.
+    let html_dashed = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:8pt}.cols{column-count:2;column-rule:1pt dashed #888;column-gap:12pt;height:80pt}.cell{height:30pt;background:#cef;margin-bottom:6pt}</style></head><body><div class="cols"><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div></body></html>"##;
+    let html_dotted = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:8pt}.cols{column-count:2;column-rule:1pt dotted #888;column-gap:12pt;height:80pt}.cell{height:30pt;background:#cef;margin-bottom:6pt}</style></head><body><div class="cols"><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf_dashed = engine.render_html_v2(html_dashed).expect("dashed render");
+    let pdf_dotted = engine.render_html_v2(html_dotted).expect("dotted render");
+    assert!(!pdf_dashed.is_empty());
+    assert!(!pdf_dotted.is_empty());
+}
+
+#[test]
+fn render_v2_smoke_paragraph_multi_fragment_slice() {
+    // Exercises `paragraph_lines_for_page` (`render.rs:1075-1138`
+    // from PR #305): a paragraph that splits across multiple pages
+    // requires the slice / rebase logic. Most fixtures keep
+    // paragraphs on one page, so this branch needs an explicit
+    // multi-page paragraph.
+    let mut paragraph_text = String::new();
+    for i in 0..400 {
+        use std::fmt::Write;
+        write!(&mut paragraph_text, "Sentence {i} with some words. ").unwrap();
+    }
+    let html = format!(
+        r##"<!DOCTYPE html><html><head><style>html,body{{margin:0;padding:0}}p{{margin:0;font-size:14pt;line-height:1.4}}</style></head><body><p>{paragraph_text}</p></body></html>"##
+    );
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(&html).expect("v2 render");
+    assert!(!pdf.is_empty());
+    // Multi-page sanity check: multiple `Type /Page` entries (one per
+    // page object) — without slicing, only the first fragment would
+    // emit any glyphs.
+    let pdf_str = String::from_utf8_lossy(&pdf);
+    let page_count = pdf_str.matches("/Type /Page\n").count();
+    assert!(
+        page_count >= 2,
+        "expected multi-page output, got {page_count} pages"
+    );
+}
+
+#[test]
+fn render_v2_smoke_list_item_image_marker() {
+    // Exercises `draw_list_item_marker`'s `ListItemMarker::Image` arm
+    // (`render.rs:1004-1019` from PR #305): a `<li>` rendered with a
+    // raster `list-style-image` so the marker takes the
+    // `ImageMarker::Raster` branch instead of the text/glyph default.
+    let png_data: Vec<u8> = vec![
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90,
+        0x77, 0x53, 0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0xF8,
+        0xCF, 0xC0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00, 0xC9, 0xFE, 0x92, 0xEF, 0x00, 0x00, 0x00,
+        0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+    ];
+    let mut bundle = AssetBundle::default();
+    bundle.add_css(r#"li { list-style-image: url("bullet.png"); }"#);
+    bundle.add_image("bullet.png", png_data);
+    let html =
+        r##"<!doctype html><html><body><ul><li>Item 1</li><li>Item 2</li></ul></body></html>"##;
+    let engine = Engine::builder().assets(bundle).build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -626,3 +626,72 @@ fn position_fixed_repeats_on_every_page() {
         "page 2 should also contain FXFXFX (per-page repetition for position:fixed)"
     );
 }
+
+// ── Phase 4 v2 render path smoke tests (fulgur-9t3z) ─────────────────
+//
+// Exercise the v2 dispatcher (`render_v2`) so the patch-coverage gate
+// sees the new draw helpers added in PR 6 (`draw_under_transform`,
+// `draw_under_clip`, `draw_under_opacity`, `paint_multicol_rule_for_page`,
+// `paint_root_block_v2`, `MarginBoxRenderer`). These run end-to-end
+// through `Engine::render_html_v2` and assert only that the bytes
+// come back non-empty — byte-eq with v1 is already covered by the
+// `render_path_parity` shadow harness.
+
+#[test]
+fn render_v2_smoke_transform_translate() {
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0}.box{width:80px;height:60px;background:#cef;transform:translate(10px,5px)}</style></head><body><div class="box"></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn render_v2_smoke_nested_transforms() {
+    // Exercises the `draw_under_transform` recursion path added in
+    // PR #305 Devin fix: outer rotate wraps an inner translate, both
+    // matrices must compose.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0}.outer{width:120px;height:80px;background:#cef;transform:rotate(10deg)}.inner{width:60px;height:40px;background:#fce;transform:translate(8px,4px)}</style></head><body><div class="outer"><div class="inner"></div></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn render_v2_smoke_multicol_with_column_rule() {
+    // Exercises `paint_multicol_rule_for_page` — most fixtures don't
+    // declare `column-rule` so this path needs an explicit smoke test.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:8pt}.cols{column-count:2;column-rule:1pt solid #888;column-gap:12pt;height:80pt}.cell{height:30pt;background:#cef;margin-bottom:6pt}</style></head><body><div class="cols"><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn render_v2_smoke_html_body_bg_multi_page() {
+    // Exercises `paint_root_block_v2` for both `<html>` (pre-pass on
+    // every page) and `<body>` (pre-pass on continuation pages).
+    let html = r##"<!DOCTYPE html><html><head><style>html,body{margin:0;background:#fafafa}.tall{height:1500px;background:#cef}</style></head><body><div class="tall"></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn render_v2_smoke_block_with_inline_root_padding() {
+    // Exercises `draw_block_with_inner_content` content-inset path —
+    // the `padding: 6px` shift fix that landed in PR 6.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0}p{margin:0;padding:6px;background:#cef}</style></head><body><p>hello</p></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn render_v2_smoke_bookmarks_under_transform() {
+    // Exercises the bookmark-anchor pre-skip path (`record(...)` runs
+    // before `transformed_descendants` skip) added in PR 6 Devin fix.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0}div{transform:rotate(5deg)}h1{margin:0;font-size:14px}</style></head><body><div><h1>Heading</h1></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().bookmarks(true).build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -695,3 +695,18 @@ fn render_v2_smoke_bookmarks_under_transform() {
     let pdf = engine.render_html_v2(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
+
+#[test]
+fn render_v2_smoke_triple_nested_transform_descendants() {
+    // Exercises the `nested_skip` pre-collection in
+    // `draw_under_transform` added in PR #305 follow-up Devin: the
+    // outer transform's `descendants` includes the inner transform's
+    // own descendants (e.g. a styled grandchild block), so the
+    // outer's iteration must skip them or they get painted twice —
+    // once correctly under outer*inner via the recursion, and once
+    // wrongly under outer only.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0}.outer{width:200px;height:120px;background:#cef;transform:translate(8px,4px)}.inner{width:120px;height:80px;background:#fce;transform:rotate(5deg)}.leaf{width:40px;height:20px;background:#ffd}</style></head><body><div class="outer"><div class="inner"><div class="leaf"></div></div></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}


### PR DESCRIPTION
## Summary

Phase 4 PR 6 — `TransformWrapperPageable` と `MulticolRulePageable` を Drawables 経路に移行し、shared-node_id inner content の content-inset 不適用バグも合わせて解消しました。

### Drawables 拡張

- **`Drawables.transforms: BTreeMap<NodeId, TransformEntry>`** (`{matrix, origin, descendants}`)
  - convert: `extract_drawables_from_pageable` で wrapper の inner subtree を walk する前後の NodeId snapshot 差分から strict descendants を採取 (wrapper 自身の `inner_id` は除外)
  - render: `dispatch_fragment` helper を hoist し、`draw_under_transform` で wrapper の payload + 全 descendants を 1 つの `push_transform / pop` group に包む。`link_collector` にも transform を push して `/Link` 矩形が device space にマップされるよう v1 と一致
- **`Drawables.multicol_rules: BTreeMap<NodeId, MulticolRuleEntry>`** (`{rule, groups}`)
  - convert: `MulticolRulePageable` arm で entry を記録、child へ recurse
  - render: 主 draw loop の後に post-pass で `paint_multicol_rule_for_page` を呼び、container の per-page fragment cumulative heights から `groups` を partition、`stroke_line` で rule 描画

### shared-node_id inner content の content-inset 修正

`convert::inline_root` (inline-root paragraph) と `convert::replaced` (replaced image / svg) は `PositionedChild { x: content_inset.x, y: content_inset.y }` で inner を offset するが、v2 flat dispatch には `PositionedChild` がないため `padding + border` が脱落していた。`draw_block_with_inner_content` と `draw_list_item_with_block` で `block.style.content_inset()` を読んで inner content の paint 位置に加算するよう修正。block bg/border 自体は border-box top-left のままで、inner content だけ content-box top-left へシフトする。

### Devin review fixes (`ba12b47`)

1. `paint_multicol_rule_for_page` で `consumed_above` を col_heights から引いてから clamp するよう v1 `slice_for_page` を mirror
2. bookmark anchor recording を `transformed_descendants` skip より前に移動 (transform 内ヘディングが PDF outline から漏れないように)
3. `TransformEntry.descendants` doc comment を "strict descendants only" の実装と一致させる

### marker wrappers

`BookmarkMarkerWrapperPageable` / `StringSetWrapperPageable` / `RunningElementWrapperPageable` / `CounterOpWrapperPageable` は Phase 3.4 で fragmenter geometry 駆動に移行済のため新規 entry type は不要、既存の delegate arm を維持。

## Coverage

- `cargo build -p fulgur`: 0 warning
- `cargo clippy --workspace --all-targets -- -D warnings`: 0 warning
- `cargo test -p fulgur --lib`: 847 passed
- `cargo test -p fulgur-vrt`: green (no regressions)
- shadow harness: **`v2 byte-identical 29 / 59 fixtures (allowlist 20)`**
  - 24/59 → 29/59 (+5: `vrt://basic/box-shadow.html`, `examples/bookmark`, `examples/border-radius`, `examples/table-header`, `examples/transform`)
  - 内訳の `examples/transform` は元 v1 比 337 B 差 → 0 B (byte-eq 達成)
- 新 inline regression case 5 件 (transform translate / rotate-origin / padded paragraph / bordered paragraph / bookmark in transform) すべて byte-eq

## 残課題

PR 6 のスコープ外として後続 PR で扱うもの:

- `vrt/layout/inline-block-*`, `inline-flex-smoke`, `inline-grid-smoke`, `review_card_inline_block` — inline-box wiring gap (transform / multicol と無関係)
- `vrt/layout/overflow-hidden{,-rounded}.html`, `examples/overflow-hidden` — overflow clip scope (PR 4 のリリースノートでも deferred 扱い)
- `vrt/paint/*-gradient-hint*` (6 fixtures) — gradient hint 共通の差分
- `vrt/gcpm/*` (4 fixtures) — GCPM (running element / string-set / counter / page-selector) のドキュメント-スコープ差分
- `vrt/bugs/cover-page-break-after`, `vrt/bugs/grid-row-promote-background`, `vrt/svg/shapes` — bug-tracker fixtures
- `examples/box-shadow`, `examples/break-inside`, `examples/header-footer{,-split}`, `examples/multicol{,-span-all}`, `examples/svg`, `examples/wasm-demo` — 個別調査要

## Test plan

- [ ] `FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur --test render_path_parity` (inline + on-disk shadow harness)
- [ ] `cargo test -p fulgur --lib`
- [ ] `cargo test -p fulgur-vrt`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo fmt --check`