### PR TITLE
test(engine): drop v1-render tests pulled in from main (PR #290 CI fix)

### DIFF
--- a/crates/fulgur/src/convert/list_marker.rs
+++ b/crates/fulgur/src/convert/list_marker.rs
@@ -424,3 +424,436 @@ pub(super) fn inject_inside_marker_item_into_children(
 
     false
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blitz_adapter::Marker;
+    use crate::image::ImageFormat;
+    use crate::pageable::{BlockPageable, PositionedChild, SpacerPageable};
+    use crate::paragraph::{
+        InlineBoxItem, InlineImage, ParagraphPageable, ShapedGlyph, ShapedGlyphRun, ShapedLine,
+        TextDecoration, VerticalAlign,
+    };
+    use std::sync::Arc;
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    fn dummy_arc() -> Arc<Vec<u8>> {
+        Arc::new(vec![])
+    }
+
+    fn text_run(font_size: f32, x_offset: f32, text: &str) -> ShapedGlyphRun {
+        ShapedGlyphRun {
+            font_data: dummy_arc(),
+            font_index: 0,
+            font_size,
+            color: [0, 0, 0, 255],
+            decoration: TextDecoration::default(),
+            glyphs: vec![ShapedGlyph {
+                id: 1,
+                x_advance: 0.5,
+                x_offset: 0.0,
+                y_offset: 0.0,
+                text_range: 0..text.len(),
+            }],
+            text: text.to_string(),
+            x_offset,
+            link: None,
+        }
+    }
+
+    fn text_run_with_two_glyphs(font_size: f32) -> ShapedGlyphRun {
+        ShapedGlyphRun {
+            font_data: dummy_arc(),
+            font_index: 0,
+            font_size,
+            color: [255, 0, 0, 255],
+            decoration: TextDecoration::default(),
+            glyphs: vec![
+                ShapedGlyph {
+                    id: 1,
+                    x_advance: 0.5,
+                    x_offset: 0.0,
+                    y_offset: 0.0,
+                    text_range: 0..1,
+                },
+                ShapedGlyph {
+                    id: 2,
+                    x_advance: 0.5,
+                    x_offset: 0.0,
+                    y_offset: 0.0,
+                    text_range: 1..2,
+                },
+            ],
+            text: "\u{2022} ".to_string(),
+            x_offset: 0.0,
+            link: None,
+        }
+    }
+
+    fn paragraph_with_items(items: Vec<LineItem>) -> ParagraphPageable {
+        ParagraphPageable::new(vec![ShapedLine {
+            height: 12.0,
+            baseline: 10.0,
+            items,
+        }])
+    }
+
+    fn in_flow(child: Box<dyn crate::pageable::Pageable>) -> PositionedChild {
+        PositionedChild::in_flow(child, 0.0, 0.0)
+    }
+
+    fn noto_sans_bytes() -> Arc<Vec<u8>> {
+        let bytes = std::fs::read("../../examples/.fonts/NotoSans-Regular.ttf")
+            .expect("NotoSans-Regular.ttf not found; run from crates/fulgur/");
+        Arc::new(bytes)
+    }
+
+    // ─── inject_inside_marker_item_into_children ──────────────────────────────
+
+    #[test]
+    fn inject_empty_children_returns_false() {
+        let marker = LineItem::Text(text_run(12.0, 0.0, "•"));
+        assert!(!inject_inside_marker_item_into_children(&mut [], marker));
+    }
+
+    #[test]
+    fn inject_no_paragraph_descendant_returns_false() {
+        let mut children = vec![in_flow(Box::new(SpacerPageable::new(10.0)))];
+        let marker = LineItem::Text(text_run(12.0, 0.0, "•"));
+        assert!(!inject_inside_marker_item_into_children(
+            &mut children,
+            marker
+        ));
+    }
+
+    #[test]
+    fn inject_text_marker_prepended_and_existing_items_shifted() {
+        let existing = LineItem::Text(text_run(12.0, 5.0, "Hello"));
+        let para = paragraph_with_items(vec![existing]);
+        let mut children = vec![in_flow(Box::new(para))];
+
+        // Two glyphs of x_advance 0.5 at font_size 12 → marker_width = 2 × 0.5 × 12 = 12 pt
+        let marker = LineItem::Text(text_run_with_two_glyphs(12.0));
+        let result = inject_inside_marker_item_into_children(&mut children, marker);
+        assert!(result);
+
+        let para = children[0]
+            .child
+            .as_any()
+            .downcast_ref::<ParagraphPageable>()
+            .unwrap();
+        let line = &para.lines[0];
+        assert_eq!(line.items.len(), 2, "marker + original");
+        // marker text is the first item
+        if let LineItem::Text(r) = &line.items[0] {
+            assert_eq!(r.text, "\u{2022} ");
+        } else {
+            panic!("expected Text at index 0");
+        }
+        // original item's x_offset shifted by marker_width (12)
+        if let LineItem::Text(r) = &line.items[1] {
+            assert!(
+                (r.x_offset - 17.0).abs() < 0.01,
+                "x_offset should be 5+12=17, got {}",
+                r.x_offset
+            );
+        } else {
+            panic!("expected Text at index 1");
+        }
+    }
+
+    #[test]
+    fn inject_image_marker_shifts_existing_items_by_image_width() {
+        let existing = LineItem::Text(text_run(12.0, 3.0, "A"));
+        let para = paragraph_with_items(vec![existing]);
+        let mut children = vec![in_flow(Box::new(para))];
+
+        let img = InlineImage {
+            data: dummy_arc(),
+            format: ImageFormat::Png,
+            width: 20.0,
+            height: 10.0,
+            x_offset: 0.0,
+            vertical_align: VerticalAlign::Baseline,
+            opacity: 1.0,
+            visible: true,
+            computed_y: 0.0,
+            link: None,
+        };
+        let result = inject_inside_marker_item_into_children(&mut children, LineItem::Image(img));
+        assert!(result);
+
+        let para = children[0]
+            .child
+            .as_any()
+            .downcast_ref::<ParagraphPageable>()
+            .unwrap();
+        // original Text item shifted by img.width = 20
+        if let LineItem::Text(r) = &para.lines[0].items[1] {
+            assert!(
+                (r.x_offset - 23.0).abs() < 0.01,
+                "x_offset should be 3+20=23, got {}",
+                r.x_offset
+            );
+        } else {
+            panic!("expected Text at index 1");
+        }
+    }
+
+    #[test]
+    fn inject_inline_box_marker_shifts_by_box_width() {
+        let existing = LineItem::Text(text_run(12.0, 0.0, "Z"));
+        let para = paragraph_with_items(vec![existing]);
+        let mut children = vec![in_flow(Box::new(para))];
+
+        let ib = InlineBoxItem {
+            content: Box::new(SpacerPageable::new(0.0)),
+            width: 15.0,
+            height: 12.0,
+            x_offset: 0.0,
+            computed_y: 0.0,
+            link: None,
+            opacity: 1.0,
+            visible: true,
+        };
+        let result =
+            inject_inside_marker_item_into_children(&mut children, LineItem::InlineBox(ib));
+        assert!(result);
+
+        let para = children[0]
+            .child
+            .as_any()
+            .downcast_ref::<ParagraphPageable>()
+            .unwrap();
+        if let LineItem::Text(r) = &para.lines[0].items[1] {
+            assert!(
+                (r.x_offset - 15.0).abs() < 0.01,
+                "x_offset should be 0+15=15, got {}",
+                r.x_offset
+            );
+        } else {
+            panic!("expected Text at index 1");
+        }
+    }
+
+    #[test]
+    fn inject_text_marker_into_empty_paragraph_creates_line() {
+        let para = ParagraphPageable::new(vec![]);
+        let mut children = vec![in_flow(Box::new(para))];
+
+        let run = text_run(10.0, 0.0, "•");
+        let result = inject_inside_marker_item_into_children(&mut children, LineItem::Text(run));
+        assert!(result);
+
+        let para = children[0]
+            .child
+            .as_any()
+            .downcast_ref::<ParagraphPageable>()
+            .unwrap();
+        assert_eq!(
+            para.lines.len(),
+            1,
+            "a line should be created for the marker"
+        );
+        assert_eq!(para.lines[0].items.len(), 1);
+        // line_height = font_size × DEFAULT_LINE_HEIGHT_RATIO = 10 × 1.2 = 12
+        assert!((para.lines[0].height - 12.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn inject_image_marker_into_empty_paragraph_uses_image_height() {
+        let para = ParagraphPageable::new(vec![]);
+        let mut children = vec![in_flow(Box::new(para))];
+
+        let img = InlineImage {
+            data: dummy_arc(),
+            format: ImageFormat::Png,
+            width: 8.0,
+            height: 18.0,
+            x_offset: 0.0,
+            vertical_align: VerticalAlign::Baseline,
+            opacity: 1.0,
+            visible: true,
+            computed_y: 0.0,
+            link: None,
+        };
+        let result = inject_inside_marker_item_into_children(&mut children, LineItem::Image(img));
+        assert!(result);
+
+        let para = children[0]
+            .child
+            .as_any()
+            .downcast_ref::<ParagraphPageable>()
+            .unwrap();
+        assert_eq!(para.lines.len(), 1);
+        assert!(
+            (para.lines[0].height - 18.0).abs() < 0.01,
+            "line height should match image height"
+        );
+    }
+
+    #[test]
+    fn inject_paragraph_nested_in_block_succeeds() {
+        let para = paragraph_with_items(vec![LineItem::Text(text_run(12.0, 0.0, "Hi"))]);
+        let block = BlockPageable::new(vec![Box::new(para)]);
+        let mut children = vec![in_flow(Box::new(block))];
+
+        let marker = LineItem::Text(text_run(12.0, 0.0, "•"));
+        assert!(inject_inside_marker_item_into_children(
+            &mut children,
+            marker
+        ));
+
+        // Verify the block child was replaced and contains the updated paragraph
+        let block = children[0]
+            .child
+            .as_any()
+            .downcast_ref::<BlockPageable>()
+            .unwrap();
+        let para = block.children[0]
+            .child
+            .as_any()
+            .downcast_ref::<ParagraphPageable>()
+            .unwrap();
+        assert_eq!(para.lines[0].items.len(), 2, "marker + original item");
+    }
+
+    // ─── shape_marker_with_skrifa ──────────────────────────────────────────────
+
+    #[test]
+    fn shape_marker_invalid_font_bytes_returns_none() {
+        let bad_font = Arc::new(b"not a font".to_vec());
+        assert!(
+            shape_marker_with_skrifa(
+                &Marker::Char('\u{2022}'),
+                &bad_font,
+                0,
+                12.0,
+                [0, 0, 0, 255]
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn shape_marker_char_appends_trailing_space() {
+        let font_data = noto_sans_bytes();
+        let run = shape_marker_with_skrifa(&Marker::Char('A'), &font_data, 0, 12.0, [0, 0, 0, 255])
+            .expect("valid font should succeed");
+        // Marker::Char appends a space → "A "
+        assert_eq!(run.text, "A ");
+        assert_eq!(run.glyphs.len(), 2, "two chars → two glyphs");
+        // glyph advances normalised by font_size
+        for g in &run.glyphs {
+            assert!(g.x_advance >= 0.0, "x_advance must be non-negative");
+        }
+        assert_eq!(run.font_size, 12.0);
+        assert_eq!(run.color, [0, 0, 0, 255]);
+        assert_eq!(run.x_offset, 0.0);
+    }
+
+    #[test]
+    fn shape_marker_string_uses_text_verbatim() {
+        let font_data = noto_sans_bytes();
+        let run = shape_marker_with_skrifa(
+            &Marker::String("1. ".to_string()),
+            &font_data,
+            0,
+            10.0,
+            [255, 0, 0, 255],
+        )
+        .expect("valid font should succeed");
+        // Marker::String → text unchanged, no extra space
+        assert_eq!(run.text, "1. ");
+        assert_eq!(run.glyphs.len(), 3, "'1', '.', ' ' → three glyphs");
+        assert_eq!(run.color, [255, 0, 0, 255]);
+        assert_eq!(run.font_size, 10.0);
+    }
+
+    #[test]
+    fn shape_marker_glyph_byte_offsets_cover_text() {
+        let font_data = noto_sans_bytes();
+        let run = shape_marker_with_skrifa(&Marker::Char('A'), &font_data, 0, 12.0, [0, 0, 0, 255])
+            .unwrap();
+        // text_range of last glyph should end at text.len()
+        let last = run.glyphs.last().unwrap();
+        assert_eq!(last.text_range.end, run.text.len());
+    }
+
+    // ─── find_marker_font ──────────────────────────────────────────────────────
+
+    #[test]
+    fn find_marker_font_no_assets_no_children_returns_none() {
+        assert!(find_marker_font(&Marker::Char('\u{2022}'), None, &[]).is_none());
+    }
+
+    #[test]
+    fn find_marker_font_from_paragraph_child() {
+        let font_data = noto_sans_bytes();
+        let run = ShapedGlyphRun {
+            font_data: Arc::clone(&font_data),
+            font_index: 0,
+            font_size: 12.0,
+            color: [0, 0, 0, 255],
+            decoration: TextDecoration::default(),
+            glyphs: vec![],
+            text: "A".to_string(),
+            x_offset: 0.0,
+            link: None,
+        };
+        let para = paragraph_with_items(vec![LineItem::Text(run)]);
+        let children = vec![in_flow(Box::new(para))];
+
+        let result = find_marker_font(&Marker::Char('A'), None, &children);
+        assert!(result.is_some(), "should find font that covers 'A'");
+        let (found, idx) = result.unwrap();
+        assert_eq!(idx, 0);
+        assert_eq!(found.len(), font_data.len());
+    }
+
+    #[test]
+    fn find_marker_font_from_block_wrapping_paragraph() {
+        let font_data = noto_sans_bytes();
+        let run = ShapedGlyphRun {
+            font_data: Arc::clone(&font_data),
+            font_index: 0,
+            font_size: 12.0,
+            color: [0, 0, 0, 255],
+            decoration: TextDecoration::default(),
+            glyphs: vec![],
+            text: "B".to_string(),
+            x_offset: 0.0,
+            link: None,
+        };
+        let para = paragraph_with_items(vec![LineItem::Text(run)]);
+        let block = BlockPageable::new(vec![Box::new(para)]);
+        let children = vec![in_flow(Box::new(block))];
+
+        let result = find_marker_font(&Marker::Char('B'), None, &children);
+        assert!(
+            result.is_some(),
+            "should find font recursively through BlockPageable"
+        );
+    }
+
+    #[test]
+    fn find_marker_font_invalid_font_bytes_skipped() {
+        // A ShapedGlyphRun with bytes that skrifa cannot parse → skipped, returns None.
+        let run = ShapedGlyphRun {
+            font_data: Arc::new(b"garbage".to_vec()),
+            font_index: 0,
+            font_size: 12.0,
+            color: [0, 0, 0, 255],
+            decoration: TextDecoration::default(),
+            glyphs: vec![],
+            text: "X".to_string(),
+            x_offset: 0.0,
+            link: None,
+        };
+        let para = paragraph_with_items(vec![LineItem::Text(run)]);
+        let children = vec![in_flow(Box::new(para))];
+        assert!(find_marker_font(&Marker::Char('X'), None, &children).is_none());
+    }
+}

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -460,6 +460,7 @@ impl EngineBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pageable::{BlockPageable, SpacerPageable};
 
     #[test]
     fn builder_bookmarks_defaults_to_false() {
@@ -510,5 +511,134 @@ mod tests {
             .build();
         let result = engine.render();
         assert!(result.is_ok());
+    }
+
+    // ── Builder: config fields and override flags ──────────────────────────
+
+    #[test]
+    fn builder_page_size_stores_size_and_sets_override() {
+        let engine = Engine::builder().page_size(PageSize::LETTER).build();
+        let config = engine.config();
+        assert!((config.page_size.width - 612.0).abs() < 0.01);
+        assert!((config.page_size.height - 792.0).abs() < 0.01);
+        assert!(config.overrides.page_size);
+    }
+
+    #[test]
+    fn builder_margin_stores_margin_and_sets_override() {
+        let engine = Engine::builder().margin(Margin::uniform(36.0)).build();
+        let config = engine.config();
+        assert_eq!(config.margin, Margin::uniform(36.0));
+        assert!(config.overrides.margin);
+    }
+
+    #[test]
+    fn builder_landscape_stores_flag_and_sets_override() {
+        let engine = Engine::builder().landscape(true).build();
+        let config = engine.config();
+        assert!(config.landscape);
+        assert!(config.overrides.landscape);
+    }
+
+    // ── Builder: metadata fields ───────────────────────────────────────────
+
+    #[test]
+    fn builder_author_appends_each_call() {
+        // author() pushes rather than overwrites — verify both entries land.
+        let engine = Engine::builder().author("Alice").author("Bob").build();
+        let authors = &engine.config().authors;
+        assert_eq!(authors, &["Alice", "Bob"]);
+    }
+
+    #[test]
+    fn builder_authors_extends_from_iterator() {
+        let engine = Engine::builder().authors(["Alice", "Bob", "Carol"]).build();
+        assert_eq!(
+            engine.config().authors,
+            vec!["Alice".to_string(), "Bob".to_string(), "Carol".to_string()]
+        );
+    }
+
+    #[test]
+    fn builder_keywords_extends_from_iterator() {
+        let engine = Engine::builder().keywords(["pdf", "html", "css"]).build();
+        assert_eq!(
+            engine.config().keywords,
+            vec!["pdf".to_string(), "html".to_string(), "css".to_string()]
+        );
+    }
+
+    #[test]
+    fn builder_metadata_fields_round_trip() {
+        let engine = Engine::builder()
+            .title("My Report")
+            .lang("en-US")
+            .description("A test document")
+            .creator("Test Suite")
+            .producer("fulgur-test")
+            .creation_date("2026-05-01")
+            .build();
+        let cfg = engine.config();
+        assert_eq!(cfg.title.as_deref(), Some("My Report"));
+        assert_eq!(cfg.lang.as_deref(), Some("en-US"));
+        assert_eq!(cfg.description.as_deref(), Some("A test document"));
+        assert_eq!(cfg.creator.as_deref(), Some("Test Suite"));
+        assert_eq!(cfg.producer.as_deref(), Some("fulgur-test"));
+        assert_eq!(cfg.creation_date.as_deref(), Some("2026-05-01"));
+    }
+
+    // ── Builder: assets getter ─────────────────────────────────────────────
+
+    #[test]
+    fn engine_assets_is_none_without_bundle() {
+        let engine = Engine::builder().build();
+        assert!(engine.assets().is_none());
+    }
+
+    #[test]
+    fn engine_assets_is_some_after_bundle_set() {
+        let mut bundle = AssetBundle::default();
+        bundle.add_css("body { color: red; }");
+        let engine = Engine::builder().assets(bundle).build();
+        assert!(engine.assets().is_some());
+    }
+
+    // ── Render methods ─────────────────────────────────────────────────────
+
+    fn make_spacer_tree() -> Box<dyn Pageable> {
+        let mut s = SpacerPageable::new(100.0);
+        s.wrap(100.0, 1000.0);
+        Box::new(BlockPageable::new(vec![Box::new(s)]))
+    }
+
+    #[test]
+    fn render_pageable_returns_valid_pdf() {
+        let engine = Engine::builder().build();
+        let pdf = engine.render_pageable(make_spacer_tree()).unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn render_html_to_file_writes_valid_pdf() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.pdf");
+        Engine::builder()
+            .build()
+            .render_html_to_file("<html><body><p>test</p></body></html>", &path)
+            .unwrap();
+        let bytes = std::fs::read(&path).unwrap();
+        assert!(bytes.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn render_pageable_to_file_writes_valid_pdf() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.pdf");
+        Engine::builder()
+            .build()
+            .render_pageable_to_file(make_spacer_tree(), &path)
+            .unwrap();
+        let bytes = std::fs::read(&path).unwrap();
+        assert!(bytes.starts_with(b"%PDF"));
     }
 }

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -553,7 +553,6 @@ impl EngineBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pageable::{BlockPageable, SpacerPageable};
 
     #[test]
     fn builder_bookmarks_defaults_to_false() {
@@ -698,19 +697,6 @@ mod tests {
 
     // ── Render methods ─────────────────────────────────────────────────────
 
-    fn make_spacer_tree() -> Box<dyn Pageable> {
-        let mut s = SpacerPageable::new(100.0);
-        s.wrap(100.0, 1000.0);
-        Box::new(BlockPageable::new(vec![Box::new(s)]))
-    }
-
-    #[test]
-    fn render_pageable_returns_valid_pdf() {
-        let engine = Engine::builder().build();
-        let pdf = engine.render_pageable(make_spacer_tree()).unwrap();
-        assert!(pdf.starts_with(b"%PDF"));
-    }
-
     #[test]
     fn render_html_to_file_writes_valid_pdf() {
         let dir = tempfile::tempdir().unwrap();
@@ -718,18 +704,6 @@ mod tests {
         Engine::builder()
             .build()
             .render_html_to_file("<html><body><p>test</p></body></html>", &path)
-            .unwrap();
-        let bytes = std::fs::read(&path).unwrap();
-        assert!(bytes.starts_with(b"%PDF"));
-    }
-
-    #[test]
-    fn render_pageable_to_file_writes_valid_pdf() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("out.pdf");
-        Engine::builder()
-            .build()
-            .render_pageable_to_file(make_spacer_tree(), &path)
             .unwrap();
         let bytes = std::fs::read(&path).unwrap();
         assert!(bytes.starts_with(b"%PDF"));


### PR DESCRIPTION
## 概要

`feat/pageable-replacement` (= PR #290) の CI が壊れていた **semantic merge conflict** を解消する。

PR #290 の CI 上で `cargo clippy --workspace --all-targets -- -D warnings` および `cargo build --tests` が以下の 3 件で fail していた:

\`\`\`text
error[E0599]: no method named \`wrap\` found for struct \`pageable::SpacerPageable\`
error[E0599]: no method named \`render_pageable\` found for struct \`engine::Engine\`
error[E0599]: no method named \`render_pageable_to_file\` found for struct \`engine::Engine\`
\`\`\`

## 根本原因

\`pull_request\` イベントの \`actions/checkout\` は head branch の HEAD ではなく **merge preview commit** (head と base の一時マージ) を取る。

- \`main\` (commit \`6df89fc\`) で \`make_spacer_tree\` / \`render_pageable_returns_valid_pdf\` / \`render_pageable_to_file_writes_valid_pdf\` が追加された。これらは \`Engine::render_pageable*\` と \`Pageable::wrap\` を呼ぶ
- \`feat/pageable-replacement\` 側で PR 8a (commit \`61dc3cb\`) が \`Engine::render_pageable*\` を削除、PR 8b (commit \`a619e7e\`) が \`Pageable::wrap\` 削除
- 純粋な \`feat/pageable-replacement\` HEAD では存在しない caller が、\`main\` を merge した preview には残っていた

## 修正内容

1. \`origin/main\` を \`feat/pageable-replacement\` ベースの本ブランチにマージ
2. \`crates/fulgur/src/engine.rs\` の test mod から削除済 API を呼ぶ 3 関数を削除
   - \`make_spacer_tree\`
   - \`render_pageable_returns_valid_pdf\`
   - \`render_pageable_to_file_writes_valid_pdf\`
3. 不要になった \`use crate::pageable::{BlockPageable, SpacerPageable}\` を削除

\`render_html_to_file_writes_valid_pdf\` は API が残っているため保持。

## Test plan

- [x] \`cargo build -p fulgur --tests\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test -p fulgur --lib\` 837 pass / 0 failed
- [x] \`FONTCONFIG_FILE=...\` \`cargo test -p fulgur-vrt\` pass
- [ ] CI green (PR #290 の CI が回復することの確認も含む)