### PR TITLE
test(engine): add coverage for builder setters and render-to-file paths

### DIFF
--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -460,6 +460,7 @@ impl EngineBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pageable::{BlockPageable, SpacerPageable};
 
     #[test]
     fn builder_bookmarks_defaults_to_false() {
@@ -510,5 +511,134 @@ mod tests {
             .build();
         let result = engine.render();
         assert!(result.is_ok());
+    }
+
+    // ── Builder: config fields and override flags ──────────────────────────
+
+    #[test]
+    fn builder_page_size_stores_size_and_sets_override() {
+        let engine = Engine::builder().page_size(PageSize::LETTER).build();
+        let config = engine.config();
+        assert!((config.page_size.width - 612.0).abs() < 0.01);
+        assert!((config.page_size.height - 792.0).abs() < 0.01);
+        assert!(config.overrides.page_size);
+    }
+
+    #[test]
+    fn builder_margin_stores_margin_and_sets_override() {
+        let engine = Engine::builder().margin(Margin::uniform(36.0)).build();
+        let config = engine.config();
+        assert_eq!(config.margin, Margin::uniform(36.0));
+        assert!(config.overrides.margin);
+    }
+
+    #[test]
+    fn builder_landscape_stores_flag_and_sets_override() {
+        let engine = Engine::builder().landscape(true).build();
+        let config = engine.config();
+        assert!(config.landscape);
+        assert!(config.overrides.landscape);
+    }
+
+    // ── Builder: metadata fields ───────────────────────────────────────────
+
+    #[test]
+    fn builder_author_appends_each_call() {
+        // author() pushes rather than overwrites — verify both entries land.
+        let engine = Engine::builder().author("Alice").author("Bob").build();
+        let authors = &engine.config().authors;
+        assert_eq!(authors, &["Alice", "Bob"]);
+    }
+
+    #[test]
+    fn builder_authors_extends_from_iterator() {
+        let engine = Engine::builder().authors(["Alice", "Bob", "Carol"]).build();
+        assert_eq!(
+            engine.config().authors,
+            vec!["Alice".to_string(), "Bob".to_string(), "Carol".to_string()]
+        );
+    }
+
+    #[test]
+    fn builder_keywords_extends_from_iterator() {
+        let engine = Engine::builder().keywords(["pdf", "html", "css"]).build();
+        assert_eq!(
+            engine.config().keywords,
+            vec!["pdf".to_string(), "html".to_string(), "css".to_string()]
+        );
+    }
+
+    #[test]
+    fn builder_metadata_fields_round_trip() {
+        let engine = Engine::builder()
+            .title("My Report")
+            .lang("en-US")
+            .description("A test document")
+            .creator("Test Suite")
+            .producer("fulgur-test")
+            .creation_date("2026-05-01")
+            .build();
+        let cfg = engine.config();
+        assert_eq!(cfg.title.as_deref(), Some("My Report"));
+        assert_eq!(cfg.lang.as_deref(), Some("en-US"));
+        assert_eq!(cfg.description.as_deref(), Some("A test document"));
+        assert_eq!(cfg.creator.as_deref(), Some("Test Suite"));
+        assert_eq!(cfg.producer.as_deref(), Some("fulgur-test"));
+        assert_eq!(cfg.creation_date.as_deref(), Some("2026-05-01"));
+    }
+
+    // ── Builder: assets getter ─────────────────────────────────────────────
+
+    #[test]
+    fn engine_assets_is_none_without_bundle() {
+        let engine = Engine::builder().build();
+        assert!(engine.assets().is_none());
+    }
+
+    #[test]
+    fn engine_assets_is_some_after_bundle_set() {
+        let mut bundle = AssetBundle::default();
+        bundle.add_css("body { color: red; }");
+        let engine = Engine::builder().assets(bundle).build();
+        assert!(engine.assets().is_some());
+    }
+
+    // ── Render methods ─────────────────────────────────────────────────────
+
+    fn make_spacer_tree() -> Box<dyn Pageable> {
+        let mut s = SpacerPageable::new(100.0);
+        s.wrap(100.0, 1000.0);
+        Box::new(BlockPageable::new(vec![Box::new(s)]))
+    }
+
+    #[test]
+    fn render_pageable_returns_valid_pdf() {
+        let engine = Engine::builder().build();
+        let pdf = engine.render_pageable(make_spacer_tree()).unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn render_html_to_file_writes_valid_pdf() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.pdf");
+        Engine::builder()
+            .build()
+            .render_html_to_file("<html><body><p>test</p></body></html>", &path)
+            .unwrap();
+        let bytes = std::fs::read(&path).unwrap();
+        assert!(bytes.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn render_pageable_to_file_writes_valid_pdf() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.pdf");
+        Engine::builder()
+            .build()
+            .render_pageable_to_file(make_spacer_tree(), &path)
+            .unwrap();
+        let bytes = std::fs::read(&path).unwrap();
+        assert!(bytes.starts_with(b"%PDF"));
     }
 }


### PR DESCRIPTION
## 対象モジュール

`crates/fulgur/src/engine.rs`

## カバレッジ変化

| 指標 | 変更前 | 変更後 |
|------|--------|--------|
| Region coverage | 69.23% | 88.25% |
| Line coverage | 74.60% | 92.40% |
| Function coverage | 70.00% | 98.11% |
| 未カバー関数数 | 12 | 1 |

測定コマンド: `cargo llvm-cov --package fulgur --lib --summary-only --no-fail-fast`

## 追加したテスト一覧

| テスト名 | カバーする挙動 |
|----------|---------------|
| `builder_page_size_stores_size_and_sets_override` | `page_size()` setter が寸法と `overrides.page_size` フラグを正しく設定すること |
| `builder_margin_stores_margin_and_sets_override` | `margin()` setter が値と `overrides.margin` フラグを正しく設定すること |
| `builder_landscape_stores_flag_and_sets_override` | `landscape()` setter がフラグと `overrides.landscape` を正しく設定すること |
| `builder_author_appends_each_call` | `author()` を複数回呼ぶと追記されること（上書きではない） |
| `builder_authors_extends_from_iterator` | `authors()` がイテレータから複数著者を一括追加すること |
| `builder_keywords_extends_from_iterator` | `keywords()` がイテレータから複数キーワードを一括追加すること |
| `builder_metadata_fields_round_trip` | `title`, `lang`, `description`, `creator`, `producer`, `creation_date` が `config()` 経由で正しく取得できること |
| `engine_assets_is_none_without_bundle` | `AssetBundle` を設定しない場合 `assets()` が `None` を返すこと |
| `engine_assets_is_some_after_bundle_set` | `assets()` builder メソッドで設定した bundle が `assets()` getter 経由で参照できること |
| `render_pageable_returns_valid_pdf` | `render_pageable()` が `%PDF` バイト列を返すこと |
| `render_html_to_file_writes_valid_pdf` | `render_html_to_file()` がファイルを作成し中身が有効な PDF であること |
| `render_pageable_to_file_writes_valid_pdf` | `render_pageable_to_file()` がファイルを作成し中身が有効な PDF であること |

## 意図的に除外したブランチ・関数

| 対象 | 除外理由 |
|------|----------|
| `build_pageable_for_testing_no_gcpm()` | Blitz の `parse_html_with_local_resources` → `resolve` → `relayout_position_fixed` を呼び出す完全な HTML 処理パイプラインが必要。インライン unit test では起動コストが大きく、同等のカバレッジは既存の integration test (`render_smoke.rs`, `engine_test.rs`) で担保されているため除外 |

## 変更ファイル

- `crates/fulgur/src/engine.rs` — テストのみ追加（本番コードの変更なし）

---
_Generated by [Claude Code](https://claude.ai/code/session_01UcRgCY624qsphA2w7U5gDz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for engine configuration, metadata handling, and rendering functionality to ensure robust behavior across builder methods and output generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->