### PR TITLE
chore(mise): add wpt:fetch and wpt:run-one tasks

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -33,6 +33,24 @@ for dir in examples/*/; do
 done
 """
 
+[tasks."wpt:fetch"]
+description = "Fetch WPT sources into target/wpt/ (pinned SHA)"
+run = "scripts/wpt/fetch.sh"
+
+[tasks."wpt:run-one"]
+description = "Run a single WPT reftest (usage: mise run wpt:run-one -- <test.html> [--dpi N])"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+if [ $# -eq 0 ]; then
+  echo "usage: mise run wpt:run-one -- <test.html> [--dpi N]" >&2
+  echo "  test.html: path under target/wpt/ or absolute" >&2
+  exit 1
+fi
+export FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf"
+cargo run -p fulgur-wpt --example run_one -- "$@"
+"""
+
 [tasks."docs:install"]
 description = "Install website Python deps via uv"
 dir = "website"


### PR DESCRIPTION
## Summary

- `mise run wpt:fetch` で `scripts/wpt/fetch.sh` を実行 (WPT ソース取得)
- `mise run wpt:run-one -- <test.html> [--dpi N]` で `fulgur-wpt` の `run_one` example をラップ
- `wpt:run-one` は `FONTCONFIG_FILE=examples/.fontconfig/fonts.conf` を自動 export するので、フォント決定性のための環境変数を毎回手で渡す必要がなくなる

## Motivation

WPT reftest を 1 本だけ手で再現する場合、これまでは

\`\`\`bash
FONTCONFIG_FILE=\"\$PWD/examples/.fontconfig/fonts.conf\" \\
  cargo run -p fulgur-wpt --example run_one -- <test.html>
\`\`\`

と打つ必要があった。PASS 昇格フロー (`crates/fulgur-wpt/README.md` の expectations 運用) に毎回登場するコマンドなので、mise タスクとして固定化して typo / 環境変数忘れを潰す。

## Test plan

- [x] `mise tasks ls` で `wpt:fetch` / `wpt:run-one` が表示されること
- [x] 引数なしの `mise run wpt:run-one` で usage メッセージが出て exit 1 すること
- [ ] 任意の WPT テストに対して `mise run wpt:run-one -- target/wpt/css/css-page/<test>.html` が verdict を出すこと (reviewer 任意)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new task to fetch Web Platform Test sources pinned to a specific version
  * Added a new task to run individual Web Platform Tests with enforced CLI arguments and custom font configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->