### PR TITLE
perf(blitz_adapter): skip system font scan when bundled fonts are supplied

### DIFF
--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -146,12 +146,14 @@ pub fn parse_and_layout(
     viewport_width: f32,
     viewport_height: f32,
     font_data: &[Arc<Vec<u8>>],
+    system_fonts: bool,
 ) -> HtmlDocument {
     let mut doc = parse_inner(
         html,
         viewport_width,
         viewport_height as u32,
         font_data,
+        system_fonts,
         None,
         None,
     );
@@ -177,7 +179,7 @@ pub trait DomPass {
 /// [`parse_html_with_local_resources`] instead, which wires fulgur's
 /// own [`crate::net::FulgurNetProvider`] into Blitz.
 pub fn parse(html: &str, viewport_width: f32, font_data: &[Arc<Vec<u8>>]) -> HtmlDocument {
-    parse_inner(html, viewport_width, 10000, font_data, None, None)
+    parse_inner(html, viewport_width, 10000, font_data, true, None, None)
 }
 
 /// Parse HTML and load any `<link rel="stylesheet">` / `@import` files
@@ -214,6 +216,7 @@ pub fn parse_html_with_local_resources(
     viewport_width: f32,
     viewport_height_px: u32,
     font_data: &[Arc<Vec<u8>>],
+    system_fonts: bool,
     base_path: Option<&Path>,
 ) -> (HtmlDocument, crate::gcpm::GcpmContext) {
     use std::collections::HashSet;
@@ -244,6 +247,7 @@ pub fn parse_html_with_local_resources(
         viewport_width,
         viewport_height_px,
         font_data,
+        system_fonts,
         Some(provider),
         base_url,
     );
@@ -295,6 +299,7 @@ fn parse_inner(
     viewport_width: f32,
     viewport_height_px: u32,
     font_data: &[Arc<Vec<u8>>],
+    system_fonts: bool,
     net_provider: Option<Arc<dyn NetProvider<Resource>>>,
     base_url: Option<String>,
 ) -> HtmlDocument {
@@ -305,10 +310,19 @@ fn parse_inner(
         ColorScheme::Light,
     );
 
-    let font_ctx = if font_data.is_empty() {
+    let font_ctx = if font_data.is_empty() && system_fonts {
+        // No bundled fonts and system fonts allowed: let Blitz use its own
+        // default FontContext (system fonts enabled).
         None
     } else {
-        let mut ctx = FontContext::new();
+        let collection = parley::fontique::Collection::new(parley::fontique::CollectionOptions {
+            system_fonts,
+            ..Default::default()
+        });
+        let mut ctx = FontContext {
+            collection,
+            source_cache: parley::fontique::SourceCache::new(Default::default()),
+        };
         for data in font_data {
             let blob: parley::fontique::Blob<u8> = (**data).clone().into();
             ctx.collection.register_fonts(blob, None);
@@ -2647,7 +2661,7 @@ mod tests {
 <body><p class="parent-rule child-rule">x</p></body></html>"#;
 
         let (_doc, gcpm) =
-            parse_html_with_local_resources(html, 400.0, 10000, &[], Some(dir.path()));
+            parse_html_with_local_resources(html, 400.0, 10000, &[], true, Some(dir.path()));
 
         let cleaned = &gcpm.cleaned_css;
         let child_pos = cleaned
@@ -2683,7 +2697,7 @@ mod tests {
     #[test]
     fn test_parse_and_layout_unchanged() {
         let html = "<html><body><p>Test</p></body></html>";
-        let doc = parse_and_layout(html, 400.0, 600.0, &[]);
+        let doc = parse_and_layout(html, 400.0, 600.0, &[], true);
         let root = doc.root_element();
         assert!(!root.children.is_empty());
     }
@@ -3110,7 +3124,7 @@ mod tests {
         }
         html.push_str("</body></html>");
 
-        let (doc, _gcpm) = parse_html_with_local_resources(&html, 400.0, 10000, &[], None);
+        let (doc, _gcpm) = parse_html_with_local_resources(&html, 400.0, 10000, &[], true, None);
         use std::ops::Deref;
         let root = doc.root_element();
         let _ = element_text(doc.deref(), root.id);
@@ -3148,7 +3162,7 @@ mod tests {
     #[test]
     fn element_text_inserts_space_between_block_children() {
         let html = "<html><body><a id='x'><div>foo</div><div>bar</div></a></body></html>";
-        let (doc, _gcpm) = parse_html_with_local_resources(html, 400.0, 10000, &[], None);
+        let (doc, _gcpm) = parse_html_with_local_resources(html, 400.0, 10000, &[], true, None);
         use std::ops::Deref;
         let a_id = find_element_by_attr_id(doc.deref(), "x");
         let text = element_text(doc.deref(), a_id);
@@ -3158,7 +3172,7 @@ mod tests {
     #[test]
     fn element_text_inserts_space_for_br() {
         let html = "<html><body><a id='x'>foo<br>bar</a></body></html>";
-        let (doc, _gcpm) = parse_html_with_local_resources(html, 400.0, 10000, &[], None);
+        let (doc, _gcpm) = parse_html_with_local_resources(html, 400.0, 10000, &[], true, None);
         use std::ops::Deref;
         let a_id = find_element_by_attr_id(doc.deref(), "x");
         let text = element_text(doc.deref(), a_id);
@@ -3170,7 +3184,7 @@ mod tests {
         // If the text already ends in whitespace, a block boundary should
         // not add another space.
         let html = "<html><body><a id='x'>foo <div>bar</div></a></body></html>";
-        let (doc, _gcpm) = parse_html_with_local_resources(html, 400.0, 10000, &[], None);
+        let (doc, _gcpm) = parse_html_with_local_resources(html, 400.0, 10000, &[], true, None);
         use std::ops::Deref;
         let a_id = find_element_by_attr_id(doc.deref(), "x");
         let text = element_text(doc.deref(), a_id);
@@ -3186,7 +3200,7 @@ mod tests {
         let html = r#"<!doctype html><html><head>
             <style>@page { size: A4 landscape; }</style>
         </head><body>x</body></html>"#;
-        let (doc, _) = parse_html_with_local_resources(html, 400.0, 10000, &[], None);
+        let (doc, _) = parse_html_with_local_resources(html, 400.0, 10000, &[], true, None);
         let gcpm = extract_gcpm_from_inline_styles(&doc);
         assert_eq!(
             gcpm.page_settings.len(),
@@ -3198,7 +3212,7 @@ mod tests {
     #[test]
     fn extract_gcpm_from_inline_styles_returns_empty_for_no_style_tag() {
         let html = r#"<!doctype html><html><body>x</body></html>"#;
-        let (doc, _) = parse_html_with_local_resources(html, 400.0, 10000, &[], None);
+        let (doc, _) = parse_html_with_local_resources(html, 400.0, 10000, &[], true, None);
         let gcpm = extract_gcpm_from_inline_styles(&doc);
         assert!(gcpm.page_settings.is_empty());
     }
@@ -3213,7 +3227,7 @@ mod tests {
             <style>@page { size: A4 landscape; }</style>
             <style>@page { margin: 2cm; }</style>
         </head><body>x</body></html>"#;
-        let (doc, _) = parse_html_with_local_resources(html, 400.0, 10000, &[], None);
+        let (doc, _) = parse_html_with_local_resources(html, 400.0, 10000, &[], true, None);
         let gcpm = extract_gcpm_from_inline_styles(&doc);
         assert_eq!(
             gcpm.page_settings.len(),
@@ -3225,7 +3239,7 @@ mod tests {
     #[test]
     fn multicol_props_absent_on_plain_block() {
         let html = r#"<html><body><div id="p">plain</div></body></html>"#;
-        let doc = parse_and_layout(html, 400.0, 2000.0, &[]);
+        let doc = parse_and_layout(html, 400.0, 2000.0, &[], true);
         let id = find_element_by_local_name(&doc, "div").expect("div");
         assert!(extract_multicol_props(doc.get_node(id).unwrap()).is_none());
     }
@@ -3235,7 +3249,7 @@ mod tests {
         let html = r#"<html><body>
             <div id="m" style="column-count: 3; column-gap: 12px;">a</div>
         </body></html>"#;
-        let doc = parse_and_layout(html, 400.0, 2000.0, &[]);
+        let doc = parse_and_layout(html, 400.0, 2000.0, &[], true);
         let id = find_element_by_local_name(&doc, "div").expect("div");
         let props = extract_multicol_props(doc.get_node(id).unwrap()).expect("should be multicol");
         assert_eq!(props.column_count, Some(3));
@@ -3248,7 +3262,7 @@ mod tests {
         let html = r#"<html><body>
             <div id="m" style="column-width: 180px;">a</div>
         </body></html>"#;
-        let doc = parse_and_layout(html, 400.0, 2000.0, &[]);
+        let doc = parse_and_layout(html, 400.0, 2000.0, &[], true);
         let id = find_element_by_local_name(&doc, "div").expect("div");
         let props = extract_multicol_props(doc.get_node(id).unwrap()).expect("should be multicol");
         assert_eq!(props.column_count, None);
@@ -3270,7 +3284,7 @@ mod tests {
         // baselines in paragraph.rs, producing a 4/3-off visual shift. Guards
         // against regression of the PR #101 unit-consolidation.
         let html = r#"<html><body><img style="vertical-align: 8px;" src=""></body></html>"#;
-        let doc = parse_and_layout(html, 400.0, 2000.0, &[]);
+        let doc = parse_and_layout(html, 400.0, 2000.0, &[], true);
         let id = find_element_by_local_name(&doc, "img").expect("img");
         let va = extract_vertical_align(doc.get_node(id).unwrap());
         match va {
@@ -3287,7 +3301,7 @@ mod tests {
         // `vertical-align: 50%` still returns a unitless ratio — the px→pt
         // fix on the Length branch must not touch Percent semantics.
         let html = r#"<html><body><img style="vertical-align: 50%;" src=""></body></html>"#;
-        let doc = parse_and_layout(html, 400.0, 2000.0, &[]);
+        let doc = parse_and_layout(html, 400.0, 2000.0, &[], true);
         let id = find_element_by_local_name(&doc, "img").expect("img");
         let va = extract_vertical_align(doc.get_node(id).unwrap());
         match va {
@@ -3304,7 +3318,7 @@ mod tests {
             <h1 style="column-span: all;">Big</h1>
             <p>plain</p>
         </body></html>"#;
-        let doc = parse_and_layout(html, 400.0, 2000.0, &[]);
+        let doc = parse_and_layout(html, 400.0, 2000.0, &[], true);
         let h1 = find_element_by_local_name(&doc, "h1").expect("h1");
         let p = find_element_by_local_name(&doc, "p").expect("p");
         assert!(has_column_span_all(doc.get_node(h1).unwrap()));
@@ -3499,7 +3513,7 @@ mod transform_tests {
     /// Parse a minimal HTML snippet and return the computed transform of
     /// the first `<div>` it contains, via `compute_transform()`.
     fn compute_for_div(html: &str, box_w: f32, box_h: f32) -> Option<(Affine2D, Point2)> {
-        let doc = parse_and_layout(html, 400.0, 2000.0, &[]);
+        let doc = parse_and_layout(html, 400.0, 2000.0, &[], true);
         let div_id = find_element_by_tag(&doc, "div")?;
         let node = doc.get_node(div_id)?;
         let styles = node.primary_styles()?;

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -1108,7 +1108,7 @@ mod semantics_tests {
         // `parse_and_layout` already runs stylo + Taffy + the
         // `position: fixed` relayout, matching what the engine feeds
         // into convert at this point.
-        let mut doc = crate::blitz_adapter::parse_and_layout(html, 595.0, 842.0, &[]);
+        let mut doc = crate::blitz_adapter::parse_and_layout(html, 595.0, 842.0, &[], true);
 
         let column_styles = crate::blitz_adapter::extract_column_style_table(&doc);
         let multicol_geometry = crate::multicol_layout::run_pass(doc.deref_mut(), &column_styles);

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -15,6 +15,7 @@ pub struct Engine {
     template: Option<(String, String)>,
     data: Option<serde_json::Value>,
     serialize_settings: SerializeSettings,
+    system_fonts: bool,
 }
 
 impl Engine {
@@ -26,6 +27,7 @@ impl Engine {
             template: None,
             data: None,
             serialize_settings: SerializeSettings::default(),
+            system_fonts: true,
         }
     }
 
@@ -84,6 +86,7 @@ impl Engine {
             crate::convert::pt_to_px(self.config.content_width()),
             crate::convert::pt_to_px(self.config.page_height()) as u32,
             fonts,
+            self.system_fonts,
             self.base_path.as_deref(),
         );
         gcpm.extend_from(link_gcpm);
@@ -408,6 +411,7 @@ impl Engine {
             &gcpm,
             &running_store,
             fonts,
+            self.system_fonts,
             &string_set_for_render,
             &counter_ops_for_render,
             self.serialize_settings.clone(),
@@ -460,6 +464,7 @@ impl Engine {
             crate::convert::pt_to_px(self.config.content_width()),
             crate::convert::pt_to_px(self.config.page_height()) as u32,
             fonts,
+            self.system_fonts,
             self.base_path.as_deref(),
         );
 
@@ -528,6 +533,7 @@ impl Engine {
             crate::convert::pt_to_px(self.config.content_width()),
             crate::convert::pt_to_px(self.config.page_height()) as u32,
             fonts,
+            self.system_fonts,
             self.base_path.as_deref(),
         );
 
@@ -621,6 +627,7 @@ pub struct EngineBuilder {
     template: Option<(String, String)>,
     data: Option<serde_json::Value>,
     serialize_settings: SerializeSettings,
+    system_fonts: bool,
 }
 
 impl EngineBuilder {
@@ -704,6 +711,11 @@ impl EngineBuilder {
         self
     }
 
+    pub fn system_fonts(mut self, enabled: bool) -> Self {
+        self.system_fonts = enabled;
+        self
+    }
+
     pub fn base_path(mut self, path: impl Into<PathBuf>) -> Self {
         self.base_path = Some(path.into());
         self
@@ -732,6 +744,7 @@ impl EngineBuilder {
             template: self.template,
             data: self.data,
             serialize_settings: self.serialize_settings,
+            system_fonts: self.system_fonts,
         }
     }
 }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -3212,6 +3212,7 @@ impl<'a> MarginBoxRenderer<'a> {
     /// Build a renderer from raw inputs. `string_set_by_node` /
     /// `counter_ops_by_node` are the per-node maps drained out of
     /// `ConvertContext` before `dom_to_drawables` consumed them.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         gcpm: &'a GcpmContext,
         running_store: &'a RunningElementStore,

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -31,6 +31,7 @@ pub fn render_v2(
     gcpm: &GcpmContext,
     running_store: &RunningElementStore,
     font_data: &[Arc<Vec<u8>>],
+    system_fonts: bool,
     string_set_by_node: &HashMap<usize, Vec<(String, String)>>,
     counter_ops_by_node: &BTreeMap<usize, Vec<crate::gcpm::CounterOp>>,
     serialize_settings: SerializeSettings,
@@ -123,6 +124,7 @@ pub fn render_v2(
         gcpm,
         running_store,
         font_data,
+        system_fonts,
         geometry,
         string_set_by_node,
         counter_ops_by_node,
@@ -3196,6 +3198,7 @@ pub(crate) struct MarginBoxRenderer<'a> {
     pub gcpm: &'a GcpmContext,
     pub running_store: &'a RunningElementStore,
     pub font_data: &'a [Arc<Vec<u8>>],
+    pub system_fonts: bool,
     pub margin_css: String,
     pub string_set_states: Vec<BTreeMap<String, crate::pagination_layout::StringSetPageState>>,
     pub running_states: Vec<BTreeMap<String, crate::pagination_layout::PageRunningState>>,
@@ -3213,6 +3216,7 @@ impl<'a> MarginBoxRenderer<'a> {
         gcpm: &'a GcpmContext,
         running_store: &'a RunningElementStore,
         font_data: &'a [Arc<Vec<u8>>],
+        system_fonts: bool,
         pagination_geometry: &crate::pagination_layout::PaginationGeometryTable,
         string_set_by_node: &HashMap<usize, Vec<(String, String)>>,
         counter_ops_by_node: &BTreeMap<usize, Vec<crate::gcpm::CounterOp>>,
@@ -3248,6 +3252,7 @@ impl<'a> MarginBoxRenderer<'a> {
             gcpm,
             running_store,
             font_data,
+            system_fonts,
             margin_css: strip_display_none(&gcpm.cleaned_css),
             string_set_states,
             running_states,
@@ -3370,6 +3375,7 @@ impl<'a> MarginBoxRenderer<'a> {
                     crate::convert::pt_to_px(content_width),
                     crate::convert::pt_to_px(page_size.height),
                     self.font_data,
+                    self.system_fonts,
                 );
                 get_body_child_dimension(&measure_doc, true)
             });
@@ -3404,6 +3410,7 @@ impl<'a> MarginBoxRenderer<'a> {
                     crate::convert::pt_to_px(fixed_width),
                     crate::convert::pt_to_px(page_size.height),
                     self.font_data,
+                    self.system_fonts,
                 );
                 get_body_child_dimension(&measure_doc, false)
             });
@@ -3470,6 +3477,7 @@ impl<'a> MarginBoxRenderer<'a> {
                     crate::convert::pt_to_px(rect.width),
                     crate::convert::pt_to_px(rect.height),
                     self.font_data,
+                    self.system_fonts,
                 );
                 let empty_column_styles = crate::column_css::ColumnStyleTable::new();
                 let geometry = crate::pagination_layout::run_pass_with_break_styles(


### PR DESCRIPTION
## 概要

`Engine::builder().system_fonts(false)` で fontique のシステムフォントスキャンをオプトアウトできるようにした。

- macOS の samply プロファイルでは `fontique::scan::scan_collection` が毎レンダリング 100–250 ms のコストになっていた（bundled fonts がある場合は純粋なオーバーヘッド）
- デフォルトは `true` のため、既存の呼び出し元の動作変更なし
- WPT ランナーが `target/wpt/fonts/` を `AssetBundle` に詰めて渡す際に `.system_fonts(false)` を渡すことで CI でのスキャンコストを排除できる

## 変更内容

- `blitz_adapter::parse_inner` / `parse_and_layout` / `parse_html_with_local_resources` に `system_fonts: bool` パラメータを追加
- `render::render_v2` と `MarginBoxRenderer` にも同フラグを貫通させ、margin-box レイアウトでも設定が効くようにした
- `Engine` / `EngineBuilder` に `system_fonts(bool)` ビルダーメソッドを追加（デフォルト `true`）

## 使い方

```rust
let engine = Engine::builder()
    .assets(load_fonts_dir(&wpt_root.join("fonts"))?)
    .system_fonts(false)
    .build();
```

## テスト計画

- [x] `cargo test -p fulgur --lib` — 902 tests パス
- [x] `cargo test -p fulgur` — 全テストパス
- [x] `cargo fmt --check` — フォーマット問題なし
- [x] `cargo clippy -p fulgur` — 警告なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * レンダリングエンジンでシステムフォントの使用を一元制御できる設定を追加。ビルダー経由で有効／無効を切替え、HTML解析からレンダリングまで一貫して反映されます。
* **修正**
  * マージンボックスや埋め込みHTMLのレイアウトでフォント解決が設定通りに適用されるよう改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->