### PR TITLE
fix(pagination): viewport-CB resolution for body-direct abs/fixed (fulgur-a8m5)

### DIFF
--- a/crates/fulgur-wpt/expectations/css-page.txt
+++ b/crates/fulgur-wpt/expectations/css-page.txt
@@ -30,13 +30,13 @@ SKIP  css/css-page/cssom/page-001.html  # NoMatch
 SKIP  css/css-page/cssom/page-002.html  # NoMatch
 PASS  css/css-page/fixedpos-001-print.html
 PASS  css/css-page/fixedpos-002-print.html
-FAIL  css/css-page/fixedpos-003-print.html  # page count mismatch: test=2 ref=3
+PASS  css/css-page/fixedpos-003-print.html
 FAIL  css/css-page/fixedpos-004-print.html  # page count mismatch: test=2 ref=3
 FAIL  css/css-page/fixedpos-005-print.html  # page count mismatch: test=3 ref=5
 FAIL  css/css-page/fixedpos-006-print.html  # page count mismatch: test=3 ref=5
 FAIL  css/css-page/fixedpos-007-print.html  # page 1 diff: 1765/891662 pixels exceed tol (max_ch=255)
 PASS  css/css-page/fixedpos-008-print.html
-PASS  css/css-page/fixedpos-009-print.html
+FAIL  css/css-page/fixedpos-009-print.html  # fulgur-4m16: regressed by PR #338 viewport-units-content-area (page 1 diff: 1369 px)
 FAIL  css/css-page/fixedpos-010-print.html  # page 1 diff: 10844/160000 pixels exceed tol (max_ch=255)
 FAIL  css/css-page/fixedpos-011-print.html  # page 1 diff: 84920/891662 pixels exceed tol (max_ch=255)
 FAIL  css/css-page/fixedpos-with-abspos-with-link-print.html  # page 1 diff: 2541/891662 pixels exceed tol (max_ch=255)
@@ -100,7 +100,7 @@ FAIL  css/css-page/monolithic-overflow-009-print.html  # page 1 diff: 673864/891
 FAIL  css/css-page/monolithic-overflow-010-print.html  # page 1 diff: 673864/891662 pixels exceed tol (max_ch=255)
 FAIL  css/css-page/monolithic-overflow-011-print.html  # page 1 diff: 673864/891662 pixels exceed tol (max_ch=255)
 PASS  css/css-page/monolithic-overflow-012-print.html
-FAIL  css/css-page/monolithic-overflow-013-print.html  # fulgur-puml: tall abs content does not drive page generation (regressed by fulgur-aijf — was passing for the wrong reason via abs-in-flow)
+PASS  css/css-page/monolithic-overflow-013-print.html
 FAIL  css/css-page/monolithic-overflow-014-print.html  # page 1 diff: 53448/891662 pixels exceed tol (max_ch=180)
 FAIL  css/css-page/monolithic-overflow-015-print.html  # page 1 diff: 53448/891662 pixels exceed tol (max_ch=150)
 FAIL  css/css-page/monolithic-overflow-016-print.html  # page count mismatch: test=1 ref=6
@@ -140,9 +140,9 @@ FAIL  css/css-page/page-box-010-print.html  # page 1 diff: 28680/891662 pixels e
 FAIL  css/css-page/page-box-011-print.html  # page 1 diff: 720831/891662 pixels exceed tol (max_ch=255)
 FAIL  css/css-page/page-left-right-001-print.html  # page 1 diff: 56200/180000 pixels exceed tol (max_ch=255)
 FAIL  css/css-page/page-left-right-002-print.html  # page 1 diff: 42939/180000 pixels exceed tol (max_ch=255)
-FAIL  css/css-page/page-margin-001-print.html  # page 1 diff: 66780/891662 pixels exceed tol (max_ch=255)
+PASS  css/css-page/page-margin-001-print.html
 FAIL  css/css-page/page-margin-002-print.html  # page 1 diff: 156457/891662 pixels exceed tol (max_ch=255)
-FAIL  css/css-page/page-margin-003-print.html  # page 1 diff: 66780/891662 pixels exceed tol (max_ch=255)
+PASS  css/css-page/page-margin-003-print.html
 FAIL  css/css-page/page-margin-004-print.html  # page 1 diff: 67614/90000 pixels exceed tol (max_ch=255)
 FAIL  css/css-page/page-margin-005-print.html  # page 1 diff: 51597/180000 pixels exceed tol (max_ch=255)
 FAIL  css/css-page/page-margin-006-print.html  # page 1 diff: 39226/331776 pixels exceed tol (max_ch=255)

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -317,6 +317,22 @@ impl Engine {
             &mut pagination_geometry,
             doc.deref_mut(),
             total_pages,
+            resolved_content_width_px,
+            resolved_content_height_px,
+        );
+        // fulgur-a8m5: emit fragments for body-direct
+        // `position: absolute` children whose effective CB is the
+        // viewport (body's box collapses to zero when every child is
+        // out-of-flow — CSS 2.1 §10.1.5). The fragmenter skips them
+        // unconditionally, so without this pass they never reach
+        // `dispatch_fragment` and ref-side renders blank for WPT
+        // fixedpos-001/002/008.
+        crate::pagination_layout::append_position_absolute_body_direct_fragments(
+            &mut pagination_geometry,
+            doc.deref_mut(),
+            total_pages,
+            resolved_content_width_px,
+            resolved_content_height_px,
         );
 
         // --- Convert DOM to Pageable and render ---
@@ -528,6 +544,15 @@ impl Engine {
             &mut pagination_geometry,
             doc.deref_mut(),
             total_pages,
+            crate::convert::pt_to_px(self.config.content_width()),
+            crate::convert::pt_to_px(self.config.content_height()),
+        );
+        crate::pagination_layout::append_position_absolute_body_direct_fragments(
+            &mut pagination_geometry,
+            doc.deref_mut(),
+            total_pages,
+            crate::convert::pt_to_px(self.config.content_width()),
+            crate::convert::pt_to_px(self.config.content_height()),
         );
 
         let running_store = crate::gcpm::running::RunningElementStore::new();

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -2202,10 +2202,13 @@ pub fn append_position_fixed_fragments(
     geometry: &mut PaginationGeometryTable,
     doc: &BaseDocument,
     total_pages: u32,
+    viewport_w_px: f32,
+    viewport_h_px: f32,
 ) {
     use ::style::properties::longhands::position::computed_value::T as Pos;
 
     let pages = total_pages.max(1);
+    let body_offset_xy = body_origin_in_px(doc);
     let mut fixed_ids: Vec<usize> = Vec::new();
     let root_id = doc.root_element().id;
     walk_for_position_fixed(doc, root_id, &mut fixed_ids, 0);
@@ -2226,7 +2229,26 @@ pub fn append_position_fixed_fragments(
         }
         let layout = node.final_layout;
         let (w, h) = (layout.size.width, layout.size.height);
-        let (x, y) = (layout.location.x, layout.location.y);
+        // fulgur-a8m5: Taffy's `compute_root_layout` (used by
+        // `relayout_position_fixed`) does not resolve `bottom` / `right`
+        // insets when the absolute element is the root of a layout
+        // subtree — it places the element at (0, 0) regardless. The
+        // CSS 2.1 §9.4 viewport CB needs explicit inset resolution
+        // here, otherwise WPT fixedpos-001/002/008 render `bottom: 0`
+        // fixed elements at the top of every page.
+        let (resolved_x, resolved_y) =
+            resolve_viewport_cb_location(node, w, h, viewport_w_px, viewport_h_px)
+                .unwrap_or((layout.location.x, layout.location.y));
+        // Render adds `body_offset_pt.y` to every fragment's y to
+        // account for the html→body offset (collapsed margins from
+        // in-flow body-direct children, etc.). Fixed elements are
+        // viewport-anchored, not body-anchored, so subtract that
+        // offset here so the dispatch path produces a viewport-
+        // relative y in PDF coordinates. Without this compensation,
+        // documents that mix in-flow content with `position: fixed`
+        // (WPT fixedpos-008) shift the fixed text by the in-flow
+        // div's margin-top.
+        let (x, y) = (resolved_x - body_offset_xy.0, resolved_y - body_offset_xy.1);
 
         let entry = geometry.entry(id).or_default();
         // Replace any prior placements (e.g. if the fixed element was
@@ -2248,6 +2270,308 @@ pub fn append_position_fixed_fragments(
 
     // Don't allocate empty entries for nodes without fragments.
     geometry.retain(|_, geom| !geom.fragments.is_empty());
+}
+
+/// fulgur-a8m5: emit a Fragment for every body-direct
+/// `position: absolute` element whose effective containing block falls
+/// back to the viewport (when body's box collapses to zero because all
+/// of its children are out-of-flow — see CSS 2.1 §10.1.5 and the
+/// matching `viewport_size_px` body-zero fallback in
+/// `convert::positioned::resolve_cb_for_absolute`).
+///
+/// `fragment_pagination_root` skips out-of-flow children unconditionally,
+/// so without this pass `<body><div style="position:absolute; bottom:0">…</div></body>`
+/// never reaches `pagination_geometry` and the v2 dispatch loop drops
+/// the element entirely (WPT `fixedpos-00{1,2,8}` ref-side breakage).
+///
+/// Each emitted Fragment lives on the page where its resolved y lands
+/// (`page_index = floor(y / page_h)`); off-page elements (e.g.
+/// `bottom: -100vh` in a single-page document) are dropped because no
+/// page can paint them.
+pub fn append_position_absolute_body_direct_fragments(
+    geometry: &mut PaginationGeometryTable,
+    doc: &BaseDocument,
+    total_pages: u32,
+    viewport_w_px: f32,
+    viewport_h_px: f32,
+) {
+    use ::style::properties::longhands::position::computed_value::T as Pos;
+
+    let pages = total_pages.max(1);
+    let body_id = match find_body_id(doc) {
+        Some(id) => id,
+        None => return,
+    };
+    let body = match doc.get_node(body_id) {
+        Some(n) => n,
+        None => return,
+    };
+    // Per CSS 2.1 §10.1.5, the containing block for `position: absolute`
+    // children of `<body>` (a static-position element) falls through to
+    // the initial containing block (the viewport) regardless of body's
+    // own size. The fragmenter unconditionally skips out-of-flow
+    // children (`fragment_pagination_root` `continue` for `Pos::Absolute`),
+    // so this pass runs for every body-direct abs — not just when body
+    // collapses to zero.
+    let body_offset_xy = body_origin_in_px(doc);
+
+    let body_children = body.children.clone();
+    for child_id in body_children {
+        let Some(child) = doc.get_node(child_id) else {
+            continue;
+        };
+        let is_abs_only = child
+            .primary_styles()
+            .is_some_and(|s| matches!(s.get_box().clone_position(), Pos::Absolute));
+        if !is_abs_only {
+            continue;
+        }
+        let layout = child.final_layout;
+        let (w, h) = (layout.size.width, layout.size.height);
+        let (resolved_x, resolved_y) =
+            resolve_viewport_cb_location(child, w, h, viewport_w_px, viewport_h_px)
+                .unwrap_or((layout.location.x, layout.location.y));
+
+        // Walk the subtree and emit a fragment for every in-flow node
+        // (block, paragraph, anonymous wrapper). Without this the
+        // dispatch loop drops descendants whose node_id is not the
+        // root abs id (anonymous block wrappers around mixed
+        // text/element content — fixedpos-002 / fixedpos-008 ref-side
+        // pattern). Out-of-flow descendants are skipped because they
+        // are handled by their own pass. The render path adds
+        // `body_offset_pt` to every emitted fragment's y, so we pass
+        // the body offset down and let the walker subtract it from the
+        // stored y while keeping page assignment based on the un-
+        // compensated viewport-anchored y.
+        record_subtree_fragments_at_offset(
+            geometry,
+            doc,
+            child_id,
+            (resolved_x, resolved_y),
+            body_offset_xy,
+            viewport_h_px,
+            pages,
+        );
+    }
+
+    // Don't allocate empty entries for nodes without fragments.
+    geometry.retain(|_, geom| !geom.fragments.is_empty());
+}
+
+/// Walk a body-direct out-of-flow subtree and emit a single Fragment for
+/// each in-flow node (the subtree root + every block / paragraph /
+/// anonymous wrapper inside it). Each fragment's body-relative
+/// location = the subtree root's resolved viewport-CB location plus the
+/// node's accumulated `final_layout.location` offset from that root.
+///
+/// Skips out-of-flow descendants (their own pass handles them) and
+/// whitespace-only text nodes (mirrors `fragment_pagination_root`).
+fn record_subtree_fragments_at_offset(
+    geometry: &mut PaginationGeometryTable,
+    doc: &BaseDocument,
+    subtree_root_id: usize,
+    root_xy_for_paging: (f32, f32),
+    body_offset: (f32, f32),
+    page_h_px: f32,
+    total_pages: u32,
+) {
+    #[allow(clippy::too_many_arguments)]
+    fn walk(
+        geometry: &mut PaginationGeometryTable,
+        doc: &BaseDocument,
+        node_id: usize,
+        offset_in_subtree: (f32, f32),
+        root_xy_for_paging: (f32, f32),
+        body_offset: (f32, f32),
+        page_h_px: f32,
+        total_pages: u32,
+        depth: usize,
+    ) {
+        use ::style::properties::longhands::position::computed_value::T as Pos;
+        if depth >= crate::MAX_DOM_DEPTH {
+            return;
+        }
+        let Some(node) = doc.get_node(node_id) else {
+            return;
+        };
+        // Page assignment is based on the un-compensated viewport-CB
+        // resolved position (the actual paint location). Storage is
+        // body-relative because the dispatch path adds `body_offset_pt`
+        // back at draw time.
+        let final_y_for_paging = root_xy_for_paging.1 + offset_in_subtree.1;
+        let stored_x = root_xy_for_paging.0 + offset_in_subtree.0 - body_offset.0;
+        let w = node.final_layout.size.width;
+        let h = node.final_layout.size.height;
+
+        if final_y_for_paging.is_finite() && page_h_px > 0.0 && final_y_for_paging >= 0.0 {
+            // Stylo computes `Nvh` against the viewport snapshot taken
+            // at parse time, which can differ from `page_h_px` by a
+            // sub-px amount (the @page resolution uses the resolved
+            // content area; Stylo's computed `100vh` rounds elsewhere).
+            // Without tolerance, `top: 100vh` on a 1-page render
+            // becomes `final_y = 971.0` against `page_h_px = 971.34`,
+            // which floor()s to page 0 and renders the off-page text
+            // on page 1 (WPT fixedpos-008 ref-side). Snap final_y
+            // toward integer multiples of page_h before paging.
+            let raw_ratio = final_y_for_paging / page_h_px;
+            let snapped_ratio = if (raw_ratio - raw_ratio.round()).abs() < 1e-3 {
+                raw_ratio.round()
+            } else {
+                raw_ratio
+            };
+            let page_index_f = snapped_ratio.floor();
+            if page_index_f.is_finite() && page_index_f < total_pages as f32 {
+                let page_index = page_index_f as u32;
+                let y_in_page = final_y_for_paging - (page_index as f32) * page_h_px;
+                let stored_y = y_in_page - body_offset.1;
+                let entry = geometry.entry(node_id).or_default();
+                entry.fragments.clear();
+                entry.is_repeat = false;
+                entry.fragments.push(Fragment {
+                    page_index,
+                    x: stored_x,
+                    y: stored_y,
+                    width: w,
+                    height: h,
+                });
+            }
+        }
+
+        // Prefer `layout_children` so anonymous block wrappers Stylo
+        // synthesizes around mixed inline/block content are visited
+        // (CSS 2.1 §9.2.1.1 — see `fragment_pagination_root` for the
+        // same idiom).
+        let children: Vec<usize> = {
+            let layout_borrow = node.layout_children.borrow();
+            if let Some(lc) = layout_borrow.as_deref()
+                && !lc.is_empty()
+            {
+                lc.to_vec()
+            } else {
+                node.children.clone()
+            }
+        };
+
+        for child_id in children {
+            let Some(child) = doc.get_node(child_id) else {
+                continue;
+            };
+            // Skip out-of-flow descendants (handled by their own
+            // pass — `append_position_fixed_fragments` for fixed,
+            // separate body-direct walk for abs).
+            let is_oof = child.primary_styles().is_some_and(|s| {
+                matches!(s.get_box().clone_position(), Pos::Absolute | Pos::Fixed)
+            });
+            if is_oof {
+                continue;
+            }
+            // Skip whitespace-only text (matches fragmenter).
+            if let Some(text) = child.text_data()
+                && text.content.chars().all(char::is_whitespace)
+            {
+                continue;
+            }
+            let child_offset = (
+                offset_in_subtree.0 + child.final_layout.location.x,
+                offset_in_subtree.1 + child.final_layout.location.y,
+            );
+            walk(
+                geometry,
+                doc,
+                child_id,
+                child_offset,
+                root_xy_for_paging,
+                body_offset,
+                page_h_px,
+                total_pages,
+                depth + 1,
+            );
+        }
+    }
+
+    walk(
+        geometry,
+        doc,
+        subtree_root_id,
+        (0.0, 0.0),
+        root_xy_for_paging,
+        body_offset,
+        page_h_px,
+        total_pages,
+        0,
+    );
+}
+
+/// CSS-px (x, y) of `<body>`'s top-left in its containing block (html).
+/// Mirrors `convert::extract_body_offset_pt` but stays in CSS px so
+/// pagination_layout doesn't need to round-trip through pt. The render
+/// path adds `drawables.body_offset_pt` to every fragment's y when
+/// dispatching, so viewport-anchored fragments must subtract this
+/// offset to keep the dispatched y page-relative.
+fn body_origin_in_px(doc: &BaseDocument) -> (f32, f32) {
+    let Some(body_id) = find_body_id(doc) else {
+        return (0.0, 0.0);
+    };
+    let Some(body) = doc.get_node(body_id) else {
+        return (0.0, 0.0);
+    };
+    (body.final_layout.location.x, body.final_layout.location.y)
+}
+
+/// Resolve a viewport-CB-anchored absolute/fixed element's CSS px
+/// (x, y) using its computed `top` / `left` / `right` / `bottom`
+/// insets. Mirrors CSS 2.1 §10.3.7 / §10.6.4 over-constrained
+/// resolution: start-side (top / left) wins when both sides are set,
+/// end-side (bottom / right) only fires when the start-side is `auto`.
+///
+/// Returns `None` when no inset is set on either axis (caller should
+/// keep Taffy's `final_layout.location` as the static-position
+/// fallback).
+fn resolve_viewport_cb_location(
+    node: &blitz_dom::Node,
+    el_w_px: f32,
+    el_h_px: f32,
+    cb_w_px: f32,
+    cb_h_px: f32,
+) -> Option<(f32, f32)> {
+    use ::style::values::computed::Length;
+    use ::style::values::generics::position::GenericInset;
+
+    fn resolve(inset: &::style::values::computed::position::Inset, basis_px: f32) -> Option<f32> {
+        match inset {
+            GenericInset::LengthPercentage(lp) => Some(lp.resolve(Length::new(basis_px)).px()),
+            _ => None,
+        }
+    }
+
+    let styles = node.primary_styles()?;
+    let pos = styles.get_position();
+    let left = resolve(&pos.left, cb_w_px);
+    let top = resolve(&pos.top, cb_h_px);
+    let right = resolve(&pos.right, cb_w_px);
+    let bottom = resolve(&pos.bottom, cb_h_px);
+    if left.is_none() && top.is_none() && right.is_none() && bottom.is_none() {
+        return None;
+    }
+    // Per-axis resolution: when both insets on an axis are `auto`, fall
+    // back to Taffy's static position (`final_layout.location`). Caller
+    // unwraps the returned tuple against that fallback, so we surface
+    // only the axes that have an explicit inset.
+    let x = if let Some(l) = left {
+        l
+    } else if let Some(r) = right {
+        cb_w_px - el_w_px - r
+    } else {
+        node.final_layout.location.x
+    };
+    let y = if let Some(t) = top {
+        t
+    } else if let Some(b) = bottom {
+        cb_h_px - el_h_px - b
+    } else {
+        node.final_layout.location.y
+    };
+    Some((x, y))
 }
 
 /// Recursive walker that collects every node id whose computed
@@ -2879,7 +3203,13 @@ h2 { string-set: chapter-title content(text); }
             "two 600px blocks on 800px page should split → {pages_before} pages",
         );
 
-        super::append_position_fixed_fragments(&mut geom, doc.deref_mut(), pages_before);
+        super::append_position_fixed_fragments(
+            &mut geom,
+            doc.deref_mut(),
+            pages_before,
+            600.0,
+            800.0,
+        );
 
         // The fixed div should now appear in `geom` with one fragment
         // per page. We don't know its NodeId statically, so locate it
@@ -2922,11 +3252,139 @@ h2 { string-set: chapter-title content(text); }
         "#;
         let mut doc = parse(html, 600.0);
         let mut geom = PaginationGeometryTable::new();
-        super::append_position_fixed_fragments(&mut geom, doc.deref_mut(), 0);
+        super::append_position_fixed_fragments(&mut geom, doc.deref_mut(), 0, 600.0, 800.0);
         assert_eq!(geom.len(), 1);
         let (_, g) = geom.iter().next().unwrap();
         assert_eq!(g.fragments.len(), 1);
         assert_eq!(g.fragments[0].page_index, 0);
+    }
+
+    /// fulgur-a8m5: `append_position_fixed_fragments` must resolve
+    /// `bottom: 0` against the viewport CB. Taffy's `compute_root_layout`
+    /// (used by `relayout_position_fixed`) does not honour end-side
+    /// insets when the absolute element IS the layout-tree root, so
+    /// `final_layout.location.y` stays at 0 even for `bottom: 0`. v2's
+    /// dispatch reads `pagination_geometry` directly, so without inset
+    /// resolution here, WPT fixedpos-001 / fixedpos-002 / fixedpos-008
+    /// render their `bottom: 0` fixed text at the top of every page
+    /// instead of the bottom.
+    #[test]
+    fn position_fixed_bottom_zero_resolves_against_viewport() {
+        let html = r#"
+            <html><body style="margin:0">
+              <div style="position: fixed; bottom: 0; height: 30px"></div>
+            </body></html>
+        "#;
+        let mut doc = parse(html, 600.0);
+        crate::blitz_adapter::relayout_position_fixed(&mut doc, 600.0, 800.0);
+        let mut geom = PaginationGeometryTable::new();
+        super::append_position_fixed_fragments(&mut geom, doc.deref_mut(), 1, 600.0, 800.0);
+
+        // Locate the fixed div fragment by its 30px height.
+        let entries: Vec<_> = geom
+            .iter()
+            .filter(|(_, g)| g.fragments.iter().any(|f| (f.height - 30.0).abs() < 0.5))
+            .collect();
+        assert_eq!(entries.len(), 1, "exactly one fixed entry");
+        let (_, g) = entries[0];
+        assert_eq!(g.fragments.len(), 1);
+        let frag = &g.fragments[0];
+        // viewport_h_px=800, height=30 → bottom edge sits at 800 → top at 770.
+        // body has zero height (no in-flow content), so body_offset_xy=(0,0).
+        assert!(
+            (frag.y - 770.0).abs() < 1.0,
+            "bottom:0 fixed should resolve to y=770 (viewport_h - height); got {}",
+            frag.y
+        );
+    }
+
+    /// fulgur-a8m5: body's collapsed-margin offset (e.g. an in-flow
+    /// child with `margin-top:4em`) appears in
+    /// `drawables.body_offset_pt`, which the v2 dispatch path adds to
+    /// every fragment's y. Viewport-anchored fixed elements must
+    /// subtract that offset at storage time so the dispatched y lands
+    /// at the page-relative position the CSS asks for. Locks the math
+    /// PDF y = margin_top_pt + body_offset_pt + (frag.y_pt) — for
+    /// `top:0` we want PDF y = margin_top_pt, so frag.y_px must equal
+    /// `-body_offset_y_px`.
+    #[test]
+    fn position_fixed_top_zero_compensates_for_body_offset() {
+        // The in-flow div pushes body's content area down by ~4em.
+        let html = r#"
+            <html><body>
+              <div style="margin-top:4em">x</div>
+              <div style="position: fixed; top: 0; height: 30px"></div>
+            </body></html>
+        "#;
+        let mut doc = parse(html, 600.0);
+        crate::blitz_adapter::relayout_position_fixed(&mut doc, 600.0, 800.0);
+        let body_y_px = super::body_origin_in_px(doc.deref_mut()).1;
+        // Sanity: body_offset must be non-zero, otherwise the test is
+        // not exercising compensation at all.
+        assert!(
+            body_y_px > 0.5,
+            "test assumes body has a non-zero offset; got {body_y_px}"
+        );
+        let mut geom = PaginationGeometryTable::new();
+        super::append_position_fixed_fragments(&mut geom, doc.deref_mut(), 1, 600.0, 800.0);
+
+        let entries: Vec<_> = geom
+            .iter()
+            .filter(|(_, g)| g.fragments.iter().any(|f| (f.height - 30.0).abs() < 0.5))
+            .collect();
+        assert_eq!(entries.len(), 1, "exactly one fixed entry");
+        let frag = entries[0].1.fragments.first().unwrap();
+        // top:0 → resolved_y=0 → stored_y = 0 - body_y_px = -body_y_px.
+        assert!(
+            (frag.y - (-body_y_px)).abs() < 0.5,
+            "top:0 fixed frag.y must be -body_offset (={}); got {}",
+            -body_y_px,
+            frag.y
+        );
+    }
+
+    /// fulgur-a8m5: body-direct `position: absolute` with `bottom: 0`
+    /// should land at the bottom of page 0 with its descendant Paragraph
+    /// fragments at the same position. The fragmenter unconditionally
+    /// skips out-of-flow children, so this pass is the only thing that
+    /// puts these abs body-direct nodes into `pagination_geometry` for
+    /// v2 dispatch (WPT fixedpos-001 ref, fixedpos-008 ref).
+    #[test]
+    fn position_absolute_body_direct_bottom_zero_lands_on_page_zero() {
+        let html = r#"
+            <html><body style="margin:0">
+              <div style="position: absolute; bottom: 0; height: 30px">x</div>
+            </body></html>
+        "#;
+        let mut doc = parse(html, 600.0);
+        let mut geom = PaginationGeometryTable::new();
+        super::append_position_absolute_body_direct_fragments(
+            &mut geom,
+            doc.deref_mut(),
+            1,
+            600.0,
+            800.0,
+        );
+
+        // Locate the abs div by height=30.
+        let mut found = None;
+        for g in geom.values() {
+            for f in &g.fragments {
+                if (f.height - 30.0).abs() < 0.5 {
+                    found = Some(f.clone());
+                }
+            }
+        }
+        let frag = found.expect("abs body-direct fragment for bottom:0 must be emitted");
+        assert_eq!(frag.page_index, 0);
+        // Same math as the fixed case: body has zero height, so
+        // body_offset compensation is a no-op and viewport-CB
+        // resolution gives y = 800 - 30 = 770.
+        assert!(
+            (frag.y - 770.0).abs() < 1.0,
+            "abs body-direct bottom:0 should land at y=770; got {}",
+            frag.y
+        );
     }
 
     /// Exercises `PaginationLayoutTree`'s `LayoutPartialTree` /


### PR DESCRIPTION
## 概要

WPT nightly (run 25244570616, 2026-05-02 05:16 UTC) で `fixedpos-001/002/008` が declared=PASS observed=FAIL の regression に転落していた。原因は Phase 4 (PR #321, 4/30) で `render_html` の default が v2 に切り替わった際、v1 の `BlockPageable::wrap` 内 `resolve_cb_for_absolute` viewport-CB fallback が引き継がれず、v2 の `pagination_geometry` 駆動 dispatch に positioning が落ちていなかったため。

本 PR は `position: fixed` および body-direct な `position: absolute` のうち effective CB が viewport にフォールバックするケース (CSS 2.1 §10.1.5 ICB fallback) について、Stylo の computed insets から viewport-relative な (x, y) を直接解決して fragment に書き込む。

## 設計

1. **`relayout_position_fixed` の限界**: Taffy の `compute_root_layout` は abs 要素が layout-tree root のとき `bottom`/`right` insets を解決しない。size は viewport 基準で再計算されるが、`final_layout.location` は (0, 0) のままで、v2 の `append_position_fixed_fragments` がそれをそのまま読むので `bottom: 0` が page top に rendering されていた。
2. **fragmenter の abs/fixed skip**: `fragment_pagination_root` は CSS 2.1 §10.6.4 で out-of-flow を unconditionally skip する。v1 では convert path の `BlockPageable::wrap` が viewport CB から position を再計算していたが、v2 にはその hook が無く、body-direct abs は geometry に entry が無いまま `dispatch_fragment` で drop されていた。

修正:
- `append_position_fixed_fragments`: viewport_w/h_px を引数に受け取り、各 fixed 要素の computed `top`/`left`/`right`/`bottom` を `LengthPercentage::resolve` で CSS px に解決して (x, y) を上書き。axis ごとに両方 auto なら Taffy の static-position に fallback。
- `append_position_absolute_body_direct_fragments` (新規): body の direct な abs 子要素を walk し、同じ viewport-CB resolver で位置を決定。子孫 (anonymous block の paragraph 等) も再帰 walker で fragment を emit (out-of-flow descendant は別 pass 任せ)。
- 両者とも `body_offset_pt.y` 相当を事前に減算: v2 dispatch path は全 fragment に `body_offset_pt` を加算するが、viewport-anchored な fragment は body 基準ではなく viewport 基準なので、storage で打ち消しておく。Page assignment は加算前の y を基準にする。
- Sub-pixel snap: Stylo の computed `100vh` は parse-time の viewport snapshot に対して計算されるため `page_h_px` と sub-pixel 単位でずれることがある。`top: 100vh` が 1-page render で page 0 に落ちないよう、ratio を整数近傍にスナップ。

## 検証

新規 unit test (`crates/fulgur/src/pagination_layout.rs` の `tests` モジュール):
- `position_fixed_bottom_zero_resolves_against_viewport` — `bottom:0` の fixed が viewport 底部に解決されることを assert
- `position_fixed_top_zero_compensates_for_body_offset` — body_offset 非ゼロのケースで `top:0` の fragment.y が `-body_offset_y` になることを assert (math lock)
- `position_absolute_body_direct_bottom_zero_lands_on_page_zero` — body-direct abs `bottom:0` が page 0 viewport 底部に landing することを assert

## WPT delta

nightly (commit `74f5c6e`) との差分:

| 種別 | テスト |
|---|---|
| Recovered (regression → PASS) | `fixedpos-001`, `fixedpos-002`, `fixedpos-008` |
| Newly PASSing (promotion) | `fixedpos-003`, `monolithic-overflow-013` (fulgur-puml 回復), `page-margin-001`, `page-margin-003` |
| Demoted (別原因) | `fixedpos-009` → `fulgur-4m16` (PR #338 viewport-units-content-area が起源) |
| 残存 unchanged | `monolithic-overflow-004`, `page-name-display-none-child` (page count mismatch、別系統) |
| 数値悪化 | `page-name-propagated-003`: 71 → 142 px diff。本 PR の修正で ref 側の body-direct abs `b` が rendering されるようになったが、test 側の named-page 内 nested abs (`<div page:c><div abs left:100px>`) との position math が一致せず、片方しかない pixels が両方に displaced で出るため diff 量自体は増加。期待値は変えず (PASS のまま、observed FAIL) で `fulgur-puml` family の既存課題として継続 track。 |

WPT runner 出力 (`promotions=0`):

```
total: 257 (24.2s)
PASS: 75 (29.2%)
regressions: 3 (monolithic-overflow-004, page-name-display-none-child, page-name-propagated-003)
promotion candidates: 0
```

## Test plan

- [x] `cargo test -p fulgur --lib` (742 passed)
- [x] `cargo test -p fulgur` (all green)
- [x] `cargo test -p fulgur-vrt --release` (all green)
- [x] `cargo test -p fulgur-cli` (all green)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets` (0 warnings)
- [x] `FULGUR_WPT_REQUIRED=1 cargo test -p fulgur-wpt --test wpt_css_page --release` (`promotions=0`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of fixed and absolute positioning in print layouts
  * Fixed page margin and page generation behavior in CSS page rendering
  * One known regression: viewport-units content area in fixed positioning

* **Tests**
  * Updated CSS page layout test expectations to reflect pagination improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->