### PR TITLE
fix(background): align corner gradient angles

### DIFF
--- a/crates/fulgur-vrt/goldens/fulgur/paint/gradient-to-top-right-tile-aspect.pdf
+++ b/crates/fulgur-vrt/goldens/fulgur/paint/gradient-to-top-right-tile-aspect.pdf
@@ -26,7 +26,7 @@ endobj
   /ColorSpace /DeviceRGB
   /AntiAlias false
   /Function 2 0 R
-  /Coords [60 86.25 90 26.25]
+  /Coords [59.999996 86.25 90 26.249998]
   /Extend [true true]
 >>
 endobj
@@ -79,7 +79,7 @@ endobj
   /Subtype /XML
 >>
 stream
-<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><pdf:Producer>fulgur</pdf:Producer><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>hIta8CQ71QGy+eyJNCRdBQ==</xmpMM:InstanceID><xmpMM:DocumentID>hIta8CQ71QGy+eyJNCRdBQ==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><pdf:Producer>fulgur</pdf:Producer><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>KE6lczM5aQH8g7Z/EJ8fAw==</xmpMM:InstanceID><xmpMM:DocumentID>KE6lczM5aQH8g7Z/EJ8fAw==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
 endstream
 endobj
 
@@ -97,19 +97,19 @@ xref
 0000000016 00000 n
 0000000080 00000 n
 0000000246 00000 n
-0000000399 00000 n
-0000000502 00000 n
-0000000706 00000 n
-0000000885 00000 n
-0000000928 00000 n
-0000001777 00000 n
+0000000410 00000 n
+0000000513 00000 n
+0000000717 00000 n
+0000000896 00000 n
+0000000939 00000 n
+0000001788 00000 n
 trailer
 <<
   /Size 10
   /Root 9 0 R
   /Info 7 0 R
-  /ID [(hIta8CQ71QGy+eyJNCRdBQ==) (hIta8CQ71QGy+eyJNCRdBQ==)]
+  /ID [(KE6lczM5aQH8g7Z/EJ8fAw==) (KE6lczM5aQH8g7Z/EJ8fAw==)]
 >>
 startxref
-1849
+1860
 %%EOF

--- a/crates/fulgur-wpt/expectations/lists/bugs.txt
+++ b/crates/fulgur-wpt/expectations/lists/bugs.txt
@@ -26,7 +26,7 @@ PASS  css/css-grid/grid-definition/grid-layout-basic.html             # fulgur-8
 # 独立検証用の test↔ref harness は
 # `crates/fulgur-vrt/tests/gradient_harness.rs` に。
 PASS  css/css-images/linear-gradient-1.html             # fulgur-yax4: linear-gradient (3-stop axis direction)
-FAIL  css/css-images/linear-gradient-non-square.html    # Tracking: beads fulgur-woge — latent regression, bisect details in issue body
+PASS  css/css-images/linear-gradient-non-square.html
 
 # fulgur-gm56: radial-gradient Phase 2 実装 (shape/size/position + %-positioned
 # stops + auto stop spacing) は実装済み。視覚比較は VRT

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -451,7 +451,12 @@ fn corner_to_angle_rad(
         BottomLeft => (-1.0, 1.0),
         BottomRight => (1.0, 1.0),
     };
-    (h * h_sign).atan2(-w * v_sign)
+    let angle_deg = (h * h_sign).atan2(-w * v_sign).to_degrees();
+    match corner {
+        BottomLeft => (angle_deg + 360.0).to_radians(),
+        BottomRight => (angle_deg - 360.0).to_radians(),
+        TopLeft | TopRight => angle_deg.to_radians(),
+    }
 }
 
 /// 範囲外 fraction を CSS Images 3 §3.5.1 準拠で `[0, 1]` 内表現に renormalize する。
@@ -2938,10 +2943,10 @@ mod tests {
     fn corner_to_angle_rad_bottom_right_square_is_3pi_over_4() {
         use crate::draw_primitives::LinearGradientCorner;
         let angle = corner_to_angle_rad(LinearGradientCorner::BottomRight, 100.0, 100.0);
-        let expected = 3.0 * std::f32::consts::FRAC_PI_4;
+        let expected = 3.0 * std::f32::consts::FRAC_PI_4 - std::f32::consts::TAU;
         assert!(
             (angle - expected).abs() < 1e-5,
-            "expected 3π/4, got {angle}"
+            "expected -5π/4, got {angle}"
         );
     }
 
@@ -2949,10 +2954,10 @@ mod tests {
     fn corner_to_angle_rad_bottom_left_square_is_neg_3pi_over_4() {
         use crate::draw_primitives::LinearGradientCorner;
         let angle = corner_to_angle_rad(LinearGradientCorner::BottomLeft, 100.0, 100.0);
-        let expected = -3.0 * std::f32::consts::FRAC_PI_4;
+        let expected = -3.0 * std::f32::consts::FRAC_PI_4 + std::f32::consts::TAU;
         assert!(
             (angle - expected).abs() < 1e-5,
-            "expected -3π/4, got {angle}"
+            "expected 5π/4, got {angle}"
         );
     }
 
@@ -2979,6 +2984,23 @@ mod tests {
             (angle - expected).abs() < 1e-5,
             "expected atan2(400,300)={expected}, got {angle}"
         );
+    }
+
+    #[test]
+    fn corner_to_angle_rad_non_square_matches_wpt_reference_angles() {
+        use crate::draw_primitives::LinearGradientCorner;
+
+        let cases = [
+            (LinearGradientCorner::BottomRight, 0xc066_bc41),
+            (LinearGradientCorner::BottomLeft, 0x4066_bc41),
+            (LinearGradientCorner::TopLeft, 0xbeed_6339),
+            (LinearGradientCorner::TopRight, 0x3eed_6339),
+        ];
+
+        for (corner, expected_bits) in cases {
+            let angle = corner_to_angle_rad(corner, 200.0, 100.0);
+            assert_eq!(angle.to_bits(), expected_bits, "corner={corner:?}");
+        }
     }
 
     // ─── ellipse_corner_scale ─────────────────────────────────────────────────


### PR DESCRIPTION
## 概要
- 非正方形ボックスの `linear-gradient(to <corner>)` で、WPT 参照の明示角と同じ `f32` 表現になるよう角度正規化を調整しました。
- `css/css-images/linear-gradient-non-square.html` を `PASS` に昇格しました。
- 角度表現差に伴う VRT golden を更新しました。

## 設計
- corner keyword の角度は数学的には等価でも、`sin/cos` の入力角表現が異なると hard-stop 境界が pixel 単位でずれるため、WPT 参照の明示角と同じ degree-to-radian 経路に揃えています。
- 非正方形 200x100 の 4 corner 方向について、期待する `f32` bit pattern を unit test で固定しました。

## 検証
- `cargo fmt --check`
- `cargo clippy --all-targets`
- `cargo test -p fulgur`
- `cargo test -p fulgur-cli`
- `cargo test -p fulgur-vrt --release`
- `cargo run -p fulgur-wpt --example run_one -- /home/ubuntu/fulgur/target/wpt/css/css-images/linear-gradient-non-square.html`
- `FULGUR_WPT_REQUIRED=1 cargo test -p fulgur-wpt --test wpt_lists --release -- --nocapture`

## WPT delta
| Test | Before | After |
|---|---|---|
| `css/css-images/linear-gradient-non-square.html` | FAIL | PASS |

`wpt-bugs` は `promotions=0` まで確認済みです。

Refs fulgur-woge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed linear gradient angle calculations for non-square elements, improving visual accuracy of gradient rendering across different aspect ratios. Gradients now correctly calculate direction and appearance based on actual element dimensions. Previously failing test cases for non-square rectangular dimensions now pass. Enhanced test coverage ensures consistency across all corner configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->