### PR TITLE
feat(gcpm): support longhand margin in @page rules

### DIFF
--- a/crates/fulgur/src/gcpm/mod.rs
+++ b/crates/fulgur/src/gcpm/mod.rs
@@ -118,8 +118,83 @@ pub struct PageSettingsRule {
     pub page_selector: Option<String>,
     /// Parsed `size` declaration, if present.
     pub size: Option<PageSizeDecl>,
-    /// Parsed `margin` declaration, if present. Values in points.
-    pub margin: Option<crate::config::Margin>,
+    /// Parsed `margin` declaration. Tracks each side independently so partial
+    /// declarations (`margin-top: 200px`) cascade per-side rather than
+    /// replacing the full margin box.
+    pub margin: PartialMargin,
+}
+
+/// Margin sides individually overridable. Sides set to `None` inherit from the
+/// preceding rule in the cascade (default `@page` rule, then [`Config::margin`]).
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct PartialMargin {
+    pub top: Option<f32>,
+    pub right: Option<f32>,
+    pub bottom: Option<f32>,
+    pub left: Option<f32>,
+}
+
+impl PartialMargin {
+    /// All sides set to the same value (used by the `margin: <length>` shorthand).
+    pub fn from_uniform(v: f32) -> Self {
+        Self {
+            top: Some(v),
+            right: Some(v),
+            bottom: Some(v),
+            left: Some(v),
+        }
+    }
+
+    /// All four sides set explicitly (used by 2/3/4-value shorthand and the
+    /// fully-resolved [`Margin`] cascade).
+    pub fn from_sides(top: f32, right: f32, bottom: f32, left: f32) -> Self {
+        Self {
+            top: Some(top),
+            right: Some(right),
+            bottom: Some(bottom),
+            left: Some(left),
+        }
+    }
+
+    /// `true` when no side has been set.
+    pub fn is_empty(&self) -> bool {
+        self.top.is_none() && self.right.is_none() && self.bottom.is_none() && self.left.is_none()
+    }
+
+    /// Apply set sides on top of the given [`Margin`] (overwrite). Sides set
+    /// to `None` leave `target` untouched.
+    pub fn apply_to_margin(&self, target: &mut crate::config::Margin) {
+        if let Some(v) = self.top {
+            target.top = v;
+        }
+        if let Some(v) = self.right {
+            target.right = v;
+        }
+        if let Some(v) = self.bottom {
+            target.bottom = v;
+        }
+        if let Some(v) = self.left {
+            target.left = v;
+        }
+    }
+
+    /// Merge `other` into `self`: every side `other` sets overwrites `self`.
+    /// Used to accumulate longhand declarations within a single `@page` rule
+    /// and across rules sharing the same selector.
+    pub fn overlay(&mut self, other: &PartialMargin) {
+        if let Some(v) = other.top {
+            self.top = Some(v);
+        }
+        if let Some(v) = other.right {
+            self.right = Some(v);
+        }
+        if let Some(v) = other.bottom {
+            self.bottom = Some(v);
+        }
+        if let Some(v) = other.left {
+            self.left = Some(v);
+        }
+    }
 }
 
 /// A single counter operation from counter-reset, counter-increment, or counter-set.

--- a/crates/fulgur/src/gcpm/mod.rs
+++ b/crates/fulgur/src/gcpm/mod.rs
@@ -118,14 +118,12 @@ pub struct PageSettingsRule {
     pub page_selector: Option<String>,
     /// Parsed `size` declaration, if present.
     pub size: Option<PageSizeDecl>,
-    /// Parsed `margin` declaration. Tracks each side independently so partial
-    /// declarations (`margin-top: 200px`) cascade per-side rather than
-    /// replacing the full margin box.
+    /// Parsed `margin` declaration; sides not declared remain `None` and
+    /// inherit from the cascade.
     pub margin: PartialMargin,
 }
 
-/// Margin sides individually overridable. Sides set to `None` inherit from the
-/// preceding rule in the cascade (default `@page` rule, then [`Config::margin`]).
+/// Per-side optional margin override. Unset sides inherit from the cascade.
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct PartialMargin {
     pub top: Option<f32>,
@@ -135,18 +133,12 @@ pub struct PartialMargin {
 }
 
 impl PartialMargin {
-    /// All sides set to the same value (used by the `margin: <length>` shorthand).
+    /// All four sides set to the same value.
     pub fn from_uniform(v: f32) -> Self {
-        Self {
-            top: Some(v),
-            right: Some(v),
-            bottom: Some(v),
-            left: Some(v),
-        }
+        Self::from_sides(v, v, v, v)
     }
 
-    /// All four sides set explicitly (used by 2/3/4-value shorthand and the
-    /// fully-resolved [`Margin`] cascade).
+    /// All four sides set explicitly.
     pub fn from_sides(top: f32, right: f32, bottom: f32, left: f32) -> Self {
         Self {
             top: Some(top),
@@ -161,8 +153,7 @@ impl PartialMargin {
         self.top.is_none() && self.right.is_none() && self.bottom.is_none() && self.left.is_none()
     }
 
-    /// Apply set sides on top of the given [`Margin`] (overwrite). Sides set
-    /// to `None` leave `target` untouched.
+    /// Overlay set sides onto `target`. Unset sides leave `target` untouched.
     pub fn apply_to_margin(&self, target: &mut crate::config::Margin) {
         if let Some(v) = self.top {
             target.top = v;
@@ -178,10 +169,8 @@ impl PartialMargin {
         }
     }
 
-    /// Merge `other` into `self`: every side `other` sets overwrites `self`.
-    /// Used to accumulate longhand declarations within a single `@page` rule
-    /// and across rules sharing the same selector.
-    pub fn overlay(&mut self, other: &PartialMargin) {
+    /// Overlay sides set in `other` onto `self`. Later wins per side.
+    pub fn merge(&mut self, other: &PartialMargin) {
         if let Some(v) = other.top {
             self.top = Some(v);
         }

--- a/crates/fulgur/src/gcpm/page_settings.rs
+++ b/crates/fulgur/src/gcpm/page_settings.rs
@@ -1,5 +1,5 @@
 use crate::config::{Config, Margin, PageSize};
-use crate::gcpm::{PageSettingsRule, PageSizeDecl};
+use crate::gcpm::{PageSettingsRule, PageSizeDecl, PartialMargin};
 
 /// Map a CSS page-size keyword (case-insensitive) to a [`PageSize`].
 /// Falls back to A4 for unrecognised keywords.
@@ -42,9 +42,9 @@ pub fn resolve_page_settings(
 ) -> (PageSize, Margin, bool) {
     // --- Collect CSS declarations, separating default from selector-matched ---
     let mut default_size: Option<&PageSizeDecl> = None;
-    let mut default_margin: Option<&Margin> = None;
+    let mut default_margin = PartialMargin::default();
     let mut matched_size: Option<&PageSizeDecl> = None;
-    let mut matched_margin: Option<&Margin> = None;
+    let mut matched_margin = PartialMargin::default();
 
     for rule in rules {
         match &rule.page_selector {
@@ -53,18 +53,14 @@ pub fn resolve_page_settings(
                 if rule.size.is_some() {
                     default_size = rule.size.as_ref();
                 }
-                if rule.margin.is_some() {
-                    default_margin = rule.margin.as_ref();
-                }
+                default_margin.overlay(&rule.margin);
             }
             Some(sel) => {
                 if selector_matches(sel, page_num) {
                     if rule.size.is_some() {
                         matched_size = rule.size.as_ref();
                     }
-                    if rule.margin.is_some() {
-                        matched_margin = rule.margin.as_ref();
-                    }
+                    matched_margin.overlay(&rule.margin);
                 }
             }
         }
@@ -72,7 +68,6 @@ pub fn resolve_page_settings(
 
     // Selector match overrides default for each property independently.
     let css_size = matched_size.or(default_size);
-    let css_margin = matched_margin.or(default_margin);
 
     // --- Resolve page size and landscape ---
     let (size, landscape) = if config.overrides.page_size {
@@ -125,13 +120,17 @@ pub fn resolve_page_settings(
     };
 
     // --- Resolve margin ---
+    // Cascade: config.margin (lowest) → default @page → matched selector
+    // (highest). Each layer overlays per-side onto the previous so partial
+    // longhand declarations like `margin-top: 200px` only affect their own
+    // side and the rest of the box inherits from the layer below.
     let margin = if config.overrides.margin {
         config.margin
     } else {
-        match css_margin {
-            Some(decl) => *decl,
-            None => config.margin,
-        }
+        let mut m = config.margin;
+        default_margin.apply_to_margin(&mut m);
+        matched_margin.apply_to_margin(&mut m);
+        m
     };
 
     (size, margin, landscape)
@@ -149,8 +148,8 @@ fn resolve_landscape_from_css(css_size: Option<&PageSizeDecl>, fallback: bool) -
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{Config, Margin, PageSize};
-    use crate::gcpm::{PageSettingsRule, PageSizeDecl};
+    use crate::config::{Config, PageSize};
+    use crate::gcpm::{PageSettingsRule, PageSizeDecl, PartialMargin};
 
     #[test]
     fn test_no_page_settings_uses_config() {
@@ -167,7 +166,7 @@ mod tests {
         let rules = vec![PageSettingsRule {
             page_selector: None,
             size: Some(PageSizeDecl::Keyword("letter".into())),
-            margin: None,
+            margin: PartialMargin::default(),
         }];
         let (size, _, _) = resolve_page_settings(&rules, 1, 10, &config);
         assert!((size.width - PageSize::LETTER.width).abs() < 0.01);
@@ -180,7 +179,7 @@ mod tests {
         let rules = vec![PageSettingsRule {
             page_selector: None,
             size: Some(PageSizeDecl::Keyword("letter".into())),
-            margin: None,
+            margin: PartialMargin::default(),
         }];
         let (size, _, _) = resolve_page_settings(&rules, 1, 10, &config);
         assert!((size.width - PageSize::A3.width).abs() < 0.01);
@@ -193,22 +192,12 @@ mod tests {
             PageSettingsRule {
                 page_selector: None,
                 size: None,
-                margin: Some(Margin {
-                    top: 20.0,
-                    right: 20.0,
-                    bottom: 20.0,
-                    left: 20.0,
-                }),
+                margin: PartialMargin::from_uniform(20.0),
             },
             PageSettingsRule {
                 page_selector: Some(":first".into()),
                 size: None,
-                margin: Some(Margin {
-                    top: 50.0,
-                    right: 50.0,
-                    bottom: 50.0,
-                    left: 50.0,
-                }),
+                margin: PartialMargin::from_uniform(50.0),
             },
         ];
         let (_, margin_p1, _) = resolve_page_settings(&rules, 1, 10, &config);
@@ -224,22 +213,12 @@ mod tests {
             PageSettingsRule {
                 page_selector: Some(":left".into()),
                 size: None,
-                margin: Some(Margin {
-                    top: 20.0,
-                    right: 30.0,
-                    bottom: 20.0,
-                    left: 10.0,
-                }),
+                margin: PartialMargin::from_sides(20.0, 30.0, 20.0, 10.0),
             },
             PageSettingsRule {
                 page_selector: Some(":right".into()),
                 size: None,
-                margin: Some(Margin {
-                    top: 20.0,
-                    right: 10.0,
-                    bottom: 20.0,
-                    left: 30.0,
-                }),
+                margin: PartialMargin::from_sides(20.0, 10.0, 20.0, 30.0),
             },
         ];
         let (_, m2, _) = resolve_page_settings(&rules, 2, 10, &config);
@@ -254,7 +233,7 @@ mod tests {
         let rules = vec![PageSettingsRule {
             page_selector: None,
             size: Some(PageSizeDecl::KeywordWithOrientation("A4".into(), true)),
-            margin: None,
+            margin: PartialMargin::default(),
         }];
         let (_, _, landscape) = resolve_page_settings(&rules, 1, 10, &config);
         assert!(landscape);
@@ -266,11 +245,62 @@ mod tests {
         let rules = vec![PageSettingsRule {
             page_selector: None,
             size: Some(PageSizeDecl::Custom(400.0, 600.0)),
-            margin: None,
+            margin: PartialMargin::default(),
         }];
         let (size, _, landscape) = resolve_page_settings(&rules, 1, 10, &config);
         assert!((size.width - 400.0).abs() < 0.01);
         assert!((size.height - 600.0).abs() < 0.01);
         assert!(!landscape);
+    }
+
+    #[test]
+    fn test_partial_margin_inherits_unset_sides_from_default() {
+        // Default `@page { margin: 0 }` should provide bottom and left when
+        // `:right` only sets top and right (the page-left-right-001 case).
+        let config = Config::default();
+        let rules = vec![
+            PageSettingsRule {
+                page_selector: None,
+                size: None,
+                margin: PartialMargin::from_uniform(0.0),
+            },
+            PageSettingsRule {
+                page_selector: Some(":right".into()),
+                size: None,
+                margin: PartialMargin {
+                    top: Some(150.0),
+                    right: Some(375.0),
+                    bottom: None,
+                    left: None,
+                },
+            },
+        ];
+        let (_, m, _) = resolve_page_settings(&rules, 1, 10, &config);
+        assert!((m.top - 150.0).abs() < 0.01);
+        assert!((m.right - 375.0).abs() < 0.01);
+        assert!((m.bottom - 0.0).abs() < 0.01);
+        assert!((m.left - 0.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_partial_margin_falls_back_to_config_when_no_default_rule() {
+        // No default `@page` rule. Sides not set by the matched selector
+        // fall back to `config.margin` (lowest cascade layer).
+        let config = Config::default();
+        let rules = vec![PageSettingsRule {
+            page_selector: Some(":first".into()),
+            size: None,
+            margin: PartialMargin {
+                top: Some(100.0),
+                right: None,
+                bottom: None,
+                left: None,
+            },
+        }];
+        let (_, m, _) = resolve_page_settings(&rules, 1, 10, &config);
+        assert!((m.top - 100.0).abs() < 0.01);
+        assert!((m.right - config.margin.right).abs() < 0.01);
+        assert!((m.bottom - config.margin.bottom).abs() < 0.01);
+        assert!((m.left - config.margin.left).abs() < 0.01);
     }
 }

--- a/crates/fulgur/src/gcpm/page_settings.rs
+++ b/crates/fulgur/src/gcpm/page_settings.rs
@@ -46,27 +46,27 @@ pub fn resolve_page_settings(
     let mut matched_size: Option<&PageSizeDecl> = None;
     let mut matched_margin = PartialMargin::default();
 
+    // Later rules override earlier ones per side; selector-matched layer
+    // wins over the default layer.
     for rule in rules {
         match &rule.page_selector {
             None => {
-                // Default (no selector) — later rules override earlier ones.
                 if rule.size.is_some() {
                     default_size = rule.size.as_ref();
                 }
-                default_margin.overlay(&rule.margin);
+                default_margin.merge(&rule.margin);
             }
             Some(sel) => {
                 if selector_matches(sel, page_num) {
                     if rule.size.is_some() {
                         matched_size = rule.size.as_ref();
                     }
-                    matched_margin.overlay(&rule.margin);
+                    matched_margin.merge(&rule.margin);
                 }
             }
         }
     }
 
-    // Selector match overrides default for each property independently.
     let css_size = matched_size.or(default_size);
 
     // --- Resolve page size and landscape ---
@@ -119,11 +119,9 @@ pub fn resolve_page_settings(
         }
     };
 
-    // --- Resolve margin ---
-    // Cascade: config.margin (lowest) → default @page → matched selector
-    // (highest). Each layer overlays per-side onto the previous so partial
-    // longhand declarations like `margin-top: 200px` only affect their own
-    // side and the rest of the box inherits from the layer below.
+    // Margin cascade: config.margin → default @page → matched selector.
+    // Each layer overlays per-side, so partial longhand declarations only
+    // affect their own side.
     let margin = if config.overrides.margin {
         config.margin
     } else {
@@ -256,7 +254,7 @@ mod tests {
     #[test]
     fn test_partial_margin_inherits_unset_sides_from_default() {
         // Default `@page { margin: 0 }` should provide bottom and left when
-        // `:right` only sets top and right (the page-left-right-001 case).
+        // a matched selector only sets top and right.
         let config = Config::default();
         let rules = vec![
             PageSettingsRule {
@@ -284,8 +282,6 @@ mod tests {
 
     #[test]
     fn test_partial_margin_falls_back_to_config_when_no_default_rule() {
-        // No default `@page` rule. Sides not set by the matched selector
-        // fall back to `config.margin` (lowest cascade layer).
         let config = Config::default();
         let rules = vec![PageSettingsRule {
             page_selector: Some(":first".into()),

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -502,7 +502,7 @@ impl<'i, 'a> DeclarationParser<'i> for PageRuleParser<'a> {
             }
         } else if name.eq_ignore_ascii_case("margin") {
             if let Some(v) = parse_page_margin_value(input) {
-                self.margin.overlay(&v);
+                self.margin.merge(&v);
             }
         } else if name.eq_ignore_ascii_case("margin-top") {
             if let Some(v) = parse_page_margin_longhand_value(input) {

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -7,10 +7,9 @@ use super::bookmark::{BookmarkLevel, BookmarkMapping};
 use super::margin_box::MarginBoxPosition;
 use super::{
     ContentCounterMapping, ContentItem, CounterMapping, CounterOp, CounterStyle, ElementPolicy,
-    GcpmContext, MarginBoxRule, PageSettingsRule, PageSizeDecl, ParsedSelector, PseudoElement,
-    RunningMapping, StringPolicy, StringSetMapping, StringSetValue,
+    GcpmContext, MarginBoxRule, PageSettingsRule, PageSizeDecl, ParsedSelector, PartialMargin,
+    PseudoElement, RunningMapping, StringPolicy, StringSetMapping, StringSetValue,
 };
-use crate::config::Margin;
 
 // ---------------------------------------------------------------------------
 // Top-level result types
@@ -89,7 +88,7 @@ impl<'i, 'a> AtRuleParser<'i> for GcpmSheetParser<'a> {
     ) -> Result<Self::AtRule, ParseError<'i, ()>> {
         let mut boxes = Vec::new();
         let mut size = None;
-        let mut margin = None;
+        let mut margin = PartialMargin::default();
         parse_page_block(input, &page_selector, &mut boxes, &mut size, &mut margin);
 
         // Record the full @page rule span for removal.
@@ -102,7 +101,7 @@ impl<'i, 'a> AtRuleParser<'i> for GcpmSheetParser<'a> {
 
         self.margin_boxes.extend(boxes);
 
-        if size.is_some() || margin.is_some() {
+        if size.is_some() || !margin.is_empty() {
             self.page_settings.push(PageSettingsRule {
                 page_selector,
                 size,
@@ -356,25 +355,26 @@ fn parse_page_size_value(input: &mut Parser<'_, '_>) -> Option<PageSizeDecl> {
     result
 }
 
-/// Parse the value of an `@page { margin: ... }` declaration (CSS shorthand).
+/// Parse a single CSS length token (dimensioned or `0`) into points.
+fn parse_length_pt_token<'i>(input: &mut Parser<'i, '_>) -> Result<f32, ParseError<'i, ()>> {
+    let tok = input.next()?.clone();
+    match tok {
+        Token::Dimension { value, unit, .. } => css_unit_to_pt(value, &unit)
+            .ok_or_else(|| input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)),
+        Token::Number { value: 0.0, .. } => Ok(0.0_f32),
+        _ => Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)),
+    }
+}
+
+/// Parse the value of an `@page { margin: ... }` shorthand into a
+/// [`PartialMargin`] with all four sides set.
 ///
 /// Returns `None` if the value is invalid or has trailing tokens
 /// (CSS requires invalid declarations to be ignored entirely).
-fn parse_page_margin_value(input: &mut Parser<'_, '_>) -> Option<Margin> {
+fn parse_page_margin_value(input: &mut Parser<'_, '_>) -> Option<PartialMargin> {
     let mut values = Vec::new();
     loop {
-        let result = input.try_parse(|input| {
-            let tok = input.next()?.clone();
-            match tok {
-                Token::Dimension { value, unit, .. } => {
-                    css_unit_to_pt(value, &unit).ok_or_else(|| {
-                        input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)
-                    })
-                }
-                Token::Number { value: 0.0, .. } => Ok(0.0_f32),
-                _ => Err(input.new_error::<()>(BasicParseErrorKind::QualifiedRuleInvalid)),
-            }
-        });
+        let result = input.try_parse(parse_length_pt_token);
         match result {
             Ok(v) => values.push(v),
             Err(_) => break,
@@ -390,32 +390,27 @@ fn parse_page_margin_value(input: &mut Parser<'_, '_>) -> Option<Margin> {
     }
 
     match values.len() {
-        1 => Some(Margin {
-            top: values[0],
-            right: values[0],
-            bottom: values[0],
-            left: values[0],
-        }),
-        2 => Some(Margin {
-            top: values[0],
-            right: values[1],
-            bottom: values[0],
-            left: values[1],
-        }),
-        3 => Some(Margin {
-            top: values[0],
-            right: values[1],
-            bottom: values[2],
-            left: values[1],
-        }),
-        4 => Some(Margin {
-            top: values[0],
-            right: values[1],
-            bottom: values[2],
-            left: values[3],
-        }),
+        1 => Some(PartialMargin::from_uniform(values[0])),
+        2 => Some(PartialMargin::from_sides(
+            values[0], values[1], values[0], values[1],
+        )),
+        3 => Some(PartialMargin::from_sides(
+            values[0], values[1], values[2], values[1],
+        )),
+        4 => Some(PartialMargin::from_sides(
+            values[0], values[1], values[2], values[3],
+        )),
         _ => None,
     }
+}
+
+/// Parse a single longhand `margin-<side>` value into points.
+fn parse_page_margin_longhand_value(input: &mut Parser<'_, '_>) -> Option<f32> {
+    let v = input.try_parse(parse_length_pt_token).ok()?;
+    if input.next().is_ok() {
+        return None;
+    }
+    Some(v)
 }
 
 // ---------------------------------------------------------------------------
@@ -427,7 +422,7 @@ fn parse_page_block(
     page_selector: &Option<String>,
     boxes: &mut Vec<MarginBoxRule>,
     size: &mut Option<PageSizeDecl>,
-    margin: &mut Option<Margin>,
+    margin: &mut PartialMargin,
 ) {
     let mut parser = PageRuleParser {
         page_selector,
@@ -445,7 +440,7 @@ struct PageRuleParser<'a> {
     page_selector: &'a Option<String>,
     boxes: &'a mut Vec<MarginBoxRule>,
     size: &'a mut Option<PageSizeDecl>,
-    margin: &'a mut Option<Margin>,
+    margin: &'a mut PartialMargin,
 }
 
 impl<'i, 'a> AtRuleParser<'i> for PageRuleParser<'a> {
@@ -507,7 +502,23 @@ impl<'i, 'a> DeclarationParser<'i> for PageRuleParser<'a> {
             }
         } else if name.eq_ignore_ascii_case("margin") {
             if let Some(v) = parse_page_margin_value(input) {
-                *self.margin = Some(v);
+                self.margin.overlay(&v);
+            }
+        } else if name.eq_ignore_ascii_case("margin-top") {
+            if let Some(v) = parse_page_margin_longhand_value(input) {
+                self.margin.top = Some(v);
+            }
+        } else if name.eq_ignore_ascii_case("margin-right") {
+            if let Some(v) = parse_page_margin_longhand_value(input) {
+                self.margin.right = Some(v);
+            }
+        } else if name.eq_ignore_ascii_case("margin-bottom") {
+            if let Some(v) = parse_page_margin_longhand_value(input) {
+                self.margin.bottom = Some(v);
+            }
+        } else if name.eq_ignore_ascii_case("margin-left") {
+            if let Some(v) = parse_page_margin_longhand_value(input) {
+                self.margin.left = Some(v);
             }
         } else {
             // Skip unknown declarations
@@ -1975,14 +1986,43 @@ mod tests {
         assert_eq!(ctx.page_settings.len(), 1, "expected 1 PageSettingsRule");
         let rule = &ctx.page_settings[0];
         assert!(rule.page_selector.is_none());
-        let m = rule.margin.as_ref().expect("margin should be parsed");
-        assert_eq!(m.top, 0.0);
-        assert_eq!(m.bottom, 0.0);
-        assert_eq!(m.left, 0.0);
-        assert_eq!(m.right, 0.0);
+        assert_eq!(rule.margin.top, Some(0.0));
+        assert_eq!(rule.margin.bottom, Some(0.0));
+        assert_eq!(rule.margin.left, Some(0.0));
+        assert_eq!(rule.margin.right, Some(0.0));
         assert!(
             !ctx.is_empty(),
             "gcpm should not be empty with page_settings"
         );
+    }
+
+    #[test]
+    fn test_page_margin_longhand_parsed() {
+        // Each longhand declaration should set only its own side; the other
+        // sides remain `None` and inherit from the cascade at resolve time.
+        let css = "@page :right { margin-top: 200px; margin-right: 500px; }";
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.page_settings.len(), 1);
+        let rule = &ctx.page_settings[0];
+        assert_eq!(rule.page_selector, Some(":right".to_string()));
+        // 200px = 150pt, 500px = 375pt at 0.75 px-to-pt
+        assert_eq!(rule.margin.top, Some(150.0));
+        assert_eq!(rule.margin.right, Some(375.0));
+        assert_eq!(rule.margin.bottom, None);
+        assert_eq!(rule.margin.left, None);
+    }
+
+    #[test]
+    fn test_page_margin_longhand_overrides_shorthand_in_same_rule() {
+        // Within a single @page rule, declarations cascade in source order:
+        // longhand after shorthand should overwrite only the named side.
+        let css = "@page { margin: 10px; margin-top: 50px; }";
+        let ctx = parse_gcpm(css);
+        let rule = &ctx.page_settings[0];
+        // 10px = 7.5pt, 50px = 37.5pt
+        assert_eq!(rule.margin.top, Some(37.5));
+        assert_eq!(rule.margin.right, Some(7.5));
+        assert_eq!(rule.margin.bottom, Some(7.5));
+        assert_eq!(rule.margin.left, Some(7.5));
     }
 }


### PR DESCRIPTION
## 概要

`@page` ルールパーサが `margin-top` / `margin-right` / `margin-bottom` / `margin-left` の longhand 宣言を `Skip unknown declarations` 経路で握り潰していたため、`@page :right { margin-top: 200px; margin-right: 500px }` のような部分指定が一切効かない状態になっていました。

`PageSettingsRule::margin` を `Option<Margin>` から **side ごとに独立した** `PartialMargin` に置き換え、shorthand と longhand の双方を解析、resolve 時に side ごとに overlay する形に修正しました。

カスケード順:

1. `Config::margin`（最下層）
2. デフォルト `@page` ルールの `PartialMargin`
3. マッチしたセレクタ（`:first` / `:left` / `:right`）の `PartialMargin`

各層を side 単位で重ね合わせるため、partial な宣言は当該 side のみを上書きし、残りは下層から引き継がれます。

## 設計

- `PartialMargin` を `gcpm/mod.rs` に追加し、`from_uniform` / `from_sides` / `overlay` / `apply_to_margin` / `is_empty` を提供。
- `PageRuleParser::parse_value` に `margin-top` / `margin-right` / `margin-bottom` / `margin-left` の分岐を追加。`parse_length_pt_token` を共有して shorthand 経路も簡素化。
- `resolve_page_settings` の margin 計算を per-side overlay に置き換え（CLI override は従来通り最優先）。

## 検証

```text
cargo fmt --check  : clean
cargo clippy       : warning なし
cargo test -p fulgur : 796 unit + 既存 integration すべて pass
cargo test -p fulgur-vrt --release : pass
cargo test -p fulgur-cli : pass
```

新規ユニットテスト:

- `gcpm::parser::tests::test_page_margin_longhand_parsed` — longhand のみが正しく per-side に乗ることを確認。
- `gcpm::parser::tests::test_page_margin_longhand_overrides_shorthand_in_same_rule` — shorthand → longhand の同一ルール内カスケード。
- `gcpm::page_settings::tests::test_partial_margin_inherits_unset_sides_from_default` — `:right` が top/right のみ宣言したときに bottom/left が default `@page` から引き継がれること。
- `gcpm::page_settings::tests::test_partial_margin_falls_back_to_config_when_no_default_rule` — default `@page` がないときに `Config::margin` まで遡ること。

## WPT delta

このパーサ修正だけでは PASS まで到達するテストはありません（**0 promotions / 0 net regressions**）。改善は出ていますが、別系統のページネーションバグ（`fulgur-ossm`）が残っており、そちらが解消するまで FAIL→PASS の flip はできません。期待値ファイル (`expectations/css-page.txt`) は変更していません。

| Test | Before | After (this PR) | 残存原因 |
|---|---|---|---|
| `page-left-right-001-print` | page 1 diff 56200 | page 2 diff 25400 | `fulgur-ossm` (forced break 後の sibling Y origin) |
| `page-left-right-002-print` | page 1 diff 42939 | page 1 diff 20000 | 同上 (rtl 版) |
| `page-margin-007-print` | page 1 diff 39964 | page count mismatch test=4 ref=1 | `:first` の margin-left が効くようになり pagination が変わった結果、ref 側の別 bug が露出 |
| `page-size-006-print` | page 1 diff 1623 | page 2 diff 1111 | `fulgur-ossm` |

レポートに出ている既存 3 件の regression（`monolithic-overflow-004`, `page-name-display-none-child`, `page-name-propagated-003`）は main でも同じ表示で、この PR とは無関係の pre-existing flakiness です。

## 関連 issue

- 修正: `fulgur-7bej`
- フォローアップ: `fulgur-ossm`（`:left`/`:right` margin 適用後の次ページ sibling Y origin が body 累積値のままになる pagination バグ。WPT 4 本の flip 条件）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Margin handling updated to support per-side partial values (top/right/bottom/left) with cascading inheritance across config → default → selector layers; shorthand and longhand declarations merge with correct precedence.
* **Tests**
  * Updated and added tests verifying partial-margin parsing, longhand-over-shorthand precedence, and inheritance fallback to defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->