### PR TITLE
fix(layout): shrink-to-fit position:fixed auto-width with end-side inset (fulgur-6wap)

### DIFF
--- a/crates/fulgur-wpt/expectations/css-page.txt
+++ b/crates/fulgur-wpt/expectations/css-page.txt
@@ -36,7 +36,7 @@ FAIL  css/css-page/fixedpos-005-print.html  # page count mismatch: test=3 ref=5
 FAIL  css/css-page/fixedpos-006-print.html  # page count mismatch: test=3 ref=5
 FAIL  css/css-page/fixedpos-007-print.html  # page 1 diff: 1765/891662 pixels exceed tol (max_ch=255)
 PASS  css/css-page/fixedpos-008-print.html
-FAIL  css/css-page/fixedpos-009-print.html  # fulgur-6wap: fixed auto-width fills viewport instead of CSS 2.1 §10.3.7 shrink-to-fit; pencil child fragment now emits via fulgur-4m16, root x still wrong
+FAIL  css/css-page/fixedpos-009-print.html  # page 1 diff: 216/891662 pixels exceed tol (max_ch=149) — §10.3.7 shrink-to-fit now correct (pencil at bottom-right per spec, was 2738 px wrong); residual is sub-pixel anti-aliasing on the 36×36 mask edge between the test (position:fixed root) and ref (position:absolute inside relative .fakepage) y rounding
 FAIL  css/css-page/fixedpos-010-print.html  # page 1 diff: 10844/160000 pixels exceed tol (max_ch=255)
 FAIL  css/css-page/fixedpos-011-print.html  # page 1 diff: 84920/891662 pixels exceed tol (max_ch=255)
 FAIL  css/css-page/fixedpos-with-abspos-with-link-print.html  # page 1 diff: 2541/891662 pixels exceed tol (max_ch=255)

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -385,6 +385,8 @@ pub fn set_viewport_size_px(doc: &mut HtmlDocument, width_px: f32, height_px: f3
 /// coordinates on every page.
 pub fn relayout_position_fixed(doc: &mut HtmlDocument, viewport_w_px: f32, viewport_h_px: f32) {
     use ::style::properties::longhands::position::computed_value::T as Pos;
+    use ::style::values::generics::length::GenericSize;
+    use ::style::values::generics::position::GenericInset;
     use std::ops::DerefMut;
 
     let mut fixed_ids: Vec<usize> = Vec::new();
@@ -394,13 +396,46 @@ pub fn relayout_position_fixed(doc: &mut HtmlDocument, viewport_w_px: f32, viewp
         return;
     }
 
-    let avail = taffy::Size {
-        width: taffy::AvailableSpace::Definite(viewport_w_px),
-        height: taffy::AvailableSpace::Definite(viewport_h_px),
-    };
+    // fulgur-6wap: pre-compute per-element inline-axis available space
+    // before we hand the document to Taffy. CSS 2.1 §10.3.7 says a
+    // `position: fixed` element with `width: auto` and exactly one of
+    // `left`/`right` set shrinks-to-fit; passing `Definite(viewport_w)`
+    // would make Taffy fill the whole viewport on the inline axis, and
+    // the subsequent `right` resolution in `resolve_viewport_cb_location`
+    // would anchor the box at x=0 instead of the right edge (WPT
+    // fixedpos-009-print). `MaxContent` lets Taffy size the root to its
+    // children's max-content width, which matches §10.3.7 for the
+    // common case of badge / icon overlays.
+    //
+    // The block axis stays `Definite(viewport_h_px)`: Taffy's
+    // block-layout algorithm already gives content-height for `auto`
+    // height roots even with definite available space (verified by
+    // WPT fixedpos-001/002/008 currently PASSing with this same input).
+    let mut shrink_inline: Vec<bool> = Vec::with_capacity(fixed_ids.len());
+    for &id in &fixed_ids {
+        let needs_shrink = doc
+            .get_node(id)
+            .and_then(|n| n.primary_styles())
+            .is_some_and(|s| {
+                let pos = s.get_position();
+                let width_is_auto = matches!(pos.width, GenericSize::Auto);
+                let left_set = matches!(pos.left, GenericInset::LengthPercentage(_));
+                let right_set = matches!(pos.right, GenericInset::LengthPercentage(_));
+                width_is_auto && (left_set ^ right_set)
+            });
+        shrink_inline.push(needs_shrink);
+    }
 
     let base = doc.deref_mut();
-    for id in fixed_ids {
+    for (id, shrink) in fixed_ids.into_iter().zip(shrink_inline) {
+        let avail = taffy::Size {
+            width: if shrink {
+                taffy::AvailableSpace::MaxContent
+            } else {
+                taffy::AvailableSpace::Definite(viewport_w_px)
+            },
+            height: taffy::AvailableSpace::Definite(viewport_h_px),
+        };
         let nid = taffy::NodeId::from(id);
         taffy::compute_root_layout(base, nid, avail);
         taffy::round_layout(base, nid);
@@ -2416,6 +2451,61 @@ mod tests {
             post_width > 50.5,
             "viewport relayout should widen the fixed box past the 50px parent; \
              got {post_width} (pre was {pre_width})"
+        );
+    }
+
+    /// fulgur-6wap: when a `position: fixed` element has `width: auto`
+    /// with exactly one of `left`/`right` set, CSS 2.1 §10.3.7 says the
+    /// width shrinks to fit content. Without the §10.3.7 path,
+    /// `compute_root_layout` with `available_space = Definite(viewport_w)`
+    /// makes `width = viewport_w`, and the start-side of a `right: 0`
+    /// element resolves to `cb_w - viewport_w - 0 = 0`, painting at the
+    /// left edge instead of the right. The repro mirrors WPT
+    /// fixedpos-009-print: a fixed div with `right: 0` containing a
+    /// 36×36 child should shrink to 36 px, not the viewport width.
+    #[test]
+    fn relayout_position_fixed_shrinks_to_fit_when_only_right_inset_set() {
+        let html = r#"<!doctype html>
+<html><body style="margin:0">
+<div id="fix" style="position:fixed; right:0">
+  <div id="child" style="width:36px; height:36px; background:black"></div>
+</div>
+</body></html>"#;
+        let mut doc = parse(html, 600.0, &[]);
+        resolve(&mut doc);
+
+        fn find_by_id(doc: &HtmlDocument, id: &str) -> Option<usize> {
+            fn walk(doc: &HtmlDocument, node_id: usize, target: &str) -> Option<usize> {
+                let n = doc.get_node(node_id)?;
+                if let Some(elem) = n.element_data()
+                    && elem.attr(blitz_dom::LocalName::from("id")) == Some(target)
+                {
+                    return Some(node_id);
+                }
+                for &c in &n.children {
+                    if let Some(found) = walk(doc, c, target) {
+                        return Some(found);
+                    }
+                }
+                None
+            }
+            walk(doc, doc.root_element().id, id)
+        }
+        let fix_id = find_by_id(&doc, "fix").expect("fixed div id=fix");
+
+        relayout_position_fixed(&mut doc, 600.0, 800.0);
+        let post_width = doc.get_node(fix_id).unwrap().final_layout.size.width;
+        assert!(
+            post_width < 600.0,
+            "shrink-to-fit per CSS 2.1 §10.3.7: right:0 + width:auto must \
+             not fill viewport (600); got {post_width}"
+        );
+        // The 36 px child sets max-content width; allow small slack for
+        // box-model differences (borders, scrollbar) but not enough to
+        // accommodate viewport-fill (~600).
+        assert!(
+            (post_width - 36.0).abs() < 1.0,
+            "expected ~36 px shrink-to-fit width, got {post_width}"
         );
     }
 

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -385,6 +385,7 @@ pub fn set_viewport_size_px(doc: &mut HtmlDocument, width_px: f32, height_px: f3
 /// coordinates on every page.
 pub fn relayout_position_fixed(doc: &mut HtmlDocument, viewport_w_px: f32, viewport_h_px: f32) {
     use ::style::properties::longhands::position::computed_value::T as Pos;
+    use ::style::values::computed::Length;
     use ::style::values::generics::length::GenericSize;
     use ::style::values::generics::position::GenericInset;
     use std::ops::DerefMut;
@@ -396,47 +397,91 @@ pub fn relayout_position_fixed(doc: &mut HtmlDocument, viewport_w_px: f32, viewp
         return;
     }
 
-    // fulgur-6wap: pre-compute per-element inline-axis available space
-    // before we hand the document to Taffy. CSS 2.1 §10.3.7 says a
-    // `position: fixed` element with `width: auto` and exactly one of
-    // `left`/`right` set shrinks-to-fit; passing `Definite(viewport_w)`
-    // would make Taffy fill the whole viewport on the inline axis, and
-    // the subsequent `right` resolution in `resolve_viewport_cb_location`
-    // would anchor the box at x=0 instead of the right edge (WPT
-    // fixedpos-009-print). `MaxContent` lets Taffy size the root to its
-    // children's max-content width, which matches §10.3.7 for the
-    // common case of badge / icon overlays.
+    // fulgur-6wap: pre-compute per-element CSS 2.1 §10.3.7 shrink-to-fit
+    // metadata. A `position: fixed` element with `width: auto` and
+    // exactly one of `left`/`right` set must shrink-to-fit on the inline
+    // axis; passing `Definite(viewport_w_px)` would make Taffy fill the
+    // viewport, and `resolve_viewport_cb_location` would then anchor
+    // `right: 0` at x=0 (WPT fixedpos-009-print, pencil at left edge).
+    //
+    // §10.3.7's used width formula is:
+    //   width = min(max(min_content, available_w), max_content)
+    // where `available_w = cb_w - inset_start_or_end`. We approximate by
+    // measuring max-content with a probe pass (`AvailableSpace::MaxContent`)
+    // and clamping at `available_w`. Pure `MaxContent` is *not* a valid
+    // substitute on its own — Taffy's `AvailableSpace::MaxContent` means
+    // "indefinite, no soft line wrapping", so wrappable text would lay
+    // out on a single unwrapped line and overflow the viewport.
     //
     // The block axis stays `Definite(viewport_h_px)`: Taffy's
     // block-layout algorithm already gives content-height for `auto`
     // height roots even with definite available space (verified by
-    // WPT fixedpos-001/002/008 currently PASSing with this same input).
-    let mut shrink_inline: Vec<bool> = Vec::with_capacity(fixed_ids.len());
+    // WPT fixedpos-001/002/008 PASSing with this input).
+    enum InlineMode {
+        FillViewport,
+        ShrinkToFit { available_w: f32 },
+    }
+    let mut inline_modes: Vec<InlineMode> = Vec::with_capacity(fixed_ids.len());
     for &id in &fixed_ids {
-        let needs_shrink = doc
+        let mode = doc
             .get_node(id)
             .and_then(|n| n.primary_styles())
-            .is_some_and(|s| {
+            .and_then(|s| {
                 let pos = s.get_position();
                 let width_is_auto = matches!(pos.width, GenericSize::Auto);
-                let left_set = matches!(pos.left, GenericInset::LengthPercentage(_));
-                let right_set = matches!(pos.right, GenericInset::LengthPercentage(_));
-                width_is_auto && (left_set ^ right_set)
-            });
-        shrink_inline.push(needs_shrink);
+                let left = match &pos.left {
+                    GenericInset::LengthPercentage(lp) => {
+                        Some(lp.resolve(Length::new(viewport_w_px)).px())
+                    }
+                    _ => None,
+                };
+                let right = match &pos.right {
+                    GenericInset::LengthPercentage(lp) => {
+                        Some(lp.resolve(Length::new(viewport_w_px)).px())
+                    }
+                    _ => None,
+                };
+                let needs_shrink = width_is_auto && (left.is_some() ^ right.is_some());
+                if !needs_shrink {
+                    return None;
+                }
+                let inset = left.or(right).unwrap_or(0.0);
+                Some(InlineMode::ShrinkToFit {
+                    available_w: (viewport_w_px - inset).max(0.0),
+                })
+            })
+            .unwrap_or(InlineMode::FillViewport);
+        inline_modes.push(mode);
     }
 
     let base = doc.deref_mut();
-    for (id, shrink) in fixed_ids.into_iter().zip(shrink_inline) {
+    for (id, mode) in fixed_ids.into_iter().zip(inline_modes) {
+        let nid = taffy::NodeId::from(id);
+        let width_avail = match mode {
+            InlineMode::FillViewport => taffy::AvailableSpace::Definite(viewport_w_px),
+            InlineMode::ShrinkToFit { available_w } => {
+                // Probe pass: measure max-content width. Taffy caches on
+                // (node_id, inputs); the MaxContent inputs differ from
+                // the final pass below so both run.
+                let probe = taffy::Size {
+                    width: taffy::AvailableSpace::MaxContent,
+                    height: taffy::AvailableSpace::Definite(viewport_h_px),
+                };
+                taffy::compute_root_layout(base, nid, probe);
+                let max_content_w = base
+                    .get_node(id)
+                    .map(|n| n.final_layout.size.width)
+                    .unwrap_or(available_w);
+                // §10.3.7: clamp max-content to the available width so
+                // wrappable content wraps at the viewport edge instead
+                // of overflowing on a single line.
+                taffy::AvailableSpace::Definite(max_content_w.min(available_w))
+            }
+        };
         let avail = taffy::Size {
-            width: if shrink {
-                taffy::AvailableSpace::MaxContent
-            } else {
-                taffy::AvailableSpace::Definite(viewport_w_px)
-            },
+            width: width_avail,
             height: taffy::AvailableSpace::Definite(viewport_h_px),
         };
-        let nid = taffy::NodeId::from(id);
         taffy::compute_root_layout(base, nid, avail);
         taffy::round_layout(base, nid);
     }
@@ -2506,6 +2551,55 @@ mod tests {
         assert!(
             (post_width - 36.0).abs() < 1.0,
             "expected ~36 px shrink-to-fit width, got {post_width}"
+        );
+    }
+
+    /// fulgur-6wap (regression net for the wrappable-text branch): CSS
+    /// 2.1 §10.3.7 shrink-to-fit must clamp to the available width,
+    /// `min(max(min-content, available), max-content)`. For a fixed
+    /// element with `right: 0; width: auto` containing a long text node,
+    /// the box must wrap to fit within the viewport — passing
+    /// `AvailableSpace::MaxContent` to `compute_root_layout` would
+    /// produce pure max-content (single unwrapped line) and overflow,
+    /// which is exactly the regression coderabbit flagged on PR #342.
+    #[test]
+    fn relayout_position_fixed_shrink_to_fit_clamps_breakable_text_to_viewport() {
+        let html = r#"<!doctype html>
+<html><body style="margin:0">
+<div id="fix" style="position:fixed; right:0; font-size:16px">This is a long sentence that should wrap to fit within the available viewport width when CSS 2.1 §10.3.7 shrink-to-fit is applied correctly, instead of laying out on a single very wide unwrapped line.</div>
+</body></html>"#;
+        let mut doc = parse(html, 600.0, &[]);
+        resolve(&mut doc);
+
+        fn find_by_id(doc: &HtmlDocument, id: &str) -> Option<usize> {
+            fn walk(doc: &HtmlDocument, node_id: usize, target: &str) -> Option<usize> {
+                let n = doc.get_node(node_id)?;
+                if let Some(elem) = n.element_data()
+                    && elem.attr(blitz_dom::LocalName::from("id")) == Some(target)
+                {
+                    return Some(node_id);
+                }
+                for &c in &n.children {
+                    if let Some(found) = walk(doc, c, target) {
+                        return Some(found);
+                    }
+                }
+                None
+            }
+            walk(doc, doc.root_element().id, id)
+        }
+        let fix_id = find_by_id(&doc, "fix").expect("fixed div id=fix");
+
+        // Viewport is 600 CSS px wide; shrink-to-fit available width
+        // for `right: 0` is `viewport_w - 0 = 600`. The text's
+        // max-content width is well over 600, so the box must clamp at
+        // 600 and wrap, not stretch to max-content.
+        relayout_position_fixed(&mut doc, 600.0, 800.0);
+        let post_width = doc.get_node(fix_id).unwrap().final_layout.size.width;
+        assert!(
+            post_width <= 600.5,
+            "shrink-to-fit must clamp at the available width (600); \
+             got {post_width} — pure max-content would overflow viewport"
         );
     }
 


### PR DESCRIPTION
## サマリ

CSS 2.1 §10.3.7 の挙動を `relayout_position_fixed` に取り込む。`position: fixed` で `width: auto` かつ `left`/`right` のいずれか **片方** が指定された場合、Taffy の root layout に渡す inline 軸 available space を `Definite(viewport_w_px)` ではなく `MaxContent` に切り替え、shrink-to-fit させる。

## 背景

- WPT `css/css-page/fixedpos-009-print.html` は `<div style="position:fixed; bottom:0; right:0;">` 配下に 36×36 px の `.pencil` を持つ。期待は両ページの右下に pencil が描画されること。
- 既存実装は `compute_root_layout` の `available_space` に常に viewport 幅を渡していたため、fixed root の `width` が viewport 全幅になり、`right: 0` の解決が `cb_w - viewport_w - 0 = 0` となって左端に張り付いていた。
- これは fulgur-4m16 で descendant fragment を出すようにした後でも残っていた最後の placement バグ。

## 変更内容

- `crates/fulgur/src/blitz_adapter.rs::relayout_position_fixed`
  - 各 fixed 要素について、`width: auto` かつ `(left set) XOR (right set)` のとき inline 軸を `MaxContent` に切り替え
  - block 軸は `Definite(viewport_h_px)` のまま（fixedpos-001/002/008 が現状 PASS なので、Taffy の block layout は auto-height でも content-height を返している ─ ここは触らない）
  - 判定は事前に Vec に集めてから `deref_mut()` で borrow するため、Vec を 1 ループ追加
- 新規 unit test `relayout_position_fixed_shrinks_to_fit_when_only_right_inset_set` で API 境界に §10.3.7 をピン留め
- `crates/fulgur-wpt/expectations/css-page.txt` の fixedpos-009 コメントを新しい状態 (216 px diff、§10.3.7 部分は修正済み) に更新

## WPT 影響

| Test | Before | After |
|------|--------|-------|
| fixedpos-009-print | 2738 px diff (pencil 左端) | **216 px diff (pencil 正しく右下、残差はマスク端の sub-pixel anti-aliasing)** |
| fixedpos-001/002/003/008 | PASS | PASS |
| page-name-fixed-pos-001 | PASS | PASS |

`css-page` 全体の regressions count は 3 → 3 で増減なし (3 件はいずれも本変更と無関係な事前存在の regression)。

## 残課題 (follow-up)

fulgur-6wap の acceptance #1 「fixedpos-009 が PASS に flip」までは届かない。残差は test (position:fixed) と ref (position:absolute inside .fakepage{position:relative}) の y 座標解決の sub-pixel rounding 差。**fulgur-orcx** に切り出し、本 issue から depends-on で繋いだ。

## 関連 issue

- fulgur-6wap (本変更)
- fulgur-orcx (sub-pixel residual、本 PR の depends-on)
- fulgur-4m16 (PR #341、本 PR の前提)

## Test plan

- [x] `cargo test -p fulgur --lib` (744 passed, 新規 test 含む)
- [x] `cargo clippy -p fulgur` (clean)
- [x] `cargo fmt --check` (clean)
- [x] WPT `wpt_css_page` フェーズ実行 (regressions 3 件は本変更と無関係、fixedpos-001/002/003/008/009/page-name-fixed-pos-001 で逆退行なし)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shrink-to-fit behavior for position: fixed elements so width is determined per CSS spec; a remaining sub-pixel anti-aliasing mismatch may still cause visual test failures.

* **Tests**
  * Updated test expectations and added unit tests covering fixed-position shrink-to-fit scenarios to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->