### PR TITLE
feat(render_v2): overflow:hidden|clip support for tables

### DIFF
--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -406,6 +406,7 @@ fn extract_drawables_from_pageable(
         return;
     }
     if let Some(table) = any.downcast_ref::<TablePageable>() {
+        let clipping = table.style.has_overflow_clip();
         if let Some(node_id) = table.node_id {
             out.tables.insert(
                 node_id,
@@ -417,14 +418,31 @@ fn extract_drawables_from_pageable(
                     layout_size: table.layout_size,
                     width: table.width,
                     cached_height: table.cached_height,
+                    clip_descendants: Vec::new(),
                 },
             );
         }
+        // Snapshot map keys before recursing so we can identify which
+        // descendants belong inside this table's `push_clip / pop`
+        // scope when `overflow: hidden | clip` is set. Mirrors the
+        // `BlockPageable` arm above.
+        let before = clipping.then(|| collect_drawables_node_ids(out));
         for pc in &table.header_cells {
             extract_drawables_from_pageable(pc.child.as_ref(), out);
         }
         for pc in &table.body_cells {
             extract_drawables_from_pageable(pc.child.as_ref(), out);
+        }
+        if let (Some(before), Some(node_id)) = (before, table.node_id) {
+            let after = collect_drawables_node_ids(out);
+            let descendants: Vec<usize> = after
+                .difference(&before)
+                .copied()
+                .filter(|&id| id != node_id)
+                .collect();
+            if let Some(entry) = out.tables.get_mut(&node_id) {
+                entry.clip_descendants = descendants;
+            }
         }
         return;
     }

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -131,8 +131,7 @@ pub struct SvgEntry {
 ///
 /// Multi-page header repetition (`<thead>` cloned on continuation
 /// pages) is **not** modelled in PR 5; single-page tables byte-eq
-/// already, multi-page tables follow in a later PR alongside the
-/// per-block clip work.
+/// already, multi-page tables follow in a later PR.
 #[derive(Debug, Clone)]
 pub struct TableEntry {
     pub style: crate::pageable::BlockStyle,
@@ -142,6 +141,11 @@ pub struct TableEntry {
     pub layout_size: Option<crate::pageable::Size>,
     pub width: f32,
     pub cached_height: f32,
+    /// Strict descendant `node_id`s (cell blocks + their children) when
+    /// `style.has_overflow_clip()` is true. Mirrors `BlockEntry::clip_descendants`
+    /// so the dispatcher can push the table's clip path once and
+    /// dispatch every cell inside it. Empty when the table doesn't clip.
+    pub clip_descendants: Vec<NodeId>,
 }
 
 /// List-item marker payload for v2. The body block paints itself

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -300,6 +300,17 @@ fn draw_v2_page(
             clipped_descendants.extend(block.clip_descendants.iter().copied());
         }
     }
+    // Tables with `overflow: hidden | clip` clip their cells to the
+    // padding box. Mirror the block-clip skip set so the main loop
+    // doesn't dispatch cell descendants outside the table's clip
+    // scope — `draw_under_clip_table` paints them inside the clip.
+    // Unlike body/root, tables are always proper geometry-recorded
+    // nodes so no special exclusion is needed.
+    for table in drawables.tables.values() {
+        if table.style.has_overflow_clip() && !table.clip_descendants.is_empty() {
+            clipped_descendants.extend(table.clip_descendants.iter().copied());
+        }
+    }
     // Mirrors `clipped_descendants` for blocks that wrap their
     // descendants in a `draw_with_opacity` group (fractional opacity,
     // no clip — see `BlockEntry.opacity_descendants` and
@@ -445,6 +456,33 @@ fn draw_v2_page(
                     canvas,
                     block,
                     node_id,
+                    geom,
+                    frag,
+                    x_pt,
+                    y_pt,
+                    geometry,
+                    drawables,
+                    margin_left_pt,
+                    margin_top_pt,
+                    page_index,
+                );
+                continue;
+            }
+            // Table with `overflow: hidden | clip`: same shape as the
+            // block clip arm above. v1's `TablePageable::draw` mirrors
+            // `BlockPageable::draw` and pushes a clip path around its
+            // cell paint when `has_overflow_clip()` is true; v2 routes
+            // through `draw_under_clip_table` which paints the outer
+            // frame outside the clip and dispatches each cell descendant
+            // inside.
+            if let Some(table) = drawables
+                .tables
+                .get(&node_id)
+                .filter(|t| t.style.has_overflow_clip())
+            {
+                draw_under_clip_table(
+                    canvas,
+                    table,
                     geom,
                     frag,
                     x_pt,
@@ -1790,10 +1828,10 @@ fn draw_block_inner_paint(
 /// `<td>` is a `BlockPageable` with its own NodeId in geometry) lands
 /// through the standard per-NodeId dispatch.
 ///
-/// Same overflow-clip caveat as `draw_block_v2`: clip is not pushed
-/// here because flat dispatch lacks a natural close point. Multi-page
-/// table header repetition is also deferred to a later PR — single-
-/// page tables byte-eq today.
+/// Tables with `overflow: hidden | clip` route through
+/// [`draw_under_clip_table`] instead so the clip path wraps every cell
+/// dispatched in the same scope. Multi-page table header repetition
+/// (`<thead>` cloned on continuation pages) is deferred to a later PR.
 fn draw_table_v2(
     canvas: &mut crate::pageable::Canvas<'_, '_>,
     entry: &crate::drawables::TableEntry,
@@ -1804,40 +1842,119 @@ fn draw_table_v2(
     use crate::pageable::draw_with_opacity;
 
     draw_with_opacity(canvas, entry.opacity, |canvas| {
-        let total_width = entry.layout_size.map(|s| s.width).unwrap_or(entry.width);
-        let total_height = entry.layout_size.map(|s| s.height).unwrap_or_else(|| {
-            let from_frag = crate::convert::px_to_pt(frag.height);
-            if from_frag > 0.0 {
-                from_frag
-            } else {
-                entry.cached_height
-            }
-        });
+        let (total_width, total_height) = table_box_size(entry, frag);
         if entry.visible {
-            crate::background::draw_box_shadows(
-                canvas,
-                &entry.style,
-                x,
-                y,
-                total_width,
-                total_height,
-            );
-            crate::background::draw_background(
-                canvas,
-                &entry.style,
-                x,
-                y,
-                total_width,
-                total_height,
-            );
-            crate::pageable::draw_block_border(
-                canvas,
-                &entry.style,
-                x,
-                y,
-                total_width,
-                total_height,
-            );
+            paint_table_outer_frame(canvas, entry, x, y, total_width, total_height);
+        }
+    });
+}
+
+/// Resolve the table's outer-frame width/height from the cached
+/// layout. Falls back to the current Fragment height (and finally
+/// `cached_height`) when `layout_size` is unset (test-only paths).
+fn table_box_size(
+    entry: &crate::drawables::TableEntry,
+    frag: &crate::pagination_layout::Fragment,
+) -> (f32, f32) {
+    let total_width = entry.layout_size.map(|s| s.width).unwrap_or(entry.width);
+    let total_height = entry.layout_size.map(|s| s.height).unwrap_or_else(|| {
+        let from_frag = crate::convert::px_to_pt(frag.height);
+        if from_frag > 0.0 {
+            from_frag
+        } else {
+            entry.cached_height
+        }
+    });
+    (total_width, total_height)
+}
+
+/// Paint the table's outer-frame bg / border / shadow at the current
+/// (x, y, width, height). Shared between the no-clip path
+/// ([`draw_table_v2`]) and the clip path ([`draw_under_clip_table`])
+/// so the two emit identical PDF operators for the same input.
+fn paint_table_outer_frame(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    entry: &crate::drawables::TableEntry,
+    x: f32,
+    y: f32,
+    total_width: f32,
+    total_height: f32,
+) {
+    crate::background::draw_box_shadows(canvas, &entry.style, x, y, total_width, total_height);
+    crate::background::draw_background(canvas, &entry.style, x, y, total_width, total_height);
+    crate::pageable::draw_block_border(canvas, &entry.style, x, y, total_width, total_height);
+}
+
+/// Push a `compute_overflow_clip_path` clip around the table's outer
+/// frame, dispatch each cell descendant inside the clip, then pop.
+/// Mirrors [`draw_under_clip`]'s shape for blocks but specialised for
+/// tables (no list-item marker, no shared-node_id inner content).
+#[allow(clippy::too_many_arguments)]
+fn draw_under_clip_table(
+    canvas: &mut crate::pageable::Canvas<'_, '_>,
+    table: &crate::drawables::TableEntry,
+    geom: &crate::pagination_layout::PaginationGeometry,
+    frag: &crate::pagination_layout::Fragment,
+    x_pt: f32,
+    y_pt: f32,
+    geometry: &crate::pagination_layout::PaginationGeometryTable,
+    drawables: &Drawables,
+    margin_left_pt: f32,
+    margin_top_pt: f32,
+    page_index: u32,
+) {
+    use crate::convert::px_to_pt;
+    use crate::pageable::draw_with_opacity;
+
+    let _ = geom;
+    let (total_width, total_height) = table_box_size(table, frag);
+
+    draw_with_opacity(canvas, table.opacity, |canvas| {
+        // bg / border / shadow OUTSIDE the clip, mirroring
+        // `draw_under_clip` for blocks (`pageable.rs:1796-1827`).
+        if table.visible {
+            paint_table_outer_frame(canvas, table, x_pt, y_pt, total_width, total_height);
+        }
+
+        // Push clip — fall through to descendant dispatch even if
+        // `compute_overflow_clip_path` returns `None` so the cells
+        // still paint (defensive, mirrors `draw_under_clip`).
+        let clip_pushed = if let Some(clip_path) = crate::pageable::compute_overflow_clip_path(
+            &table.style,
+            x_pt,
+            y_pt,
+            total_width,
+            total_height,
+        ) {
+            canvas
+                .surface
+                .push_clip_path(&clip_path, &krilla::paint::FillRule::default());
+            true
+        } else {
+            false
+        };
+
+        // Dispatch each cell descendant inside the clip. `dispatch_fragment`
+        // handles cells (BlockEntry) and any inner content sharing
+        // their node_id (e.g. inline-root paragraph in a `<td>text</td>`).
+        for &desc_id in &table.clip_descendants {
+            let Some(desc_geom) = geometry.get(&desc_id) else {
+                continue;
+            };
+            for desc_frag in &desc_geom.fragments {
+                if desc_frag.page_index != page_index {
+                    continue;
+                }
+                let desc_x = margin_left_pt + px_to_pt(desc_frag.x);
+                let desc_y = margin_top_pt + px_to_pt(desc_frag.y);
+                dispatch_fragment(
+                    canvas, desc_id, desc_geom, desc_frag, desc_x, desc_y, drawables, page_index,
+                );
+            }
+        }
+
+        if clip_pushed {
+            canvas.surface.pop();
         }
     });
 }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -755,13 +755,24 @@ fn draw_under_transform(
     // `dispatch_fragment` would double-paint them outside the clip.
     // Mirrors the symmetric handling in `draw_under_clip`'s descendant
     // loop (PR #309 follow-up Devin).
-    let clip_skip: std::collections::BTreeSet<usize> = tx
+    let mut clip_skip: std::collections::BTreeSet<usize> = tx
         .descendants
         .iter()
         .filter_map(|id| drawables.block_styles.get(id))
         .filter(|b| b.style.has_overflow_clip())
         .flat_map(|b| b.clip_descendants.iter().copied())
         .collect();
+    // Tables with `overflow: hidden | clip` carry `clip_descendants`
+    // too — `draw_under_clip_table` (called below) iterates them
+    // inside the clip path, so the dispatch loop must skip them
+    // here just like the block-clip case (fulgur-bvhw PR #320 Devin).
+    clip_skip.extend(
+        tx.descendants
+            .iter()
+            .filter_map(|id| drawables.tables.get(id))
+            .filter(|t| t.style.has_overflow_clip())
+            .flat_map(|t| t.clip_descendants.iter().copied()),
+    );
     // Symmetric pre-skip for opacity-scoped descendants. When an
     // opacity block sits inside this transform, `draw_under_opacity`
     // (called below) iterates its own `opacity_descendants` to paint
@@ -822,6 +833,31 @@ fn draw_under_transform(
                     canvas,
                     desc_block,
                     desc_id,
+                    desc_geom,
+                    desc_frag,
+                    desc_x,
+                    desc_y,
+                    geometry,
+                    drawables,
+                    margin_left_pt,
+                    margin_top_pt,
+                    page_index,
+                );
+            } else if let Some(desc_table) = drawables
+                .tables
+                .get(&desc_id)
+                .filter(|t| t.style.has_overflow_clip())
+            {
+                // Table descendant with `overflow:hidden|clip` —
+                // mirror the block-clip arm above so the table's clip
+                // path is pushed inside the transform scope. Without
+                // this, `<div style="transform:..."><table style=
+                // "overflow:hidden">` paints cells under the transform
+                // but loses the table boundary (fulgur-bvhw PR #320
+                // Devin).
+                draw_under_clip_table(
+                    canvas,
+                    desc_table,
                     desc_geom,
                     desc_frag,
                     desc_x,
@@ -1107,13 +1143,26 @@ fn draw_under_clip(
         // outer's `clip_descendants` for those same nodes here would
         // re-dispatch them outside the inner clip
         // (PR #309 follow-up Devin).
-        let nested_clip_skip: std::collections::BTreeSet<usize> = block
+        let mut nested_clip_skip: std::collections::BTreeSet<usize> = block
             .clip_descendants
             .iter()
             .filter_map(|id| drawables.block_styles.get(id))
             .filter(|b| b.style.has_overflow_clip())
             .flat_map(|b| b.clip_descendants.iter().copied())
             .collect();
+        // Tables with overflow-clip nested inside this block's clip
+        // scope carry their own `clip_descendants` — the recursive
+        // `draw_under_clip_table` arm below paints them inside the
+        // table's clip path, so skip them here too (fulgur-bvhw PR
+        // #320 Devin).
+        nested_clip_skip.extend(
+            block
+                .clip_descendants
+                .iter()
+                .filter_map(|id| drawables.tables.get(id))
+                .filter(|t| t.style.has_overflow_clip())
+                .flat_map(|t| t.clip_descendants.iter().copied()),
+        );
         // Symmetric pre-skip for opacity-scoped descendants nested
         // inside this clip. Mirrors `nested_clip_skip` — without it,
         // an opacity descendant's sub-children would be dispatched by
@@ -1174,6 +1223,28 @@ fn draw_under_clip(
                         canvas,
                         desc_block,
                         desc_id,
+                        desc_geom,
+                        desc_frag,
+                        desc_x,
+                        desc_y,
+                        geometry,
+                        drawables,
+                        margin_left_pt,
+                        margin_top_pt,
+                        page_index,
+                    );
+                } else if let Some(desc_table) = drawables
+                    .tables
+                    .get(&desc_id)
+                    .filter(|t| t.style.has_overflow_clip())
+                {
+                    // Nested table with overflow-clip — recurse into
+                    // `draw_under_clip_table` so the table boundary
+                    // is pushed inside this block's clip scope.
+                    // (fulgur-bvhw PR #320 Devin)
+                    draw_under_clip_table(
+                        canvas,
+                        desc_table,
                         desc_geom,
                         desc_frag,
                         desc_x,
@@ -1384,13 +1455,25 @@ fn draw_under_opacity(
             .filter_map(|id| drawables.transforms.get(id))
             .flat_map(|tx| tx.descendants.iter().copied())
             .collect();
-        let nested_clip_skip: std::collections::BTreeSet<usize> = block
+        let mut nested_clip_skip: std::collections::BTreeSet<usize> = block
             .opacity_descendants
             .iter()
             .filter_map(|id| drawables.block_styles.get(id))
             .filter(|b| b.style.has_overflow_clip())
             .flat_map(|b| b.clip_descendants.iter().copied())
             .collect();
+        // Tables with overflow-clip nested inside this opacity scope
+        // recurse into `draw_under_clip_table`; pre-skip their cell
+        // descendants here so they don't double-paint outside the
+        // table's clip path (fulgur-bvhw PR #320 Devin).
+        nested_clip_skip.extend(
+            block
+                .opacity_descendants
+                .iter()
+                .filter_map(|id| drawables.tables.get(id))
+                .filter(|t| t.style.has_overflow_clip())
+                .flat_map(|t| t.clip_descendants.iter().copied()),
+        );
         let nested_opacity_skip: std::collections::BTreeSet<usize> = block
             .opacity_descendants
             .iter()
@@ -1438,6 +1521,26 @@ fn draw_under_opacity(
                         canvas,
                         desc_block,
                         desc_id,
+                        desc_geom,
+                        desc_frag,
+                        desc_x,
+                        desc_y,
+                        geometry,
+                        drawables,
+                        margin_left_pt,
+                        margin_top_pt,
+                        page_index,
+                    );
+                } else if let Some(desc_table) = drawables
+                    .tables
+                    .get(&desc_id)
+                    .filter(|t| t.style.has_overflow_clip())
+                {
+                    // Table with overflow-clip nested inside this
+                    // opacity scope. (fulgur-bvhw PR #320 Devin)
+                    draw_under_clip_table(
+                        canvas,
+                        desc_table,
                         desc_geom,
                         desc_frag,
                         desc_x,
@@ -1934,10 +2037,47 @@ fn draw_under_clip_table(
             false
         };
 
-        // Dispatch each cell descendant inside the clip. `dispatch_fragment`
-        // handles cells (BlockEntry) and any inner content sharing
-        // their node_id (e.g. inline-root paragraph in a `<td>text</td>`).
+        // Mirror `draw_under_clip`'s nested-scope skip sets so cells
+        // carrying their own `transform` / `overflow:hidden` /
+        // fractional opacity recurse into the proper helper rather
+        // than fall through to plain `dispatch_fragment` (which would
+        // silently lose the inner clip / transform / opacity wrap).
+        // (PR #320 Devin Review)
+        let transform_skip: std::collections::BTreeSet<usize> = table
+            .clip_descendants
+            .iter()
+            .filter_map(|id| drawables.transforms.get(id))
+            .flat_map(|tx| tx.descendants.iter().copied())
+            .collect();
+        let mut nested_clip_skip: std::collections::BTreeSet<usize> = table
+            .clip_descendants
+            .iter()
+            .filter_map(|id| drawables.block_styles.get(id))
+            .filter(|b| b.style.has_overflow_clip())
+            .flat_map(|b| b.clip_descendants.iter().copied())
+            .collect();
+        nested_clip_skip.extend(
+            table
+                .clip_descendants
+                .iter()
+                .filter_map(|id| drawables.tables.get(id))
+                .filter(|t| t.style.has_overflow_clip())
+                .flat_map(|t| t.clip_descendants.iter().copied()),
+        );
+        let nested_opacity_skip: std::collections::BTreeSet<usize> = table
+            .clip_descendants
+            .iter()
+            .filter_map(|id| drawables.block_styles.get(id))
+            .flat_map(|b| b.opacity_descendants.iter().copied())
+            .collect();
+
         for &desc_id in &table.clip_descendants {
+            if transform_skip.contains(&desc_id)
+                || nested_clip_skip.contains(&desc_id)
+                || nested_opacity_skip.contains(&desc_id)
+            {
+                continue;
+            }
             let Some(desc_geom) = geometry.get(&desc_id) else {
                 continue;
             };
@@ -1947,9 +2087,84 @@ fn draw_under_clip_table(
                 }
                 let desc_x = margin_left_pt + px_to_pt(desc_frag.x);
                 let desc_y = margin_top_pt + px_to_pt(desc_frag.y);
-                dispatch_fragment(
-                    canvas, desc_id, desc_geom, desc_frag, desc_x, desc_y, drawables, page_index,
-                );
+                if let Some(desc_tx) = drawables.transforms.get(&desc_id) {
+                    draw_under_transform(
+                        canvas,
+                        desc_tx,
+                        desc_id,
+                        desc_geom,
+                        desc_frag,
+                        desc_x,
+                        desc_y,
+                        geometry,
+                        drawables,
+                        margin_left_pt,
+                        margin_top_pt,
+                        page_index,
+                    );
+                } else if let Some(desc_block) = drawables
+                    .block_styles
+                    .get(&desc_id)
+                    .filter(|b| b.style.has_overflow_clip())
+                    .filter(|_| Some(desc_id) != drawables.body_id)
+                {
+                    draw_under_clip(
+                        canvas,
+                        desc_block,
+                        desc_id,
+                        desc_geom,
+                        desc_frag,
+                        desc_x,
+                        desc_y,
+                        geometry,
+                        drawables,
+                        margin_left_pt,
+                        margin_top_pt,
+                        page_index,
+                    );
+                } else if let Some(desc_table) = drawables
+                    .tables
+                    .get(&desc_id)
+                    .filter(|t| t.style.has_overflow_clip())
+                {
+                    draw_under_clip_table(
+                        canvas,
+                        desc_table,
+                        desc_geom,
+                        desc_frag,
+                        desc_x,
+                        desc_y,
+                        geometry,
+                        drawables,
+                        margin_left_pt,
+                        margin_top_pt,
+                        page_index,
+                    );
+                } else if let Some(desc_block) = drawables
+                    .block_styles
+                    .get(&desc_id)
+                    .filter(|b| !b.opacity_descendants.is_empty())
+                {
+                    draw_under_opacity(
+                        canvas,
+                        desc_block,
+                        desc_id,
+                        desc_geom,
+                        desc_frag,
+                        desc_x,
+                        desc_y,
+                        geometry,
+                        drawables,
+                        margin_left_pt,
+                        margin_top_pt,
+                        page_index,
+                    );
+                } else {
+                    dispatch_fragment(
+                        canvas, desc_id, desc_geom, desc_frag, desc_x, desc_y, drawables,
+                        page_index,
+                    );
+                }
             }
         }
 

--- a/crates/fulgur/tests/v2_table_overflow_clip.rs
+++ b/crates/fulgur/tests/v2_table_overflow_clip.rs
@@ -27,3 +27,69 @@ fn v2_table_overflow_hidden_emits_clip_path() {
         "v2: overflow:hidden on a table should emit a clip path different from default"
     );
 }
+
+/// PR #320 Devin: an `overflow:hidden` table inside a `transform`
+/// scope must still push its clip path. Without the table-clip arm
+/// in `draw_under_transform`'s descendant dispatch chain, cells
+/// would paint under the transform but lose the table boundary.
+#[test]
+fn v2_overflow_hidden_table_inside_transform_keeps_clip() {
+    let engine = Engine::builder().page_size(PageSize::A4).build();
+    let html_hidden = r#"<html><body>
+        <div style="transform:rotate(5deg)">
+            <table style="width:100px;height:60px;overflow:hidden">
+                <tr><td style="width:300px;height:300px;background:orange">cell</td></tr>
+            </table>
+        </div>
+    </body></html>"#;
+    let pdf_hidden = engine.render_html_v2(html_hidden).expect("render v2");
+    assert!(pdf_hidden.starts_with(b"%PDF"));
+
+    let html_visible = r#"<html><body>
+        <div style="transform:rotate(5deg)">
+            <table style="width:100px;height:60px">
+                <tr><td style="width:300px;height:300px;background:orange">cell</td></tr>
+            </table>
+        </div>
+    </body></html>"#;
+    let pdf_visible = engine.render_html_v2(html_visible).expect("render v2");
+
+    assert_ne!(
+        pdf_hidden, pdf_visible,
+        "v2: overflow:hidden table inside transform must still emit a clip path"
+    );
+}
+
+/// PR #320 Devin: a cell with its own `overflow:hidden` inside a
+/// clipping table must still push its inner clip. Without the
+/// nested-scope dispatch chain inside `draw_under_clip_table`,
+/// the cell's 50px boundary would be lost.
+#[test]
+fn v2_table_clip_with_inner_cell_clip_keeps_inner_boundary() {
+    let engine = Engine::builder().page_size(PageSize::A4).build();
+    let html_inner_hidden = r#"<html><body>
+        <table style="width:200px;height:120px;overflow:hidden">
+            <tr><td style="width:50px;height:50px;overflow:hidden;background:orange">
+                <div style="width:300px;height:300px;background:purple"></div>
+            </td></tr>
+        </table>
+    </body></html>"#;
+    let pdf_inner_hidden = engine.render_html_v2(html_inner_hidden).expect("render v2");
+    assert!(pdf_inner_hidden.starts_with(b"%PDF"));
+
+    let html_inner_visible = r#"<html><body>
+        <table style="width:200px;height:120px;overflow:hidden">
+            <tr><td style="width:50px;height:50px;background:orange">
+                <div style="width:300px;height:300px;background:purple"></div>
+            </td></tr>
+        </table>
+    </body></html>"#;
+    let pdf_inner_visible = engine
+        .render_html_v2(html_inner_visible)
+        .expect("render v2");
+
+    assert_ne!(
+        pdf_inner_hidden, pdf_inner_visible,
+        "v2: inner cell overflow:hidden inside a clipping table must still emit its own clip"
+    );
+}

--- a/crates/fulgur/tests/v2_table_overflow_clip.rs
+++ b/crates/fulgur/tests/v2_table_overflow_clip.rs
@@ -1,0 +1,29 @@
+//! fulgur-9t3z: v2 path support for `<table style="overflow:hidden">`
+//! cell clipping. Mirrors `style_test.rs::test_overflow_hidden_on_table_clips`
+//! but routes explicitly through `render_html_v2`.
+
+use fulgur::{Engine, PageSize};
+
+#[test]
+fn v2_table_overflow_hidden_emits_clip_path() {
+    let engine = Engine::builder().page_size(PageSize::A4).build();
+    let html_hidden = r#"<html><body>
+        <table style="width:100px;height:60px;overflow:hidden">
+            <tr><td style="width:300px;height:300px;background:orange">cell</td></tr>
+        </table>
+    </body></html>"#;
+    let pdf_hidden = engine.render_html_v2(html_hidden).expect("render v2");
+    assert!(pdf_hidden.starts_with(b"%PDF"));
+
+    let html_visible = r#"<html><body>
+        <table style="width:100px;height:60px">
+            <tr><td style="width:300px;height:300px;background:orange">cell</td></tr>
+        </table>
+    </body></html>"#;
+    let pdf_visible = engine.render_html_v2(html_visible).expect("render v2");
+
+    assert_ne!(
+        pdf_hidden, pdf_visible,
+        "v2: overflow:hidden on a table should emit a clip path different from default"
+    );
+}


### PR DESCRIPTION
## 概要

Phase 4 PR 7 (default flip) を準備するための v1↔v2 audit (PR #319 fixed-position support の後に実施) で見つかった**最後の production gap** を潰す。fixed-position と同じく独立 stacked PR として PR 7 の前段に配置する。

## 背景

PR #319 マージ後、`engine.rs::render_html` のデフォルトを v1→v2 に instrument して全テストを通す audit を実行した。結果:

- `fulgur-cli`: ✅ 全 pass
- `fulgur` lib テスト 847: ✅ 全 pass
- Shadow harness (parity allowlist 54 fixtures): ✅ 全 pass
- examples_determinism 11: ✅ 全 pass
- VRT 39 fixtures: 既知 1 件 (`grid-row-promote-background`、parity allowlist で documented)

**想定外 gap は 1 件のみ**: `<table style=\"overflow:hidden\">` のクリップが v2 で未実装。`style_test.rs::test_overflow_hidden_on_table_clips` (v2 で render すると clipped/unclipped PDF が同一になる) が default flip で fail。`render.rs::draw_table_v2` のコメントでも \"flat dispatch lacks a natural close point\" として deferred 宣言済み。

これを潰せば PR 7 (default flip) は audit 上クリーンに通る。

## 変更内容

block の clip 実装 (\`draw_under_clip\`、\`BlockEntry::clip_descendants\`) と同じパターンを table に適用:

### 1. \`TableEntry::clip_descendants: Vec<NodeId>\` を追加

block と同じ default 空。\`style.has_overflow_clip()\` が true のとき、cell + その子孫の \`node_id\` が入る。

### 2. \`extract_drawables_from_pageable\` の table arm で populate

\`block\` と同じ before/after snapshot pattern。\`clipping = table.style.has_overflow_clip()\` のとき、再帰前後の drawables map keys 差分から strict descendants を集める。

### 3. \`render_v2\` の \`clipped_descendants\` skip set に table を追加

block と並列に table も \`clipped_descendants\` に descendant を投入。main loop は table の clip scope 外で cell を dispatch しない。

### 4. \`draw_under_clip_table\` 新設

block の \`draw_under_clip\` を簡素化した版:

- bg / border / shadow を **clip の外** で paint (v1 \`TablePageable::draw\` の順序に対応)
- \`compute_overflow_clip_path\` で clip push
- \`table.clip_descendants\` を iterate して各 cell descendant を \`dispatch_fragment\` で paint (clip 内)
- pop

block 版の list-item marker 処理や opacity-scope 入れ子の処理は省略 (table には該当なし)。
共通化のため \`paint_table_outer_frame\` と \`table_box_size\` を helper として抽出 — no-clip path (\`draw_table_v2\`) と clip path (\`draw_under_clip_table\`) が同一バイトを emit する保証。

### 5. dispatch loop に table-clip arm を追加

block-clip arm の直後に同形のロジック。\`drawables.tables.get(&node_id).filter(|t| t.style.has_overflow_clip())\` で routing。

## テスト

新規:
- \`tests/v2_table_overflow_clip.rs::v2_table_overflow_hidden_emits_clip_path\` — \`render_html_v2\` 経由で clipped vs unclipped PDF が異なることを確認

既存:
- \`tests/style_test.rs::test_overflow_hidden_on_table_clips\` (v1 経由) は既存通り pass
- 847 lib tests: 全 pass
- Shadow harness 4/4 byte-eq pass — **parity allowlist の byte-eq には影響なし** (allowlist 内 fixture に table-with-overflow を含むものはなく、新 path は has_overflow_clip 時のみ起動するため)
- VRT 39 fixtures: 既知 1 件のみ
- examples_determinism 11: 全 pass

## 後続

- Phase 4 PR 7 (default flip) — 本 PR + PR #319 のマージ後、audit 上クリーンに進められる
- Phase 4 PR 8 (v1 deletion) — \`TablePageable::draw\` の clip 経路削除後、本 PR の機構が唯一の table-overflow-clip 実装となる
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
