### PR TITLE
feat(render_v2): per-page repetition for position:fixed

### DIFF
--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -281,11 +281,29 @@ impl Engine {
         };
         let resolved_content_height_pt =
             resolved_page_size.height - resolved_page_margin.top - resolved_page_margin.bottom;
-        let pagination_geometry = crate::pagination_layout::run_pass_with_break_and_running(
+        let mut pagination_geometry = crate::pagination_layout::run_pass_with_break_and_running(
             doc.deref_mut(),
             crate::convert::pt_to_px(resolved_content_height_pt),
             &column_styles,
             &running_store,
+        );
+
+        // fulgur-rpvu: append per-page fragments for every `position:
+        // fixed` element so v2's geometry-driven dispatch repeats them
+        // on every page. The fragmenter itself skips out-of-flow nodes
+        // (`fragment_pagination_root` `continue` for `Pos::Fixed`), so
+        // without this pass `position: fixed` elements never reach
+        // `dispatch_fragment` under v2. v1's `PositionedChild::is_fixed`
+        // slice path provides the same per-page repetition until PR 8
+        // deletes v1; both paths produce equivalent observable output.
+        // The added geometry entries set `is_repeat = true` so paragraph
+        // / block slicers know each fragment carries the *full* content
+        // rather than a slice (see `PaginationGeometry::is_split`).
+        let total_pages = crate::pagination_layout::implied_page_count(&pagination_geometry).max(1);
+        crate::pagination_layout::append_position_fixed_fragments(
+            &mut pagination_geometry,
+            doc.deref_mut(),
+            total_pages,
         );
 
         // --- Convert DOM to Pageable and render ---

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -53,15 +53,13 @@
 //! - `break-before` / `break-after` / `break-inside: avoid` from the
 //!   shared [`crate::column_css::ColumnStyleTable`] side-table.
 //!
-//! # Test-gated experimental surface
+//! # Production extension points
 //!
-//! [`collect_string_set_states`], [`append_position_fixed_fragments`],
-//! and [`implied_page_count`] are gated `#[cfg(test)]` because they
-//! describe extension points (Pageable's string-set walk replacement,
-//! geometry-driven fixed repetition) that have no production consumer
-//! yet. They stay visible to the in-file test module so the fragmenter's
-//! comparison harness can exercise them; future PRs un-gate them when
-//! a real consumer lands.
+//! [`collect_string_set_states`] and [`implied_page_count`] are `pub`
+//! for use by `render_v2` and friends. [`append_position_fixed_fragments`]
+//! is wired into `engine.rs` so v2's geometry-driven dispatch can
+//! repeat `position: fixed` elements on every page (`is_repeat=true`
+//! on the resulting `PaginationGeometry`).
 
 use blitz_dom::BaseDocument;
 use std::collections::BTreeMap;
@@ -92,9 +90,35 @@ pub struct Fragment {
 /// fragments — but in the current measurement-only implementation we
 /// emit it as a single oversized fragment on the page where its top
 /// edge lands, because we have no inline / break point information yet.
+///
+/// # Repeat vs. split semantics
+///
+/// `is_repeat = false` (default): the vector represents a *split* —
+/// each fragment is one slice of the same content, so consumers
+/// accumulate `frag.height` to recover where to slice paragraph lines
+/// or block content.
+///
+/// `is_repeat = true`: the vector represents *per-page repetition* —
+/// every fragment carries the full content (`width` / `height` ==
+/// the full element size). Consumers must NOT slice; each fragment
+/// is a complete redraw at the same coordinates. Used by
+/// [`append_position_fixed_fragments`] for `position: fixed` elements
+/// that repeat on every page.
 #[derive(Clone, Debug, Default)]
 pub struct PaginationGeometry {
     pub fragments: Vec<Fragment>,
+    pub is_repeat: bool,
+}
+
+impl PaginationGeometry {
+    /// Whether this node's content was *split* across multiple pages —
+    /// i.e. each fragment is a slice of the same content. Returns
+    /// `false` when the geometry represents per-page repetition
+    /// (`is_repeat == true`), because in that case every fragment
+    /// carries the full content and slicers must NOT subdivide it.
+    pub fn is_split(&self) -> bool {
+        !self.is_repeat && self.fragments.len() > 1
+    }
 }
 
 /// Side-table mapping DOM `usize` NodeIds to their pagination geometry.
@@ -1889,14 +1913,17 @@ pub fn collect_counter_states(
 /// page (Chrome-compatible behaviour for paged media — see WPT
 /// fixedpos-* family).
 ///
-/// Production currently achieves per-page fixed-element repetition via
-/// `pageable::PositionedChild::is_fixed` (the slice path replicates
-/// fixed children at their viewport-relative coordinates on every
-/// page). The geometry-table approach this function provides is kept
-/// under `#[cfg(test)]` as scaffolding for a future architecture where
-/// convert / render consume the fragmenter's geometry directly. Both
-/// paths produce equivalent observable output today.
-#[cfg(test)]
+/// fulgur-rpvu: wired into the v2 production path. v2's
+/// `dispatch_fragment` loop iterates `Fragment`s per (node_id, page),
+/// so emitting one Fragment per page for each `position: fixed`
+/// element produces the expected per-page repetition naturally. The
+/// resulting `PaginationGeometry.is_repeat` is set to `true` so
+/// consumers know each fragment carries the *full* content rather
+/// than a slice (paragraph-line / block-height slicing must be
+/// suppressed for repeat fragments). v1's
+/// `pageable::PositionedChild::is_fixed` slice path remains in place
+/// while v1 is compiled; both paths produce equivalent output for
+/// fixed elements until PR 8 deletes v1.
 ///
 /// `total_pages` is the document's resolved page count, typically
 /// computed from `PaginationGeometryTable`'s max `page_index + 1` after
@@ -1954,6 +1981,7 @@ pub fn append_position_fixed_fragments(
         // single fragment). Per-page repetition is the canonical
         // representation for fixed content.
         entry.fragments.clear();
+        entry.is_repeat = true;
         for page_index in 0..pages {
             entry.fragments.push(Fragment {
                 page_index,
@@ -1976,9 +2004,7 @@ pub fn append_position_fixed_fragments(
 /// by the time this runs, and pseudo-elements (`::before` / `::after`)
 /// live in `node.before` / `node.after` outside the children vec.
 ///
-/// Test-only — only [`append_position_fixed_fragments`] uses it, and
-/// that function is `#[cfg(test)]`.
-#[cfg(test)]
+/// Used by [`append_position_fixed_fragments`].
 fn walk_for_position_fixed(doc: &BaseDocument, node_id: usize, out: &mut Vec<usize>, depth: usize) {
     use ::style::properties::longhands::position::computed_value::T as Pos;
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -566,7 +566,7 @@ fn dispatch_fragment(
     // slice height (`frag.height`) instead of `layout_size.height`
     // — without it, every slice paints the FULL block, which
     // doubled the callout in `examples/break-inside` (fulgur-bq6i).
-    let is_split = geom.fragments.len() > 1;
+    let is_split = geom.is_split();
     // ListItem case: marker + body block + inline-root paragraph
     // share a single opacity group. See `draw_list_item_with_block`
     // for the v1 mirror.
@@ -621,7 +621,15 @@ fn dispatch_fragment(
         return;
     }
     if let Some(para) = drawables.paragraphs.get(&node_id) {
-        draw_paragraph_v2(canvas, para, x_pt, y_pt, &geom.fragments, page_index);
+        draw_paragraph_v2(
+            canvas,
+            para,
+            x_pt,
+            y_pt,
+            &geom.fragments,
+            page_index,
+            is_split,
+        );
     }
 }
 
@@ -922,7 +930,7 @@ fn draw_under_clip(
     // continuation pages, AND the clip rect on continuation pages
     // covers content that should be cut off.
     // (PR #313 follow-up Devin Review — completes the PR #316 fix.)
-    let is_split = geom.fragments.len() > 1;
+    let is_split = geom.is_split();
     let total_height = block
         .layout_size
         .map(|s| {
@@ -1017,7 +1025,15 @@ fn draw_under_clip(
         let inner_x = x_pt + inner_inset.0;
         let inner_y = y_pt + inner_inset.1;
         if let Some(p) = para_for_block {
-            draw_paragraph_inner_paint(canvas, p, inner_x, inner_y, &geom.fragments, page_index);
+            draw_paragraph_inner_paint(
+                canvas,
+                p,
+                inner_x,
+                inner_y,
+                &geom.fragments,
+                page_index,
+                is_split,
+            );
         }
         if let Some(i) = img_for_block {
             draw_image_inner_paint(canvas, i, inner_x, inner_y);
@@ -1260,7 +1276,7 @@ fn draw_under_opacity(
             // paints on continuation pages, exactly the bug the
             // `draw_block_inner_paint` fix addresses for non-opacity
             // blocks (PR #316). (PR #314 follow-up Devin Review)
-            let is_split = geom.fragments.len() > 1;
+            let is_split = geom.is_split();
             let total_height = block
                 .layout_size
                 .map(|s| {
@@ -1308,6 +1324,7 @@ fn draw_under_opacity(
                     inner_y,
                     &geom.fragments,
                     page_index,
+                    is_split,
                 );
             }
             if let Some(i) = img_for_block {
@@ -1871,7 +1888,9 @@ fn draw_block_with_inner_content(
     draw_with_opacity(canvas, block.opacity, |canvas| {
         draw_block_inner_paint(canvas, block, x, y, frag, is_split);
         if let Some(p) = paragraph {
-            draw_paragraph_inner_paint(canvas, p, inner_x, inner_y, fragments, page_index);
+            draw_paragraph_inner_paint(
+                canvas, p, inner_x, inner_y, fragments, page_index, is_split,
+            );
         }
         if let Some(i) = image {
             draw_image_inner_paint(canvas, i, inner_x, inner_y);
@@ -1926,7 +1945,9 @@ fn draw_list_item_with_block(
             draw_block_inner_paint(canvas, b, x, y, frag, is_split);
         }
         if let Some(p) = paragraph {
-            draw_paragraph_inner_paint(canvas, p, inner_x, inner_y, fragments, page_index);
+            draw_paragraph_inner_paint(
+                canvas, p, inner_x, inner_y, fragments, page_index, is_split,
+            );
         }
     });
 }
@@ -1979,10 +2000,11 @@ fn draw_paragraph_v2(
     y: f32,
     fragments: &[crate::pagination_layout::Fragment],
     page_index: u32,
+    is_split: bool,
 ) {
     use crate::pageable::draw_with_opacity;
     draw_with_opacity(canvas, entry.opacity, |canvas| {
-        draw_paragraph_inner_paint(canvas, entry, x, y, fragments, page_index);
+        draw_paragraph_inner_paint(canvas, entry, x, y, fragments, page_index, is_split);
     });
 }
 
@@ -1999,11 +2021,13 @@ fn draw_paragraph_inner_paint(
     y: f32,
     fragments: &[crate::pagination_layout::Fragment],
     page_index: u32,
+    is_split: bool,
 ) {
     if !entry.visible {
         return;
     }
-    let Some(slice) = paragraph_lines_for_page(&entry.lines, fragments, page_index) else {
+    let Some(slice) = paragraph_lines_for_page(&entry.lines, fragments, page_index, is_split)
+    else {
         return;
     };
     crate::paragraph::draw_shaped_lines(canvas, &slice, x, y);
@@ -2013,18 +2037,21 @@ fn draw_paragraph_inner_paint(
 /// `ParagraphPageable::slice_for_page` so multi-page paragraphs only
 /// emit the lines belonging to the requested page.
 ///
-/// Single-fragment fast path: clone every line. Multi-fragment case:
-/// recover line range from cumulative fragment heights (CSS px → pt
-/// before comparing) and rebase line baselines / inline-image
-/// `computed_y` by the consumed amount so the slice is fragment-local.
+/// `is_split` is the parent `PaginationGeometry::is_split()` —
+/// `false` when the paragraph fits one page OR when the geometry
+/// represents per-page repetition (`is_repeat=true`, e.g.
+/// `position: fixed`). Either case means each fragment carries the
+/// full content, so the function returns every line unmodified.
+/// `true` triggers the cumulative-height slicing logic.
 fn paragraph_lines_for_page(
     all_lines: &[crate::paragraph::ShapedLine],
     fragments: &[crate::pagination_layout::Fragment],
     page_index: u32,
+    is_split: bool,
 ) -> Option<Vec<crate::paragraph::ShapedLine>> {
     let target_pos = fragments.iter().position(|f| f.page_index == page_index)?;
 
-    if fragments.len() == 1 && target_pos == 0 {
+    if !is_split {
         return Some(all_lines.to_vec());
     }
 

--- a/crates/fulgur/tests/v2_fixed_smoke.rs
+++ b/crates/fulgur/tests/v2_fixed_smoke.rs
@@ -1,0 +1,47 @@
+//! fulgur-rpvu: v2 path support for `position: fixed` per-page repetition.
+
+use fulgur::{Engine, PageSize};
+
+#[test]
+fn v2_fixed_repeats_on_every_page() {
+    let html = r#"<html><body>
+          <div style="height: 600px"></div>
+          <div style="height: 600px"></div>
+          <div style="position: fixed; top: 10px; left: 20px;
+                      width: 200px; height: 50px">FXFXFX</div>
+        </body></html>"#;
+    let engine = Engine::builder().page_size(PageSize::A4).build();
+    let pdf = engine.render_html_v2(html).expect("render v2");
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pdf_path = dir.path().join("out.pdf");
+    std::fs::write(&pdf_path, &pdf).unwrap();
+    if std::process::Command::new("pdftotext")
+        .arg("-v")
+        .output()
+        .is_err()
+    {
+        eprintln!("pdftotext not available; skipping per-page text assertion");
+        return;
+    }
+
+    let extract = |page: u32| {
+        std::process::Command::new("pdftotext")
+            .args(["-f", &page.to_string(), "-l", &page.to_string(), "-layout"])
+            .arg(&pdf_path)
+            .arg("-")
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .unwrap_or_default()
+    };
+
+    assert!(
+        extract(1).contains("FXFXFX"),
+        "page 1 should contain FXFXFX (v2 fixed repetition)"
+    );
+    assert!(
+        extract(2).contains("FXFXFX"),
+        "page 2 should also contain FXFXFX (v2 per-page fixed repetition)"
+    );
+}


### PR DESCRIPTION
## 概要

Phase 4 PR 7 (default flip) で発覚した v2 経路の `position: fixed` 未対応を解決する独立 PR。`feat/pageable-replacement` (Phase 4 stack base) に積み上げ、PR 7 の前段に置く。

## 背景

Phase 4 PR 7 で v2 を `render_html` のデフォルトに切り替えた瞬間、`tests/render_smoke.rs::position_fixed_repeats_on_every_page` (FXFXFX が 2 ページ目に出ることを pdftotext で確認するテスト) が失敗。原因:

- `fragment_pagination_root` が out-of-flow ノード (`Pos::Absolute | Pos::Fixed`) を `continue` で skip するため、`pagination_geometry` に固定要素の `Fragment` が**1 つも乗らない**
- v2 の dispatch は `geometry` を iterate するだけなので、固定要素が**全ページで非表示**になる
- v1 は `PositionedChild::is_fixed` の slice path が per-page repetition を担っていたため、本機能が v1 専用になっていた
- 既存の `pagination_layout::append_position_fixed_fragments` は scaffolding として `#[cfg(test)]` 配下に存在していたが、本番経路から呼ばれていなかった

PR 7 を「純粋な default flip commit」に保つため、本機能実装を独立 PR として stack に挟む。

## 変更内容

### 1. `PaginationGeometry` に `is_repeat: bool` を追加

`fragments` の意味論を 2 系統に分離:

- `is_repeat = false` (default, 既存挙動): *split* — 各 Fragment は同一コンテンツの slice。consumers は `frag.height` を累積して slice 範囲を計算する
- `is_repeat = true`: *per-page repetition* — 各 Fragment は **完全な** コンテンツ。consumers は slicing せず、毎 Fragment を全体として再描画する

`is_split() -> bool` ヘルパを新設:

\`\`\`rust
pub fn is_split(&self) -> bool {
    !self.is_repeat && self.fragments.len() > 1
}
\`\`\`

### 2. `append_position_fixed_fragments` を本番経路に接続

`#[cfg(test)]` ゲートを撤去し、`engine.rs` の fragmenter pass 直後に呼び出し。`is_repeat = true` をセット。

### 3. slicer 群を `is_split` 経由で repeat 対応

- `paragraph_lines_for_page` に `is_split: bool` 引数追加 — `!is_split` の高速パスで全 line を返す (旧 `fragments.len() == 1 && target_pos == 0` ヒューリスティックを置換)
- `draw_paragraph_v2` / `draw_paragraph_inner_paint` も `is_split` を thread-through
- `draw_block_with_inner_content` / `draw_list_item_with_block` 経由の paragraph paint にも is_split を伝播
- block 側の `is_split = geom.fragments.len() > 1` 3 箇所を `geom.is_split()` に置換

## 後方互換性

- `is_repeat` field は `Default` で `false` → 既存の `PaginationGeometry` 構築箇所はそのまま動作
- v1 経路 (`PositionedChild::is_fixed` slice path) は引き続き有効。両経路が同じ observable output を出す
- shadow harness allowlist (54 fixtures) は byte-eq を維持

## テスト

新規:
- `tests/v2_fixed_smoke.rs::v2_fixed_repeats_on_every_page` — `render_html_v2` 経由で 2-page document 上の `position: fixed` テキストが両ページに paint されることを pdftotext で検証

既存:
- lib テスト 847 全 pass
- shadow harness `render_path_byte_equality` 4/4 pass
- VRT 全 fixture pass
- examples_determinism 11 全 pass
- `position_fixed_repeats_on_every_page` (v1 経由) 既存通り pass

## 後続

- Phase 4 PR 7 (default flip) — 本 PR のマージ後 stack 上に置き直す
- Phase 4 PR 8 (v1 deletion) — `PositionedChild::is_fixed` slice path 削除後、本 PR の機構が唯一の per-page fixed repetition 実装となる
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
