### PR TITLE
fix(fragmenter): walk body.layout_children for anonymous-block siblings (fulgur-bq6i:wasm-demo)

### DIFF
--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -388,10 +388,40 @@ impl<'a> PaginationLayoutTree<'a> {
                 height: body_layout.size.height,
             });
 
+        // Prefer body's `layout_children` — same rationale as
+        // `record_subtree_descendants`. When a block container has
+        // mixed block-level and inline-level children, Stylo
+        // synthesizes anonymous block wrappers around the inline-
+        // level siblings (CSS 2.1 §9.2.1.1). Those wrappers carry
+        // their own `node_id` and Taffy layout, but they live ONLY
+        // in `layout_children` — `children` still points at the
+        // underlying inline elements (e.g. a body containing
+        // `<label>` followed by `<fieldset>` followed by
+        // `<select><option>...</option></select>` produces an
+        // anonymous block wrapping the `<select>` siblings, visible
+        // only in `layout_children`).
+        //
+        // Without this preference v2 silently drops the inline-level
+        // group's paint: extract assigns the inner paragraph's
+        // `node_id` to the synthesized wrapper, but the body iteration
+        // walks raw `children` and never visits the wrapper, so
+        // geometry has no fragment for that node_id and
+        // `dispatch_fragment` skips the paragraph entirely
+        // (fulgur-bq6i: examples/wasm-demo lost label / legend / option
+        // text content for this exact reason).
         let children = self
             .doc
             .get_node(body_id)
-            .map(|n| n.children.clone())
+            .map(|n| {
+                let layout_borrow = n.layout_children.borrow();
+                if let Some(lc) = layout_borrow.as_deref()
+                    && !lc.is_empty()
+                {
+                    lc.to_vec()
+                } else {
+                    n.children.clone()
+                }
+            })
             .unwrap_or_default();
 
         let mut page_index: u32 = 0;

--- a/crates/fulgur/tests/render_path_parity.toml
+++ b/crates/fulgur/tests/render_path_parity.toml
@@ -229,3 +229,29 @@ allowlist = [
 #
 # Resolution: defer to PR 8 v1 deletion. Fixing v1 in flight would
 # touch `slice_for_page` for a quirk that disappears with the path.
+
+# Known-divergent: v2 renders content v1 silently drops (fulgur-bq6i:wasm-demo)
+# ----------------------------------------------------------------------
+# `examples/wasm-demo` is intentionally NOT allowlisted because v2's
+# `fragment_pagination_root` now walks `body.layout_children` (when
+# present) for the same reason `record_subtree_descendants` does:
+# Stylo synthesizes anonymous block wrappers around inline-level
+# siblings of block-level body children, and those wrappers carry
+# the inline content's `node_id`.
+#
+# After the body-level layout_children fix, v2 picks up
+# `<label>` / `<legend>` / `<select>` / `<option>` / `<input>` /
+# `<button>` paint that v1 silently drops because v1's body
+# iteration only saw the raw children list (which omits the
+# anonymous wrappers Stylo creates for the form-element row).
+#
+# Net delta: v2 is 53 bytes longer than v1 on this fixture because
+# v2 also paints the `<button id="render" disabled>Loading WASM…
+# </button>` text that v1 omits. v2 is the more visually correct
+# output — Phase 4's whole point is that the geometry-driven path
+# fixes coverage gaps in the Pageable path, and this is one such
+# gap that becomes the canonical behavior after PR 8 v1 deletion.
+#
+# Resolution: defer to PR 8 v1 deletion. Once the v1 path is gone,
+# the parity test compares v2 vs v2 (trivially byte-eq). For users
+# rendering form-heavy HTML to PDF, this is a v2 improvement.

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -974,3 +974,38 @@ fn render_v2_smoke_split_block_uses_per_slice_height() {
         "expected multi-page output for split block, got {page_count}",
     );
 }
+
+#[test]
+fn render_v2_smoke_body_layout_children_for_form_siblings() {
+    // Regression for fulgur-bq6i:wasm-demo — body with mixed
+    // block-level and inline-level children triggers Stylo's
+    // anonymous-block synthesis at the BODY level (CSS 2.1
+    // §9.2.1.1). The synthesized wrapper appears in
+    // `body.layout_children` but NOT in `body.children`, so the
+    // fragmenter's `fragment_pagination_root` (now preferring
+    // `layout_children` when non-empty) must visit it for v2 to
+    // see the inline-level group's paint.
+    //
+    // Without this fix, a body containing
+    // `<h1>title</h1><label>field: <input></label>` paints only
+    // the h1; the label + input row gets dropped because its
+    // anonymous wrapper isn't visited.
+    let html = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:8pt;font-size:10pt}label{margin-right:8pt}input{padding:2pt;border:1pt solid #888;width:120pt}</style></head><body><h1>Form sample</h1><label>Name:</label><input type="text" value="hello"></body></html>"##;
+    let html_no_inline = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:8pt;font-size:10pt}</style></head><body><h1>Form sample</h1></body></html>"##;
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render_html_v2(html).expect("v2 render");
+    let pdf_no_inline = engine.render_html_v2(html_no_inline).expect("v2 render");
+    assert!(!pdf.is_empty());
+    // Sanity: body with inline-level form siblings produces a
+    // larger PDF than h1-only baseline. Without the body-level
+    // layout_children walk, the label + input row is dropped and
+    // the two sizes converge.
+    assert!(
+        pdf.len() > pdf_no_inline.len(),
+        "expected form-row rendering to produce more bytes than \
+         h1-only baseline (got {} vs {}); did body layout_children \
+         walk regress?",
+        pdf.len(),
+        pdf_no_inline.len(),
+    );
+}


### PR DESCRIPTION
## Summary

\`examples/wasm-demo\` (form 要素を含む) で v2 が **label / legend / select / option / input の text を完全 missing** していたバグを修正。原因は \`fragment_pagination_root\` が \`body.children\` (raw DOM) を walk しており、Stylo が inline-level siblings 用に synthesize する **anonymous block wrapper** を見ていなかったこと。

PR #315 (review_card) で \`record_subtree_descendants\` には同様の \`layout_children\` 優先 fix を入れたが、body 直接 children を読む \`fragment_pagination_root\` 側が漏れていた。

## 詳細

wasm-demo body の structure:
\`\`\`
body.children       = [14, 15, 17, 18, 26, 27, 29, 30, 32, 33, 64, 65, 70, 71, 72, 73, 74, 75, 77]
body.layout_children = [15, 18, 78, 65, 71, 73, 75]
\`\`\`

node 78 は \`<label>\` + \`<fieldset>\` + \`<select>\` siblings を wrap する Stylo synthesized anonymous block。\`fragment_pagination_root\` は raw \`children\` だけを walk するため node 78 が geometry に入らず、対応する paragraph が dispatch_fragment から skip されていた (-2330B regression)。

## 効果

- v2 が **v1 の text 全部 + \`<button id=\"render\" disabled>Loading WASM…</button>\` も描画** するようになる (button 描画は **v1 が silently drop していた v1 ギャップ**)
- 差分が -2330B → **+53B** (v2 が button 分だけ長い)
- v2 は **視覚的により正しい** 出力 (button text の rendering は v1 gap)
- byte-eq には到達しないが、これは v2 improvement なので **known-divergent v2-improvement** として toml に記録

## 修正

\`fragment_pagination_root\` で \`body.layout_children\` が \`Some\` かつ非空のとき優先して walk。\`children\` への fallback は \`layout_children\` が None / 空のときのみ。\`record_subtree_descendants\` と同じパターン。

## Test plan

- [x] 新 smoke \`render_v2_smoke_body_layout_children_for_form_siblings\`: form row 描画が h1-only baseline より大きいことの sanity (regression catch)
- [x] \`FONTCONFIG_FILE=... cargo test -p fulgur --test render_path_parity\` 4/4 pass (54/59 byte-identical)
- [x] \`cargo test -p fulgur\` 847 lib + 全 integration pass (regression なし)
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy -p fulgur --tests\` clean

## 関連

- bd: \`fulgur-bq6i\` (wasm-demo sub-task、本 PR で消化 — bq6i 全体は本 PR + PR #315 + PR #316 + PR #317 で完了)
- Stack: PR #317 (grid-row-promote) → PR #316 (break-inside) → PR #315 (review_card) → PR #314 (gdb9) → PR #313 (allowlist) → PR #312 (g7a1) → PR #302 (Phase 4 base)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
