### PR TITLE
feat(tagging): add semantic layer for Tagged PDF (fulgur-izp.3)

### DIFF
--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -168,6 +168,7 @@ pub fn dom_to_drawables(
     drawables.body_offset_pt = extract_body_offset_pt(doc);
     drawables.root_id = Some(root.id);
     drawables.body_id = find_body_id_in_dom(doc);
+    record_semantics_pass(doc, &mut drawables);
     drawables
 }
 
@@ -316,6 +317,70 @@ pub(super) fn convert_node(
     convert_node_inner(doc, node_id, ctx, depth, out);
     record_multicol_rule(doc, node_id, ctx, out);
     record_transform(doc, node_id, &before, out);
+}
+
+/// Walk the DOM top-down from `<body>` and populate `out.semantics`
+/// with one `SemanticEntry` per element whose local name is recognised
+/// by `crate::tagging::classify_element`. Runs as a standalone pass
+/// after `convert_node` so the classification covers elements (e.g.
+/// `<thead>`, `<tbody>`) that the per-type converters traverse via
+/// custom child walks instead of recursing through `convert_node`.
+///
+/// `<head>` and its descendants are intentionally skipped — none of
+/// them participate in the StructTree, and starting from `<body>`
+/// keeps later expansions of `classify_element` (e.g. promoting
+/// `<header>` / `<footer>` to dedicated tags) from accidentally
+/// classifying `<head>`'s `<title>` / `<style>` etc.
+///
+/// fulgur-izp.3: pure data layer. The render path does not consume
+/// these entries yet, so PDF byte equality is preserved across this
+/// change.
+fn record_semantics_pass(doc: &HtmlDocument, out: &mut crate::drawables::Drawables) {
+    use std::ops::Deref;
+    let base = doc.deref();
+    let Some(body_id) = out.body_id else {
+        return;
+    };
+    walk_semantics(base, body_id, 0, out);
+}
+
+fn walk_semantics(
+    doc: &BaseDocument,
+    node_id: usize,
+    depth: usize,
+    out: &mut crate::drawables::Drawables,
+) {
+    if depth >= MAX_DOM_DEPTH {
+        return;
+    }
+    let Some(node) = doc.get_node(node_id) else {
+        return;
+    };
+    if let Some(elem) = node.element_data() {
+        if let Some(tag) = crate::tagging::classify_element(elem.name.local.as_ref()) {
+            // Walk up `node.parent` until an already-recorded ancestor
+            // is found. The traversal is top-down so any classified
+            // ancestor is guaranteed to be present.
+            let mut parent = node.parent;
+            let parent_node_id = loop {
+                let Some(pid) = parent else { break None };
+                if out.semantics.contains_key(&pid) {
+                    break Some(pid);
+                }
+                parent = doc.get_node(pid).and_then(|p| p.parent);
+            };
+            out.semantics.insert(
+                node_id,
+                crate::tagging::SemanticEntry {
+                    tag,
+                    parent: parent_node_id,
+                },
+            );
+        }
+    }
+    for &child_id in &node.children {
+        walk_semantics(doc, child_id, depth + 1, out);
+    }
 }
 
 /// Inner dispatcher. Tries each specialized converter in order; falls
@@ -639,6 +704,195 @@ mod bookmark_outline_tests {
         assert!(
             pdf_str.contains("/Outlines"),
             "bookmark anchors must reach the v2 outline pipeline; PDF missing /Outlines"
+        );
+    }
+}
+
+#[cfg(test)]
+mod semantics_tests {
+    //! fulgur-izp.3: convert-side semantic tag classification. Verifies
+    //! `dom_to_drawables` populates `Drawables.semantics` with the
+    //! expected `(tag, parent)` pairs for representative HTML fixtures.
+    //!
+    //! Render-side wire-up (`fulgur-izp.4`) and StructTree assembly
+    //! (`fulgur-izp.5`) are out of scope; these tests assert the data
+    //! shape only.
+
+    use crate::tagging::PdfTag;
+    use std::ops::DerefMut;
+
+    fn build_drawables(html: &str) -> crate::drawables::Drawables {
+        // Drive the convert pipeline directly without the full Engine
+        // so the assertions stay focused on `dom_to_drawables`.
+        // `parse_and_layout` already runs stylo + Taffy + the
+        // `position: fixed` relayout, matching what the engine feeds
+        // into convert at this point.
+        let mut doc = crate::blitz_adapter::parse_and_layout(html, 595.0, 842.0, &[]);
+
+        let column_styles = crate::blitz_adapter::extract_column_style_table(&doc);
+        let multicol_geometry = crate::multicol_layout::run_pass(doc.deref_mut(), &column_styles);
+        let pagination_geometry = crate::pagination_layout::run_pass(doc.deref_mut(), 842.0);
+        let running_store = crate::gcpm::running::RunningElementStore::new();
+        let mut ctx = super::ConvertContext {
+            running_store: &running_store,
+            assets: None,
+            font_cache: Default::default(),
+            string_set_by_node: Default::default(),
+            counter_ops_by_node: Default::default(),
+            bookmark_by_node: Default::default(),
+            column_styles,
+            multicol_geometry,
+            pagination_geometry,
+            link_cache: Default::default(),
+            viewport_size_px: Some((595.0, 842.0)),
+        };
+        super::dom_to_drawables(&doc, &mut ctx)
+    }
+
+    fn entries_by_tag(
+        d: &crate::drawables::Drawables,
+        target: &PdfTag,
+    ) -> Vec<(usize, Option<usize>)> {
+        d.semantics
+            .iter()
+            .filter(|(_, e)| e.tag == *target)
+            .map(|(id, e)| (*id, e.parent))
+            .collect()
+    }
+
+    #[test]
+    fn dom_to_drawables_records_semantic_entries_for_block_elements() {
+        let html = "<!DOCTYPE html><html><body><h1>T</h1><p>x</p><div><img src='a.png' alt='a'></div><p>y <span>inside</span> z</p></body></html>";
+        let d = build_drawables(html);
+
+        let h1s = entries_by_tag(&d, &PdfTag::H { level: 1 });
+        assert_eq!(h1s.len(), 1, "expected one h1 entry");
+        let ps = entries_by_tag(&d, &PdfTag::P);
+        assert_eq!(ps.len(), 2, "expected two p entries");
+        let divs = entries_by_tag(&d, &PdfTag::Div);
+        assert_eq!(divs.len(), 1, "expected one div entry");
+        let figures = entries_by_tag(&d, &PdfTag::Figure);
+        assert_eq!(figures.len(), 1, "expected one figure entry for <img>");
+        let spans = entries_by_tag(&d, &PdfTag::Span);
+        assert_eq!(spans.len(), 1, "expected one span entry");
+
+        let (img_id, img_parent) = figures[0];
+        let (div_id, _) = divs[0];
+        assert_eq!(
+            img_parent,
+            Some(div_id),
+            "img semantic parent should be its enclosing div, got {img_parent:?} for img id {img_id}"
+        );
+
+        // span's parent must be one of the recorded paragraphs — the
+        // exact NodeId depends on Blitz's parse order which is stable
+        // but not part of the contract under test. Asserting set
+        // membership keeps the test robust to renumbering.
+        let p_ids: std::collections::BTreeSet<_> = ps.iter().map(|(id, _)| *id).collect();
+        let (_, span_parent) = spans[0];
+        assert!(
+            span_parent.map(|p| p_ids.contains(&p)).unwrap_or(false),
+            "span parent must be one of the recorded p NodeIds, got {span_parent:?}"
+        );
+    }
+
+    #[test]
+    fn dom_to_drawables_records_semantic_entries_for_lists() {
+        let html = "<!DOCTYPE html><html><body><ul><li>a</li><li>b</li></ul></body></html>";
+        let d = build_drawables(html);
+        let lists = entries_by_tag(&d, &PdfTag::L);
+        assert_eq!(lists.len(), 1, "expected one ul entry");
+        let items = entries_by_tag(&d, &PdfTag::Li);
+        assert_eq!(items.len(), 2, "expected two li entries");
+
+        let (ul_id, _) = lists[0];
+        for (li_id, parent) in &items {
+            assert_eq!(
+                *parent,
+                Some(ul_id),
+                "li {li_id} parent should be ul {ul_id}, got {parent:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn dom_to_drawables_records_semantic_entries_for_tables() {
+        let html = "<!DOCTYPE html><html><body><table><thead><tr><th>h</th></tr></thead><tbody><tr><td>d</td></tr></tbody></table></body></html>";
+        let d = build_drawables(html);
+
+        let tables = entries_by_tag(&d, &PdfTag::Table);
+        assert_eq!(tables.len(), 1);
+        let row_groups = entries_by_tag(&d, &PdfTag::TRowGroup);
+        assert_eq!(row_groups.len(), 2, "thead + tbody");
+        let rows = entries_by_tag(&d, &PdfTag::Tr);
+        assert_eq!(rows.len(), 2);
+        let ths = entries_by_tag(&d, &PdfTag::Th);
+        assert_eq!(ths.len(), 1);
+        let tds = entries_by_tag(&d, &PdfTag::Td);
+        assert_eq!(tds.len(), 1);
+
+        let (table_id, _) = tables[0];
+        for (_, parent) in &row_groups {
+            assert_eq!(*parent, Some(table_id), "row group should parent to table");
+        }
+        // Each row's parent must be one of the row-group ids; each
+        // header/data cell's parent must be one of the row ids. We
+        // assert containment rather than specific ids because Blitz
+        // assigns NodeIds during parse — the order is stable but
+        // hard-coding ids would couple the test to internal numbering.
+        let row_group_ids: std::collections::BTreeSet<_> =
+            row_groups.iter().map(|(id, _)| *id).collect();
+        for (_, parent) in &rows {
+            assert!(
+                parent.map(|p| row_group_ids.contains(&p)).unwrap_or(false),
+                "tr parent must be a row group, got {parent:?}"
+            );
+        }
+        let row_ids: std::collections::BTreeSet<_> = rows.iter().map(|(id, _)| *id).collect();
+        for (_, parent) in ths.iter().chain(tds.iter()) {
+            assert!(
+                parent.map(|p| row_ids.contains(&p)).unwrap_or(false),
+                "th/td parent must be a tr, got {parent:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn dom_to_drawables_skips_unrecognised_elements() {
+        // <a>, <body>, <html>, <script>, <style>, custom-tag must
+        // never appear in `semantics` because `classify_element`
+        // returns None for them. <p> is included so we know the test
+        // exercised a non-empty pipeline.
+        let html = "<!DOCTYPE html><html><body><script>x=1</script><a href='#'>link</a><custom-tag>y</custom-tag><p>z</p></body></html>";
+        let d = build_drawables(html);
+
+        for entry in d.semantics.values() {
+            assert_ne!(entry.tag, PdfTag::Span, "no span fixture used");
+        }
+        // Confirm the recognised tags actually landed.
+        assert_eq!(entries_by_tag(&d, &PdfTag::P).len(), 1);
+        // No anchor / custom / script / body / html should ever map.
+        // `classify_element` returning None for those is unit-tested
+        // in `tagging::tests`; here we additionally confirm the convert
+        // post-pass does not synthesise any extra entries from them.
+        let recognised_tags = d.semantics.values().map(|e| &e.tag).collect::<Vec<_>>();
+        assert!(
+            recognised_tags.iter().all(|t| matches!(
+                t,
+                PdfTag::P
+                    | PdfTag::H { .. }
+                    | PdfTag::Div
+                    | PdfTag::Span
+                    | PdfTag::Figure
+                    | PdfTag::L
+                    | PdfTag::Li
+                    | PdfTag::Table
+                    | PdfTag::TRowGroup
+                    | PdfTag::Tr
+                    | PdfTag::Th
+                    | PdfTag::Td
+            )),
+            "unexpected tag variant in {recognised_tags:?}"
         );
     }
 }

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -859,40 +859,29 @@ mod semantics_tests {
 
     #[test]
     fn dom_to_drawables_skips_unrecognised_elements() {
-        // <a>, <body>, <html>, <script>, <style>, custom-tag must
-        // never appear in `semantics` because `classify_element`
-        // returns None for them. <p> is included so we know the test
-        // exercised a non-empty pipeline.
+        // Fixture intentionally contains only one classifiable element
+        // (`<p>`). Everything else (`<script>`, `<a>`, `<custom-tag>`,
+        // `<body>`, `<html>`) must produce no `SemanticEntry`. The
+        // assertions below pin the *exact* contents of `semantics` so
+        // any future regression that synthesises an extra entry from
+        // an unrecognised element fails immediately, regardless of
+        // which tag variant it picks.
         let html = "<!DOCTYPE html><html><body><script>x=1</script><a href='#'>link</a><custom-tag>y</custom-tag><p>z</p></body></html>";
         let d = build_drawables(html);
 
-        for entry in d.semantics.values() {
-            assert_ne!(entry.tag, PdfTag::Span, "no span fixture used");
-        }
-        // Confirm the recognised tags actually landed.
-        assert_eq!(entries_by_tag(&d, &PdfTag::P).len(), 1);
-        // No anchor / custom / script / body / html should ever map.
-        // `classify_element` returning None for those is unit-tested
-        // in `tagging::tests`; here we additionally confirm the convert
-        // post-pass does not synthesise any extra entries from them.
-        let recognised_tags = d.semantics.values().map(|e| &e.tag).collect::<Vec<_>>();
-        assert!(
-            recognised_tags.iter().all(|t| matches!(
-                t,
-                PdfTag::P
-                    | PdfTag::H { .. }
-                    | PdfTag::Div
-                    | PdfTag::Span
-                    | PdfTag::Figure
-                    | PdfTag::L
-                    | PdfTag::Li
-                    | PdfTag::Table
-                    | PdfTag::TRowGroup
-                    | PdfTag::Tr
-                    | PdfTag::Th
-                    | PdfTag::Td
-            )),
-            "unexpected tag variant in {recognised_tags:?}"
+        let tags: Vec<&PdfTag> = d.semantics.values().map(|e| &e.tag).collect();
+        assert_eq!(
+            d.semantics.len(),
+            1,
+            "expected exactly one semantic entry for the <p>, got {} entries: {tags:?}",
+            d.semantics.len()
+        );
+        let only_entry = d.semantics.values().next().expect("one entry asserted");
+        assert_eq!(
+            only_entry.tag,
+            PdfTag::P,
+            "the single entry must be the <p>, got {:?}",
+            only_entry.tag
         );
     }
 }

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -294,6 +294,14 @@ pub struct Drawables {
     pub transforms: BTreeMap<NodeId, TransformEntry>,
     pub bookmark_anchors: BTreeMap<NodeId, BookmarkAnchorEntry>,
     pub link_spans: Vec<(NodeId, LinkSpanEntry)>,
+    /// Tagged-PDF semantic classification keyed by source NodeId
+    /// (fulgur-izp.3). Convert-side populates this from element local
+    /// names; render integration arrives in fulgur-izp.4 and tag-tree
+    /// assembly in fulgur-izp.5. Empty when tagging-related conversion
+    /// records nothing — for example a fixture with `<custom-tag>`
+    /// only — so byte-identical output is preserved while the data
+    /// layer lands in isolation.
+    pub semantics: BTreeMap<NodeId, crate::tagging::SemanticEntry>,
     /// PR 8g: NodeIds the v2 dispatcher's main loop must skip because
     /// they belong to inline-box content (or its descendants) dispatched
     /// explicitly by `paragraph::draw_shaped_lines` under an offset
@@ -335,6 +343,7 @@ impl Drawables {
             && self.transforms.is_empty()
             && self.bookmark_anchors.is_empty()
             && self.link_spans.is_empty()
+            && self.semantics.is_empty()
     }
 }
 

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -27,6 +27,7 @@ pub mod paragraph;
 pub mod render;
 pub mod schema;
 pub mod svg;
+pub mod tagging;
 pub mod template;
 
 pub use asset::AssetBundle;

--- a/crates/fulgur/src/tagging.rs
+++ b/crates/fulgur/src/tagging.rs
@@ -1,0 +1,130 @@
+//! Tagged PDF semantic layer (fulgur-izp.3).
+//!
+//! Carries a fulgur-internal classification of HTML elements that the
+//! render pass (`fulgur-izp.4`) and the StructTree builder
+//! (`fulgur-izp.5`) translate into Krilla `Tag` / `ContentTag` calls.
+//!
+//! See `docs/plans/2026-05-03-tagged-pdf-drawables-redesign.md` for the
+//! design and `docs/plans/2026-04-22-tagged-pdf-krilla-api-design.md`
+//! for the underlying Krilla API analysis.
+
+use crate::drawables::NodeId;
+
+/// Subset of Krilla `tagging::Tag` variants that fulgur intends to map
+/// HTML semantics to. Render-side translation to the Krilla type
+/// happens in `fulgur-izp.5`; until then this enum is convert-side
+/// only, so it intentionally avoids carrying Krilla-specific types
+/// (`ListNumbering`, `TableHeaderScope`, alt text, heading title) —
+/// those flow from the DOM at render time once the wire-up lands.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PdfTag {
+    P,
+    H { level: u8 },
+    Div,
+    Span,
+    Figure,
+    L,
+    Li,
+    Table,
+    TRowGroup,
+    Tr,
+    Th,
+    Td,
+}
+
+/// Per-NodeId semantic record stored in `Drawables.semantics`.
+///
+/// `parent` points to the nearest ancestor NodeId whose own
+/// `SemanticEntry` is recorded, letting a render-time pass rebuild the
+/// StructTree without re-walking the DOM. `None` marks an entry whose
+/// ancestors carry no recognised tag.
+#[derive(Debug, Clone)]
+pub struct SemanticEntry {
+    pub tag: PdfTag,
+    pub parent: Option<NodeId>,
+}
+
+/// Map an HTML element local name to a `PdfTag` when the element has a
+/// known semantic mapping. Returns `None` for elements that should not
+/// participate in the StructTree (text-only wrappers, custom elements,
+/// `<script>`, `<style>`, etc.).
+///
+/// Heading levels are encoded as `PdfTag::H { level }` with `level` in
+/// `1..=6`. `<thead>` / `<tbody>` / `<tfoot>` collapse into
+/// `TRowGroup`; render-side may emit them as `Tag::TBody` etc. when the
+/// distinction matters for PDF/UA.
+pub fn classify_element(local_name: &str) -> Option<PdfTag> {
+    match local_name {
+        "p" => Some(PdfTag::P),
+        "h1" => Some(PdfTag::H { level: 1 }),
+        "h2" => Some(PdfTag::H { level: 2 }),
+        "h3" => Some(PdfTag::H { level: 3 }),
+        "h4" => Some(PdfTag::H { level: 4 }),
+        "h5" => Some(PdfTag::H { level: 5 }),
+        "h6" => Some(PdfTag::H { level: 6 }),
+        "div" | "section" | "article" | "main" | "aside" | "nav" | "header" | "footer" => {
+            Some(PdfTag::Div)
+        }
+        "span" => Some(PdfTag::Span),
+        "img" => Some(PdfTag::Figure),
+        "ul" | "ol" => Some(PdfTag::L),
+        "li" => Some(PdfTag::Li),
+        "table" => Some(PdfTag::Table),
+        "thead" | "tbody" | "tfoot" => Some(PdfTag::TRowGroup),
+        "tr" => Some(PdfTag::Tr),
+        "th" => Some(PdfTag::Th),
+        "td" => Some(PdfTag::Td),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_element_recognises_block_text() {
+        assert_eq!(classify_element("p"), Some(PdfTag::P));
+        assert_eq!(classify_element("h1"), Some(PdfTag::H { level: 1 }));
+        assert_eq!(classify_element("h6"), Some(PdfTag::H { level: 6 }));
+    }
+
+    #[test]
+    fn classify_element_recognises_generic_containers_as_div() {
+        for tag in [
+            "div", "section", "article", "main", "aside", "nav", "header", "footer",
+        ] {
+            assert_eq!(classify_element(tag), Some(PdfTag::Div), "tag = {tag}");
+        }
+    }
+
+    #[test]
+    fn classify_element_recognises_span_and_img() {
+        assert_eq!(classify_element("span"), Some(PdfTag::Span));
+        assert_eq!(classify_element("img"), Some(PdfTag::Figure));
+    }
+
+    #[test]
+    fn classify_element_recognises_lists_and_tables() {
+        assert_eq!(classify_element("ul"), Some(PdfTag::L));
+        assert_eq!(classify_element("ol"), Some(PdfTag::L));
+        assert_eq!(classify_element("li"), Some(PdfTag::Li));
+        assert_eq!(classify_element("table"), Some(PdfTag::Table));
+        assert_eq!(classify_element("thead"), Some(PdfTag::TRowGroup));
+        assert_eq!(classify_element("tbody"), Some(PdfTag::TRowGroup));
+        assert_eq!(classify_element("tfoot"), Some(PdfTag::TRowGroup));
+        assert_eq!(classify_element("tr"), Some(PdfTag::Tr));
+        assert_eq!(classify_element("th"), Some(PdfTag::Th));
+        assert_eq!(classify_element("td"), Some(PdfTag::Td));
+    }
+
+    #[test]
+    fn classify_element_returns_none_for_unrecognised() {
+        assert_eq!(classify_element("script"), None);
+        assert_eq!(classify_element("style"), None);
+        assert_eq!(classify_element("custom-tag"), None);
+        assert_eq!(classify_element("a"), None);
+        assert_eq!(classify_element("body"), None);
+        assert_eq!(classify_element("html"), None);
+    }
+}

--- a/docs/plans/2026-05-03-tagged-pdf-drawables-redesign.md
+++ b/docs/plans/2026-05-03-tagged-pdf-drawables-redesign.md
@@ -41,8 +41,9 @@ In:
    intend to support.
 2. New `Drawables` field `semantics: BTreeMap<NodeId, SemanticEntry>`
    carrying `(tag, parent: Option<NodeId>)`.
-3. `convert::convert_node` post-pass that classifies the current
-   element and inserts a `SemanticEntry` when the tag is recognised.
+3. A standalone `record_semantics_pass` invoked from
+   `dom_to_drawables` that classifies elements and inserts
+   `SemanticEntry` records for recognised tags.
 4. `Drawables::is_empty()` updated to include the new map (mirrors
    the existing `bookmark_anchors` precedent).
 5. Convert-layer unit tests asserting the map content for an HTML

--- a/docs/plans/2026-05-03-tagged-pdf-drawables-redesign.md
+++ b/docs/plans/2026-05-03-tagged-pdf-drawables-redesign.md
@@ -1,0 +1,235 @@
+# Tagged PDF Semantic Layer — Drawables Redesign Δ
+
+Issue: `fulgur-izp.3`
+Supersedes the "Pageable / Canvas wrapper / TagCollector" portion of
+`docs/plans/2026-04-22-tagged-pdf-krilla-api-design.md` (sections
+"Existing Fulgur Pipeline", "Draw-Time Collector", "DOM / Pageable
+Connection"). The Krilla API analysis and the PDF/UA-first product
+direction in the original memo remain valid.
+
+## Why this Δ
+
+`fulgur-izp.1` was written when the render pipeline still walked a
+`Box<dyn Pageable>` tree built by `convert.rs`. Phase 4 (PR 8i,
+fulgur-9t3z) replaced that tree with `convert::dom_to_drawables`
+producing a flat node-keyed `Drawables` struct that
+`render::render_v2` consumes by walking `PaginationGeometryTable`
+per page. There is no Pageable trait, no `Canvas`-attached
+collector chain to mirror, and no central place to wrap a
+"tagging wrapper" around an inner pageable. The semantic layer
+must follow the new shape:
+
+- **Convert side**: write per-NodeId entries into a new
+  `Drawables.semantics` map at the same DOM walk that already
+  populates `block_styles`, `paragraphs`, etc.
+- **Render side (later issue)**: `render_v2` looks up
+  `drawables.semantics.get(&node_id)` per fragment and calls
+  `surface.start_tagged(...) / end_tagged()` around the existing
+  per-type draw functions. No `Canvas.tag_collector` field, no
+  trait wrappers.
+
+This issue delivers the convert side only. Render integration
+ships in `fulgur-izp.4` (basic block/inline tagging) and
+`fulgur-izp.5` (TagTree assembly + `set_tag_tree`).
+
+## Scope of fulgur-izp.3
+
+In:
+
+1. New module `crates/fulgur/src/tagging.rs` exposing a fulgur-internal
+   `PdfTag` enum that mirrors the subset of Krilla `Tag` variants we
+   intend to support.
+2. New `Drawables` field `semantics: BTreeMap<NodeId, SemanticEntry>`
+   carrying `(tag, parent: Option<NodeId>)`.
+3. `convert::convert_node` post-pass that classifies the current
+   element and inserts a `SemanticEntry` when the tag is recognised.
+4. `Drawables::is_empty()` updated to include the new map (mirrors
+   the existing `bookmark_anchors` precedent).
+5. Convert-layer unit tests asserting the map content for an HTML
+   fixture spanning every recognised element class.
+
+Out (handled by later issues):
+
+- Krilla `start_tagged` / `end_tagged` calls.
+- TagTree construction and `Document::set_tag_tree`.
+- Config / Engine / CLI flags (`fulgur-izp.2`).
+- Img alt text propagation as `Tag::Figure(Some(alt))`
+  (`fulgur-izp.6`).
+- List, table, link structure tags (`fulgur-izp.7..9`).
+- PDF/UA validator and metadata (`fulgur-izp.10`).
+
+The acceptance criteria reduce to:
+
+- `dom_to_drawables` emits a recognisable `SemanticEntry` for h1-h6,
+  p, span, div, img, ul, ol, li, table-family elements.
+- Tagging-disabled draw output is byte-identical (we add data only;
+  `render_v2` does not read it yet).
+- A `convert` test asserts the recorded entries for a fixture HTML.
+
+## Data shape
+
+```rust
+// crates/fulgur/src/tagging.rs
+
+/// Subset of Krilla tag variants we intend to map HTML semantics to.
+/// Carried per-NodeId in `Drawables.semantics`. Render-side translation
+/// to `krilla::tagging::Tag` happens in fulgur-izp.5.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PdfTag {
+    /// `<p>` and other generic paragraph-like blocks.
+    P,
+    /// `<h1>`..`<h6>` — `level` is `1..=6`.
+    H { level: u8 },
+    /// Generic block container (`<div>`, `<section>`, `<article>`,
+    /// `<main>`, `<aside>`, `<nav>`, `<header>`, `<footer>`).
+    /// Renders as `Tag::NonStruct` in the simplest mapping; a future
+    /// pass may promote some of these to `Sect` / `Art` etc.
+    Div,
+    /// `<span>` — inline grouping. Maps to `Tag::Span`.
+    Span,
+    /// `<img>` — alt text is read from the DOM at render time
+    /// (fulgur-izp.6); not stored here.
+    Figure,
+    /// `<ul>` / `<ol>` — list container. Numbering style stays at the
+    /// DOM until fulgur-izp.7 wires `ListNumbering`.
+    L,
+    /// `<li>` — list item.
+    Li,
+    /// `<table>`.
+    Table,
+    /// `<thead>` / `<tbody>` / `<tfoot>` — table row group. Optional
+    /// in PDF/UA but useful for downstream consumers.
+    TRowGroup,
+    /// `<tr>`.
+    Tr,
+    /// `<th>`. Header scope is read at render time (fulgur-izp.8).
+    Th,
+    /// `<td>`.
+    Td,
+}
+
+/// Per-NodeId semantic record. `parent` lets a render-time pass
+/// reconstruct the StructTree without re-walking the DOM. `None`
+/// marks roots of the recorded subtree (e.g. `<body>` itself when
+/// it gains a tag, or any element whose ancestors carry no
+/// recognised tag).
+#[derive(Debug, Clone)]
+pub struct SemanticEntry {
+    pub tag: PdfTag,
+    pub parent: Option<NodeId>,
+}
+```
+
+`Drawables` gains:
+
+```rust
+pub semantics: BTreeMap<NodeId, SemanticEntry>,
+```
+
+`Drawables::is_empty()` adds `&& self.semantics.is_empty()` (parallel
+to `bookmark_anchors`).
+
+## Convert-side wiring
+
+Semantic classification runs as a separate top-down DOM pass invoked
+from `dom_to_drawables` after the main `convert_node` walk:
+
+```rust
+// crates/fulgur/src/convert/mod.rs
+
+pub fn dom_to_drawables(...) -> Drawables {
+    ...
+    convert_node(doc.deref(), root.id, ctx, 0, &mut drawables);
+    drawables.bookmark_anchors = extract_bookmark_anchors(...);
+    drawables.body_offset_pt = extract_body_offset_pt(doc);
+    drawables.root_id = Some(root.id);
+    drawables.body_id = find_body_id_in_dom(doc);
+    record_semantics_pass(doc, &mut drawables);   // ← new
+    drawables
+}
+```
+
+`record_semantics_pass`:
+
+1. Start from `drawables.body_id`. `<head>` and its descendants are
+   intentionally skipped — none participate in the StructTree, and
+   confining the walk to body keeps later expansions of
+   `classify_element` (e.g. a future promotion of `<header>` /
+   `<footer>` to dedicated tags) from accidentally classifying
+   `<head>`'s `<title>` / `<style>` etc.
+2. For each element node, call `tagging::classify_element` on the
+   local name. Skip when it returns `None`.
+3. Walk ancestors via `node.parent` until an already-recorded ancestor
+   is found; that NodeId becomes `parent`. The walk is top-down, so
+   classified ancestors are guaranteed to be present.
+4. Insert the `SemanticEntry` into `out.semantics`.
+
+The classifier intentionally stays element-local. `<a>` is
+deliberately deferred — inline link spans interact with
+`paragraph::LinkSpan` and must be coordinated with `link_spans` in
+`fulgur-izp.9`.
+
+### Why a standalone pass instead of a `convert_node` post-step
+
+The first iteration of this design hooked classification into
+`convert_node` directly. That broke for table rows and sections
+because `convert::table::convert_table` walks `<thead>` / `<tbody>`
+through a custom `collect_table_cells` helper that does **not**
+recurse via `convert_node` — only the cell elements re-enter the
+main dispatch. Any tag classification anchored to `convert_node`
+silently misses the entire row-group / row layer.
+
+A standalone DOM walk decouples semantic classification from each
+per-type converter's child-traversal contract. It also keeps the
+draw-payload converters from having to know about the StructTree at
+all, which mirrors the way bookmark anchors are projected into
+Drawables from a separate snapshot rather than threaded through the
+draw walk.
+
+## Why parent: Option<NodeId> rather than a separate tree
+
+The advisor reviewed three options:
+
+- **A: `parent` per entry, flat map.** Matches every other entry
+  shape in `Drawables`; lets render assemble the tree on demand by
+  `O(N)` traversal. Chosen.
+- **B: Separate `Vec<TagTreeNode>` with explicit children.** Diverges
+  from the flat per-NodeId pattern, requires a second invariant
+  ("entries match the map") to maintain.
+- **C: No parent in convert, re-walk the DOM at render time.** Forces
+  the render path to keep the `BaseDocument` alive past `convert` and
+  re-do classification, doubling the source of truth.
+
+A is the lowest-friction fit for the existing Drawables shape.
+
+## Tests
+
+`crates/fulgur/src/convert/mod.rs` already contains a
+`dom_to_drawables_preserves_bookmark_anchors_for_outline` test. Add
+siblings:
+
+- `dom_to_drawables_records_semantic_entries_for_block_elements`:
+  fixture HTML containing `<h1>..</h1><p>..</p><div><img src=...></div>`
+  asserts `semantics` map contents and `parent` chain.
+- `dom_to_drawables_records_semantic_entries_for_lists`: `<ul><li>..</li></ul>`
+  asserts `L` parent of `Li`.
+- `dom_to_drawables_records_semantic_entries_for_tables`: `<table><thead><tr><th>..`
+  full table fixture asserts the row-group / row / cell parent chain.
+- `dom_to_drawables_skips_unrecognised_elements`: `<custom-tag>` and
+  `<script>` produce no semantic entry.
+
+Verification beyond unit tests:
+
+- `cargo test -p fulgur --lib` continues to pass.
+- VRT (`crates/fulgur-vrt`) byte-identical: render path is
+  untouched, so all goldens hold without regeneration.
+
+## Files touched
+
+- `crates/fulgur/src/tagging.rs` — new.
+- `crates/fulgur/src/lib.rs` — `pub mod tagging;`.
+- `crates/fulgur/src/drawables.rs` — `semantics` field, `is_empty()`.
+- `crates/fulgur/src/convert/mod.rs` — `record_semantics`, test sibs.
+
+No other module changes; render, paginate, link, paragraph, image,
+gcpm all stay byte-equivalent.


### PR DESCRIPTION
## サマリ

- `crates/fulgur/src/tagging.rs` を新設し、HTML 要素を fulgur 内部の `PdfTag` enum に分類する `classify_element` を追加 (h1-h6 / p / span / div / img / ul / ol / li / table 系をカバー)。
- `Drawables.semantics: BTreeMap<NodeId, SemanticEntry>` を追加。`SemanticEntry` は `tag` と `parent: Option<NodeId>` を保持し、render 時に StructTree を再構築できるようにする。
- `dom_to_drawables` 末尾で `record_semantics_pass` を実行 (body 起点の独立 DOM 走査)。

## なぜ独立パスか

当初メモ (`docs/plans/2026-04-22-tagged-pdf-krilla-api-design.md`) は Pageable + Canvas に TagCollector を attach する想定だったが、Phase 4 PR 8i で Pageable は廃止され、`Drawables` をフラットマップで持つ v2 アーキテクチャに移行している。さらに `convert::table` は `<thead>`/`<tbody>` を `convert_node` 経由で訪問しないため、`convert_node` post-step に分類を載せると row-group 階層が漏れる。standalone DOM walk にすることで、各 per-type converter の child-traversal contract と semantic 分類を完全に直交させる。

詳しい再設計の Δ は `docs/plans/2026-05-03-tagged-pdf-drawables-redesign.md` 参照。

## スコープ境界

- このPRは **データ層のみ**。`render_v2` は `Drawables.semantics` をまだ読まないので tagging-off の PDF 出力は完全 byte-identical。
- `start_tagged` / `end_tagged` の wire-up は fulgur-izp.4。
- `TagTree` 構築 + `set_tag_tree` 呼び出しは fulgur-izp.5。
- Config / Engine / CLI フラグは fulgur-izp.2。
- `<a>` / 画像 alt / list-numbering / table-header-scope は後続 issue に分割済み。

## Acceptance criteria (fulgur-izp.3)

- [x] h1-h6 / p / span / div / img / ul / ol / li / table 系を識別できる内部表現がある (`tagging::PdfTag`)
- [x] tagging 無効時に挙動が変わらない (VRT byte-identical 維持)
- [x] semantic 情報の単体テストがある (`tagging::tests` 5件 + `convert::semantics_tests` 4件)

## Test plan

- [x] `cargo test -p fulgur --lib` (774 passed)
- [x] `cargo test -p fulgur-vrt` (byte-identical 維持)
- [x] `cargo clippy -p fulgur --tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `npx markdownlint-cli2 'docs/plans/2026-05-03-tagged-pdf-drawables-redesign.md'`

Refs: fulgur-izp.3 (parent: fulgur-izp Tagged PDF / PDF-UA epic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a semantic tagging layer that classifies HTML elements (paragraphs, headings, lists, tables, figures, containers) and records parent relationships for PDF structuring; semantic data is now considered when determining whether there is drawable output.

* **Tests**
  * Added unit tests validating element-to-tag mappings and recorded parent–child semantics.

* **Documentation**
  * Added design plan documenting the semantic tagging approach and expected behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->