### PR TITLE
Phase 4 PR 6 follow-up — opacity scope tracking via BlockEntry.scope_descendants

### DIFF
--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -339,7 +339,12 @@ fn extract_drawables_from_pageable(
     // Block / List / Table / wrappers — recurse into children. Block
     // also records its own paint payload (PR 4).
     if let Some(block) = any.downcast_ref::<BlockPageable>() {
-        let clipping = block.style.has_overflow_clip();
+        // Track strict descendants when the block needs a scope group
+        // — `overflow: hidden|clip` (clip path) OR non-trivial opacity
+        // (compositing group). Without that scope, cross-node_id
+        // children would either escape the clip or land in a separate
+        // PDF compositing group from the parent's bg / border / shadow.
+        let needs_scope = block.style.has_overflow_clip() || block.opacity < 1.0;
         if let Some(node_id) = block.node_id {
             out.block_styles.insert(
                 node_id,
@@ -349,38 +354,33 @@ fn extract_drawables_from_pageable(
                     visible: block.visible,
                     id: block.id.clone(),
                     layout_size: block.layout_size.or(block.cached_size),
-                    clip_descendants: Vec::new(),
+                    scope_descendants: Vec::new(),
                 },
             );
         }
-        // Snapshot the per-NodeId map keys before recursing so we can
-        // identify which descendants belong inside this block's
-        // `push_clip / pop` scope when the block carries
-        // `overflow: hidden | clip`. Mirrors the
-        // `TransformWrapperPageable` arm exactly.
-        let before = clipping.then(|| collect_drawables_node_ids(out));
+        // Snapshot the per-NodeId map keys before recursing into
+        // children so the difference (after - before) gives the strict
+        // descendant set. Mirrors the `TransformWrapperPageable` arm.
+        let before = needs_scope.then(|| collect_drawables_node_ids(out));
         for pc in &block.children {
             extract_drawables_from_pageable(pc.child.as_ref(), out);
         }
         if let (Some(before), Some(node_id)) = (before, block.node_id) {
             let after = collect_drawables_node_ids(out);
-            // Strict descendants only — exclude the wrapper's own key
-            // because the dispatcher emits its bg / border / shadow
-            // OUTSIDE the clip (matching v1's
-            // `BlockPageable::draw` ordering at
-            // `pageable.rs:1796-1827`). Inner content sharing the
-            // wrapper's `node_id` (inline-root paragraph, replaced
-            // image / svg from `convert::replaced` /
-            // `convert::inline_root`) is dispatched as part of the
-            // wrapper's own painting path, not via descendant
-            // iteration.
+            // Strict descendants only — exclude the wrapper's own key.
+            // The dispatcher paints the wrapper's bg / border / shadow
+            // and any inner content sharing `node_id` (inline-root
+            // paragraph, replaced image / svg from
+            // `convert::inline_root` / `convert::replaced`) inside the
+            // same scope group. Matches v1
+            // `BlockPageable::draw` (`pageable.rs:1796-1827`).
             let descendants: Vec<usize> = after
                 .difference(&before)
                 .copied()
                 .filter(|&id| id != node_id)
                 .collect();
             if let Some(entry) = out.block_styles.get_mut(&node_id) {
-                entry.clip_descendants = descendants;
+                entry.scope_descendants = descendants;
             }
         }
         return;

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -50,17 +50,24 @@ pub struct BlockEntry {
     /// time when absent.
     pub layout_size: Option<crate::pageable::Size>,
     /// Strict descendant `NodeId`s that must paint INSIDE this block's
-    /// `push_clip_path` / `pop` group. Populated by
-    /// `extract_drawables_from_pageable` only when
-    /// `style.has_overflow_clip()` is true — non-clipping blocks leave
-    /// this empty so the dispatcher's main loop handles them with the
-    /// regular shared-node_id pattern.
+    /// scope group (`push_clip_path / pop`, `draw_with_opacity`, or
+    /// both). Populated by `extract_drawables_from_pageable` only when
+    /// the block needs a scope group — i.e.
+    /// `style.has_overflow_clip() || opacity != 1.0`. Blocks without
+    /// any scope leave this empty so the dispatcher's main loop
+    /// handles them with the regular shared-node_id pattern.
     ///
-    /// Mirrors the `TransformEntry.descendants` shape: render time
-    /// emits bg / border / shadow first (outside the clip, matching v1
-    /// `BlockPageable::draw` at `pageable.rs:1796-1827`), then pushes
-    /// the clip path, dispatches each descendant fragment, and pops.
-    pub clip_descendants: Vec<NodeId>,
+    /// Mirrors the `TransformEntry.descendants` shape:
+    ///
+    /// - **Clipping blocks**: bg / border / shadow paint outside the
+    ///   clip, `push_clip_path`, descendants paint inside, `pop` —
+    ///   matches v1 `BlockPageable::draw` at `pageable.rs:1796-1827`.
+    /// - **Opacity-only blocks**: everything wraps in a single
+    ///   `draw_with_opacity(opacity, ...)` group so cross-node_id
+    ///   children (e.g. `<div style="opacity:0.4"><svg>`) compose into
+    ///   one PDF compositing group, matching v1's
+    ///   `draw_with_opacity → recurse children`.
+    pub scope_descendants: Vec<NodeId>,
 }
 
 /// Paragraph draw payload for v2. Holds the shaped lines that

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -264,15 +264,16 @@ fn draw_v2_page(
         transformed_descendants.extend(tx.descendants.iter().copied());
     }
     // Same shape as `transformed_descendants` but keyed by an ancestor
-    // block whose `style.has_overflow_clip()` is true. Strict
-    // descendants paint inside the clip's `push_clip_path / pop` group;
-    // skipping them here prevents the main loop from also dispatching
-    // them outside the clip.
-    let mut clipped_descendants: std::collections::BTreeSet<usize> =
+    // block that needs a scope group (`overflow: hidden|clip`,
+    // non-trivial opacity, or both). Strict descendants paint inside
+    // that scope's `push_clip_path / pop` or `draw_with_opacity`
+    // group; skipping them here prevents the main loop from also
+    // dispatching them outside the scope.
+    let mut block_scope_descendants: std::collections::BTreeSet<usize> =
         std::collections::BTreeSet::new();
     for block in drawables.block_styles.values() {
-        if block.style.has_overflow_clip() {
-            clipped_descendants.extend(block.clip_descendants.iter().copied());
+        if block.style.has_overflow_clip() || block.opacity < 1.0 {
+            block_scope_descendants.extend(block.scope_descendants.iter().copied());
         }
     }
 
@@ -305,9 +306,11 @@ fn draw_v2_page(
             // anchor recording above already ran unconditionally.
             continue;
         }
-        if clipped_descendants.contains(&node_id) {
-            // Drawn inside an ancestor `overflow: hidden|clip` block's
-            // `push_clip_path / pop` group elsewhere in this loop.
+        if block_scope_descendants.contains(&node_id) {
+            // Drawn inside an ancestor block's scope group
+            // (`push_clip_path / pop` for `overflow: hidden|clip`,
+            // `draw_with_opacity` for non-trivial opacity, or both)
+            // elsewhere in this loop.
             continue;
         }
         // Skip the html root: its bg / border / shadow are painted
@@ -351,23 +354,50 @@ fn draw_v2_page(
             // `BlockPageable::draw` ordering at
             // `pageable.rs:1796-1827`), then push the clip path,
             // dispatch self's inner content + every strict descendant
-            // INSIDE the clip, then pop. Same shape as
-            // `draw_under_transform` but with `push_clip_path`.
+            // INSIDE the clip, then pop. Whole region is wrapped in
+            // `draw_with_opacity` so a block with both clip and
+            // opacity still produces one combined group.
             //
-            // No `!clip_descendants.is_empty()` guard: shared-node_id
+            // No `!scope_descendants.is_empty()` guard: shared-node_id
             // inner content (inline-root paragraph from
             // `convert::inline_root`, replaced image / svg from
             // `convert::replaced`) lands at the same `node_id` as the
-            // wrapper and so produces an empty `clip_descendants`. v1
+            // wrapper and so produces an empty `scope_descendants`. v1
             // pushes the clip unconditionally when
             // `has_overflow_clip()` is true (`pageable.rs:1808-1826`),
             // so a `<div style="overflow:hidden;width:50px">long
-            // text</div>` still needs the text clipped at the 50px
-            // box even with no separate descendant NodeIds.
+            // text</div>` still needs the text clipped at the 50px box
+            // even with no separate descendant NodeIds (PR #310 Devin).
             if let Some(block) = drawables.block_styles.get(&node_id)
                 && block.style.has_overflow_clip()
             {
                 draw_under_clip(
+                    canvas,
+                    block,
+                    node_id,
+                    geom,
+                    frag,
+                    x_pt,
+                    y_pt,
+                    geometry,
+                    drawables,
+                    margin_left_pt,
+                    margin_top_pt,
+                    page_index,
+                );
+                continue;
+            }
+            // Opacity-only scope: block has `opacity < 1.0` but no
+            // overflow clip, AND there are cross-node_id descendants.
+            // v1 wraps everything in a single `draw_with_opacity`
+            // group; v2 must too or
+            // `<div style="opacity:0.4"><svg>` paints `<svg>` in a
+            // separate compositing group from `<div>`'s bg/border.
+            if let Some(block) = drawables.block_styles.get(&node_id)
+                && block.opacity < 1.0
+                && !block.scope_descendants.is_empty()
+            {
+                draw_under_opacity(
                     canvas,
                     block,
                     node_id,
@@ -683,7 +713,7 @@ fn draw_under_clip(
         }
 
         // Strict descendants — each at its own fragment's coords.
-        for &desc_id in &block.clip_descendants {
+        for &desc_id in &block.scope_descendants {
             let Some(desc_geom) = geometry.get(&desc_id) else {
                 continue;
             };
@@ -701,6 +731,76 @@ fn draw_under_clip(
 
         if clip_pushed {
             canvas.surface.pop();
+        }
+    });
+}
+
+/// Wrap a non-trivial-opacity block + its strict descendants in a
+/// single `draw_with_opacity` group. Mirrors v1's
+/// `BlockPageable::draw` for the case where the block has
+/// `opacity < 1.0` but no overflow clip — v1 emits one
+/// `q (gs ..) ... Q` covering bg / border / shadow + every recursed
+/// child. v2 had no equivalent path before this PR, so cross-node_id
+/// children (e.g. `<div style="opacity:0.4"><svg>`) painted in a
+/// separate compositing group from the block's own bg / border.
+///
+/// Same shape as `draw_under_clip` minus the `push_clip_path`.
+#[allow(clippy::too_many_arguments)]
+fn draw_under_opacity(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    block: &crate::drawables::BlockEntry,
+    node_id: usize,
+    geom: &crate::pagination_layout::PaginationGeometry,
+    frag: &crate::pagination_layout::Fragment,
+    x_pt: f32,
+    y_pt: f32,
+    geometry: &crate::pagination_layout::PaginationGeometryTable,
+    drawables: &Drawables,
+    margin_left_pt: f32,
+    margin_top_pt: f32,
+    page_index: u32,
+) {
+    use crate::convert::px_to_pt;
+    use crate::pageable::draw_with_opacity;
+
+    let para_for_block = drawables.paragraphs.get(&node_id);
+    let img_for_block = drawables.images.get(&node_id);
+    let svg_for_block = drawables.svgs.get(&node_id);
+    let inner_inset = block.style.content_inset();
+
+    draw_with_opacity(canvas, block.opacity, |canvas| {
+        // bg / border / shadow at the block's border-box.
+        draw_block_inner_paint(canvas, block, x_pt, y_pt, frag);
+
+        // Inner content sharing `node_id` (inline-root paragraph,
+        // replaced image / svg) at the content-box top-left.
+        let inner_x = x_pt + inner_inset.0;
+        let inner_y = y_pt + inner_inset.1;
+        if let Some(p) = para_for_block {
+            draw_paragraph_inner_paint(canvas, p, inner_x, inner_y, &geom.fragments, page_index);
+        }
+        if let Some(i) = img_for_block {
+            draw_image_inner_paint(canvas, i, inner_x, inner_y);
+        }
+        if let Some(s) = svg_for_block {
+            draw_svg_inner_paint(canvas, s, inner_x, inner_y);
+        }
+
+        // Strict descendants at their own fragment coords.
+        for &desc_id in &block.scope_descendants {
+            let Some(desc_geom) = geometry.get(&desc_id) else {
+                continue;
+            };
+            for desc_frag in &desc_geom.fragments {
+                if desc_frag.page_index != page_index {
+                    continue;
+                }
+                let desc_x = margin_left_pt + px_to_pt(desc_frag.x);
+                let desc_y = margin_top_pt + px_to_pt(desc_frag.y);
+                dispatch_fragment(
+                    canvas, desc_id, desc_geom, desc_frag, desc_x, desc_y, drawables, page_index,
+                );
+            }
         }
     });
 }

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -442,7 +442,7 @@ fn inline_byte_equality_cases() {
         // v1 `BlockPageable::draw` (`pageable.rs:1796-1827`) paints
         // bg / border / shadow OUTSIDE the clip, then pushes the
         // overflow clip path, draws children INSIDE, then pops. v2 now
-        // tracks `BlockEntry.clip_descendants` and replays the same
+        // tracks `BlockEntry.scope_descendants` and replays the same
         // ordering via `draw_under_clip`. Without this fix, overflow
         // children that overshoot the parent's box paint past the
         // clip boundary.
@@ -457,10 +457,21 @@ fn inline_byte_equality_cases() {
         // `<div style="overflow:hidden;width:50px">long overflowing
         // text</div>` clips the long text at the 50px boundary. v2's
         // dispatcher must do the same regardless of whether
-        // `clip_descendants` is empty.
+        // `scope_descendants` is empty.
         (
             "overflow hidden block with shared-node_id inline text",
             r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.box{width:50px;height:30px;overflow:hidden;background:#cef;font-size:8pt;line-height:1.2;white-space:nowrap}</style></head><body><div class="box">long overflowing text content</div></body></html>"##,
+        ),
+        // PR 6 follow-up (opacity scope tracking, fulgur-gdb9). v1
+        // `BlockPageable::draw` wraps bg / border / shadow + every
+        // recursed child in one `draw_with_opacity` group. Without
+        // scope tracking, v2 painted `<div style="opacity:0.4">`'s
+        // bg/border in one compositing group and its child `<svg>`
+        // in a separate group, diverging in PDF stream output even
+        // though the visible result was the same.
+        (
+            "opacity-only block with cross-node-id child",
+            r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.faded{opacity:0.4}</style></head><body><div class="faded"><svg width="120" height="40" xmlns="http://www.w3.org/2000/svg"><rect width="120" height="40" fill="#1a6faa"/></svg></div></body></html>"##,
         ),
     ];
 

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -97,7 +97,7 @@ allowlist = [
     "examples://header-footer-split",
     # PR 6 follow-up (overflow clip scope tracking, fulgur-ekz7) —
     # `overflow: hidden | clip` blocks now record their strict
-    # descendants in `BlockEntry.clip_descendants`. v2 dispatcher
+    # descendants in `BlockEntry.scope_descendants`. v2 dispatcher
     # paints bg / border / shadow OUTSIDE the clip, pushes the clip
     # path, dispatches inner content + descendants INSIDE the clip,
     # then pops — mirroring v1's `BlockPageable::draw` ordering
@@ -106,4 +106,14 @@ allowlist = [
     "vrt://layout/overflow-hidden.html",
     "vrt://layout/overflow-hidden-rounded.html",
     "examples://overflow-hidden",
+    # PR 6 follow-up (opacity scope tracking, fulgur-gdb9) —
+    # `<div style="opacity:0.4"><svg>` etc. with cross-node_id
+    # children now emits a single `draw_with_opacity` group covering
+    # bg / border + every descendant. v1 wraps the whole subtree in
+    # one `q (gs ..) … Q`; v2 was emitting separate compositing groups
+    # for the parent's bg vs the children. `BlockEntry.scope_descendants`
+    # is now also populated for opacity-only blocks;
+    # `draw_under_opacity` mirrors `draw_under_clip` without the
+    # `push_clip_path`.
+    "examples://svg",
 ]


### PR DESCRIPTION
## Summary

`opacity < 1.0` のブロックの cross-node_id 子要素が v1 と異なる PDF compositing group に分裂する問題を解消。Group D の `clip_descendants` 機構を拡張して clip / opacity 両方の scope に対応。

## 変更点

### `BlockEntry.clip_descendants` → `scope_descendants` (rename + 意味拡張)

Populate 条件を `has_overflow_clip()` のみ → `has_overflow_clip() || opacity < 1.0` に拡張。clip と opacity の両方が strict descendants tracking を必要とする scope であり、API も同形 (extract で snapshot diff、render で skip set + helper)。

### `render_v2` dispatcher

- `clipped_descendants` → `block_scope_descendants` に rename。clip / opacity 両方を取り込み
- 新 helper `draw_under_opacity`:
  - `draw_with_opacity(block.opacity, |c| { bg/border + inner content + descendants })`
  - `draw_under_clip` から `push_clip_path / pop` を抜いた形 (clip なし opacity あり case)
- dispatcher の order: clip → opacity (clip 側は `draw_with_opacity` を内包しているので両方持つブロックは clip path で十分)

### byte-eq 進捗

**51 / 59 (allowlist 42) → 52 / 59 (allowlist 43)**

新規 allowlist (1 fixture, Group C 完了):

- `examples/svg` (`<div class="faded" style="opacity:0.4"><svg>` パターンを含む)

inline regression case `opacity-only block with cross-node-id child` を追加。

## Coverage

- `cargo build -p fulgur`: 0 warning
- `cargo clippy --workspace --all-targets -- -D warnings`: 0 warning
- `cargo fmt --check`: clean
- `cargo test -p fulgur --lib`: 847 passed
- `cargo test -p fulgur-vrt`: green
- shadow harness: 52/59 byte-identical, allowlist 43

## Stack

```text
PR #305 (Transform + MulticolRule)              24/59
  ↑
PR #307 (html / body bg pre-pass)               35/59
  ↑
PR #308 (drop InlineBox recurse)                41/59
  ↑
PR #309 (GCPM margin box port)                  48/59
  ↑
PR #310 (overflow clip scope tracking)          51/59
  ↑
本 PR (opacity scope tracking)                  52/59
```

## 残 7 fixtures (3 グループ)

- Group A (float precision): box-shadow, multicol, multicol-span-all, break-inside (4)
- Group E: review_card_inline_block, grid-row-promote-background, examples/wasm-demo (3)

## Test plan

- [ ] `FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur --test render_path_parity`
- [ ] `cargo test -p fulgur --lib`
- [ ] `cargo test -p fulgur-vrt`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo fmt --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
