### PR TITLE
feat(render): wire tagged-content start/end around P/H/Span draws (fulgur-izp.4)

### DIFF
--- a/crates/fulgur/src/draw_primitives.rs
+++ b/crates/fulgur/src/draw_primitives.rs
@@ -451,6 +451,7 @@ pub struct TagCollector {
         crate::drawables::NodeId,
         crate::tagging::PdfTag,
         krilla::tagging::Identifier,
+        Option<String>,
     )>,
 }
 
@@ -466,8 +467,9 @@ impl TagCollector {
         node_id: crate::drawables::NodeId,
         tag: crate::tagging::PdfTag,
         id: krilla::tagging::Identifier,
+        heading_title: Option<String>,
     ) {
-        self.entries.push((node_id, tag, id));
+        self.entries.push((node_id, tag, id, heading_title));
     }
 
     pub fn into_entries(
@@ -476,6 +478,7 @@ impl TagCollector {
         crate::drawables::NodeId,
         crate::tagging::PdfTag,
         krilla::tagging::Identifier,
+        Option<String>,
     )> {
         self.entries
     }

--- a/crates/fulgur/src/draw_primitives.rs
+++ b/crates/fulgur/src/draw_primitives.rs
@@ -440,12 +440,44 @@ impl LinkCollector {
     }
 }
 
+/// Per-render accumulator for tagged-content identifiers.
+///
+/// Each `record` call stores one (NodeId, PdfTag, Identifier) triple
+/// produced by `surface.start_tagged` during a single page draw. After
+/// all pages are rendered, `render_v2` groups entries by NodeId and
+/// builds a `krilla::tagging::TagTree`.
+pub struct TagCollector {
+    entries: Vec<(crate::drawables::NodeId, crate::tagging::PdfTag, krilla::tagging::Identifier)>,
+}
+
+impl TagCollector {
+    pub fn new() -> Self {
+        Self { entries: Vec::new() }
+    }
+
+    pub fn record(
+        &mut self,
+        node_id: crate::drawables::NodeId,
+        tag: crate::tagging::PdfTag,
+        id: krilla::tagging::Identifier,
+    ) {
+        self.entries.push((node_id, tag, id));
+    }
+
+    pub fn into_entries(
+        self,
+    ) -> Vec<(crate::drawables::NodeId, crate::tagging::PdfTag, krilla::tagging::Identifier)> {
+        self.entries
+    }
+}
+
 /// Wrapper around Krilla Surface for drawing commands.
 /// This decouples Pageable types from Krilla's concrete Surface type.
 pub struct Canvas<'a, 'b> {
     pub surface: &'a mut krilla::surface::Surface<'b>,
     pub bookmark_collector: Option<&'a mut BookmarkCollector>,
     pub link_collector: Option<&'a mut LinkCollector>,
+    pub tag_collector: Option<&'a mut TagCollector>,
 }
 
 /// Run a draw closure wrapped in opacity guards.

--- a/crates/fulgur/src/draw_primitives.rs
+++ b/crates/fulgur/src/draw_primitives.rs
@@ -447,12 +447,18 @@ impl LinkCollector {
 /// all pages are rendered, `render_v2` groups entries by NodeId and
 /// builds a `krilla::tagging::TagTree`.
 pub struct TagCollector {
-    entries: Vec<(crate::drawables::NodeId, crate::tagging::PdfTag, krilla::tagging::Identifier)>,
+    entries: Vec<(
+        crate::drawables::NodeId,
+        crate::tagging::PdfTag,
+        krilla::tagging::Identifier,
+    )>,
 }
 
 impl TagCollector {
     pub fn new() -> Self {
-        Self { entries: Vec::new() }
+        Self {
+            entries: Vec::new(),
+        }
     }
 
     pub fn record(
@@ -466,8 +472,18 @@ impl TagCollector {
 
     pub fn into_entries(
         self,
-    ) -> Vec<(crate::drawables::NodeId, crate::tagging::PdfTag, krilla::tagging::Identifier)> {
+    ) -> Vec<(
+        crate::drawables::NodeId,
+        crate::tagging::PdfTag,
+        krilla::tagging::Identifier,
+    )> {
         self.entries
+    }
+}
+
+impl Default for TagCollector {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -242,17 +242,18 @@ pub fn render_v2(
         let mut tree = TagTree::new().with_lang(config.lang.clone());
         let mut groups: BTreeMap<
             crate::drawables::NodeId,
-            (crate::tagging::PdfTag, Vec<Identifier>),
+            (crate::tagging::PdfTag, Vec<Identifier>, Option<String>),
         > = BTreeMap::new();
-        for (node_id, tag, id) in tc.into_entries() {
+        for (node_id, tag, id, heading_title) in tc.into_entries() {
             groups
                 .entry(node_id)
-                .or_insert_with(|| (tag, Vec::new()))
+                .or_insert_with(|| (tag, Vec::new(), heading_title))
                 .1
                 .push(id);
         }
-        for (_, (tag, ids)) in groups {
-            let mut group = TagGroup::new(crate::tagging::pdf_tag_to_krilla_tag(&tag));
+        for (_, (tag, ids, heading_title)) in groups {
+            let mut group =
+                TagGroup::new(crate::tagging::pdf_tag_to_krilla_tag(&tag, heading_title));
             for id in ids {
                 group.push(Node::Leaf(id));
             }
@@ -789,7 +790,7 @@ fn try_start_tagged(
     canvas: &mut crate::draw_primitives::Canvas<'_, '_>,
     node_id: usize,
     drawables: &Drawables,
-) -> Option<(crate::tagging::PdfTag, krilla::tagging::Identifier)> {
+) -> Option<(crate::tagging::PdfTag, krilla::tagging::Identifier, Option<String>)> {
     canvas.tag_collector.as_ref()?;
     let semantic = drawables.semantics.get(&node_id)?;
     if !matches!(
@@ -798,11 +799,27 @@ fn try_start_tagged(
     ) {
         return None;
     }
+    // For heading tags, extract the plain text so Tag::Hn gets the /T (Title)
+    // attribute that PDF/UA-1 validators require.
+    let heading_title = if matches!(semantic.tag, crate::tagging::PdfTag::H { .. }) {
+        drawables.paragraphs.get(&node_id).map(|para| {
+            para.lines
+                .iter()
+                .flat_map(|line| line.items.iter())
+                .filter_map(|item| match item {
+                    crate::paragraph::LineItem::Text(run) => Some(run.text.as_str()),
+                    _ => None,
+                })
+                .collect::<String>()
+        })
+    } else {
+        None
+    };
     use krilla::tagging::{ContentTag, SpanTag};
     let id = canvas
         .surface
         .start_tagged(ContentTag::Span(SpanTag::empty()));
-    Some((semantic.tag.clone(), id))
+    Some((semantic.tag.clone(), id, heading_title))
 }
 
 /// Close a tagged content sequence opened by `try_start_tagged` and record
@@ -818,15 +835,15 @@ fn try_start_tagged(
 fn finish_tagged(
     canvas: &mut crate::draw_primitives::Canvas<'_, '_>,
     node_id: usize,
-    tag_info: Option<(crate::tagging::PdfTag, krilla::tagging::Identifier)>,
+    tag_info: Option<(crate::tagging::PdfTag, krilla::tagging::Identifier, Option<String>)>,
 ) {
-    if let Some((tag, id)) = tag_info {
+    if let Some((tag, id, heading_title)) = tag_info {
         canvas.surface.end_tagged();
         canvas
             .tag_collector
             .as_mut()
             .expect("tag_collector is Some when tag_info is Some")
-            .record(node_id, tag, id);
+            .record(node_id, tag, id, heading_title);
     }
 }
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -780,6 +780,54 @@ pub(crate) fn dispatch_inline_box_content(
     }
 }
 
+/// Start a Krilla tagged content sequence for a paragraph-bearing node when
+/// tagging is enabled and the node has a P / H / Span semantic entry.
+///
+/// Returns `Some((tag, id))` on success so that `finish_tagged` can close it.
+/// Returns `None` when tagging is disabled, the node has no recognised
+/// semantic entry, or the node carries no paragraph content (pure containers
+/// must not call `start_tagged` — it is not nestable and would panic on a
+/// second call before `end_tagged`).
+fn try_start_tagged(
+    canvas: &mut crate::draw_primitives::Canvas<'_, '_>,
+    node_id: usize,
+    drawables: &Drawables,
+) -> Option<(crate::tagging::PdfTag, krilla::tagging::Identifier)> {
+    if canvas.tag_collector.is_none() {
+        return None;
+    }
+    let semantic = drawables.semantics.get(&node_id)?;
+    if !matches!(
+        semantic.tag,
+        crate::tagging::PdfTag::P | crate::tagging::PdfTag::H { .. } | crate::tagging::PdfTag::Span
+    ) {
+        return None;
+    }
+    if !drawables.paragraphs.contains_key(&node_id) {
+        return None;
+    }
+    use krilla::tagging::{ContentTag, SpanTag};
+    let id = canvas.surface.start_tagged(ContentTag::Span(SpanTag::empty()));
+    Some((semantic.tag.clone(), id))
+}
+
+/// Close a tagged content sequence opened by `try_start_tagged` and record
+/// the resulting `Identifier` in the `TagCollector` for StructTree assembly.
+///
+/// No-op when `tag_info` is `None` (tagging disabled or not applicable).
+fn finish_tagged(
+    canvas: &mut crate::draw_primitives::Canvas<'_, '_>,
+    node_id: usize,
+    tag_info: Option<(crate::tagging::PdfTag, krilla::tagging::Identifier)>,
+) {
+    if let Some((tag, id)) = tag_info {
+        canvas.surface.end_tagged();
+        if let Some(tc) = canvas.tag_collector.as_mut() {
+            tc.record(node_id, tag, id);
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn dispatch_fragment(
     canvas: &mut crate::draw_primitives::Canvas<'_, '_>,
@@ -856,6 +904,11 @@ pub(crate) fn dispatch_fragment(
         let img_for_block = drawables.images.get(&node_id);
         let svg_for_block = drawables.svgs.get(&node_id);
         if para_for_block.is_some() || img_for_block.is_some() || svg_for_block.is_some() {
+            let tag_info = if para_for_block.is_some() {
+                try_start_tagged(canvas, node_id, drawables)
+            } else {
+                None
+            };
             draw_block_with_inner_content(
                 canvas,
                 block,
@@ -884,6 +937,7 @@ pub(crate) fn dispatch_fragment(
                     page_index,
                 );
             }
+            finish_tagged(canvas, node_id, tag_info);
             return;
         }
         draw_block_v2(canvas, block, x_pt, y_pt, frag, is_split);
@@ -909,6 +963,7 @@ pub(crate) fn dispatch_fragment(
         return;
     }
     if let Some(para) = drawables.paragraphs.get(&node_id) {
+        let tag_info = try_start_tagged(canvas, node_id, drawables);
         draw_paragraph_v2(
             canvas,
             para,
@@ -922,6 +977,7 @@ pub(crate) fn dispatch_fragment(
             margin_left_pt,
             margin_top_pt,
         );
+        finish_tagged(canvas, node_id, tag_info);
     }
 }
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -790,7 +790,11 @@ fn try_start_tagged(
     canvas: &mut crate::draw_primitives::Canvas<'_, '_>,
     node_id: usize,
     drawables: &Drawables,
-) -> Option<(crate::tagging::PdfTag, krilla::tagging::Identifier, Option<String>)> {
+) -> Option<(
+    crate::tagging::PdfTag,
+    krilla::tagging::Identifier,
+    Option<String>,
+)> {
     canvas.tag_collector.as_ref()?;
     let semantic = drawables.semantics.get(&node_id)?;
     if !matches!(
@@ -835,7 +839,11 @@ fn try_start_tagged(
 fn finish_tagged(
     canvas: &mut crate::draw_primitives::Canvas<'_, '_>,
     node_id: usize,
-    tag_info: Option<(crate::tagging::PdfTag, krilla::tagging::Identifier, Option<String>)>,
+    tag_info: Option<(
+        crate::tagging::PdfTag,
+        krilla::tagging::Identifier,
+        Option<String>,
+    )>,
 ) {
     if let Some((tag, id, heading_title)) = tag_info {
         canvas.surface.end_tagged();

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -155,6 +155,7 @@ pub fn render_v2(
                     surface: &mut surface,
                     bookmark_collector: bookmark_collector.as_mut(),
                     link_collector: Some(&mut link_collector),
+                    tag_collector: None,
                 };
                 // Root `<html>` + `<body>` background pre-pass. v1's
                 // `BlockPageable::draw` for these elements paints
@@ -216,6 +217,7 @@ pub fn render_v2(
                 surface: &mut surface,
                 bookmark_collector: None,
                 link_collector: Some(&mut link_collector),
+                tag_collector: None,
             };
             let page_content_width = page_size.width - resolved_margin.left - resolved_margin.right;
             margin_box_renderer.render_page(

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -239,10 +239,7 @@ pub fn render_v2(
     }
 
     if let Some(tc) = tag_collector {
-        let mut tree = TagTree::new();
-        if config.lang.is_some() {
-            tree = tree.with_lang(config.lang.clone());
-        }
+        let mut tree = TagTree::new().with_lang(config.lang.clone());
         let mut groups: BTreeMap<
             crate::drawables::NodeId,
             (crate::tagging::PdfTag, Vec<Identifier>),
@@ -801,9 +798,6 @@ fn try_start_tagged(
     ) {
         return None;
     }
-    if !drawables.paragraphs.contains_key(&node_id) {
-        return None;
-    }
     use krilla::tagging::{ContentTag, SpanTag};
     let id = canvas
         .surface
@@ -822,9 +816,11 @@ fn finish_tagged(
 ) {
     if let Some((tag, id)) = tag_info {
         canvas.surface.end_tagged();
-        if let Some(tc) = canvas.tag_collector.as_mut() {
-            tc.record(node_id, tag, id);
-        }
+        canvas
+            .tag_collector
+            .as_mut()
+            .expect("tag_collector is Some when tag_info is Some")
+            .record(node_id, tag, id);
     }
 }
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -243,10 +243,10 @@ pub fn render_v2(
         if config.lang.is_some() {
             tree = tree.with_lang(config.lang.clone());
         }
-        let mut groups: std::collections::BTreeMap<
+        let mut groups: BTreeMap<
             crate::drawables::NodeId,
             (crate::tagging::PdfTag, Vec<Identifier>),
-        > = std::collections::BTreeMap::new();
+        > = BTreeMap::new();
         for (node_id, tag, id) in tc.into_entries() {
             groups
                 .entry(node_id)

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -8,7 +8,7 @@ use crate::gcpm::margin_box::{Edge, MarginBoxPosition, MarginBoxRect, compute_ed
 use crate::gcpm::running::RunningElementStore;
 use krilla::SerializeSettings;
 use krilla::configure::{Configuration, Validator};
-use krilla::tagging::TagTree;
+use krilla::tagging::{Identifier, Node, TagGroup, TagTree};
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
@@ -40,19 +40,23 @@ pub fn render_v2(
         } else {
             Configuration::new()
         };
-        let mut doc = krilla::Document::new_with(SerializeSettings {
+        krilla::Document::new_with(SerializeSettings {
             enable_tagging: true,
             configuration,
             ..Default::default()
-        });
-        doc.set_tag_tree(TagTree::new());
-        doc
+        })
     } else {
         krilla::Document::new()
     };
 
     let mut bookmark_collector = if config.effective_bookmarks() {
         Some(crate::draw_primitives::BookmarkCollector::new())
+    } else {
+        None
+    };
+
+    let mut tag_collector = if config.effective_tagging() {
+        Some(crate::draw_primitives::TagCollector::new())
     } else {
         None
     };
@@ -155,7 +159,7 @@ pub fn render_v2(
                     surface: &mut surface,
                     bookmark_collector: bookmark_collector.as_mut(),
                     link_collector: Some(&mut link_collector),
-                    tag_collector: None,
+                    tag_collector: tag_collector.as_mut(),
                 };
                 // Root `<html>` + `<body>` background pre-pass. v1's
                 // `BlockPageable::draw` for these elements paints
@@ -232,6 +236,32 @@ pub fn render_v2(
         }
         let per_page = link_collector.take_page(page_idx);
         crate::link::emit_link_annotations(&mut page, &per_page, &dest_registry);
+    }
+
+    if let Some(tc) = tag_collector {
+        let mut tree = TagTree::new();
+        if config.lang.is_some() {
+            tree = tree.with_lang(config.lang.clone());
+        }
+        let mut groups: std::collections::BTreeMap<
+            crate::drawables::NodeId,
+            (crate::tagging::PdfTag, Vec<Identifier>),
+        > = std::collections::BTreeMap::new();
+        for (node_id, tag, id) in tc.into_entries() {
+            groups
+                .entry(node_id)
+                .or_insert_with(|| (tag, Vec::new()))
+                .1
+                .push(id);
+        }
+        for (_, (tag, ids)) in groups {
+            let mut group = TagGroup::new(crate::tagging::pdf_tag_to_krilla_tag(&tag));
+            for id in ids {
+                group.push(Node::Leaf(id));
+            }
+            tree.push(group);
+        }
+        document.set_tag_tree(tree);
     }
 
     if let Some(c) = bookmark_collector {

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -793,9 +793,7 @@ fn try_start_tagged(
     node_id: usize,
     drawables: &Drawables,
 ) -> Option<(crate::tagging::PdfTag, krilla::tagging::Identifier)> {
-    if canvas.tag_collector.is_none() {
-        return None;
-    }
+    canvas.tag_collector.as_ref()?;
     let semantic = drawables.semantics.get(&node_id)?;
     if !matches!(
         semantic.tag,
@@ -807,7 +805,9 @@ fn try_start_tagged(
         return None;
     }
     use krilla::tagging::{ContentTag, SpanTag};
-    let id = canvas.surface.start_tagged(ContentTag::Span(SpanTag::empty()));
+    let id = canvas
+        .surface
+        .start_tagged(ContentTag::Span(SpanTag::empty()));
     Some((semantic.tag.clone(), id))
 }
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -809,6 +809,12 @@ fn try_start_tagged(
 /// the resulting `Identifier` in the `TagCollector` for StructTree assembly.
 ///
 /// No-op when `tag_info` is `None` (tagging disabled or not applicable).
+///
+/// # Invariant
+/// `tag_info` must only hold values produced by `try_start_tagged` on the
+/// same `canvas`. `try_start_tagged` returns `None` when `tag_collector` is
+/// absent, so if `tag_info` is `Some`, `canvas.tag_collector` is guaranteed
+/// to be `Some` as well.
 fn finish_tagged(
     canvas: &mut crate::draw_primitives::Canvas<'_, '_>,
     node_id: usize,

--- a/crates/fulgur/src/svg.rs
+++ b/crates/fulgur/src/svg.rs
@@ -99,6 +99,7 @@ mod tests {
                     surface: &mut surface,
                     bookmark_collector: None,
                     link_collector: None,
+                    tag_collector: None,
                 };
                 svg.draw(&mut canvas, 10.0, 20.0, 400.0, 400.0);
             }

--- a/crates/fulgur/src/tagging.rs
+++ b/crates/fulgur/src/tagging.rs
@@ -86,7 +86,10 @@ pub fn classify_element(local_name: &str) -> Option<PdfTag> {
 ///
 /// Only P / H{n} / Span are fully wired; all other variants fall back to
 /// `Tag::P` as a placeholder until list, table, and figure tagging lands.
-pub fn pdf_tag_to_krilla_tag(tag: &PdfTag, heading_title: Option<String>) -> krilla::tagging::TagKind {
+pub fn pdf_tag_to_krilla_tag(
+    tag: &PdfTag,
+    heading_title: Option<String>,
+) -> krilla::tagging::TagKind {
     use std::num::NonZeroU16;
     match tag {
         PdfTag::P => krilla::tagging::Tag::<krilla::tagging::kind::P>::P.into(),

--- a/crates/fulgur/src/tagging.rs
+++ b/crates/fulgur/src/tagging.rs
@@ -78,6 +78,26 @@ pub fn classify_element(local_name: &str) -> Option<PdfTag> {
     }
 }
 
+/// Convert a fulgur `PdfTag` to the corresponding Krilla `TagKind`.
+///
+/// Called by `render_v2` when building the flat TagTree after all pages
+/// are drawn. Only P / H{n} / Span are supported in fulgur-izp.4; all
+/// other variants fall back to `Tag::P` as a safe placeholder until later
+/// issues wire lists, tables, and figures.
+pub fn pdf_tag_to_krilla_tag(tag: &PdfTag) -> krilla::tagging::TagKind {
+    use std::num::NonZeroU16;
+    match tag {
+        PdfTag::P => krilla::tagging::Tag::<krilla::tagging::kind::P>::P.into(),
+        PdfTag::H { level } => {
+            let level = NonZeroU16::new((*level).max(1) as u16)
+                .unwrap_or_else(|| NonZeroU16::new(1).unwrap());
+            krilla::tagging::Tag::Hn(level, None).into()
+        }
+        PdfTag::Span => krilla::tagging::Tag::<krilla::tagging::kind::Span>::Span.into(),
+        _ => krilla::tagging::Tag::<krilla::tagging::kind::P>::P.into(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -126,5 +146,25 @@ mod tests {
         assert_eq!(classify_element("a"), None);
         assert_eq!(classify_element("body"), None);
         assert_eq!(classify_element("html"), None);
+    }
+
+    #[test]
+    fn pdf_tag_to_krilla_tag_p() {
+        let k = pdf_tag_to_krilla_tag(&PdfTag::P);
+        assert!(matches!(k, krilla::tagging::TagKind::P(_)));
+    }
+
+    #[test]
+    fn pdf_tag_to_krilla_tag_headings() {
+        for level in 1u8..=6 {
+            let k = pdf_tag_to_krilla_tag(&PdfTag::H { level });
+            assert!(matches!(k, krilla::tagging::TagKind::Hn(_)), "level={level}");
+        }
+    }
+
+    #[test]
+    fn pdf_tag_to_krilla_tag_span() {
+        let k = pdf_tag_to_krilla_tag(&PdfTag::Span);
+        assert!(matches!(k, krilla::tagging::TagKind::Span(_)));
     }
 }

--- a/crates/fulgur/src/tagging.rs
+++ b/crates/fulgur/src/tagging.rs
@@ -158,7 +158,10 @@ mod tests {
     fn pdf_tag_to_krilla_tag_headings() {
         for level in 1u8..=6 {
             let k = pdf_tag_to_krilla_tag(&PdfTag::H { level });
-            assert!(matches!(k, krilla::tagging::TagKind::Hn(_)), "level={level}");
+            assert!(
+                matches!(k, krilla::tagging::TagKind::Hn(_)),
+                "level={level}"
+            );
         }
     }
 

--- a/crates/fulgur/src/tagging.rs
+++ b/crates/fulgur/src/tagging.rs
@@ -80,18 +80,20 @@ pub fn classify_element(local_name: &str) -> Option<PdfTag> {
 
 /// Convert a fulgur `PdfTag` to the corresponding Krilla `TagKind`.
 ///
-/// Called by `render_v2` when building the flat TagTree after all pages
-/// are drawn. Only P / H{n} / Span are supported in fulgur-izp.4; all
-/// other variants fall back to `Tag::P` as a safe placeholder until later
-/// issues wire lists, tables, and figures.
-pub fn pdf_tag_to_krilla_tag(tag: &PdfTag) -> krilla::tagging::TagKind {
+/// `heading_title` is forwarded to `Tag::Hn` so PDF/UA-1 validators find the
+/// required `/T` (Title) attribute on heading tags. Pass `None` for non-heading
+/// tags or when the text is unavailable.
+///
+/// Only P / H{n} / Span are fully wired; all other variants fall back to
+/// `Tag::P` as a placeholder until list, table, and figure tagging lands.
+pub fn pdf_tag_to_krilla_tag(tag: &PdfTag, heading_title: Option<String>) -> krilla::tagging::TagKind {
     use std::num::NonZeroU16;
     match tag {
         PdfTag::P => krilla::tagging::Tag::<krilla::tagging::kind::P>::P.into(),
         PdfTag::H { level } => {
             let level = NonZeroU16::new((*level).max(1) as u16)
                 .unwrap_or_else(|| NonZeroU16::new(1).unwrap());
-            krilla::tagging::Tag::Hn(level, None).into()
+            krilla::tagging::Tag::Hn(level, heading_title).into()
         }
         PdfTag::Span => krilla::tagging::Tag::<krilla::tagging::kind::Span>::Span.into(),
         _ => krilla::tagging::Tag::<krilla::tagging::kind::P>::P.into(),
@@ -150,14 +152,14 @@ mod tests {
 
     #[test]
     fn pdf_tag_to_krilla_tag_p() {
-        let k = pdf_tag_to_krilla_tag(&PdfTag::P);
+        let k = pdf_tag_to_krilla_tag(&PdfTag::P, None);
         assert!(matches!(k, krilla::tagging::TagKind::P(_)));
     }
 
     #[test]
     fn pdf_tag_to_krilla_tag_headings() {
         for level in 1u8..=6 {
-            let k = pdf_tag_to_krilla_tag(&PdfTag::H { level });
+            let k = pdf_tag_to_krilla_tag(&PdfTag::H { level }, None);
             assert!(
                 matches!(k, krilla::tagging::TagKind::Hn(_)),
                 "level={level}"
@@ -167,7 +169,7 @@ mod tests {
 
     #[test]
     fn pdf_tag_to_krilla_tag_span() {
-        let k = pdf_tag_to_krilla_tag(&PdfTag::Span);
+        let k = pdf_tag_to_krilla_tag(&PdfTag::Span, None);
         assert!(matches!(k, krilla::tagging::TagKind::Span(_)));
     }
 }

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -2514,3 +2514,20 @@ fn untagged_pdf_has_no_struct_tree_root() {
         "untagged PDF must not contain /StructTreeRoot"
     );
 }
+
+#[test]
+fn pdf_ua_fails_ua1_validation_until_full_compliance_lands() {
+    // pdf_ua=true enables UA1 validation which requires structural
+    // attributes (document title, heading /Title entries) beyond
+    // what this issue wires. Full PDF/UA-1 compliance is out of scope
+    // for fulgur-izp.4; this test documents the known failure mode so
+    // regressions (e.g. a panic instead of a clean Err) are visible.
+    let result = Engine::builder()
+        .pdf_ua(true)
+        .build()
+        .render_html("<html><body><h1>Hello</h1><p>World</p></body></html>");
+    assert!(
+        result.is_err(),
+        "expected UA1 validation error until full compliance lands"
+    );
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -2457,3 +2457,60 @@ fn tagged_render_produces_pdf() {
         "tagged PDF must have StructTreeRoot"
     );
 }
+
+#[test]
+fn tagged_pdf_headings_and_paragraphs_produce_struct_tree() {
+    let html = r#"<!DOCTYPE html><html lang="en"><body>
+        <h1>Heading One</h1>
+        <p>First paragraph.</p>
+        <h2>Heading Two</h2>
+        <p>Second paragraph.</p>
+    </body></html>"#;
+
+    let pdf = Engine::builder()
+        .tagged(true)
+        .lang("en")
+        .build()
+        .render_html(html)
+        .expect("render tagged headings");
+
+    assert!(!pdf.is_empty());
+    let s = String::from_utf8_lossy(&pdf);
+    assert!(
+        s.contains("/StructTreeRoot"),
+        "tagged PDF must contain /StructTreeRoot"
+    );
+}
+
+#[test]
+fn tagged_pdf_multipage_does_not_panic() {
+    let mut html = String::from("<!DOCTYPE html><html><body>");
+    for i in 0..40 {
+        html.push_str(&format!("<h2>Section {i}</h2><p>Content line for section {i}. This is a longer paragraph to ensure we get multi-page output from the renderer.</p>"));
+    }
+    html.push_str("</body></html>");
+
+    let pdf = Engine::builder()
+        .tagged(true)
+        .build()
+        .render_html(&html)
+        .expect("render multi-page tagged");
+
+    assert!(!pdf.is_empty());
+    let s = String::from_utf8_lossy(&pdf);
+    assert!(s.contains("/StructTreeRoot"));
+}
+
+#[test]
+fn untagged_pdf_has_no_struct_tree_root() {
+    let pdf = Engine::builder()
+        .build()
+        .render_html("<html><body><h1>Hello</h1><p>World</p></body></html>")
+        .expect("render untagged");
+
+    let s = String::from_utf8_lossy(&pdf);
+    assert!(
+        !s.contains("/StructTreeRoot"),
+        "untagged PDF must not contain /StructTreeRoot"
+    );
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -2499,6 +2499,16 @@ fn tagged_pdf_multipage_does_not_panic() {
     assert!(!pdf.is_empty());
     let s = String::from_utf8_lossy(&pdf);
     assert!(s.contains("/StructTreeRoot"));
+
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("tagged-multipage.pdf");
+    std::fs::write(&path, &pdf).expect("write pdf");
+    let doc = lopdf::Document::load(&path).expect("PDF must parse");
+    assert!(
+        doc.get_pages().len() >= 2,
+        "fixture must produce a multi-page document; got {} page(s)",
+        doc.get_pages().len()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## 概要

- `TagCollector` 構造体と `Canvas.tag_collector` フィールドを追加（タグ付きコンテンツの NodeId→Identifier 収集）
- `render_v2` の `dispatch_fragment` で P/H/Span の描画を `start_tagged` / `end_tagged` で囲む
- フラットな TagTree を組み立て `document.set_tag_tree` を呼ぶ（階層化は izp.5 で拡張）
- P/H/Span に heading_title（`/T` 属性）を付与（PDF/UA-1 要件）

## テスト計画

- [x] `cargo test -p fulgur --lib` — 全テストパス
- [x] tagged block/inline wiring の統合テスト追加（`crates/fulgur/tests/render_smoke.rs`）
- [x] マルチページ tagged render の smoke テスト

## 依存

izp.3（`drawables.semantics` BTreeMap）が前提。  
izp.5（`feat/fulgur-izp-5-tagged-pdf-struct-tree`）で階層 TagTree ビルダーに置き換わる。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
- PDF/UAタグ付け機能により、セマンティックな文書構造の生成に対応
- タグ付きPDFにおいて自動的にドキュメント構造ツリーを生成

## テスト
- タグ付きPDF出力の検証テストを拡充
- 複数ページドキュメントの構造化レンダリング検証を追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->