### PR TITLE
docs(pyfulgur): mirror docstrings into __init__.pyi for mkdocstrings

### DIFF
--- a/crates/pyfulgur/python/pyfulgur/__init__.pyi
+++ b/crates/pyfulgur/python/pyfulgur/__init__.pyi
@@ -1,9 +1,14 @@
-"""Type stubs for pyfulgur.
+"""Type stubs and rendered documentation for pyfulgur.
 
-Docstrings are intentionally omitted here — the canonical source is the Rust
-``///`` doc comments, which PyO3 surfaces as ``__doc__`` at runtime. griffe
-(mkdocstrings) and modern IDEs merge ``.pyi`` types with runtime docstrings
-automatically.
+Docstrings here mirror the Rust ``///`` comments on each PyO3 binding so that:
+
+- mkdocstrings / griffe in static mode can render the API reference without
+  ``force_inspection`` (which would drop type annotations from signatures).
+- IDEs (pyright, pylance) show the same docstring in hover that ``help()``
+  shows at runtime.
+
+The Rust ``///`` comments remain the canonical source for runtime ``__doc__``;
+when changing one, change the other.
 """
 
 import os
@@ -13,74 +18,350 @@ __version__: str
 __all__: List[str]
 
 
-class RenderError(Exception): ...
+class RenderError(Exception):
+    """Raised when fulgur fails to render an HTML document to PDF.
+
+    Wraps parse, layout, font, and PDF-generation errors from the underlying
+    fulgur engine.
+    """
 
 
 class PageSize:
+    """Page size with dimensions in millimeters.
+
+    Use the predefined class attributes ``A4``, ``LETTER``, or ``A3``, or
+    `custom` for arbitrary sizes. ``PageSize`` is immutable.
+
+    Example:
+        ```python
+        from pyfulgur import PageSize
+        a4 = PageSize.A4
+        custom = PageSize.custom(210.0, 297.0)
+        landscape = a4.landscape()
+        ```
+    """
+
     A4: PageSize
     LETTER: PageSize
     A3: PageSize
 
     @staticmethod
-    def custom(width_mm: float, height_mm: float) -> PageSize: ...
-    def landscape(self) -> PageSize: ...
+    def custom(width_mm: float, height_mm: float) -> PageSize:
+        """Create a page size with arbitrary dimensions.
+
+        Args:
+            width_mm: Page width in millimeters.
+            height_mm: Page height in millimeters.
+
+        Returns:
+            A new ``PageSize`` instance.
+        """
+
+    def landscape(self) -> PageSize:
+        """Return a new ``PageSize`` with width and height swapped.
+
+        Returns:
+            A new ``PageSize`` rotated 90 degrees from this one.
+        """
+
     @property
-    def width(self) -> float: ...
+    def width(self) -> float:
+        """Page width in millimeters."""
+
     @property
-    def height(self) -> float: ...
+    def height(self) -> float:
+        """Page height in millimeters."""
+
     def __repr__(self) -> str: ...
 
 
 class Margin:
+    """Page margin in points (PDF pt).
+
+    Margins apply uniformly to every generated page. Use the constructor for
+    explicit per-side values, or one of the helper factories
+    (`uniform`, `symmetric`, `uniform_mm`).
+
+    Example:
+        ```python
+        from pyfulgur import Margin
+        Margin(36.0, 36.0, 36.0, 36.0)
+        Margin.uniform_mm(20.0)
+        ```
+    """
+
     def __init__(
         self,
         top: float,
         right: float,
         bottom: float,
         left: float,
-    ) -> None: ...
+    ) -> None:
+        """
+        Args:
+            top: Top margin in points.
+            right: Right margin in points.
+            bottom: Bottom margin in points.
+            left: Left margin in points.
+        """
+
     @staticmethod
-    def uniform(pt: float) -> Margin: ...
+    def uniform(pt: float) -> Margin:
+        """Create a uniform margin (the same value on all four sides).
+
+        Args:
+            pt: Margin value in points (PDF pt).
+
+        Returns:
+            A new ``Margin`` with all sides set to ``pt``.
+        """
+
     @staticmethod
-    def symmetric(vertical: float, horizontal: float) -> Margin: ...
+    def symmetric(vertical: float, horizontal: float) -> Margin:
+        """Create a symmetric margin (vertical and horizontal pairs).
+
+        Args:
+            vertical: Top and bottom margin in points.
+            horizontal: Left and right margin in points.
+
+        Returns:
+            A new ``Margin`` with the given symmetric values.
+        """
+
     @staticmethod
-    def uniform_mm(mm: float) -> Margin: ...
+    def uniform_mm(mm: float) -> Margin:
+        """Create a uniform margin specified in millimeters.
+
+        Args:
+            mm: Margin value in millimeters.
+
+        Returns:
+            A new ``Margin`` with all sides set to the equivalent point value.
+        """
+
     @property
-    def top(self) -> float: ...
+    def top(self) -> float:
+        """Top margin in points."""
+
     @property
-    def right(self) -> float: ...
+    def right(self) -> float:
+        """Right margin in points."""
+
     @property
-    def bottom(self) -> float: ...
+    def bottom(self) -> float:
+        """Bottom margin in points."""
+
     @property
-    def left(self) -> float: ...
+    def left(self) -> float:
+        """Left margin in points."""
+
     def __repr__(self) -> str: ...
 
 
 class AssetBundle:
+    """Bundle of CSS, fonts, and images passed to `Engine`.
+
+    fulgur is offline-first: every asset must be explicitly registered before
+    rendering. The engine never performs network fetches.
+
+    Example:
+        ```python
+        from pyfulgur import AssetBundle, Engine
+        bundle = AssetBundle()
+        bundle.add_css("body { font-family: sans-serif; }")
+        engine = Engine(assets=bundle)
+        ```
+    """
+
     def __init__(self) -> None: ...
-    def add_css(self, css: str) -> None: ...
-    def add_css_file(self, path: Union[str, "os.PathLike[str]"]) -> None: ...
-    def add_font_file(self, path: Union[str, "os.PathLike[str]"]) -> None: ...
-    def add_image(self, name: str, data: bytes) -> None: ...
+
+    def add_css(self, css: str) -> None:
+        """Add an inline CSS string to the bundle.
+
+        Args:
+            css: CSS source text.
+        """
+
+    def add_css_file(self, path: Union[str, "os.PathLike[str]"]) -> None:
+        """Add a CSS file from disk.
+
+        Args:
+            path: Filesystem path to the CSS file.
+
+        Raises:
+            FileNotFoundError: When ``path`` does not exist.
+            ValueError: When the CSS file cannot be read or decoded.
+        """
+
+    def add_font_file(self, path: Union[str, "os.PathLike[str]"]) -> None:
+        """Add a font file (TTF, OTF, WOFF, or WOFF2) from disk.
+
+        Args:
+            path: Filesystem path to the font file.
+
+        Raises:
+            FileNotFoundError: When ``path`` does not exist.
+            ValueError: When the font format is unsupported.
+        """
+
+    def add_image(self, name: str, data: bytes) -> None:
+        """Add an image with an explicit logical name and raw bytes.
+
+        Args:
+            name: Logical name to reference from CSS or HTML
+                (e.g. ``"logo.png"``).
+            data: Raw image bytes (PNG, JPEG, etc.).
+        """
+
     def add_image_file(
         self, name: str, path: Union[str, "os.PathLike[str]"]
-    ) -> None: ...
+    ) -> None:
+        """Add an image file from disk.
+
+        Args:
+            name: Logical name to reference from CSS or HTML.
+            path: Filesystem path to the image file.
+
+        Raises:
+            FileNotFoundError: When ``path`` does not exist.
+        """
 
 
 class EngineBuilder:
+    """Builder for configuring and constructing an `Engine`.
+
+    All setters return ``self`` to support method chaining. Each builder
+    instance can be ``build()`` ed only once; subsequent calls raise
+    ``RuntimeError``.
+
+    Example:
+        ```python
+        from pyfulgur import Engine, PageSize, Margin
+        engine = (
+            Engine.builder()
+            .page_size(PageSize.A4)
+            .margin(Margin.uniform_mm(20.0))
+            .title("Doc")
+            .build()
+        )
+        ```
+    """
+
     def __init__(self) -> None: ...
-    def page_size(self, value: Union[PageSize, str]) -> EngineBuilder: ...
-    def margin(self, margin: Margin) -> EngineBuilder: ...
-    def landscape(self, value: bool) -> EngineBuilder: ...
-    def title(self, value: str) -> EngineBuilder: ...
-    def author(self, value: str) -> EngineBuilder: ...
-    def lang(self, value: str) -> EngineBuilder: ...
-    def bookmarks(self, value: bool) -> EngineBuilder: ...
-    def assets(self, bundle: AssetBundle) -> EngineBuilder: ...
-    def build(self) -> Engine: ...
+
+    def page_size(self, value: Union[PageSize, str]) -> EngineBuilder:
+        """Set the page size.
+
+        Args:
+            value: Either a `PageSize` instance or a string name
+                (``"A4"``, ``"LETTER"``, ``"A3"``; case-insensitive).
+
+        Returns:
+            ``self`` for method chaining.
+
+        Raises:
+            ValueError: When ``value`` is an unknown size name or wrong type.
+        """
+
+    def margin(self, margin: Margin) -> EngineBuilder:
+        """Set the page margins.
+
+        Args:
+            margin: A `Margin` instance.
+
+        Returns:
+            ``self`` for method chaining.
+        """
+
+    def landscape(self, value: bool) -> EngineBuilder:
+        """Toggle landscape orientation.
+
+        Args:
+            value: ``True`` to render in landscape, ``False`` for portrait.
+
+        Returns:
+            ``self`` for method chaining.
+        """
+
+    def title(self, value: str) -> EngineBuilder:
+        """Set the PDF document title metadata.
+
+        Args:
+            value: Title string written to the PDF metadata.
+
+        Returns:
+            ``self`` for method chaining.
+        """
+
+    def author(self, value: str) -> EngineBuilder:
+        """Set the PDF document author metadata.
+
+        Args:
+            value: Author string written to the PDF metadata.
+
+        Returns:
+            ``self`` for method chaining.
+        """
+
+    def lang(self, value: str) -> EngineBuilder:
+        """Set the document language tag.
+
+        Args:
+            value: BCP 47 language tag (e.g. ``"en"``, ``"ja"``).
+
+        Returns:
+            ``self`` for method chaining.
+        """
+
+    def bookmarks(self, value: bool) -> EngineBuilder:
+        """Toggle PDF bookmark generation.
+
+        Args:
+            value: ``True`` to generate bookmarks from heading hierarchy.
+
+        Returns:
+            ``self`` for method chaining.
+        """
+
+    def assets(self, bundle: AssetBundle) -> EngineBuilder:
+        """Attach an `AssetBundle` of CSS, fonts, and images.
+
+        The bundle is consumed and reset to an empty state so it can be
+        reused for a new build cycle.
+
+        Args:
+            bundle: The `AssetBundle` to attach.
+
+        Returns:
+            ``self`` for method chaining.
+        """
+
+    def build(self) -> Engine:
+        """Finalize the configuration and build an `Engine`.
+
+        Returns:
+            A new `Engine` ready to render HTML.
+
+        Raises:
+            RuntimeError: When the builder has already been consumed.
+        """
 
 
 class Engine:
+    """HTML/CSS to PDF conversion engine.
+
+    fulgur converts HTML, CSS, and SVG into a PDF document deterministically
+    and offline. All assets must be explicitly bundled via `AssetBundle`;
+    no network fetches are performed.
+
+    Example:
+        ```python
+        from pyfulgur import Engine, PageSize
+        engine = Engine(page_size=PageSize.A4, title="Hello")
+        engine.render_html_to_file("<h1>Hi</h1>", "out.pdf")
+        ```
+    """
+
     def __init__(
         self,
         *,
@@ -92,10 +373,60 @@ class Engine:
         lang: Optional[str] = ...,
         bookmarks: Optional[bool] = ...,
         assets: Optional[AssetBundle] = ...,
-    ) -> None: ...
+    ) -> None:
+        """
+        Args:
+            page_size: Page dimensions, either a `PageSize` or a
+                case-insensitive string name (``"A4"``, ``"LETTER"``,
+                ``"A3"``).
+            margin: Page margins.
+            landscape: ``True`` for landscape orientation.
+            title: PDF title metadata.
+            author: PDF author metadata.
+            lang: BCP 47 language tag.
+            bookmarks: ``True`` to generate bookmarks from heading hierarchy.
+            assets: An `AssetBundle` of CSS, fonts, and images.
+
+        Raises:
+            ValueError: When ``page_size`` is an unknown name.
+        """
+
     @staticmethod
-    def builder() -> EngineBuilder: ...
-    def render_html(self, html: str) -> bytes: ...
+    def builder() -> EngineBuilder:
+        """Return a fresh `EngineBuilder` for fluent configuration.
+
+        Returns:
+            A new `EngineBuilder`.
+        """
+
+    def render_html(self, html: str) -> bytes:
+        """Render HTML to PDF bytes.
+
+        The Python GIL is released for the duration of the render so multiple
+        threads can render in parallel.
+
+        Args:
+            html: HTML source string.
+
+        Returns:
+            PDF bytes (always start with ``b"%PDF"``).
+
+        Raises:
+            RenderError: When parsing, layout, or PDF generation fails.
+        """
+
     def render_html_to_file(
         self, html: str, path: Union[str, "os.PathLike[str]"]
-    ) -> None: ...
+    ) -> None:
+        """Render HTML and write the PDF to a file.
+
+        The GIL is released for the duration of the render.
+
+        Args:
+            html: HTML source string.
+            path: Filesystem path to write the PDF to.
+
+        Raises:
+            RenderError: When rendering or writing fails.
+            FileNotFoundError: When the parent directory does not exist.
+        """

--- a/crates/pyfulgur/python/pyfulgur/__init__.pyi
+++ b/crates/pyfulgur/python/pyfulgur/__init__.pyi
@@ -230,9 +230,8 @@ class AssetBundle:
 class EngineBuilder:
     """Builder for configuring and constructing an `Engine`.
 
-    All setters return ``self`` to support method chaining. Each builder
-    instance can be ``build()`` ed only once; subsequent calls raise
-    ``RuntimeError``.
+    All setters return ``self`` to support method chaining. ``build()`` can
+    be called only once per builder; subsequent calls raise ``RuntimeError``.
 
     Example:
         ```python

--- a/crates/pyfulgur/src/asset_bundle.rs
+++ b/crates/pyfulgur/src/asset_bundle.rs
@@ -4,16 +4,18 @@ use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use std::path::PathBuf;
 
-/// Bundle of CSS, fonts, and images passed to :class:`Engine`.
+/// Bundle of CSS, fonts, and images passed to `Engine`.
 ///
 /// fulgur is offline-first: every asset must be explicitly registered before
 /// rendering. The engine never performs network fetches.
 ///
 /// Example:
-///     >>> from pyfulgur import AssetBundle, Engine
-///     >>> bundle = AssetBundle()
-///     >>> bundle.add_css("body { font-family: sans-serif; }")
-///     >>> engine = Engine(assets=bundle)
+///     ```python
+///     from pyfulgur import AssetBundle, Engine
+///     bundle = AssetBundle()
+///     bundle.add_css("body { font-family: sans-serif; }")
+///     engine = Engine(assets=bundle)
+///     ```
 #[pyclass(name = "AssetBundle", module = "pyfulgur")]
 pub struct PyAssetBundle {
     pub(crate) inner: AssetBundle,
@@ -21,7 +23,6 @@ pub struct PyAssetBundle {
 
 #[pymethods]
 impl PyAssetBundle {
-    /// Create an empty asset bundle.
     #[new]
     fn new() -> Self {
         Self {

--- a/crates/pyfulgur/src/engine.rs
+++ b/crates/pyfulgur/src/engine.rs
@@ -11,9 +11,8 @@ use crate::page_size::PyPageSize;
 
 /// Builder for configuring and constructing an `Engine`.
 ///
-/// All setters return ``self`` to support method chaining. Each builder
-/// instance can be ``build()`` ed only once; subsequent calls raise
-/// ``RuntimeError``.
+/// All setters return ``self`` to support method chaining. ``build()`` can
+/// be called only once per builder; subsequent calls raise ``RuntimeError``.
 ///
 /// Example:
 ///     ```python

--- a/crates/pyfulgur/src/engine.rs
+++ b/crates/pyfulgur/src/engine.rs
@@ -9,21 +9,23 @@ use crate::asset_bundle::PyAssetBundle;
 use crate::margin::PyMargin;
 use crate::page_size::PyPageSize;
 
-/// Builder for configuring and constructing an :class:`Engine`.
+/// Builder for configuring and constructing an `Engine`.
 ///
 /// All setters return ``self`` to support method chaining. Each builder
 /// instance can be ``build()`` ed only once; subsequent calls raise
 /// ``RuntimeError``.
 ///
 /// Example:
-///     >>> from pyfulgur import Engine, PageSize, Margin
-///     >>> engine = (
-///     ...     Engine.builder()
-///     ...     .page_size(PageSize.A4)
-///     ...     .margin(Margin.uniform_mm(20.0))
-///     ...     .title("Doc")
-///     ...     .build()
-///     ... )
+///     ```python
+///     from pyfulgur import Engine, PageSize, Margin
+///     engine = (
+///         Engine.builder()
+///         .page_size(PageSize.A4)
+///         .margin(Margin.uniform_mm(20.0))
+///         .title("Doc")
+///         .build()
+///     )
+///     ```
 #[pyclass(name = "EngineBuilder", module = "pyfulgur")]
 pub struct PyEngineBuilder {
     inner: Option<EngineBuilder>,
@@ -65,7 +67,6 @@ pub(crate) fn extract_page_size(value: &Bound<'_, PyAny>) -> PyResult<PageSize> 
 
 #[pymethods]
 impl PyEngineBuilder {
-    /// Create a new builder seeded with default configuration.
     #[new]
     fn new() -> Self {
         Self {
@@ -76,7 +77,7 @@ impl PyEngineBuilder {
     /// Set the page size.
     ///
     /// Args:
-    ///     value: Either a :class:`PageSize` instance or a string name
+    ///     value: Either a `PageSize` instance or a string name
     ///         (``"A4"``, ``"LETTER"``, ``"A3"``; case-insensitive).
     ///
     /// Returns:
@@ -93,7 +94,7 @@ impl PyEngineBuilder {
     /// Set the page margins.
     ///
     /// Args:
-    ///     margin: A :class:`Margin` instance.
+    ///     margin: A `Margin` instance.
     ///
     /// Returns:
     ///     ``self`` for method chaining.
@@ -162,13 +163,13 @@ impl PyEngineBuilder {
         Ok(slf.into())
     }
 
-    /// Attach an :class:`AssetBundle` of CSS, fonts, and images.
+    /// Attach an `AssetBundle` of CSS, fonts, and images.
     ///
     /// The bundle is consumed and reset to an empty state so it can be
     /// reused for a new build cycle.
     ///
     /// Args:
-    ///     bundle: The :class:`AssetBundle` to attach.
+    ///     bundle: The `AssetBundle` to attach.
     ///
     /// Returns:
     ///     ``self`` for method chaining.
@@ -181,10 +182,10 @@ impl PyEngineBuilder {
         Ok(slf.into())
     }
 
-    /// Finalize the configuration and build an :class:`Engine`.
+    /// Finalize the configuration and build an `Engine`.
     ///
     /// Returns:
-    ///     A new :class:`Engine` ready to render HTML.
+    ///     A new `Engine` ready to render HTML.
     ///
     /// Raises:
     ///     RuntimeError: When the builder has already been consumed.
@@ -197,14 +198,15 @@ impl PyEngineBuilder {
 /// HTML/CSS to PDF conversion engine.
 ///
 /// fulgur converts HTML, CSS, and SVG into a PDF document deterministically
-/// and offline. All assets must be explicitly bundled via
-/// :class:`AssetBundle`; no network fetches are performed.
+/// and offline. All assets must be explicitly bundled via `AssetBundle`;
+/// no network fetches are performed.
 ///
 /// Example:
-///     >>> from pyfulgur import Engine, PageSize
-///     >>> engine = Engine(page_size=PageSize.A4, title="Hello")
-///     >>> pdf = engine.render_html("<h1>Hi</h1>")
-///     >>> assert pdf.startswith(b"%PDF")
+///     ```python
+///     from pyfulgur import Engine, PageSize
+///     engine = Engine(page_size=PageSize.A4, title="Hello")
+///     engine.render_html_to_file("<h1>Hi</h1>", "out.pdf")
+///     ```
 #[pyclass(name = "Engine", module = "pyfulgur")]
 pub struct PyEngine {
     pub(crate) inner: Engine,
@@ -212,13 +214,8 @@ pub struct PyEngine {
 
 #[pymethods]
 impl PyEngine {
-    /// Construct an engine directly with keyword arguments.
-    ///
-    /// All arguments are keyword-only and optional. For more granular
-    /// configuration use :meth:`builder`.
-    ///
     /// Args:
-    ///     page_size: Page dimensions, either a :class:`PageSize` or a
+    ///     page_size: Page dimensions, either a `PageSize` or a
     ///         case-insensitive string name (``"A4"``, ``"LETTER"``,
     ///         ``"A3"``).
     ///     margin: Page margins.
@@ -227,7 +224,7 @@ impl PyEngine {
     ///     author: PDF author metadata.
     ///     lang: BCP 47 language tag.
     ///     bookmarks: ``True`` to generate bookmarks from heading hierarchy.
-    ///     assets: An :class:`AssetBundle` of CSS, fonts, and images.
+    ///     assets: An `AssetBundle` of CSS, fonts, and images.
     ///
     /// Raises:
     ///     ValueError: When ``page_size`` is an unknown name.
@@ -282,10 +279,10 @@ impl PyEngine {
         Ok(Self { inner: b.build() })
     }
 
-    /// Return a fresh :class:`EngineBuilder` for fluent configuration.
+    /// Return a fresh `EngineBuilder` for fluent configuration.
     ///
     /// Returns:
-    ///     A new :class:`EngineBuilder`.
+    ///     A new `EngineBuilder`.
     #[staticmethod]
     fn builder() -> PyEngineBuilder {
         PyEngineBuilder::new()

--- a/crates/pyfulgur/src/margin.rs
+++ b/crates/pyfulgur/src/margin.rs
@@ -5,12 +5,14 @@ use pyo3::prelude::*;
 ///
 /// Margins apply uniformly to every generated page. Use the constructor for
 /// explicit per-side values, or one of the helper factories
-/// (:meth:`uniform`, :meth:`symmetric`, :meth:`uniform_mm`).
+/// (`uniform`, `symmetric`, `uniform_mm`).
 ///
 /// Example:
-///     >>> from pyfulgur import Margin
-///     >>> Margin(36.0, 36.0, 36.0, 36.0)
-///     >>> Margin.uniform_mm(20.0)
+///     ```python
+///     from pyfulgur import Margin
+///     Margin(36.0, 36.0, 36.0, 36.0)
+///     Margin.uniform_mm(20.0)
+///     ```
 #[pyclass(name = "Margin", module = "pyfulgur", frozen, from_py_object)]
 #[derive(Clone, Copy)]
 pub struct PyMargin {
@@ -19,8 +21,6 @@ pub struct PyMargin {
 
 #[pymethods]
 impl PyMargin {
-    /// Create a margin with explicit per-side values.
-    ///
     /// Args:
     ///     top: Top margin in points.
     ///     right: Right margin in points.

--- a/crates/pyfulgur/src/page_size.rs
+++ b/crates/pyfulgur/src/page_size.rs
@@ -4,13 +4,15 @@ use pyo3::prelude::*;
 /// Page size with dimensions in millimeters.
 ///
 /// Use the predefined class attributes ``A4``, ``LETTER``, or ``A3``, or
-/// :meth:`custom` for arbitrary sizes. ``PageSize`` is immutable.
+/// `custom` for arbitrary sizes. ``PageSize`` is immutable.
 ///
 /// Example:
-///     >>> from pyfulgur import PageSize
-///     >>> a4 = PageSize.A4
-///     >>> custom = PageSize.custom(210.0, 297.0)
-///     >>> landscape = a4.landscape()
+///     ```python
+///     from pyfulgur import PageSize
+///     a4 = PageSize.A4
+///     custom = PageSize.custom(210.0, 297.0)
+///     landscape = a4.landscape()
+///     ```
 #[pyclass(name = "PageSize", module = "pyfulgur", frozen, from_py_object)]
 #[derive(Clone, Copy)]
 pub struct PyPageSize {


### PR DESCRIPTION
## 概要

mkdocstrings (griffe) で pyfulgur の API リファレンスを正しく描画できるよう、Rust `///` の docstring を `__init__.pyi` に mirror する。fulgur-lxy0 (website 側 mkdocstrings 組込み) の前提条件 (Refs `fulgur-td0a`)。

## 経緯

PR #346 で「docstring は Rust `///` 一元、`.pyi` は型のみ」という設計を採用した。advisor の事前指摘 "griffe inspection は default で `__doc__` を merge する" を信じた選択だったが、ローカル mkdocs build で実機検証したところ griffe 静的モードは runtime `__doc__` を merge しないことが判明:

- 静的モード (default): `.pyi` から型シグネチャ完全表示 ✅ / docstring 空 ❌
- `force_inspection: true`: docstring 表示 ✅ / 型シグネチャから型情報が消える ❌ (`page_size(value)` のみ。`(value: Union[PageSize, str])` ではない)
- hybrid (両モード merge) は mkdocstrings に存在しない

両方を成立させるため、`.pyi` に Google 形式 docstring を mirror した。Rust `///` は runtime `help()` / Jupyter `?` のため維持 (二重メンテだが API 5 クラスで安定、drift リスク低)。

## 主な変更

- **`crates/pyfulgur/python/pyfulgur/__init__.pyi`**: 全 public クラス・メソッド・staticmethod・property に Google 形式 docstring を追加 (Args / Returns / Raises 表)。
- **mkdocstrings 描画品質の整理 (両方の docstring 源を一斉に修正)**:
  - **Sphinx 形式 `:class:` / `:meth:` を削除**: mkdocstrings autorefs はプレーンな backtick code を自動でリンク化する。`:class:` プレフィックス付きだと `:class:<code>X</code>` のリテラルテキストとして出てしまうため除去。
  - **doctest `>>>` ブロックを fenced code block に置換**: mkdocstrings の Google parser は `>>>` を doctest として処理せず、深く入れ子になった blockquote として render してしまう。`\`\`\`python ... \`\`\`` に統一してシンタックスハイライト付き code block に。
  - **`__init__` docstring からリード文を削除**: `merge_init_into_class: true` 構成で class docstring の直後に `__init__` の prose が連なって重複していた。`Args:` / `Raises:` セクションだけ残せば、merge 時に Parameters / Raises 表だけが綺麗に追加される。
- **Engine class Example の出力を `render_html_to_file` に変更**: `pdf = engine.render_html(...); assert pdf.startswith(b"%PDF")` だと検証イディオムで例として読みにくいため、`engine.render_html_to_file("<h1>Hi</h1>", \"out.pdf\")` に置換。実用パターンに近づける。

## ローカル検証

`mkdocstrings[python]` と `mkdocs-material` を install し、`::: pyfulgur.Engine` 等を含む temp `mkdocs.yml` で `mkdocs build` / `mkdocs serve` で実機確認:

- ✅ クラス見出し + 概要 + Example (シンタックスハイライト付き code block) が表示
- ✅ コンストラクタの完全シグネチャ (`Engine(*, page_size: Optional[Union[PageSize, str]] = ..., margin: Optional[Margin] = ..., ...)`) が `.pyi` 由来で render
- ✅ Parameters 表が型 (autoref で内部リンク) + 説明付きで表示
- ✅ メソッド毎に Args / Returns / Raises 表
- ✅ 各クラスの間にリード文重複なし、`:class:` プレフィックスなし、`>>>` blockquote ネストなし

## Test plan

- [x] `pytest crates/pyfulgur/tests/` — 60 passed (既存 + docstring keyword test)
- [x] `cargo test --workspace --exclude fulgur-vrt` — green
- [x] `cargo clippy -p pyfulgur --features extension-module --all-targets -- -D warnings` — warnings 0
- [x] `cargo fmt --check` — clean
- [x] ローカル `mkdocs build --strict` (mkdocs-material + mkdocstrings[python] 静的モード) で warnings なし、全 6 クラスが完全にリファレンス表示

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed API docstrings for all public classes and methods to improve clarity and error/argument guidance.
  * Standardized and refreshed Python usage examples across the library with consistent fenced-code formatting.
  * Enhanced module-level documentation and parameter descriptions for better discoverability and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->