### PR TITLE
refactor(render): remove remaining Pageable::draw() call sites (Phase 4 PR 8h)

### DIFF
--- a/crates/fulgur/src/convert/list_marker.rs
+++ b/crates/fulgur/src/convert/list_marker.rs
@@ -71,9 +71,16 @@ pub(super) fn resolve_list_marker(
     match kind {
         AssetKind::Raster(format) => {
             let (width, height) = size_raster_marker(data, format, line_height)?;
-            let img = ImagePageable::new(Arc::clone(data), format, width, height);
+            let entry = crate::drawables::ImageEntry {
+                image_data: Arc::clone(data),
+                format,
+                width,
+                height,
+                opacity: 1.0,
+                visible: true,
+            };
             Some(ListItemMarker::Image {
-                marker: ImageMarker::Raster(img),
+                marker: ImageMarker::Raster(entry),
                 width,
                 height,
             })
@@ -85,9 +92,15 @@ pub(super) fn resolve_list_marker(
             let intrinsic_h = px_to_pt(size.height());
             let (width, height) =
                 crate::pageable::clamp_marker_size(intrinsic_w, intrinsic_h, line_height);
-            let svg = SvgPageable::new(Arc::new(tree), width, height);
+            let entry = crate::drawables::SvgEntry {
+                tree: Arc::new(tree),
+                width,
+                height,
+                opacity: 1.0,
+                visible: true,
+            };
             Some(ListItemMarker::Image {
-                marker: ImageMarker::Svg(svg),
+                marker: ImageMarker::Svg(entry),
                 width,
                 height,
             })

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -2,14 +2,15 @@
 
 use crate::asset::AssetBundle;
 use crate::blitz_adapter::{BaseDocument, Node, NodeData};
+use crate::drawables::{ImageMarker, ListItemMarker};
 use crate::gcpm::CounterOp;
 use crate::gcpm::running::RunningElementStore;
 use crate::image::ImagePageable;
 use crate::pageable::{
-    BlockPageable, BlockStyle, CounterOpMarkerPageable, CounterOpWrapperPageable, ImageMarker,
-    ListItemMarker, ListItemPageable, Pageable, PositionedChild, RunningElementMarkerPageable,
-    RunningElementWrapperPageable, Size, SpacerPageable, StringSetPageable,
-    StringSetWrapperPageable, TablePageable, TransformWrapperPageable,
+    BlockPageable, BlockStyle, CounterOpMarkerPageable, CounterOpWrapperPageable, ListItemPageable,
+    Pageable, PositionedChild, RunningElementMarkerPageable, RunningElementWrapperPageable, Size,
+    SpacerPageable, StringSetPageable, StringSetWrapperPageable, TablePageable,
+    TransformWrapperPageable,
 };
 use crate::paragraph::{
     InlineImage, LineFontMetrics, LineItem, LinkSpan, LinkTarget, ParagraphPageable, ShapedGlyph,

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -148,13 +148,43 @@ pub struct TableEntry {
     pub clip_descendants: Vec<NodeId>,
 }
 
+/// Image marker contents — either a raster image or a parsed SVG tree.
+#[derive(Clone)]
+pub enum ImageMarker {
+    Raster(ImageEntry),
+    Svg(SvgEntry),
+}
+
+/// List-item marker variants. Exactly one variant holds valid content per
+/// list item, enforced by the type system. `None` is used for the second
+/// fragment after a page-break split (the marker only appears on the first
+/// fragment).
+#[derive(Clone)]
+pub enum ListItemMarker {
+    /// Text marker with shaped glyph runs extracted from Blitz/Parley.
+    Text {
+        lines: Vec<crate::paragraph::ShapedLine>,
+        width: f32,
+    },
+    /// Image marker (`list-style-image: url(...)`) — raster or SVG.
+    Image {
+        marker: ImageMarker,
+        /// Display width after clamp (pt).
+        width: f32,
+        /// Display height after clamp (pt).
+        height: f32,
+    },
+    /// No marker — split trailing fragment or `list-style-type: none`.
+    None,
+}
+
 /// List-item marker payload for v2. The body block paints itself
 /// through `BlockEntry`; `ListItemEntry` only carries the marker
 /// (text / image / svg / none) and the line-height needed to
 /// vertically centre image markers.
 #[derive(Clone)]
 pub struct ListItemEntry {
-    pub marker: crate::pageable::ListItemMarker,
+    pub marker: ListItemMarker,
     pub marker_line_height: f32,
     pub opacity: f32,
     pub visible: bool,

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -2338,8 +2338,8 @@ pub(crate) fn clamp_marker_size(
 /// Image marker contents — either a raster image or a parsed SVG tree.
 #[derive(Clone)]
 pub enum ImageMarker {
-    Raster(crate::image::ImagePageable),
-    Svg(crate::svg::SvgPageable),
+    Raster(crate::drawables::ImageEntry),
+    Svg(crate::drawables::SvgEntry),
 }
 
 /// Marker attached to a `ListItemPageable`.
@@ -2408,12 +2408,34 @@ impl Pageable for ListItemPageable {
                     } => {
                         let marker_x = x - *width;
                         let marker_y = y + (self.marker_line_height - *height) / 2.0;
+                        // v1 dead-code path (public entry points removed in PR 8a;
+                        // will be deleted with all of pageable.rs in PR 8j).
+                        // Reconstruct v1 types from ImageEntry/SvgEntry to reuse
+                        // their Pageable::draw impls rather than duplicating krilla
+                        // drawing code here.
                         match marker {
-                            ImageMarker::Raster(img) => {
-                                img.draw(canvas, marker_x, marker_y, *width, *height);
+                            ImageMarker::Raster(entry) => {
+                                crate::image::ImagePageable {
+                                    image_data: entry.image_data.clone(),
+                                    format: entry.format,
+                                    width: entry.width,
+                                    height: entry.height,
+                                    opacity: entry.opacity,
+                                    visible: entry.visible,
+                                    node_id: None,
+                                }
+                                .draw(canvas, marker_x, marker_y, *width, *height);
                             }
-                            ImageMarker::Svg(svg) => {
-                                svg.draw(canvas, marker_x, marker_y, *width, *height);
+                            ImageMarker::Svg(entry) => {
+                                crate::svg::SvgPageable {
+                                    tree: entry.tree.clone(),
+                                    width: entry.width,
+                                    height: entry.height,
+                                    opacity: entry.opacity,
+                                    visible: entry.visible,
+                                    node_id: None,
+                                }
+                                .draw(canvas, marker_x, marker_y, *width, *height);
                             }
                         }
                     }

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use crate::drawables::ListItemMarker;
 use crate::gcpm::CounterOp;
 use crate::image::ImageFormat;
 
@@ -2335,37 +2336,6 @@ pub(crate) fn clamp_marker_size(
     }
 }
 
-/// Image marker contents — either a raster image or a parsed SVG tree.
-#[derive(Clone)]
-pub enum ImageMarker {
-    Raster(crate::drawables::ImageEntry),
-    Svg(crate::drawables::SvgEntry),
-}
-
-/// Marker attached to a `ListItemPageable`.
-///
-/// Exactly one variant holds valid content per list item, enforced by the
-/// type system. `None` is used for the second fragment after a page-break
-/// split (the marker only appears on the first fragment).
-#[derive(Clone)]
-pub enum ListItemMarker {
-    /// Text marker with shaped glyph runs extracted from Blitz/Parley.
-    Text {
-        lines: Vec<crate::paragraph::ShapedLine>,
-        width: Pt,
-    },
-    /// Image marker (list-style-image: url(...)) — raster or SVG.
-    Image {
-        marker: ImageMarker,
-        /// Display width after clamp (pt).
-        width: Pt,
-        /// Display height after clamp (pt).
-        height: Pt,
-    },
-    /// No marker — split trailing fragment or list-style-type: none.
-    None,
-}
-
 /// A list item with an outside-positioned marker.
 #[derive(Clone)]
 pub struct ListItemPageable {
@@ -2401,43 +2371,14 @@ impl Pageable for ListItemPageable {
                         let marker_x = x - width;
                         crate::paragraph::draw_shaped_lines(canvas, lines, marker_x, y, None);
                     }
-                    ListItemMarker::Image {
-                        marker,
-                        width,
-                        height,
-                    } => {
-                        let marker_x = x - *width;
-                        let marker_y = y + (self.marker_line_height - *height) / 2.0;
-                        // v1 dead-code path (public entry points removed in PR 8a;
-                        // will be deleted with all of pageable.rs in PR 8j).
-                        // Reconstruct v1 types from ImageEntry/SvgEntry to reuse
-                        // their Pageable::draw impls rather than duplicating krilla
-                        // drawing code here.
-                        match marker {
-                            ImageMarker::Raster(entry) => {
-                                crate::image::ImagePageable {
-                                    image_data: entry.image_data.clone(),
-                                    format: entry.format,
-                                    width: entry.width,
-                                    height: entry.height,
-                                    opacity: entry.opacity,
-                                    visible: entry.visible,
-                                    node_id: None,
-                                }
-                                .draw(canvas, marker_x, marker_y, *width, *height);
-                            }
-                            ImageMarker::Svg(entry) => {
-                                crate::svg::SvgPageable {
-                                    tree: entry.tree.clone(),
-                                    width: entry.width,
-                                    height: entry.height,
-                                    opacity: entry.opacity,
-                                    visible: entry.visible,
-                                    node_id: None,
-                                }
-                                .draw(canvas, marker_x, marker_y, *width, *height);
-                            }
-                        }
+                    ListItemMarker::Image { .. } => {
+                        // v1 dead-code path: image markers carry `ImageEntry` /
+                        // `SvgEntry` (drawables components, no draw method by
+                        // design — see ECS separation in render.rs systems).
+                        // The v2 path draws them via `render::draw_list_item_marker`
+                        // → `draw_image_v2` / `draw_svg_v2`. v1 entry points were
+                        // removed in PR 8a; this arm is kept only for compilation
+                        // and will be deleted with pageable.rs in PR 8j.
                     }
                     _ => {}
                 }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -2552,7 +2552,7 @@ fn draw_list_item_marker(
     x: f32,
     y: f32,
 ) {
-    use crate::pageable::{ImageMarker, ListItemMarker};
+    use crate::drawables::{ImageMarker, ListItemMarker};
 
     match &entry.marker {
         ListItemMarker::Text { lines, width } if !lines.is_empty() => {

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -3153,6 +3153,10 @@ impl<'a> MarginBoxRenderer<'a> {
                         paint_root_block_v2(canvas, root_block, rect.x, rect.y);
                     }
                 }
+                // `body_offset_pt` is (0, 0) here because the wrapper HTML fixes
+                // `body { margin: 0; padding: 0; }` via an inline style, which
+                // takes higher specificity than `self.margin_css`. No adjustment
+                // needed unlike `render_v2`.
                 draw_v2_page(canvas, 0, rect.x, rect.y, geometry, drawables);
             }
         }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -2567,10 +2567,25 @@ fn draw_list_item_marker(
             let marker_y = y + (entry.marker_line_height - *height) / 2.0;
             match marker {
                 ImageMarker::Raster(img) => {
-                    img.draw(canvas, marker_x, marker_y, *width, *height);
+                    let entry = crate::drawables::ImageEntry {
+                        image_data: img.image_data.clone(),
+                        format: img.format,
+                        width: img.width,
+                        height: img.height,
+                        opacity: img.opacity,
+                        visible: img.visible,
+                    };
+                    draw_image_v2(canvas, &entry, marker_x, marker_y);
                 }
                 ImageMarker::Svg(svg) => {
-                    svg.draw(canvas, marker_x, marker_y, *width, *height);
+                    let entry = crate::drawables::SvgEntry {
+                        tree: svg.tree.clone(),
+                        width: svg.width,
+                        height: svg.height,
+                        opacity: svg.opacity,
+                        visible: svg.visible,
+                    };
+                    draw_svg_v2(canvas, &entry, marker_x, marker_y);
                 }
             }
         }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -2566,27 +2566,8 @@ fn draw_list_item_marker(
             let marker_x = x - *width;
             let marker_y = y + (entry.marker_line_height - *height) / 2.0;
             match marker {
-                ImageMarker::Raster(img) => {
-                    let entry = crate::drawables::ImageEntry {
-                        image_data: img.image_data.clone(),
-                        format: img.format,
-                        width: img.width,
-                        height: img.height,
-                        opacity: img.opacity,
-                        visible: img.visible,
-                    };
-                    draw_image_v2(canvas, &entry, marker_x, marker_y);
-                }
-                ImageMarker::Svg(svg) => {
-                    let entry = crate::drawables::SvgEntry {
-                        tree: svg.tree.clone(),
-                        width: svg.width,
-                        height: svg.height,
-                        opacity: svg.opacity,
-                        visible: svg.visible,
-                    };
-                    draw_svg_v2(canvas, &entry, marker_x, marker_y);
-                }
+                ImageMarker::Raster(img) => draw_image_v2(canvas, img, marker_x, marker_y),
+                ImageMarker::Svg(svg) => draw_svg_v2(canvas, svg, marker_x, marker_y),
             }
         }
         _ => {}

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -5,7 +5,7 @@ use crate::gcpm::GcpmContext;
 use crate::gcpm::counter::resolve_content_to_html;
 use crate::gcpm::margin_box::{Edge, MarginBoxPosition, MarginBoxRect, compute_edge_layout};
 use crate::gcpm::running::RunningElementStore;
-use crate::pageable::{Canvas, Pageable};
+use crate::pageable::Canvas;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
@@ -2823,7 +2823,13 @@ fn parse_datetime(s: &str) -> Option<krilla::metadata::DateTime> {
 /// Measure cache: (html, page_height as bits) → max-content width.
 /// Render cache: (html, final_width as bits, final_height as bits) → Pageable.
 type MeasureCache = HashMap<(String, u32, u32), f32>;
-type RenderCache = HashMap<(String, u32, u32), Box<dyn Pageable>>;
+type RenderCache = HashMap<
+    (String, u32, u32),
+    (
+        crate::drawables::Drawables,
+        crate::pagination_layout::PaginationGeometryTable,
+    ),
+>;
 
 fn width_key(w: f32) -> u32 {
     w.to_bits()
@@ -3109,11 +3115,17 @@ impl<'a> MarginBoxRenderer<'a> {
                     "<html><head><style>{}</style></head><body style=\"margin:0;padding:0;\">{}</body></html>",
                     self.margin_css, html
                 );
-                let render_doc = crate::blitz_adapter::parse_and_layout(
+                let mut render_doc = crate::blitz_adapter::parse_and_layout(
                     &render_html,
                     crate::convert::pt_to_px(rect.width),
                     crate::convert::pt_to_px(rect.height),
                     self.font_data,
+                );
+                let empty_column_styles = crate::column_css::ColumnStyleTable::new();
+                let geometry = crate::pagination_layout::run_pass_with_break_styles(
+                    &mut *render_doc,
+                    crate::convert::pt_to_px(rect.height),
+                    &empty_column_styles,
                 );
                 let dummy_store = RunningElementStore::new();
                 let mut dummy_ctx = crate::convert::ConvertContext {
@@ -3125,16 +3137,23 @@ impl<'a> MarginBoxRenderer<'a> {
                     bookmark_by_node: HashMap::new(),
                     column_styles: crate::column_css::ColumnStyleTable::new(),
                     multicol_geometry: crate::multicol_layout::MulticolGeometryTable::new(),
-                    pagination_geometry: crate::pagination_layout::PaginationGeometryTable::new(),
+                    pagination_geometry: geometry,
                     link_cache: Default::default(),
                     viewport_size_px: None,
                 };
-                let pageable = crate::convert::dom_to_pageable(&render_doc, &mut dummy_ctx);
-                self.render_cache.insert(cache_key.clone(), pageable);
+                let drawables = crate::convert::dom_to_drawables(&render_doc, &mut dummy_ctx);
+                let geometry = dummy_ctx.pagination_geometry;
+                self.render_cache
+                    .insert(cache_key.clone(), (drawables, geometry));
             }
 
-            if let Some(pageable) = self.render_cache.get(&cache_key) {
-                pageable.draw(canvas, rect.x, rect.y, rect.width, rect.height);
+            if let Some((drawables, geometry)) = self.render_cache.get(&cache_key) {
+                if let Some(root_id) = drawables.root_id {
+                    if let Some(root_block) = drawables.block_styles.get(&root_id) {
+                        paint_root_block_v2(canvas, root_block, rect.x, rect.y);
+                    }
+                }
+                draw_v2_page(canvas, 0, rect.x, rect.y, geometry, drawables);
             }
         }
     }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -3123,7 +3123,7 @@ impl<'a> MarginBoxRenderer<'a> {
                 );
                 let empty_column_styles = crate::column_css::ColumnStyleTable::new();
                 let geometry = crate::pagination_layout::run_pass_with_break_styles(
-                    &mut *render_doc,
+                    &mut render_doc,
                     crate::convert::pt_to_px(rect.height),
                     &empty_column_styles,
                 );

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -1338,3 +1338,31 @@ fn render_v2_smoke_inline_block_image_child_via_dispatch_fragment() {
     assert!(!pdf.is_empty());
     assert!(pdf.starts_with(b"%PDF"));
 }
+
+#[test]
+fn render_v2_smoke_list_item_svg_marker() {
+    // Exercises `draw_list_item_marker`'s `ImageMarker::Svg` branch
+    // (render.rs: svg.draw call) — a `<li>` with an SVG list-style-image.
+    let svg_data = br#"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><circle cx="5" cy="5" r="4" fill="blue"/></svg>"#;
+    let mut bundle = AssetBundle::default();
+    bundle.add_css(r#"li { list-style-image: url("bullet.svg"); }"#);
+    bundle.add_image("bullet.svg", svg_data.to_vec());
+    let html = r##"<!doctype html><html><body><ul><li>Alpha</li><li>Beta</li></ul></body></html>"##;
+    let engine = Engine::builder().assets(bundle).build();
+    let pdf = engine.render_html(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn render_v2_smoke_margin_box_renderer() {
+    // Exercises `MarginBoxRenderer`'s Stage 3 draw path
+    // (render.rs: pageable.draw call) — a simple @top-center counter.
+    let html = r##"<!DOCTYPE html><html><head><style>
+        @page { margin: 36pt; @top-center { content: counter(page); } }
+        body { margin: 0; }
+        p { height: 500pt; background: #eee; }
+    </style></head><body><p>Page 1</p><p>Page 2</p></body></html>"##;
+    let engine = Engine::builder().build();
+    let pdf = engine.render_html(html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}


### PR DESCRIPTION
## 概要

render.rs に残っていた `Pageable::draw()` 呼び出し 3 箇所を v2 描画パスに移行し、合わせて `ImageMarker` / `ListItemMarker` を ECS の Component として `drawables` モジュールへ移植した。

### 変更内容

- **`draw_list_item_marker` (render.rs:2570/2573)**: `img.draw()` / `svg.draw()` を `draw_image_v2` / `draw_svg_v2` に置き換え
- **`MarginBoxRenderer` (render.rs:3122)**: `RenderCache` 型を `Box<dyn Pageable>` から `(Drawables, PaginationGeometryTable)` に変更し、cache miss パスで `run_pass_with_break_styles` + `dom_to_drawables` + `draw_v2_page` に移行
- **`ImageMarker` / `ListItemMarker`**: pageable.rs (v1) から drawables.rs (v2) に移植
  - 中身も `ImagePageable` / `SvgPageable` から `ImageEntry` / `SvgEntry` に変更
  - `resolve_list_marker` の時点で v2 components を構築（draw 時の中間変換が消える）
  - draw メソッドは生やさず、データと振る舞いを分離（render.rs の system 側で描画）
- **v1 `ListItemPageable::draw` の image marker arm**: dead-code stub に縮小（PR 8a で v1 entry points は削除済み、PR 8j で全削除予定）

## テスト計画

- [x] `render_v2_smoke_list_item_svg_marker` smoke test 追加（`ImageMarker::Svg` 分岐カバー）
- [x] `render_v2_smoke_margin_box_renderer` smoke test 追加（MarginBoxRenderer Stage 3 カバー）
- [x] `cargo test -p fulgur --lib` — 811 passed
- [x] `cargo test -p fulgur --test render_smoke` — 62 passed
- [x] `cargo test -p fulgur --test gcpm_integration` — 25 passed
- [x] `cargo clippy -p fulgur` — 警告・エラーなし
- [x] `cargo fmt -p fulgur --check` — 差分なし