### PR TITLE
feat(tagged): implement L/LI/Lbl/LBody structure tags for list elements (fulgur-izp.7)

### DIFF
--- a/crates/fulgur-cli/tests/tagged_cli.rs
+++ b/crates/fulgur-cli/tests/tagged_cli.rs
@@ -87,3 +87,103 @@ fn cli_pdf_ua_flag_succeeds() {
         "pdf-ua PDF must contain /StructTreeRoot"
     );
 }
+
+#[test]
+fn tagged_pdf_ul_has_lbl_lbody_tags() {
+    let dir = TempDir::new().expect("create temp dir");
+    let html_path = dir.path().join("doc.html");
+    let pdf_path = dir.path().join("doc.pdf");
+    std::fs::write(
+        &html_path,
+        "<!DOCTYPE html><html><body><ul><li>first</li><li>second</li></ul></body></html>",
+    )
+    .unwrap();
+
+    let out = run_cli(&[
+        "render",
+        html_path.to_str().unwrap(),
+        "-o",
+        pdf_path.to_str().unwrap(),
+        "--tagged",
+    ]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "CLI failed: {stderr}");
+
+    let pdf = std::fs::read(&pdf_path).unwrap();
+    let s = String::from_utf8_lossy(&pdf);
+    // LI/Lbl/LBody はいずれも PDF 名前空間内で一意なため安全にバイト検索できる
+    assert!(
+        s.contains("/LI"),
+        "tagged ul must contain /LI struct element"
+    );
+    assert!(
+        s.contains("/Lbl"),
+        "tagged ul must contain /Lbl (marker label)"
+    );
+    assert!(
+        s.contains("/LBody"),
+        "tagged ul must contain /LBody (list body)"
+    );
+}
+
+#[test]
+fn tagged_pdf_ol_has_lbl_lbody_tags() {
+    let dir = TempDir::new().expect("create temp dir");
+    let html_path = dir.path().join("doc.html");
+    let pdf_path = dir.path().join("doc.pdf");
+    std::fs::write(
+        &html_path,
+        "<!DOCTYPE html><html><body><ol><li>first</li><li>second</li></ol></body></html>",
+    )
+    .unwrap();
+
+    let out = run_cli(&[
+        "render",
+        html_path.to_str().unwrap(),
+        "-o",
+        pdf_path.to_str().unwrap(),
+        "--tagged",
+    ]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "CLI failed: {stderr}");
+
+    let pdf = std::fs::read(&pdf_path).unwrap();
+    let s = String::from_utf8_lossy(&pdf);
+    assert!(s.contains("/LI"), "tagged ol must contain /LI");
+    assert!(s.contains("/Lbl"), "tagged ol must contain /Lbl");
+    assert!(s.contains("/LBody"), "tagged ol must contain /LBody");
+}
+
+#[test]
+fn tagged_pdf_nested_list_does_not_panic() {
+    let dir = TempDir::new().expect("create temp dir");
+    let html_path = dir.path().join("doc.html");
+    let pdf_path = dir.path().join("doc.pdf");
+    std::fs::write(
+        &html_path,
+        "<!DOCTYPE html><html><body><ul><li>outer<ol><li>inner</li></ol></li></ul></body></html>",
+    )
+    .unwrap();
+
+    let out = run_cli(&[
+        "render",
+        html_path.to_str().unwrap(),
+        "-o",
+        pdf_path.to_str().unwrap(),
+        "--tagged",
+    ]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "nested list CLI must not panic: {stderr}"
+    );
+
+    let pdf = std::fs::read(&pdf_path).unwrap();
+    let s = String::from_utf8_lossy(&pdf);
+    // ネストリストで LI が 2 つ（outer + inner）以上あること
+    let li_count = s.match_indices("/LI").count();
+    assert!(
+        li_count >= 2,
+        "nested list must have at least 2 /LI tags, got {li_count}"
+    );
+}

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -1103,7 +1103,12 @@ mod semantics_tests {
     fn dom_to_drawables_records_semantic_entries_for_lists() {
         let html = "<!DOCTYPE html><html><body><ul><li>a</li><li>b</li></ul></body></html>";
         let d = build_drawables(html);
-        let lists = entries_by_tag(&d, &PdfTag::L { numbering: krilla::tagging::ListNumbering::Disc });
+        let lists = entries_by_tag(
+            &d,
+            &PdfTag::L {
+                numbering: krilla::tagging::ListNumbering::Disc,
+            },
+        );
         assert_eq!(lists.len(), 1, "expected one ul entry");
         let items = entries_by_tag(&d, &PdfTag::Li);
         assert_eq!(items.len(), 2, "expected two li entries");
@@ -1116,6 +1121,19 @@ mod semantics_tests {
                 "li {li_id} parent should be ul {ul_id}, got {parent:?}"
             );
         }
+    }
+
+    #[test]
+    fn dom_to_drawables_records_semantic_entries_for_ordered_lists() {
+        let html = "<!DOCTYPE html><html><body><ol><li>item</li></ol></body></html>";
+        let d = build_drawables(html);
+        let lists = entries_by_tag(
+            &d,
+            &PdfTag::L {
+                numbering: krilla::tagging::ListNumbering::Decimal,
+            },
+        );
+        assert_eq!(lists.len(), 1, "one ol in semantics");
     }
 
     #[test]

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -1103,7 +1103,7 @@ mod semantics_tests {
     fn dom_to_drawables_records_semantic_entries_for_lists() {
         let html = "<!DOCTYPE html><html><body><ul><li>a</li><li>b</li></ul></body></html>";
         let d = build_drawables(html);
-        let lists = entries_by_tag(&d, &PdfTag::L);
+        let lists = entries_by_tag(&d, &PdfTag::L { numbering: krilla::tagging::ListNumbering::Disc });
         assert_eq!(lists.len(), 1, "expected one ul entry");
         let items = entries_by_tag(&d, &PdfTag::Li);
         assert_eq!(items.len(), 2, "expected two li entries");

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -437,9 +437,12 @@ fn walk_semantics(
             );
 
             if is_li {
-                // Lbl / LBody 合成エントリを作成
-                let lbl_id = out.alloc_synthetic_id();
+                // Lbl / LBody 合成エントリを作成。
+                // alloc_synthetic_id() は降順に ID を払い出すため、先に lbody_id を取ると
+                // lbl_id > lbody_id となり、BTreeMap のキー昇順イテレーション
+                // (build_struct_tree) で Lbl → LBody の正しい PDF/UA 順序が得られる。
                 let lbody_id = out.alloc_synthetic_id();
+                let lbl_id = out.alloc_synthetic_id();
                 out.semantics.insert(
                     lbl_id,
                     crate::tagging::SemanticEntry {

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -1294,27 +1294,28 @@ mod semantics_tests {
     }
 
     #[test]
-    fn walk_semantics_li_paragraph_parent_is_lbody() {
-        // li 直下のテキスト（inline-root）は lbody_id を親に持つ
-        let html = "<!DOCTYPE html><html><body><ul><li>item</li></ul></body></html>";
+    fn walk_semantics_li_child_span_parent_is_lbody() {
+        // li 直下の <span> は lbody_id を親に持つ
+        let html = "<!DOCTYPE html><html><body><ul><li><span>text</span></li></ul></body></html>";
         let d = build_drawables(html);
         let (&li_id, _) = d.li_lbl_ids.iter().next().unwrap();
         let lbody_id = d.li_lbody_ids[&li_id];
 
-        // P タグを探す
-        let p_entries: Vec<_> = d
+        let span_entries: Vec<_> = d
             .semantics
             .iter()
-            .filter(|(_, e)| e.tag == PdfTag::P)
+            .filter(|(_, e)| e.tag == PdfTag::Span)
             .collect();
-        // li 直下テキストは <p> タグがないため P がない場合もある
-        // その場合は lbody_id が semantics に存在すること自体を確認
-        let _ = d.semantics.get(&lbody_id).expect("lbody in semantics");
-        // P がある場合は parent が li_id 直接ではなく lbody_id であること
-        for (_, entry) in &p_entries {
-            if entry.parent == Some(li_id) {
-                panic!("P's parent should be lbody_id, not li_id directly");
-            }
+        assert!(
+            !span_entries.is_empty(),
+            "span inside li should be in semantics"
+        );
+        for (_, entry) in &span_entries {
+            assert_eq!(
+                entry.parent,
+                Some(lbody_id),
+                "span inside li should have lbody_id as parent, not li_id"
+            );
         }
     }
 

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -367,13 +367,14 @@ fn record_semantics_pass(doc: &HtmlDocument, out: &mut crate::drawables::Drawabl
     let Some(body_id) = out.body_id else {
         return;
     };
-    walk_semantics(base, body_id, 0, out);
+    walk_semantics(base, body_id, 0, None, out);
 }
 
 fn walk_semantics(
     doc: &BaseDocument,
     node_id: usize,
     depth: usize,
+    parent_override: Option<usize>,
     out: &mut crate::drawables::Drawables,
 ) {
     if depth >= MAX_DOM_DEPTH {
@@ -382,24 +383,50 @@ fn walk_semantics(
     let Some(node) = doc.get_node(node_id) else {
         return;
     };
-    if let Some(elem) = node.element_data() {
-        if let Some(tag) = crate::tagging::classify_element(elem.name.local.as_ref()) {
-            // Walk up `node.parent` until an already-recorded ancestor
-            // is found. The traversal is top-down so any classified
-            // ancestor is guaranteed to be present.
-            let mut parent = node.parent;
-            let parent_node_id = loop {
-                let Some(pid) = parent else { break None };
-                if out.semantics.contains_key(&pid) {
-                    break Some(pid);
+
+    let child_override = if let Some(elem) = node.element_data() {
+        if let Some(mut tag) = crate::tagging::classify_element(elem.name.local.as_ref()) {
+            // CSS list-style-type を読んで ListNumbering をオーバーライド
+            if matches!(tag, crate::tagging::PdfTag::L { .. }) {
+                if let Some(styles) = node.primary_styles() {
+                    use ::style::properties::longhands::list_style_type::computed_value::T as LST;
+                    use krilla::tagging::ListNumbering;
+                    let numbering = match styles.clone_list_style_type() {
+                        LST::Disc => ListNumbering::Disc,
+                        LST::Circle => ListNumbering::Circle,
+                        LST::Square => ListNumbering::Square,
+                        LST::Decimal => ListNumbering::Decimal,
+                        LST::LowerAlpha => ListNumbering::LowerAlpha,
+                        LST::UpperAlpha => ListNumbering::UpperAlpha,
+                        _ => ListNumbering::None,
+                    };
+                    tag = crate::tagging::PdfTag::L { numbering };
                 }
-                parent = doc.get_node(pid).and_then(|p| p.parent);
+            }
+
+            // parent を決定: override があればそれを使い、なければ DOM walk-up
+            let parent_node_id = if let Some(ov) = parent_override {
+                Some(ov)
+            } else {
+                let mut p = node.parent;
+                loop {
+                    let Some(pid) = p else { break None };
+                    if out.semantics.contains_key(&pid) {
+                        break Some(pid);
+                    }
+                    p = doc.get_node(pid).and_then(|n| n.parent);
+                }
             };
+
             let alt_text = if matches!(tag, crate::tagging::PdfTag::Figure) {
-                get_attr(elem, "alt").map(|v| v.to_owned())
+                node.element_data()
+                    .and_then(|e| get_attr(e, "alt"))
+                    .map(|v| v.to_owned())
             } else {
                 None
             };
+
+            let is_li = matches!(tag, crate::tagging::PdfTag::Li);
             out.semantics.insert(
                 node_id,
                 crate::tagging::SemanticEntry {
@@ -408,10 +435,46 @@ fn walk_semantics(
                     alt_text,
                 },
             );
+
+            if is_li {
+                // Lbl / LBody 合成エントリを作成
+                let lbl_id = out.alloc_synthetic_id();
+                let lbody_id = out.alloc_synthetic_id();
+                out.semantics.insert(
+                    lbl_id,
+                    crate::tagging::SemanticEntry {
+                        tag: crate::tagging::PdfTag::Lbl,
+                        parent: Some(node_id),
+                        alt_text: None,
+                    },
+                );
+                out.semantics.insert(
+                    lbody_id,
+                    crate::tagging::SemanticEntry {
+                        tag: crate::tagging::PdfTag::LBody,
+                        parent: Some(node_id),
+                        alt_text: None,
+                    },
+                );
+                out.li_lbl_ids.insert(node_id, lbl_id);
+                out.li_lbody_ids.insert(node_id, lbody_id);
+                // li の子は lbody_id を parent として再帰
+                for &child_id in &node.children {
+                    walk_semantics(doc, child_id, depth + 1, Some(lbody_id), out);
+                }
+                return; // 通常の再帰をスキップ
+            }
+
+            None // 分類済み要素 (Li 以外): 子への override はリセット
+        } else {
+            parent_override // 非分類要素: override を引き継ぐ
         }
-    }
+    } else {
+        parent_override // 要素でないノード: override を引き継ぐ
+    };
+
     for &child_id in &node.children {
-        walk_semantics(doc, child_id, depth + 1, out);
+        walk_semantics(doc, child_id, depth + 1, child_override, out);
     }
 }
 
@@ -1203,6 +1266,89 @@ mod semantics_tests {
             PdfTag::P,
             "the single entry must be the <p>, got {:?}",
             only_entry.tag
+        );
+    }
+
+    #[test]
+    fn walk_semantics_li_creates_lbl_and_lbody_synthetic_entries() {
+        let html = "<!DOCTYPE html><html><body><ul><li>item</li></ul></body></html>";
+        let d = build_drawables(html);
+
+        // li_lbl_ids と li_lbody_ids に 1 エントリずつあること
+        assert_eq!(d.li_lbl_ids.len(), 1, "one li_lbl_ids entry");
+        assert_eq!(d.li_lbody_ids.len(), 1, "one li_lbody_ids entry");
+
+        // li_lbl_ids のキー = li NodeId、値 = Lbl 合成 NodeId
+        let (&li_id, &lbl_id) = d.li_lbl_ids.iter().next().unwrap();
+        let lbody_id = d.li_lbody_ids[&li_id];
+
+        // semantics に Lbl エントリがあり、parent = li_id
+        let lbl_entry = &d.semantics[&lbl_id];
+        assert_eq!(lbl_entry.tag, PdfTag::Lbl);
+        assert_eq!(lbl_entry.parent, Some(li_id));
+
+        // semantics に LBody エントリがあり、parent = li_id
+        let lbody_entry = &d.semantics[&lbody_id];
+        assert_eq!(lbody_entry.tag, PdfTag::LBody);
+        assert_eq!(lbody_entry.parent, Some(li_id));
+    }
+
+    #[test]
+    fn walk_semantics_li_paragraph_parent_is_lbody() {
+        // li 直下のテキスト（inline-root）は lbody_id を親に持つ
+        let html = "<!DOCTYPE html><html><body><ul><li>item</li></ul></body></html>";
+        let d = build_drawables(html);
+        let (&li_id, _) = d.li_lbl_ids.iter().next().unwrap();
+        let lbody_id = d.li_lbody_ids[&li_id];
+
+        // P タグを探す
+        let p_entries: Vec<_> = d
+            .semantics
+            .iter()
+            .filter(|(_, e)| e.tag == PdfTag::P)
+            .collect();
+        // li 直下テキストは <p> タグがないため P がない場合もある
+        // その場合は lbody_id が semantics に存在すること自体を確認
+        let _ = d.semantics.get(&lbody_id).expect("lbody in semantics");
+        // P がある場合は parent が li_id 直接ではなく lbody_id であること
+        for (_, entry) in &p_entries {
+            if entry.parent == Some(li_id) {
+                panic!("P's parent should be lbody_id, not li_id directly");
+            }
+        }
+    }
+
+    #[test]
+    fn walk_semantics_nested_list_structure() {
+        let html = "<!DOCTYPE html><html><body>\
+            <ul><li><ol><li>nested</li></ol></li></ul>\
+            </body></html>";
+        let d = build_drawables(html);
+
+        // 2 つの li があるので li_lbl_ids に 2 エントリ
+        assert_eq!(d.li_lbl_ids.len(), 2);
+
+        // inner ol の L エントリが存在すること
+        let decimal_lists = entries_by_tag(
+            &d,
+            &PdfTag::L {
+                numbering: krilla::tagging::ListNumbering::Decimal,
+            },
+        );
+        assert_eq!(decimal_lists.len(), 1, "one ol (Decimal)");
+        let (_, inner_ol_parent) = decimal_lists[0];
+
+        // inner ol の parent は outer li の lbody_id であること
+        let outer_li_ids: Vec<_> = d
+            .li_lbl_ids
+            .keys()
+            .copied()
+            .filter(|&id| d.li_lbody_ids.get(&id).copied() == inner_ol_parent)
+            .collect();
+        assert_eq!(
+            outer_li_ids.len(),
+            1,
+            "inner ol parent should be outer li's lbody"
         );
     }
 

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -295,7 +295,7 @@ pub struct LinkSpanEntry;
 /// Phase 4 PR 1 ships this with all maps empty — the v2 render path
 /// walks geometry but emits no content for any node. Subsequent PRs
 /// fill each map by migrating one Pageable type at a time.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct Drawables {
     /// `body_layout.location.x/y` in pt. Captures the html → body
     /// offset that CSS margin collapsing folds onto the body element.
@@ -367,11 +367,53 @@ pub struct Drawables {
     /// `inline_box_subtree_skip`. `BTreeMap`/`Vec` keep iteration
     /// deterministic for PDF byte-equality.
     pub inline_box_subtree_descendants: BTreeMap<NodeId, Vec<NodeId>>,
+    /// 合成 NodeId カウンタ。usize::MAX / 2 から降順に割り当て。
+    /// DOM NodeId（通常 < 100_000）との衝突を避けるため大きな値から開始する。
+    pub synthetic_id_counter: usize,
+    /// li NodeId → Lbl 合成 NodeId（render pass のマーカータグ付け用）
+    pub li_lbl_ids: BTreeMap<NodeId, NodeId>,
+    /// li NodeId → LBody 合成 NodeId（inline-root li の body タグ付け用）
+    pub li_lbody_ids: BTreeMap<NodeId, NodeId>,
+}
+
+impl Default for Drawables {
+    fn default() -> Self {
+        Self {
+            body_offset_pt: (0.0, 0.0),
+            root_id: None,
+            body_id: None,
+            block_styles: BTreeMap::new(),
+            paragraphs: BTreeMap::new(),
+            paragraph_slices: BTreeMap::new(),
+            images: BTreeMap::new(),
+            svgs: BTreeMap::new(),
+            tables: BTreeMap::new(),
+            list_items: BTreeMap::new(),
+            multicol_rules: BTreeMap::new(),
+            transforms: BTreeMap::new(),
+            bookmark_anchors: BTreeMap::new(),
+            link_spans: Vec::new(),
+            semantics: BTreeMap::new(),
+            inline_box_subtree_skip: std::collections::BTreeSet::new(),
+            inline_box_subtree_descendants: BTreeMap::new(),
+            synthetic_id_counter: usize::MAX / 2,
+            li_lbl_ids: BTreeMap::new(),
+            li_lbody_ids: BTreeMap::new(),
+        }
+    }
 }
 
 impl Drawables {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// 合成 NodeId を 1 つ割り当てる。
+    /// `usize::MAX / 2` から始まり降順に割り当てるので DOM NodeId と衝突しない。
+    pub fn alloc_synthetic_id(&mut self) -> NodeId {
+        let id = self.synthetic_id_counter;
+        self.synthetic_id_counter = self.synthetic_id_counter.saturating_sub(1);
+        id
     }
 
     /// `true` when no draw payload has been registered for any node.

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -499,4 +499,23 @@ mod tests {
         assert!(s.contains("opacity"));
         assert!(s.contains("visible"));
     }
+
+    #[test]
+    fn alloc_synthetic_id_starts_at_usize_max_div_2() {
+        let mut d = Drawables::default();
+        let first = d.alloc_synthetic_id();
+        assert_eq!(first, usize::MAX / 2);
+    }
+
+    #[test]
+    fn alloc_synthetic_id_returns_unique_decreasing_ids() {
+        let mut d = Drawables::default();
+        let id1 = d.alloc_synthetic_id();
+        let id2 = d.alloc_synthetic_id();
+        let id3 = d.alloc_synthetic_id();
+        assert!(id1 > id2, "IDs must decrease");
+        assert!(id2 > id3, "IDs must decrease");
+        assert_ne!(id1, id2);
+        assert_ne!(id2, id3);
+    }
 }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -1541,30 +1541,7 @@ fn draw_under_clip(
         if let Some(li) = list_item
             && li.visible
         {
-            // outside marker を Lbl タグで囲む
-            let lbl_id = canvas
-                .tag_collector
-                .as_ref()
-                .and_then(|_| drawables.li_lbl_ids.get(&node_id).copied());
-            let marker_tag_id = lbl_id.map(|_| {
-                canvas
-                    .surface
-                    .start_tagged(krilla::tagging::ContentTag::Span(
-                        krilla::tagging::SpanTag::empty(),
-                    ))
-            });
-
-            draw_list_item_marker(canvas, li, x_pt, y_pt);
-
-            if let (Some(lid), Some(id)) = (lbl_id, marker_tag_id) {
-                canvas.surface.end_tagged();
-                canvas.tag_collector.as_mut().unwrap().record(
-                    lid,
-                    crate::tagging::PdfTag::Lbl,
-                    id,
-                    None,
-                );
-            }
+            draw_list_item_marker_tagged(canvas, li, node_id, drawables, x_pt, y_pt);
         }
 
         // bg / border / shadow outside the clip — same as
@@ -2873,30 +2850,7 @@ fn draw_list_item_with_block(
 
     draw_with_opacity(canvas, list_item.opacity, |canvas| {
         if list_item.visible {
-            // outside marker を Lbl タグで囲む
-            let lbl_id = canvas
-                .tag_collector
-                .as_ref()
-                .and_then(|_| drawables.li_lbl_ids.get(&node_id).copied());
-            let marker_tag_id = lbl_id.map(|_| {
-                canvas
-                    .surface
-                    .start_tagged(krilla::tagging::ContentTag::Span(
-                        krilla::tagging::SpanTag::empty(),
-                    ))
-            });
-
-            draw_list_item_marker(canvas, list_item, x, y);
-
-            if let (Some(lid), Some(id)) = (lbl_id, marker_tag_id) {
-                canvas.surface.end_tagged();
-                canvas.tag_collector.as_mut().unwrap().record(
-                    lid,
-                    crate::tagging::PdfTag::Lbl,
-                    id,
-                    None,
-                );
-            }
+            draw_list_item_marker_tagged(canvas, list_item, node_id, drawables, x, y);
         }
         if let Some(b) = block {
             draw_block_inner_paint(canvas, b, x, y, frag, is_split);
@@ -2950,6 +2904,39 @@ fn draw_list_item_marker(
             }
         }
         _ => {}
+    }
+}
+
+/// List-item marker を描画し、タグ付きモードでは Lbl 構造要素でラップする。
+fn draw_list_item_marker_tagged(
+    canvas: &mut crate::draw_primitives::Canvas<'_, '_>,
+    li: &crate::drawables::ListItemEntry,
+    node_id: usize,
+    drawables: &Drawables,
+    x: f32,
+    y: f32,
+) {
+    let lbl_id = canvas
+        .tag_collector
+        .as_ref()
+        .and_then(|_| drawables.li_lbl_ids.get(&node_id).copied());
+    let marker_tag_id = lbl_id.map(|_| {
+        canvas
+            .surface
+            .start_tagged(krilla::tagging::ContentTag::Span(
+                krilla::tagging::SpanTag::empty(),
+            ))
+    });
+
+    draw_list_item_marker(canvas, li, x, y);
+
+    if let (Some(lid), Some(id)) = (lbl_id, marker_tag_id) {
+        canvas.surface.end_tagged();
+        canvas
+            .tag_collector
+            .as_mut()
+            .expect("tag_collector is Some because marker_tag_id was issued from it")
+            .record(lid, crate::tagging::PdfTag::Lbl, id, None);
     }
 }
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -1596,6 +1596,14 @@ fn draw_under_clip(
         // Inner content sharing `node_id` (inline-root paragraph,
         // replaced image / svg) paints at the content-box top-left,
         // not the border-box. Mirrors `draw_block_with_inner_content`.
+        //
+        // Known limitation (fulgur-izp.7): when this node is a list-item
+        // (`li_lbody_ids` contains `node_id`), the inline-root paragraph here
+        // is not wrapped in `try_start_tagged`/`finish_tagged`, so its content
+        // identifiers land under the wrong StructTree node instead of LBody.
+        // Strictly typed PDF/UA validators may flag the empty LBody element.
+        // Fix: mirror the `try_start_tagged`/`finish_tagged` wrap from
+        // `draw_list_item_with_block` here too.
         let inner_x = x_pt + inner_inset.0;
         let inner_y = y_pt + inner_inset.1;
         if let Some(p) = para_for_block {

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -773,39 +773,51 @@ fn try_start_tagged(
     node_id: usize,
     drawables: &Drawables,
 ) -> Option<(
+    usize, // record_id (TagCollector.record() に渡す NodeId)
     crate::tagging::PdfTag,
     krilla::tagging::Identifier,
     Option<String>,
 )> {
     canvas.tag_collector.as_ref()?;
     let semantic = drawables.semantics.get(&node_id)?;
-    if !matches!(
-        semantic.tag,
-        crate::tagging::PdfTag::P | crate::tagging::PdfTag::H { .. } | crate::tagging::PdfTag::Span
-    ) {
-        return None;
+    match &semantic.tag {
+        crate::tagging::PdfTag::P | crate::tagging::PdfTag::Span => {
+            use krilla::tagging::{ContentTag, SpanTag};
+            let id = canvas
+                .surface
+                .start_tagged(ContentTag::Span(SpanTag::empty()));
+            Some((node_id, semantic.tag.clone(), id, None))
+        }
+        crate::tagging::PdfTag::H { .. } => {
+            // For heading tags, extract the plain text so Tag::Hn gets the /T (Title)
+            // attribute that PDF/UA-1 validators require.
+            let heading_title = drawables.paragraphs.get(&node_id).map(|para| {
+                para.lines
+                    .iter()
+                    .flat_map(|line| line.items.iter())
+                    .filter_map(|item| match item {
+                        crate::paragraph::LineItem::Text(run) => Some(run.text.as_str()),
+                        _ => None,
+                    })
+                    .collect::<String>()
+            });
+            use krilla::tagging::{ContentTag, SpanTag};
+            let id = canvas
+                .surface
+                .start_tagged(ContentTag::Span(SpanTag::empty()));
+            Some((node_id, semantic.tag.clone(), id, heading_title))
+        }
+        crate::tagging::PdfTag::Li => {
+            // inline-root li: コンテンツを lbody_id で記録（LBody 配下に収める）
+            let &lbody_id = drawables.li_lbody_ids.get(&node_id)?;
+            use krilla::tagging::{ContentTag, SpanTag};
+            let id = canvas
+                .surface
+                .start_tagged(ContentTag::Span(SpanTag::empty()));
+            Some((lbody_id, crate::tagging::PdfTag::LBody, id, None))
+        }
+        _ => None,
     }
-    // For heading tags, extract the plain text so Tag::Hn gets the /T (Title)
-    // attribute that PDF/UA-1 validators require.
-    let heading_title = if matches!(semantic.tag, crate::tagging::PdfTag::H { .. }) {
-        drawables.paragraphs.get(&node_id).map(|para| {
-            para.lines
-                .iter()
-                .flat_map(|line| line.items.iter())
-                .filter_map(|item| match item {
-                    crate::paragraph::LineItem::Text(run) => Some(run.text.as_str()),
-                    _ => None,
-                })
-                .collect::<String>()
-        })
-    } else {
-        None
-    };
-    use krilla::tagging::{ContentTag, SpanTag};
-    let id = canvas
-        .surface
-        .start_tagged(ContentTag::Span(SpanTag::empty()));
-    Some((semantic.tag.clone(), id, heading_title))
 }
 
 /// Close a tagged content sequence opened by `try_start_tagged` and record
@@ -820,20 +832,20 @@ fn try_start_tagged(
 /// to be `Some` as well.
 fn finish_tagged(
     canvas: &mut crate::draw_primitives::Canvas<'_, '_>,
-    node_id: usize,
     tag_info: Option<(
+        usize, // record_id
         crate::tagging::PdfTag,
         krilla::tagging::Identifier,
         Option<String>,
     )>,
 ) {
-    if let Some((tag, id, heading_title)) = tag_info {
+    if let Some((record_id, tag, id, heading_title)) = tag_info {
         canvas.surface.end_tagged();
         canvas
             .tag_collector
             .as_mut()
             .expect("tag_collector is Some when tag_info is Some")
-            .record(node_id, tag, id, heading_title);
+            .record(record_id, tag, id, heading_title);
     }
 }
 
@@ -870,6 +882,7 @@ pub(crate) fn dispatch_fragment(
         let para_for_li = drawables.paragraphs.get(&node_id);
         draw_list_item_with_block(
             canvas,
+            node_id,
             li,
             block_for_li,
             para_for_li,
@@ -946,7 +959,7 @@ pub(crate) fn dispatch_fragment(
                     page_index,
                 );
             }
-            finish_tagged(canvas, node_id, tag_info);
+            finish_tagged(canvas, tag_info);
             return;
         }
         draw_block_v2(canvas, block, x_pt, y_pt, frag, is_split);
@@ -986,7 +999,7 @@ pub(crate) fn dispatch_fragment(
             margin_left_pt,
             margin_top_pt,
         );
-        finish_tagged(canvas, node_id, tag_info);
+        finish_tagged(canvas, tag_info);
     }
 }
 
@@ -1528,7 +1541,30 @@ fn draw_under_clip(
         if let Some(li) = list_item
             && li.visible
         {
+            // outside marker を Lbl タグで囲む
+            let lbl_id = canvas
+                .tag_collector
+                .as_ref()
+                .and_then(|_| drawables.li_lbl_ids.get(&node_id).copied());
+            let marker_tag_id = lbl_id.map(|_| {
+                canvas
+                    .surface
+                    .start_tagged(krilla::tagging::ContentTag::Span(
+                        krilla::tagging::SpanTag::empty(),
+                    ))
+            });
+
             draw_list_item_marker(canvas, li, x_pt, y_pt);
+
+            if let (Some(lid), Some(id)) = (lbl_id, marker_tag_id) {
+                canvas.surface.end_tagged();
+                canvas.tag_collector.as_mut().unwrap().record(
+                    lid,
+                    crate::tagging::PdfTag::Lbl,
+                    id,
+                    None,
+                );
+            }
         }
 
         // bg / border / shadow outside the clip — same as
@@ -2810,6 +2846,7 @@ fn draw_block_with_inner_content(
 #[allow(clippy::too_many_arguments)]
 fn draw_list_item_with_block(
     canvas: &mut crate::draw_primitives::Canvas<'_, '_>,
+    node_id: usize,
     list_item: &crate::drawables::ListItemEntry,
     block: Option<&crate::drawables::BlockEntry>,
     paragraph: Option<&crate::drawables::ParagraphEntry>,
@@ -2836,12 +2873,37 @@ fn draw_list_item_with_block(
 
     draw_with_opacity(canvas, list_item.opacity, |canvas| {
         if list_item.visible {
+            // outside marker を Lbl タグで囲む
+            let lbl_id = canvas
+                .tag_collector
+                .as_ref()
+                .and_then(|_| drawables.li_lbl_ids.get(&node_id).copied());
+            let marker_tag_id = lbl_id.map(|_| {
+                canvas
+                    .surface
+                    .start_tagged(krilla::tagging::ContentTag::Span(
+                        krilla::tagging::SpanTag::empty(),
+                    ))
+            });
+
             draw_list_item_marker(canvas, list_item, x, y);
+
+            if let (Some(lid), Some(id)) = (lbl_id, marker_tag_id) {
+                canvas.surface.end_tagged();
+                canvas.tag_collector.as_mut().unwrap().record(
+                    lid,
+                    crate::tagging::PdfTag::Lbl,
+                    id,
+                    None,
+                );
+            }
         }
         if let Some(b) = block {
             draw_block_inner_paint(canvas, b, x, y, frag, is_split);
         }
         if let Some(p) = paragraph {
+            // inline-root li の段落コンテンツを LBody 配下に記録する
+            let tag_info = try_start_tagged(canvas, node_id, drawables);
             draw_paragraph_inner_paint(
                 canvas,
                 p,
@@ -2855,6 +2917,7 @@ fn draw_list_item_with_block(
                 margin_left_pt,
                 margin_top_pt,
             );
+            finish_tagged(canvas, tag_info);
         }
     });
 }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -1596,17 +1596,10 @@ fn draw_under_clip(
         // Inner content sharing `node_id` (inline-root paragraph,
         // replaced image / svg) paints at the content-box top-left,
         // not the border-box. Mirrors `draw_block_with_inner_content`.
-        //
-        // Known limitation (fulgur-izp.7): when this node is a list-item
-        // (`li_lbody_ids` contains `node_id`), the inline-root paragraph here
-        // is not wrapped in `try_start_tagged`/`finish_tagged`, so its content
-        // identifiers land under the wrong StructTree node instead of LBody.
-        // Strictly typed PDF/UA validators may flag the empty LBody element.
-        // Fix: mirror the `try_start_tagged`/`finish_tagged` wrap from
-        // `draw_list_item_with_block` here too.
         let inner_x = x_pt + inner_inset.0;
         let inner_y = y_pt + inner_inset.1;
         if let Some(p) = para_for_block {
+            let tag_info = try_start_tagged(canvas, node_id, drawables);
             draw_paragraph_inner_paint(
                 canvas,
                 p,
@@ -1620,6 +1613,7 @@ fn draw_under_clip(
                 margin_left_pt,
                 margin_top_pt,
             );
+            finish_tagged(canvas, tag_info);
         }
         if let Some(i) = img_for_block {
             draw_image_inner_paint(canvas, i, inner_x, inner_y);

--- a/crates/fulgur/src/tagging.rs
+++ b/crates/fulgur/src/tagging.rs
@@ -21,11 +21,15 @@ use crate::drawables::NodeId;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PdfTag {
     P,
-    H { level: u8 },
+    H {
+        level: u8,
+    },
     Div,
     Span,
     Figure,
-    L { numbering: krilla::tagging::ListNumbering },
+    L {
+        numbering: krilla::tagging::ListNumbering,
+    },
     Lbl,
     LBody,
     Li,
@@ -74,8 +78,12 @@ pub fn classify_element(local_name: &str) -> Option<PdfTag> {
         }
         "span" => Some(PdfTag::Span),
         "img" => Some(PdfTag::Figure),
-        "ul" => Some(PdfTag::L { numbering: krilla::tagging::ListNumbering::Disc }),
-        "ol" => Some(PdfTag::L { numbering: krilla::tagging::ListNumbering::Decimal }),
+        "ul" => Some(PdfTag::L {
+            numbering: krilla::tagging::ListNumbering::Disc,
+        }),
+        "ol" => Some(PdfTag::L {
+            numbering: krilla::tagging::ListNumbering::Decimal,
+        }),
         "li" => Some(PdfTag::Li),
         "table" => Some(PdfTag::Table),
         "thead" | "tbody" | "tfoot" => Some(PdfTag::TRowGroup),
@@ -112,9 +120,7 @@ pub fn pdf_tag_to_krilla_tag(
         PdfTag::Figure => {
             krilla::tagging::Tag::<krilla::tagging::kind::Figure>::Figure(alt_text).into()
         }
-        PdfTag::L { numbering } => {
-            krilla::tagging::Tag::L(*numbering).into()
-        }
+        PdfTag::L { numbering } => krilla::tagging::Tag::L(*numbering).into(),
         PdfTag::Lbl => krilla::tagging::Tag::<krilla::tagging::kind::Lbl>::Lbl.into(),
         PdfTag::LBody => krilla::tagging::Tag::<krilla::tagging::kind::LBody>::LBody.into(),
         PdfTag::Li => krilla::tagging::Tag::<krilla::tagging::kind::LI>::LI.into(),
@@ -159,11 +165,15 @@ mod tests {
         use krilla::tagging::ListNumbering;
         assert_eq!(
             classify_element("ul"),
-            Some(PdfTag::L { numbering: ListNumbering::Disc })
+            Some(PdfTag::L {
+                numbering: ListNumbering::Disc
+            })
         );
         assert_eq!(
             classify_element("ol"),
-            Some(PdfTag::L { numbering: ListNumbering::Decimal })
+            Some(PdfTag::L {
+                numbering: ListNumbering::Decimal
+            })
         );
         assert_eq!(classify_element("li"), Some(PdfTag::Li));
         assert_eq!(classify_element("table"), Some(PdfTag::Table));
@@ -221,7 +231,9 @@ mod tests {
         ));
         assert!(matches!(
             pdf_tag_to_krilla_tag(
-                &PdfTag::L { numbering: krilla::tagging::ListNumbering::Disc },
+                &PdfTag::L {
+                    numbering: krilla::tagging::ListNumbering::Disc
+                },
                 None,
                 None
             ),

--- a/crates/fulgur/src/tagging.rs
+++ b/crates/fulgur/src/tagging.rs
@@ -14,8 +14,10 @@ use crate::drawables::NodeId;
 /// HTML semantics to. Render-side translation to the Krilla type
 /// happens in `fulgur-izp.5`; until then this enum is convert-side
 /// only, so it intentionally avoids carrying Krilla-specific types
-/// (`ListNumbering`, `TableHeaderScope`, alt text, heading title) —
+/// (`TableHeaderScope`, alt text, heading title) —
 /// those flow from the DOM at render time once the wire-up lands.
+/// `ListNumbering` is carried here because `ul`/`ol` distinction is
+/// known at classify time from the element local name.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PdfTag {
     P,
@@ -23,7 +25,9 @@ pub enum PdfTag {
     Div,
     Span,
     Figure,
-    L,
+    L { numbering: krilla::tagging::ListNumbering },
+    Lbl,
+    LBody,
     Li,
     Table,
     TRowGroup,
@@ -70,7 +74,8 @@ pub fn classify_element(local_name: &str) -> Option<PdfTag> {
         }
         "span" => Some(PdfTag::Span),
         "img" => Some(PdfTag::Figure),
-        "ul" | "ol" => Some(PdfTag::L),
+        "ul" => Some(PdfTag::L { numbering: krilla::tagging::ListNumbering::Disc }),
+        "ol" => Some(PdfTag::L { numbering: krilla::tagging::ListNumbering::Decimal }),
         "li" => Some(PdfTag::Li),
         "table" => Some(PdfTag::Table),
         "thead" | "tbody" | "tfoot" => Some(PdfTag::TRowGroup),
@@ -107,9 +112,11 @@ pub fn pdf_tag_to_krilla_tag(
         PdfTag::Figure => {
             krilla::tagging::Tag::<krilla::tagging::kind::Figure>::Figure(alt_text).into()
         }
-        PdfTag::L => {
-            krilla::tagging::Tag::L(krilla::tagging::ListNumbering::None).into() // numbering: fulgur-izp.7
+        PdfTag::L { numbering } => {
+            krilla::tagging::Tag::L(*numbering).into()
         }
+        PdfTag::Lbl => krilla::tagging::Tag::<krilla::tagging::kind::Lbl>::Lbl.into(),
+        PdfTag::LBody => krilla::tagging::Tag::<krilla::tagging::kind::LBody>::LBody.into(),
         PdfTag::Li => krilla::tagging::Tag::<krilla::tagging::kind::LI>::LI.into(),
         PdfTag::Table => krilla::tagging::Tag::<krilla::tagging::kind::Table>::Table.into(),
         PdfTag::TRowGroup => krilla::tagging::Tag::<krilla::tagging::kind::TBody>::TBody.into(),
@@ -149,8 +156,15 @@ mod tests {
 
     #[test]
     fn classify_element_recognises_lists_and_tables() {
-        assert_eq!(classify_element("ul"), Some(PdfTag::L));
-        assert_eq!(classify_element("ol"), Some(PdfTag::L));
+        use krilla::tagging::ListNumbering;
+        assert_eq!(
+            classify_element("ul"),
+            Some(PdfTag::L { numbering: ListNumbering::Disc })
+        );
+        assert_eq!(
+            classify_element("ol"),
+            Some(PdfTag::L { numbering: ListNumbering::Decimal })
+        );
         assert_eq!(classify_element("li"), Some(PdfTag::Li));
         assert_eq!(classify_element("table"), Some(PdfTag::Table));
         assert_eq!(classify_element("thead"), Some(PdfTag::TRowGroup));
@@ -206,8 +220,20 @@ mod tests {
             TagKind::Figure(_)
         ));
         assert!(matches!(
-            pdf_tag_to_krilla_tag(&PdfTag::L, None, None),
+            pdf_tag_to_krilla_tag(
+                &PdfTag::L { numbering: krilla::tagging::ListNumbering::Disc },
+                None,
+                None
+            ),
             TagKind::L(_)
+        ));
+        assert!(matches!(
+            pdf_tag_to_krilla_tag(&PdfTag::Lbl, None, None),
+            TagKind::Lbl(_)
+        ));
+        assert!(matches!(
+            pdf_tag_to_krilla_tag(&PdfTag::LBody, None, None),
+            TagKind::LBody(_)
         ));
         assert!(matches!(
             pdf_tag_to_krilla_tag(&PdfTag::Li, None, None),

--- a/docs/plans/2026-05-05-tagged-pdf-list-tags-impl.md
+++ b/docs/plans/2026-05-05-tagged-pdf-list-tags-impl.md
@@ -1,0 +1,786 @@
+# Tagged PDF List Structure Tags Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** `ul`/`ol`/`li` を PDF StructTree で L / LI / Lbl / LBody へ対応させ、マーカーと本文を正しくタグ付けする。
+
+**Architecture:** `PdfTag::L` に `ListNumbering` を追加。`walk_semantics` に `parent_override` を導入し `li` ごとに合成 `Lbl`/`LBody` エントリを作成。render 側でマーカー描画を `Lbl` タグコンテンツで囲み、inline-root `li` の body を `LBody` 配下に記録する。
+
+**Tech Stack:** Rust, krilla (PDF/Tagged), Stylo (CSS computed values), Blitz DOM, BTreeMap for semantics
+
+---
+
+### Task 1: `PdfTag` 拡張 — `Lbl`/`LBody` 追加と `L` への `ListNumbering`
+
+**Files:**
+- Modify: `crates/fulgur/src/tagging.rs`
+
+**Step 1: 既存テストを確認し変更対象を把握**
+
+```bash
+cargo test --package fulgur -- tagging 2>&1 | tail -10
+```
+
+期待: 全テスト pass（現状確認）
+
+**Step 2: `PdfTag` に `Lbl`/`LBody` を追加し `L` に `numbering` フィールドを追加**
+
+`crates/fulgur/src/tagging.rs` の `PdfTag` enum を変更:
+
+```rust
+pub enum PdfTag {
+    P,
+    H { level: u8 },
+    Div,
+    Span,
+    Figure,
+    L { numbering: krilla::tagging::ListNumbering },
+    Lbl,
+    LBody,
+    Li,
+    Table,
+    TRowGroup,
+    Tr,
+    Th,
+    Td,
+}
+```
+
+**Step 3: `classify_element` を更新**
+
+```rust
+"ul" => Some(PdfTag::L { numbering: krilla::tagging::ListNumbering::Disc }),
+"ol" => Some(PdfTag::L { numbering: krilla::tagging::ListNumbering::Decimal }),
+```
+
+**Step 4: `pdf_tag_to_krilla_tag` を更新**
+
+```rust
+PdfTag::L { numbering } => {
+    krilla::tagging::Tag::L(*numbering).into()
+}
+PdfTag::Lbl => krilla::tagging::Tag::<krilla::tagging::kind::Lbl>::Lbl.into(),
+PdfTag::LBody => krilla::tagging::Tag::<krilla::tagging::kind::LBody>::LBody.into(),
+```
+
+**Step 5: `tagging.rs` 内テストを更新**
+
+- `classify_element_recognises_lists_and_tables` で `L { numbering: Disc/Decimal }` を確認するよう修正
+- `pdf_tag_to_krilla_tag_covers_all_variants` に `Lbl`/`LBody` ケースを追加
+
+```rust
+assert!(matches!(
+    pdf_tag_to_krilla_tag(&PdfTag::L { numbering: ListNumbering::Disc }, None, None),
+    TagKind::L(_)
+));
+assert!(matches!(
+    pdf_tag_to_krilla_tag(&PdfTag::Lbl, None, None),
+    TagKind::Lbl(_)
+));
+assert!(matches!(
+    pdf_tag_to_krilla_tag(&PdfTag::LBody, None, None),
+    TagKind::LBody(_)
+));
+```
+
+**Step 6: コンパイルエラーを修正してテストを通す**
+
+`PdfTag::L` に `numbering` フィールドを追加すると、`convert/mod.rs:1106` にコンパイルエラーが発生する。
+render.rs には `PdfTag::L` のパターンマッチがないためそこは影響なし。
+
+`crates/fulgur/src/convert/mod.rs:1106` を修正:
+```rust
+// Before:
+let lists = entries_by_tag(&d, &PdfTag::L);
+// After:
+let lists = entries_by_tag(&d, &PdfTag::L { numbering: krilla::tagging::ListNumbering::Disc });
+```
+
+コンパイル確認:
+```bash
+cargo build --package fulgur 2>&1 | grep "^error" | head -10
+```
+
+期待: エラー 0 件
+
+テスト確認:
+```bash
+cargo test --package fulgur -- tagging 2>&1 | tail -10
+```
+
+期待: 全テスト pass
+
+**Step 7: コミット**
+
+```bash
+git add crates/fulgur/src/tagging.rs
+git commit -m "feat(tagging): add Lbl/LBody variants and ListNumbering to PdfTag::L (fulgur-izp.7)"
+```
+
+---
+
+### Task 2: `Drawables` に合成 NodeId サポートを追加
+
+**Files:**
+- Modify: `crates/fulgur/src/drawables.rs`
+
+**Step 1: 既存テストを確認**
+
+```bash
+cargo test --package fulgur 2>&1 | tail -5
+```
+
+**Step 2: `Drawables` にフィールドを追加**
+
+`crates/fulgur/src/drawables.rs` の `Drawables` struct に追加:
+
+```rust
+/// 合成 NodeId カウンタ。usize::MAX / 2 から降順に割り当て。
+/// DOM NodeId（通常 < 100_000）との衝突を避けるため大きな値から開始する。
+pub synthetic_id_counter: usize,
+/// li NodeId → Lbl 合成 NodeId（render pass のマーカータグ付け用）
+pub li_lbl_ids: BTreeMap<NodeId, NodeId>,
+/// li NodeId → LBody 合成 NodeId（inline-root li の body タグ付け用）
+pub li_lbody_ids: BTreeMap<NodeId, NodeId>,
+```
+
+**Step 3: `Default` derivation を確認し、手動 impl が必要なら追加**
+
+`Drawables` が `#[derive(Default)]` を使っているなら `synthetic_id_counter` の初期値が `0` になるため、手動 impl が必要。
+
+`Drawables` の `Default` を確認:
+```bash
+grep -n "derive.*Default\|impl Default for Drawables" crates/fulgur/src/drawables.rs
+```
+
+`#[derive(Default)]` ならば `Default` を手動に切り替え:
+
+```rust
+impl Default for Drawables {
+    fn default() -> Self {
+        Self {
+            body_id: None,
+            body_offset_pt: (0.0, 0.0),
+            block_styles: BTreeMap::new(),
+            paragraphs: BTreeMap::new(),
+            paragraph_slices: BTreeMap::new(),
+            images: BTreeMap::new(),
+            svgs: BTreeMap::new(),
+            tables: BTreeMap::new(),
+            list_items: BTreeMap::new(),
+            multicol_rules: BTreeMap::new(),
+            transforms: BTreeMap::new(),
+            bookmark_anchors: BTreeMap::new(),
+            link_spans: Vec::new(),
+            semantics: BTreeMap::new(),
+            inline_box_subtree_skip: std::collections::BTreeSet::new(),
+            inline_box_subtree_descendants: BTreeMap::new(),
+            synthetic_id_counter: usize::MAX / 2,
+            li_lbl_ids: BTreeMap::new(),
+            li_lbody_ids: BTreeMap::new(),
+        }
+    }
+}
+```
+
+**Step 4: `alloc_synthetic_id` メソッドを追加**
+
+`Drawables` impl ブロックに:
+
+```rust
+/// 合成 NodeId を 1 つ割り当てる。
+/// `usize::MAX / 2` から始まり降順に割り当てるので DOM NodeId と衝突しない。
+pub fn alloc_synthetic_id(&mut self) -> NodeId {
+    let id = self.synthetic_id_counter;
+    self.synthetic_id_counter = self.synthetic_id_counter.saturating_sub(1);
+    id
+}
+```
+
+**Step 5: `is_empty` メソッドを更新**
+
+`li_lbl_ids` / `li_lbody_ids` は semantics ベースのメタデータなので `is_empty` には含めない（データペイロードではないため）。
+
+**Step 6: テスト通過確認**
+
+```bash
+cargo test --package fulgur 2>&1 | tail -5
+```
+
+**Step 7: コミット**
+
+```bash
+git add crates/fulgur/src/drawables.rs
+git commit -m "feat(drawables): add synthetic_id_counter, li_lbl_ids, li_lbody_ids for Lbl/LBody (fulgur-izp.7)"
+```
+
+---
+
+### Task 3: `walk_semantics` に `parent_override` と li 特別処理を追加
+
+**Files:**
+- Modify: `crates/fulgur/src/convert/mod.rs`
+
+**Step 1: テスト用ヘルパーを確認**
+
+```bash
+grep -n "dom_to_drawables_records_semantic\|make_drawables\|entries_by_tag" crates/fulgur/src/convert/mod.rs | head -10
+```
+
+**Step 2: フェイリングテストを書く**
+
+`crates/fulgur/src/convert/mod.rs` の `#[cfg(test)]` セクションに追加:
+
+```rust
+#[test]
+fn walk_semantics_li_creates_lbl_and_lbody_synthetic_entries() {
+    let html = "<!DOCTYPE html><html><body><ul><li>item</li></ul></body></html>";
+    let d = make_drawables(html);
+
+    // li_lbl_ids と li_lbody_ids に 1 エントリずつあること
+    assert_eq!(d.li_lbl_ids.len(), 1, "one li_lbl_ids entry");
+    assert_eq!(d.li_lbody_ids.len(), 1, "one li_lbody_ids entry");
+
+    // li_lbl_ids のキー = li NodeId、値 = Lbl 合成 NodeId
+    let (&li_id, &lbl_id) = d.li_lbl_ids.iter().next().unwrap();
+    let lbody_id = d.li_lbody_ids[&li_id];
+
+    // semantics に Lbl エントリがあり、parent = li_id
+    let lbl_entry = &d.semantics[&lbl_id];
+    assert_eq!(lbl_entry.tag, PdfTag::Lbl);
+    assert_eq!(lbl_entry.parent, Some(li_id));
+
+    // semantics に LBody エントリがあり、parent = li_id
+    let lbody_entry = &d.semantics[&lbody_id];
+    assert_eq!(lbody_entry.tag, PdfTag::LBody);
+    assert_eq!(lbody_entry.parent, Some(li_id));
+}
+
+#[test]
+fn walk_semantics_li_paragraph_parent_is_lbody() {
+    // li 直下のテキスト（inline-root）は lbody_id を親に持つ
+    let html = "<!DOCTYPE html><html><body><ul><li>item</li></ul></body></html>";
+    let d = make_drawables(html);
+    let (&li_id, _) = d.li_lbl_ids.iter().next().unwrap();
+    let lbody_id = d.li_lbody_ids[&li_id];
+
+    // P タグを探す
+    let p_entries: Vec<_> = d.semantics.iter()
+        .filter(|(_, e)| e.tag == PdfTag::P)
+        .collect();
+    // li 直下テキストは <p> タグがないため P がない場合もある
+    // その場合は lbody_id が semantics に存在すること自体を確認
+    let _ = d.semantics.get(&lbody_id).expect("lbody in semantics");
+    // P がある場合は parent が lbody_id であること
+    for (_, entry) in &p_entries {
+        if entry.parent == Some(li_id) {
+            panic!("P's parent should be lbody_id, not li_id directly");
+        }
+    }
+}
+
+#[test]
+fn walk_semantics_nested_list_structure() {
+    let html = "<!DOCTYPE html><html><body>\
+        <ul><li><ol><li>nested</li></ol></li></ul>\
+        </body></html>";
+    let d = make_drawables(html);
+
+    // 2 つの li があるので li_lbl_ids に 2 エントリ
+    assert_eq!(d.li_lbl_ids.len(), 2);
+
+    // inner li の Lbl の parent chain を確認
+    // inner li → inner ul → outer LBody → outer LI
+    let lists = entries_by_tag(&d, &PdfTag::L { numbering: krilla::tagging::ListNumbering::Decimal });
+    assert_eq!(lists.len(), 1, "one ol");
+    let (inner_ul_id, inner_ul_entry) = lists[0];
+
+    // inner ul の parent は outer li の lbody_id であること
+    let outer_li_ids: Vec<_> = d.li_lbl_ids.keys().copied()
+        .filter(|&id| d.li_lbody_ids.get(&id).copied() == inner_ul_entry.parent)
+        .collect();
+    assert_eq!(outer_li_ids.len(), 1, "inner ul parent should be outer li's lbody");
+}
+```
+
+**Step 3: テストが失敗することを確認**
+
+```bash
+cargo test --package fulgur -- walk_semantics_li 2>&1 | tail -20
+```
+
+期待: FAIL（`li_lbl_ids` フィールドが空など）
+
+**Step 4: `walk_semantics` に `parent_override` を追加**
+
+`crates/fulgur/src/convert/mod.rs` の `walk_semantics` 関数のシグネチャを変更:
+
+```rust
+fn walk_semantics(
+    doc: &BaseDocument,
+    node_id: usize,
+    depth: usize,
+    parent_override: Option<usize>,
+    out: &mut crate::drawables::Drawables,
+)
+```
+
+呼び出し元 (`record_semantics_pass`) を更新:
+```rust
+walk_semantics(base, body_id, 0, None, out);
+```
+
+**Step 5: `walk_semantics` の本体を書き直す**
+
+```rust
+fn walk_semantics(
+    doc: &BaseDocument,
+    node_id: usize,
+    depth: usize,
+    parent_override: Option<usize>,
+    out: &mut crate::drawables::Drawables,
+) {
+    if depth >= MAX_DOM_DEPTH {
+        return;
+    }
+    let Some(node) = doc.get_node(node_id) else {
+        return;
+    };
+
+    let (classified, child_override) = if let Some(elem) = node.element_data() {
+        if let Some(mut tag) = crate::tagging::classify_element(elem.name.local.as_ref()) {
+            // CSS list-style-type を読んで ListNumbering をオーバーライド
+            if matches!(tag, crate::tagging::PdfTag::L { .. }) {
+                if let Some(styles) = node.primary_styles() {
+                    use ::style::computed_values::list_style_type::T as LST;
+                    use krilla::tagging::ListNumbering;
+                    let numbering = match styles.clone_list_style_type() {
+                        LST::Disc => ListNumbering::Disc,
+                        LST::Circle => ListNumbering::Circle,
+                        LST::Square => ListNumbering::Square,
+                        LST::Decimal => ListNumbering::Decimal,
+                        LST::LowerAlpha => ListNumbering::LowerAlpha,
+                        LST::UpperAlpha => ListNumbering::UpperAlpha,
+                        _ => ListNumbering::None,
+                    };
+                    tag = crate::tagging::PdfTag::L { numbering };
+                }
+            }
+
+            // parent を決定: override があればそれを使い、なければ DOM walk-up
+            let parent_node_id = if let Some(ov) = parent_override {
+                Some(ov)
+            } else {
+                let mut p = node.parent;
+                loop {
+                    let Some(pid) = p else { break None };
+                    if out.semantics.contains_key(&pid) {
+                        break Some(pid);
+                    }
+                    p = doc.get_node(pid).and_then(|n| n.parent);
+                }
+            };
+
+            let alt_text = if matches!(tag, crate::tagging::PdfTag::Figure) {
+                // get_attr は既存のローカル関数
+                node.element_data()
+                    .and_then(|e| get_attr(e, "alt"))
+                    .map(|v| v.to_owned())
+            } else {
+                None
+            };
+
+            let is_li = matches!(tag, crate::tagging::PdfTag::Li);
+            out.semantics.insert(
+                node_id,
+                crate::tagging::SemanticEntry {
+                    tag,
+                    parent: parent_node_id,
+                    alt_text,
+                },
+            );
+
+            if is_li {
+                // Lbl / LBody 合成エントリを作成
+                let lbl_id = out.alloc_synthetic_id();
+                let lbody_id = out.alloc_synthetic_id();
+                out.semantics.insert(
+                    lbl_id,
+                    crate::tagging::SemanticEntry {
+                        tag: crate::tagging::PdfTag::Lbl,
+                        parent: Some(node_id),
+                        alt_text: None,
+                    },
+                );
+                out.semantics.insert(
+                    lbody_id,
+                    crate::tagging::SemanticEntry {
+                        tag: crate::tagging::PdfTag::LBody,
+                        parent: Some(node_id),
+                        alt_text: None,
+                    },
+                );
+                out.li_lbl_ids.insert(node_id, lbl_id);
+                out.li_lbody_ids.insert(node_id, lbody_id);
+                // li の子は lbody_id を parent として再帰
+                for &child_id in &node.children {
+                    walk_semantics(doc, child_id, depth + 1, Some(lbody_id), out);
+                }
+                return; // 通常の再帰をスキップ
+            }
+
+            (true, None) // 分類済み要素: 子は override リセット
+        } else {
+            (false, parent_override) // 非分類要素: override を引き継ぐ
+        }
+    } else {
+        (false, parent_override) // 要素でないノード: override を引き継ぐ
+    };
+
+    let _ = classified; // unused variable を抑制
+    for &child_id in &node.children {
+        walk_semantics(doc, child_id, depth + 1, child_override, out);
+    }
+}
+```
+
+**Step 6: 既存テスト `dom_to_drawables_records_semantic_entries_for_lists` を更新**
+
+`PdfTag::L` → `PdfTag::L { numbering: ListNumbering::Disc }` に合わせて修正。
+
+**Step 7: テストを通す**
+
+```bash
+cargo test --package fulgur -- semantics 2>&1 | tail -20
+```
+
+**Step 8: コミット**
+
+```bash
+git add crates/fulgur/src/convert/mod.rs
+git commit -m "feat(convert): walk_semantics creates Lbl/LBody synthetic entries for li (fulgur-izp.7)"
+```
+
+---
+
+### Task 4: `render.rs` — `try_start_tagged` / `finish_tagged` 拡張とマーカータグ付け
+
+**Files:**
+- Modify: `crates/fulgur/src/render.rs`
+
+**Step 1: `try_start_tagged` の返り型を変更**
+
+`record_id`（TagCollector.record に渡す NodeId）を tuple に含める:
+
+```rust
+// Before:
+fn try_start_tagged(...) -> Option<(PdfTag, Identifier, Option<String>)>
+
+// After:
+fn try_start_tagged(...) -> Option<(usize, PdfTag, Identifier, Option<String>)>
+```
+
+**Step 2: `try_start_tagged` の本体を更新**
+
+```rust
+fn try_start_tagged(
+    canvas: &mut crate::draw_primitives::Canvas<'_, '_>,
+    node_id: usize,
+    drawables: &Drawables,
+) -> Option<(usize, crate::tagging::PdfTag, krilla::tagging::Identifier, Option<String>)> {
+    canvas.tag_collector.as_ref()?;
+    let semantic = drawables.semantics.get(&node_id)?;
+    match &semantic.tag {
+        crate::tagging::PdfTag::P | crate::tagging::PdfTag::Span => {
+            use krilla::tagging::{ContentTag, SpanTag};
+            let id = canvas.surface.start_tagged(ContentTag::Span(SpanTag::empty()));
+            Some((node_id, semantic.tag.clone(), id, None))
+        }
+        crate::tagging::PdfTag::H { .. } => {
+            let heading_title = drawables.paragraphs.get(&node_id).map(|para| {
+                para.lines
+                    .iter()
+                    .flat_map(|line| line.items.iter())
+                    .filter_map(|item| match item {
+                        crate::paragraph::LineItem::Text(run) => Some(run.text.as_str()),
+                        _ => None,
+                    })
+                    .collect::<String>()
+            });
+            use krilla::tagging::{ContentTag, SpanTag};
+            let id = canvas.surface.start_tagged(ContentTag::Span(SpanTag::empty()));
+            Some((node_id, semantic.tag.clone(), id, heading_title))
+        }
+        crate::tagging::PdfTag::Li => {
+            // inline-root li: コンテンツを lbody_id で記録
+            let &lbody_id = drawables.li_lbody_ids.get(&node_id)?;
+            use krilla::tagging::{ContentTag, SpanTag};
+            let id = canvas.surface.start_tagged(ContentTag::Span(SpanTag::empty()));
+            Some((lbody_id, crate::tagging::PdfTag::LBody, id, None))
+        }
+        _ => None,
+    }
+}
+```
+
+**Step 3: `finish_tagged` の引数を変更**
+
+```rust
+fn finish_tagged(
+    canvas: &mut crate::draw_primitives::Canvas<'_, '_>,
+    tag_info: Option<(usize, crate::tagging::PdfTag, krilla::tagging::Identifier, Option<String>)>,
+) {
+    if let Some((record_id, tag, id, heading_title)) = tag_info {
+        canvas.surface.end_tagged();
+        canvas
+            .tag_collector
+            .as_mut()
+            .expect("tag_collector is Some when tag_info is Some")
+            .record(record_id, tag, id, heading_title);
+    }
+}
+```
+
+**Step 4: `finish_tagged` の呼び出し側を更新**
+
+呼び出し元:
+- Line 949: `finish_tagged(canvas, node_id, tag_info)` → `finish_tagged(canvas, tag_info)`
+- Line 989: `finish_tagged(canvas, node_id, tag_info)` → `finish_tagged(canvas, tag_info)`
+
+**Step 5: `draw_list_item_with_block` に `node_id` を追加し、マーカータグ付けを実装**
+
+```rust
+fn draw_list_item_with_block(
+    canvas: &mut crate::draw_primitives::Canvas<'_, '_>,
+    node_id: usize,  // 追加
+    list_item: &crate::drawables::ListItemEntry,
+    // ... 既存パラメータ
+) {
+    // ...
+
+    draw_with_opacity(canvas, list_item.opacity, |canvas| {
+        if list_item.visible {
+            // outside marker タグ付け
+            let lbl_id = canvas.tag_collector.as_ref()
+                .and_then(|_| drawables.li_lbl_ids.get(&node_id).copied());
+            let marker_tag_id = lbl_id.map(|_| {
+                canvas.surface.start_tagged(
+                    krilla::tagging::ContentTag::Span(krilla::tagging::SpanTag::empty())
+                )
+            });
+
+            draw_list_item_marker(canvas, list_item, x, y);
+
+            if let (Some(lid), Some(id)) = (lbl_id, marker_tag_id) {
+                canvas.surface.end_tagged();
+                canvas.tag_collector.as_mut()
+                    .unwrap()
+                    .record(lid, crate::tagging::PdfTag::Lbl, id, None);
+            }
+        }
+        // ... 残り既存コード
+    });
+}
+```
+
+呼び出し元 (`dispatch_fragment` の line 871 付近) に `node_id` を追加:
+```rust
+draw_list_item_with_block(
+    canvas,
+    node_id,  // 追加
+    li,
+    block_for_li,
+    // ...
+);
+```
+
+**Step 6: `draw_under_clip` 内のマーカー描画にもタグ付けを追加**
+
+`draw_under_clip` 関数内の `draw_list_item_marker` 呼び出し（line 1531 付近）:
+
+```rust
+if let Some(li) = list_item
+    && li.visible
+{
+    let lbl_id = canvas.tag_collector.as_ref()
+        .and_then(|_| drawables.li_lbl_ids.get(&node_id).copied());
+    let marker_tag_id = lbl_id.map(|_| {
+        canvas.surface.start_tagged(
+            krilla::tagging::ContentTag::Span(krilla::tagging::SpanTag::empty())
+        )
+    });
+
+    draw_list_item_marker(canvas, li, x_pt, y_pt);
+
+    if let (Some(lid), Some(id)) = (lbl_id, marker_tag_id) {
+        canvas.surface.end_tagged();
+        canvas.tag_collector.as_mut()
+            .unwrap()
+            .record(lid, crate::tagging::PdfTag::Lbl, id, None);
+    }
+}
+```
+
+**Step 7: コンパイル確認**
+
+```bash
+cargo build --package fulgur 2>&1 | tail -10
+```
+
+**Step 8: 全テスト通過確認**
+
+```bash
+cargo test --package fulgur 2>&1 | tail -10
+```
+
+**Step 9: コミット**
+
+```bash
+git add crates/fulgur/src/render.rs
+git commit -m "feat(render): tag list marker under Lbl, inline-root li body under LBody (fulgur-izp.7)"
+```
+
+---
+
+### Task 5: インテグレーションテスト
+
+**Files:**
+- Modify: `crates/fulgur-cli/tests/tagged_cli.rs`
+
+既存のテストは `run_cli` ヘルパー経由でバイナリを起動し、生成した PDF バイト列を
+`String::from_utf8_lossy` で確認するパターン。同じパターンで追加する。
+
+**Step 1: フェイリングテストを追加**
+
+`crates/fulgur-cli/tests/tagged_cli.rs` の末尾に追加:
+
+```rust
+#[test]
+fn tagged_pdf_ul_has_lbl_lbody_tags() {
+    let dir = TempDir::new().expect("create temp dir");
+    let html_path = dir.path().join("doc.html");
+    let pdf_path = dir.path().join("doc.pdf");
+    std::fs::write(
+        &html_path,
+        "<!DOCTYPE html><html><body><ul><li>first</li><li>second</li></ul></body></html>",
+    )
+    .unwrap();
+
+    let out = run_cli(&[
+        "render",
+        html_path.to_str().unwrap(),
+        "-o",
+        pdf_path.to_str().unwrap(),
+        "--tagged",
+    ]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "CLI failed: {stderr}");
+
+    let pdf = std::fs::read(&pdf_path).unwrap();
+    let s = String::from_utf8_lossy(&pdf);
+    // LI/Lbl/LBody はいずれも PDF 名前空間内で一意なため安全にバイト検索できる
+    assert!(s.contains("/LI"), "tagged ul must contain /LI struct element");
+    assert!(s.contains("/Lbl"), "tagged ul must contain /Lbl (marker label)");
+    assert!(s.contains("/LBody"), "tagged ul must contain /LBody (list body)");
+}
+
+#[test]
+fn tagged_pdf_ol_has_lbl_lbody_tags() {
+    let dir = TempDir::new().expect("create temp dir");
+    let html_path = dir.path().join("doc.html");
+    let pdf_path = dir.path().join("doc.pdf");
+    std::fs::write(
+        &html_path,
+        "<!DOCTYPE html><html><body><ol><li>first</li><li>second</li></ol></body></html>",
+    )
+    .unwrap();
+
+    let out = run_cli(&[
+        "render",
+        html_path.to_str().unwrap(),
+        "-o",
+        pdf_path.to_str().unwrap(),
+        "--tagged",
+    ]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "CLI failed: {stderr}");
+
+    let pdf = std::fs::read(&pdf_path).unwrap();
+    let s = String::from_utf8_lossy(&pdf);
+    assert!(s.contains("/LI"), "tagged ol must contain /LI");
+    assert!(s.contains("/Lbl"), "tagged ol must contain /Lbl");
+    assert!(s.contains("/LBody"), "tagged ol must contain /LBody");
+}
+
+#[test]
+fn tagged_pdf_nested_list_does_not_panic() {
+    let dir = TempDir::new().expect("create temp dir");
+    let html_path = dir.path().join("doc.html");
+    let pdf_path = dir.path().join("doc.pdf");
+    std::fs::write(
+        &html_path,
+        "<!DOCTYPE html><html><body><ul><li>outer<ol><li>inner</li></ol></li></ul></body></html>",
+    )
+    .unwrap();
+
+    let out = run_cli(&[
+        "render",
+        html_path.to_str().unwrap(),
+        "-o",
+        pdf_path.to_str().unwrap(),
+        "--tagged",
+    ]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "nested list CLI must not panic: {stderr}");
+
+    let pdf = std::fs::read(&pdf_path).unwrap();
+    let s = String::from_utf8_lossy(&pdf);
+    // ネストリストで LI が 2 つ（outer + inner）以上あること
+    let li_count = s.match_indices("/LI").count();
+    assert!(li_count >= 2, "nested list must have at least 2 /LI tags, got {li_count}");
+}
+```
+
+**Step 2: テストを実行して失敗を確認**
+
+```bash
+cargo test --package fulgur-cli -- tagged_pdf_ul 2>&1 | tail -20
+```
+
+Task 1〜4 実装前なら fail（または pass でも可、CLI test はバイナリをビルドして実行するので
+Task 1〜4 完了後に最終確認）。
+
+**Step 3: Task 1〜4 完了後にフル確認**
+
+```bash
+cargo test --package fulgur-cli 2>&1 | tail -15
+```
+
+全 tagged CLI テストが pass すること。
+
+**Step 4: 全テスト suite を通す**
+
+```bash
+cargo test --workspace 2>&1 | tail -15
+```
+
+**Step 5: コミット**
+
+```bash
+git add crates/fulgur-cli/tests/tagged_cli.rs
+git commit -m "test(tagged): add CLI integration tests for L/LI/Lbl/LBody list structure (fulgur-izp.7)"
+```
+
+---
+
+## 実行後の確認
+
+1. `cargo test --workspace` が全 pass すること
+2. `cargo clippy --workspace` でエラーがないこと
+3. `cargo fmt --check --workspace` でフォーマットエラーがないこと
+
+## 注意事項
+
+- `PdfTag::L { numbering }` のパターンマッチが render.rs や他の箇所で必要になる（Task 1 でコンパイルエラーを修正時に対応）
+- `Drawables` の `Default` が `#[derive(Default)]` の場合は手動 `impl Default` に切り替えが必要（`synthetic_id_counter = usize::MAX / 2` のため）
+- inside marker（`list-style-position: inside`）は `Lbl` タグなし（`Lbl` グループが空になる）。これは既知の制限事項


### PR DESCRIPTION
## 概要

tagged PDF で `ul`/`ol`/`li` 要素が PDF StructTree の L / LI / Lbl / LBody タグへ対応されるようにする（fulgur-izp.7）。

- `PdfTag::L` に `numbering: ListNumbering` フィールドを追加し、`Lbl`/`LBody` variant を新規追加
- `ul` → `ListNumbering::Disc`、`ol` → `ListNumbering::Decimal`（CSS `list-style-type` でオーバーライド可能）
- `walk_semantics` に `parent_override` を導入し、各 `li` ごとに Lbl/LBody 合成エントリを作成
- render 時にリストマーカーを `Lbl` タグで、inline-root li のコンテンツを `LBody` タグで記録
- ネストリスト（`ul > li > ol > li`）で parent_override が正しく連鎖する
- CLI インテグレーションテスト 3 件追加（ul/ol/ネストリスト）

## 既知の制限事項

- `overflow:hidden` な `li` の inline-root 段落は `draw_under_clip` 経路では LBody タグ付けされない（`render.rs` にコメントあり）
- inside marker（`list-style-position: inside`）の Lbl タグ付けは未実装

## テスト計画

- [x] `cargo test --workspace` 全 pass
- [x] `cargo clippy --workspace` エラーなし
- [x] `cargo fmt --check --workspace` 差分なし
- [x] `tagged_pdf_ul_has_lbl_lbody_tags` — ul で /LI /Lbl /LBody が PDF に含まれることを CLI 経由で確認
- [x] `tagged_pdf_ol_has_lbl_lbody_tags` — ol で同様
- [x] `tagged_pdf_nested_list_does_not_panic` — ネストリストでパニックせず /LI が 2 件以上あることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * HTML のリスト出力の PDF/UA タグ対応を強化し、箇条・番号リスト、リストマーカーおよびリスト本文が適切にタグ付けされ、番号付け表現を反映します。

* **テスト**
  * タグ付きリスト構造（/LI, /Lbl, /LBody を含む）とネスト時の振る舞いを検証する統合／単体テストを追加しました。

* **ドキュメント**
  * タグ付きリスト対応の実装計画を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->