### PR TITLE
test(convert/pseudo): add coverage for inject_inline_pseudo_images

### DIFF
--- a/crates/fulgur/src/convert/pseudo.rs
+++ b/crates/fulgur/src/convert/pseudo.rs
@@ -252,3 +252,431 @@ fn resolve_pseudo_size(size: &::style::values::computed::Size, parent_width: f32
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::image::ImageFormat;
+    use crate::paragraph::{
+        InlineBoxItem, InlineImage, LineItem, ShapedGlyph, ShapedGlyphRun, ShapedLine,
+        TextDecoration, VerticalAlign,
+    };
+    use std::sync::Arc;
+
+    fn make_image(width: f32) -> InlineImage {
+        InlineImage {
+            data: Arc::new(vec![]),
+            format: ImageFormat::Png,
+            width,
+            height: 10.0,
+            x_offset: 0.0,
+            vertical_align: VerticalAlign::Baseline,
+            opacity: 1.0,
+            visible: true,
+            computed_y: 0.0,
+            link: None,
+        }
+    }
+
+    fn empty_line() -> ShapedLine {
+        ShapedLine {
+            height: 16.0,
+            baseline: 12.0,
+            items: vec![],
+        }
+    }
+
+    fn image_line(x_offset: f32, width: f32) -> ShapedLine {
+        ShapedLine {
+            height: 16.0,
+            baseline: 12.0,
+            items: vec![LineItem::Image(InlineImage {
+                data: Arc::new(vec![]),
+                format: ImageFormat::Png,
+                width,
+                height: 10.0,
+                x_offset,
+                vertical_align: VerticalAlign::Baseline,
+                opacity: 1.0,
+                visible: true,
+                computed_y: 0.0,
+                link: None,
+            })],
+        }
+    }
+
+    fn approx(a: f32, b: f32) -> bool {
+        (a - b).abs() < 0.001
+    }
+
+    // ── empty-lines guards ───────────────────────────────────────────────────
+
+    #[test]
+    fn no_lines_both_none_is_noop() {
+        let mut lines: Vec<ShapedLine> = vec![];
+        super::inject_inline_pseudo_images(&mut lines, None, None);
+        assert!(lines.is_empty());
+    }
+
+    #[test]
+    fn no_lines_before_some_is_noop() {
+        let mut lines: Vec<ShapedLine> = vec![];
+        super::inject_inline_pseudo_images(&mut lines, Some(make_image(20.0)), None);
+        assert!(lines.is_empty());
+    }
+
+    #[test]
+    fn no_lines_after_some_is_noop() {
+        let mut lines: Vec<ShapedLine> = vec![];
+        super::inject_inline_pseudo_images(&mut lines, None, Some(make_image(20.0)));
+        assert!(lines.is_empty());
+    }
+
+    // ── ::before insertion ───────────────────────────────────────────────────
+
+    #[test]
+    fn before_inserts_at_start_of_first_line() {
+        let mut lines = vec![empty_line()];
+        super::inject_inline_pseudo_images(&mut lines, Some(make_image(20.0)), None);
+        assert_eq!(lines[0].items.len(), 1);
+        match &lines[0].items[0] {
+            LineItem::Image(img) => {
+                assert!(approx(img.x_offset, 0.0), "x_offset={}", img.x_offset);
+                assert!(approx(img.width, 20.0));
+            }
+            _ => panic!("expected Image at index 0"),
+        }
+    }
+
+    #[test]
+    fn before_shifts_existing_image_items() {
+        // Original image at x=5, w=10.  Before image w=15.
+        // After injection: before@x=0, original@x=20.
+        let mut lines = vec![image_line(5.0, 10.0)];
+        super::inject_inline_pseudo_images(&mut lines, Some(make_image(15.0)), None);
+        assert_eq!(lines[0].items.len(), 2);
+        match &lines[0].items[0] {
+            LineItem::Image(img) => assert!(approx(img.x_offset, 0.0)),
+            _ => panic!("expected before Image at index 0"),
+        }
+        match &lines[0].items[1] {
+            LineItem::Image(img) => {
+                assert!(approx(img.x_offset, 20.0), "shifted x={}", img.x_offset);
+            }
+            _ => panic!("expected shifted Image at index 1"),
+        }
+    }
+
+    #[test]
+    fn before_shifts_text_items() {
+        // Text run at x_offset=3, font_size=10, glyph advance=5.
+        // Before image w=20 → text run shifts to x=23.
+        let run = ShapedGlyphRun {
+            font_data: Arc::new(vec![]),
+            font_index: 0,
+            font_size: 10.0,
+            color: [0, 0, 0, 255],
+            decoration: TextDecoration::default(),
+            glyphs: vec![ShapedGlyph {
+                id: 0,
+                x_advance: 5.0,
+                x_offset: 0.0,
+                y_offset: 0.0,
+                text_range: 0..1,
+            }],
+            text: "a".to_string(),
+            x_offset: 3.0,
+            link: None,
+        };
+        let mut lines = vec![ShapedLine {
+            height: 16.0,
+            baseline: 12.0,
+            items: vec![LineItem::Text(run)],
+        }];
+        super::inject_inline_pseudo_images(&mut lines, Some(make_image(20.0)), None);
+        assert_eq!(lines[0].items.len(), 2);
+        match &lines[0].items[1] {
+            LineItem::Text(r) => {
+                assert!(approx(r.x_offset, 23.0), "x_offset={}", r.x_offset);
+            }
+            _ => panic!("expected Text at index 1"),
+        }
+    }
+
+    #[test]
+    fn before_shifts_inline_box_items() {
+        let ib = InlineBoxItem {
+            node_id: None,
+            width: 30.0,
+            height: 10.0,
+            x_offset: 5.0,
+            computed_y: 0.0,
+            link: None,
+            opacity: 1.0,
+            visible: true,
+        };
+        let mut lines = vec![ShapedLine {
+            height: 16.0,
+            baseline: 12.0,
+            items: vec![LineItem::InlineBox(ib)],
+        }];
+        super::inject_inline_pseudo_images(&mut lines, Some(make_image(10.0)), None);
+        assert_eq!(lines[0].items.len(), 2);
+        match &lines[0].items[1] {
+            LineItem::InlineBox(b) => {
+                assert!(approx(b.x_offset, 15.0), "x_offset={}", b.x_offset);
+            }
+            _ => panic!("expected InlineBox at index 1"),
+        }
+    }
+
+    #[test]
+    fn before_only_affects_first_line() {
+        // Second line must not have its items shifted.
+        let mut lines = vec![image_line(0.0, 10.0), image_line(7.0, 10.0)];
+        super::inject_inline_pseudo_images(&mut lines, Some(make_image(20.0)), None);
+        assert_eq!(lines[1].items.len(), 1);
+        match &lines[1].items[0] {
+            LineItem::Image(img) => {
+                assert!(
+                    approx(img.x_offset, 7.0),
+                    "second-line x_offset={}",
+                    img.x_offset
+                );
+            }
+            _ => panic!("expected untouched Image in second line"),
+        }
+    }
+
+    // ── ::after insertion ────────────────────────────────────────────────────
+
+    #[test]
+    fn after_appends_to_last_line_x_offset_from_image_item() {
+        // Existing image: x=5, w=10 → end=15.  After gets x_offset=15.
+        let mut lines = vec![image_line(5.0, 10.0)];
+        super::inject_inline_pseudo_images(&mut lines, None, Some(make_image(20.0)));
+        assert_eq!(lines[0].items.len(), 2);
+        match &lines[0].items[1] {
+            LineItem::Image(img) => {
+                assert!(
+                    approx(img.x_offset, 15.0),
+                    "after x_offset={}",
+                    img.x_offset
+                );
+            }
+            _ => panic!("expected appended after Image"),
+        }
+    }
+
+    #[test]
+    fn after_x_offset_computed_from_text_run_glyphs() {
+        // x_offset=2, font_size=4, glyphs=[advance=3, advance=5]
+        // end_x = 2 + (3+5)*4 = 2 + 32 = 34
+        let run = ShapedGlyphRun {
+            font_data: Arc::new(vec![]),
+            font_index: 0,
+            font_size: 4.0,
+            color: [0, 0, 0, 255],
+            decoration: TextDecoration::default(),
+            glyphs: vec![
+                ShapedGlyph {
+                    id: 0,
+                    x_advance: 3.0,
+                    x_offset: 0.0,
+                    y_offset: 0.0,
+                    text_range: 0..1,
+                },
+                ShapedGlyph {
+                    id: 1,
+                    x_advance: 5.0,
+                    x_offset: 0.0,
+                    y_offset: 0.0,
+                    text_range: 1..2,
+                },
+            ],
+            text: "ab".to_string(),
+            x_offset: 2.0,
+            link: None,
+        };
+        let mut lines = vec![ShapedLine {
+            height: 16.0,
+            baseline: 12.0,
+            items: vec![LineItem::Text(run)],
+        }];
+        super::inject_inline_pseudo_images(&mut lines, None, Some(make_image(20.0)));
+        match &lines[0].items[1] {
+            LineItem::Image(img) => {
+                assert!(
+                    approx(img.x_offset, 34.0),
+                    "after x_offset={}",
+                    img.x_offset
+                );
+            }
+            _ => panic!("expected appended after Image"),
+        }
+    }
+
+    #[test]
+    fn after_x_offset_from_inline_box() {
+        // x_offset=3, width=7 → end=10
+        let ib = InlineBoxItem {
+            node_id: None,
+            width: 7.0,
+            height: 5.0,
+            x_offset: 3.0,
+            computed_y: 0.0,
+            link: None,
+            opacity: 1.0,
+            visible: true,
+        };
+        let mut lines = vec![ShapedLine {
+            height: 16.0,
+            baseline: 12.0,
+            items: vec![LineItem::InlineBox(ib)],
+        }];
+        super::inject_inline_pseudo_images(&mut lines, None, Some(make_image(5.0)));
+        match &lines[0].items[1] {
+            LineItem::Image(img) => {
+                assert!(
+                    approx(img.x_offset, 10.0),
+                    "after x_offset={}",
+                    img.x_offset
+                );
+            }
+            _ => panic!("expected appended after Image"),
+        }
+    }
+
+    #[test]
+    fn after_empty_last_line_gets_zero_x_offset() {
+        let mut lines = vec![empty_line()];
+        super::inject_inline_pseudo_images(&mut lines, None, Some(make_image(20.0)));
+        assert_eq!(lines[0].items.len(), 1);
+        match &lines[0].items[0] {
+            LineItem::Image(img) => {
+                assert!(approx(img.x_offset, 0.0), "x_offset={}", img.x_offset);
+            }
+            _ => panic!("expected after Image in empty line"),
+        }
+    }
+
+    #[test]
+    fn after_only_affects_last_line() {
+        let mut lines = vec![image_line(0.0, 10.0), image_line(0.0, 20.0)];
+        super::inject_inline_pseudo_images(&mut lines, None, Some(make_image(5.0)));
+        assert_eq!(lines[0].items.len(), 1, "first line must be untouched");
+        assert_eq!(lines[1].items.len(), 2, "last line gets after image");
+    }
+
+    #[test]
+    fn after_uses_max_across_multiple_item_types() {
+        // item1: Image x=0 w=5 → end=5
+        // item2: InlineBox x=3 w=10 → end=13  (rightmost)
+        // item3: Image x=1 w=8 → end=9
+        // fold(f32::max) must yield 13
+        let mut lines = vec![ShapedLine {
+            height: 16.0,
+            baseline: 12.0,
+            items: vec![
+                LineItem::Image(InlineImage {
+                    data: Arc::new(vec![]),
+                    format: ImageFormat::Png,
+                    width: 5.0,
+                    height: 10.0,
+                    x_offset: 0.0,
+                    vertical_align: VerticalAlign::Baseline,
+                    opacity: 1.0,
+                    visible: true,
+                    computed_y: 0.0,
+                    link: None,
+                }),
+                LineItem::InlineBox(InlineBoxItem {
+                    node_id: None,
+                    width: 10.0,
+                    height: 5.0,
+                    x_offset: 3.0,
+                    computed_y: 0.0,
+                    link: None,
+                    opacity: 1.0,
+                    visible: true,
+                }),
+                LineItem::Image(InlineImage {
+                    data: Arc::new(vec![]),
+                    format: ImageFormat::Png,
+                    width: 8.0,
+                    height: 10.0,
+                    x_offset: 1.0,
+                    vertical_align: VerticalAlign::Baseline,
+                    opacity: 1.0,
+                    visible: true,
+                    computed_y: 0.0,
+                    link: None,
+                }),
+            ],
+        }];
+        super::inject_inline_pseudo_images(&mut lines, None, Some(make_image(20.0)));
+        match lines[0].items.last().unwrap() {
+            LineItem::Image(img) => {
+                assert!(
+                    approx(img.x_offset, 13.0),
+                    "after x_offset={}",
+                    img.x_offset
+                );
+            }
+            _ => panic!("expected after Image appended"),
+        }
+    }
+
+    // ── before + after together ──────────────────────────────────────────────
+
+    #[test]
+    fn before_and_after_on_separate_lines() {
+        let mut lines = vec![image_line(0.0, 10.0), image_line(0.0, 20.0)];
+        super::inject_inline_pseudo_images(
+            &mut lines,
+            Some(make_image(5.0)),
+            Some(make_image(5.0)),
+        );
+        // First line: [before_img, shifted_original]
+        assert_eq!(lines[0].items.len(), 2);
+        match &lines[0].items[0] {
+            LineItem::Image(img) => assert!(approx(img.width, 5.0)),
+            _ => panic!("expected before Image"),
+        }
+        // Last line: [original, after_img]
+        assert_eq!(lines[1].items.len(), 2);
+        match lines[1].items.last().unwrap() {
+            LineItem::Image(img) => assert!(approx(img.width, 5.0)),
+            _ => panic!("expected after Image"),
+        }
+    }
+
+    #[test]
+    fn single_line_before_and_after_both_affect_it() {
+        // Line: image x=5 w=10.  Before w=3, after w=7.
+        // After before insertion: [before@x=0 w=3, original@x=8 w=10]
+        // After after insertion: x_offset = max(0+3, 8+10) = 18
+        let mut lines = vec![image_line(5.0, 10.0)];
+        super::inject_inline_pseudo_images(
+            &mut lines,
+            Some(make_image(3.0)),
+            Some(make_image(7.0)),
+        );
+        assert_eq!(lines[0].items.len(), 3);
+        match &lines[0].items[0] {
+            LineItem::Image(img) => assert!(approx(img.x_offset, 0.0)),
+            _ => panic!("expected before Image at 0"),
+        }
+        match &lines[0].items[1] {
+            LineItem::Image(img) => {
+                assert!(approx(img.x_offset, 8.0), "shifted x={}", img.x_offset);
+            }
+            _ => panic!("expected shifted Image at 1"),
+        }
+        match lines[0].items.last().unwrap() {
+            LineItem::Image(img) => {
+                assert!(approx(img.x_offset, 18.0), "after x={}", img.x_offset);
+            }
+            _ => panic!("expected after Image at end"),
+        }
+    }
+}


### PR DESCRIPTION
## 対象モジュール

`crates/fulgur/src/convert/pseudo.rs`

## カバレッジ変化

| 指標 | 変更前 | 変更後 |
|------|--------|--------|
| リージョンカバレッジ | 18.86% (56/297) | 67.76% (435/642) |
| 行カバレッジ | 23.81% (45/189) | 76.20% (381/500) |
| 関数カバレッジ | 33.33% (5/15) | 80.00% (28/35) |

## 追加したテスト (16件)

`inject_inline_pseudo_images` は `ShapedLine` スライスを受け取る純粋関数で、Blitz DOM を一切必要としないため単体テストが書きやすかった。

**空行ガード (3件)**
- `no_lines_both_none_is_noop` — 両方 None で空スライス → 変化なし
- `no_lines_before_some_is_noop` — 空スライスに before 画像を渡しても no-op
- `no_lines_after_some_is_noop` — 空スライスに after 画像を渡しても no-op

**`::before` 挿入 (5件)**
- `before_inserts_at_start_of_first_line` — 先頭行のインデックス 0 に挿入される
- `before_shifts_existing_image_items` — 既存の Image アイテムが width 分だけ右にシフトされる
- `before_shifts_text_items` — ShapedGlyphRun のx_offset がシフトされる
- `before_shifts_inline_box_items` — InlineBoxItem のx_offset がシフトされる
- `before_only_affects_first_line` — 2行目以降のアイテムは変化しない

**`::after` 挿入 (5件)**
- `after_appends_to_last_line_x_offset_from_image_item` — Image end_x を x_offset として追記
- `after_x_offset_computed_from_text_run_glyphs` — `x_offset + Σ(advance × font_size)` の計算を検証
- `after_x_offset_from_inline_box` — InlineBox end_x を使う
- `after_empty_last_line_gets_zero_x_offset` — 空の最終行では x_offset=0
- `after_only_affects_last_line` — 先頭行は変化しない

**`::before` + `::after` の組み合わせ (3件)**
- `after_uses_max_across_multiple_item_types` — `fold(f32::max)` が複数アイテムの最大 end_x を返す
- `before_and_after_on_separate_lines` — 複数行で before が先頭行・after が末尾行に適用される
- `single_line_before_and_after_both_affect_it` — 1行で両方適用された場合の挿入順と x_offset 計算を検証

## 意図的に除外したブランチ

以下の関数はすべて Blitz DOM (`Node`, `BaseDocument`) またはStylo computed スタイル型への依存があるため、このランでは対象外とした。

- `build_pseudo_image_entry` / `build_block_pseudo_image_entries` — `Node` と `AssetBundle` が必要
- `is_block_pseudo` / `node_has_block_pseudo_image` / `node_has_absolute_pseudo` — Stylo スタイル解決が必要
- `register_pseudo_content` — 上記ヘルパーの組み合わせ
- `build_inline_pseudo_image` / `attach_link_to_inline_image` — Blitz DOM walk が必要
- `resolve_pseudo_size` — Stylo `computed::Size` 型のコンストラクタが非公開

これらは VRT (Visual Regression Test) の通過を通じて間接的にカバーされている。

https://claude.ai/code/session_01MBLJdA815zAHs3sgcpZAF1

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBLJdA815zAHs3sgcpZAF1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * 内部テスト機能の拡張を実施しました。

**注記：** このリリースに含まれるのは内部テストの改善のみであり、ユーザーに対する直接的な影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->