### PR TITLE
fix(pagination): align grid/flex parallel sibling recursion entry to row y

### DIFF
--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -4095,6 +4095,43 @@ h2 { string-set: chapter-title content(text); }
         );
     }
 
+    #[test]
+    fn fragment_block_subtree_flex_row_co_splits_at_same_y() {
+        let html = r#"
+            <html><body style="margin: 0; padding: 0">
+              <div style="height: 100px; width: 200px"></div>
+              <div style="display: flex; width: 200px;">
+                <div style="height: 250px; width: 100px; flex: 0 0 100px"></div>
+                <div style="height: 250px; width: 100px; flex: 0 0 100px"></div>
+              </div>
+            </body></html>
+        "#;
+        let mut doc = parse(html, 600.0);
+        let table = blitz_adapter::extract_column_style_table(&doc);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 250.0, &table);
+
+        let mut cells: Vec<(u32, f32, f32, f32)> = geom
+            .values()
+            .flat_map(|g| g.fragments.iter())
+            .filter(|f| (f.width - 100.0).abs() < 0.5)
+            .map(|f| (f.page_index, f.x, f.y, f.height))
+            .collect();
+        cells.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+        let page0_cells: Vec<_> = cells.iter().filter(|(p, _, _, _)| *p == 0).collect();
+        let page1_cells: Vec<_> = cells.iter().filter(|(p, _, _, _)| *p == 1).collect();
+        assert_eq!(page0_cells.len(), 2, "{cells:?}");
+        assert_eq!(page1_cells.len(), 2, "{cells:?}");
+        assert!(
+            (page0_cells[0].2 - page0_cells[1].2).abs() < 0.5,
+            "{cells:?}"
+        );
+        assert!(
+            (page1_cells[0].2 - page1_cells[1].2).abs() < 0.5,
+            "{cells:?}"
+        );
+    }
+
     /// fulgur-916y: a multicol container with a `column-span: all`
     /// child whose subtree exceeds one page must split across pages
     /// in the partition path. Pre-fix, the multicol gate

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -4119,7 +4119,7 @@ h2 { string-set: chapter-title content(text); }
         // 左 column (x=0): y=0 と y=50 の 2 個
         let left_ys: Vec<f32> = inner
             .iter()
-            .filter(|(_, x, _)| (x - 0.0).abs() < 0.5)
+            .filter(|(_, x, _)| x.abs() < 0.5)
             .map(|(_, _, y)| *y)
             .collect();
         assert_eq!(left_ys, vec![0.0, 50.0], "left column y, inner={inner:?}");
@@ -4166,12 +4166,19 @@ h2 { string-set: chapter-title content(text); }
             .collect();
         inner.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
-        assert_eq!(inner.len(), 4, "inner={inner:?}");
-        assert!(inner.iter().all(|(p, _, _)| *p == 0), "inner={inner:?}");
+        assert_eq!(
+            inner.len(),
+            4,
+            "expected 4 inner divs (2 per column × 2 columns), got inner={inner:?}"
+        );
+        assert!(
+            inner.iter().all(|(p, _, _)| *p == 0),
+            "all 4 inner divs must be on page 0, inner={inner:?}"
+        );
 
         let left_ys: Vec<f32> = inner
             .iter()
-            .filter(|(_, x, _)| (x - 0.0).abs() < 0.5)
+            .filter(|(_, x, _)| x.abs() < 0.5)
             .map(|(_, _, y)| *y)
             .collect();
         let right_ys: Vec<f32> = inner
@@ -4183,7 +4190,7 @@ h2 { string-set: chapter-title content(text); }
         assert_eq!(
             right_ys,
             vec![0.0, 50.0],
-            "right column y must match left column, inner={inner:?}"
+            "right column y must match left column (parallel siblings, not stacked), inner={inner:?}"
         );
     }
 

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -4122,7 +4122,13 @@ h2 { string-set: chapter-title content(text); }
             .filter(|(_, x, _)| x.abs() < 0.5)
             .map(|(_, _, y)| *y)
             .collect();
-        assert_eq!(left_ys, vec![0.0, 50.0], "left column y, inner={inner:?}");
+        let approx_eq = |a: &[f32], b: &[f32]| -> bool {
+            a.len() == b.len() && a.iter().zip(b).all(|(x, y)| (x - y).abs() < 0.5)
+        };
+        assert!(
+            approx_eq(&left_ys, &[0.0, 50.0]),
+            "left column y, inner={inner:?}"
+        );
 
         // 右 column (x=100): y=0 と y=50 の 2 個 (block flow になっていれば
         // y=100, y=150 になる)
@@ -4131,9 +4137,8 @@ h2 { string-set: chapter-title content(text); }
             .filter(|(_, x, _)| (x - 100.0).abs() < 0.5)
             .map(|(_, _, y)| *y)
             .collect();
-        assert_eq!(
-            right_ys,
-            vec![0.0, 50.0],
+        assert!(
+            approx_eq(&right_ys, &[0.0, 50.0]),
             "right column y must match left column (parallel siblings, not stacked), inner={inner:?}"
         );
     }
@@ -4186,10 +4191,15 @@ h2 { string-set: chapter-title content(text); }
             .filter(|(_, x, _)| (x - 100.0).abs() < 0.5)
             .map(|(_, _, y)| *y)
             .collect();
-        assert_eq!(left_ys, vec![0.0, 50.0], "left column y, inner={inner:?}");
-        assert_eq!(
-            right_ys,
-            vec![0.0, 50.0],
+        let approx_eq = |a: &[f32], b: &[f32]| -> bool {
+            a.len() == b.len() && a.iter().zip(b).all(|(x, y)| (x - y).abs() < 0.5)
+        };
+        assert!(
+            approx_eq(&left_ys, &[0.0, 50.0]),
+            "left column y, inner={inner:?}"
+        );
+        assert!(
+            approx_eq(&right_ys, &[0.0, 50.0]),
             "right column y must match left column (parallel siblings, not stacked), inner={inner:?}"
         );
     }

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -4048,17 +4048,27 @@ h2 { string-set: chapter-title content(text); }
 
     #[test]
     fn fragment_block_subtree_grid_row_co_splits_at_same_y() {
-        // 1 row の 2 cell が 1 page strip を超える case (cell が inner
-        // content を持つ — fragment_block_subtree が recursion 経路を
-        // 通る). pre-fix: card1 だけ split (or page promote), card2 は
-        // 別ページに promote されて co-split しない. post-fix: 両 cell
-        // とも page 0 + page 1 に同じ y で co-split.
+        // 1 row の 2 cell が page boundary をまたぐ co-split case (cell
+        // 内に natural break point を持つよう inner div を 2 段重ねた).
+        //
+        // pre-fix (A だけ未修正): 右 column の cell の recursion 入り口
+        // が parent の cursor_y (= 左 column の bottom) になり、右 column
+        // が y=300 付近に積まれる block flow フォールバック挙動を示す。
+        //
+        // post-fix: 両 cell とも grid row として同じ y=100 から開始し、
+        // div1 は page 0 (y=100), div2 は page 1 (y=0) に co-split する。
         let html = r#"
             <html><body style="margin: 0; padding: 0">
               <div style="height: 100px; width: 200px"></div>
               <div style="display: grid; grid-template-columns: 100px 100px; width: 200px;">
-                <div style="width: 100px"><div style="height: 250px; width: 100px"></div></div>
-                <div style="width: 100px"><div style="height: 250px; width: 100px"></div></div>
+                <div style="width: 100px">
+                  <div style="height: 100px; width: 100px"></div>
+                  <div style="height: 100px; width: 100px"></div>
+                </div>
+                <div style="width: 100px">
+                  <div style="height: 100px; width: 100px"></div>
+                  <div style="height: 100px; width: 100px"></div>
+                </div>
               </div>
             </body></html>
         "#;
@@ -4066,53 +4076,64 @@ h2 { string-set: chapter-title content(text); }
         let table = blitz_adapter::extract_column_style_table(&doc);
         let geom = super::run_pass_with_break_styles(doc.deref_mut(), 250.0, &table);
 
-        // 100×100 もしくは 100×NN の inner div fragment を集める。
-        // (cell wrapper も width=100 になるが、co-split が動けば inner
-        // div 側も両ページに fragment を持つので両者で OK)
-        // height のフィルタは外し、page index と y で同 row を識別する。
-        let mut cells: Vec<(u32, f32, f32, f32)> = geom
+        // 100×100 の inner div fragment だけを集めて (page, x, y) で
+        // 同 row co-split を検証する。cell wrapper (width 100, height 200)
+        // は除外して inner div (width 100, height 100) のみ見る。
+        let mut inner: Vec<(u32, f32, f32)> = geom
             .values()
             .flat_map(|g| g.fragments.iter())
-            .filter(|f| (f.width - 100.0).abs() < 0.5)
-            .map(|f| (f.page_index, f.x, f.y, f.height))
+            .filter(|f| (f.width - 100.0).abs() < 0.5 && (f.height - 100.0).abs() < 0.5)
+            .map(|f| (f.page_index, f.x, f.y))
             .collect();
-        cells.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        inner.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
-        // x は cell wrapper も inner div も同じ (0 か 100). 同じ x の
-        // fragments のうち各 page の最も上の y を取る — これが「その
-        // 列の cell の page-local 開始 y」。
-        let column_top_y = |page: u32, x_target: f32| -> Option<f32> {
-            cells
+        let count_at = |page: u32, x: f32| {
+            inner
                 .iter()
-                .filter(|(p, x, _, _)| *p == page && (*x - x_target).abs() < 0.5)
-                .map(|(_, _, y, _)| *y)
-                .min_by(|a, b| a.partial_cmp(b).unwrap())
+                .filter(|(p, ix, _)| *p == page && (ix - x).abs() < 0.5)
+                .count()
+        };
+        let y_at = |page: u32, x: f32| {
+            inner
+                .iter()
+                .find(|(p, ix, _)| *p == page && (ix - x).abs() < 0.5)
+                .map(|(_, _, y)| *y)
         };
 
-        let p0_left = column_top_y(0, 0.0);
-        let p0_right = column_top_y(0, 100.0);
-        let p1_left = column_top_y(1, 0.0);
-        let p1_right = column_top_y(1, 100.0);
+        // 各列に対し page 0 と page 1 にちょうど 1 個の inner div が並ぶ
+        // (div1 が page 0、div2 が page 1) ことを期待する。
+        assert_eq!(
+            count_at(0, 0.0),
+            1,
+            "left column page-0 inner div, inner={inner:?}"
+        );
+        assert_eq!(
+            count_at(0, 100.0),
+            1,
+            "right column page-0 inner div, inner={inner:?}"
+        );
+        assert_eq!(
+            count_at(1, 0.0),
+            1,
+            "left column page-1 inner div, inner={inner:?}"
+        );
+        assert_eq!(
+            count_at(1, 100.0),
+            1,
+            "right column page-1 inner div, inner={inner:?}"
+        );
 
-        assert!(
-            p0_left.is_some() && p0_right.is_some(),
-            "expected both columns to have a page-0 fragment, cells={cells:?}"
+        // page 0 の左右 column の上端 y が一致 (= row top)
+        assert_eq!(
+            y_at(0, 0.0),
+            y_at(0, 100.0),
+            "page 0 row top must share y across columns, inner={inner:?}"
         );
-        assert!(
-            p1_left.is_some() && p1_right.is_some(),
-            "expected both columns to have a page-1 fragment (co-split), cells={cells:?}"
-        );
-        assert!(
-            (p0_left.unwrap() - p0_right.unwrap()).abs() < 0.5,
-            "page-0 row top must share y across columns, got left={:?} right={:?}",
-            p0_left,
-            p0_right
-        );
-        assert!(
-            (p1_left.unwrap() - p1_right.unwrap()).abs() < 0.5,
-            "page-1 row top must share y across columns, got left={:?} right={:?}",
-            p1_left,
-            p1_right
+        // page 1 の左右 column の上端 y が一致 (= 0)
+        assert_eq!(
+            y_at(1, 0.0),
+            y_at(1, 100.0),
+            "page 1 row top must share y across columns, inner={inner:?}"
         );
     }
 
@@ -4122,8 +4143,14 @@ h2 { string-set: chapter-title content(text); }
             <html><body style="margin: 0; padding: 0">
               <div style="height: 100px; width: 200px"></div>
               <div style="display: flex; width: 200px;">
-                <div style="width: 100px; flex: 0 0 100px"><div style="height: 250px; width: 100px"></div></div>
-                <div style="width: 100px; flex: 0 0 100px"><div style="height: 250px; width: 100px"></div></div>
+                <div style="width: 100px; flex: 0 0 100px">
+                  <div style="height: 100px; width: 100px"></div>
+                  <div style="height: 100px; width: 100px"></div>
+                </div>
+                <div style="width: 100px; flex: 0 0 100px">
+                  <div style="height: 100px; width: 100px"></div>
+                  <div style="height: 100px; width: 100px"></div>
+                </div>
               </div>
             </body></html>
         "#;
@@ -4131,46 +4158,41 @@ h2 { string-set: chapter-title content(text); }
         let table = blitz_adapter::extract_column_style_table(&doc);
         let geom = super::run_pass_with_break_styles(doc.deref_mut(), 250.0, &table);
 
-        let mut cells: Vec<(u32, f32, f32, f32)> = geom
+        let mut inner: Vec<(u32, f32, f32)> = geom
             .values()
             .flat_map(|g| g.fragments.iter())
-            .filter(|f| (f.width - 100.0).abs() < 0.5)
-            .map(|f| (f.page_index, f.x, f.y, f.height))
+            .filter(|f| (f.width - 100.0).abs() < 0.5 && (f.height - 100.0).abs() < 0.5)
+            .map(|f| (f.page_index, f.x, f.y))
             .collect();
-        cells.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        inner.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
-        let column_top_y = |page: u32, x_target: f32| -> Option<f32> {
-            cells
+        let count_at = |page: u32, x: f32| {
+            inner
                 .iter()
-                .filter(|(p, x, _, _)| *p == page && (*x - x_target).abs() < 0.5)
-                .map(|(_, _, y, _)| *y)
-                .min_by(|a, b| a.partial_cmp(b).unwrap())
+                .filter(|(p, ix, _)| *p == page && (ix - x).abs() < 0.5)
+                .count()
+        };
+        let y_at = |page: u32, x: f32| {
+            inner
+                .iter()
+                .find(|(p, ix, _)| *p == page && (ix - x).abs() < 0.5)
+                .map(|(_, _, y)| *y)
         };
 
-        let p0_left = column_top_y(0, 0.0);
-        let p0_right = column_top_y(0, 100.0);
-        let p1_left = column_top_y(1, 0.0);
-        let p1_right = column_top_y(1, 100.0);
+        assert_eq!(count_at(0, 0.0), 1, "left page-0, inner={inner:?}");
+        assert_eq!(count_at(0, 100.0), 1, "right page-0, inner={inner:?}");
+        assert_eq!(count_at(1, 0.0), 1, "left page-1, inner={inner:?}");
+        assert_eq!(count_at(1, 100.0), 1, "right page-1, inner={inner:?}");
 
-        assert!(
-            p0_left.is_some() && p0_right.is_some(),
-            "expected both columns to have a page-0 fragment, cells={cells:?}"
+        assert_eq!(
+            y_at(0, 0.0),
+            y_at(0, 100.0),
+            "page 0 row top, inner={inner:?}"
         );
-        assert!(
-            p1_left.is_some() && p1_right.is_some(),
-            "expected both columns to have a page-1 fragment (co-split), cells={cells:?}"
-        );
-        assert!(
-            (p0_left.unwrap() - p0_right.unwrap()).abs() < 0.5,
-            "page-0 row top must share y across columns, got left={:?} right={:?}",
-            p0_left,
-            p0_right
-        );
-        assert!(
-            (p1_left.unwrap() - p1_right.unwrap()).abs() < 0.5,
-            "page-1 row top must share y across columns, got left={:?} right={:?}",
-            p1_left,
-            p1_right
+        assert_eq!(
+            y_at(1, 0.0),
+            y_at(1, 100.0),
+            "page 1 row top, inner={inner:?}"
         );
     }
 

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -1684,6 +1684,16 @@ fn fragment_block_subtree(
         if needs_recursion {
             let pre_recursion_page = page_index;
             let pre_recursion_cursor_y = cursor_y;
+            // fulgur-u0p0: enter recursion from `child_page_y` (the rebased
+            // page-local y of THIS child) instead of the parent's running
+            // `cursor_y`. For block flow, `child_page_y == cursor_y` after
+            // the cursor_y update above, so this is a no-op. For grid / flex
+            // parallel siblings (same Taffy `location.y` as a previous
+            // sibling on this page), `cursor_y` still holds the previous
+            // sibling's bottom — passing it would stack the parallel cell
+            // below the previous one instead of beside it. Using
+            // `child_page_y` keeps each cell's recursion strip aligned to
+            // the row's y on the current page.
             let (np, nc) = fragment_block_subtree(
                 geometry,
                 doc,
@@ -1693,12 +1703,21 @@ fn fragment_block_subtree(
                 child_w,
                 child_x_in_body,
                 page_index,
-                cursor_y,
+                child_page_y,
                 page_height_px,
                 depth + 1,
             );
             page_index = np;
-            cursor_y = nc;
+            // fulgur-u0p0: when the recursion stayed on the same page,
+            // keep the larger of the parent's existing `cursor_y` (row max
+            // bottom from a previous parallel sibling) and the recursion's
+            // returned `nc`. When the recursion crossed pages, the previous
+            // page's `cursor_y` is stale — adopt `nc` directly.
+            cursor_y = if np == pre_recursion_page {
+                cursor_y.max(nc)
+            } else {
+                nc
+            };
             // If the recursion crossed a boundary, the parent's
             // current-page fragment must restart at y=0 on the new
             // page. Defensive `nc < page_start_y` guards against
@@ -4047,152 +4066,124 @@ h2 { string-set: chapter-title content(text); }
     }
 
     #[test]
-    fn fragment_block_subtree_grid_row_co_splits_at_same_y() {
-        // 1 row の 2 cell が page boundary をまたぐ co-split case (cell
-        // 内に natural break point を持つよう inner div を 2 段重ねた).
+    fn fragment_block_subtree_grid_row_recursive_cells_share_page_y() {
+        // 2 cell の grid row で、両 cell が inner content を持ち
+        // recursion 経路を通る (`needs_recursion=true`) case。両 cell
+        // が page 内に収まるサイズなので page boundary は跨がない。
         //
-        // pre-fix (A だけ未修正): 右 column の cell の recursion 入り口
-        // が parent の cursor_y (= 左 column の bottom) になり、右 column
-        // が y=300 付近に積まれる block flow フォールバック挙動を示す。
+        // pre-fix: 右 cell の recursion が parent の `cursor_y`
+        // (= 左 cell の bottom = 200) を引きずり、右 column の inner
+        // div が y=200 (block flow stacking) に積まれる。
         //
-        // post-fix: 両 cell とも grid row として同じ y=100 から開始し、
-        // div1 は page 0 (y=100), div2 は page 1 (y=0) に co-split する。
+        // post-fix: 両 cell とも row top y=0 から開始し、各 inner div
+        // が y=0..50, y=50..100 に並ぶ。
         let html = r#"
             <html><body style="margin: 0; padding: 0">
-              <div style="height: 100px; width: 200px"></div>
               <div style="display: grid; grid-template-columns: 100px 100px; width: 200px;">
                 <div style="width: 100px">
-                  <div style="height: 100px; width: 100px"></div>
-                  <div style="height: 100px; width: 100px"></div>
+                  <div style="height: 50px; width: 100px"></div>
+                  <div style="height: 50px; width: 100px"></div>
                 </div>
                 <div style="width: 100px">
-                  <div style="height: 100px; width: 100px"></div>
-                  <div style="height: 100px; width: 100px"></div>
+                  <div style="height: 50px; width: 100px"></div>
+                  <div style="height: 50px; width: 100px"></div>
                 </div>
               </div>
             </body></html>
         "#;
         let mut doc = parse(html, 600.0);
         let table = blitz_adapter::extract_column_style_table(&doc);
-        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 250.0, &table);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 800.0, &table);
 
-        // 100×100 の inner div fragment だけを集めて (page, x, y) で
-        // 同 row co-split を検証する。cell wrapper (width 100, height 200)
-        // は除外して inner div (width 100, height 100) のみ見る。
+        // 100×50 の inner div fragment 4 個を集める。
         let mut inner: Vec<(u32, f32, f32)> = geom
             .values()
             .flat_map(|g| g.fragments.iter())
-            .filter(|f| (f.width - 100.0).abs() < 0.5 && (f.height - 100.0).abs() < 0.5)
+            .filter(|f| (f.width - 100.0).abs() < 0.5 && (f.height - 50.0).abs() < 0.5)
             .map(|f| (f.page_index, f.x, f.y))
             .collect();
         inner.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
-        let count_at = |page: u32, x: f32| {
-            inner
-                .iter()
-                .filter(|(p, ix, _)| *p == page && (ix - x).abs() < 0.5)
-                .count()
-        };
-        let y_at = |page: u32, x: f32| {
-            inner
-                .iter()
-                .find(|(p, ix, _)| *p == page && (ix - x).abs() < 0.5)
-                .map(|(_, _, y)| *y)
-        };
-
-        // 各列に対し page 0 と page 1 にちょうど 1 個の inner div が並ぶ
-        // (div1 が page 0、div2 が page 1) ことを期待する。
         assert_eq!(
-            count_at(0, 0.0),
-            1,
-            "left column page-0 inner div, inner={inner:?}"
-        );
-        assert_eq!(
-            count_at(0, 100.0),
-            1,
-            "right column page-0 inner div, inner={inner:?}"
-        );
-        assert_eq!(
-            count_at(1, 0.0),
-            1,
-            "left column page-1 inner div, inner={inner:?}"
-        );
-        assert_eq!(
-            count_at(1, 100.0),
-            1,
-            "right column page-1 inner div, inner={inner:?}"
+            inner.len(),
+            4,
+            "expected 4 inner divs (2 per column × 2 columns), got inner={inner:?}"
         );
 
-        // page 0 の左右 column の上端 y が一致 (= row top)
-        assert_eq!(
-            y_at(0, 0.0),
-            y_at(0, 100.0),
-            "page 0 row top must share y across columns, inner={inner:?}"
+        // すべて page 0 に収まる
+        assert!(
+            inner.iter().all(|(p, _, _)| *p == 0),
+            "all 4 inner divs must be on page 0, inner={inner:?}"
         );
-        // page 1 の左右 column の上端 y が一致 (= 0)
+
+        // 左 column (x=0): y=0 と y=50 の 2 個
+        let left_ys: Vec<f32> = inner
+            .iter()
+            .filter(|(_, x, _)| (x - 0.0).abs() < 0.5)
+            .map(|(_, _, y)| *y)
+            .collect();
+        assert_eq!(left_ys, vec![0.0, 50.0], "left column y, inner={inner:?}");
+
+        // 右 column (x=100): y=0 と y=50 の 2 個 (block flow になっていれば
+        // y=100, y=150 になる)
+        let right_ys: Vec<f32> = inner
+            .iter()
+            .filter(|(_, x, _)| (x - 100.0).abs() < 0.5)
+            .map(|(_, _, y)| *y)
+            .collect();
         assert_eq!(
-            y_at(1, 0.0),
-            y_at(1, 100.0),
-            "page 1 row top must share y across columns, inner={inner:?}"
+            right_ys,
+            vec![0.0, 50.0],
+            "right column y must match left column (parallel siblings, not stacked), inner={inner:?}"
         );
     }
 
     #[test]
-    fn fragment_block_subtree_flex_row_co_splits_at_same_y() {
+    fn fragment_block_subtree_flex_row_recursive_cells_share_page_y() {
         let html = r#"
             <html><body style="margin: 0; padding: 0">
-              <div style="height: 100px; width: 200px"></div>
               <div style="display: flex; width: 200px;">
                 <div style="width: 100px; flex: 0 0 100px">
-                  <div style="height: 100px; width: 100px"></div>
-                  <div style="height: 100px; width: 100px"></div>
+                  <div style="height: 50px; width: 100px"></div>
+                  <div style="height: 50px; width: 100px"></div>
                 </div>
                 <div style="width: 100px; flex: 0 0 100px">
-                  <div style="height: 100px; width: 100px"></div>
-                  <div style="height: 100px; width: 100px"></div>
+                  <div style="height: 50px; width: 100px"></div>
+                  <div style="height: 50px; width: 100px"></div>
                 </div>
               </div>
             </body></html>
         "#;
         let mut doc = parse(html, 600.0);
         let table = blitz_adapter::extract_column_style_table(&doc);
-        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 250.0, &table);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 800.0, &table);
 
         let mut inner: Vec<(u32, f32, f32)> = geom
             .values()
             .flat_map(|g| g.fragments.iter())
-            .filter(|f| (f.width - 100.0).abs() < 0.5 && (f.height - 100.0).abs() < 0.5)
+            .filter(|f| (f.width - 100.0).abs() < 0.5 && (f.height - 50.0).abs() < 0.5)
             .map(|f| (f.page_index, f.x, f.y))
             .collect();
         inner.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
-        let count_at = |page: u32, x: f32| {
-            inner
-                .iter()
-                .filter(|(p, ix, _)| *p == page && (ix - x).abs() < 0.5)
-                .count()
-        };
-        let y_at = |page: u32, x: f32| {
-            inner
-                .iter()
-                .find(|(p, ix, _)| *p == page && (ix - x).abs() < 0.5)
-                .map(|(_, _, y)| *y)
-        };
+        assert_eq!(inner.len(), 4, "inner={inner:?}");
+        assert!(inner.iter().all(|(p, _, _)| *p == 0), "inner={inner:?}");
 
-        assert_eq!(count_at(0, 0.0), 1, "left page-0, inner={inner:?}");
-        assert_eq!(count_at(0, 100.0), 1, "right page-0, inner={inner:?}");
-        assert_eq!(count_at(1, 0.0), 1, "left page-1, inner={inner:?}");
-        assert_eq!(count_at(1, 100.0), 1, "right page-1, inner={inner:?}");
-
+        let left_ys: Vec<f32> = inner
+            .iter()
+            .filter(|(_, x, _)| (x - 0.0).abs() < 0.5)
+            .map(|(_, _, y)| *y)
+            .collect();
+        let right_ys: Vec<f32> = inner
+            .iter()
+            .filter(|(_, x, _)| (x - 100.0).abs() < 0.5)
+            .map(|(_, _, y)| *y)
+            .collect();
+        assert_eq!(left_ys, vec![0.0, 50.0], "left column y, inner={inner:?}");
         assert_eq!(
-            y_at(0, 0.0),
-            y_at(0, 100.0),
-            "page 0 row top, inner={inner:?}"
-        );
-        assert_eq!(
-            y_at(1, 0.0),
-            y_at(1, 100.0),
-            "page 1 row top, inner={inner:?}"
+            right_ys,
+            vec![0.0, 50.0],
+            "right column y must match left column, inner={inner:?}"
         );
     }
 

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -4046,6 +4046,55 @@ h2 { string-set: chapter-title content(text); }
         );
     }
 
+    #[test]
+    fn fragment_block_subtree_grid_row_co_splits_at_same_y() {
+        // 1 row の 2 cell が 1 page strip を超える case。
+        // pre-fix: card1 が page 0 内で split → card2 は page 1 へ promote
+        //   (page 0 に card2 上半分が出ない / page 1 上部に空白)
+        // post-fix: 両 cell とも page 0 + page 1 に同じ y で co-split
+        let html = r#"
+            <html><body style="margin: 0; padding: 0">
+              <div style="height: 100px; width: 200px"></div>
+              <div style="display: grid; grid-template-columns: 100px 100px; width: 200px;">
+                <div style="height: 250px; width: 100px"></div>
+                <div style="height: 250px; width: 100px"></div>
+              </div>
+            </body></html>
+        "#;
+        let mut doc = parse(html, 600.0);
+        let table = blitz_adapter::extract_column_style_table(&doc);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 250.0, &table);
+
+        let mut cells: Vec<(u32, f32, f32, f32)> = geom
+            .values()
+            .flat_map(|g| g.fragments.iter())
+            .filter(|f| (f.width - 100.0).abs() < 0.5)
+            .map(|f| (f.page_index, f.x, f.y, f.height))
+            .collect();
+        cells.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+        let page0_cells: Vec<_> = cells.iter().filter(|(p, _, _, _)| *p == 0).collect();
+        let page1_cells: Vec<_> = cells.iter().filter(|(p, _, _, _)| *p == 1).collect();
+        assert_eq!(
+            page0_cells.len(),
+            2,
+            "expected both grid cells to have a page-0 fragment (co-split), got {cells:?}"
+        );
+        assert_eq!(
+            page1_cells.len(),
+            2,
+            "expected both grid cells to have a page-1 fragment (co-split), got {cells:?}"
+        );
+        assert!(
+            (page0_cells[0].2 - page0_cells[1].2).abs() < 0.5,
+            "page-0 co-split cells must share y, got {cells:?}"
+        );
+        assert!(
+            (page1_cells[0].2 - page1_cells[1].2).abs() < 0.5,
+            "page-1 co-split cells must share y, got {cells:?}"
+        );
+    }
+
     /// fulgur-916y: a multicol container with a `column-span: all`
     /// child whose subtree exceeds one page must split across pages
     /// in the partition path. Pre-fix, the multicol gate

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -4048,16 +4048,17 @@ h2 { string-set: chapter-title content(text); }
 
     #[test]
     fn fragment_block_subtree_grid_row_co_splits_at_same_y() {
-        // 1 row の 2 cell が 1 page strip を超える case。
-        // pre-fix: card1 が page 0 内で split → card2 は page 1 へ promote
-        //   (page 0 に card2 上半分が出ない / page 1 上部に空白)
-        // post-fix: 両 cell とも page 0 + page 1 に同じ y で co-split
+        // 1 row の 2 cell が 1 page strip を超える case (cell が inner
+        // content を持つ — fragment_block_subtree が recursion 経路を
+        // 通る). pre-fix: card1 だけ split (or page promote), card2 は
+        // 別ページに promote されて co-split しない. post-fix: 両 cell
+        // とも page 0 + page 1 に同じ y で co-split.
         let html = r#"
             <html><body style="margin: 0; padding: 0">
               <div style="height: 100px; width: 200px"></div>
               <div style="display: grid; grid-template-columns: 100px 100px; width: 200px;">
-                <div style="height: 250px; width: 100px"></div>
-                <div style="height: 250px; width: 100px"></div>
+                <div style="width: 100px"><div style="height: 250px; width: 100px"></div></div>
+                <div style="width: 100px"><div style="height: 250px; width: 100px"></div></div>
               </div>
             </body></html>
         "#;
@@ -4065,6 +4066,10 @@ h2 { string-set: chapter-title content(text); }
         let table = blitz_adapter::extract_column_style_table(&doc);
         let geom = super::run_pass_with_break_styles(doc.deref_mut(), 250.0, &table);
 
+        // 100×100 もしくは 100×NN の inner div fragment を集める。
+        // (cell wrapper も width=100 になるが、co-split が動けば inner
+        // div 側も両ページに fragment を持つので両者で OK)
+        // height のフィルタは外し、page index と y で同 row を識別する。
         let mut cells: Vec<(u32, f32, f32, f32)> = geom
             .values()
             .flat_map(|g| g.fragments.iter())
@@ -4073,25 +4078,41 @@ h2 { string-set: chapter-title content(text); }
             .collect();
         cells.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
-        let page0_cells: Vec<_> = cells.iter().filter(|(p, _, _, _)| *p == 0).collect();
-        let page1_cells: Vec<_> = cells.iter().filter(|(p, _, _, _)| *p == 1).collect();
-        assert_eq!(
-            page0_cells.len(),
-            2,
-            "expected both grid cells to have a page-0 fragment (co-split), got {cells:?}"
-        );
-        assert_eq!(
-            page1_cells.len(),
-            2,
-            "expected both grid cells to have a page-1 fragment (co-split), got {cells:?}"
+        // x は cell wrapper も inner div も同じ (0 か 100). 同じ x の
+        // fragments のうち各 page の最も上の y を取る — これが「その
+        // 列の cell の page-local 開始 y」。
+        let column_top_y = |page: u32, x_target: f32| -> Option<f32> {
+            cells
+                .iter()
+                .filter(|(p, x, _, _)| *p == page && (*x - x_target).abs() < 0.5)
+                .map(|(_, _, y, _)| *y)
+                .min_by(|a, b| a.partial_cmp(b).unwrap())
+        };
+
+        let p0_left = column_top_y(0, 0.0);
+        let p0_right = column_top_y(0, 100.0);
+        let p1_left = column_top_y(1, 0.0);
+        let p1_right = column_top_y(1, 100.0);
+
+        assert!(
+            p0_left.is_some() && p0_right.is_some(),
+            "expected both columns to have a page-0 fragment, cells={cells:?}"
         );
         assert!(
-            (page0_cells[0].2 - page0_cells[1].2).abs() < 0.5,
-            "page-0 co-split cells must share y, got {cells:?}"
+            p1_left.is_some() && p1_right.is_some(),
+            "expected both columns to have a page-1 fragment (co-split), cells={cells:?}"
         );
         assert!(
-            (page1_cells[0].2 - page1_cells[1].2).abs() < 0.5,
-            "page-1 co-split cells must share y, got {cells:?}"
+            (p0_left.unwrap() - p0_right.unwrap()).abs() < 0.5,
+            "page-0 row top must share y across columns, got left={:?} right={:?}",
+            p0_left,
+            p0_right
+        );
+        assert!(
+            (p1_left.unwrap() - p1_right.unwrap()).abs() < 0.5,
+            "page-1 row top must share y across columns, got left={:?} right={:?}",
+            p1_left,
+            p1_right
         );
     }
 
@@ -4101,8 +4122,8 @@ h2 { string-set: chapter-title content(text); }
             <html><body style="margin: 0; padding: 0">
               <div style="height: 100px; width: 200px"></div>
               <div style="display: flex; width: 200px;">
-                <div style="height: 250px; width: 100px; flex: 0 0 100px"></div>
-                <div style="height: 250px; width: 100px; flex: 0 0 100px"></div>
+                <div style="width: 100px; flex: 0 0 100px"><div style="height: 250px; width: 100px"></div></div>
+                <div style="width: 100px; flex: 0 0 100px"><div style="height: 250px; width: 100px"></div></div>
               </div>
             </body></html>
         "#;
@@ -4118,17 +4139,38 @@ h2 { string-set: chapter-title content(text); }
             .collect();
         cells.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
-        let page0_cells: Vec<_> = cells.iter().filter(|(p, _, _, _)| *p == 0).collect();
-        let page1_cells: Vec<_> = cells.iter().filter(|(p, _, _, _)| *p == 1).collect();
-        assert_eq!(page0_cells.len(), 2, "{cells:?}");
-        assert_eq!(page1_cells.len(), 2, "{cells:?}");
+        let column_top_y = |page: u32, x_target: f32| -> Option<f32> {
+            cells
+                .iter()
+                .filter(|(p, x, _, _)| *p == page && (*x - x_target).abs() < 0.5)
+                .map(|(_, _, y, _)| *y)
+                .min_by(|a, b| a.partial_cmp(b).unwrap())
+        };
+
+        let p0_left = column_top_y(0, 0.0);
+        let p0_right = column_top_y(0, 100.0);
+        let p1_left = column_top_y(1, 0.0);
+        let p1_right = column_top_y(1, 100.0);
+
         assert!(
-            (page0_cells[0].2 - page0_cells[1].2).abs() < 0.5,
-            "{cells:?}"
+            p0_left.is_some() && p0_right.is_some(),
+            "expected both columns to have a page-0 fragment, cells={cells:?}"
         );
         assert!(
-            (page1_cells[0].2 - page1_cells[1].2).abs() < 0.5,
-            "{cells:?}"
+            p1_left.is_some() && p1_right.is_some(),
+            "expected both columns to have a page-1 fragment (co-split), cells={cells:?}"
+        );
+        assert!(
+            (p0_left.unwrap() - p0_right.unwrap()).abs() < 0.5,
+            "page-0 row top must share y across columns, got left={:?} right={:?}",
+            p0_left,
+            p0_right
+        );
+        assert!(
+            (p1_left.unwrap() - p1_right.unwrap()).abs() < 0.5,
+            "page-1 row top must share y across columns, got left={:?} right={:?}",
+            p1_left,
+            p1_right
         );
     }
 

--- a/docs/plans/2026-05-04-fulgur-u0p0-grid-row-cosplit.md
+++ b/docs/plans/2026-05-04-fulgur-u0p0-grid-row-cosplit.md
@@ -1,0 +1,501 @@
+# Grid/Flex Row Co-split Implementation Plan (fulgur-u0p0)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 同じ row が page boundary をまたぐとき、grid/flex の parallel siblings を **両方** 同じ row-relative y で分割描画する (片方を次ページに promote しない)。
+
+**Architecture:** `fragment_block_subtree` の recursion 入り口で、`origin_pending_same_row` 経由で rebase された parallel sibling については、recursion の `cursor_in` 引数に **rebase 後の `child_page_y`** を渡す (現状は parent の `cursor_y` = row max bottom を渡している)。これにより同じ row の各 cell が同じ y から strip 評価され、true co-split が実現する。recursion 復帰後は `cursor_y / page_index` を全 cell の max にまとめる。
+
+**Tech Stack:** Rust workspace (fulgur library + fulgur-vrt reftest crate)。既存の `pagination_layout.rs` 内の `fragment_block_subtree` のみ変更。
+
+---
+
+## Task 1: 失敗 unit test (grid co-split)
+
+**Files:**
+- Modify: `crates/fulgur/src/pagination_layout.rs` (テストモジュール末尾、line ~4047 付近)
+
+**Step 1: 失敗テストを追加**
+
+`#[test]` を `pagination_layout::tests` 末尾に追加:
+
+```rust
+#[test]
+fn fragment_block_subtree_grid_row_co_splits_at_same_y() {
+    // 1 row の 2 cell が 1 page strip を超える case。
+    // pre-fix: card1 が page 0 内で split → card2 は page 1 へ promote
+    //   (page 0 に card2 上半分が出ない / page 1 上部に空白)
+    // post-fix: 両 cell とも page 0 + page 1 に同じ y で co-split
+    let html = r#"
+        <html><body style="margin: 0; padding: 0">
+          <div style="height: 100px; width: 200px"></div>
+          <div style="display: grid; grid-template-columns: 100px 100px; width: 200px;">
+            <div style="height: 250px; width: 100px"></div>
+            <div style="height: 250px; width: 100px"></div>
+          </div>
+        </body></html>
+    "#;
+    let mut doc = parse(html, 600.0);
+    let table = blitz_adapter::extract_column_style_table(&doc);
+    let geom = super::run_pass_with_break_styles(doc.deref_mut(), 250.0, &table);
+
+    // 100×100 もしくは 100×NN の cell fragment を集める。
+    // 100pt 幅 × 任意高さ のフラグメントで filter (split で height < 250 になる)。
+    let mut cells: Vec<(u32, f32, f32, f32)> = geom
+        .values()
+        .flat_map(|g| g.fragments.iter())
+        .filter(|f| (f.width - 100.0).abs() < 0.5)
+        .map(|f| (f.page_index, f.x, f.y, f.height))
+        .collect();
+    cells.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+    let page0_cells: Vec<_> = cells.iter().filter(|(p, _, _, _)| *p == 0).collect();
+    let page1_cells: Vec<_> = cells.iter().filter(|(p, _, _, _)| *p == 1).collect();
+    assert_eq!(
+        page0_cells.len(),
+        2,
+        "expected both grid cells to have a page-0 fragment (co-split), got {cells:?}"
+    );
+    assert_eq!(
+        page1_cells.len(),
+        2,
+        "expected both grid cells to have a page-1 fragment (co-split), got {cells:?}"
+    );
+    assert!(
+        (page0_cells[0].2 - page0_cells[1].2).abs() < 0.5,
+        "page-0 co-split cells must share y, got {cells:?}"
+    );
+    assert!(
+        (page1_cells[0].2 - page1_cells[1].2).abs() < 0.5,
+        "page-1 co-split cells must share y, got {cells:?}"
+    );
+}
+```
+
+**Step 2: 失敗を確認**
+
+```bash
+cd .worktrees/fulgur-u0p0
+cargo test -p fulgur --lib fragment_block_subtree_grid_row_co_splits_at_same_y 2>&1 | tail -20
+```
+
+期待: 失敗 (page0_cells.len() = 1 が出るはず)
+
+**Step 3: コミット**
+
+```bash
+git add crates/fulgur/src/pagination_layout.rs
+git commit -m "test(pagination): add failing test for grid row co-split (fulgur-u0p0)"
+```
+
+---
+
+## Task 2: 失敗 unit test (flex co-split)
+
+**Files:**
+- Modify: `crates/fulgur/src/pagination_layout.rs` (Task 1 のテスト直後)
+
+**Step 1: flex 版テストを追加**
+
+```rust
+#[test]
+fn fragment_block_subtree_flex_row_co_splits_at_same_y() {
+    let html = r#"
+        <html><body style="margin: 0; padding: 0">
+          <div style="height: 100px; width: 200px"></div>
+          <div style="display: flex; width: 200px;">
+            <div style="height: 250px; width: 100px; flex: 0 0 100px"></div>
+            <div style="height: 250px; width: 100px; flex: 0 0 100px"></div>
+          </div>
+        </body></html>
+    "#;
+    let mut doc = parse(html, 600.0);
+    let table = blitz_adapter::extract_column_style_table(&doc);
+    let geom = super::run_pass_with_break_styles(doc.deref_mut(), 250.0, &table);
+
+    let mut cells: Vec<(u32, f32, f32, f32)> = geom
+        .values()
+        .flat_map(|g| g.fragments.iter())
+        .filter(|f| (f.width - 100.0).abs() < 0.5)
+        .map(|f| (f.page_index, f.x, f.y, f.height))
+        .collect();
+    cells.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+    let page0_cells: Vec<_> = cells.iter().filter(|(p, _, _, _)| *p == 0).collect();
+    let page1_cells: Vec<_> = cells.iter().filter(|(p, _, _, _)| *p == 1).collect();
+    assert_eq!(page0_cells.len(), 2, "{cells:?}");
+    assert_eq!(page1_cells.len(), 2, "{cells:?}");
+    assert!((page0_cells[0].2 - page0_cells[1].2).abs() < 0.5, "{cells:?}");
+    assert!((page1_cells[0].2 - page1_cells[1].2).abs() < 0.5, "{cells:?}");
+}
+```
+
+**Step 2: 失敗を確認**
+
+```bash
+cargo test -p fulgur --lib fragment_block_subtree_flex_row_co_splits_at_same_y 2>&1 | tail -20
+```
+
+期待: 失敗 (grid と同じパターン)
+
+**Step 3: コミット**
+
+```bash
+git add crates/fulgur/src/pagination_layout.rs
+git commit -m "test(pagination): add failing test for flex row co-split (fulgur-u0p0)"
+```
+
+---
+
+## Task 3: parallel sibling フラグを recursion 入り口に伝搬
+
+**Files:**
+- Modify: `crates/fulgur/src/pagination_layout.rs:1530-1537` (origin_pending_* の take 部分)
+- Modify: `crates/fulgur/src/pagination_layout.rs:1684-1699` (recursion 入り口)
+
+**Step 1: same-row 消費フラグを追加**
+
+`pagination_layout.rs:1530-1537` の `if let Some(mut target_y) = origin_pending_target_y.take() { ... }` ブロックを以下に置き換える:
+
+```rust
+// fulgur-u0p0: track whether THIS child consumed a same-row rebase
+// — if so, the recursion below must enter from `child_page_y`
+// (rebased to the row's y on the new page strip), not from the
+// parent's `cursor_y` (which still holds the row's max bottom from
+// the previous sibling). Without this hand-off, the recursion sees
+// a tiny `available_strip = page_height_px - cursor_y` and
+// promotes the entire sibling to a fresh page rather than co-
+// splitting.
+let mut child_is_same_row_sibling = false;
+if let Some(mut target_y) = origin_pending_target_y.take() {
+    if let Some((row_top, row_bottom, same_row_y)) = origin_pending_same_row.take()
+        && this_top_in_parent < row_bottom - 0.5
+    {
+        target_y = same_row_y + (this_top_in_parent - row_top);
+        child_is_same_row_sibling = true;
+    }
+    page_taffy_origin = this_top_in_parent - (target_y - page_start_y);
+}
+```
+
+**Step 2: recursion 入り口で cursor_in を切り替え**
+
+`pagination_layout.rs:1685` 付近、`let pre_recursion_page = page_index;` の直後に変更を加える。
+
+現状の recursion 呼び出し:
+
+```rust
+let (np, nc) = fragment_block_subtree(
+    geometry,
+    doc,
+    column_styles,
+    used_page_names,
+    child_id,
+    child_w,
+    child_x_in_body,
+    page_index,
+    cursor_y,
+    page_height_px,
+    depth + 1,
+);
+```
+
+を以下に変更:
+
+```rust
+// fulgur-u0p0: parallel sibling co-split — when this child was
+// rebased to a same-row y on the new page, enter the recursion
+// from `child_page_y` (the rebased row-local y) rather than the
+// outer `cursor_y` (which holds the row's max bottom advanced by
+// the previous sibling). The recursion's strip-overflow gate uses
+// `cursor_in` as the starting y, so passing the row's max bottom
+// would force a premature next-page cut for every co-split cell.
+let recursion_cursor_in = if child_is_same_row_sibling {
+    child_page_y
+} else {
+    cursor_y
+};
+let (np, nc) = fragment_block_subtree(
+    geometry,
+    doc,
+    column_styles,
+    used_page_names,
+    child_id,
+    child_w,
+    child_x_in_body,
+    page_index,
+    recursion_cursor_in,
+    page_height_px,
+    depth + 1,
+);
+```
+
+**Step 3: recursion 復帰後の cursor_y を row max にまとめる**
+
+`pagination_layout.rs:1700-1701` の現状:
+
+```rust
+page_index = np;
+cursor_y = nc;
+```
+
+を以下に変更:
+
+```rust
+page_index = np;
+// fulgur-u0p0: for parallel siblings, the recursion's returned
+// cursor sits at the rebased y plane (row-local). The parent's
+// outer cursor still tracks the previous sibling's bottom — keep
+// the larger value so the next non-row sibling resumes from the
+// row's full extent on the latest page reached.
+cursor_y = if child_is_same_row_sibling && np == pre_recursion_page {
+    cursor_y.max(nc)
+} else {
+    nc
+};
+```
+
+**Step 4: テスト実行 (grid)**
+
+```bash
+cargo test -p fulgur --lib fragment_block_subtree_grid_row_co_splits_at_same_y 2>&1 | tail -15
+```
+
+期待: PASS
+
+**Step 5: テスト実行 (flex)**
+
+```bash
+cargo test -p fulgur --lib fragment_block_subtree_flex_row_co_splits_at_same_y 2>&1 | tail -15
+```
+
+期待: PASS
+
+**Step 6: 既存テスト regression 確認**
+
+```bash
+cargo test -p fulgur --lib pagination_layout::tests 2>&1 | tail -10
+```
+
+期待: 36 passed (元 34 + 新規 2)。失敗があれば各テストを個別に走らせて原因確認。
+
+特に注意:
+- `fragment_block_subtree_grid_later_row_*` (3902-): later row alignment — same-row フラグは「同じ row 内」のみ立つので影響しないはず
+- `fragment_block_subtree_following_block_continues_after_split_*_tail` (3830-): row 後続の block sibling
+
+**Step 7: コミット**
+
+```bash
+git add crates/fulgur/src/pagination_layout.rs
+git commit -m "fix(pagination): co-split grid/flex parallel siblings at same row y (fulgur-u0p0)"
+```
+
+---
+
+## Task 4: VRT fixture (grid-row-co-split.html)
+
+**Files:**
+- Create: `crates/fulgur-vrt/fixtures/bugs/grid-row-co-split.html`
+
+**Step 1: fixture を作成**
+
+```bash
+cat > crates/fulgur-vrt/fixtures/bugs/grid-row-co-split.html << 'EOF'
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><title>VRT fixture: bugs/grid-row-co-split (fulgur-u0p0)</title>
+<style>
+  @page { size: A4; margin: 20mm 18mm; }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body { background: #fff; }
+  /* Spacer pushes a 2-cell grid row across the page boundary. Both
+     cells should appear on page 1 (top half) and page 2 (bottom half)
+     at the same y — co-split — instead of card 2 promoting to page 2
+     while card 1 splits in place. */
+  .spacer { height: 600pt; background: #eef; }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 10pt;
+    margin-top: 12pt;
+  }
+  .card {
+    background: #fafafa;
+    border: 1pt solid #888;
+    border-radius: 8pt;
+    padding: 12pt;
+    height: 280pt;
+  }
+  .icon { width: 18pt; height: 18pt; background: #c33; margin-bottom: 6pt; }
+  .body { width: 80%; height: 30pt; background: #999; }
+</style>
+</head><body>
+<div class="spacer"></div>
+<div class="grid">
+  <div class="card"><div class="icon"></div><div class="body"></div></div>
+  <div class="card"><div class="icon"></div><div class="body"></div></div>
+</div>
+</body></html>
+EOF
+```
+
+**Step 2: golden 生成**
+
+```bash
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" FULGUR_VRT_UPDATE=1 \
+  cargo test -p fulgur-vrt grid_row_co_split 2>&1 | tail -10
+```
+
+期待: golden が生成される (`crates/fulgur-vrt/goldens/fulgur/bugs/grid-row-co-split.pdf`)
+
+**Step 3: 生成された golden を視覚確認**
+
+```bash
+pdftocairo -png -r 100 crates/fulgur-vrt/goldens/fulgur/bugs/grid-row-co-split.pdf /tmp/co-split-golden
+ls /tmp/co-split-golden*.png
+```
+
+PNG を読んで page 1 に両 card の上半分があり、page 2 に両 card の下半分があることを確認 (Read tool で表示)。
+
+**Step 4: 通常実行で byte-wise compare**
+
+```bash
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur-vrt 2>&1 | tail -10
+```
+
+期待: 全 fixture PASS (新規 fixture 含む)
+
+**Step 5: コミット**
+
+```bash
+git add crates/fulgur-vrt/fixtures/bugs/grid-row-co-split.html crates/fulgur-vrt/goldens/fulgur/bugs/grid-row-co-split.pdf
+git commit -m "test(fulgur-vrt): add grid-row-co-split fixture (fulgur-u0p0)"
+```
+
+---
+
+## Task 5: 既存 fixture grid-row-promote-background の golden 更新
+
+**Files:**
+- Modify: `crates/fulgur-vrt/goldens/fulgur/bugs/grid-row-promote-background.pdf`
+
+**Step 1: 現状再生成前に視覚確認**
+
+```bash
+pdftocairo -png -r 100 crates/fulgur-vrt/goldens/fulgur/bugs/grid-row-promote-background.pdf /tmp/old-golden
+ls /tmp/old-golden*.png
+```
+
+PNG を Read tool で確認。pre-fix の挙動 (page 1 に空白、page 2 に両 card) のはず。
+
+**Step 2: 通常実行で fail を確認**
+
+```bash
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur-vrt grid_row_promote_background 2>&1 | tail -15
+```
+
+期待: 失敗 (golden と現行出力が byte 不一致)
+
+**Step 3: golden 再生成**
+
+```bash
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" FULGUR_VRT_UPDATE=1 \
+  cargo test -p fulgur-vrt grid_row_promote_background 2>&1 | tail -10
+```
+
+**Step 4: 新 golden を視覚確認 (acceptance #3)**
+
+```bash
+pdftocairo -png -r 100 crates/fulgur-vrt/goldens/fulgur/bugs/grid-row-promote-background.pdf /tmp/new-golden
+ls /tmp/new-golden*.png
+```
+
+PNG を Read tool で確認。**page 1 に Card 2 の上半分が描画されている** ことを確認 (issue acceptance #3)。
+
+**Step 5: コミット**
+
+```bash
+git add crates/fulgur-vrt/goldens/fulgur/bugs/grid-row-promote-background.pdf
+git commit -m "test(fulgur-vrt): regenerate grid-row-promote-background golden after co-split fix (fulgur-u0p0)"
+```
+
+---
+
+## Task 6: 全 lib テスト + WPT regression check
+
+**Step 1: fulgur library 全 lib test**
+
+```bash
+cargo test -p fulgur --lib 2>&1 | tail -10
+```
+
+期待: 全 PASS (元の通過数 + 2)
+
+**Step 2: WPT bugs リグレッション**
+
+```bash
+cargo test -p fulgur-wpt --test wpt_lists -- wpt_list_bugs 2>&1 | tail -10
+```
+
+期待: 既存 PASS 数を維持
+
+**Step 3: VRT 全件**
+
+```bash
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur-vrt 2>&1 | tail -10
+```
+
+期待: 全 PASS
+
+**Step 4: clippy / fmt / markdownlint**
+
+```bash
+cargo fmt --check 2>&1 | tail -5
+cargo clippy --workspace --all-targets 2>&1 | tail -20
+npx markdownlint-cli2 'docs/plans/2026-05-04-fulgur-u0p0-grid-row-cosplit.md' 2>&1 | tail -10
+```
+
+期待: いずれも warning/error なし
+
+**Step 5: 何らかの fail があれば修正してコミット**
+
+ない場合は次の Task へ。
+
+---
+
+## Task 7: follow-up issue (table-row / multicol co-split)
+
+**Step 1: beads に follow-up issue を作成**
+
+```bash
+bd create --title="grid/flex co-split を table-row と multicol へ拡張する" \
+  --type=bug --priority=2 \
+  --description="fulgur-u0p0 で grid/flex の row co-split が実装された。同じ問題 (parallel siblings の row 跨ぎ) は table-row (display: table-row, anonymous table boxes) と multi-column container (column-count > 1) でも発生しうる。
+
+table-row は Taffy の table layout 経由なので is_flex_or_grid_container_node の判定が table parent でも有効になるか確認が必要。multicol は multicol_layout.rs に独自経路があり、別アプローチになる可能性が高い。
+
+acceptance: table-row 跨ぎと multicol column 跨ぎで parallel cell が同じ row-relative y で co-split される。" \
+  2>&1 | tail -5
+```
+
+**Step 2: 依存関係を追加 (本 issue を blocks)**
+
+```bash
+bd dep add <new-issue-id> fulgur-u0p0
+```
+
+**Step 3: コミット (なし — beads は dolt 管理なので git 不要)**
+
+---
+
+## Final: PR 準備
+
+すべて green になったら:
+
+```bash
+git log --oneline main..HEAD
+git status
+```
+
+## 実行方式
+
+**Subagent-Driven (推奨)** — このセッションで Task 1 から順次 fresh subagent に投げる。Task 間で簡単なレビューを挟む。


### PR DESCRIPTION
## Summary

- `fragment_block_subtree` の grid/flex 親で、parallel sibling cell の recursion 入口に親の `cursor_y` (前 cell の bottom) が渡されていた問題を修正
- 結果: 右 column の content が block flow 縦積み (`y = 左 cell の終端`) になり、grid row として横並びにならない症状
- Fix: recursion `cursor_in` 引数を `child_page_y` に変更 + post-recursion で同ページなら `cursor_y.max(nc)`、cross-page なら `nc` を採用

## Scope

本 PR は **same-page parallel sibling alignment** のみを対象とする。1 row が page boundary を跨ぐケース (acceptance #3 の Card 2 上半分を page 1 に表示) は **真の cross-page co-split** を要求し、row state save/restore + parent fragment dedup の構造的変更が必要。これは follow-up issue [fulgur-ysms](beads-internal) で追跡。

## Issue

Closes \`#fulgur-u0p0\` (Phase 1 of 2)

## Test plan

- [x] `cargo test -p fulgur --lib pagination_layout::tests` → 36/36 PASS (新規 2 本含む)
- [x] `cargo test -p fulgur --lib` → 800/800 PASS
- [x] `cargo test -p fulgur-vrt` → 全 fixture PASS (byte-wise compare green)
- [x] `cargo test -p fulgur-wpt --test wpt_lists -- wpt_list_bugs` → green
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets` no warnings
- [x] 元 fixture `bugs/grid-row-promote-background.html` の visual 検証 (page 2 で 2 cards 同 y に landing — 変化なし、Phase 2 で Card 2 上半分 page 1 表示を追加予定)

## Commit history

```
7181483 docs(plans): add fulgur-u0p0 grid/flex row cosplit plan
67e597c fix(pagination): align grid/flex parallel sibling recursion entry to row y (fulgur-u0p0)
3a19c28 test(pagination): scope row co-split tests to multi-child cells (recursion alignment only)
9162efd test(pagination): pivot row co-split red tests to inner-content cells
2f0980c test(pagination): add failing test for flex row co-split
4210848 test(pagination): add failing test for grid row co-split
```

test commits 4 本は scope を絞り込む過程の iteration trail。最終 67e597c の fix が本体。

## Follow-up

- fulgur-ysms: true cross-page co-split (row state save/restore + parent fragment dedup)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * ページ跨ぎ時にグリッド/フレックスの並列兄弟要素が縦に重なって表示される問題を修正

* **テスト**
  * 再帰的なグリッド／フレックスの並列セル共有シナリオに対する回帰テストを追加し、各列の内側フラグメントの垂直位置が正しく揃うことを検証

* **ドキュメント**
  * ページ境界を跨ぐ際の並列兄弟要素の取り扱いに関する実装手順書を追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->