### PR TITLE
fix(pagination): emit per-page fragments for fixed-root descendants (fulgur-4m16)

### DIFF
--- a/crates/fulgur-wpt/expectations/css-page.txt
+++ b/crates/fulgur-wpt/expectations/css-page.txt
@@ -36,7 +36,7 @@ FAIL  css/css-page/fixedpos-005-print.html  # page count mismatch: test=3 ref=5
 FAIL  css/css-page/fixedpos-006-print.html  # page count mismatch: test=3 ref=5
 FAIL  css/css-page/fixedpos-007-print.html  # page 1 diff: 1765/891662 pixels exceed tol (max_ch=255)
 PASS  css/css-page/fixedpos-008-print.html
-FAIL  css/css-page/fixedpos-009-print.html  # fulgur-4m16: regressed by PR #338 viewport-units-content-area (page 1 diff: 1369 px)
+FAIL  css/css-page/fixedpos-009-print.html  # fulgur-6wap: fixed auto-width fills viewport instead of CSS 2.1 §10.3.7 shrink-to-fit; pencil child fragment now emits via fulgur-4m16, root x still wrong
 FAIL  css/css-page/fixedpos-010-print.html  # page 1 diff: 10844/160000 pixels exceed tol (max_ch=255)
 FAIL  css/css-page/fixedpos-011-print.html  # page 1 diff: 84920/891662 pixels exceed tol (max_ch=255)
 FAIL  css/css-page/fixedpos-with-abspos-with-link-print.html  # page 1 diff: 2541/891662 pixels exceed tol (max_ch=255)
@@ -167,7 +167,7 @@ PASS  css/css-page/page-name-canvas-002-print.html
 PASS  css/css-page/page-name-canvas-003-print.html
 PASS  css/css-page/page-name-canvas-004-print.html
 PASS  css/css-page/page-name-display-none-child-print.html
-FAIL  css/css-page/page-name-fixed-pos-001-print.html  # page 1 diff: 272/891662 pixels exceed tol (max_ch=255)
+PASS  css/css-page/page-name-fixed-pos-001-print.html
 PASS  css/css-page/page-name-flex-001-print.html
 PASS  css/css-page/page-name-flex-002-print.html
 PASS  css/css-page/page-name-flex-003-print.html

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -2266,10 +2266,163 @@ pub fn append_position_fixed_fragments(
                 height: h,
             });
         }
+
+        // fulgur-4m16: emit per-page repeated fragments for every
+        // in-flow descendant of the fixed root. v2 dispatch is
+        // geometry-driven and reads fragments per `node_id`, so a
+        // fixed root with a sized block-element child (e.g. WPT
+        // fixedpos-009 `<div style="position:fixed; bottom:0; right:0">
+        // <div class="pencil" style="width:36px; height:36px;
+        // background:black; mask-image:..."></div></div>`) needs an
+        // entry for the pencil child or v2 never reaches it. The
+        // existing root-only fragment carries inline text rendering
+        // (fixedpos-001 / 008 ref pattern) but not block descendants.
+        record_fixed_subtree_descendants(geometry, doc, id, (x, y), pages);
     }
 
     // Don't allocate empty entries for nodes without fragments.
     geometry.retain(|_, geom| !geom.fragments.is_empty());
+}
+
+/// fulgur-4m16: walk every in-flow descendant of a `position: fixed`
+/// root and emit one fragment per page (`is_repeat = true`) at the
+/// descendant's offset within the fixed subtree, anchored to the
+/// root's already-resolved viewport-CB position.
+///
+/// Mirrors [`record_subtree_fragments_at_offset`] (used by
+/// `append_position_absolute_body_direct_fragments`) except:
+///   - fragments repeat on every page instead of landing on a single
+///     y-derived page,
+///   - the caller passes the root's body-relative stored (x, y) so we
+///     don't re-resolve viewport-CB here (the root's `final_layout`
+///     can lack end-side inset resolution — see fulgur-a8m5),
+///   - body-offset compensation already happened on the caller's `(x, y)`,
+///     so descendants just add their subtree offset on top.
+///
+/// Skips out-of-flow descendants (handled by their own pass) and
+/// whitespace-only text nodes (matches fragmenter behavior).
+fn record_fixed_subtree_descendants(
+    geometry: &mut PaginationGeometryTable,
+    doc: &BaseDocument,
+    fixed_root_id: usize,
+    root_stored_xy: (f32, f32),
+    pages: u32,
+) {
+    use ::style::properties::longhands::position::computed_value::T as Pos;
+
+    fn walk(
+        geometry: &mut PaginationGeometryTable,
+        doc: &BaseDocument,
+        node_id: usize,
+        offset_in_subtree: (f32, f32),
+        root_stored_xy: (f32, f32),
+        pages: u32,
+        depth: usize,
+    ) {
+        if depth >= crate::MAX_DOM_DEPTH {
+            return;
+        }
+        let Some(node) = doc.get_node(node_id) else {
+            return;
+        };
+        let stored_x = root_stored_xy.0 + offset_in_subtree.0;
+        let stored_y = root_stored_xy.1 + offset_in_subtree.1;
+        let w = node.final_layout.size.width;
+        let h = node.final_layout.size.height;
+
+        let entry = geometry.entry(node_id).or_default();
+        entry.fragments.clear();
+        entry.is_repeat = true;
+        for page_index in 0..pages.max(1) {
+            entry.fragments.push(Fragment {
+                page_index,
+                x: stored_x,
+                y: stored_y,
+                width: w,
+                height: h,
+            });
+        }
+
+        let children: Vec<usize> = {
+            let layout_borrow = node.layout_children.borrow();
+            if let Some(lc) = layout_borrow.as_deref()
+                && !lc.is_empty()
+            {
+                lc.to_vec()
+            } else {
+                node.children.clone()
+            }
+        };
+        for child_id in children {
+            let Some(child) = doc.get_node(child_id) else {
+                continue;
+            };
+            let is_oof = child.primary_styles().is_some_and(|s| {
+                matches!(s.get_box().clone_position(), Pos::Absolute | Pos::Fixed)
+            });
+            if is_oof {
+                continue;
+            }
+            if let Some(text) = child.text_data()
+                && text.content.chars().all(char::is_whitespace)
+            {
+                continue;
+            }
+            let child_offset = (
+                offset_in_subtree.0 + child.final_layout.location.x,
+                offset_in_subtree.1 + child.final_layout.location.y,
+            );
+            walk(
+                geometry,
+                doc,
+                child_id,
+                child_offset,
+                root_stored_xy,
+                pages,
+                depth + 1,
+            );
+        }
+    }
+
+    let Some(root) = doc.get_node(fixed_root_id) else {
+        return;
+    };
+    let children: Vec<usize> = {
+        let layout_borrow = root.layout_children.borrow();
+        if let Some(lc) = layout_borrow.as_deref()
+            && !lc.is_empty()
+        {
+            lc.to_vec()
+        } else {
+            root.children.clone()
+        }
+    };
+    for child_id in children {
+        let Some(child) = doc.get_node(child_id) else {
+            continue;
+        };
+        let is_oof = child
+            .primary_styles()
+            .is_some_and(|s| matches!(s.get_box().clone_position(), Pos::Absolute | Pos::Fixed));
+        if is_oof {
+            continue;
+        }
+        if let Some(text) = child.text_data()
+            && text.content.chars().all(char::is_whitespace)
+        {
+            continue;
+        }
+        let child_offset = (child.final_layout.location.x, child.final_layout.location.y);
+        walk(
+            geometry,
+            doc,
+            child_id,
+            child_offset,
+            root_stored_xy,
+            pages,
+            1,
+        );
+    }
 }
 
 /// fulgur-a8m5: emit a Fragment for every body-direct
@@ -3340,6 +3493,89 @@ h2 { string-set: chapter-title content(text); }
             "top:0 fixed frag.y must be -body_offset (={}); got {}",
             -body_y_px,
             frag.y
+        );
+    }
+
+    /// fulgur-4m16: when a `position: fixed` root has a sized
+    /// block-element child, the child must also receive per-page
+    /// repeated fragments. v2 dispatch reads
+    /// `pagination_geometry[node_id]` and never recurses into a fixed
+    /// root's subtree, so without per-descendant fragments the child
+    /// is never drawn (WPT fixedpos-009: a `<div class="pencil"
+    /// style="width:36px; height:36px">` inside the fixed root never
+    /// renders, leaving every page blank where the pencil should be).
+    #[test]
+    fn position_fixed_emits_fragments_for_block_descendants() {
+        // Use shrink-to-fit-friendly width / height on the fixed root
+        // so Taffy gives it a definite size; otherwise an unsized fixed
+        // root inherits available_space (600 wide), which obscures the
+        // root-vs-child position relationship the test pins. The bug
+        // being tested (descendants missing from geometry) is
+        // independent of root sizing.
+        let html = r#"
+            <html><body style="margin:0">
+              <div style="position: fixed; bottom: 0; width: 36px; height: 36px">
+                <div style="width: 36px; height: 36px"></div>
+              </div>
+            </body></html>
+        "#;
+        let mut doc = parse(html, 600.0);
+        crate::blitz_adapter::relayout_position_fixed(&mut doc, 600.0, 800.0);
+        let mut geom = PaginationGeometryTable::new();
+        super::append_position_fixed_fragments(&mut geom, doc.deref_mut(), 2, 600.0, 800.0);
+
+        // Both root and its 36×36 child must appear in `geom`. The
+        // root's fragments come from the existing inset-resolution
+        // path; the child's fragments come from the new descendants
+        // walker (fulgur-4m16). Without that walker, only one entry
+        // (the root) shows up.
+        let entries: Vec<_> = geom
+            .iter()
+            .filter(|(_, g)| {
+                g.fragments
+                    .iter()
+                    .any(|f| (f.width - 36.0).abs() < 0.5 && (f.height - 36.0).abs() < 0.5)
+            })
+            .collect();
+        assert_eq!(
+            entries.len(),
+            2,
+            "expected 2 entries (fixed root + child), got {} — fulgur-4m16: \
+             without record_fixed_subtree_descendants the child entry is missing",
+            entries.len(),
+        );
+
+        // Both must be `is_repeat = true` with one fragment per page.
+        for (_, g) in &entries {
+            assert!(g.is_repeat, "entry must be is_repeat=true");
+            assert_eq!(g.fragments.len(), 2, "entry: one fragment per page");
+            let pages_seen: Vec<u32> = g.fragments.iter().map(|f| f.page_index).collect();
+            assert_eq!(pages_seen, vec![0u32, 1u32]);
+        }
+
+        // Both entries' first fragments must agree on (x, y) because
+        // the child's `final_layout.location` inside the root is
+        // (0, 0) (no padding/margin/border on the root). A divergence
+        // here would mean the descendants walker is computing offsets
+        // wrong.
+        let f0 = &entries[0].1.fragments[0];
+        let f1 = &entries[1].1.fragments[0];
+        assert!(
+            (f0.x - f1.x).abs() < 0.5 && (f0.y - f1.y).abs() < 0.5,
+            "root and child must share (x, y); got root=({},{}) child=({},{})",
+            f0.x,
+            f0.y,
+            f1.x,
+            f1.y,
+        );
+
+        // Pin the y coordinate: bottom:0 with height=36 in an 800px
+        // viewport places the box top at y=764. body is empty so
+        // body_offset_xy=(0,0).
+        assert!(
+            (f0.y - 764.0).abs() < 1.0,
+            "bottom:0 fixed (h=36) must resolve to y=764 (viewport_h - h); got {}",
+            f0.y,
         );
     }
 


### PR DESCRIPTION
## 概要

`position: fixed` の root に **block 要素の子** がある場合、子が v2 dispatch で描画されない既存バグを修正します。`append_position_fixed_fragments` は fixed root 自身の fragment しか emit せず、`pagination_geometry[child_id]` が空のため v2 はその子に到達できませんでした。

WPT `css/css-page/fixedpos-009-print.html` がこの典型例で、`<div style="position:fixed; bottom:0; right:0"><div class="pencil" style="width:36px;height:36px;..."></div></div>` の pencil が test 側で全く描画されていませんでした (両ページとも本文テキストのみ)。fixedpos-001/008 は fixed root の中身が **inline text** なので既存の paragraph dispatch で描画されていましたが、9 のように **block 子要素 + 背景 + mask** を持つケースは穴になっていました。

## 調査経緯 (重要: 元の issue タイトルは誤帰属でした)

fulgur-4m16 は \"PR #338 viewport-units-content-area regression\" として起票されていましたが、74f5c6e (PR #338 前) と HEAD の両方で fixedpos-009 を render して比較したところ:

- **pre-PR #338**: test も ref も pencil **両方とも未描画** (両側等しく壊れていたから diff が小さく PASS していた)
- **post-PR #338**: ref 側だけが正しく描画されるようになった (`100vh` が @page-resolved content area で解決されるようになり `.fakepage` が page 内に収まるようになった結果、その内部の abs `bottom:0` が正しい位置に着地)
- **test 側の bug** (本 PR が修正): 元から block 子要素を持つ fixed の子が v2 で dispatch されていなかった

つまり PR #338 は ref を **直し**、test 側の **既存バグ** を露見させただけでした。

## 変更内容

`record_fixed_subtree_descendants` を新規追加 (`record_subtree_fragments_at_offset` パターンを踏襲、a8m5 と同形):

- fixed root の各 in-flow 子孫について、ページごとに 1 fragment 計 N (ページ数) emit
- `is_repeat = true`
- 子孫の (x, y) は root の解決済 (x, y) + subtree 内オフセット
- out-of-flow 子孫 (それぞれの pass で扱う) と whitespace-only text は skip

`append_position_fixed_fragments` の root 処理直後で呼び出します。

## WPT delta

- `page-name-fixed-pos-001-print.html`: **FAIL → PASS** (新規昇格、272 px diff 解消)
- `fixedpos-009-print.html`: **依然 FAIL** だが理由が変化。pencil child の fragment は出るようになった (本 PR) ものの、fixed の auto-width が viewport を埋めてしまう別バグ (CSS 2.1 §10.3.7 shrink-to-fit 未実装) で `right:0` が root x=0 に解決され、pencil が左端に描画される。
  - **fulgur-6wap** で別途 tracking
- regressions count: **3** (main と同じ、nightly baseline 6 を依然下回る)
- fixedpos-001/002/008 は PASS 維持 (純粋に追加経路、inline-only fixed root では追加 entry は no-op)

## 検証

- `cargo test -p fulgur --lib` 全 743 件 PASS
- `cargo test -p fulgur-wpt --test wpt_css_page --release` (詳細 summary 上記)
- `cargo test -p fulgur-vrt --release` 全 PASS (golden 影響なし)
- `cargo fmt --check` clean
- `cargo clippy -p fulgur --all-targets` clean

## 補足

実装は design の <50 LOC heuristic を超えますが (テスト込み ~150 LOC)、a8m5 の確立されたパターンの mirror であり妥当性は確認済。`record_subtree_fragments_at_offset` への `repeat: bool` パラメータ化も検討しましたが、page-index 計算と fragment 数のロジックが大きく異なるため独立 helper の方が読みやすいと判断しました。

Refs: beads fulgur-4m16
Follow-up: beads fulgur-6wap (fixed/abs auto-width shrink-to-fit)

## Test plan

- [x] Unit test: `position_fixed_emits_fragments_for_block_descendants` (root + child の両方が fragment を持ち is_repeat=true、page=2 で2 fragments)
- [x] Existing fixed/abs unit tests still pass (5 件)
- [x] `cargo test -p fulgur-wpt --test wpt_css_page --release`: PASS 75→76, regressions 3
- [x] `cargo test -p fulgur-vrt --release`: 全 PASS
- [x] `cargo fmt --check` / `cargo clippy`: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed rendering of position: fixed elements to properly display descendant elements across multiple pages in print layouts.
  * Resolved CSS page print test failure.

* **Tests**
  * Added test coverage for fixed-position elements with block descendants across paginated layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->