### PR TITLE
refactor(pageable): delete Pageable::collect_ids trait method (Phase 4 PR 8e)

### DIFF
--- a/crates/fulgur/src/convert/inline_root.rs
+++ b/crates/fulgur/src/convert/inline_root.rs
@@ -870,24 +870,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn inline_block_inner_id_is_registered_with_destination_registry() {
-        use crate::pageable::DestinationRegistry;
-        // A `<span id="target">` placed as an inline-block inside a paragraph
-        // must still register with the destination registry so that
-        // `href="#target"` links can resolve. Before Fix 2 to
-        // `ParagraphPageable::collect_ids`, the registry walk stopped at the
-        // paragraph and ignored nested inline-box content.
-        let html = r#"<!DOCTYPE html><html><body><div>before <span id="target" style="display:inline-block;width:40px;height:20px;background:red">x</span> after</div></body></html>"#;
-        let tree = build_tree(html);
-        let mut reg = DestinationRegistry::default();
-        tree.collect_ids(0.0, 0.0, 400.0, 600.0, &mut reg);
-        assert!(
-            reg.get("target").is_some(),
-            "inline-block inner id should be registered with DestinationRegistry"
-        );
-    }
-
     // ---- metrics_from_line tests ----
 
     /// Default fallback metrics returned by `metrics_from_line` when no

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -491,17 +491,6 @@ pub trait Pageable: Send + Sync {
     /// Downcast support for tests.
     fn as_any(&self) -> &dyn std::any::Any;
 
-    /// Walk this Pageable and record any block-level `id` anchors into
-    /// `registry`, in page-local coordinates.
-    ///
-    /// `(x, y)` is the top-left of this element in the current page's
-    /// content area. Containers must recurse into their children using the
-    /// same positional arithmetic that `draw()` uses so anchor positions
-    /// match the rendered output.
-    ///
-    /// Default: no-op. Overridden on block-like Pageables (`BlockPageable`)
-    /// and containers that hold children (pagination wrappers, `ListItemPageable`,
-    /// `TablePageable`, etc.).
     /// Whether this pageable should be drawn. Defaults to `true`.
     ///
     /// Concrete types that track a `visibility: hidden` style (Block,

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -502,16 +502,6 @@ pub trait Pageable: Send + Sync {
     /// Default: no-op. Overridden on block-like Pageables (`BlockPageable`)
     /// and containers that hold children (pagination wrappers, `ListItemPageable`,
     /// `TablePageable`, etc.).
-    fn collect_ids(
-        &self,
-        _x: Pt,
-        _y: Pt,
-        _avail_width: Pt,
-        _avail_height: Pt,
-        _registry: &mut DestinationRegistry,
-    ) {
-    }
-
     /// Whether this pageable should be drawn. Defaults to `true`.
     ///
     /// Concrete types that track a `visibility: hidden` style (Block,
@@ -1711,30 +1701,6 @@ impl Pageable for BlockPageable {
         self
     }
 
-    fn collect_ids(
-        &self,
-        x: Pt,
-        y: Pt,
-        avail_width: Pt,
-        _avail_height: Pt,
-        registry: &mut DestinationRegistry,
-    ) {
-        // Record this block's own id at its top-left in page-local coords.
-        if let Some(id) = &self.id
-            && !id.is_empty()
-        {
-            registry.record(id, x, y);
-        }
-        // Recurse into children using the same positional arithmetic
-        // `draw()` uses (see the loop at the end of `draw`). We do NOT
-        // need to replicate clipping / opacity / background paths —
-        // anchor registration only cares about block-top coordinates.
-        for pc in &self.children {
-            pc.child
-                .collect_ids(x + pc.x, y + pc.y, avail_width, pc.child.height(), registry);
-        }
-    }
-
     fn is_visible(&self) -> bool {
         self.visible
     }
@@ -1910,18 +1876,6 @@ impl Pageable for BookmarkMarkerWrapperPageable {
         self
     }
 
-    fn collect_ids(
-        &self,
-        x: Pt,
-        y: Pt,
-        avail_width: Pt,
-        avail_height: Pt,
-        registry: &mut DestinationRegistry,
-    ) {
-        self.child
-            .collect_ids(x, y, avail_width, avail_height, registry);
-    }
-
     fn is_visible(&self) -> bool {
         self.child.is_visible()
     }
@@ -2087,18 +2041,6 @@ impl Pageable for CounterOpWrapperPageable {
         self
     }
 
-    fn collect_ids(
-        &self,
-        x: Pt,
-        y: Pt,
-        avail_width: Pt,
-        avail_height: Pt,
-        registry: &mut DestinationRegistry,
-    ) {
-        self.child
-            .collect_ids(x, y, avail_width, avail_height, registry);
-    }
-
     fn is_visible(&self) -> bool {
         self.child.is_visible()
     }
@@ -2180,21 +2122,6 @@ impl Pageable for TransformWrapperPageable {
         self
     }
 
-    fn collect_ids(
-        &self,
-        x: Pt,
-        y: Pt,
-        avail_width: Pt,
-        avail_height: Pt,
-        registry: &mut DestinationRegistry,
-    ) {
-        let full = self.effective_matrix(x, y);
-        registry.push_transform(full);
-        self.inner
-            .collect_ids(x, y, avail_width, avail_height, registry);
-        registry.pop_transform();
-    }
-
     fn is_visible(&self) -> bool {
         self.inner.is_visible()
     }
@@ -2245,18 +2172,6 @@ impl Pageable for StringSetWrapperPageable {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
-    }
-
-    fn collect_ids(
-        &self,
-        x: Pt,
-        y: Pt,
-        avail_width: Pt,
-        avail_height: Pt,
-        registry: &mut DestinationRegistry,
-    ) {
-        self.child
-            .collect_ids(x, y, avail_width, avail_height, registry);
     }
 
     fn is_visible(&self) -> bool {
@@ -2311,18 +2226,6 @@ impl Pageable for RunningElementWrapperPageable {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
-    }
-
-    fn collect_ids(
-        &self,
-        x: Pt,
-        y: Pt,
-        avail_width: Pt,
-        avail_height: Pt,
-        registry: &mut DestinationRegistry,
-    ) {
-        self.child
-            .collect_ids(x, y, avail_width, avail_height, registry);
     }
 
     fn is_visible(&self) -> bool {
@@ -2483,18 +2386,6 @@ impl Pageable for MulticolRulePageable {
         self
     }
 
-    fn collect_ids(
-        &self,
-        x: Pt,
-        y: Pt,
-        avail_width: Pt,
-        avail_height: Pt,
-        registry: &mut DestinationRegistry,
-    ) {
-        self.child
-            .collect_ids(x, y, avail_width, avail_height, registry);
-    }
-
     fn node_id(&self) -> Option<usize> {
         self.child.node_id()
     }
@@ -2625,21 +2516,6 @@ impl Pageable for ListItemPageable {
         self
     }
 
-    fn collect_ids(
-        &self,
-        x: Pt,
-        y: Pt,
-        avail_width: Pt,
-        avail_height: Pt,
-        registry: &mut DestinationRegistry,
-    ) {
-        // `draw` calls `self.body.draw(canvas, x, y, ...)` (markers drawn
-        // at negative x); the body is the positional root for any nested
-        // block ids, so walk it at the same (x, y).
-        self.body
-            .collect_ids(x, y, avail_width, avail_height, registry);
-    }
-
     fn node_id(&self) -> Option<usize> {
         self.node_id
     }
@@ -2743,28 +2619,6 @@ impl Pageable for TablePageable {
         self
     }
 
-    fn collect_ids(
-        &self,
-        x: Pt,
-        y: Pt,
-        _avail_width: Pt,
-        _avail_height: Pt,
-        registry: &mut DestinationRegistry,
-    ) {
-        // Record this table's own id at its top-left (mirrors BlockPageable).
-        if let Some(id) = &self.id
-            && !id.is_empty()
-        {
-            registry.record(id, x, y);
-        }
-        // Mirror TablePageable::draw child iteration — header + body cells.
-        let total_width = self.width;
-        for pc in self.header_cells.iter().chain(self.body_cells.iter()) {
-            pc.child
-                .collect_ids(x + pc.x, y + pc.y, total_width, pc.child.height(), registry);
-        }
-    }
-
     fn node_id(&self) -> Option<usize> {
         self.node_id
     }
@@ -2815,144 +2669,6 @@ mod tests {
         let p = StringSetPageable::new("title".to_string(), "Chapter 1".to_string());
         assert_eq!(p.name, "title");
         assert_eq!(p.value, "Chapter 1");
-    }
-
-    // ─── DestinationRegistry tests ───────────────────────────
-
-    #[test]
-    fn destination_registry_collects_block_ids_from_paginated_pages() {
-        use crate::convert::{self, ConvertContext};
-        use crate::gcpm::running::RunningElementStore;
-        use std::collections::HashMap;
-
-        // Use `<div>` wrappers (container nodes, always BlockPageable) so
-        // the test does not depend on whether headings gain a block wrapper
-        // via default CSS — `<h1>` is an inline root that only becomes a
-        // BlockPageable when `needs_block_wrapper()` triggers on its style.
-        let html = r##"<html><body>
-            <div id="top" style="border:1px solid red">Top</div>
-            <div style="height:2000px"></div>
-            <div id="next" style="border:1px solid red">Next</div>
-        </body></html>"##;
-        let doc = crate::blitz_adapter::parse_and_layout(html, 400.0, 600.0, &[]);
-        let dummy_store = RunningElementStore::new();
-        let mut ctx = ConvertContext {
-            running_store: &dummy_store,
-            assets: None,
-            font_cache: HashMap::new(),
-            string_set_by_node: HashMap::new(),
-            counter_ops_by_node: HashMap::new(),
-            bookmark_by_node: HashMap::new(),
-            column_styles: crate::column_css::ColumnStyleTable::new(),
-            multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
-            pagination_geometry: ::std::collections::BTreeMap::new(),
-            link_cache: Default::default(),
-            viewport_size_px: None,
-        };
-        let pageable = convert::dom_to_pageable(&doc, &mut ctx);
-        let mut registry = DestinationRegistry::default();
-        registry.set_current_page(0);
-        pageable.collect_ids(0.0, 0.0, 400.0, 600.0, &mut registry);
-        assert!(registry.get("top").is_some(), "missing top");
-        assert!(registry.get("next").is_some(), "missing next");
-        // `top` and `next` should be on different pages (or different y) since
-        // the spacer between them is 2000px tall.
-        assert_ne!(registry.get("top"), registry.get("next"));
-    }
-
-    #[test]
-    fn destination_registry_ignores_blocks_without_id() {
-        // A BlockPageable with `id: None` should not register anything.
-        let block = BlockPageable::with_positioned_children(vec![]);
-        let mut registry = DestinationRegistry::default();
-        registry.set_current_page(0);
-        block.collect_ids(0.0, 0.0, 100.0, 100.0, &mut registry);
-        assert!(registry.get("anything").is_none());
-    }
-
-    #[test]
-    fn destination_registry_captures_paragraph_id_for_headings() {
-        // Headings like `<h1 id="top">` are inline roots that typically
-        // become `ParagraphPageable`, not `BlockPageable`. Ensure their ids
-        // are still captured so `href="#top"` links resolve.
-        use crate::convert::{self, ConvertContext};
-        use crate::gcpm::running::RunningElementStore;
-        use std::collections::HashMap;
-
-        let html = r##"<html><body>
-            <h1 id="top">Top</h1>
-            <div style="height:2000px"></div>
-            <h2 id="next">Next</h2>
-        </body></html>"##;
-        let doc = crate::blitz_adapter::parse_and_layout(html, 400.0, 600.0, &[]);
-        let dummy_store = RunningElementStore::new();
-        let mut ctx = ConvertContext {
-            running_store: &dummy_store,
-            assets: None,
-            font_cache: HashMap::new(),
-            string_set_by_node: HashMap::new(),
-            counter_ops_by_node: HashMap::new(),
-            bookmark_by_node: HashMap::new(),
-            column_styles: crate::column_css::ColumnStyleTable::new(),
-            multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
-            pagination_geometry: ::std::collections::BTreeMap::new(),
-            link_cache: Default::default(),
-            viewport_size_px: None,
-        };
-        let pageable = convert::dom_to_pageable(&doc, &mut ctx);
-        let mut registry = DestinationRegistry::default();
-        registry.set_current_page(0);
-        pageable.collect_ids(0.0, 0.0, 400.0, 600.0, &mut registry);
-        assert!(
-            registry.get("top").is_some(),
-            "expected <h1 id=top> to be captured"
-        );
-        assert!(
-            registry.get("next").is_some(),
-            "expected <h2 id=next> to be captured"
-        );
-        assert_ne!(
-            registry.get("top"),
-            registry.get("next"),
-            "headings separated by 2000px spacer should not share location"
-        );
-    }
-
-    #[test]
-    fn destination_registry_captures_table_id() {
-        // Regression: `<table id=...>` previously skipped BlockPageable
-        // wrapping, so TablePageable never registered its own id.
-        use crate::convert::{self, ConvertContext};
-        use crate::gcpm::running::RunningElementStore;
-        use std::collections::HashMap;
-
-        let html = r##"<html><body>
-            <table id="data"><tr><td>x</td></tr></table>
-        </body></html>"##;
-        let doc = crate::blitz_adapter::parse_and_layout(html, 400.0, 600.0, &[]);
-        let dummy_store = RunningElementStore::new();
-        let mut ctx = ConvertContext {
-            running_store: &dummy_store,
-            assets: None,
-            font_cache: HashMap::new(),
-            string_set_by_node: HashMap::new(),
-            counter_ops_by_node: HashMap::new(),
-            bookmark_by_node: HashMap::new(),
-            column_styles: crate::column_css::ColumnStyleTable::new(),
-            multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
-            pagination_geometry: ::std::collections::BTreeMap::new(),
-            link_cache: Default::default(),
-            viewport_size_px: None,
-        };
-        let pageable = convert::dom_to_pageable(&doc, &mut ctx);
-        let mut registry = DestinationRegistry::default();
-        registry.set_current_page(0);
-        pageable.collect_ids(0.0, 0.0, 400.0, 600.0, &mut registry);
-        assert!(
-            registry.get("data").is_some(),
-            "table id was not captured (entries: {:?})",
-            registry
-        );
     }
 
     #[test]

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -966,40 +966,6 @@ impl Pageable for ParagraphPageable {
         self.visible
     }
 
-    fn collect_ids(
-        &self,
-        x: Pt,
-        y: Pt,
-        _avail_width: Pt,
-        _avail_height: Pt,
-        registry: &mut crate::pageable::DestinationRegistry,
-    ) {
-        if let Some(id) = &self.id
-            && !id.is_empty()
-        {
-            registry.record(id, x, y);
-        }
-        // Recurse into inline-box content so nested `id`s (e.g. an
-        // `<a id="target">` inside `<span style="display:inline-block">`)
-        // still reach the destination registry for `href="#target"`
-        // resolution. The coordinate arithmetic mirrors `draw_shaped_lines`
-        // (see paragraph.rs:614): `line_top` starts at 0, advances by
-        // `line.height` after each line, so `oy = y + line_top + computed_y`
-        // matches the draw-path's `line_top_abs + computed_y`.
-        let mut line_top: f32 = 0.0;
-        for line in &self.lines {
-            for item in &line.items {
-                if let LineItem::InlineBox(ib) = item {
-                    let child_x = x + ib.x_offset;
-                    let child_y = y + line_top + ib.computed_y;
-                    ib.content
-                        .collect_ids(child_x, child_y, ib.width, ib.height, registry);
-                }
-            }
-            line_top += line.height;
-        }
-    }
-
     fn node_id(&self) -> Option<usize> {
         self.node_id
     }
@@ -1349,25 +1315,6 @@ mod tests {
     }
 
     #[test]
-    fn collect_ids_records_paragraph_id() {
-        use crate::pageable::DestinationRegistry;
-        let p = ParagraphPageable::new(Vec::new()).with_id(Some(Arc::new("anchor".to_string())));
-        let mut reg = DestinationRegistry::default();
-        reg.set_current_page(3);
-        p.collect_ids(10.0, 42.0, 400.0, 600.0, &mut reg);
-        assert_eq!(reg.get("anchor"), Some((3, 10.0, 42.0)));
-    }
-
-    #[test]
-    fn collect_ids_is_noop_without_id() {
-        use crate::pageable::DestinationRegistry;
-        let p = ParagraphPageable::new(Vec::new());
-        let mut reg = DestinationRegistry::default();
-        p.collect_ids(0.0, 0.0, 400.0, 600.0, &mut reg);
-        assert!(reg.get("anything").is_none());
-    }
-
-    #[test]
     fn line_item_inline_box_variant_can_be_constructed() {
         use crate::pageable::BlockPageable;
         // BlockPageable::new takes Vec<Box<dyn Pageable>>; an empty vec is
@@ -1511,40 +1458,6 @@ mod tests {
             }
             _ => panic!("expected InlineBox at index 1"),
         }
-    }
-
-    // ---------- collect_ids recursion into inline-box Paragraph content ----------
-
-    /// Covers the `ib.content.collect_ids(..)` path in
-    /// `ParagraphPageable::collect_ids` when the inline-box hosts a
-    /// `ParagraphPageable`. Existing integration tests use Block content
-    /// exclusively, so this branch stays otherwise untested.
-    #[test]
-    fn collect_ids_recurses_into_inline_box_paragraph_content() {
-        use crate::pageable::DestinationRegistry;
-        let inner =
-            ParagraphPageable::new(Vec::new()).with_id(Some(Arc::new("inner-id".to_string())));
-        let outer_line = ShapedLine {
-            height: 20.0,
-            baseline: 15.0,
-            items: vec![LineItem::InlineBox(InlineBoxItem {
-                content: Box::new(inner) as InlineBoxContent,
-                width: 30.0,
-                height: 20.0,
-                x_offset: 5.0,
-                computed_y: 0.0,
-                link: None,
-                opacity: 1.0,
-                visible: true,
-            })],
-        };
-        let outer = ParagraphPageable::new(vec![outer_line]);
-        let mut reg = DestinationRegistry::default();
-        reg.set_current_page(2);
-        outer.collect_ids(10.0, 20.0, 400.0, 600.0, &mut reg);
-        // Recorded at (x + ib.x_offset, y + line_top + computed_y) =
-        // (10+5, 20+0+0) = (15, 20) on page 2.
-        assert_eq!(reg.get("inner-id"), Some((2, 15.0, 20.0)));
     }
 
     // ---------- pageable_last_baseline walks wrappers ----------


### PR DESCRIPTION
## Summary

v2 production の anchor 解決は Drawables 経由で完結している (\`extract_drawables_from_pageable\` が \`ParagraphEntry.id\`/\`BlockEntry.id\`/\`TableEntry.id\` に記録 → \`render::render_v2\` が render.rs:60-90 で fragment 座標から \`DestinationRegistry\` に登録)。\`Pageable::collect_ids\` trait method は v2 production の caller ゼロで dead code。

**Net delta: -389 / +0 LOC**

## 削除内容

- \`Pageable::collect_ids\` (default + 14 impls in pageable.rs / paragraph.rs)
- v1 collect_ids 直接呼び出し test:
  - pageable.rs: 4 tests (\`destination_registry_collects_block_ids_from_paginated_pages\` 等)
  - convert/inline_root.rs: 1 test (\`inline_block_inner_id_is_registered_with_destination_registry\`)
  - paragraph.rs: 1 test (\`collect_ids_recurses_into_inline_box_paragraph_content\`)

## スコープ調整の経緯

当初プランは「inline-box draw migration to Drawables」(\`ib.content.draw()\` を v2 dispatcher 経由に置き換えて \`Pageable::draw\` も削除) でしたが、実装中に位置不整合が判明:

- inline-box content の geometry は Taffy の \`final_layout.location\` ベース (body-relative)
- paragraph の inline 流れは Parley の \`positioned.x/y + baseline_shift\` ベース
- 両者は一致せず、v2 dispatcher で render すると \`layout/inline-block-basic.html\` 等で位置ズレ

architectural な拡張 (Drawables に inline-box 位置メタデータ追加) が必要なため、\`Pageable::draw\` 削除は先送り。本 PR は \`collect_ids\` のみ削除に絞った。

## Stack 位置

ベース: \`feat/phase4-pr8c-pagination-delete\` (#324; 8c+8d 合流済み)

## Test plan

- [x] \`cargo test -p fulgur --lib\` (814 pass)
- [x] \`cargo test -p fulgur-vrt\` (byte一致)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo fmt --check\`

bd: parent fulgur-9evx
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fulgur-rs/fulgur/pull/326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
