### PR TITLE
fix(pagination): paginate absolute body overflow across multiple pages

### DIFF
--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -551,20 +551,22 @@ impl Engine {
         // render emits (see the `append_position_fixed_fragments` block
         // in `render_html`). Without this, the helper would diverge
         // from `render_html` for documents with `position: fixed`.
+        let content_w_px = crate::convert::pt_to_px(self.config.content_width());
+        let content_h_px = crate::convert::pt_to_px(self.config.content_height());
         let total_pages = crate::pagination_layout::implied_page_count(&pagination_geometry).max(1);
         crate::pagination_layout::append_position_fixed_fragments(
             &mut pagination_geometry,
             doc.deref_mut(),
             total_pages,
-            crate::convert::pt_to_px(self.config.content_width()),
-            crate::convert::pt_to_px(self.config.content_height()),
+            content_w_px,
+            content_h_px,
         );
         crate::pagination_layout::append_position_absolute_body_direct_fragments(
             &mut pagination_geometry,
             doc.deref_mut(),
             total_pages,
-            crate::convert::pt_to_px(self.config.content_width()),
-            crate::convert::pt_to_px(self.config.content_height()),
+            content_w_px,
+            content_h_px,
             None,
         );
         let expanded_total_pages =
@@ -574,8 +576,8 @@ impl Engine {
                 &mut pagination_geometry,
                 doc.deref_mut(),
                 expanded_total_pages,
-                crate::convert::pt_to_px(self.config.content_width()),
-                crate::convert::pt_to_px(self.config.content_height()),
+                content_w_px,
+                content_h_px,
             );
         }
 
@@ -591,10 +593,7 @@ impl Engine {
             multicol_geometry,
             pagination_geometry,
             link_cache: Default::default(),
-            viewport_size_px: Some((
-                crate::convert::pt_to_px(self.config.content_width()),
-                crate::convert::pt_to_px(self.config.content_height()),
-            )),
+            viewport_size_px: Some((content_w_px, content_h_px)),
         };
         let drawables = crate::convert::dom_to_drawables(&doc, &mut convert_ctx);
         // PR 8i regression fix: read geometry AFTER convert. Convert

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -2573,7 +2573,7 @@ pub fn append_position_absolute_body_direct_fragments(
         if running_store.is_some_and(|s| s.instance_for_node(child_id).is_some()) {
             return false;
         }
-        !is_out_of_flow_positioned(child)
+        !is_out_of_flow_positioned(child) && !crate::blitz_adapter::node_is_floating(child)
     });
     for child_id in body_children {
         let Some(child) = doc.get_node(child_id) else {
@@ -2614,7 +2614,6 @@ pub fn append_position_absolute_body_direct_fragments(
         );
     }
 
-    // Don't allocate empty entries for nodes without fragments.
     geometry.retain(|_, geom| !geom.fragments.is_empty());
 }
 
@@ -2651,7 +2650,6 @@ fn record_subtree_fragments_at_offset(
         may_extend_pages: bool,
         depth: usize,
     ) {
-        use ::style::properties::longhands::position::computed_value::T as Pos;
         if depth >= crate::MAX_DOM_DEPTH {
             return;
         }
@@ -2680,22 +2678,11 @@ fn record_subtree_fragments_at_offset(
         let stored_x = root_xy_for_paging.0 + offset_in_subtree.0 - body_offset.0;
         let w = node.final_layout.size.width;
         let h = node.final_layout.size.height;
-        let is_size_contained = node.primary_styles().is_some_and(|s| {
-            s.get_box()
-                .clone_contain()
-                .contains(::style::values::computed::box_::Contain::SIZE)
-        });
+        let is_size_contained = has_contain_size(node);
         let monolithic_adjust: f32 = children
             .iter()
             .filter_map(|child_id| doc.get_node(*child_id))
-            .filter(|child| {
-                !is_out_of_flow_positioned(child)
-                    && child.primary_styles().is_some_and(|s| {
-                        s.get_box()
-                            .clone_contain()
-                            .contains(::style::values::computed::box_::Contain::SIZE)
-                    })
-            })
+            .filter(|child| !is_out_of_flow_positioned(child) && has_contain_size(child))
             .map(|child| (child.final_layout.size.height - page_h_px).max(0.0))
             .sum();
         let h_for_paging = (h - monolithic_adjust).max(0.0);
@@ -2784,10 +2771,7 @@ fn record_subtree_fragments_at_offset(
             // Skip out-of-flow descendants (handled by their own
             // pass — `append_position_fixed_fragments` for fixed,
             // separate body-direct walk for abs).
-            let is_oof = child.primary_styles().is_some_and(|s| {
-                matches!(s.get_box().clone_position(), Pos::Absolute | Pos::Fixed)
-            });
-            if is_oof {
+            if is_out_of_flow_positioned(child) {
                 continue;
             }
             // Skip whitespace-only text (matches fragmenter).
@@ -2812,11 +2796,7 @@ fn record_subtree_fragments_at_offset(
                 may_extend_pages,
                 depth + 1,
             );
-            if child.primary_styles().is_some_and(|s| {
-                s.get_box()
-                    .clone_contain()
-                    .contains(::style::values::computed::box_::Contain::SIZE)
-            }) {
+            if has_contain_size(child) {
                 monolithic_y_adjust += (child.final_layout.size.height - page_h_px).max(0.0);
             }
         }
@@ -2841,6 +2821,14 @@ fn is_out_of_flow_positioned(node: &blitz_dom::Node) -> bool {
 
     node.primary_styles()
         .is_some_and(|s| matches!(s.get_box().clone_position(), Pos::Absolute | Pos::Fixed))
+}
+
+fn has_contain_size(node: &blitz_dom::Node) -> bool {
+    node.primary_styles().is_some_and(|s| {
+        s.get_box()
+            .clone_contain()
+            .contains(::style::values::computed::box_::Contain::SIZE)
+    })
 }
 
 /// CSS-px (x, y) of `<body>`'s top-left in its containing block (html).


### PR DESCRIPTION
## 概要

`position: absolute` で body の直接の子になっている要素が複数ページにまたがる場合（高さがページ高を超える場合）、2ページ目以降に描画されないバグを修正する。

- body-direct absolute 要素のサブツリーを、要素の y 範囲が交差する全ページに対してフラグメントを記録するよう変更
- `contain: size` なモノリシック子を含む場合、子の超過分を y オフセット補正（後続コンテンツが正しいページに配置される）
- body が in-flow コンテンツを持たない場合（position:absolute のみ等）は expanded_total_pages を使って fixed 要素のページ繰り返しも拡張

## 変更点

- `record_subtree_fragments_at_offset`: 単一フラグメントではなく、ページ範囲ループで各ページにフラグメントを生成
- `append_position_absolute_body_direct_fragments`: `body_has_in_flow_content` フラグを判定し、OOF-only body の場合は `may_extend_pages = true` で呼び出す（float 除外バグも修正）
- `engine.rs`: absolute pass 後に `implied_page_count` を再計算し、増えたページ分 fixed フラグメントを追加
- `has_contain_size` ヘルパー抽出、`is_out_of_flow_positioned` の内部ループ統一など cleanup

## テスト

- `position_absolute_body_direct_overflow_emits_fragments_on_each_page`
- `position_absolute_body_direct_expanded_pages_reach_later_text`
- `position_fixed_repeats_on_pages_added_by_body_direct_absolute`
- `position_absolute_body_direct_tiny_overflow_reaches_next_page`
- `position_absolute_body_direct_height_overflow_extends_to_last_page`
- `position_absolute_body_direct_running_only_body_extends_pages`
- `position_absolute_body_direct_beyond_page_budget_extends_pages`
- WPT: `monolithic-overflow-013` PASS に昇格（79 PASS）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * レイアウト計算処理の内部的な効率化を行いました。
  * ページング処理および配置計算ロジックの最適化を実施しました。

※このリリースはユーザー向けの新機能追加やバグ修正ではなく、内部的なパフォーマンス改善となります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->