### PR TITLE
fix(render_v2): cross-node_id opacity grouping (fulgur-gdb9)

### DIFF
--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -348,6 +348,12 @@ fn extract_drawables_from_pageable(
     // also records its own paint payload (PR 4).
     if let Some(block) = any.downcast_ref::<BlockPageable>() {
         let clipping = block.style.has_overflow_clip();
+        // Track an opacity scope only when the block has fractional
+        // opacity AND does NOT also clip — the clip path arm already
+        // wraps descendants in `draw_with_opacity` (see
+        // `draw_under_clip`), so the dual case is covered there and
+        // recording it here would double-track.
+        let opacity_scope = !clipping && block.opacity < 1.0;
         if let Some(node_id) = block.node_id {
             out.block_styles.insert(
                 node_id,
@@ -358,15 +364,17 @@ fn extract_drawables_from_pageable(
                     id: block.id.clone(),
                     layout_size: block.layout_size.or(block.cached_size),
                     clip_descendants: Vec::new(),
+                    opacity_descendants: Vec::new(),
                 },
             );
         }
         // Snapshot the per-NodeId map keys before recursing so we can
         // identify which descendants belong inside this block's
         // `push_clip / pop` scope when the block carries
-        // `overflow: hidden | clip`. Mirrors the
+        // `overflow: hidden | clip`, OR inside its `draw_with_opacity`
+        // group when the block carries fractional opacity. Mirrors the
         // `TransformWrapperPageable` arm exactly.
-        let before = clipping.then(|| collect_drawables_node_ids(out));
+        let before = (clipping || opacity_scope).then(|| collect_drawables_node_ids(out));
         for pc in &block.children {
             extract_drawables_from_pageable(pc.child.as_ref(), out);
         }
@@ -388,7 +396,11 @@ fn extract_drawables_from_pageable(
                 .filter(|&id| id != node_id)
                 .collect();
             if let Some(entry) = out.block_styles.get_mut(&node_id) {
-                entry.clip_descendants = descendants;
+                if clipping {
+                    entry.clip_descendants = descendants;
+                } else {
+                    entry.opacity_descendants = descendants;
+                }
             }
         }
         return;

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -61,6 +61,20 @@ pub struct BlockEntry {
     /// `BlockPageable::draw` at `pageable.rs:1796-1827`), then pushes
     /// the clip path, dispatches each descendant fragment, and pops.
     pub clip_descendants: Vec<NodeId>,
+    /// Strict descendant `NodeId`s that must paint INSIDE this block's
+    /// `draw_with_opacity` group. Populated by
+    /// `extract_drawables_from_pageable` only when `opacity < 1.0`
+    /// AND the block does NOT have overflow clip (clip's
+    /// `draw_under_clip` already wraps its descendants in
+    /// `draw_with_opacity` so the dual case is covered there).
+    ///
+    /// Mirrors v1's `BlockPageable::draw` ordering: opacity wraps
+    /// EVERYTHING — bg/border/shadow + descendants — so a
+    /// `<div style="opacity:0.4"><svg>..</svg></div>` produces a
+    /// single transparency group. v2's flat dispatch without this
+    /// scope tracking would emit the svg outside the parent's
+    /// opacity wrap, dropping the parent's opacity from the svg.
+    pub opacity_descendants: Vec<NodeId>,
 }
 
 /// Paragraph draw payload for v2. Holds the shaped lines that

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -840,7 +840,30 @@ fn record_subtree_descendants(
     let Some(parent) = doc.get_node(parent_id) else {
         return;
     };
-    for &child_id in &parent.children {
+    // Prefer Blitz's `layout_children` over the raw DOM `children` when
+    // it's been computed: when a block container has mixed
+    // block-level and inline-level children, Stylo synthesizes
+    // anonymous block wrappers around inline-level siblings (CSS 2.1
+    // §9.2.1.1). Those wrappers are real `Node` instances with their
+    // own `node_id` and Taffy layout, but they live ONLY in
+    // `layout_children` — the original `children` list still points
+    // at the underlying inline elements (e.g. a `<span
+    // display:inline-block>`).
+    //
+    // Without this preference v2 silently drops the inline-level
+    // span: extract assigns the inner paragraph's `node_id` to the
+    // anonymous wrapper (because Blitz's `is_inline_root()` flag sits
+    // on the wrapper), but the fragmenter — walking `children` —
+    // never visits the wrapper, so geometry has no fragment for that
+    // node_id and `dispatch_fragment` skips the paragraph entirely.
+    // (fulgur-bq6i: review_card_inline_block.html lost its
+    // "OK Approved" rounded badge for this exact reason.)
+    let layout_children_borrow = parent.layout_children.borrow();
+    let walk_children: &[usize] = layout_children_borrow
+        .as_deref()
+        .filter(|v| !v.is_empty())
+        .unwrap_or(&parent.children);
+    for &child_id in walk_children {
         let Some(child) = doc.get_node(child_id) else {
             continue;
         };

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -388,10 +388,40 @@ impl<'a> PaginationLayoutTree<'a> {
                 height: body_layout.size.height,
             });
 
+        // Prefer body's `layout_children` — same rationale as
+        // `record_subtree_descendants`. When a block container has
+        // mixed block-level and inline-level children, Stylo
+        // synthesizes anonymous block wrappers around the inline-
+        // level siblings (CSS 2.1 §9.2.1.1). Those wrappers carry
+        // their own `node_id` and Taffy layout, but they live ONLY
+        // in `layout_children` — `children` still points at the
+        // underlying inline elements (e.g. a body containing
+        // `<label>` followed by `<fieldset>` followed by
+        // `<select><option>...</option></select>` produces an
+        // anonymous block wrapping the `<select>` siblings, visible
+        // only in `layout_children`).
+        //
+        // Without this preference v2 silently drops the inline-level
+        // group's paint: extract assigns the inner paragraph's
+        // `node_id` to the synthesized wrapper, but the body iteration
+        // walks raw `children` and never visits the wrapper, so
+        // geometry has no fragment for that node_id and
+        // `dispatch_fragment` skips the paragraph entirely
+        // (fulgur-bq6i: examples/wasm-demo lost label / legend / option
+        // text content for this exact reason).
         let children = self
             .doc
             .get_node(body_id)
-            .map(|n| n.children.clone())
+            .map(|n| {
+                let layout_borrow = n.layout_children.borrow();
+                if let Some(lc) = layout_borrow.as_deref()
+                    && !lc.is_empty()
+                {
+                    lc.to_vec()
+                } else {
+                    n.children.clone()
+                }
+            })
             .unwrap_or_default();
 
         let mut page_index: u32 = 0;

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -289,6 +289,19 @@ fn draw_v2_page(
             clipped_descendants.extend(block.clip_descendants.iter().copied());
         }
     }
+    // Mirrors `clipped_descendants` for blocks that wrap their
+    // descendants in a `draw_with_opacity` group (fractional opacity,
+    // no clip — see `BlockEntry.opacity_descendants` and
+    // `draw_under_opacity`). Without skipping these in the main loop
+    // they'd be dispatched twice: once at full opacity here, once
+    // again under the parent's opacity wrap.
+    let mut opacity_wrapped_descendants: std::collections::BTreeSet<usize> =
+        std::collections::BTreeSet::new();
+    for block in drawables.block_styles.values() {
+        if !block.opacity_descendants.is_empty() {
+            opacity_wrapped_descendants.extend(block.opacity_descendants.iter().copied());
+        }
+    }
 
     for (&node_id, geom) in geometry {
         // Bookmark anchor: emit on the page where the node's *first*
@@ -322,6 +335,14 @@ fn draw_v2_page(
         if clipped_descendants.contains(&node_id) {
             // Drawn inside an ancestor `overflow: hidden|clip` block's
             // `push_clip_path / pop` group elsewhere in this loop.
+            continue;
+        }
+        if opacity_wrapped_descendants.contains(&node_id) {
+            // Drawn inside an ancestor `draw_with_opacity` group via
+            // `draw_under_opacity` elsewhere in this loop. Mirrors the
+            // `clipped_descendants` skip — without it, the descendant
+            // paints once at full opacity here and once under the
+            // parent's opacity wrap. (fulgur-gdb9)
             continue;
         }
         // Skip the html root: its bg / border / shadow are painted
@@ -394,6 +415,35 @@ fn draw_v2_page(
                 && Some(node_id) != drawables.body_id
             {
                 draw_under_clip(
+                    canvas,
+                    block,
+                    node_id,
+                    geom,
+                    frag,
+                    x_pt,
+                    y_pt,
+                    geometry,
+                    drawables,
+                    margin_left_pt,
+                    margin_top_pt,
+                    page_index,
+                );
+                continue;
+            }
+            // Fractional-opacity block with descendants: wrap own
+            // paint + descendant fragments in a single
+            // `draw_with_opacity` group. Mirrors v1's
+            // `BlockPageable::draw` recursion under
+            // `draw_with_opacity(self.opacity, ..)`. Without this,
+            // `<div opacity:0.4><svg>..</svg></div>` paints the svg
+            // outside the parent's opacity wrap, dropping the parent's
+            // opacity from the svg. (fulgur-gdb9)
+            if let Some(block) = drawables
+                .block_styles
+                .get(&node_id)
+                .filter(|b| !b.opacity_descendants.is_empty())
+            {
+                draw_under_opacity(
                     canvas,
                     block,
                     node_id,
@@ -619,8 +669,23 @@ fn draw_under_transform(
         .filter(|b| b.style.has_overflow_clip())
         .flat_map(|b| b.clip_descendants.iter().copied())
         .collect();
+    // Symmetric pre-skip for opacity-scoped descendants. When an
+    // opacity block sits inside this transform, `draw_under_opacity`
+    // (called below) iterates its own `opacity_descendants` to paint
+    // them inside the opacity wrap; iterating those nodes again here
+    // via `dispatch_fragment` would emit a second draw outside the
+    // opacity group. Mirrors `clip_skip`. (fulgur-gdb9)
+    let opacity_skip: std::collections::BTreeSet<usize> = tx
+        .descendants
+        .iter()
+        .filter_map(|id| drawables.block_styles.get(id))
+        .flat_map(|b| b.opacity_descendants.iter().copied())
+        .collect();
     for &desc_id in &tx.descendants {
-        if nested_skip.contains(&desc_id) || clip_skip.contains(&desc_id) {
+        if nested_skip.contains(&desc_id)
+            || clip_skip.contains(&desc_id)
+            || opacity_skip.contains(&desc_id)
+        {
             continue;
         }
         let Some(desc_geom) = geometry.get(&desc_id) else {
@@ -661,6 +726,32 @@ fn draw_under_transform(
                 // overflow content past the clip boundary
                 // (PR #309 follow-up Devin).
                 draw_under_clip(
+                    canvas,
+                    desc_block,
+                    desc_id,
+                    desc_geom,
+                    desc_frag,
+                    desc_x,
+                    desc_y,
+                    geometry,
+                    drawables,
+                    margin_left_pt,
+                    margin_top_pt,
+                    page_index,
+                );
+            } else if let Some(desc_block) = drawables
+                .block_styles
+                .get(&desc_id)
+                .filter(|b| !b.opacity_descendants.is_empty())
+            {
+                // Opacity-scoped descendant inside this transform.
+                // Without this branch, transforms wrapping an opacity
+                // block would dispatch the descendant's own paint via
+                // `dispatch_fragment` but skip the opacity wrap of
+                // the descendant's children, dropping the descendant
+                // block's opacity from its sub-children.
+                // (fulgur-gdb9)
+                draw_under_opacity(
                     canvas,
                     desc_block,
                     desc_id,
@@ -905,8 +996,22 @@ fn draw_under_clip(
             .filter(|b| b.style.has_overflow_clip())
             .flat_map(|b| b.clip_descendants.iter().copied())
             .collect();
+        // Symmetric pre-skip for opacity-scoped descendants nested
+        // inside this clip. Mirrors `nested_clip_skip` — without it,
+        // an opacity descendant's sub-children would be dispatched by
+        // the loop AND by `draw_under_opacity` below, double-painting
+        // them. (fulgur-gdb9)
+        let nested_opacity_skip: std::collections::BTreeSet<usize> = block
+            .clip_descendants
+            .iter()
+            .filter_map(|id| drawables.block_styles.get(id))
+            .flat_map(|b| b.opacity_descendants.iter().copied())
+            .collect();
         for &desc_id in &block.clip_descendants {
-            if transform_skip.contains(&desc_id) || nested_clip_skip.contains(&desc_id) {
+            if transform_skip.contains(&desc_id)
+                || nested_clip_skip.contains(&desc_id)
+                || nested_opacity_skip.contains(&desc_id)
+            {
                 continue;
             }
             let Some(desc_geom) = geometry.get(&desc_id) else {
@@ -961,6 +1066,28 @@ fn draw_under_clip(
                         margin_top_pt,
                         page_index,
                     );
+                } else if let Some(desc_block) = drawables
+                    .block_styles
+                    .get(&desc_id)
+                    .filter(|b| !b.opacity_descendants.is_empty())
+                {
+                    // Nested opacity-scoped block — recurse so its
+                    // descendants paint inside its `draw_with_opacity`
+                    // wrap. (fulgur-gdb9)
+                    draw_under_opacity(
+                        canvas,
+                        desc_block,
+                        desc_id,
+                        desc_geom,
+                        desc_frag,
+                        desc_x,
+                        desc_y,
+                        geometry,
+                        drawables,
+                        margin_left_pt,
+                        margin_top_pt,
+                        page_index,
+                    );
                 } else {
                     dispatch_fragment(
                         canvas, desc_id, desc_geom, desc_frag, desc_x, desc_y, drawables,
@@ -972,6 +1099,246 @@ fn draw_under_clip(
 
         if clip_pushed {
             canvas.surface.pop();
+        }
+    });
+}
+
+/// Wrap the block's `dispatch_fragment` + every strict descendant in a
+/// single `draw_with_opacity` group. Used for blocks that have
+/// fractional opacity but no overflow clip (the clip arm,
+/// `draw_under_clip`, already handles its own opacity wrap).
+///
+/// Mirrors v1's `BlockPageable::draw` (`pageable.rs:1770-1828`):
+///
+/// ```text
+/// draw_with_opacity(canvas, self.opacity, |c| {
+///     bg + border + shadow at (x, y, total_w, total_h);
+///     for pc in self.children { pc.child.draw(c, x + pc.x, y + pc.y, ..); }
+/// });
+/// ```
+///
+/// v1 emits a single transparency-group XObject for the entire
+/// subtree. v2's flat dispatch without scope tracking would emit the
+/// block's own paint inside opacity but every descendant outside,
+/// dropping the parent's opacity on those descendants. Mirrors
+/// `draw_under_clip` minus the `push_clip_path` / `pop` calls and the
+/// list-item marker arm (a list-item with opacity uses
+/// `draw_list_item_with_block`, not this path, since list-item
+/// markers are owned by `ListItemEntry` rather than `BlockEntry`).
+#[allow(clippy::too_many_arguments)]
+fn draw_under_opacity(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    block: &crate::drawables::BlockEntry,
+    node_id: usize,
+    geom: &crate::pagination_layout::PaginationGeometry,
+    frag: &crate::pagination_layout::Fragment,
+    x_pt: f32,
+    y_pt: f32,
+    geometry: &crate::pagination_layout::PaginationGeometryTable,
+    drawables: &Drawables,
+    margin_left_pt: f32,
+    margin_top_pt: f32,
+    page_index: u32,
+) {
+    use crate::convert::px_to_pt;
+    use crate::pageable::draw_with_opacity;
+
+    draw_with_opacity(canvas, block.opacity, |canvas| {
+        // Block's own paint + shared-node_id inner content. We can
+        // re-use `dispatch_fragment` because it already handles the
+        // shared-node_id case via `draw_block_with_inner_content`,
+        // which itself opens a `draw_with_opacity(block.opacity, ..)`
+        // wrap. That nested wrap is harmless: krilla composes nested
+        // opacity groups by multiplication (0.4 × 1.0 = 0.4, since the
+        // inner block-with-inner-content uses the SAME opacity),
+        // matching the v1 chain `draw_with_opacity(0.4) → child draws`
+        // where the child happens to also be a block at full opacity.
+        //
+        // For pure-block-with-descendants (the case we're fixing —
+        // `<div opacity:0.4><svg>..</svg></div>`), `dispatch_fragment`
+        // calls `draw_block_v2` which wraps own paint in
+        // `draw_with_opacity(0.4)`. The outer wrap here multiplies to
+        // 0.16 — wrong! Inline the block's own paint without the inner
+        // opacity wrap to avoid this.
+        if drawables.list_items.contains_key(&node_id) {
+            // Inside an opacity-scoped block path we never reach a
+            // list-item: list-items dispatch through their own
+            // `draw_list_item_with_block` which composes the marker +
+            // body block + paragraph in one opacity group. If a
+            // list-item carries opacity, it would not have entered
+            // `draw_under_opacity` because list-item's opacity comes
+            // from `ListItemEntry`, not `BlockEntry`. Defensive guard
+            // only — should be unreachable.
+            dispatch_fragment(
+                canvas, node_id, geom, frag, x_pt, y_pt, drawables, page_index,
+            );
+        } else {
+            // Block bg / border / shadow without the inner opacity
+            // wrap. The shared-node_id (`paragraph` / `image` / `svg`
+            // at the same node_id) inner content paints at the
+            // content-box top-left; mirrors
+            // `draw_block_with_inner_content`'s body but without its
+            // own `draw_with_opacity` since the outer wrap already
+            // covers it.
+            let para_for_block = drawables.paragraphs.get(&node_id);
+            let img_for_block = drawables.images.get(&node_id);
+            let svg_for_block = drawables.svgs.get(&node_id);
+            let total_width = block
+                .layout_size
+                .map(|s| s.width)
+                .unwrap_or_else(|| px_to_pt(frag.width));
+            let total_height = block
+                .layout_size
+                .map(|s| s.height)
+                .unwrap_or_else(|| px_to_pt(frag.height));
+            if block.visible {
+                crate::background::draw_box_shadows(
+                    canvas,
+                    &block.style,
+                    x_pt,
+                    y_pt,
+                    total_width,
+                    total_height,
+                );
+                crate::background::draw_background(
+                    canvas,
+                    &block.style,
+                    x_pt,
+                    y_pt,
+                    total_width,
+                    total_height,
+                );
+                crate::pageable::draw_block_border(
+                    canvas,
+                    &block.style,
+                    x_pt,
+                    y_pt,
+                    total_width,
+                    total_height,
+                );
+            }
+            let inner_inset = block.style.content_inset();
+            let inner_x = x_pt + inner_inset.0;
+            let inner_y = y_pt + inner_inset.1;
+            if let Some(p) = para_for_block {
+                draw_paragraph_inner_paint(
+                    canvas,
+                    p,
+                    inner_x,
+                    inner_y,
+                    &geom.fragments,
+                    page_index,
+                );
+            }
+            if let Some(i) = img_for_block {
+                draw_image_inner_paint(canvas, i, inner_x, inner_y);
+            }
+            if let Some(s) = svg_for_block {
+                draw_svg_inner_paint(canvas, s, inner_x, inner_y);
+            }
+        }
+
+        // Descendants — same dispatch tree as `draw_under_clip` minus
+        // the nested-clip recursion (an opacity-scoped block by
+        // construction has `clipping == false`, so its descendants
+        // can still individually have clip / transform / opacity, and
+        // those need their own scope helpers).
+        let transform_skip: std::collections::BTreeSet<usize> = block
+            .opacity_descendants
+            .iter()
+            .filter_map(|id| drawables.transforms.get(id))
+            .flat_map(|tx| tx.descendants.iter().copied())
+            .collect();
+        let nested_clip_skip: std::collections::BTreeSet<usize> = block
+            .opacity_descendants
+            .iter()
+            .filter_map(|id| drawables.block_styles.get(id))
+            .filter(|b| b.style.has_overflow_clip())
+            .flat_map(|b| b.clip_descendants.iter().copied())
+            .collect();
+        let nested_opacity_skip: std::collections::BTreeSet<usize> = block
+            .opacity_descendants
+            .iter()
+            .filter_map(|id| drawables.block_styles.get(id))
+            .flat_map(|b| b.opacity_descendants.iter().copied())
+            .collect();
+        for &desc_id in &block.opacity_descendants {
+            if transform_skip.contains(&desc_id)
+                || nested_clip_skip.contains(&desc_id)
+                || nested_opacity_skip.contains(&desc_id)
+            {
+                continue;
+            }
+            let Some(desc_geom) = geometry.get(&desc_id) else {
+                continue;
+            };
+            for desc_frag in &desc_geom.fragments {
+                if desc_frag.page_index != page_index {
+                    continue;
+                }
+                let desc_x = margin_left_pt + px_to_pt(desc_frag.x);
+                let desc_y = margin_top_pt + px_to_pt(desc_frag.y);
+                if let Some(desc_tx) = drawables.transforms.get(&desc_id) {
+                    draw_under_transform(
+                        canvas,
+                        desc_tx,
+                        desc_id,
+                        desc_geom,
+                        desc_frag,
+                        desc_x,
+                        desc_y,
+                        geometry,
+                        drawables,
+                        margin_left_pt,
+                        margin_top_pt,
+                        page_index,
+                    );
+                } else if let Some(desc_block) = drawables
+                    .block_styles
+                    .get(&desc_id)
+                    .filter(|b| b.style.has_overflow_clip())
+                    .filter(|_| Some(desc_id) != drawables.body_id)
+                {
+                    draw_under_clip(
+                        canvas,
+                        desc_block,
+                        desc_id,
+                        desc_geom,
+                        desc_frag,
+                        desc_x,
+                        desc_y,
+                        geometry,
+                        drawables,
+                        margin_left_pt,
+                        margin_top_pt,
+                        page_index,
+                    );
+                } else if let Some(desc_block) = drawables
+                    .block_styles
+                    .get(&desc_id)
+                    .filter(|b| !b.opacity_descendants.is_empty())
+                {
+                    draw_under_opacity(
+                        canvas,
+                        desc_block,
+                        desc_id,
+                        desc_geom,
+                        desc_frag,
+                        desc_x,
+                        desc_y,
+                        geometry,
+                        drawables,
+                        margin_left_pt,
+                        margin_top_pt,
+                        page_index,
+                    );
+                } else {
+                    dispatch_fragment(
+                        canvas, desc_id, desc_geom, desc_frag, desc_x, desc_y, drawables,
+                        page_index,
+                    );
+                }
+            }
         }
     });
 }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -295,10 +295,20 @@ fn draw_v2_page(
     // `draw_under_opacity`). Without skipping these in the main loop
     // they'd be dispatched twice: once at full opacity here, once
     // again under the parent's opacity wrap.
+    //
+    // Body is excluded for the same reason as `clipped_descendants`:
+    // the fragmenter records body with exactly one fragment at
+    // `page_index = 0`, so `draw_under_opacity(body)` only fires on
+    // page 0. Keeping body's descendants in this set would silently
+    // blank all content on pages 1+ (descendants get skipped by the
+    // `opacity_wrapped_descendants.contains(...)` guard but no-one
+    // dispatches them — same `body { opacity: 0.5 }` pitfall the
+    // clip path documents at the `clipped_descendants` collection
+    // (PR #314 follow-up Devin Review).
     let mut opacity_wrapped_descendants: std::collections::BTreeSet<usize> =
         std::collections::BTreeSet::new();
-    for block in drawables.block_styles.values() {
-        if !block.opacity_descendants.is_empty() {
+    for (&node_id, block) in &drawables.block_styles {
+        if !block.opacity_descendants.is_empty() && Some(node_id) != drawables.body_id {
             opacity_wrapped_descendants.extend(block.opacity_descendants.iter().copied());
         }
     }
@@ -438,10 +448,21 @@ fn draw_v2_page(
             // `<div opacity:0.4><svg>..</svg></div>` paints the svg
             // outside the parent's opacity wrap, dropping the parent's
             // opacity from the svg. (fulgur-gdb9)
+            //
+            // Body is excluded for the same reason as the clip arm
+            // above: body has only a page-0 fragment so a
+            // `draw_under_opacity(body)` would only wrap page-0
+            // content while the `opacity_wrapped_descendants` skip
+            // (collected above) excludes body explicitly so the main
+            // loop dispatches body's descendants on pages 1+
+            // normally. Without this exclusion `body { opacity: 0.5 }`
+            // would silently blank pages 1+. (PR #314 follow-up Devin
+            // Review)
             if let Some(block) = drawables
                 .block_styles
                 .get(&node_id)
                 .filter(|b| !b.opacity_descendants.is_empty())
+                .filter(|_| Some(node_id) != drawables.body_id)
             {
                 draw_under_opacity(
                     canvas,
@@ -1196,9 +1217,25 @@ fn draw_under_opacity(
                 .layout_size
                 .map(|s| s.width)
                 .unwrap_or_else(|| px_to_pt(frag.width));
+            // Mirror `draw_block_inner_paint`'s `is_split` height fix.
+            // When this opacity-scoped block spans multiple pages
+            // (one fragment per page slice), use `frag.height` so each
+            // slice paints its per-page bg / border height instead of
+            // the full layout height — without this the bg / border
+            // overflows the page bottom on earlier slices and double-
+            // paints on continuation pages, exactly the bug the
+            // `draw_block_inner_paint` fix addresses for non-opacity
+            // blocks (PR #316). (PR #314 follow-up Devin Review)
+            let is_split = geom.fragments.len() > 1;
             let total_height = block
                 .layout_size
-                .map(|s| s.height)
+                .map(|s| {
+                    if is_split && frag.height > 0.0 {
+                        px_to_pt(frag.height)
+                    } else {
+                        s.height
+                    }
+                })
                 .unwrap_or_else(|| px_to_pt(frag.height));
             if block.visible {
                 crate::background::draw_box_shadows(

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -522,6 +522,13 @@ fn dispatch_fragment(
         draw_table_v2(canvas, table, x_pt, y_pt, frag);
         return;
     }
+    // True when this block / list-item / paragraph spans multiple
+    // pages (the fragmenter recorded one fragment per page slice).
+    // Passed down so `draw_block_inner_paint` can use the per-page
+    // slice height (`frag.height`) instead of `layout_size.height`
+    // — without it, every slice paints the FULL block, which
+    // doubled the callout in `examples/break-inside` (fulgur-bq6i).
+    let is_split = geom.fragments.len() > 1;
     // ListItem case: marker + body block + inline-root paragraph
     // share a single opacity group. See `draw_list_item_with_block`
     // for the v1 mirror.
@@ -538,6 +545,7 @@ fn dispatch_fragment(
             frag,
             &geom.fragments,
             page_index,
+            is_split,
         );
         return;
     }
@@ -560,10 +568,11 @@ fn dispatch_fragment(
                 frag,
                 &geom.fragments,
                 page_index,
+                is_split,
             );
             return;
         }
-        draw_block_v2(canvas, block, x_pt, y_pt, frag);
+        draw_block_v2(canvas, block, x_pt, y_pt, frag, is_split);
     }
     if let Some(img) = drawables.images.get(&node_id) {
         draw_image_v2(canvas, img, x_pt, y_pt);
@@ -1574,11 +1583,12 @@ fn draw_block_v2(
     x: f32,
     y: f32,
     frag: &crate::pagination_layout::Fragment,
+    is_split: bool,
 ) {
     use crate::pageable::draw_with_opacity;
 
     draw_with_opacity(canvas, entry.opacity, |canvas| {
-        draw_block_inner_paint(canvas, entry, x, y, frag);
+        draw_block_inner_paint(canvas, entry, x, y, frag, is_split);
     });
 }
 
@@ -1645,14 +1655,39 @@ fn draw_block_inner_paint(
     x: f32,
     y: f32,
     frag: &crate::pagination_layout::Fragment,
+    is_split: bool,
 ) {
     let total_width = entry
         .layout_size
         .map(|s| s.width)
         .unwrap_or_else(|| crate::convert::px_to_pt(frag.width));
+    // For split blocks (one fragment per page), `frag.height` reports
+    // the per-page slice height. `entry.layout_size.height` always
+    // carries Taffy's full block height, so painting bg / border with
+    // `layout_size` would draw the FULL block on every slice — visible
+    // as a callout-box overflowing page bottom on page 1 AND repeating
+    // full-size on page 2 (fulgur-bq6i: `examples/break-inside`).
+    //
+    // Mirror v1: `BlockPageable::slice_for_page` returns a sliced
+    // pageable whose `layout_size.height` already equals the slice
+    // height, so v1's draw uses the slice-correct height naturally.
+    // v2 has a single `BlockEntry` per node_id holding the full
+    // layout, so we recover the slice-correct height from
+    // `frag.height` only when the dispatcher tells us this is a
+    // split fragment (`is_split = geom.fragments.len() > 1`). Using
+    // a multi-fragment signal — not a `frag_h < layout_h` comparison
+    // — avoids spurious flips for single-page blocks where the two
+    // values may differ by 1 ULP after CSS-px → pt conversion
+    // rounding.
     let total_height = entry
         .layout_size
-        .map(|s| s.height)
+        .map(|s| {
+            if is_split && frag.height > 0.0 {
+                crate::convert::px_to_pt(frag.height)
+            } else {
+                s.height
+            }
+        })
         .unwrap_or_else(|| crate::convert::px_to_pt(frag.height));
 
     if entry.visible {
@@ -1743,6 +1778,7 @@ fn draw_block_with_inner_content(
     frag: &crate::pagination_layout::Fragment,
     fragments: &[crate::pagination_layout::Fragment],
     page_index: u32,
+    is_split: bool,
 ) {
     use crate::pageable::draw_with_opacity;
 
@@ -1762,7 +1798,7 @@ fn draw_block_with_inner_content(
     let inner_y = y + iy;
 
     draw_with_opacity(canvas, block.opacity, |canvas| {
-        draw_block_inner_paint(canvas, block, x, y, frag);
+        draw_block_inner_paint(canvas, block, x, y, frag, is_split);
         if let Some(p) = paragraph {
             draw_paragraph_inner_paint(canvas, p, inner_x, inner_y, fragments, page_index);
         }
@@ -1799,6 +1835,7 @@ fn draw_list_item_with_block(
     frag: &crate::pagination_layout::Fragment,
     fragments: &[crate::pagination_layout::Fragment],
     page_index: u32,
+    is_split: bool,
 ) {
     use crate::pageable::draw_with_opacity;
 
@@ -1815,7 +1852,7 @@ fn draw_list_item_with_block(
             draw_list_item_marker(canvas, list_item, x, y);
         }
         if let Some(b) = block {
-            draw_block_inner_paint(canvas, b, x, y, frag);
+            draw_block_inner_paint(canvas, b, x, y, frag, is_split);
         }
         if let Some(p) = paragraph {
             draw_paragraph_inner_paint(canvas, p, inner_x, inner_y, fragments, page_index);

--- a/crates/fulgur/tests/render_path_parity.rs
+++ b/crates/fulgur/tests/render_path_parity.rs
@@ -675,3 +675,52 @@ fn known_divergent_fixtures_stay_within_f32_ulp_bound() {
         );
     }
 }
+
+/// Bounded-divergence regression for `vrt://bugs/grid-row-promote-background.html`
+/// (fulgur-bq6i). v1 paints an off-page card slice at a different
+/// numeric y than v2 because of a `BlockPageable::slice_for_page`
+/// quirk: when an ancestor (`.grid`) has no fragment on the current
+/// page but its descendants do, `self_page_y` falls back to 0 and
+/// the child's `new_y` is computed against that fallback while the
+/// ancestor's own `pc.y` (body-relative) is also added by the draw
+/// chain — producing y = 1681pt vs v2's correct 868.94pt. Both are
+/// off-page (page bottom is 822pt); only the numeric Tm operand
+/// differs and the renderer clips both via the page MediaBox.
+///
+/// See the "Known-divergent v1 quirk" comment block in
+/// `render_path_parity.toml` for the full chain.
+///
+/// Resolution: defer to PR 8 v1 deletion. This test asserts the
+/// divergence stays within the v1-quirk-only bound; if some future
+/// change grows it past that, this fires.
+#[test]
+fn grid_row_promote_v1_quirk_stays_within_quirk_bound() {
+    use fulgur::Engine;
+
+    let root = repo_root();
+    let html_path = root.join("crates/fulgur-vrt/fixtures/bugs/grid-row-promote-background.html");
+    let html = std::fs::read_to_string(&html_path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", html_path.display()));
+
+    let engine = Engine::builder().build();
+    let v1 = engine
+        .render_html(&html)
+        .unwrap_or_else(|e| panic!("v1 render: {e}"));
+    let v2 = engine
+        .render_html_v2(&html)
+        .unwrap_or_else(|e| panic!("v2 render: {e}"));
+
+    // Empirically the diff is 15 bytes — single off-page slice y plus
+    // matching border-edge y. ≤32 leaves margin for xref re-flow
+    // without masking real layout regressions.
+    let len_diff = (v1.len() as isize - v2.len() as isize).unsigned_abs();
+    assert!(
+        len_diff <= 32,
+        "grid-row-promote: byte-length divergence ballooned \
+         (v1={}B v2={}B, |diff|={len_diff}B). Expected ≤32B for the \
+         v1 slice-y quirk. A larger diff means real visible layout \
+         has changed — investigate before raising the bound.",
+        v1.len(),
+        v2.len(),
+    );
+}

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -143,6 +143,16 @@ allowlist = [
     # `vrt://layout/review_card_inline_block.html` and any future
     # mixed-block-and-inline content.
     "vrt://layout/review_card_inline_block.html",
+    # PR follow-up (per-slice block height, fulgur-bq6i:break-inside) —
+    # split blocks (one fragment per page) were painting the FULL
+    # `layout_size.height` on every slice, so a `break-inside: avoid`
+    # callout that doesn't fit on page 1 painted overflowing-the-page-
+    # bottom on page 1 AND repeated full-size on page 2. v2 now passes
+    # `is_split = geom.fragments.len() > 1` from `dispatch_fragment` to
+    # `draw_block_inner_paint`, which uses `frag.height` per slice when
+    # split — mirroring v1's `BlockPageable::slice_for_page` which
+    # adjusts `layout_size.height` per sliced pageable.
+    "examples://break-inside",
 ]
 
 # Known-divergent fixtures (fulgur-g7a1, 2026-04-30)

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -229,3 +229,29 @@ allowlist = [
 #
 # Resolution: defer to PR 8 v1 deletion. Fixing v1 in flight would
 # touch `slice_for_page` for a quirk that disappears with the path.
+
+# Known-divergent: v2 renders content v1 silently drops (fulgur-bq6i:wasm-demo)
+# ----------------------------------------------------------------------
+# `examples/wasm-demo` is intentionally NOT allowlisted because v2's
+# `fragment_pagination_root` now walks `body.layout_children` (when
+# present) for the same reason `record_subtree_descendants` does:
+# Stylo synthesizes anonymous block wrappers around inline-level
+# siblings of block-level body children, and those wrappers carry
+# the inline content's `node_id`.
+#
+# After the body-level layout_children fix, v2 picks up
+# `<label>` / `<legend>` / `<select>` / `<option>` / `<input>` /
+# `<button>` paint that v1 silently drops because v1's body
+# iteration only saw the raw children list (which omits the
+# anonymous wrappers Stylo creates for the form-element row).
+#
+# Net delta: v2 is 53 bytes longer than v1 on this fixture because
+# v2 also paints the `<button id="render" disabled>Loading WASM…
+# </button>` text that v1 omits. v2 is the more visually correct
+# output — Phase 4's whole point is that the geometry-driven path
+# fixes coverage gaps in the Pageable path, and this is one such
+# gap that becomes the canonical behavior after PR 8 v1 deletion.
+#
+# Resolution: defer to PR 8 v1 deletion. Once the v1 path is gone,
+# the parity test compares v2 vs v2 (trivially byte-eq). For users
+# rendering form-heavy HTML to PDF, this is a v2 improvement.

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -120,6 +120,17 @@ allowlist = [
     "examples://pseudo-content-url",
     "examples://text-align",
     "examples://text-decoration",
+    # PR follow-up (cross-node_id opacity grouping, fulgur-gdb9) —
+    # `<div style="opacity:0.4"><svg>..</svg></div>` was painting the
+    # svg outside the parent's `draw_with_opacity` wrap because v2's
+    # flat dispatch had no way to nest descendants under a parent's
+    # opacity group. `BlockEntry.opacity_descendants` + new
+    # `draw_under_opacity` mirror the existing
+    # `clip_descendants` / `draw_under_clip` shape so opacity wraps
+    # everything (own paint + descendants), matching v1's
+    # `BlockPageable::draw` recursion under
+    # `draw_with_opacity(self.opacity, ..)`.
+    "examples://svg",
 ]
 
 # Known-divergent fixtures (fulgur-g7a1, 2026-04-30)

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -196,3 +196,36 @@ allowlist = [
 # Resolution: defer to PR 8 v1 deletion. Once v1 is gone, the parity
 # test compares v2 vs v2 (trivially byte-eq) and these fixtures need
 # no special handling.
+
+# Known-divergent v1 quirk: off-page slice y (fulgur-bq6i:grid-row-promote)
+# ----------------------------------------------------------------------
+# `vrt://bugs/grid-row-promote-background.html` is intentionally NOT
+# allowlisted because v1 emits an off-page card slice at a different
+# numeric y than v2. The visual output is identical (both clipped by
+# the page MediaBox) — only the numeric Tm operand differs.
+#
+# Root cause: a v1 quirk in `BlockPageable::slice_for_page` when an
+# ancestor (here `.grid`) has NO fragment on the current page but its
+# descendants (cards) do. The ancestor's `self_page_y` falls back to
+# `0.0`, and the child's slice computes
+# `new_y = px_to_pt(child_frag.y - 0)` treating body-content-relative
+# `child_frag.y` as parent-relative. The Pageable draw chain then
+# double-adds the ancestor's `pc.y` (from convert) AND the child's
+# new_y (which is also body-relative), producing y = 1681pt — far
+# off the page bottom.
+#
+#   v1: body.draw(y=56.69) → grid.draw(y=56.69 + 812 = 868.69) →
+#       card_1_slice.draw(y=868.69 + 812.25 = 1680.94pt)
+#   v2: dispatch_fragment uses frag.y_page_local =
+#       56.69 + px_to_pt(1083) = 868.94pt
+#
+# v2 is correct (page-local from fragmenter); v1's value is the sum
+# of two body-relative offsets due to the slice-coord bug.
+#
+# Both renders emit the slice off-page (anywhere past 822pt is past
+# the page bottom for an A4 with 20mm margin). The slice gets clipped
+# by the MediaBox so neither is visible; the difference is purely in
+# the numeric operand the renderer emits before the clip.
+#
+# Resolution: defer to PR 8 v1 deletion. Fixing v1 in flight would
+# touch `slice_for_page` for a quirk that disappears with the path.

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -131,6 +131,18 @@ allowlist = [
     # `BlockPageable::draw` recursion under
     # `draw_with_opacity(self.opacity, ..)`.
     "examples://svg",
+    # PR follow-up (anonymous-block layout walk, fulgur-bq6i:review_card)
+    # — Stylo synthesizes anonymous block wrappers around inline-level
+    # siblings of block-level siblings (CSS 2.1 §9.2.1.1). Those
+    # wrappers carry their own `node_id` and live in
+    # `Node.layout_children` but NOT in `Node.children`. The fragmenter's
+    # `record_subtree_descendants` walked `children`, missing the
+    # synthesized anonymous block, so geometry never recorded its
+    # fragment and v2 dispatch silently dropped its inline-root
+    # paragraph. Switching to `layout_children` (when `Some`) lights up
+    # `vrt://layout/review_card_inline_block.html` and any future
+    # mixed-block-and-inline content.
+    "vrt://layout/review_card_inline_block.html",
 ]
 
 # Known-divergent fixtures (fulgur-g7a1, 2026-04-30)

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -859,3 +859,47 @@ fn render_v2_smoke_multicol_rule_inside_transform() {
     let pdf = engine.render_html_v2(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
+
+#[test]
+fn render_v2_smoke_opacity_descendants_block_with_svg() {
+    // Regression for fulgur-gdb9: a fractional-opacity block wrapping
+    // a child element of a different node_id (the canonical
+    // `<div opacity:0.4><svg>..</svg></div>` shape) must paint the
+    // svg INSIDE the parent's `draw_with_opacity` group. Without
+    // `BlockEntry.opacity_descendants` + `draw_under_opacity`, v2's
+    // flat dispatch paints svg at full opacity and double-emits the
+    // transparency group. This smoke exercises the new
+    // `draw_under_opacity` arm in `dispatch_fragment`'s precedence
+    // chain.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.faded{opacity:0.4}</style></head><body><div class="faded"><svg xmlns="http://www.w3.org/2000/svg" width="40" height="40"><rect width="40" height="40" fill="#1a6faa"/></svg></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn render_v2_smoke_opacity_inside_overflow_clip() {
+    // Composition: a clipping ancestor with an opacity-scoped
+    // descendant. Exercises the new `nested_opacity_skip` set inside
+    // `draw_under_clip`'s descendant loop and the `draw_under_opacity`
+    // arm in the recursive descend. Without the skip, the inner
+    // opacity block's strict descendants would dispatch twice (once
+    // by the clip's main loop iteration, once under the opacity
+    // wrap).
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.clip{overflow:hidden;width:120pt;height:80pt}.faded{opacity:0.5}</style></head><body><div class="clip"><div class="faded"><svg xmlns="http://www.w3.org/2000/svg" width="60" height="60"><circle cx="30" cy="30" r="25" fill="#e74c3c"/></svg></div></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn render_v2_smoke_opacity_inside_transform() {
+    // Composition: a transformed ancestor with an opacity-scoped
+    // descendant. Exercises the new `opacity_skip` set inside
+    // `draw_under_transform`'s descendant loop and the
+    // `draw_under_opacity` arm in the recursive descend.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.tx{transform:rotate(5deg)}.faded{opacity:0.6}</style></head><body><div class="tx"><div class="faded"><svg xmlns="http://www.w3.org/2000/svg" width="40" height="40"><rect width="40" height="40" fill="#27ae60"/></svg></div></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -937,3 +937,40 @@ fn render_v2_smoke_anonymous_block_inline_level_sibling() {
         pdf_no_badge.len(),
     );
 }
+
+#[test]
+fn render_v2_smoke_split_block_uses_per_slice_height() {
+    // Regression for fulgur-bq6i:break-inside — when a block spans
+    // multiple pages (the fragmenter records one fragment per page
+    // slice), `draw_block_inner_paint` must paint each slice at its
+    // per-page `frag.height` rather than the block's full
+    // `layout_size.height`. Without this, the block's bg / border
+    // paints full-size on every slice, leaking past the page bottom on
+    // earlier slices and double-painting on the continuation page.
+    //
+    // Construct a body that overflows page 1 with a tall styled box
+    // straddling the page break. The styled box has a colored bg so a
+    // full-height repaint on page 2 (the bug) would emit an
+    // unmistakably oversized rect — verifiable via PDF size: split
+    // version stays close to single-page version + per-slice paints,
+    // not 2× the block-area worth of bg fills.
+    let html = r##"<!DOCTYPE html><html><head><style>
+        body{margin:0;padding:0;font-size:10pt}
+        .filler{height:600pt;background:#eef}
+        .box{height:300pt;background:#cef;border:2pt solid #44a}
+    </style></head><body>
+        <div class="filler"></div>
+        <div class="box"></div>
+    </body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+    // Sanity: must produce a multi-page PDF (the box straddles page
+    // bottom).
+    let pdf_str = String::from_utf8_lossy(&pdf);
+    let page_count = pdf_str.matches("/Type /Page\n").count();
+    assert!(
+        page_count >= 2,
+        "expected multi-page output for split block, got {page_count}",
+    );
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -1009,3 +1009,105 @@ fn render_v2_smoke_body_layout_children_for_form_siblings() {
         pdf_no_inline.len(),
     );
 }
+
+#[test]
+fn render_v2_smoke_body_opacity_multi_page_content_survives() {
+    // Regression for PR #314 follow-up Devin Review:
+    // `body { opacity: 0.5 }` with content that spans multiple
+    // pages must NOT silently blank pages 1+. The `body` element
+    // gets exactly one fragment at `page_index = 0`
+    // (`pagination_layout.rs:380-384`), so
+    // `draw_under_opacity(body)` only fires on page 0. If body's
+    // descendants are added to `opacity_wrapped_descendants`
+    // unconditionally, they get skipped on pages 1+ by the
+    // `opacity_wrapped_descendants.contains(...)` guard but no-one
+    // dispatches them — silently blanking everything after page 1.
+    //
+    // Body is now excluded from `opacity_wrapped_descendants` (and
+    // from the `draw_under_opacity` dispatch arm) for the same
+    // reason `clipped_descendants` excludes it (PR #310 Devin).
+    let html = r##"<!DOCTYPE html><html><head><style>
+        body{margin:0;padding:0;opacity:0.5;font-size:10pt}
+        .filler{height:800pt;background:#eef}
+        .tail{height:120pt;background:#cef;margin-top:12pt}
+    </style></head><body>
+        <div class="filler"></div>
+        <div class="tail">tail content on page 2</div>
+    </body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+    // Sanity: must be multi-page (filler 800pt + tail 132pt > A4
+    // content height of ~842pt).
+    let pdf_str = String::from_utf8_lossy(&pdf);
+    let page_count = pdf_str.matches("/Type /Page\n").count();
+    assert!(
+        page_count >= 2,
+        "expected multi-page output for body-opacity test, got {page_count}",
+    );
+    // Compare to a no-opacity baseline. Without the body exclusion
+    // fix, body's descendants on page 2 silently disappear and the
+    // PDF shrinks compared to the no-opacity version. The opacity-
+    // group XObject adds a small constant; the test simply asserts
+    // the with-opacity PDF retains MOST of the no-opacity content
+    // (i.e. didn't lose page 2 entirely).
+    let html_baseline = r##"<!DOCTYPE html><html><head><style>
+        body{margin:0;padding:0;font-size:10pt}
+        .filler{height:800pt;background:#eef}
+        .tail{height:120pt;background:#cef;margin-top:12pt}
+    </style></head><body>
+        <div class="filler"></div>
+        <div class="tail">tail content on page 2</div>
+    </body></html>"##;
+    let pdf_baseline = engine.render_html_v2(html_baseline).expect("v2 render");
+    // Allow some room for the opacity group XObject overhead but
+    // require at least 90% of the baseline content survives. A real
+    // regression (silent page-2 blanking) drops the size by far more
+    // than 10%.
+    assert!(
+        pdf.len() * 100 >= pdf_baseline.len() * 90,
+        "with-opacity PDF lost too much content vs baseline \
+         (with={}B baseline={}B); did body exclusion regress?",
+        pdf.len(),
+        pdf_baseline.len(),
+    );
+}
+
+#[test]
+fn render_v2_smoke_split_opacity_block_uses_per_slice_height() {
+    // Regression for PR #314 follow-up Devin Review: a fractional-
+    // opacity block with descendants that ALSO spans multiple pages
+    // (split slice) must paint each per-page slice at its
+    // `frag.height`, not the full `layout_size.height`. v2's
+    // `draw_under_opacity` inlines the bg / border / shadow paint;
+    // without the `is_split` height fix that
+    // `draw_block_inner_paint` got in PR #316, the inlined paint
+    // overflows the page bottom on earlier slices and double-paints
+    // on continuation pages.
+    //
+    // Construct a body with a tall opacity-wrapped block (containing
+    // a same-node_id-different SVG descendant so the opacity arm
+    // fires) that straddles the page boundary.
+    let html = r##"<!DOCTYPE html><html><head><style>
+        body{margin:0;padding:0;font-size:10pt}
+        .filler{height:600pt;background:#eef}
+        .opaque{opacity:0.5;height:300pt;background:#cef;border:2pt solid #44a;margin-top:12pt}
+    </style></head><body>
+        <div class="filler"></div>
+        <div class="opaque">
+            <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40">
+                <rect width="40" height="40" fill="#1a6faa"/>
+            </svg>
+        </div>
+    </body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+    // Multi-page sanity.
+    let pdf_str = String::from_utf8_lossy(&pdf);
+    let page_count = pdf_str.matches("/Type /Page\n").count();
+    assert!(
+        page_count >= 2,
+        "expected multi-page output for split-opacity test, got {page_count}",
+    );
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -903,3 +903,37 @@ fn render_v2_smoke_opacity_inside_transform() {
     let pdf = engine.render_html_v2(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
+
+#[test]
+fn render_v2_smoke_anonymous_block_inline_level_sibling() {
+    // Regression for fulgur-bq6i (review_card_inline_block):
+    // a block container with mixed block-level and inline-level
+    // children triggers Stylo's anonymous-block synthesis (CSS 2.1
+    // §9.2.1.1). The anonymous wrapper has its own `node_id` and
+    // appears in `Node.layout_children` but NOT in `Node.children`.
+    // The fragmenter's `record_subtree_descendants` previously
+    // walked `children`, missing the wrapper and silently dropping
+    // the inline-level child's paint. Now `layout_children` is
+    // preferred when `Some`.
+    //
+    // Without the fix, the BADGE span content (background + text)
+    // never paints in v2 because its wrapping inline-root
+    // paragraph's `node_id` lacks a geometry entry, so
+    // `dispatch_fragment` skips it. The size-comparison sanity
+    // check below catches a regression where the anonymous-block
+    // walk gets dropped: with-badge PDF must be measurably larger
+    // than no-badge PDF.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.card{padding:8pt}.label{display:inline-block;background:#cef;padding:2pt 6pt}</style></head><body><div class="card"><div>block child</div><span class="label">BADGE</span></div></body></html>"##;
+    let html_no_badge = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.card{padding:8pt}</style></head><body><div class="card"><div>block child</div></div></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    let pdf_no_badge = engine.render_html_v2(html_no_badge).expect("v2 render");
+    assert!(!pdf.is_empty());
+    assert!(
+        pdf.len() > pdf_no_badge.len(),
+        "expected BADGE rendering to produce more bytes than no-badge \
+         baseline (got {} vs {}); did anonymous-block walk regress?",
+        pdf.len(),
+        pdf_no_badge.len(),
+    );
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -974,3 +974,38 @@ fn render_v2_smoke_split_block_uses_per_slice_height() {
         "expected multi-page output for split block, got {page_count}",
     );
 }
+
+#[test]
+fn render_v2_smoke_body_layout_children_for_form_siblings() {
+    // Regression for fulgur-bq6i:wasm-demo — body with mixed
+    // block-level and inline-level children triggers Stylo's
+    // anonymous-block synthesis at the BODY level (CSS 2.1
+    // §9.2.1.1). The synthesized wrapper appears in
+    // `body.layout_children` but NOT in `body.children`, so the
+    // fragmenter's `fragment_pagination_root` (now preferring
+    // `layout_children` when non-empty) must visit it for v2 to
+    // see the inline-level group's paint.
+    //
+    // Without this fix, a body containing
+    // `<h1>title</h1><label>field: <input></label>` paints only
+    // the h1; the label + input row gets dropped because its
+    // anonymous wrapper isn't visited.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:8pt;font-size:10pt}label{margin-right:8pt}input{padding:2pt;border:1pt solid #888;width:120pt}</style></head><body><h1>Form sample</h1><label>Name:</label><input type="text" value="hello"></body></html>"##;
+    let html_no_inline = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:8pt;font-size:10pt}</style></head><body><h1>Form sample</h1></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    let pdf_no_inline = engine.render_html_v2(html_no_inline).expect("v2 render");
+    assert!(!pdf.is_empty());
+    // Sanity: body with inline-level form siblings produces a
+    // larger PDF than h1-only baseline. Without the body-level
+    // layout_children walk, the label + input row is dropped and
+    // the two sizes converge.
+    assert!(
+        pdf.len() > pdf_no_inline.len(),
+        "expected form-row rendering to produce more bytes than \
+         h1-only baseline (got {} vs {}); did body layout_children \
+         walk regress?",
+        pdf.len(),
+        pdf_no_inline.len(),
+    );
+}


### PR DESCRIPTION
## Summary

`<div style=\"opacity:0.4\"><svg>..</svg></div>` 構造で、v2 が svg を **親の `draw_with_opacity` wrap の外に描画** していた視覚バグを修正。v1 は `BlockPageable::draw` の `draw_with_opacity(self.opacity, ..)` 内で children を再帰描画するため、svg が 0.4 opacity を継承。v2 は flat dispatch のため別 node_id の svg は full opacity で描画され、余計な transparency group XObject が出力されていた。

## 設計

既存の `clip_descendants` / `draw_under_clip` パターンと完全対称:

| 軸 | 既存 | 新設 |
|---|---|---|
| Storage | `BlockEntry.clip_descendants` | `BlockEntry.opacity_descendants` |
| Populate condition | `style.has_overflow_clip()` | `opacity < 1.0` AND NOT clipping |
| Render helper | `draw_under_clip` (opacity wrap 内蔵) | `draw_under_opacity` (clip なし) |
| Main loop skip set | `clipped_descendants` | `opacity_wrapped_descendants` |
| Dispatch precedence | transform → clip → fragment | transform → clip → **opacity** → fragment |

`draw_under_opacity` は `draw_under_clip` から `push_clip_path` / `pop` 呼び出しを除いた構造。bg/border/shadow + shared-node_id inner content + descendants をすべて 1 つの `draw_with_opacity` group に包む。`draw_block_with_inner_content` を流用しないのは内側に追加の `draw_with_opacity` 呼び出しがあり、二重 opacity (0.4 × 0.4 = 0.16) になってしまうため。

## 入れ子対応 (symmetric pre-skip)

- `draw_under_clip` 内: `nested_opacity_skip` を追加、opacity-scoped 子孫を捕捉して再帰 `draw_under_opacity`
- `draw_under_transform` 内: `opacity_skip` を追加、同上
- `draw_under_opacity` 内: `nested_clip_skip` / `transform_skip` / `nested_opacity_skip` の 3 軸対称
- 各 helper 末尾の dispatch tree も clip / transform / opacity の 3 軸 fork

## 効果

- examples/svg が byte-eq 化 → allowlist enrollment (52/59 byte-identical, was 51/59)
- 同パターン (任意の opacity ancestor + 別 node_id descendant) 全般を修正

## Test plan

- [x] 新規 lib smoke (3 件) が \`cargo test -p fulgur --test render_smoke\` で pass
  - \`render_v2_smoke_opacity_descendants_block_with_svg\`
  - \`render_v2_smoke_opacity_inside_overflow_clip\`
  - \`render_v2_smoke_opacity_inside_transform\`
- [x] \`FONTCONFIG_FILE=... cargo test -p fulgur --test render_path_parity\` 3/3 pass (52/59 byte-identical, allowlist 52)
- [x] \`cargo test -p fulgur\` 847 lib + 全 integration tests pass
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy -p fulgur --tests\` clean

## 関連

- bd: \`fulgur-gdb9\` (本 PR で完了)
- Stack base: PR #313 (allowlist enrollment) → PR #312 (g7a1) → PR #302 (Phase 4 base)
- 前提: \`fulgur-9t3z.4\` (PR 7 default flip) — 本 PR で 1 件カバレッジ進捗
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
