### PR TITLE
Phase 4 PR 6 follow-up — drop InlineBox recurse to prevent double-paint

### DIFF
--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -319,9 +319,8 @@ fn extract_drawables_from_pageable(
     // Paragraph leaf — record the shaped lines verbatim. The lines
     // already carry per-glyph positions, link spans, decoration spans,
     // and inline-image / inline-box items, so no re-shaping at render
-    // time. Inline content (LineItem::InlineBox) embeds whole Pageable
-    // subtrees that need their own draw payload — recurse so wrapper
-    // markers / nested blocks land in the appropriate `Drawables` map.
+    // time. Inline content (LineItem::InlineBox) is intentionally NOT
+    // recursed into — see the comment inside the arm for rationale.
     if let Some(para) = any.downcast_ref::<ParagraphPageable>() {
         if let Some(node_id) = para.node_id {
             out.paragraphs.insert(

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -334,17 +334,15 @@ fn extract_drawables_from_pageable(
                 },
             );
         }
-        // Recurse into inline-box content. Each `LineItem::InlineBox`
-        // holds a `Box<dyn Pageable>` (typically a `BlockPageable` for
-        // `<span>`-style inline blocks) so its descendants can register
-        // their own payloads.
-        for line in &para.lines {
-            for item in &line.items {
-                if let crate::paragraph::LineItem::InlineBox(ib) = item {
-                    extract_drawables_from_pageable(ib.content.as_ref(), out);
-                }
-            }
-        }
+        // Inline-box content (e.g. inline `<svg>`, inline-block
+        // `<span>`) is painted via `paragraph::draw_shaped_lines`
+        // which calls `ib.content.draw(...)` directly (line ~820 of
+        // paragraph.rs). Recursing here and registering the inner
+        // content in `block_styles` / `svgs` / `images` would
+        // double-paint at render time — once via the paragraph's
+        // inline call, once via the v2 dispatcher's per-NodeId loop.
+        // Skip recursion entirely so inline content stays a v1-style
+        // draw rooted in the paragraph's own dispatch.
         return;
     }
     // Block / List / Table / wrappers — recurse into children. Block

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -436,6 +436,20 @@ fn inline_byte_equality_cases() {
             "html background distinct from body background",
             r##"<!DOCTYPE html><html><head><style>html, body { margin:0; padding:0; background:white; } .g { width:120px; height:80px; margin:24px; background:red; }</style></head><body><div class="g"></div></body></html>"##,
         ),
+        // PR 6 follow-up (fulgur-9y1a) — `extract_drawables_from_pageable`
+        // recurses into the Pageable tree to populate per-NodeId draw
+        // payloads. `LineItem::InlineBox` carries inner content (e.g.
+        // an inline `<svg>`) that `paragraph::draw_shaped_lines`
+        // paints via `ib.content.draw(...)` directly. Recursing into
+        // that content registered it again in `svgs` / `block_styles`
+        // and the v2 dispatcher then double-painted at the fragment's
+        // own coordinates (e.g. `body + svg_margin` for
+        // `<svg style="margin:Npx">`). Drop the recurse so inline-box
+        // content stays a pure paragraph-rooted draw.
+        (
+            "body with inline svg margin",
+            r##"<!DOCTYPE html><html><head><style>html,body{margin:0;padding:0}</style></head><body><svg width="40" height="40" xmlns="http://www.w3.org/2000/svg" style="margin:20px"><rect x="0" y="0" width="40" height="40" fill="#fa0"/></svg></body></html>"##,
+        ),
     ];
 
     // Bookmark-inside-transform regression (PR #305 Devin): a heading

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -67,4 +67,18 @@ allowlist = [
     "vrt://paint/repeating-linear-gradient.html",
     "vrt://paint/repeating-linear-gradient-hint.html",
     "vrt://paint/repeating-radial-gradient.html",
+    # PR 6 follow-up (skip InlineBox.content recurse, fulgur-9y1a) —
+    # inline-block / inline-flex / inline-grid / inline-svg content is
+    # painted via `paragraph::draw_shaped_lines` calling
+    # `ib.content.draw(...)`. extract was recursing into
+    # `InlineBox.content` and registering the inner Pageable in
+    # `block_styles` / `svgs` / etc., so v2 dispatch double-painted
+    # everything inside an inline box. Six layout fixtures lit up at
+    # once after dropping the recurse.
+    "vrt://layout/inline-block-basic.html",
+    "vrt://layout/inline-block-nested.html",
+    "vrt://layout/inline-block-overflow-hidden.html",
+    "vrt://layout/inline-flex-smoke.html",
+    "vrt://layout/inline-grid-smoke.html",
+    "vrt://svg/shapes.html",
 ]


### PR DESCRIPTION
## Summary

`extract_drawables_from_pageable` の `LineItem::InlineBox.content` 再帰を削除し、inline-box の内部 Pageable が v2 dispatch で double-paint される問題を解消。

## Root cause

`ParagraphPageable.lines[].items[LineItem::InlineBox].content` は v1 / v2 両方で `paragraph::draw_shaped_lines` から `ib.content.draw(...)` で paint される (paragraph.rs:820)。

しかし extract が再帰してその inner Pageable (inline `<svg>`, inline-block `<span>` など) を `svgs` / `block_styles` / `images` に登録してしまうと、v2 の per-NodeId dispatcher も同じ内容を fragment 座標で再 paint し、二重描画になっていた。

`vrt://svg/shapes.html` が代表例:
- v1: paragraph の inline 呼び出しで SVG を body 左上に 1 回 paint
- v2: paragraph 経由 (body 左上) + dispatcher 経由 (`body + svg.margin` = `(86.69, 86.69)`) の **2 回 paint** で +42 B 差

## Fix

`extract_drawables_from_pageable` の `ParagraphPageable` arm から InlineBox 再帰を削除。コメントで意図を明記。

```rust
// Inline-box content (e.g. inline `<svg>`, inline-block `<span>`)
// is painted via `paragraph::draw_shaped_lines` which calls
// `ib.content.draw(...)` directly. Recursing here and registering
// the inner content in `block_styles` / `svgs` / `images` would
// double-paint at render time...
return;
```

## Coverage

shadow harness: **35 / 59 (allowlist 26) → 41 / 59 (allowlist 32)**

新規 allowlist 入り (6 fixtures):
- `vrt://layout/inline-block-basic.html`
- `vrt://layout/inline-block-nested.html`
- `vrt://layout/inline-block-overflow-hidden.html`
- `vrt://layout/inline-flex-smoke.html`
- `vrt://layout/inline-grid-smoke.html`
- `vrt://svg/shapes.html`

inline regression case `body with inline svg margin` を追加 (`<svg style="margin:Npx">` を body 直下に配置するパターン)。

## 注意

wrapper markers (Bookmark / StringSet / Counter / Running) は inline-box 内にあっても影響なし。これらは `bookmark_anchors` map (DOM 走査) と GCPM state (`geometry` 由来) から収集しており、この再帰経路に依存していない。

## Stack

base = `feat/phase4-pr6-residual` (PR #307 = html / body bg pre-pass)
PR #305 (PR 6 main) 直後に PR #307 → 本 PR と段階リベース。

## Test plan

- [ ] `FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur --test render_path_parity`
- [ ] `cargo test -p fulgur --lib`
- [ ] `cargo test -p fulgur-vrt`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo fmt --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
