### PR TITLE
refactor(phase4 pr8j-1): decouple Pageable trait + rename to Render

### DIFF
--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -709,7 +709,7 @@ pub fn extract_inline_svg_tree(
 /// into a child image node — the match arm in
 /// `blitz-dom/src/layout/construct.rs` for non-`String` ContentItem variants is
 /// a TODO. fulgur bypasses that by reading the stylo computed value directly
-/// and constructing an `ImagePageable` itself (see `convert::build_pseudo_image`
+/// and constructing an `ImageRender` itself (see `convert::build_pseudo_image`
 /// and the normal-element `content: url()` path in `convert::convert_node_inner`).
 ///
 /// Scope: only single-item content is matched (per the fulgur-ai3 design scope

--- a/crates/fulgur/src/convert/block.rs
+++ b/crates/fulgur/src/convert/block.rs
@@ -4,7 +4,7 @@ use super::{positioned, pseudo};
 /// Catch-all dispatch for nodes not matched by list_item / table / replaced /
 /// inline_root. Inserts a `BlockEntry` into `out.block_styles` (and walks
 /// children recursively into `out`) — a leaf with no visual style and no
-/// pseudo content registers nothing, matching the v1 `SpacerPageable`
+/// pseudo content registers nothing, matching the v1 zero-height spacer
 /// behaviour where the dispatcher had no per-NodeId payload to record.
 pub(super) fn convert(
     doc: &BaseDocument,

--- a/crates/fulgur/src/convert/inline_root.rs
+++ b/crates/fulgur/src/convert/inline_root.rs
@@ -1,6 +1,6 @@
 use super::*;
 use super::{list_marker, positioned, pseudo};
-use crate::paragraph::{InlineBoxItem, InlineBoxPlaceholder, ParagraphPageable};
+use crate::paragraph::{InlineBoxItem, InlineBoxPlaceholder, ParagraphRender};
 
 /// Dispatcher entry for inline-root nodes (those with `node.flags.is_inline_root()`).
 ///
@@ -431,10 +431,10 @@ fn convert_inline_box_node(
     }
 }
 
-/// Extract a `ParagraphPageable` from an inline root node. The caller
+/// Extract a `ParagraphRender` from an inline root node. The caller
 /// (`try_convert` above, or `list_item::build_list_item_body`) consumes
 /// the returned paragraph and inserts a `ParagraphEntry` into `out`. We
-/// keep returning `Option<ParagraphPageable>` instead of writing into `out`
+/// keep returning `Option<ParagraphRender>` instead of writing into `out`
 /// here so callers can inject pseudo images / list markers BEFORE
 /// committing the entry — the pre-PR-8i interface in that respect.
 ///
@@ -449,7 +449,7 @@ pub(super) fn extract_paragraph(
     ctx: &mut ConvertContext<'_>,
     depth: usize,
     out: &mut crate::drawables::Drawables,
-) -> Option<ParagraphPageable> {
+) -> Option<ParagraphRender> {
     let elem_data = node.element_data()?;
     let text_layout = elem_data.inline_layout_data.as_ref()?;
 
@@ -580,5 +580,5 @@ pub(super) fn extract_paragraph(
         return None;
     }
 
-    Some(ParagraphPageable::new(shaped_lines).with_id(extract_block_id(node)))
+    Some(ParagraphRender::new(shaped_lines).with_id(extract_block_id(node)))
 }

--- a/crates/fulgur/src/convert/inline_root.rs
+++ b/crates/fulgur/src/convert/inline_root.rs
@@ -1,7 +1,6 @@
 use super::*;
 use super::{list_marker, positioned, pseudo};
-use crate::pageable::SpacerPageable;
-use crate::paragraph::{InlineBoxItem, ParagraphPageable};
+use crate::paragraph::{InlineBoxItem, InlineBoxPlaceholder, ParagraphPageable};
 
 /// Dispatcher entry for inline-root nodes (those with `node.flags.is_inline_root()`).
 ///
@@ -313,13 +312,12 @@ pub(super) fn resolve_enclosing_anchor(
 /// available, in which case the caller falls back to the bottom margin
 /// edge (zero `baseline_shift`).
 ///
-/// Drawables-aware replacement for `paragraph::inline_box_baseline_offset`,
-/// which walked the v1 `Box<dyn Pageable>` tree via downcasting. After
-/// PR 8i, inline-box content is a `SpacerPageable` placeholder so the
-/// trait walk returns `None` for every inline-block. Read the baseline
-/// from `out.paragraphs[node_id]` (the inline-root case) or recurse into
-/// the node's Taffy children (flex / grid / ordinary block) to find the
-/// last in-flow descendant that contributes a baseline.
+/// Drawables-aware baseline lookup. Inline-box content is represented by an
+/// `InlineBoxPlaceholder` carrying only `node_id`, so there is
+/// no trait tree to walk. Read the baseline from `out.paragraphs[node_id]`
+/// (the inline-root case) or recurse into the node's Taffy children
+/// (flex / grid / ordinary block) to find the last in-flow descendant that
+/// contributes a baseline.
 ///
 /// Returns `None` when:
 /// - the inline-block has `overflow: clip|hidden|scroll|auto` (the spec
@@ -395,41 +393,42 @@ fn pageable_last_baseline_from_drawables(
 
 /// Recursively convert the Blitz node referenced by a Parley `InlineBox.id`.
 ///
-/// Returns a placeholder `Pageable` content (a zero-height `SpacerPageable`)
-/// for the `LineItem::InlineBox.content` slot — that field still has the v1
-/// `Box<dyn Pageable>` shape, but PR 8g routes inline-box rendering through
-/// the v2 dispatcher (`dispatch_inline_box_content` keyed by content node
-/// id) so the placeholder content is never actually drawn through the v1
-/// `Pageable::draw` path. The side-effect call to `convert_node` registers
-/// the inline-box subtree into `out` so the v2 dispatcher can find it.
+/// Returns an `InlineBoxPlaceholder` carrying the content `node_id` for the
+/// `LineItem::InlineBox.placeholder` slot. PR 8g/8i routes inline-box
+/// rendering through the v2 dispatcher (`dispatch_inline_box_content` keyed
+/// by content node id), so the placeholder is geometry-only — there is no
+/// trait object to draw through. The side-effect call to `convert_node`
+/// registers the inline-box subtree into `out` so the v2 dispatcher can
+/// find it.
 ///
-/// The placeholder MUST carry `node_id` via `with_node_id(Some(node_id))`
-/// because `paragraph::draw_shaped_lines` reads `ib.content.node_id()` to
-/// look up the content's geometry / drawables entry and dispatch it through
+/// The placeholder MUST carry `node_id` because
+/// `paragraph::draw_shaped_lines` reads `ib.placeholder.node_id` to look up
+/// the content's geometry / drawables entry and dispatch it through
 /// `render::dispatch_inline_box_content`. Without it, every inline-block
 /// (and inline `<svg>` / `<img>`) silently disappears from the PDF.
-/// (Phase 4 PR 8i regression — was returned by `convert_node` in PR 8g.)
 fn convert_inline_box_node(
     doc: &BaseDocument,
     node_id: usize,
     ctx: &mut ConvertContext<'_>,
     depth: usize,
     out: &mut crate::drawables::Drawables,
-) -> crate::paragraph::InlineBoxContent {
+) -> crate::paragraph::InlineBoxPlaceholder {
     // Suppress the rendering path for absolutely-positioned pseudos that
     // Blitz routes through Parley's inline layout — they are re-emitted by
     // `walk_absolute_pseudo_children` at the CSS-correct position. Letting
     // them register here would double-paint via the inline-box dispatch.
     // The placeholder intentionally has no `node_id` so
-    // `paragraph::draw_shaped_lines`'s `ib.content.node_id()` returns
-    // `None` and the inline-box dispatch is skipped.
+    // `paragraph::draw_shaped_lines`'s `ib.placeholder.node_id` is `None`
+    // and the inline-box dispatch is skipped.
     if let Some(node) = doc.get_node(node_id) {
         if positioned::is_absolutely_positioned(node) && is_pseudo_node(doc, node) {
-            return Box::new(SpacerPageable::new(0.0));
+            return InlineBoxPlaceholder { node_id: None };
         }
     }
     convert_node(doc, node_id, ctx, depth + 1, out);
-    Box::new(SpacerPageable::new(0.0).with_node_id(Some(node_id)))
+    InlineBoxPlaceholder {
+        node_id: Some(node_id),
+    }
 }
 
 /// Extract a `ParagraphPageable` from an inline root node. The caller
@@ -540,11 +539,8 @@ pub(super) fn extract_paragraph(
 
                     let link = ctx.link_cache.lookup(doc, node_id);
                     let height_pt = px_to_pt(positioned.height);
-                    // PR 8i: read baseline from `out` (Drawables) — `content`
-                    // is now a `SpacerPageable` placeholder, so the v1
-                    // `inline_box_baseline_offset(content)` walk through
-                    // BlockPageable / ParagraphPageable trees no longer
-                    // works. The Drawables-aware lookup queries
+                    // PR 8i: read baseline from `out` (Drawables). The
+                    // placeholder carries `node_id` only; the lookup queries
                     // `out.paragraphs[node_id]` (and `block_styles[node_id]`
                     // for top-inset) directly.
                     let baseline_shift =
@@ -558,7 +554,7 @@ pub(super) fn extract_paragraph(
                         .map(|(_, v)| v)
                         .unwrap_or(true);
                     items.push(LineItem::InlineBox(InlineBoxItem {
-                        content,
+                        placeholder: content,
                         width: px_to_pt(positioned.width),
                         height: height_pt,
                         x_offset: px_to_pt(positioned.x),

--- a/crates/fulgur/src/convert/list_marker.rs
+++ b/crates/fulgur/src/convert/list_marker.rs
@@ -34,7 +34,7 @@ fn size_raster_marker(
     format: crate::image::ImageFormat,
     line_height: f32,
 ) -> Option<(f32, f32)> {
-    let (iw, ih) = ImagePageable::decode_dimensions(data, format)?;
+    let (iw, ih) = ImageRender::decode_dimensions(data, format)?;
     let intrinsic_w = px_to_pt(iw as f32);
     let intrinsic_h = px_to_pt(ih as f32);
     Some(crate::pageable::clamp_marker_size(

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -14,7 +14,7 @@ use crate::blitz_adapter::{BaseDocument, Node, NodeData};
 use crate::drawables::{ImageMarker, ListItemMarker};
 use crate::gcpm::CounterOp;
 use crate::gcpm::running::RunningElementStore;
-use crate::image::ImagePageable;
+use crate::image::ImageRender;
 use crate::pageable::{BlockStyle, Size};
 use crate::paragraph::{
     InlineImage, LineFontMetrics, LineItem, LinkSpan, LinkTarget, ShapedGlyph, ShapedGlyphRun,

--- a/crates/fulgur/src/convert/pseudo.rs
+++ b/crates/fulgur/src/convert/pseudo.rs
@@ -18,7 +18,7 @@ pub(super) fn build_pseudo_image_entry(
     let raw_url = crate::blitz_adapter::extract_content_image_url(pseudo_node)?;
     let asset_name = extract_asset_name(&raw_url);
     let data = Arc::clone(assets.get_image(asset_name)?);
-    let format = ImagePageable::detect_format(&data)?;
+    let format = ImageRender::detect_format(&data)?;
 
     let styles = pseudo_node.primary_styles()?;
     let css_w = resolve_pseudo_size(&styles.clone_width(), parent_content_width);
@@ -160,7 +160,7 @@ pub(super) fn build_inline_pseudo_image(
     let raw_url = crate::blitz_adapter::extract_content_image_url(pseudo_node)?;
     let asset_name = extract_asset_name(&raw_url);
     let data = Arc::clone(assets.get_image(asset_name)?);
-    let format = ImagePageable::detect_format(&data)?;
+    let format = ImageRender::detect_format(&data)?;
 
     let styles = pseudo_node.primary_styles()?;
     let css_w = resolve_pseudo_size(&styles.clone_width(), parent_content_width);

--- a/crates/fulgur/src/convert/replaced.rs
+++ b/crates/fulgur/src/convert/replaced.rs
@@ -85,7 +85,7 @@ pub(super) fn resolve_image_dimensions(
     css_w: Option<f32>,
     css_h: Option<f32>,
 ) -> (f32, f32) {
-    let (iw, ih) = ImagePageable::decode_dimensions(data, format).unwrap_or((1, 1));
+    let (iw, ih) = ImageRender::decode_dimensions(data, format).unwrap_or((1, 1));
     let iw = iw as f32;
     let ih = ih as f32;
     let aspect = if ih > 0.0 { iw / ih } else { 1.0 };
@@ -141,7 +141,7 @@ fn convert_content_url(
     let Some(data) = bundle.get_image(asset_name).cloned() else {
         return false;
     };
-    let Some(format) = ImagePageable::detect_format(&data) else {
+    let Some(format) = ImageRender::detect_format(&data) else {
         return false;
     };
 
@@ -177,7 +177,7 @@ fn convert_image(
     let Some(data) = bundle.get_image(src).cloned() else {
         return false;
     };
-    let Some(format) = ImagePageable::detect_format(&data) else {
+    let Some(format) = ImageRender::detect_format(&data) else {
         return false;
     };
 

--- a/crates/fulgur/src/convert/style/background.rs
+++ b/crates/fulgur/src/convert/style/background.rs
@@ -2,7 +2,7 @@
 
 use super::{StyleContext, absolute_to_rgba};
 use crate::convert::{extract_asset_name, px_to_pt};
-use crate::image::ImagePageable;
+use crate::image::ImageRender;
 use crate::pageable::{
     BackgroundLayer, BgBox, BgClip, BgImageContent, BgLengthPercentage, BgRepeat, BgSize,
     BlockStyle,
@@ -51,7 +51,7 @@ pub(super) fn apply_to(style: &mut BlockStyle, ctx: &StyleContext<'_>) {
                     match AssetKind::detect(data) {
                         AssetKind::Raster(format) => {
                             let (iw, ih) =
-                                ImagePageable::decode_dimensions(data, format).unwrap_or((1, 1));
+                                ImageRender::decode_dimensions(data, format).unwrap_or((1, 1));
                             Some((
                                 BgImageContent::Raster {
                                     data: Arc::clone(data),

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -80,7 +80,7 @@ pub struct BlockEntry {
 /// Paragraph draw payload for v2. Holds the shaped lines that
 /// `paragraph::draw_shaped_lines` consumes verbatim — no re-shaping
 /// at render time. Mirrors the per-paragraph fields from
-/// `ParagraphPageable` that survive draw.
+/// `ParagraphRender` that survive draw.
 #[derive(Clone)]
 pub struct ParagraphEntry {
     pub lines: Vec<crate::paragraph::ShapedLine>,
@@ -102,7 +102,7 @@ impl std::fmt::Debug for ParagraphEntry {
     }
 }
 
-/// Image draw payload for v2. Mirrors the fields `ImagePageable` holds.
+/// Image draw payload for v2. Mirrors the fields `ImageRender` holds.
 #[derive(Debug, Clone)]
 pub struct ImageEntry {
     pub image_data: std::sync::Arc<Vec<u8>>,
@@ -113,7 +113,7 @@ pub struct ImageEntry {
     pub visible: bool,
 }
 
-/// SVG draw payload for v2. Mirrors the fields `SvgPageable` holds.
+/// SVG draw payload for v2. Mirrors the fields `SvgRender` holds.
 #[derive(Debug, Clone)]
 pub struct SvgEntry {
     pub tree: std::sync::Arc<usvg::Tree>,

--- a/crates/fulgur/src/image.rs
+++ b/crates/fulgur/src/image.rs
@@ -2,8 +2,6 @@
 
 use std::sync::Arc;
 
-use crate::pageable::{Canvas, Pageable, Pt};
-
 /// Image format detected from data.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ImageFormat {
@@ -166,49 +164,6 @@ impl ImagePageable {
         } else {
             None
         }
-    }
-}
-
-impl Pageable for ImagePageable {
-    fn draw(&self, canvas: &mut Canvas<'_, '_>, x: Pt, y: Pt, _avail_width: Pt, _avail_height: Pt) {
-        use crate::pageable::draw_with_opacity;
-
-        if !self.visible {
-            return;
-        }
-        draw_with_opacity(canvas, self.opacity, |canvas| {
-            let data: krilla::Data = Arc::clone(&self.image_data).into();
-            let image_result = match self.format {
-                ImageFormat::Png => krilla::image::Image::from_png(data, true),
-                ImageFormat::Jpeg => krilla::image::Image::from_jpeg(data, true),
-                ImageFormat::Gif => krilla::image::Image::from_gif(data, true),
-            };
-
-            let Ok(image) = image_result else {
-                return;
-            };
-
-            let Some(size) = krilla::geom::Size::from_wh(self.width, self.height) else {
-                return;
-            };
-
-            let transform = krilla::geom::Transform::from_translate(x, y);
-            canvas.surface.push_transform(&transform);
-            canvas.surface.draw_image(image, size);
-            canvas.surface.pop();
-        });
-    }
-
-    fn clone_box(&self) -> Box<dyn Pageable> {
-        Box::new(self.clone())
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
-    fn node_id(&self) -> Option<usize> {
-        self.node_id
     }
 }
 

--- a/crates/fulgur/src/image.rs
+++ b/crates/fulgur/src/image.rs
@@ -1,4 +1,4 @@
-//! ImagePageable — renders images in PDF via Krilla's Image API.
+//! ImageRender — renders images in PDF via Krilla's Image API.
 
 use std::sync::Arc;
 
@@ -25,9 +25,9 @@ impl ImageFormat {
 /// Classification of an asset's bytes for rendering path selection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AssetKind {
-    /// Raster image (PNG/JPEG/GIF) → renders via `ImagePageable`.
+    /// Raster image (PNG/JPEG/GIF) → renders via `ImageRender`.
     Raster(ImageFormat),
-    /// SVG vector image → renders via `SvgPageable`.
+    /// SVG vector image → renders via `SvgRender`.
     Svg,
     /// Unrecognized / unsupported.
     Unknown,
@@ -38,9 +38,9 @@ impl AssetKind {
     ///
     /// Accepts SVG via the `<svg` element start or `<?xml` prolog, tolerant
     /// of an optional leading UTF-8 BOM and ASCII whitespace. Falls through
-    /// to `ImagePageable::detect_format` for raster magic bytes.
+    /// to `ImageRender::detect_format` for raster magic bytes.
     pub fn detect(data: &[u8]) -> AssetKind {
-        if let Some(format) = ImagePageable::detect_format(data) {
+        if let Some(format) = ImageRender::detect_format(data) {
             return AssetKind::Raster(format);
         }
         let mut slice = data;
@@ -65,7 +65,7 @@ impl AssetKind {
 
 /// An image element that renders an image at its computed size.
 #[derive(Clone)]
-pub struct ImagePageable {
+pub struct ImageRender {
     pub image_data: Arc<Vec<u8>>,
     pub format: ImageFormat,
     pub width: f32,
@@ -77,7 +77,7 @@ pub struct ImagePageable {
     pub node_id: Option<usize>,
 }
 
-impl ImagePageable {
+impl ImageRender {
     pub fn new(data: Arc<Vec<u8>>, format: ImageFormat, width: f32, height: f32) -> Self {
         Self {
             image_data: data,
@@ -187,13 +187,13 @@ mod tests {
 
     #[test]
     fn test_png_dimensions() {
-        let dims = ImagePageable::decode_dimensions(MINIMAL_PNG, ImageFormat::Png);
+        let dims = ImageRender::decode_dimensions(MINIMAL_PNG, ImageFormat::Png);
         assert_eq!(dims, Some((1, 1)));
     }
 
     #[test]
     fn test_gif_dimensions() {
-        let dims = ImagePageable::decode_dimensions(MINIMAL_GIF, ImageFormat::Gif);
+        let dims = ImageRender::decode_dimensions(MINIMAL_GIF, ImageFormat::Gif);
         assert_eq!(dims, Some((1, 1)));
     }
 
@@ -220,13 +220,13 @@ mod tests {
 
     #[test]
     fn test_jpeg_dimensions() {
-        let dims = ImagePageable::decode_dimensions(MINIMAL_JPEG, ImageFormat::Jpeg);
+        let dims = ImageRender::decode_dimensions(MINIMAL_JPEG, ImageFormat::Jpeg);
         assert_eq!(dims, Some((1, 1)));
     }
 
     #[test]
     fn test_truncated_data_returns_none() {
-        let dims = ImagePageable::decode_dimensions(&[0x89, 0x50], ImageFormat::Png);
+        let dims = ImageRender::decode_dimensions(&[0x89, 0x50], ImageFormat::Png);
         assert_eq!(dims, None);
     }
 

--- a/crates/fulgur/src/pageable.rs
+++ b/crates/fulgur/src/pageable.rs
@@ -504,9 +504,9 @@ pub trait Pageable: Send + Sync {
     /// they piggyback on the host element's geometry entry).
     ///
     /// Default `None` for impls that have no DOM correspondence
-    /// (synthetic Pageables built by tests, etc.). Plain types
-    /// (`BlockPageable`, `ParagraphPageable`, `SpacerPageable`,
-    /// `ImagePageable`) override to return their stored `node_id`.
+    /// (synthetic Pageables built by tests, etc.). Concrete plain types
+    /// (`BlockPageable`, `SpacerPageable`) override to return their
+    /// stored `node_id`; wrappers delegate to their inner Pageable.
     fn node_id(&self) -> Option<usize> {
         None
     }

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -631,8 +631,9 @@ impl<'a> PaginationLayoutTree<'a> {
 
             // fulgur-p55h: if the child carries a Parley inline layout,
             // probe its line metrics and split at line boundaries —
-            // mirrors `paragraph::ParagraphPageable::split` (line 945)
-            // but inside the Taffy hook rather than post-conversion.
+            // mirrors the v1 paragraph-pageable split path (removed in
+            // PR 8j-1; see git history) but inside the Taffy hook rather
+            // than post-conversion.
             //
             // fulgur-k0g0: when `break-inside: avoid` is set, fall
             // through to the block path below so the paragraph emits
@@ -649,9 +650,9 @@ impl<'a> PaginationLayoutTree<'a> {
                 // advance the page boundary before calling
                 // `fragment_inline_root`. Mirrors Pageable's
                 // `BlockPageable::split` falling back to `AtIndex`
-                // (split before the child) when
-                // `ParagraphPageable::split` cannot honour widow /
-                // orphan and returns `None`.
+                // (split before the child) when the v1 paragraph-pageable
+                // split path (removed in PR 8j-1) could not honour
+                // widow / orphan and returned `None`.
                 let para_total_h = line_metrics
                     .last()
                     .map(|l| l.1 - line_metrics[0].0)
@@ -1587,10 +1588,10 @@ fn collect_inline_line_metrics(node: &blitz_dom::Node) -> Vec<(f32, f32)> {
 /// at line edges, append one Fragment per page span to the geometry
 /// table, and return the updated `(page_index, cursor_y, fragments_emitted)`.
 ///
-/// Mirrors `paragraph::ParagraphPageable::split` (paragraph.rs:945+):
-/// walk lines, track the first line of the current fragment in
-/// `fragment_start_idx`, and split when the cumulative height in
-/// paragraph-local coords would push the bottom past
+/// Mirrors the v1 paragraph-pageable split path (removed in PR 8j-1;
+/// see git history): walk lines, track the first line of the current
+/// fragment in `fragment_start_idx`, and split when the cumulative
+/// height in paragraph-local coords would push the bottom past
 /// `page_height_px - paragraph_top_in_body`.
 ///
 /// fulgur-s67g Phase 2.1 (widow / orphan): each candidate split point
@@ -1599,11 +1600,12 @@ fn collect_inline_line_metrics(node: &blitz_dom::Node) -> Vec<(f32, f32)> {
 /// When neither holds at the natural overflow point, the split is
 /// skipped — subsequent lines accumulate into the current fragment
 /// (overflow-tolerant) until a valid split is found or the paragraph
-/// ends. This matches the Pageable side: `ParagraphPageable::split`
-/// (paragraph.rs:973-983) returns `None` when widows/orphans cannot
-/// be honoured, which the outer `BlockPageable::split` resolves by
-/// emitting the whole paragraph at the current position (oversized
-/// or pushed to a fresh page by sibling-driven flow).
+/// ends. This matches the v1 Pageable side: the paragraph-pageable
+/// split path (removed in PR 8j-1; see git history) returned `None`
+/// when widows/orphans could not be honoured, which the outer
+/// `BlockPageable::split` resolved by emitting the whole paragraph at
+/// the current position (oversized or pushed to a fresh page by
+/// sibling-driven flow).
 ///
 /// Pageable hard-codes `orphans = widows = 2` via `Pagination::default()`
 /// (`pageable.rs:268-275`). CSS `orphans` / `widows` properties are

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -135,125 +135,24 @@ pub struct InlineImage {
     pub link: Option<Arc<LinkSpan>>,
 }
 
-/// Content of an atomic inline box. Alias for `Box<dyn Pageable>` so wrapper
-/// Pageables (Transform / StringSet / CounterOp / BookmarkMarker /
-/// RunningElement) survive at the inline-box root and their side effects —
-/// CSS transform, named-string capture, counter ops, outline markers,
-/// running-element rehosting — apply when the inline-box is rendered.
-///
-/// `Box<dyn Pageable>` implements `Clone` via `clone_box()` (see
-/// `impl Clone for Box<dyn Pageable>` in `pageable.rs`), so `LineItem`
-/// still derives `Clone` without an explicit `dyn_clone` crate.
-pub type InlineBoxContent = Box<dyn crate::pageable::Pageable>;
-
-/// Returns the offset from `content`'s top edge to the baseline used by CSS
-/// for `vertical-align: baseline`. Returns `None` when no in-flow baseline is
-/// available, in which case the caller should fall back to the bottom margin
-/// edge (CSS 2.1 §10.8.1).
-///
-/// CSS 2.1 §10.8.1 specifies that for an inline-block with `overflow: visible`
-/// and in-flow text, the baseline of the box is the baseline of the last
-/// line box inside. If the box has `overflow != visible`, or has no in-flow
-/// line boxes, the baseline is the bottom margin edge.
-///
-/// PR 8i: production callers now use the Drawables-aware
-/// `convert::inline_root::inline_box_baseline_offset_from_drawables`
-/// because the v1 `Box<dyn Pageable>` content is a `SpacerPageable`
-/// placeholder that the trait-walk can't see through. The original
-/// helpers stay alive as `#[allow(dead_code)]` so the existing
-/// `pageable_last_baseline_walks_through_wrappers` unit test still
-/// runs (it asserts the wrapper-walk semantics on a synthetic
-/// Pageable tree); the v2 unit-test migration lives in PR 8i Task 8.
-#[allow(dead_code)]
-pub(crate) fn inline_box_baseline_offset(content: &dyn crate::pageable::Pageable) -> Option<f32> {
-    // CSS fallback: when the outermost clippable block has overflow clip
-    // set, the inline-box baseline is the bottom margin edge. Returning
-    // `None` here signals that to the caller (convert.rs), which defaults
-    // to zero shift. Wrapper layers are transparent for this check — we
-    // only peek through them to reach the actual Block / Paragraph.
-    if has_outer_overflow_clip(content) {
-        return None;
-    }
-    pageable_last_baseline(content)
-}
-
-/// Peek through wrapper pageables to the outermost Block/Paragraph and ask
-/// whether it has `overflow: clip` (or hidden/scroll/auto). Wrappers
-/// themselves never clip — they only carry markers / transforms.
-#[allow(dead_code)]
-fn has_outer_overflow_clip(p: &dyn crate::pageable::Pageable) -> bool {
-    let any = p.as_any();
-    if let Some(b) = any.downcast_ref::<crate::pageable::BlockPageable>() {
-        return b.style.has_overflow_clip();
-    }
-    if let Some(w) = any.downcast_ref::<crate::pageable::TransformWrapperPageable>() {
-        return has_outer_overflow_clip(w.inner.as_ref());
-    }
-    if let Some(w) = any.downcast_ref::<crate::pageable::BookmarkMarkerWrapperPageable>() {
-        return has_outer_overflow_clip(w.child.as_ref());
-    }
-    if let Some(w) = any.downcast_ref::<crate::pageable::CounterOpWrapperPageable>() {
-        return has_outer_overflow_clip(w.child.as_ref());
-    }
-    if let Some(w) = any.downcast_ref::<crate::pageable::StringSetWrapperPageable>() {
-        return has_outer_overflow_clip(w.child.as_ref());
-    }
-    if let Some(w) = any.downcast_ref::<crate::pageable::RunningElementWrapperPageable>() {
-        return has_outer_overflow_clip(w.child.as_ref());
-    }
-    // Paragraph or any other concrete pageable: no overflow style → no clip.
-    false
-}
-
-/// Recursively find the offset from `p`'s top edge to the last in-flow
-/// baseline inside. Walks through wrapper pageables transparently and
-/// descends into `BlockPageable`'s children. Returns `None` when nothing
-/// paragraph-like is reachable (e.g. a pure image / spacer inline-box).
-///
-/// Note: `TransformWrapperPageable` is walked without reversing its
-/// matrix. For the small rotate/skew transforms common on inline-blocks,
-/// the visual delta is minor; a fully matrix-aware baseline would have
-/// to project the inner baseline back through `self.matrix`, which is
-/// outside this refactor's scope.
-///
-/// Exposed at `pub(crate)` so unit tests can assert the walk directly.
-#[allow(dead_code)]
-pub(crate) fn pageable_last_baseline(p: &dyn crate::pageable::Pageable) -> Option<f32> {
-    let any = p.as_any();
-    if let Some(para) = any.downcast_ref::<ParagraphPageable>() {
-        return para.lines.last().map(|l| l.baseline);
-    }
-    if let Some(block) = any.downcast_ref::<crate::pageable::BlockPageable>() {
-        for pc in block.children.iter().rev() {
-            if let Some(inner_bo) = pageable_last_baseline(pc.child.as_ref()) {
-                return Some(pc.y + inner_bo);
-            }
-        }
-        return None;
-    }
-    if let Some(w) = any.downcast_ref::<crate::pageable::TransformWrapperPageable>() {
-        return pageable_last_baseline(w.inner.as_ref());
-    }
-    if let Some(w) = any.downcast_ref::<crate::pageable::BookmarkMarkerWrapperPageable>() {
-        return pageable_last_baseline(w.child.as_ref());
-    }
-    if let Some(w) = any.downcast_ref::<crate::pageable::CounterOpWrapperPageable>() {
-        return pageable_last_baseline(w.child.as_ref());
-    }
-    if let Some(w) = any.downcast_ref::<crate::pageable::StringSetWrapperPageable>() {
-        return pageable_last_baseline(w.child.as_ref());
-    }
-    if let Some(w) = any.downcast_ref::<crate::pageable::RunningElementWrapperPageable>() {
-        return pageable_last_baseline(w.child.as_ref());
-    }
-    None
+/// Geometry-only stand-in for the inline-box content. The actual draw
+/// path is dispatched via `crate::render::dispatch_inline_box_content`
+/// keyed by `node_id` against `Drawables`/`geometry`. Holding the
+/// content NodeId instead of a `Box<dyn Pageable>` lets the v1
+/// `Pageable` trait disappear from `LineItem` entirely (PR 8j-1).
+#[derive(Clone, Debug)]
+pub struct InlineBoxPlaceholder {
+    /// Content NodeId; `None` when the content is suppressed (e.g.
+    /// absolutely-positioned pseudo re-emitted by
+    /// `walk_absolute_pseudo_children`) so `draw_shaped_lines` skips dispatch.
+    pub node_id: Option<usize>,
 }
 
 /// An atomic inline box (display: inline-block / inline-flex / inline-grid /
 /// inline-table) within a shaped line.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct InlineBoxItem {
-    pub content: InlineBoxContent,
+    pub placeholder: InlineBoxPlaceholder,
     pub width: f32,
     pub height: f32,
     pub x_offset: f32,
@@ -273,62 +172,11 @@ pub struct InlineBoxItem {
 /// A single item in a shaped line: text glyph run, inline image, or an
 /// atomic inline box (display: inline-block / inline-flex / inline-grid /
 /// inline-table).
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum LineItem {
     Text(ShapedGlyphRun),
     Image(InlineImage),
     InlineBox(InlineBoxItem),
-}
-
-// Manual `Debug` for `LineItem`: `BlockPageable` / `ParagraphPageable`
-// (reachable via `InlineBox.content`, now a `Box<dyn Pageable>`) do not
-// themselves implement `Debug`, so the derive can't traverse them. Delegate
-// to the existing Text/Image impls and print a compact variant-only form
-// for InlineBox, labeling the inner pageable by type via `Any` introspection.
-impl std::fmt::Debug for LineItem {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            LineItem::Text(t) => f.debug_tuple("Text").field(t).finish(),
-            LineItem::Image(i) => f.debug_tuple("Image").field(i).finish(),
-            LineItem::InlineBox(ib) => f
-                .debug_struct("InlineBox")
-                .field("width", &ib.width)
-                .field("height", &ib.height)
-                .field("x_offset", &ib.x_offset)
-                .field("computed_y", &ib.computed_y)
-                .field("opacity", &ib.opacity)
-                .field("visible", &ib.visible)
-                .field("link", &ib.link.is_some())
-                .field("content", &inline_box_content_label(ib.content.as_ref()))
-                .finish(),
-        }
-    }
-}
-
-/// Best-effort label for the pageable type hosted inside an
-/// `InlineBoxItem.content`. Used only by the manual `Debug` impl so
-/// `{:?}` output keeps the pre-refactor `Block(..)` / `Paragraph(..)`
-/// wording (tests assert on those substrings) while still covering the
-/// wrapper pageables that now flow through.
-fn inline_box_content_label(p: &dyn crate::pageable::Pageable) -> &'static str {
-    let any = p.as_any();
-    if any.is::<crate::pageable::BlockPageable>() {
-        "Block(..)"
-    } else if any.is::<ParagraphPageable>() {
-        "Paragraph(..)"
-    } else if any.is::<crate::pageable::TransformWrapperPageable>() {
-        "Transform(..)"
-    } else if any.is::<crate::pageable::BookmarkMarkerWrapperPageable>() {
-        "BookmarkMarker(..)"
-    } else if any.is::<crate::pageable::CounterOpWrapperPageable>() {
-        "CounterOp(..)"
-    } else if any.is::<crate::pageable::StringSetWrapperPageable>() {
-        "StringSet(..)"
-    } else if any.is::<crate::pageable::RunningElementWrapperPageable>() {
-        "RunningElement(..)"
-    } else {
-        "Other(..)"
-    }
 }
 
 /// A shaped line of text.
@@ -850,9 +698,9 @@ pub fn draw_shaped_lines(
                     let oy = line_top_abs + ib.computed_y;
 
                     // PR 8g: dispatch via the v2 path under an offset
-                    // transform. `ib.content`'s geometry-recorded position
-                    // (Taffy/Parley body-relative) does not include the
-                    // CSS 2.1 §10.8.1 baseline_shift that `convert/
+                    // transform. `ib.placeholder.node_id`'s geometry-recorded
+                    // position (Taffy/Parley body-relative) does not include
+                    // the CSS 2.1 §10.8.1 baseline_shift that `convert/
                     // inline_root.rs:493` applies at convert time, so the
                     // standard dispatcher would render the content at the
                     // wrong y. Push a translate transform equal to the
@@ -860,7 +708,7 @@ pub fn draw_shaped_lines(
                     // `(ox, oy)` and the dispatcher's `(geo_x_pt, geo_y_pt)`
                     // before invoking `render::dispatch_fragment`.
                     if let Some(ctx) = inline_box_ctx
-                        && let Some(content_id) = ib.content.node_id()
+                        && let Some(content_id) = ib.placeholder.node_id
                         && let Some(content_geom) = ctx.geometry.get(&content_id)
                         && let Some(content_frag) = content_geom
                             .fragments
@@ -911,18 +759,6 @@ pub fn draw_shaped_lines(
                             if let Some(lc) = canvas.link_collector.as_deref_mut() {
                                 lc.pop_transform();
                             }
-                        });
-                    } else {
-                        // No v2 ctx (legacy `Pageable::draw` invocation
-                        // path), or the inline-box content has no
-                        // `node_id` / no geometry entry. Preserve the
-                        // direct trait-method dispatch so test-only
-                        // pageable trees (`render_at_rect` /
-                        // gcpm-pageable callers) keep rendering. PR 8h
-                        // (direct convert) deletes this fallback when
-                        // every caller routes through Drawables.
-                        crate::pageable::draw_with_opacity(canvas, ib.opacity, |canvas| {
-                            ib.content.draw(canvas, ox, oy, ib.width, ib.height);
                         });
                     }
 
@@ -1416,12 +1252,8 @@ mod tests {
 
     #[test]
     fn line_item_inline_box_variant_can_be_constructed() {
-        use crate::pageable::BlockPageable;
-        // BlockPageable::new takes Vec<Box<dyn Pageable>>; an empty vec is
-        // enough for the construction test.
-        let block = BlockPageable::new(Vec::new());
         let item = LineItem::InlineBox(InlineBoxItem {
-            content: Box::new(block) as InlineBoxContent,
+            placeholder: InlineBoxPlaceholder { node_id: Some(42) },
             width: 50.0,
             height: 20.0,
             x_offset: 10.0,
@@ -1434,29 +1266,15 @@ mod tests {
             LineItem::InlineBox(ib) => {
                 assert_eq!(ib.width, 50.0);
                 assert_eq!(ib.height, 20.0);
-                assert!(
-                    ib.content
-                        .as_any()
-                        .downcast_ref::<BlockPageable>()
-                        .is_some()
-                );
+                assert_eq!(ib.placeholder.node_id, Some(42));
             }
             _ => panic!("expected InlineBox variant"),
         }
     }
 
-    // ---------- Manual Debug impl coverage (L230-252) ----------
-
-    /// Covers the manual `Debug` impl for every `LineItem` variant, including
-    /// the `InlineBox` struct fields and the inner `Block(..)` / `Paragraph(..)`
-    /// content branches. The derive can't traverse BlockPageable/Paragraph-
-    /// Pageable because they don't implement Debug, so this path is all
-    /// custom.
     #[test]
     fn line_item_debug_impl_covers_all_variants() {
-        use crate::pageable::BlockPageable;
-
-        // Text variant — delegates to the ShapedGlyphRun derive.
+        // Text variant
         let glyph_run = ShapedGlyphRun {
             font_data: Arc::new(Vec::new()),
             font_index: 0,
@@ -1469,18 +1287,15 @@ mod tests {
             link: None,
         };
         let text = LineItem::Text(glyph_run);
-        let s = format!("{:?}", text);
-        assert!(s.contains("Text"), "{}", s);
+        assert!(format!("{:?}", text).contains("Text"));
 
-        // Image variant — delegates to InlineImage derive.
+        // Image variant
         let img = LineItem::Image(make_inline_image(10.0, 10.0, VerticalAlign::Baseline));
-        let s = format!("{:?}", img);
-        assert!(s.contains("Image"), "{}", s);
+        assert!(format!("{:?}", img).contains("Image"));
 
-        // InlineBox with Block content.
-        let block = BlockPageable::new(Vec::new());
-        let ib_block = LineItem::InlineBox(InlineBoxItem {
-            content: Box::new(block) as InlineBoxContent,
+        // InlineBox variant
+        let ib = LineItem::InlineBox(InlineBoxItem {
+            placeholder: InlineBoxPlaceholder { node_id: Some(7) },
             width: 10.0,
             height: 5.0,
             x_offset: 1.0,
@@ -1489,33 +1304,11 @@ mod tests {
             opacity: 1.0,
             visible: true,
         });
-        let s = format!("{:?}", ib_block);
-        assert!(s.contains("InlineBox"), "{}", s);
-        assert!(s.contains("width: 10.0"), "{}", s);
-        assert!(s.contains("Block(..)"), "{}", s);
-        assert!(s.contains("link: false"), "{}", s);
-
-        // InlineBox with Paragraph content (exercises the Paragraph(..) arm
-        // inside the manual Debug's content label lookup — otherwise never
-        // hit).
-        let para = ParagraphPageable::new(Vec::new());
-        let ib_para = LineItem::InlineBox(InlineBoxItem {
-            content: Box::new(para) as InlineBoxContent,
-            width: 0.0,
-            height: 0.0,
-            x_offset: 0.0,
-            computed_y: 0.0,
-            link: Some(Arc::new(LinkSpan {
-                target: LinkTarget::External(Arc::new("https://x".into())),
-                alt_text: None,
-            })),
-            opacity: 0.5,
-            visible: false,
-        });
-        let s = format!("{:?}", ib_para);
-        assert!(s.contains("Paragraph(..)"), "{}", s);
-        assert!(s.contains("visible: false"), "{}", s);
-        assert!(s.contains("link: true"), "{}", s);
+        let s = format!("{:?}", ib);
+        assert!(s.contains("InlineBox"));
+        assert!(s.contains("placeholder"));
+        assert!(s.contains("node_id"));
+        assert!(s.contains("Some(7)"));
     }
 
     // ---------- recalculate_line_box InlineBox `continue` arms (L815, L847) ----------
@@ -1525,16 +1318,13 @@ mod tests {
     /// reach these branches; this mixed-item test does.
     #[test]
     fn recalculate_line_box_skips_inline_box_items() {
-        use crate::pageable::BlockPageable;
-        let block = BlockPageable::new(Vec::new());
         let mut line = ShapedLine {
             height: 16.0,
             baseline: 12.0,
             items: vec![
-                // Image with Top alignment forces phase 2 to iterate too.
                 LineItem::Image(make_inline_image(10.0, 6.0, VerticalAlign::Top)),
                 LineItem::InlineBox(InlineBoxItem {
-                    content: Box::new(block) as InlineBoxContent,
+                    placeholder: InlineBoxPlaceholder { node_id: None },
                     width: 30.0,
                     height: 20.0,
                     x_offset: 0.0,
@@ -1547,49 +1337,14 @@ mod tests {
         };
         let m = default_metrics();
         recalculate_line_box(&mut line, &m);
-        // InlineBox must still be present unmodified (skipped by both phases).
         assert_eq!(line.items.len(), 2);
         match &line.items[1] {
             LineItem::InlineBox(ib) => {
                 assert_eq!(ib.width, 30.0);
-                // computed_y is line-relative and not touched by
-                // recalculate_line_box — must match the input verbatim.
                 assert!(approx(ib.computed_y, 3.0), "computed_y={}", ib.computed_y);
             }
             _ => panic!("expected InlineBox at index 1"),
         }
-    }
-
-    // ---------- pageable_last_baseline walks wrappers ----------
-
-    /// Verifies that `pageable_last_baseline` walks through wrapper
-    /// pageables (e.g. `BookmarkMarkerWrapperPageable`) to reach the inner
-    /// `ParagraphPageable`'s last-line baseline. This is the core baseline
-    /// guarantee that the `Box<dyn Pageable>` refactor enables: prior to
-    /// this, the helper only accepted `BlockPageable` / `ParagraphPageable`
-    /// directly and silently dropped the baseline when a wrapper got in
-    /// the way.
-    #[test]
-    fn pageable_last_baseline_walks_through_wrappers() {
-        use crate::pageable::{BookmarkMarkerPageable, BookmarkMarkerWrapperPageable};
-
-        // ParagraphPageable with a single line of baseline = 10pt.
-        let para = ParagraphPageable::new(vec![ShapedLine {
-            height: 14.0,
-            baseline: 10.0,
-            items: Vec::new(),
-        }]);
-
-        // Wrap in a bookmark marker (zero-size wrapper).
-        let marker = BookmarkMarkerPageable::new(1, "H".to_string());
-        let wrapped: Box<dyn crate::pageable::Pageable> =
-            Box::new(BookmarkMarkerWrapperPageable::new(marker, Box::new(para)));
-
-        assert_eq!(
-            super::pageable_last_baseline(wrapped.as_ref()),
-            Some(10.0),
-            "pageable_last_baseline must walk through the wrapper to reach the inner paragraph's baseline"
-        );
     }
 }
 

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -1,4 +1,4 @@
-//! ParagraphPageable — renders text via the Parley→Krilla glyph bridge.
+//! ParagraphRender — renders text via the Parley→Krilla glyph bridge.
 
 use std::sync::Arc;
 
@@ -190,7 +190,7 @@ pub struct ShapedLine {
 
 /// Paragraph element that renders shaped text.
 #[derive(Clone)]
-pub struct ParagraphPageable {
+pub struct ParagraphRender {
     pub lines: Vec<ShapedLine>,
     pub cached_height: f32,
     pub opacity: f32,
@@ -205,7 +205,7 @@ pub struct ParagraphPageable {
     pub node_id: Option<usize>,
 }
 
-impl ParagraphPageable {
+impl ParagraphRender {
     pub fn new(lines: Vec<ShapedLine>) -> Self {
         let cached_height: f32 = lines.iter().map(|l| l.height).sum();
         Self {
@@ -540,11 +540,11 @@ fn draw_line_decorations(canvas: &mut Canvas<'_, '_>, items: &[LineItem], x: Pt,
 /// PR 8g: render-side context that lets `draw_shaped_lines` dispatch
 /// inline-box content (`LineItem::InlineBox`) through the v2 dispatcher.
 ///
-/// `None` is passed by:
-/// - The list-item marker text render path (markers contain only Text /
-///   Image items, never InlineBox).
-/// - Trait-method callers that exercise `draw_shaped_lines` outside the
-///   v2 render pipeline (PR 8g deletes these alongside `Pageable::draw`).
+/// `None` is passed by the list-item marker text render paths
+/// (`ListItemPageable::draw` in `pageable.rs` and
+/// `render::draw_list_item_marker`), because marker line streams only
+/// contain Text / Image items — never `LineItem::InlineBox` — and
+/// therefore have no inline-box children to dispatch.
 ///
 /// When `Some`, the InlineBox arm computes the inline-flow position
 /// `(ox, oy)` and dispatches the inline-box content directly at those
@@ -1217,13 +1217,13 @@ mod tests {
 
     #[test]
     fn paragraph_default_has_no_id() {
-        let p = ParagraphPageable::new(Vec::new());
+        let p = ParagraphRender::new(Vec::new());
         assert!(p.id.is_none());
     }
 
     #[test]
     fn paragraph_with_id_stores_value() {
-        let p = ParagraphPageable::new(Vec::new()).with_id(Some(Arc::new("section-1".to_string())));
+        let p = ParagraphRender::new(Vec::new()).with_id(Some(Arc::new("section-1".to_string())));
         assert_eq!(p.id.as_deref().map(String::as_str), Some("section-1"));
     }
 

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use skrifa::MetadataProvider;
 
 use crate::image::ImageFormat;
-use crate::pageable::{Canvas, Pageable, Pt};
+use crate::pageable::{Canvas, Pt};
 
 /// Which decoration lines to draw (bitflags).
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -881,29 +881,6 @@ pub fn recalculate_line_box(line: &mut ShapedLine, metrics: &LineFontMetrics) {
         if let LineItem::Image(img) = &mut line.items[idx] {
             img.computed_y = img_top + shift;
         }
-    }
-}
-
-impl Pageable for ParagraphPageable {
-    fn draw(&self, canvas: &mut Canvas<'_, '_>, x: Pt, y: Pt, _avail_width: Pt, _avail_height: Pt) {
-        if !self.visible {
-            return;
-        }
-        crate::pageable::draw_with_opacity(canvas, self.opacity, |canvas| {
-            draw_shaped_lines(canvas, &self.lines, x, y, None);
-        });
-    }
-
-    fn clone_box(&self) -> Box<dyn Pageable> {
-        Box::new(self.clone())
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
-    fn node_id(&self) -> Option<usize> {
-        self.node_id
     }
 }
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -1926,10 +1926,10 @@ fn build_multicol_stroke(
     Some(stroke)
 }
 
-/// v2 image draw. Mirrors `image::ImagePageable::draw` but operates on
+/// v2 image draw. Mirrors `image::ImageRender::draw` but operates on
 /// the side-channel `ImageEntry` data; the `width`/`height` are the
 /// CSS-resolved size in pt that fulgur stores on the original
-/// `ImagePageable`.
+/// `ImageRender`.
 fn draw_image_v2(
     canvas: &mut crate::pageable::Canvas<'_, '_>,
     entry: &crate::drawables::ImageEntry,
@@ -1980,7 +1980,7 @@ fn decode_image_for_v2(entry: &crate::drawables::ImageEntry) -> Option<krilla::i
     image_result.ok()
 }
 
-/// v2 SVG draw. Mirrors `svg::SvgPageable::draw`.
+/// v2 SVG draw. Mirrors `svg::SvgRender::draw`.
 fn draw_svg_v2(
     canvas: &mut crate::pageable::Canvas<'_, '_>,
     entry: &crate::drawables::SvgEntry,
@@ -2574,7 +2574,7 @@ fn draw_list_item_marker(
     }
 }
 
-/// v2 paragraph draw. Mirrors `paragraph::ParagraphPageable::draw`:
+/// v2 paragraph draw. Mirrors `paragraph::ParagraphRender::draw`:
 /// honour `visible`, wrap with `draw_with_opacity`, then call the
 /// existing `paragraph::draw_shaped_lines` which already handles glyph
 /// runs / inline images / inline boxes / link rect emission /
@@ -2657,7 +2657,7 @@ fn draw_paragraph_inner_paint(
 }
 
 /// Phase 4 PR 3 follow-up (PR #302 Devin): mirror
-/// `ParagraphPageable::slice_for_page` so multi-page paragraphs only
+/// `ParagraphRender::slice_for_page` so multi-page paragraphs only
 /// emit the lines belonging to the requested page.
 ///
 /// `is_split` is the parent `PaginationGeometry::is_split()` —
@@ -2719,7 +2719,7 @@ fn paragraph_lines_for_page(
         .map(|mut line| {
             // Rebase paragraph-absolute coords (baseline + inline
             // image `computed_y`) to fragment-local. Mirror
-            // `ParagraphPageable::slice_for_page` exactly.
+            // `ParagraphRender::slice_for_page` exactly.
             line.baseline -= consumed;
             for item in &mut line.items {
                 if let crate::paragraph::LineItem::Image(img) = item {

--- a/crates/fulgur/src/svg.rs
+++ b/crates/fulgur/src/svg.rs
@@ -1,4 +1,4 @@
-//! SvgPageable — renders inline <svg> elements to PDF as vector graphics
+//! SvgRender — renders inline <svg> elements to PDF as vector graphics
 //! via krilla-svg's SurfaceExt::draw_svg.
 
 use std::sync::Arc;
@@ -7,7 +7,7 @@ use usvg::Tree;
 
 /// An inline `<svg>` element rendered as vector graphics.
 #[derive(Clone)]
-pub struct SvgPageable {
+pub struct SvgRender {
     /// Parsed SVG tree, shared via Arc for cheap cloning during pagination.
     pub tree: Arc<Tree>,
     /// Display width in PDF points — CSS-resolved by Blitz/Taffy, NOT the
@@ -23,7 +23,7 @@ pub struct SvgPageable {
     pub node_id: Option<usize>,
 }
 
-impl SvgPageable {
+impl SvgRender {
     pub fn new(tree: Arc<Tree>, width: f32, height: f32) -> Self {
         Self {
             tree,
@@ -56,13 +56,13 @@ mod tests {
 
     #[test]
     fn test_height_returns_configured_height() {
-        let svg = SvgPageable::new(parse_tree(), 100.0, 50.0);
+        let svg = SvgRender::new(parse_tree(), 100.0, 50.0);
         assert_eq!(svg.height, 50.0);
     }
 
     #[test]
-    fn test_clone_box_shares_tree_via_arc() {
-        let original = SvgPageable::new(parse_tree(), 100.0, 50.0);
+    fn test_clone_shares_tree_via_arc() {
+        let original = SvgRender::new(parse_tree(), 100.0, 50.0);
         let original_ptr = Arc::as_ptr(&original.tree);
         let cloned = original.clone();
         let cloned_ptr = Arc::as_ptr(&cloned.tree);
@@ -74,7 +74,7 @@ mod tests {
 
     #[test]
     fn test_default_opacity_and_visible() {
-        let svg = SvgPageable::new(parse_tree(), 100.0, 50.0);
+        let svg = SvgRender::new(parse_tree(), 100.0, 50.0);
         assert_eq!(svg.opacity, 1.0);
         assert!(svg.visible);
     }

--- a/crates/fulgur/src/svg.rs
+++ b/crates/fulgur/src/svg.rs
@@ -5,8 +5,6 @@ use std::sync::Arc;
 
 use usvg::Tree;
 
-use crate::pageable::{Canvas, Pageable, Pt};
-
 /// An inline `<svg>` element rendered as vector graphics.
 #[derive(Clone)]
 pub struct SvgPageable {
@@ -43,47 +41,9 @@ impl SvgPageable {
     }
 }
 
-impl Pageable for SvgPageable {
-    fn draw(&self, canvas: &mut Canvas<'_, '_>, x: Pt, y: Pt, _avail_width: Pt, _avail_height: Pt) {
-        use crate::pageable::draw_with_opacity;
-        use krilla_svg::{SurfaceExt, SvgSettings};
-
-        if !self.visible {
-            return;
-        }
-        draw_with_opacity(canvas, self.opacity, |canvas| {
-            let Some(size) = krilla::geom::Size::from_wh(self.width, self.height) else {
-                return;
-            };
-            let transform = krilla::geom::Transform::from_translate(x, y);
-            canvas.surface.push_transform(&transform);
-            // draw_svg returns Option<()>; None means the tree was malformed.
-            // We silently skip rather than panic, matching ImagePageable's behavior
-            // when krilla::image::Image::from_* returns Err.
-            let _ = canvas
-                .surface
-                .draw_svg(&self.tree, size, SvgSettings::default());
-            canvas.surface.pop();
-        });
-    }
-
-    fn clone_box(&self) -> Box<dyn Pageable> {
-        Box::new(self.clone())
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
-    fn node_id(&self) -> Option<usize> {
-        self.node_id
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pageable::Canvas;
 
     // Minimal valid SVG: 100x50 red rectangle
     const MINIMAL_SVG: &str = r#"<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50"><rect width="100" height="50" fill="red"/></svg>"#;
@@ -92,27 +52,6 @@ mod tests {
         let opts = usvg::Options::default();
         let tree = Tree::from_str(MINIMAL_SVG, &opts).expect("parse minimal svg");
         Arc::new(tree)
-    }
-
-    /// Draw `svg` onto a freshly-created krilla Document and discard the output.
-    /// Used to exercise `draw()` without asserting on surface state.
-    fn draw_onto_surface(svg: &SvgPageable) {
-        let mut doc = krilla::Document::new();
-        {
-            let settings = krilla::page::PageSettings::from_wh(400.0, 400.0)
-                .expect("400×400 is a valid page size");
-            let mut page = doc.start_page_with(settings);
-            let mut surface = page.surface();
-            {
-                let mut canvas = Canvas {
-                    surface: &mut surface,
-                    bookmark_collector: None,
-                    link_collector: None,
-                };
-                svg.draw(&mut canvas, 10.0, 20.0, 400.0, 400.0);
-            }
-        }
-        let _ = doc.finish();
     }
 
     #[test]
@@ -138,47 +77,5 @@ mod tests {
         let svg = SvgPageable::new(parse_tree(), 100.0, 50.0);
         assert_eq!(svg.opacity, 1.0);
         assert!(svg.visible);
-    }
-
-    #[test]
-    fn test_as_any_downcasts_to_svg_pageable() {
-        let svg = SvgPageable::new(parse_tree(), 100.0, 50.0);
-        assert!(svg.as_any().downcast_ref::<SvgPageable>().is_some());
-    }
-
-    #[test]
-    fn test_draw_visible_does_not_panic() {
-        let svg = SvgPageable::new(parse_tree(), 100.0, 50.0);
-        draw_onto_surface(&svg);
-    }
-
-    #[test]
-    fn test_draw_not_visible_returns_early() {
-        let mut svg = SvgPageable::new(parse_tree(), 100.0, 50.0);
-        svg.visible = false;
-        draw_onto_surface(&svg);
-    }
-
-    #[test]
-    fn test_draw_zero_size_skips_draw() {
-        // Size::from_wh(0.0, …) returns None (NonZeroPositiveF32 rejects zero);
-        // this exercises the `let Some(size) = … else { return; }` branch.
-        let svg = SvgPageable::new(parse_tree(), 0.0, 50.0);
-        draw_onto_surface(&svg);
-    }
-
-    #[test]
-    fn test_draw_partial_opacity() {
-        let mut svg = SvgPageable::new(parse_tree(), 100.0, 50.0);
-        svg.opacity = 0.5;
-        draw_onto_surface(&svg);
-    }
-
-    #[test]
-    fn test_draw_zero_opacity_returns_early() {
-        // draw_with_opacity short-circuits when opacity == 0.0.
-        let mut svg = SvgPageable::new(parse_tree(), 100.0, 50.0);
-        svg.opacity = 0.0;
-        draw_onto_surface(&svg);
     }
 }

--- a/crates/fulgur/tests/link_integration.rs
+++ b/crates/fulgur/tests/link_integration.rs
@@ -138,7 +138,7 @@ fn link_works_through_gcpm_render_path() {
 //      silently dropped. No `LineItem::Image` is produced, no image data is
 //      embedded, the content stream is empty — `/Link` annotations are moot
 //      because there is nothing to click through to.
-//   3. The ImagePageable path in `convert::convert_image` only fires when
+//   3. The ImageRender path in `convert::convert_image` only fires when
 //      `<img>` is visited as its own node (i.e. block-level, such as
 //      `<div><img style="display:block"/></div>` in `image_test.rs`), and
 //      that path currently has no link support either.

--- a/crates/fulgur/tests/opacity_visibility_test.rs
+++ b/crates/fulgur/tests/opacity_visibility_test.rs
@@ -124,7 +124,7 @@ fn test_visibility_hidden_preserves_layout() {
 }
 
 /// Regression test: styled inline root with visibility:hidden must hide text.
-/// Exercises the convert.rs path where a ParagraphPageable is wrapped in a
+/// Exercises the convert.rs path where a ParagraphRender is wrapped in a
 /// BlockPageable for background/border — the inner paragraph must inherit visible.
 #[test]
 fn test_visibility_hidden_styled_inline_root() {

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -520,7 +520,7 @@ fn position_fixed_inside_absolute_relayouts_against_viewport() {
     // element against the abs's narrow box. The %PDF byte check only
     // proves engine completion; the structural assertion is the real
     // regression guard — we walk the Pageable tree, find every
-    // out-of-flow `ParagraphPageable`, and assert the fixed text laid
+    // out-of-flow `ParagraphRender`, and assert the fixed text laid
     // itself out as a single line. Without `relayout_position_fixed`,
     // Parley shapes the long sentence at the abs's ~37.5pt width and
     // produces multiple wrapped lines; with the relayout, the fixed


### PR DESCRIPTION
## サマリ

Phase 4 PR 8j の前段 (PR 8j-1)。`pageable.rs` **外** に残存する v1 `Pageable` trait 依存と旧 `XxxPageable` 命名を全て剥がし、PR 8j-2 (`fulgur-3z6n`) で `pageable.rs` 自体を削除できるよう pageable module を孤立させる。

3 commit 構成 (各 commit 単独で build/test pass):

1. **`542e3cb`** `refactor(paragraph): replace InlineBox.content with geometry-only placeholder`
   - `LineItem::InlineBox.content: Box<dyn Pageable>` → `placeholder: InlineBoxPlaceholder { node_id: Option<usize> }` (NodeId 単一フィールド)
   - dead helper 4 件 (`inline_box_baseline_offset` / `has_outer_overflow_clip` / `pageable_last_baseline` / `inline_box_content_label`) と関連 unit test 削除
   - 手書き `Debug for LineItem` → `#[derive(Debug)]`
   - `draw_shaped_lines` から到達不能な v1 trait fallback (`else { ib.content.draw(...) }`) を削除
   - `convert/inline_root.rs::convert_inline_box_node` 戻り値を `InlineBoxPlaceholder` に変更

2. **`70f6d2a`** `refactor: remove Pageable trait impls from Paragraph/Image/Svg structs`
   - `impl Pageable for {Paragraph,Image,Svg}Pageable` を削除 (production は既に `ParagraphEntry` / `ImageEntry` / `SvgEntry` 経由で `render::draw_*_v2` から描画)
   - svg.rs の trait 依存テスト 6 件 (5× `test_draw_*` + 1× `test_as_any_*`) を削除
   - 不要になった `Pageable` / `Canvas` / `Pt` import を整理

3. **`9171a7c`** `refactor: rename {Paragraph,Image,Svg}Pageable -> {...}Render`
   - workspace 全体で機械的 rename (18 files)
   - svg.rs `test_clone_box_shares_tree_via_arc` → `test_clone_shares_tree_via_arc` (body は derive `Clone`、もはや `clone_box` を呼ばない)
   - `paragraph.rs` の stale doc-comment (`InlineBoxRenderCtx` 前) を current の `None` callers (list-marker draws) を反映する文言に更新
   - `pageable.rs:506-509` の `node_id` default doc / `pagination_layout.rs` 4 箇所の stale `ParagraphRender::split` 言及を refresh
   - `convert/block.rs:7` `v1 SpacerPageable behaviour` → `v1 zero-height spacer behaviour` (acceptance grep cleanliness)

## Acceptance criteria 達成状況

- [x] `pageable.rs` **外** に `impl Pageable for X` ゼロ
- [x] `pageable.rs` **外** に live code としての `Box<dyn Pageable>` / `dyn Pageable` ゼロ (paragraph.rs:141 の doc-comment narrative 1 件は意図的残存 — 設計意図を歴史的文脈で説明)
- [x] `ParagraphPageable` / `ImagePageable` / `SvgPageable` / `InlineBoxContent` 識別子が workspace 全体でゼロ
- [x] `SpacerPageable` は `pageable.rs` 内のみ (PR 8j-2 で削除)
- [x] `cargo test -p fulgur --lib` 754 pass (pre-PR 761 → -7: dead-helper test 1 + svg trait-method test 6)
- [x] `cargo clippy -p fulgur --no-deps -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] **VRT byte-identity 全 fixture pass** (`FONTCONFIG_FILE=examples/.fontconfig/fonts.conf cargo test -p fulgur-vrt`)

## Out of scope (PR 8j-2 = `fulgur-3z6n` に委譲)

- `pageable.rs` ファイル削除
- `Pageable` trait 自体と `Spacer/Block/各 Wrapper` の `impl Pageable` 削除
- `pageable.rs` から primitives (`Canvas`, `Pt`, `BlockStyle` 等) の `draw_primitives.rs` 移動
- `pub mod pageable;` 削除
- 残存する stale doc-comment (`render.rs::draw_*_v2` 上の `Mirrors XxxRender::draw` / `ParagraphRender::slice_for_page` 等) — `pageable.rs` 削除と合わせて整理する方が手戻りが少ない

## Test plan

- [x] `cargo test -p fulgur --lib` (754 pass)
- [x] `cargo clippy -p fulgur --no-deps -- -D warnings`
- [x] `cargo fmt --check`
- [x] `FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur-vrt` (全 PDF fixture byte-match)
- [x] `rg 'impl Pageable for|Box<dyn Pageable>|dyn Pageable' crates/fulgur/src --type rust | grep -v 'src/pageable.rs:'` (live ref ゼロ)
- [x] `rg 'ParagraphPageable|ImagePageable|SvgPageable|InlineBoxContent' crates/` (識別子ゼロ)

## 参照

- beads: `fulgur-x4bo`
- design plan: `docs/plans/2026-05-01-phase4-pr8j-1-pageable-decouple.md`
- 後続: `fulgur-3z6n` (PR 8j-2: `pageable.rs` 全削除)