### PR TITLE
Phase 4 PR 6 follow-up — overflow clip scope tracking via BlockEntry.clip_descendants

### DIFF
--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -347,6 +347,7 @@ fn extract_drawables_from_pageable(
     // Block / List / Table / wrappers — recurse into children. Block
     // also records its own paint payload (PR 4).
     if let Some(block) = any.downcast_ref::<BlockPageable>() {
+        let clipping = block.style.has_overflow_clip();
         if let Some(node_id) = block.node_id {
             out.block_styles.insert(
                 node_id,
@@ -356,11 +357,39 @@ fn extract_drawables_from_pageable(
                     visible: block.visible,
                     id: block.id.clone(),
                     layout_size: block.layout_size.or(block.cached_size),
+                    clip_descendants: Vec::new(),
                 },
             );
         }
+        // Snapshot the per-NodeId map keys before recursing so we can
+        // identify which descendants belong inside this block's
+        // `push_clip / pop` scope when the block carries
+        // `overflow: hidden | clip`. Mirrors the
+        // `TransformWrapperPageable` arm exactly.
+        let before = clipping.then(|| collect_drawables_node_ids(out));
         for pc in &block.children {
             extract_drawables_from_pageable(pc.child.as_ref(), out);
+        }
+        if let (Some(before), Some(node_id)) = (before, block.node_id) {
+            let after = collect_drawables_node_ids(out);
+            // Strict descendants only — exclude the wrapper's own key
+            // because the dispatcher emits its bg / border / shadow
+            // OUTSIDE the clip (matching v1's
+            // `BlockPageable::draw` ordering at
+            // `pageable.rs:1796-1827`). Inner content sharing the
+            // wrapper's `node_id` (inline-root paragraph, replaced
+            // image / svg from `convert::replaced` /
+            // `convert::inline_root`) is dispatched as part of the
+            // wrapper's own painting path, not via descendant
+            // iteration.
+            let descendants: Vec<usize> = after
+                .difference(&before)
+                .copied()
+                .filter(|&id| id != node_id)
+                .collect();
+            if let Some(entry) = out.block_styles.get_mut(&node_id) {
+                entry.clip_descendants = descendants;
+            }
         }
         return;
     }

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -49,6 +49,18 @@ pub struct BlockEntry {
     /// back to the fragment's width/height (CSS px → pt) at render
     /// time when absent.
     pub layout_size: Option<crate::pageable::Size>,
+    /// Strict descendant `NodeId`s that must paint INSIDE this block's
+    /// `push_clip_path` / `pop` group. Populated by
+    /// `extract_drawables_from_pageable` only when
+    /// `style.has_overflow_clip()` is true — non-clipping blocks leave
+    /// this empty so the dispatcher's main loop handles them with the
+    /// regular shared-node_id pattern.
+    ///
+    /// Mirrors the `TransformEntry.descendants` shape: render time
+    /// emits bg / border / shadow first (outside the clip, matching v1
+    /// `BlockPageable::draw` at `pageable.rs:1796-1827`), then pushes
+    /// the clip path, dispatches each descendant fragment, and pops.
+    pub clip_descendants: Vec<NodeId>,
 }
 
 /// Paragraph draw payload for v2. Holds the shaped lines that

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -268,10 +268,24 @@ fn draw_v2_page(
     // descendants paint inside the clip's `push_clip_path / pop` group;
     // skipping them here prevents the main loop from also dispatching
     // them outside the clip.
+    //
+    // Body is excluded from this collection: the fragmenter records
+    // body with exactly one fragment at `page_index = 0`
+    // (`pagination_layout.rs:380-384`), so `draw_under_clip(body)`
+    // only fires on page 0. If we kept body in `clipped_descendants`,
+    // every descendant would still be skipped via the
+    // `clipped_descendants.contains(&node_id)` guard on page 1+ but
+    // nobody would dispatch them — silently blanking all content
+    // after page 1 on `<body style="overflow:hidden|auto|scroll">`
+    // (PR #310 follow-up Devin). Skipping body here means body-level
+    // overflow clip is not applied in v2, matching the pre-PR
+    // behavior; body clipping in a paged context is unusual and the
+    // pre-pass at `paint_root_block_v2` already handles body's own
+    // bg / border on continuation pages.
     let mut clipped_descendants: std::collections::BTreeSet<usize> =
         std::collections::BTreeSet::new();
-    for block in drawables.block_styles.values() {
-        if block.style.has_overflow_clip() {
+    for (&node_id, block) in &drawables.block_styles {
+        if block.style.has_overflow_clip() && Some(node_id) != drawables.body_id {
             clipped_descendants.extend(block.clip_descendants.iter().copied());
         }
     }
@@ -364,8 +378,20 @@ fn draw_v2_page(
             // so a `<div style="overflow:hidden;width:50px">long
             // text</div>` still needs the text clipped at the 50px
             // box even with no separate descendant NodeIds.
+            // Body is intentionally excluded from `draw_under_clip`:
+            // body has only a page-0 fragment so the clip would only
+            // wrap page-0 content, but body's `clip_descendants`
+            // include every block in the document. Descendants on
+            // page 1+ are dispatched by the main loop via
+            // `dispatch_fragment` (they're omitted from
+            // `clipped_descendants` above). Without this skip, body's
+            // page-0 clip would also re-dispatch every descendant
+            // already painted by the main loop, causing a double
+            // paint. See the `clipped_descendants` collection block
+            // for the rest of the body-overflow rationale.
             if let Some(block) = drawables.block_styles.get(&node_id)
                 && block.style.has_overflow_clip()
+                && Some(node_id) != drawables.body_id
             {
                 draw_under_clip(
                     canvas,

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -749,7 +749,30 @@ fn draw_under_clip(
         }
 
         // Strict descendants — each at its own fragment's coords.
+        //
+        // Transform-aware dispatch: a descendant that has its own
+        // `TransformEntry` must enter `draw_under_transform` so the
+        // surface transform composes correctly. The main loop skips
+        // these nodes via `clipped_descendants.contains(...)` BEFORE
+        // it reaches the per-fragment transform check, so without the
+        // recursion below v2 silently drops transforms inside an
+        // `overflow: hidden` ancestor (`<div style="overflow:hidden">
+        // <div style="transform:..."/></div>` — PR #310 Devin).
+        //
+        // Pre-skip the strict descendants of those transforms so they
+        // are not dispatched twice — once via `draw_under_transform`
+        // (which iterates `tx.descendants`) and once via the loop
+        // body's `dispatch_fragment`.
+        let transform_skip: std::collections::BTreeSet<usize> = block
+            .clip_descendants
+            .iter()
+            .filter_map(|id| drawables.transforms.get(id))
+            .flat_map(|tx| tx.descendants.iter().copied())
+            .collect();
         for &desc_id in &block.clip_descendants {
+            if transform_skip.contains(&desc_id) {
+                continue;
+            }
             let Some(desc_geom) = geometry.get(&desc_id) else {
                 continue;
             };
@@ -759,9 +782,27 @@ fn draw_under_clip(
                 }
                 let desc_x = margin_left_pt + px_to_pt(desc_frag.x);
                 let desc_y = margin_top_pt + px_to_pt(desc_frag.y);
-                dispatch_fragment(
-                    canvas, desc_id, desc_geom, desc_frag, desc_x, desc_y, drawables, page_index,
-                );
+                if let Some(desc_tx) = drawables.transforms.get(&desc_id) {
+                    draw_under_transform(
+                        canvas,
+                        desc_tx,
+                        desc_id,
+                        desc_geom,
+                        desc_frag,
+                        desc_x,
+                        desc_y,
+                        geometry,
+                        drawables,
+                        margin_left_pt,
+                        margin_top_pt,
+                        page_index,
+                    );
+                } else {
+                    dispatch_fragment(
+                        canvas, desc_id, desc_geom, desc_frag, desc_x, desc_y, drawables,
+                        page_index,
+                    );
+                }
             }
         }
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -353,9 +353,19 @@ fn draw_v2_page(
             // dispatch self's inner content + every strict descendant
             // INSIDE the clip, then pop. Same shape as
             // `draw_under_transform` but with `push_clip_path`.
+            //
+            // No `!clip_descendants.is_empty()` guard: shared-node_id
+            // inner content (inline-root paragraph from
+            // `convert::inline_root`, replaced image / svg from
+            // `convert::replaced`) lands at the same `node_id` as the
+            // wrapper and so produces an empty `clip_descendants`. v1
+            // pushes the clip unconditionally when
+            // `has_overflow_clip()` is true (`pageable.rs:1808-1826`),
+            // so a `<div style="overflow:hidden;width:50px">long
+            // text</div>` still needs the text clipped at the 50px
+            // box even with no separate descendant NodeIds.
             if let Some(block) = drawables.block_styles.get(&node_id)
                 && block.style.has_overflow_clip()
-                && !block.clip_descendants.is_empty()
             {
                 draw_under_clip(
                     canvas,

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -661,7 +661,30 @@ fn draw_under_clip(
     let svg_for_block = drawables.svgs.get(&node_id);
     let inner_inset = block.style.content_inset();
 
-    draw_with_opacity(canvas, block.opacity, |canvas| {
+    // When this node is a list-item with overflow clip, mirror v1's
+    // `ListItemPageable::draw` ordering: outer opacity uses
+    // `list_item.opacity` (the body BlockPageable inside is built with
+    // default opacity=1.0 in `convert::list_item::build_list_item_body`,
+    // so `block.opacity` here would silently drop CSS opacity), and
+    // the marker draws before `push_clip_path` (markers sit at negative
+    // x outside the body box, so they must not be clipped). Without
+    // this, `<li style="overflow:hidden">` loses its marker entirely
+    // and any opacity set on the `<li>` is ignored. (PR #310 Devin)
+    let list_item = drawables.list_items.get(&node_id);
+    let opacity = list_item.map_or(block.opacity, |li| li.opacity);
+
+    draw_with_opacity(canvas, opacity, |canvas| {
+        // List-item marker paints first, OUTSIDE the clip — v1's
+        // `ListItemPageable::draw` emits the marker before delegating
+        // to `body.draw` (which paints bg / border / shadow). Markers
+        // sit at negative x relative to (x_pt, y_pt), so they must
+        // also stay outside the clip path pushed below.
+        if let Some(li) = list_item
+            && li.visible
+        {
+            draw_list_item_marker(canvas, li, x_pt, y_pt);
+        }
+
         // bg / border / shadow outside the clip — same as
         // `draw_block_inner_paint` but inlined so the opacity wrap
         // covers the entire clipped region too.

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -263,6 +263,18 @@ fn draw_v2_page(
     for tx in drawables.transforms.values() {
         transformed_descendants.extend(tx.descendants.iter().copied());
     }
+    // Same shape as `transformed_descendants` but keyed by an ancestor
+    // block whose `style.has_overflow_clip()` is true. Strict
+    // descendants paint inside the clip's `push_clip_path / pop` group;
+    // skipping them here prevents the main loop from also dispatching
+    // them outside the clip.
+    let mut clipped_descendants: std::collections::BTreeSet<usize> =
+        std::collections::BTreeSet::new();
+    for block in drawables.block_styles.values() {
+        if block.style.has_overflow_clip() {
+            clipped_descendants.extend(block.clip_descendants.iter().copied());
+        }
+    }
 
     for (&node_id, geom) in geometry {
         // Bookmark anchor: emit on the page where the node's *first*
@@ -291,6 +303,11 @@ fn draw_v2_page(
             // Drawn inside an ancestor transform group elsewhere in
             // this loop. Skipping prevents double-painting. Bookmark
             // anchor recording above already ran unconditionally.
+            continue;
+        }
+        if clipped_descendants.contains(&node_id) {
+            // Drawn inside an ancestor `overflow: hidden|clip` block's
+            // `push_clip_path / pop` group elsewhere in this loop.
             continue;
         }
         // Skip the html root: its bg / border / shadow are painted
@@ -327,11 +344,38 @@ fn draw_v2_page(
                     margin_top_pt,
                     page_index,
                 );
-            } else {
-                dispatch_fragment(
-                    canvas, node_id, geom, frag, x_pt, y_pt, drawables, page_index,
-                );
+                continue;
             }
+            // `overflow: hidden | clip` block: bg / border / shadow
+            // paint OUTSIDE the clip (matching v1's
+            // `BlockPageable::draw` ordering at
+            // `pageable.rs:1796-1827`), then push the clip path,
+            // dispatch self's inner content + every strict descendant
+            // INSIDE the clip, then pop. Same shape as
+            // `draw_under_transform` but with `push_clip_path`.
+            if let Some(block) = drawables.block_styles.get(&node_id)
+                && block.style.has_overflow_clip()
+                && !block.clip_descendants.is_empty()
+            {
+                draw_under_clip(
+                    canvas,
+                    block,
+                    node_id,
+                    geom,
+                    frag,
+                    x_pt,
+                    y_pt,
+                    geometry,
+                    drawables,
+                    margin_left_pt,
+                    margin_top_pt,
+                    page_index,
+                );
+                continue;
+            }
+            dispatch_fragment(
+                canvas, node_id, geom, frag, x_pt, y_pt, drawables, page_index,
+            );
         }
     }
 
@@ -548,6 +592,150 @@ fn draw_under_transform(
     if let Some(lc) = canvas.link_collector.as_deref_mut() {
         lc.pop_transform();
     }
+}
+
+/// Push the block's overflow-clip path onto the surface, dispatch the
+/// wrapper's own bg / border / shadow + every descendant fragment that
+/// lands on `page_index`, then pop. Mirrors v1's `BlockPageable::draw`
+/// (`pageable.rs:1796-1827`):
+///
+/// ```text
+/// // bg/border/shadow paint OUTSIDE the clip
+/// draw_with_opacity(canvas, opacity, |c| {
+///     bg + border + shadow at (x, y, total_w, total_h);
+///     if let Some(clip) = compute_overflow_clip_path(...) {
+///         c.surface.push_clip_path(&clip, FillRule::default());
+///         for child in children { child.draw(c, x + child.x, y + child.y, ..); }
+///         c.surface.pop();
+///     }
+/// });
+/// ```
+///
+/// In v2 the wrapper's own inner content (paragraph / image / svg
+/// sharing the same `node_id`) is dispatched as part of the clipped
+/// region, then strict descendants iterate inside the clip. The block
+/// dispatcher's "shared node_id" combined helper
+/// (`draw_block_with_inner_content`) already handles the outer
+/// opacity wrap when used; here we replicate that ordering manually
+/// — bg/border outside clip, inner content + descendants inside clip,
+/// all wrapped in one opacity group.
+#[allow(clippy::too_many_arguments)]
+fn draw_under_clip(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    block: &crate::drawables::BlockEntry,
+    node_id: usize,
+    geom: &crate::pagination_layout::PaginationGeometry,
+    frag: &crate::pagination_layout::Fragment,
+    x_pt: f32,
+    y_pt: f32,
+    geometry: &crate::pagination_layout::PaginationGeometryTable,
+    drawables: &Drawables,
+    margin_left_pt: f32,
+    margin_top_pt: f32,
+    page_index: u32,
+) {
+    use crate::convert::px_to_pt;
+    use crate::pageable::draw_with_opacity;
+
+    let total_width = block
+        .layout_size
+        .map(|s| s.width)
+        .unwrap_or_else(|| px_to_pt(frag.width));
+    let total_height = block
+        .layout_size
+        .map(|s| s.height)
+        .unwrap_or_else(|| px_to_pt(frag.height));
+
+    let para_for_block = drawables.paragraphs.get(&node_id);
+    let img_for_block = drawables.images.get(&node_id);
+    let svg_for_block = drawables.svgs.get(&node_id);
+    let inner_inset = block.style.content_inset();
+
+    draw_with_opacity(canvas, block.opacity, |canvas| {
+        // bg / border / shadow outside the clip — same as
+        // `draw_block_inner_paint` but inlined so the opacity wrap
+        // covers the entire clipped region too.
+        if block.visible {
+            crate::background::draw_box_shadows(
+                canvas,
+                &block.style,
+                x_pt,
+                y_pt,
+                total_width,
+                total_height,
+            );
+            crate::background::draw_background(
+                canvas,
+                &block.style,
+                x_pt,
+                y_pt,
+                total_width,
+                total_height,
+            );
+            crate::pageable::draw_block_border(
+                canvas,
+                &block.style,
+                x_pt,
+                y_pt,
+                total_width,
+                total_height,
+            );
+        }
+
+        // Push clip — fall through to inner content + descendants if
+        // `compute_overflow_clip_path` returns `None` (style somehow
+        // changed since extract decided this block clips).
+        let clip_pushed = if let Some(clip_path) = crate::pageable::compute_overflow_clip_path(
+            &block.style,
+            x_pt,
+            y_pt,
+            total_width,
+            total_height,
+        ) {
+            canvas
+                .surface
+                .push_clip_path(&clip_path, &krilla::paint::FillRule::default());
+            true
+        } else {
+            false
+        };
+
+        // Inner content sharing `node_id` (inline-root paragraph,
+        // replaced image / svg) paints at the content-box top-left,
+        // not the border-box. Mirrors `draw_block_with_inner_content`.
+        let inner_x = x_pt + inner_inset.0;
+        let inner_y = y_pt + inner_inset.1;
+        if let Some(p) = para_for_block {
+            draw_paragraph_inner_paint(canvas, p, inner_x, inner_y, &geom.fragments, page_index);
+        }
+        if let Some(i) = img_for_block {
+            draw_image_inner_paint(canvas, i, inner_x, inner_y);
+        }
+        if let Some(s) = svg_for_block {
+            draw_svg_inner_paint(canvas, s, inner_x, inner_y);
+        }
+
+        // Strict descendants — each at its own fragment's coords.
+        for &desc_id in &block.clip_descendants {
+            let Some(desc_geom) = geometry.get(&desc_id) else {
+                continue;
+            };
+            for desc_frag in &desc_geom.fragments {
+                if desc_frag.page_index != page_index {
+                    continue;
+                }
+                let desc_x = margin_left_pt + px_to_pt(desc_frag.x);
+                let desc_y = margin_top_pt + px_to_pt(desc_frag.y);
+                dispatch_fragment(
+                    canvas, desc_id, desc_geom, desc_frag, desc_x, desc_y, drawables, page_index,
+                );
+            }
+        }
+
+        if clip_pushed {
+            canvas.surface.pop();
+        }
+    });
 }
 
 /// Paint multicol column-rule lines on `page_index` for one

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -486,6 +486,25 @@ fn inline_byte_equality_cases() {
             "overflow hidden block with shared-node_id inline text",
             r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.box{width:50px;height:30px;overflow:hidden;background:#cef;font-size:8pt;line-height:1.2;white-space:nowrap}</style></head><body><div class="box">long overflowing text content</div></body></html>"##,
         ),
+        // PR #310 follow-up Devin: `<li style="overflow:hidden">` must
+        // (a) draw its marker (markers sit outside the body box at
+        // negative x, so `draw_under_clip` must emit the marker before
+        // pushing the clip path), and (b) honour `list_item.opacity`,
+        // not `block.opacity` — `convert::list_item::build_list_item_body`
+        // builds the body block with default opacity=1.0 because v1's
+        // `ListItemPageable::draw` carries the opacity at the outer
+        // wrap. Using `block.opacity` here silently drops any CSS
+        // opacity set on the `<li>`.
+        //
+        // The `<li>` wraps a sized `<div>` block child so the body
+        // BlockPageable's `cached_size.height` carries a non-zero
+        // value through to render — `convert::list_item::build_list_item_body`'s
+        // non-inline-root branch (line 508) doesn't set `layout_size`,
+        // and an empty body would collapse the bg paint to height=0.
+        (
+            "list item with overflow:hidden and opacity",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}ul{margin:0;padding:0 0 0 24px}li{background:#cef;overflow:hidden;opacity:0.5}.inner{height:30px;background:#fce}</style></head><body><ul><li><div class="inner"></div></li></ul></body></html>"##,
+        ),
     ];
 
     // Bookmark-inside-transform regression (PR #305 Devin): a heading

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -462,6 +462,18 @@ fn inline_byte_equality_cases() {
             "page counter in @bottom-center",
             r##"<!DOCTYPE html><html><head><style>@page { @bottom-center { content: counter(page) " / " counter(pages); font-size: 8pt; } } body { margin: 0; padding: 0; } .item { height: 720px; }</style></head><body><div class="item">first</div><div class="item">second</div></body></html>"##,
         ),
+        // PR 6 follow-up (overflow clip scope tracking, fulgur-ekz7) —
+        // v1 `BlockPageable::draw` (`pageable.rs:1796-1827`) paints
+        // bg / border / shadow OUTSIDE the clip, then pushes the
+        // overflow clip path, draws children INSIDE, then pops. v2 now
+        // tracks `BlockEntry.clip_descendants` and replays the same
+        // ordering via `draw_under_clip`. Without this fix, overflow
+        // children that overshoot the parent's box paint past the
+        // clip boundary.
+        (
+            "overflow hidden block with overflowing child",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.outer{width:80px;height:60px;overflow:hidden;background:#cef}.inner{width:200px;height:200px;background:#fce;margin:-20px}</style></head><body><div class="outer"><div class="inner"></div></div></body></html>"##,
+        ),
     ];
 
     // Bookmark-inside-transform regression (PR #305 Devin): a heading

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -486,6 +486,17 @@ fn inline_byte_equality_cases() {
             "overflow hidden block with shared-node_id inline text",
             r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.box{width:50px;height:30px;overflow:hidden;background:#cef;font-size:8pt;line-height:1.2;white-space:nowrap}</style></head><body><div class="box">long overflowing text content</div></body></html>"##,
         ),
+        // PR #310 follow-up Devin: a transform nested inside an
+        // `overflow:hidden` block was silently dropped because the
+        // main loop pre-skips `clipped_descendants` BEFORE the
+        // per-fragment transform check. `draw_under_clip` now
+        // dispatches transform-key descendants via
+        // `draw_under_transform` (and pre-skips their own descendants
+        // so they are not painted twice).
+        (
+            "transform inside overflow:hidden ancestor",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.outer{width:120px;height:80px;overflow:hidden;background:#cef}.inner{width:60px;height:40px;background:#fce;transform:rotate(10deg)}</style></head><body><div class="outer"><div class="inner"></div></div></body></html>"##,
+        ),
         // PR #310 follow-up Devin: `<li style="overflow:hidden">` must
         // (a) draw its marker (markers sit outside the body box at
         // negative x, so `draw_under_clip` must emit the marker before

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -474,6 +474,18 @@ fn inline_byte_equality_cases() {
             "overflow hidden block with overflowing child",
             r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.outer{width:80px;height:60px;overflow:hidden;background:#cef}.inner{width:200px;height:200px;background:#fce;margin:-20px}</style></head><body><div class="outer"><div class="inner"></div></div></body></html>"##,
         ),
+        // PR #310 Devin: overflow:hidden block with shared-node_id
+        // inner content only (inline-root paragraph at the same
+        // `node_id`) — no separate descendant NodeIds. v1 pushes the
+        // clip unconditionally when `has_overflow_clip()` is true, so
+        // `<div style="overflow:hidden;width:50px">long overflowing
+        // text</div>` clips the long text at the 50px boundary. v2's
+        // dispatcher must do the same regardless of whether
+        // `clip_descendants` is empty.
+        (
+            "overflow hidden block with shared-node_id inline text",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.box{width:50px;height:30px;overflow:hidden;background:#cef;font-size:8pt;line-height:1.2;white-space:nowrap}</style></head><body><div class="box">long overflowing text content</div></body></html>"##,
+        ),
     ];
 
     // Bookmark-inside-transform regression (PR #305 Devin): a heading

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -95,4 +95,15 @@ allowlist = [
     "vrt://bugs/cover-page-break-after.html",
     "examples://header-footer",
     "examples://header-footer-split",
+    # PR 6 follow-up (overflow clip scope tracking, fulgur-ekz7) —
+    # `overflow: hidden | clip` blocks now record their strict
+    # descendants in `BlockEntry.clip_descendants`. v2 dispatcher
+    # paints bg / border / shadow OUTSIDE the clip, pushes the clip
+    # path, dispatches inner content + descendants INSIDE the clip,
+    # then pops — mirroring v1's `BlockPageable::draw` ordering
+    # (`pageable.rs:1796-1827`). Both VRT overflow-hidden fixtures and
+    # the examples/overflow-hidden demo lit up.
+    "vrt://layout/overflow-hidden.html",
+    "vrt://layout/overflow-hidden-rounded.html",
+    "examples://overflow-hidden",
 ]

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -697,15 +697,12 @@ fn render_v2_smoke_bookmarks_under_transform() {
 }
 
 #[test]
-fn render_v2_smoke_triple_nested_transform_descendants() {
-    // Exercises the `nested_skip` pre-collection in
-    // `draw_under_transform` added in PR #305 follow-up Devin: the
-    // outer transform's `descendants` includes the inner transform's
-    // own descendants (e.g. a styled grandchild block), so the
-    // outer's iteration must skip them or they get painted twice —
-    // once correctly under outer*inner via the recursion, and once
-    // wrongly under outer only.
-    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0}.outer{width:200px;height:120px;background:#cef;transform:translate(8px,4px)}.inner{width:120px;height:80px;background:#fce;transform:rotate(5deg)}.leaf{width:40px;height:20px;background:#ffd}</style></head><body><div class="outer"><div class="inner"><div class="leaf"></div></div></div></body></html>"##;
+fn render_v2_smoke_transform_inside_overflow_clip() {
+    // Exercises `draw_under_clip`'s transform-aware descendant
+    // dispatch added in PR #310 Devin fix: a `transform` nested
+    // inside `overflow:hidden` was dropped because the main loop
+    // pre-skips `clipped_descendants` before the transform check.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0}.outer{width:120px;height:80px;overflow:hidden;background:#cef}.inner{width:60px;height:40px;background:#fce;transform:rotate(10deg)}</style></head><body><div class="outer"><div class="inner"></div></div></body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
     let pdf = engine.render_html_v2(html).expect("v2 render");
     assert!(!pdf.is_empty());

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -709,6 +709,38 @@ fn render_v2_smoke_transform_inside_overflow_clip() {
 }
 
 #[test]
+fn render_v2_smoke_body_overflow_hidden_multi_page_content_survives() {
+    // Regression for PR #310 follow-up Devin: `<body style="overflow:
+    // hidden|auto|scroll">` previously blanked every descendant on
+    // page 1+. The fragmenter records body with a single fragment at
+    // `page_index=0`, so `draw_under_clip(body)` would only fire on
+    // page 0; the main loop's `clipped_descendants.contains` guard
+    // then ate every body descendant on every page, leaving page 1+
+    // with only the body bg pre-pass and nothing else.
+    //
+    // Render with `body{overflow:hidden}` AND with a tall enough
+    // child to force multi-page output, and assert the v2 PDF size
+    // stays close to the no-overflow render (within 5%). If the bug
+    // returns, page 1's content stream collapses and the PDF shrinks
+    // dramatically.
+    let with_clip = r##"<!DOCTYPE html><html><head><style>html,body{margin:0;padding:0;background:#fff}body{overflow:hidden}.tall{height:1500px;background:#cef}</style></head><body><div class="tall"></div></body></html>"##;
+    let without_clip = r##"<!DOCTYPE html><html><head><style>html,body{margin:0;padding:0;background:#fff}.tall{height:1500px;background:#cef}</style></head><body><div class="tall"></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf_clip = engine.render_html_v2(with_clip).expect("v2 render w/ clip");
+    let pdf_plain = engine
+        .render_html_v2(without_clip)
+        .expect("v2 render w/o clip");
+    let ratio = pdf_clip.len() as f32 / pdf_plain.len() as f32;
+    assert!(
+        ratio > 0.95 && ratio < 1.05,
+        "body overflow:hidden v2 size ({} B) diverges too much from baseline ({} B); \
+         likely indicates page 1+ content was dropped by the clipped_descendants pre-skip",
+        pdf_clip.len(),
+        pdf_plain.len(),
+    );
+}
+
+#[test]
 fn render_v2_smoke_list_item_overflow_clip_with_opacity() {
     // Exercises `draw_under_clip`'s list_items branch added in PR #310
     // Devin fix: when the clipped block's NodeId also has a

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -710,3 +710,17 @@ fn render_v2_smoke_triple_nested_transform_descendants() {
     let pdf = engine.render_html_v2(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
+
+#[test]
+fn render_v2_smoke_list_item_overflow_clip_with_opacity() {
+    // Exercises `draw_under_clip`'s list_items branch added in PR #310
+    // Devin fix: when the clipped block's NodeId also has a
+    // `ListItemEntry`, the outer opacity wrap must use
+    // `list_item.opacity` (the body block carries default opacity=1.0
+    // from `convert::list_item::build_list_item_body`) and the marker
+    // must paint before `push_clip_path`.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}ul{margin:0;padding:0 0 0 24px}li{background:#cef;overflow:hidden;opacity:0.5}.inner{height:30px;background:#fce}</style></head><body><ul><li><div class="inner"></div></li></ul></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}


### PR DESCRIPTION
## Summary

`overflow: hidden | clip` のブロックで bg/border/shadow を clip の外、children を clip の中に描画する v1 の挙動を v2 で再現。`TransformEntry.descendants` と同じパターンで `BlockEntry.clip_descendants` を追加し、scope tracking を実装。

PR 4 のリリースノートで deferred 扱いされていた overflow clip の本質はこの "end-of-children point" の欠如。v1 は `BlockPageable::draw` (`pageable.rs:1796-1827`) の recursive walk の前後で push/pop できるが、v2 の flat dispatch は一度子要素群を抜けたかが分からない。**descendants set を extract で採取しておく** ことで scope を再構築する。

## 変更点

### `BlockEntry.clip_descendants: Vec<NodeId>`

- `extract_drawables_from_pageable` の `BlockPageable` arm で `block.style.has_overflow_clip()` 時のみ populate
- snapshot ベースで `(after - before) - inner_id` を採取 (wrapper 自身の inner content は共有 node_id 経由で別 path で描画される)

### `render_v2` dispatcher

- 全 clipping block の descendants を `clipped_descendants: BTreeSet<NodeId>` 集合化
- main iteration で skip set 化 (transformed_descendants と同じパターン)
- 新 helper `draw_under_clip`:
  1. bg / border / shadow paint OUTSIDE the clip (v1 と同じ order)
  2. `compute_overflow_clip_path` で clip path 計算 → push
  3. 共有 node_id の inner content を content-inset offset で paint
  4. 各 descendant を fragment 座標で `dispatch_fragment`
  5. pop_clip
- 全体を `draw_with_opacity` で包む → `.faded { opacity:0.4; overflow:hidden }` のような複合パターンも v1 と同じ "1 つの opacity group" 構造を維持

### byte-eq 進捗

**48 / 59 (allowlist 39) → 51 / 59 (allowlist 42)**

新規 allowlist (3 fixtures, Group D 完了):

- vrt/layout/overflow-hidden.html
- vrt/layout/overflow-hidden-rounded.html
- examples/overflow-hidden

inline regression case `overflow hidden block with overflowing child` を追加 (`<div style="overflow:hidden;width:80px">` 内に大きな children を配置するパターン、v1/v2 byte-eq assert)。

## Coverage

- `cargo build -p fulgur`: 0 warning
- `cargo clippy --workspace --all-targets -- -D warnings`: 0 warning
- `cargo fmt --check`: clean
- `cargo test -p fulgur --lib`: 847 passed
- `cargo test -p fulgur-vrt`: green
- shadow harness: 51/59 byte-identical, allowlist 42

## Stack

```text
PR #305 (Transform + MulticolRule)              24/59
  ↑
PR #307 (html / body bg pre-pass)               35/59
  ↑
PR #308 (drop InlineBox recurse)                41/59
  ↑
PR #309 (GCPM margin box port)                  48/59
  ↑
本 PR (overflow clip scope tracking)            51/59
```

## 残 8 fixtures

- Group A (float precision): box-shadow, multicol, multicol-span-all, break-inside (4)
- Group C: examples/svg (1)
- Group E: review_card_inline_block, grid-row-promote-background, examples/wasm-demo (3)

## Test plan

- [ ] `FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur --test render_path_parity`
- [ ] `cargo test -p fulgur --lib`
- [ ] `cargo test -p fulgur-vrt`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo fmt --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
