### PR TITLE
test(draw_primitives): add coverage for Affine2D, BlockStyle, TextDecorationLine, and collectors

### DIFF
--- a/crates/fulgur/src/draw_primitives.rs
+++ b/crates/fulgur/src/draw_primitives.rs
@@ -1742,6 +1742,412 @@ mod dp_unit_tests {
         assert!((w - 20.0).abs() < 1e-5);
         assert!((h - 10.0).abs() < 1e-5);
     }
+
+    // ── Affine2D math ───────────────────────────────────────
+
+    #[test]
+    fn affine2d_identity_is_recognized() {
+        assert!(Affine2D::IDENTITY.is_identity());
+    }
+
+    #[test]
+    fn affine2d_translation_is_not_identity() {
+        assert!(!Affine2D::translation(1.0, 0.0).is_identity());
+    }
+
+    #[test]
+    fn affine2d_scale_is_not_identity() {
+        assert!(!Affine2D::scale(2.0, 1.0).is_identity());
+    }
+
+    #[test]
+    fn affine2d_rotation_90_maps_x_to_y() {
+        use std::f32::consts::FRAC_PI_2;
+        let r = Affine2D::rotation(FRAC_PI_2);
+        let (x, y) = r.transform_point(1.0, 0.0);
+        assert!((x - 0.0).abs() < 1e-5, "x={x}");
+        assert!((y - 1.0).abs() < 1e-5, "y={y}");
+    }
+
+    #[test]
+    fn affine2d_rotation_is_not_identity() {
+        use std::f32::consts::FRAC_PI_4;
+        assert!(!Affine2D::rotation(FRAC_PI_4).is_identity());
+    }
+
+    #[test]
+    fn affine2d_skew_x_shears_y_axis() {
+        use std::f32::consts::FRAC_PI_4;
+        // skew(π/4, 0) → b=tan(0)=0, c=tan(π/4)=1
+        let s = Affine2D::skew(FRAC_PI_4, 0.0);
+        let (x, y) = s.transform_point(0.0, 1.0);
+        assert!((x - 1.0).abs() < 1e-5, "x={x}");
+        assert!((y - 1.0).abs() < 1e-5, "y={y}");
+    }
+
+    #[test]
+    fn affine2d_mul_two_translations_add() {
+        let t1 = Affine2D::translation(3.0, 4.0);
+        let t2 = Affine2D::translation(1.0, -2.0);
+        let composed = t1 * t2;
+        assert!((composed.e - 4.0).abs() < 1e-5);
+        assert!((composed.f - 2.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn affine2d_mul_scale_then_translate() {
+        let s = Affine2D::scale(2.0, 3.0);
+        let t = Affine2D::translation(10.0, 5.0);
+        // (s * t) * p = s * (t * p): translate first, then scale
+        let composed = s * t;
+        let (x, y) = composed.transform_point(1.0, 1.0);
+        // translate: (1+10, 1+5) = (11, 6); scale: (22, 18)
+        assert!((x - 22.0).abs() < 1e-5, "x={x}");
+        assert!((y - 18.0).abs() < 1e-5, "y={y}");
+    }
+
+    #[test]
+    fn affine2d_transform_rect_identity_is_noop() {
+        let r = Rect {
+            x: 2.0,
+            y: 3.0,
+            width: 4.0,
+            height: 5.0,
+        };
+        let q = Affine2D::IDENTITY.transform_rect(&r);
+        // bottom-left, bottom-right, top-right, top-left in Y-down coords
+        assert!((q.points[0][0] - 2.0).abs() < 1e-5); // bl.x
+        assert!((q.points[0][1] - 8.0).abs() < 1e-5); // bl.y = y+h
+        assert!((q.points[1][0] - 6.0).abs() < 1e-5); // br.x = x+w
+        assert!((q.points[1][1] - 8.0).abs() < 1e-5); // br.y = y+h
+        assert!((q.points[2][0] - 6.0).abs() < 1e-5); // tr.x
+        assert!((q.points[2][1] - 3.0).abs() < 1e-5); // tr.y = y
+        assert!((q.points[3][0] - 2.0).abs() < 1e-5); // tl.x
+        assert!((q.points[3][1] - 3.0).abs() < 1e-5); // tl.y = y
+    }
+
+    #[test]
+    fn affine2d_transform_rect_translation_shifts_all_corners() {
+        let r = Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 10.0,
+            height: 5.0,
+        };
+        let t = Affine2D::translation(2.0, 3.0);
+        let q = t.transform_rect(&r);
+        for pt in &q.points {
+            assert!(pt[0] >= 2.0 - 1e-5 && pt[0] <= 12.0 + 1e-5, "x={}", pt[0]);
+            assert!(pt[1] >= 3.0 - 1e-5 && pt[1] <= 8.0 + 1e-5, "y={}", pt[1]);
+        }
+    }
+
+    // ── Quad ────────────────────────────────────────────────
+
+    #[test]
+    fn quad_non_degenerate_has_positive_area() {
+        let q = Quad {
+            points: [[0.0, 5.0], [5.0, 5.0], [5.0, 0.0], [0.0, 0.0]],
+        };
+        assert!(!q.is_degenerate());
+    }
+
+    #[test]
+    fn quad_collapsed_to_line_is_degenerate() {
+        // All points on the same horizontal line → zero area.
+        let q = Quad {
+            points: [[0.0, 0.0], [5.0, 0.0], [5.0, 0.0], [0.0, 0.0]],
+        };
+        assert!(q.is_degenerate());
+    }
+
+    #[test]
+    fn quad_single_point_is_degenerate() {
+        let q = Quad {
+            points: [[3.0, 3.0]; 4],
+        };
+        assert!(q.is_degenerate());
+    }
+
+    // ── BlockStyle predicates ────────────────────────────────
+
+    #[test]
+    fn block_style_has_radius_false_for_default() {
+        let s = BlockStyle::default();
+        assert!(!s.has_radius());
+    }
+
+    #[test]
+    fn block_style_has_radius_true_when_any_nonzero() {
+        let mut s = BlockStyle::default();
+        s.border_radii[2] = [0.0, 5.0];
+        assert!(s.has_radius());
+    }
+
+    #[test]
+    fn block_style_has_visual_style_background_color() {
+        let s = BlockStyle {
+            background_color: Some([255, 0, 0, 255]),
+            ..Default::default()
+        };
+        assert!(s.has_visual_style());
+    }
+
+    #[test]
+    fn block_style_has_visual_style_border_width() {
+        let s = BlockStyle {
+            border_widths: [0.0, 1.0, 0.0, 0.0],
+            ..Default::default()
+        };
+        assert!(s.has_visual_style());
+    }
+
+    #[test]
+    fn block_style_has_visual_style_padding() {
+        let s = BlockStyle {
+            padding: [0.0, 0.0, 0.0, 3.0],
+            ..Default::default()
+        };
+        assert!(s.has_visual_style());
+    }
+
+    #[test]
+    fn block_style_has_visual_style_box_shadow() {
+        let s = BlockStyle {
+            box_shadows: vec![BoxShadow::default()],
+            ..Default::default()
+        };
+        assert!(s.has_visual_style());
+    }
+
+    #[test]
+    fn block_style_has_visual_style_false_for_default() {
+        assert!(!BlockStyle::default().has_visual_style());
+    }
+
+    #[test]
+    fn block_style_content_inset_sums_left_border_and_left_padding() {
+        let s = BlockStyle {
+            border_widths: [5.0, 0.0, 0.0, 3.0], // top, right, bottom, left
+            padding: [7.0, 0.0, 0.0, 2.0],       // top, right, bottom, left
+            ..Default::default()
+        };
+        let (left, top) = s.content_inset();
+        assert!((left - 5.0).abs() < 1e-5, "left={left}"); // bl(3)+pl(2)=5
+        assert!((top - 12.0).abs() < 1e-5, "top={top}"); // bt(5)+pt(7)=12
+    }
+
+    #[test]
+    fn block_style_has_overflow_clip_x_only() {
+        let s = BlockStyle {
+            overflow_x: Overflow::Clip,
+            overflow_y: Overflow::Visible,
+            ..Default::default()
+        };
+        assert!(s.has_overflow_clip());
+    }
+
+    #[test]
+    fn block_style_has_overflow_clip_y_only() {
+        let s = BlockStyle {
+            overflow_x: Overflow::Visible,
+            overflow_y: Overflow::Clip,
+            ..Default::default()
+        };
+        assert!(s.has_overflow_clip());
+    }
+
+    #[test]
+    fn block_style_has_overflow_clip_false_for_visible() {
+        let s = BlockStyle::default(); // both Visible
+        assert!(!s.has_overflow_clip());
+    }
+
+    #[test]
+    fn block_style_needs_block_wrapper_from_radius_alone() {
+        let s = BlockStyle {
+            border_radii: [[5.0, 5.0]; 4],
+            ..Default::default()
+        };
+        assert!(s.needs_block_wrapper());
+    }
+
+    #[test]
+    fn block_style_needs_block_wrapper_from_overflow_clip_alone() {
+        let s = BlockStyle {
+            overflow_x: Overflow::Clip,
+            ..Default::default()
+        };
+        assert!(s.needs_block_wrapper());
+    }
+
+    #[test]
+    fn block_style_needs_block_wrapper_false_for_default() {
+        assert!(!BlockStyle::default().needs_block_wrapper());
+    }
+
+    // ── BookmarkCollector ────────────────────────────────────
+
+    #[test]
+    fn bookmark_collector_records_on_correct_page() {
+        let mut bc = BookmarkCollector::new();
+        bc.set_current_page(2);
+        bc.record(1, "Chapter One".to_string(), 100.0);
+        bc.set_current_page(5);
+        bc.record(2, "Section 5.1".to_string(), 42.0);
+
+        let entries = bc.into_entries();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].page_idx, 2);
+        assert_eq!(entries[0].level, 1);
+        assert_eq!(entries[0].label, "Chapter One");
+        assert!((entries[0].y_pt - 100.0).abs() < 1e-5);
+        assert_eq!(entries[1].page_idx, 5);
+        assert_eq!(entries[1].level, 2);
+        assert_eq!(entries[1].label, "Section 5.1");
+    }
+
+    #[test]
+    fn bookmark_collector_empty_by_default() {
+        let bc = BookmarkCollector::new();
+        assert!(bc.into_entries().is_empty());
+    }
+
+    // ── alpha_to_opacity ─────────────────────────────────────
+
+    #[test]
+    fn alpha_to_opacity_255_is_one() {
+        let v = alpha_to_opacity(255);
+        assert!((v.get() - 1.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn alpha_to_opacity_0_is_zero() {
+        let v = alpha_to_opacity(0);
+        assert!(v.get() < 1e-3);
+    }
+
+    #[test]
+    fn alpha_to_opacity_128_is_near_half() {
+        let v = alpha_to_opacity(128);
+        assert!((v.get() - 128.0 / 255.0).abs() < 1e-3);
+    }
+
+    // ── LinkCollector::take_page ─────────────────────────────
+
+    #[test]
+    fn link_collector_take_page_removes_and_returns_entries() {
+        let mut collector = LinkCollector::new();
+        let link = make_test_link();
+        collector.set_current_page(1);
+        collector.push_rect(
+            &link,
+            Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 10.0,
+                height: 5.0,
+            },
+        );
+        collector.set_current_page(2);
+        collector.push_rect(
+            &link,
+            Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 20.0,
+                height: 5.0,
+            },
+        );
+
+        let page1 = collector.take_page(1);
+        assert_eq!(page1.len(), 1);
+        assert_eq!(page1[0].page_idx, 1);
+
+        // Page 1 entries are gone; page 2 still present.
+        assert!(collector.take_page(1).is_empty());
+        let page2 = collector.take_page(2);
+        assert_eq!(page2.len(), 1);
+        assert_eq!(page2[0].page_idx, 2);
+    }
+
+    #[test]
+    fn link_collector_take_missing_page_returns_empty() {
+        let mut collector = LinkCollector::new();
+        assert!(collector.take_page(99).is_empty());
+    }
+
+    // ── LinkCollector: same-link multiple pages → separate occurrences ──
+
+    #[test]
+    fn link_collector_same_link_different_pages_produces_separate_occurrences() {
+        let mut collector = LinkCollector::new();
+        let link = make_test_link();
+        collector.set_current_page(0);
+        collector.push_rect(
+            &link,
+            Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 10.0,
+                height: 5.0,
+            },
+        );
+        collector.set_current_page(1);
+        collector.push_rect(
+            &link,
+            Rect {
+                x: 5.0,
+                y: 0.0,
+                width: 10.0,
+                height: 5.0,
+            },
+        );
+
+        let all = collector.into_occurrences();
+        assert_eq!(all.len(), 2, "expected one occurrence per page");
+    }
+
+    // ── DestinationRegistry: first-write-wins ────────────────
+
+    #[test]
+    fn destination_registry_first_write_wins_for_duplicate_ids() {
+        let mut reg = DestinationRegistry::new();
+        reg.set_current_page(0);
+        reg.record("anchor", 10.0, 20.0);
+        reg.set_current_page(1);
+        reg.record("anchor", 99.0, 99.0); // duplicate — should be ignored
+        let (page, x, y) = reg.get("anchor").expect("recorded");
+        assert_eq!(page, 0, "first write should win");
+        assert!((x - 10.0).abs() < 1e-5);
+        assert!((y - 20.0).abs() < 1e-5);
+    }
+
+    // ── compute_overflow_clip_path: y-only clip branch ───────
+
+    #[test]
+    fn compute_overflow_clip_y_clip_x_visible_returns_path() {
+        let style = BlockStyle {
+            overflow_x: Overflow::Visible,
+            overflow_y: Overflow::Clip,
+            border_widths: [1.0, 1.0, 1.0, 1.0],
+            ..Default::default()
+        };
+        assert!(compute_overflow_clip_path(&style, 0.0, 0.0, 100.0, 100.0).is_some());
+    }
+
+    // ── compute_overflow_clip_path: both-axes, no-radius branch ──
+
+    #[test]
+    fn compute_overflow_clip_both_axes_no_radius_returns_path() {
+        let style = BlockStyle {
+            overflow_x: Overflow::Clip,
+            overflow_y: Overflow::Clip,
+            border_widths: [1.0, 1.0, 1.0, 1.0],
+            ..Default::default()
+        };
+        assert!(compute_overflow_clip_path(&style, 0.0, 0.0, 100.0, 100.0).is_some());
+    }
 }
 
 /// Float-tolerance helpers shared across the in-crate transform test

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -1352,3 +1352,104 @@ mod link_span_tests {
 // (PDF byte / `/Link` substring assertions) and the VRT byte-identical
 // fixtures. The Pageable trait + `LinkCollector` are slated for full
 // removal in PR 8j.
+
+#[cfg(test)]
+mod text_decoration_tests {
+    use super::*;
+
+    // ── TextDecorationLine ───────────────────────────────────
+
+    #[test]
+    fn text_decoration_line_none_is_none() {
+        assert!(TextDecorationLine::NONE.is_none());
+    }
+
+    #[test]
+    fn text_decoration_line_underline_is_not_none() {
+        assert!(!TextDecorationLine::UNDERLINE.is_none());
+    }
+
+    #[test]
+    fn text_decoration_line_contains_self() {
+        assert!(TextDecorationLine::UNDERLINE.contains(TextDecorationLine::UNDERLINE));
+    }
+
+    #[test]
+    fn text_decoration_line_contains_returns_false_when_missing() {
+        assert!(!TextDecorationLine::UNDERLINE.contains(TextDecorationLine::OVERLINE));
+    }
+
+    #[test]
+    fn text_decoration_line_bitor_combines_flags() {
+        let combined = TextDecorationLine::UNDERLINE | TextDecorationLine::OVERLINE;
+        assert!(combined.contains(TextDecorationLine::UNDERLINE));
+        assert!(combined.contains(TextDecorationLine::OVERLINE));
+        assert!(!combined.contains(TextDecorationLine::LINE_THROUGH));
+        assert!(!combined.is_none());
+    }
+
+    #[test]
+    fn text_decoration_line_line_through_is_not_none() {
+        assert!(!TextDecorationLine::LINE_THROUGH.is_none());
+    }
+
+    // ── TextDecoration::same_appearance ─────────────────────
+
+    #[test]
+    fn text_decoration_same_appearance_identical() {
+        let d = TextDecoration {
+            line: TextDecorationLine::UNDERLINE,
+            style: TextDecorationStyle::Solid,
+            color: [0, 0, 0, 255],
+        };
+        assert!(d.same_appearance(&d));
+    }
+
+    #[test]
+    fn text_decoration_same_appearance_differs_on_color() {
+        let a = TextDecoration {
+            line: TextDecorationLine::UNDERLINE,
+            style: TextDecorationStyle::Solid,
+            color: [0, 0, 0, 255],
+        };
+        let b = TextDecoration {
+            color: [255, 0, 0, 255],
+            ..a
+        };
+        assert!(!a.same_appearance(&b));
+    }
+
+    #[test]
+    fn text_decoration_same_appearance_differs_on_style() {
+        let a = TextDecoration {
+            line: TextDecorationLine::UNDERLINE,
+            style: TextDecorationStyle::Solid,
+            color: [0, 0, 0, 255],
+        };
+        let b = TextDecoration {
+            style: TextDecorationStyle::Dashed,
+            ..a
+        };
+        assert!(!a.same_appearance(&b));
+    }
+
+    #[test]
+    fn text_decoration_same_appearance_differs_on_line() {
+        let a = TextDecoration {
+            line: TextDecorationLine::UNDERLINE,
+            style: TextDecorationStyle::Solid,
+            color: [0, 0, 0, 255],
+        };
+        let b = TextDecoration {
+            line: TextDecorationLine::LINE_THROUGH,
+            ..a
+        };
+        assert!(!a.same_appearance(&b));
+    }
+
+    #[test]
+    fn text_decoration_default_has_no_line() {
+        let d = TextDecoration::default();
+        assert!(d.line.is_none());
+    }
+}


### PR DESCRIPTION
## 対象モジュール

`crates/fulgur/src/draw_primitives.rs` および `crates/fulgur/src/paragraph.rs`

## カバレッジ変化

| ファイル | 変更前 (行) | 変更後 (行) | 差分 |
|---|---|---|---|
| `draw_primitives.rs` | 69.37% | 77.63% | **+8.26 pp** |
| `paragraph.rs` | 60.74% | 64.55% | **+3.81 pp** |
| TOTAL | 80.19% | 80.55% | +0.36 pp |

## 追加したテスト一覧

### `draw_primitives.rs` — `dp_unit_tests` モジュール (37テスト追加)

**Affine2D 行列演算 (9テスト)**
- `affine2d_identity_is_recognized` — `IDENTITY.is_identity()` が true
- `affine2d_translation_is_not_identity` — 平行移動行列は identity でない
- `affine2d_scale_is_not_identity` — スケール行列は identity でない
- `affine2d_rotation_90_maps_x_to_y` — 90° 回転で (1,0) → (0,1)
- `affine2d_rotation_is_not_identity` — 45° 回転は identity でない
- `affine2d_skew_x_shears_y_axis` — x軸スキューで y軸方向のシア確認
- `affine2d_mul_two_translations_add` — 2つの平行移動の合成で加算
- `affine2d_mul_scale_then_translate` — スケール × 平行移動の合成
- `affine2d_transform_rect_identity_is_noop` / `..translation_shifts_all_corners` — Rect→Quad 変換

**Quad (3テスト)**
- `quad_non_degenerate_has_positive_area` — 正の面積は degenerate でない
- `quad_collapsed_to_line_is_degenerate` — 同一水平線上は degenerate
- `quad_single_point_is_degenerate` — 1点に収束は degenerate

**BlockStyle 述語 (12テスト)**
- `has_radius`: false (default) / true (1コーナー非ゼロ)
- `has_visual_style`: background_color / border_width / padding / box_shadow / false (default)
- `content_inset`: left border + left padding の合計確認
- `has_overflow_clip`: x のみ / y のみ / false (両方 Visible)
- `needs_block_wrapper`: radius のみ / overflow_clip のみ / false (default)

**BookmarkCollector (2テスト)**
- `bookmark_collector_records_on_correct_page` — 複数ページへの記録・ページ番号確認
- `bookmark_collector_empty_by_default` — デフォルトで空

**alpha_to_opacity (3テスト)**
- 255→1.0、0→0.0、128→~0.502

**LinkCollector (3テスト追加)**
- `link_collector_take_page_removes_and_returns_entries` — ページ単位取り出し・削除
- `link_collector_take_missing_page_returns_empty` — 未登録ページは空 Vec
- `link_collector_same_link_different_pages_produces_separate_occurrences` — 同Arc異ページで別 occurrence

**DestinationRegistry (1テスト追加)**
- `destination_registry_first_write_wins_for_duplicate_ids` — 重複 ID は先着優先

**compute_overflow_clip_path 追加分岐 (2テスト)**
- `compute_overflow_clip_y_clip_x_visible_returns_path` — y のみクリップ
- `compute_overflow_clip_both_axes_no_radius_returns_path` — 両軸クリップ・角丸なし

### `paragraph.rs` — `text_decoration_tests` モジュール (10テスト追加)

- `TextDecorationLine::NONE.is_none()` — None フラグ確認
- `TextDecorationLine::UNDERLINE.is_none()` — false 確認
- `contains(self)` — 自分自身を含む
- `contains` 不一致 — UNDERLINE に OVERLINE を含まない
- `bitor` — UNDERLINE | OVERLINE の合成フラグ確認
- `LINE_THROUGH.is_none()` — false 確認
- `TextDecoration::same_appearance` — 同一/color違い/style違い/line違い の4ケース
- `TextDecoration::default` — line が NONE

## 意図的に除外した未カバー箇所

| 箇所 | 除外理由 |
|---|---|
| `draw_with_opacity`, `stroke_line`, `draw_border_line`, `draw_block_border` など Canvas を受け取る関数 | krilla `Surface` のセットアップが必要で、単体テストでは spin-up コストが高い。VRT や render_smoke.rs 経由でカバー済み |
| `Affine2D::to_krilla` / `Quad::to_krilla` | krilla 型を返すだけのラッパー。実際の描画パスで VRT がカバー |
| `convert/positioned.rs`、`convert/pseudo.rs` の低カバー関数 | Blitz DOM ノードが必要で blitz_adapter 経由の統合テストが必要 |

---
_Generated by [Claude Code](https://claude.ai/code/session_012xE69Mx17iB3U1QgJnPHiT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for drawing primitives and text decoration features to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->