### PR TITLE
feat(tagged): wire link annotations into PDF structure tree (fulgur-izp.9)

### DIFF
--- a/crates/fulgur/src/draw_primitives.rs
+++ b/crates/fulgur/src/draw_primitives.rs
@@ -440,6 +440,22 @@ impl LinkCollector {
     }
 }
 
+/// Per-run tagged item for paragraphs drawn in per-run tagging mode.
+///
+/// Collected by `draw_shaped_lines` when `Canvas::link_run_node_id` is set.
+/// `build_struct_tree` assembles these into `P` children, grouping consecutive
+/// `LinkContent` items with the same `span_ptr` into `Link` TagGroups.
+#[derive(Debug)]
+pub enum ParagraphRunItem {
+    /// Non-link content identifier (child of P/H/LBody directly).
+    Content(krilla::tagging::Identifier),
+    /// Link content identifier grouped by the `Arc<LinkSpan>` pointer.
+    LinkContent {
+        span_ptr: usize,
+        identifier: krilla::tagging::Identifier,
+    },
+}
+
 /// Per-render accumulator for tagged-content identifiers.
 ///
 /// Each `record` call stores one (NodeId, PdfTag, Identifier) triple
@@ -453,12 +469,14 @@ pub struct TagCollector {
         krilla::tagging::Identifier,
         Option<String>,
     )>,
+    pub run_entries: BTreeMap<crate::drawables::NodeId, Vec<ParagraphRunItem>>,
 }
 
 impl TagCollector {
     pub fn new() -> Self {
         Self {
             entries: Vec::new(),
+            run_entries: BTreeMap::new(),
         }
     }
 
@@ -482,6 +500,24 @@ impl TagCollector {
     )> {
         self.entries
     }
+
+    /// Record a per-run item under `node_id` (paragraph NodeId).
+    pub fn record_run(&mut self, node_id: crate::drawables::NodeId, item: ParagraphRunItem) {
+        self.run_entries.entry(node_id).or_default().push(item);
+    }
+
+    /// Return a reference to run entries for `node_id` (empty slice if none).
+    pub fn run_entries_for(&self, node_id: crate::drawables::NodeId) -> &[ParagraphRunItem] {
+        self.run_entries.get(&node_id).map_or(&[], Vec::as_slice)
+    }
+
+    /// Remove and return run entries for `node_id`.
+    pub fn take_run_entries(
+        &mut self,
+        node_id: crate::drawables::NodeId,
+    ) -> Vec<ParagraphRunItem> {
+        self.run_entries.remove(&node_id).unwrap_or_default()
+    }
 }
 
 impl Default for TagCollector {
@@ -497,6 +533,10 @@ pub struct Canvas<'a, 'b> {
     pub bookmark_collector: Option<&'a mut BookmarkCollector>,
     pub link_collector: Option<&'a mut LinkCollector>,
     pub tag_collector: Option<&'a mut TagCollector>,
+    /// When `Some(node_id)`, `draw_shaped_lines` operates in per-run tagging mode:
+    /// each glyph-run cluster bounded by `Arc<LinkSpan>` identity gets its own
+    /// `start_tagged/end_tagged` region recorded as a `ParagraphRunItem`.
+    pub link_run_node_id: Option<usize>,
 }
 
 /// Run a draw closure wrapped in opacity guards.
@@ -2198,6 +2238,55 @@ mod dp_unit_tests {
             ..Default::default()
         };
         assert!(compute_overflow_clip_path(&style, 0.0, 0.0, 100.0, 100.0).is_some());
+    }
+}
+
+#[cfg(test)]
+mod run_tag_tests {
+    use super::*;
+    use krilla::tagging::{ContentTag, Identifier, SpanTag};
+
+    fn make_identifier() -> Identifier {
+        let mut doc = krilla::Document::new();
+        let settings = krilla::page::PageSettings::from_wh(100.0, 100.0)
+            .expect("valid page size");
+        let mut page = doc.start_page_with(settings);
+        let mut surface = page.surface();
+        let id = surface.start_tagged(ContentTag::Span(SpanTag::empty()));
+        surface.end_tagged();
+        id
+    }
+
+    #[test]
+    fn record_run_content_round_trips() {
+        let mut tc = TagCollector::new();
+        tc.record_run(42, ParagraphRunItem::Content(make_identifier()));
+        let runs = tc.take_run_entries(42);
+        assert_eq!(runs.len(), 1);
+        assert!(matches!(runs[0], ParagraphRunItem::Content(_)));
+    }
+
+    #[test]
+    fn record_run_link_content_round_trips() {
+        let mut tc = TagCollector::new();
+        tc.record_run(
+            7,
+            ParagraphRunItem::LinkContent {
+                span_ptr: 0xdeadbeef,
+                identifier: make_identifier(),
+            },
+        );
+        let runs = tc.take_run_entries(7);
+        assert_eq!(runs.len(), 1);
+        assert!(
+            matches!(runs[0], ParagraphRunItem::LinkContent { span_ptr: 0xdeadbeef, .. })
+        );
+    }
+
+    #[test]
+    fn run_entries_for_returns_empty_when_absent() {
+        let tc = TagCollector::new();
+        assert!(tc.run_entries_for(99).is_empty());
     }
 }
 

--- a/crates/fulgur/src/draw_primitives.rs
+++ b/crates/fulgur/src/draw_primitives.rs
@@ -314,6 +314,8 @@ pub struct LinkOccurrence {
     pub target: crate::paragraph::LinkTarget,
     pub alt_text: Option<String>,
     pub quads: Vec<Quad>,
+    /// `Arc::as_ptr(link_span) as usize` — correlates with `TagCollector` run entries.
+    pub span_ptr: usize,
 }
 
 /// Per-page collector of link activation rects, grouped by `<a>` identity.
@@ -414,6 +416,7 @@ impl LinkCollector {
             target: link.target.clone(),
             alt_text: link.alt_text.clone(),
             quads: vec![quad],
+            span_ptr: std::sync::Arc::as_ptr(link) as usize,
         });
     }
 
@@ -512,10 +515,7 @@ impl TagCollector {
     }
 
     /// Remove and return run entries for `node_id`.
-    pub fn take_run_entries(
-        &mut self,
-        node_id: crate::drawables::NodeId,
-    ) -> Vec<ParagraphRunItem> {
+    pub fn take_run_entries(&mut self, node_id: crate::drawables::NodeId) -> Vec<ParagraphRunItem> {
         self.run_entries.remove(&node_id).unwrap_or_default()
     }
 }
@@ -2248,8 +2248,7 @@ mod run_tag_tests {
 
     fn make_identifier() -> Identifier {
         let mut doc = krilla::Document::new();
-        let settings = krilla::page::PageSettings::from_wh(100.0, 100.0)
-            .expect("valid page size");
+        let settings = krilla::page::PageSettings::from_wh(100.0, 100.0).expect("valid page size");
         let mut page = doc.start_page_with(settings);
         let mut surface = page.surface();
         let id = surface.start_tagged(ContentTag::Span(SpanTag::empty()));
@@ -2278,9 +2277,13 @@ mod run_tag_tests {
         );
         let runs = tc.take_run_entries(7);
         assert_eq!(runs.len(), 1);
-        assert!(
-            matches!(runs[0], ParagraphRunItem::LinkContent { span_ptr: 0xdeadbeef, .. })
-        );
+        assert!(matches!(
+            runs[0],
+            ParagraphRunItem::LinkContent {
+                span_ptr: 0xdeadbeef,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/fulgur/src/draw_primitives.rs
+++ b/crates/fulgur/src/draw_primitives.rs
@@ -504,6 +504,24 @@ impl TagCollector {
         self.entries
     }
 
+    /// Consume `self` and return `(entries, run_entries)` as separate owned
+    /// values. Used by `build_struct_tree` to avoid a partial-move error when
+    /// both fields are needed independently.
+    #[allow(clippy::type_complexity)]
+    pub fn into_parts(
+        self,
+    ) -> (
+        Vec<(
+            crate::drawables::NodeId,
+            crate::tagging::PdfTag,
+            krilla::tagging::Identifier,
+            Option<String>,
+        )>,
+        BTreeMap<crate::drawables::NodeId, Vec<ParagraphRunItem>>,
+    ) {
+        (self.entries, self.run_entries)
+    }
+
     /// Record a per-run item under `node_id` (paragraph NodeId).
     pub fn record_run(&mut self, node_id: crate::drawables::NodeId, item: ParagraphRunItem) {
         self.run_entries.entry(node_id).or_default().push(item);

--- a/crates/fulgur/src/draw_primitives.rs
+++ b/crates/fulgur/src/draw_primitives.rs
@@ -459,20 +459,25 @@ pub enum ParagraphRunItem {
     },
 }
 
+/// One entry recorded by [`TagCollector::record`] for whole-paragraph tagging:
+/// `(node_id, pdf_tag, content_identifier, heading_title)`.
+pub type TagEntry = (
+    crate::drawables::NodeId,
+    crate::tagging::PdfTag,
+    krilla::tagging::Identifier,
+    Option<String>,
+);
+
 /// Per-render accumulator for tagged-content identifiers.
 ///
-/// Each `record` call stores one (NodeId, PdfTag, Identifier) triple
-/// produced by `surface.start_tagged` during a single page draw. After
-/// all pages are rendered, `render_v2` groups entries by NodeId and
-/// builds a `krilla::tagging::TagTree`.
+/// `entries` stores one tuple per `surface.start_tagged` call made for
+/// whole-paragraph tagging. `run_entries` stores per-run identifiers for
+/// paragraphs that opened multiple regions (one per `<a>` link span). After
+/// all pages are rendered, `render_v2` consumes both via [`Self::into_parts`]
+/// and builds a `krilla::tagging::TagTree`.
 pub struct TagCollector {
-    entries: Vec<(
-        crate::drawables::NodeId,
-        crate::tagging::PdfTag,
-        krilla::tagging::Identifier,
-        Option<String>,
-    )>,
-    pub run_entries: BTreeMap<crate::drawables::NodeId, Vec<ParagraphRunItem>>,
+    entries: Vec<TagEntry>,
+    run_entries: BTreeMap<crate::drawables::NodeId, Vec<ParagraphRunItem>>,
 }
 
 impl TagCollector {
@@ -493,30 +498,15 @@ impl TagCollector {
         self.entries.push((node_id, tag, id, heading_title));
     }
 
-    pub fn into_entries(
-        self,
-    ) -> Vec<(
-        crate::drawables::NodeId,
-        crate::tagging::PdfTag,
-        krilla::tagging::Identifier,
-        Option<String>,
-    )> {
-        self.entries
-    }
-
-    /// Consume `self` and return `(entries, run_entries)` as separate owned
-    /// values. Used by `build_struct_tree` to avoid a partial-move error when
-    /// both fields are needed independently.
-    #[allow(clippy::type_complexity)]
+    /// Consume `self` and return the whole-paragraph entries and per-run
+    /// entries as separate owned values. Both fields are needed independently
+    /// by `build_struct_tree`; returning them together avoids the partial-move
+    /// error that `tc.run_entries` followed by a `tc`-consuming call would
+    /// cause.
     pub fn into_parts(
         self,
     ) -> (
-        Vec<(
-            crate::drawables::NodeId,
-            crate::tagging::PdfTag,
-            krilla::tagging::Identifier,
-            Option<String>,
-        )>,
+        Vec<TagEntry>,
         BTreeMap<crate::drawables::NodeId, Vec<ParagraphRunItem>>,
     ) {
         (self.entries, self.run_entries)
@@ -527,14 +517,19 @@ impl TagCollector {
         self.run_entries.entry(node_id).or_default().push(item);
     }
 
-    /// Return a reference to run entries for `node_id` (empty slice if none).
-    pub fn run_entries_for(&self, node_id: crate::drawables::NodeId) -> &[ParagraphRunItem] {
-        self.run_entries.get(&node_id).map_or(&[], Vec::as_slice)
-    }
-
-    /// Remove and return run entries for `node_id`.
-    pub fn take_run_entries(&mut self, node_id: crate::drawables::NodeId) -> Vec<ParagraphRunItem> {
-        self.run_entries.remove(&node_id).unwrap_or_default()
+    /// Collect every `LinkContent::span_ptr` recorded across all paragraphs.
+    /// `emit_link_annotations` uses this set to decide whether a given link
+    /// occurrence is wired into the struct tree (and thus eligible for
+    /// `add_tagged_annotation`).
+    pub fn wired_link_span_ptrs(&self) -> std::collections::BTreeSet<usize> {
+        self.run_entries
+            .values()
+            .flatten()
+            .filter_map(|item| match item {
+                ParagraphRunItem::LinkContent { span_ptr, .. } => Some(*span_ptr),
+                ParagraphRunItem::Content(_) => None,
+            })
+            .collect()
     }
 }
 
@@ -551,10 +546,11 @@ pub struct Canvas<'a, 'b> {
     pub bookmark_collector: Option<&'a mut BookmarkCollector>,
     pub link_collector: Option<&'a mut LinkCollector>,
     pub tag_collector: Option<&'a mut TagCollector>,
-    /// When `Some(node_id)`, `draw_shaped_lines` operates in per-run tagging mode:
-    /// each glyph-run cluster bounded by `Arc<LinkSpan>` identity gets its own
-    /// `start_tagged/end_tagged` region recorded as a `ParagraphRunItem`.
-    pub link_run_node_id: Option<usize>,
+    /// When `Some(node_id)` (a `drawables::NodeId`), `draw_shaped_lines`
+    /// operates in per-run tagging mode: each glyph-run cluster bounded by
+    /// `Arc<LinkSpan>` identity gets its own `start_tagged/end_tagged` region
+    /// recorded as a `ParagraphRunItem` under that paragraph's NodeId.
+    pub link_run_node_id: Option<crate::drawables::NodeId>,
 }
 
 /// Run a draw closure wrapped in opacity guards.
@@ -2260,11 +2256,11 @@ mod dp_unit_tests {
 }
 
 #[cfg(test)]
-mod run_tag_tests {
+pub(crate) mod run_tag_tests {
     use super::*;
     use krilla::tagging::{ContentTag, Identifier, SpanTag};
 
-    fn make_identifier() -> Identifier {
+    pub(crate) fn make_identifier() -> Identifier {
         let mut doc = krilla::Document::new();
         let settings = krilla::page::PageSettings::from_wh(100.0, 100.0).expect("valid page size");
         let mut page = doc.start_page_with(settings);
@@ -2278,7 +2274,7 @@ mod run_tag_tests {
     fn record_run_content_round_trips() {
         let mut tc = TagCollector::new();
         tc.record_run(42, ParagraphRunItem::Content(make_identifier()));
-        let runs = tc.take_run_entries(42);
+        let runs = tc.run_entries.get(&42).expect("run entry recorded");
         assert_eq!(runs.len(), 1);
         assert!(matches!(runs[0], ParagraphRunItem::Content(_)));
     }
@@ -2293,7 +2289,7 @@ mod run_tag_tests {
                 identifier: make_identifier(),
             },
         );
-        let runs = tc.take_run_entries(7);
+        let runs = tc.run_entries.get(&7).expect("run entry recorded");
         assert_eq!(runs.len(), 1);
         assert!(matches!(
             runs[0],
@@ -2305,9 +2301,33 @@ mod run_tag_tests {
     }
 
     #[test]
-    fn run_entries_for_returns_empty_when_absent() {
+    fn run_entries_empty_by_default() {
         let tc = TagCollector::new();
-        assert!(tc.run_entries_for(99).is_empty());
+        assert!(tc.run_entries.is_empty());
+    }
+
+    #[test]
+    fn wired_link_span_ptrs_collects_link_content_only() {
+        let mut tc = TagCollector::new();
+        tc.record_run(1, ParagraphRunItem::Content(make_identifier()));
+        tc.record_run(
+            1,
+            ParagraphRunItem::LinkContent {
+                span_ptr: 0x1234,
+                identifier: make_identifier(),
+            },
+        );
+        tc.record_run(
+            2,
+            ParagraphRunItem::LinkContent {
+                span_ptr: 0xabcd,
+                identifier: make_identifier(),
+            },
+        );
+        let wired = tc.wired_link_span_ptrs();
+        assert!(wired.contains(&0x1234));
+        assert!(wired.contains(&0xabcd));
+        assert_eq!(wired.len(), 2);
     }
 }
 

--- a/crates/fulgur/src/link.rs
+++ b/crates/fulgur/src/link.rs
@@ -27,16 +27,21 @@ use crate::paragraph::LinkTarget;
 /// Internal anchors that cannot be resolved in `registry` are logged via
 /// `eprintln!` and skipped; rendering continues.
 ///
-/// When `tagging` is `true`, `add_tagged_annotation` is used instead of
-/// `add_annotation`, and the returned `Vec` maps each `span_ptr` to the
-/// resulting annotation [`Identifier`] (for struct-tree wiring in Task 7).
-/// When `tagging` is `false`, annotations are added untagged and an empty
-/// `Vec` is returned.
+/// When `tagging` is `true`, `add_tagged_annotation` is used for occurrences
+/// whose `span_ptr` is present in `wired_span_ptrs` (meaning a corresponding
+/// `LinkContent` run entry exists in the struct tree).  Occurrences that are
+/// not wired — e.g. links whose content rendered as `LineItem::InlineBox`
+/// rather than `LineItem::Text`/`LineItem::Image` — are added as plain
+/// untagged annotations so that the click target is preserved without
+/// triggering a Krilla panic (tagged annotations must appear in the tag tree).
+/// When `tagging` is `false`, `wired_span_ptrs` is ignored and all annotations
+/// are added untagged; an empty `Vec` is returned.
 pub(crate) fn emit_link_annotations(
     page: &mut Page,
     occurrences: &[LinkOccurrence],
     registry: &DestinationRegistry,
     tagging: bool,
+    wired_span_ptrs: Option<&std::collections::BTreeSet<usize>>,
 ) -> Vec<(usize, Identifier)> {
     let mut annot_ids = Vec::new();
 
@@ -66,7 +71,18 @@ pub(crate) fn emit_link_annotations(
 
         let link_ann = LinkAnnotation::new_with_quad_points(quads, target);
         let annotation = Annotation::new_link(link_ann, occ.alt_text.clone());
-        if tagging {
+        // Use add_tagged_annotation only when the span_ptr is wired into the
+        // struct tree via a ParagraphRunItem::LinkContent entry.  Unwired
+        // occurrences (e.g. image-only links rendered as LineItem::InlineBox)
+        // fall back to add_annotation so the click target is preserved without
+        // violating Krilla's invariant that every tagged annotation must appear
+        // in the tag tree.  Link struct element emission for InlineBox links is
+        // a follow-up task.
+        let is_wired = tagging
+            && wired_span_ptrs
+                .map(|set| set.contains(&occ.span_ptr))
+                .unwrap_or(false);
+        if is_wired {
             let annot_id = page.add_tagged_annotation(annotation);
             annot_ids.push((occ.span_ptr, annot_id));
         } else {
@@ -158,7 +174,7 @@ mod tests {
         {
             let mut page = doc.start_page_with(page_settings());
             let registry = DestinationRegistry::new();
-            emit_link_annotations(&mut page, &[], &registry, false);
+            emit_link_annotations(&mut page, &[], &registry, false, None);
         }
         assert_eq!(page0_annotation_count(doc), 0);
     }
@@ -175,7 +191,7 @@ mod tests {
                 "https://example.com",
                 vec![make_quad(10.0, 20.0, 80.0, 14.0)],
             );
-            emit_link_annotations(&mut page, &[occ], &registry, false);
+            emit_link_annotations(&mut page, &[occ], &registry, false, None);
         }
         assert_eq!(page0_annotation_count(doc), 1);
     }
@@ -193,7 +209,7 @@ mod tests {
                 quads: vec![make_quad(0.0, 0.0, 100.0, 12.0)],
                 span_ptr: 0,
             };
-            emit_link_annotations(&mut page, &[occ], &registry, false);
+            emit_link_annotations(&mut page, &[occ], &registry, false, None);
         }
         assert_eq!(page0_annotation_count(doc), 1);
     }
@@ -212,7 +228,7 @@ mod tests {
                     make_quad(0.0, 14.0, 150.0, 14.0),
                 ],
             );
-            emit_link_annotations(&mut page, &[occ], &registry, false);
+            emit_link_annotations(&mut page, &[occ], &registry, false, None);
         }
         assert_eq!(page0_annotation_count(doc), 1);
     }
@@ -229,7 +245,7 @@ mod tests {
             registry.set_current_page(0);
             registry.record("section1", 0.0, 120.0);
             let occ = int_occ("section1", vec![make_quad(10.0, 40.0, 80.0, 12.0)]);
-            emit_link_annotations(&mut page, &[occ], &registry, false);
+            emit_link_annotations(&mut page, &[occ], &registry, false, None);
         }
         assert_eq!(page0_annotation_count(doc), 1);
     }
@@ -242,7 +258,7 @@ mod tests {
             let registry = DestinationRegistry::new(); // "missing" is not registered
             let occ = int_occ("missing", vec![make_quad(0.0, 0.0, 50.0, 12.0)]);
             // eprintln! log is emitted; the occurrence must be skipped entirely.
-            emit_link_annotations(&mut page, &[occ], &registry, false);
+            emit_link_annotations(&mut page, &[occ], &registry, false, None);
         }
         assert_eq!(page0_annotation_count(doc), 0);
     }
@@ -256,7 +272,7 @@ mod tests {
             let mut page = doc.start_page_with(page_settings());
             let registry = DestinationRegistry::new();
             let occ = ext_occ("https://no-quads.example", vec![]);
-            emit_link_annotations(&mut page, &[occ], &registry, false);
+            emit_link_annotations(&mut page, &[occ], &registry, false, None);
         }
         assert_eq!(page0_annotation_count(doc), 0);
     }
@@ -274,7 +290,7 @@ mod tests {
                     vec![make_quad(0.0, 0.0, 80.0, 12.0)],
                 ),
             ];
-            emit_link_annotations(&mut page, &occs, &registry, false);
+            emit_link_annotations(&mut page, &occs, &registry, false, None);
         }
         // First occurrence has empty quads (skipped); second is valid → 1 annotation.
         assert_eq!(page0_annotation_count(doc), 1);
@@ -289,7 +305,7 @@ mod tests {
             let mut page = doc.start_page_with(page_settings());
             let registry = DestinationRegistry::new();
             let occ = ext_occ("https://x.example", vec![make_quad(0.0, 0.0, 50.0, 12.0)]);
-            let ids = emit_link_annotations(&mut page, &[occ], &registry, false);
+            let ids = emit_link_annotations(&mut page, &[occ], &registry, false, None);
             assert!(ids.is_empty());
         }
         assert_eq!(page0_annotation_count(doc), 1);
@@ -311,7 +327,7 @@ mod tests {
                 int_occ("gone", vec![make_quad(0.0, 40.0, 60.0, 12.0)]),   // skipped (unresolved)
                 ext_occ("https://empty.example", vec![]),                  // skipped (empty quads)
             ];
-            emit_link_annotations(&mut page, &occs, &registry, false);
+            emit_link_annotations(&mut page, &occs, &registry, false, None);
         }
         assert_eq!(page0_annotation_count(doc), 2);
     }

--- a/crates/fulgur/src/link.rs
+++ b/crates/fulgur/src/link.rs
@@ -86,6 +86,7 @@ mod tests {
             target: LinkTarget::External(Arc::new(url.to_string())),
             alt_text: None,
             quads,
+            span_ptr: 0,
         }
     }
 
@@ -95,6 +96,7 @@ mod tests {
             target: LinkTarget::Internal(Arc::new(id.to_string())),
             alt_text: None,
             quads,
+            span_ptr: 0,
         }
     }
 
@@ -172,6 +174,7 @@ mod tests {
                 target: LinkTarget::External(Arc::new("https://alt.example".to_string())),
                 alt_text: Some("Visit example".to_string()),
                 quads: vec![make_quad(0.0, 0.0, 100.0, 12.0)],
+                span_ptr: 0,
             };
             emit_link_annotations(&mut page, &[occ], &registry);
         }

--- a/crates/fulgur/src/link.rs
+++ b/crates/fulgur/src/link.rs
@@ -27,20 +27,19 @@ use crate::paragraph::LinkTarget;
 /// Internal anchors that cannot be resolved in `registry` are logged via
 /// `eprintln!` and skipped; rendering continues.
 ///
-/// When `tagging` is `true`, `add_tagged_annotation` is used for occurrences
-/// whose `span_ptr` is present in `wired_span_ptrs` (meaning a corresponding
+/// When `wired_span_ptrs` is `Some`, `add_tagged_annotation` is used for
+/// occurrences whose `span_ptr` is in the set (meaning a corresponding
 /// `LinkContent` run entry exists in the struct tree).  Occurrences that are
 /// not wired — e.g. links whose content rendered as `LineItem::InlineBox`
-/// rather than `LineItem::Text`/`LineItem::Image` — are added as plain
-/// untagged annotations so that the click target is preserved without
-/// triggering a Krilla panic (tagged annotations must appear in the tag tree).
-/// When `tagging` is `false`, `wired_span_ptrs` is ignored and all annotations
-/// are added untagged; an empty `Vec` is returned.
+/// rather than `LineItem::Text`/`LineItem::Image` — fall back to plain
+/// `add_annotation` so the click target is preserved without violating
+/// Krilla's invariant (every tagged annotation must appear in the tag tree).
+/// When `wired_span_ptrs` is `None`, all annotations are added untagged and
+/// an empty `Vec` is returned.
 pub(crate) fn emit_link_annotations(
     page: &mut Page,
     occurrences: &[LinkOccurrence],
     registry: &DestinationRegistry,
-    tagging: bool,
     wired_span_ptrs: Option<&std::collections::BTreeSet<usize>>,
 ) -> Vec<(usize, Identifier)> {
     let mut annot_ids = Vec::new();
@@ -72,16 +71,13 @@ pub(crate) fn emit_link_annotations(
         let link_ann = LinkAnnotation::new_with_quad_points(quads, target);
         let annotation = Annotation::new_link(link_ann, occ.alt_text.clone());
         // Use add_tagged_annotation only when the span_ptr is wired into the
-        // struct tree via a ParagraphRunItem::LinkContent entry.  Unwired
+        // struct tree via a ParagraphRunItem::LinkContent entry. Unwired
         // occurrences (e.g. image-only links rendered as LineItem::InlineBox)
         // fall back to add_annotation so the click target is preserved without
         // violating Krilla's invariant that every tagged annotation must appear
-        // in the tag tree.  Link struct element emission for InlineBox links is
+        // in the tag tree. Link struct element emission for InlineBox links is
         // a follow-up task.
-        let is_wired = tagging
-            && wired_span_ptrs
-                .map(|set| set.contains(&occ.span_ptr))
-                .unwrap_or(false);
+        let is_wired = wired_span_ptrs.is_some_and(|set| set.contains(&occ.span_ptr));
         if is_wired {
             let annot_id = page.add_tagged_annotation(annotation);
             annot_ids.push((occ.span_ptr, annot_id));
@@ -174,7 +170,7 @@ mod tests {
         {
             let mut page = doc.start_page_with(page_settings());
             let registry = DestinationRegistry::new();
-            emit_link_annotations(&mut page, &[], &registry, false, None);
+            emit_link_annotations(&mut page, &[], &registry, None);
         }
         assert_eq!(page0_annotation_count(doc), 0);
     }
@@ -191,7 +187,7 @@ mod tests {
                 "https://example.com",
                 vec![make_quad(10.0, 20.0, 80.0, 14.0)],
             );
-            emit_link_annotations(&mut page, &[occ], &registry, false, None);
+            emit_link_annotations(&mut page, &[occ], &registry, None);
         }
         assert_eq!(page0_annotation_count(doc), 1);
     }
@@ -209,7 +205,7 @@ mod tests {
                 quads: vec![make_quad(0.0, 0.0, 100.0, 12.0)],
                 span_ptr: 0,
             };
-            emit_link_annotations(&mut page, &[occ], &registry, false, None);
+            emit_link_annotations(&mut page, &[occ], &registry, None);
         }
         assert_eq!(page0_annotation_count(doc), 1);
     }
@@ -228,7 +224,7 @@ mod tests {
                     make_quad(0.0, 14.0, 150.0, 14.0),
                 ],
             );
-            emit_link_annotations(&mut page, &[occ], &registry, false, None);
+            emit_link_annotations(&mut page, &[occ], &registry, None);
         }
         assert_eq!(page0_annotation_count(doc), 1);
     }
@@ -245,7 +241,7 @@ mod tests {
             registry.set_current_page(0);
             registry.record("section1", 0.0, 120.0);
             let occ = int_occ("section1", vec![make_quad(10.0, 40.0, 80.0, 12.0)]);
-            emit_link_annotations(&mut page, &[occ], &registry, false, None);
+            emit_link_annotations(&mut page, &[occ], &registry, None);
         }
         assert_eq!(page0_annotation_count(doc), 1);
     }
@@ -258,7 +254,7 @@ mod tests {
             let registry = DestinationRegistry::new(); // "missing" is not registered
             let occ = int_occ("missing", vec![make_quad(0.0, 0.0, 50.0, 12.0)]);
             // eprintln! log is emitted; the occurrence must be skipped entirely.
-            emit_link_annotations(&mut page, &[occ], &registry, false, None);
+            emit_link_annotations(&mut page, &[occ], &registry, None);
         }
         assert_eq!(page0_annotation_count(doc), 0);
     }
@@ -272,7 +268,7 @@ mod tests {
             let mut page = doc.start_page_with(page_settings());
             let registry = DestinationRegistry::new();
             let occ = ext_occ("https://no-quads.example", vec![]);
-            emit_link_annotations(&mut page, &[occ], &registry, false, None);
+            emit_link_annotations(&mut page, &[occ], &registry, None);
         }
         assert_eq!(page0_annotation_count(doc), 0);
     }
@@ -290,7 +286,7 @@ mod tests {
                     vec![make_quad(0.0, 0.0, 80.0, 12.0)],
                 ),
             ];
-            emit_link_annotations(&mut page, &occs, &registry, false, None);
+            emit_link_annotations(&mut page, &occs, &registry, None);
         }
         // First occurrence has empty quads (skipped); second is valid → 1 annotation.
         assert_eq!(page0_annotation_count(doc), 1);
@@ -305,7 +301,7 @@ mod tests {
             let mut page = doc.start_page_with(page_settings());
             let registry = DestinationRegistry::new();
             let occ = ext_occ("https://x.example", vec![make_quad(0.0, 0.0, 50.0, 12.0)]);
-            let ids = emit_link_annotations(&mut page, &[occ], &registry, false, None);
+            let ids = emit_link_annotations(&mut page, &[occ], &registry, None);
             assert!(ids.is_empty());
         }
         assert_eq!(page0_annotation_count(doc), 1);
@@ -327,7 +323,7 @@ mod tests {
                 int_occ("gone", vec![make_quad(0.0, 40.0, 60.0, 12.0)]),   // skipped (unresolved)
                 ext_occ("https://empty.example", vec![]),                  // skipped (empty quads)
             ];
-            emit_link_annotations(&mut page, &occs, &registry, false, None);
+            emit_link_annotations(&mut page, &occs, &registry, None);
         }
         assert_eq!(page0_annotation_count(doc), 2);
     }

--- a/crates/fulgur/src/link.rs
+++ b/crates/fulgur/src/link.rs
@@ -16,6 +16,7 @@ use krilla::annotation::{Annotation, LinkAnnotation, Target};
 use krilla::destination::{Destination, XyzDestination};
 use krilla::geom::{Point, Quadrilateral};
 use krilla::page::Page;
+use krilla::tagging::Identifier;
 
 use crate::draw_primitives::{DestinationRegistry, LinkOccurrence};
 use crate::paragraph::LinkTarget;
@@ -25,11 +26,20 @@ use crate::paragraph::LinkTarget;
 /// `occurrences` must already be filtered to the page represented by `page`.
 /// Internal anchors that cannot be resolved in `registry` are logged via
 /// `eprintln!` and skipped; rendering continues.
+///
+/// When `tagging` is `true`, `add_tagged_annotation` is used instead of
+/// `add_annotation`, and the returned `Vec` maps each `span_ptr` to the
+/// resulting annotation [`Identifier`] (for struct-tree wiring in Task 7).
+/// When `tagging` is `false`, annotations are added untagged and an empty
+/// `Vec` is returned.
 pub(crate) fn emit_link_annotations(
     page: &mut Page,
     occurrences: &[LinkOccurrence],
     registry: &DestinationRegistry,
-) {
+    tagging: bool,
+) -> Vec<(usize, Identifier)> {
+    let mut annot_ids = Vec::new();
+
     for occ in occurrences {
         let target = match &occ.target {
             LinkTarget::External(uri) => {
@@ -56,8 +66,15 @@ pub(crate) fn emit_link_annotations(
 
         let link_ann = LinkAnnotation::new_with_quad_points(quads, target);
         let annotation = Annotation::new_link(link_ann, occ.alt_text.clone());
-        page.add_annotation(annotation);
+        if tagging {
+            let annot_id = page.add_tagged_annotation(annotation);
+            annot_ids.push((occ.span_ptr, annot_id));
+        } else {
+            page.add_annotation(annotation);
+        }
     }
+
+    annot_ids
 }
 
 #[cfg(test)]
@@ -141,7 +158,7 @@ mod tests {
         {
             let mut page = doc.start_page_with(page_settings());
             let registry = DestinationRegistry::new();
-            emit_link_annotations(&mut page, &[], &registry);
+            emit_link_annotations(&mut page, &[], &registry, false);
         }
         assert_eq!(page0_annotation_count(doc), 0);
     }
@@ -158,7 +175,7 @@ mod tests {
                 "https://example.com",
                 vec![make_quad(10.0, 20.0, 80.0, 14.0)],
             );
-            emit_link_annotations(&mut page, &[occ], &registry);
+            emit_link_annotations(&mut page, &[occ], &registry, false);
         }
         assert_eq!(page0_annotation_count(doc), 1);
     }
@@ -176,7 +193,7 @@ mod tests {
                 quads: vec![make_quad(0.0, 0.0, 100.0, 12.0)],
                 span_ptr: 0,
             };
-            emit_link_annotations(&mut page, &[occ], &registry);
+            emit_link_annotations(&mut page, &[occ], &registry, false);
         }
         assert_eq!(page0_annotation_count(doc), 1);
     }
@@ -195,7 +212,7 @@ mod tests {
                     make_quad(0.0, 14.0, 150.0, 14.0),
                 ],
             );
-            emit_link_annotations(&mut page, &[occ], &registry);
+            emit_link_annotations(&mut page, &[occ], &registry, false);
         }
         assert_eq!(page0_annotation_count(doc), 1);
     }
@@ -212,7 +229,7 @@ mod tests {
             registry.set_current_page(0);
             registry.record("section1", 0.0, 120.0);
             let occ = int_occ("section1", vec![make_quad(10.0, 40.0, 80.0, 12.0)]);
-            emit_link_annotations(&mut page, &[occ], &registry);
+            emit_link_annotations(&mut page, &[occ], &registry, false);
         }
         assert_eq!(page0_annotation_count(doc), 1);
     }
@@ -225,7 +242,7 @@ mod tests {
             let registry = DestinationRegistry::new(); // "missing" is not registered
             let occ = int_occ("missing", vec![make_quad(0.0, 0.0, 50.0, 12.0)]);
             // eprintln! log is emitted; the occurrence must be skipped entirely.
-            emit_link_annotations(&mut page, &[occ], &registry);
+            emit_link_annotations(&mut page, &[occ], &registry, false);
         }
         assert_eq!(page0_annotation_count(doc), 0);
     }
@@ -239,7 +256,7 @@ mod tests {
             let mut page = doc.start_page_with(page_settings());
             let registry = DestinationRegistry::new();
             let occ = ext_occ("https://no-quads.example", vec![]);
-            emit_link_annotations(&mut page, &[occ], &registry);
+            emit_link_annotations(&mut page, &[occ], &registry, false);
         }
         assert_eq!(page0_annotation_count(doc), 0);
     }
@@ -257,9 +274,24 @@ mod tests {
                     vec![make_quad(0.0, 0.0, 80.0, 12.0)],
                 ),
             ];
-            emit_link_annotations(&mut page, &occs, &registry);
+            emit_link_annotations(&mut page, &occs, &registry, false);
         }
         // First occurrence has empty quads (skipped); second is valid → 1 annotation.
+        assert_eq!(page0_annotation_count(doc), 1);
+    }
+
+    // ── tagging mode ──────────────────────────────────────────────────────
+
+    #[test]
+    fn non_tagged_emit_returns_empty_vec() {
+        let mut doc = krilla::Document::new();
+        {
+            let mut page = doc.start_page_with(page_settings());
+            let registry = DestinationRegistry::new();
+            let occ = ext_occ("https://x.example", vec![make_quad(0.0, 0.0, 50.0, 12.0)]);
+            let ids = emit_link_annotations(&mut page, &[occ], &registry, false);
+            assert!(ids.is_empty());
+        }
         assert_eq!(page0_annotation_count(doc), 1);
     }
 
@@ -279,7 +311,7 @@ mod tests {
                 int_occ("gone", vec![make_quad(0.0, 40.0, 60.0, 12.0)]),   // skipped (unresolved)
                 ext_occ("https://empty.example", vec![]),                  // skipped (empty quads)
             ];
-            emit_link_annotations(&mut page, &occs, &registry);
+            emit_link_annotations(&mut page, &occs, &registry, false);
         }
         assert_eq!(page0_annotation_count(doc), 2);
     }

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -588,7 +588,7 @@ pub fn draw_shaped_lines(
                             .link
                             .as_ref()
                             .map(|l| std::sync::Arc::as_ptr(l) as usize);
-                        if cur_region_ptr.as_ref().map(|p| *p) != Some(new_ptr) {
+                        if cur_region_ptr != Some(new_ptr) {
                             // Close previous region
                             if cur_region_ptr.is_some() {
                                 canvas.surface.end_tagged();
@@ -691,7 +691,7 @@ pub fn draw_shaped_lines(
                             .link
                             .as_ref()
                             .map(|l| std::sync::Arc::as_ptr(l) as usize);
-                        if cur_region_ptr.as_ref().map(|p| *p) != Some(new_ptr) {
+                        if cur_region_ptr != Some(new_ptr) {
                             // Close previous region
                             if cur_region_ptr.is_some() {
                                 canvas.surface.end_tagged();

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -566,6 +566,16 @@ pub fn draw_shaped_lines(
     // to derive it from `line.baseline` (which is an absolute baseline offset
     // and does not carry per-line ascent).
     let mut line_top: f32 = 0.0;
+    // Per-run tagging mode is active when canvas.link_run_node_id is set and tagging is enabled.
+    // In this mode each glyph-run or image cluster gets its own start_tagged/end_tagged region.
+    let run_tag_node_id: Option<usize> = if canvas.tag_collector.is_some() {
+        canvas.link_run_node_id
+    } else {
+        None
+    };
+    // None = no region open; Some(None) = non-link region open; Some(Some(ptr)) = link region open.
+    let mut cur_region_ptr: Option<Option<usize>> = None;
+    let mut cur_region_id: Option<krilla::tagging::Identifier> = None;
     for line in lines {
         let line_top_abs = y + line_top;
         let baseline_y = y + line.baseline;
@@ -573,6 +583,39 @@ pub fn draw_shaped_lines(
         for item in &line.items {
             match item {
                 LineItem::Text(run) => {
+                    if let Some(nid) = run_tag_node_id {
+                        let new_ptr = run
+                            .link
+                            .as_ref()
+                            .map(|l| std::sync::Arc::as_ptr(l) as usize);
+                        if cur_region_ptr.as_ref().map(|p| *p) != Some(new_ptr) {
+                            // Close previous region
+                            if cur_region_ptr.is_some() {
+                                canvas.surface.end_tagged();
+                                let ptr_opt = cur_region_ptr.take().unwrap();
+                                let id = cur_region_id.take().unwrap();
+                                let item = match ptr_opt {
+                                    Some(ptr) => {
+                                        crate::draw_primitives::ParagraphRunItem::LinkContent {
+                                            span_ptr: ptr,
+                                            identifier: id,
+                                        }
+                                    }
+                                    None => crate::draw_primitives::ParagraphRunItem::Content(id),
+                                };
+                                if let Some(tc) = canvas.tag_collector.as_mut() {
+                                    tc.record_run(nid, item);
+                                }
+                            }
+                            // Open new region
+                            use krilla::tagging::{ContentTag, SpanTag};
+                            let id = canvas
+                                .surface
+                                .start_tagged(ContentTag::Span(SpanTag::empty()));
+                            cur_region_ptr = Some(new_ptr);
+                            cur_region_id = Some(id);
+                        }
+                    }
                     // Create Krilla font from cached data
                     let data: krilla::Data = Arc::clone(&run.font_data).into();
                     let Some(font) = krilla::text::Font::new(data, run.font_index) else {
@@ -643,6 +686,39 @@ pub fn draw_shaped_lines(
                     }
                 }
                 LineItem::Image(img) => {
+                    if let Some(nid) = run_tag_node_id {
+                        let new_ptr = img
+                            .link
+                            .as_ref()
+                            .map(|l| std::sync::Arc::as_ptr(l) as usize);
+                        if cur_region_ptr.as_ref().map(|p| *p) != Some(new_ptr) {
+                            // Close previous region
+                            if cur_region_ptr.is_some() {
+                                canvas.surface.end_tagged();
+                                let ptr_opt = cur_region_ptr.take().unwrap();
+                                let id = cur_region_id.take().unwrap();
+                                let item = match ptr_opt {
+                                    Some(ptr) => {
+                                        crate::draw_primitives::ParagraphRunItem::LinkContent {
+                                            span_ptr: ptr,
+                                            identifier: id,
+                                        }
+                                    }
+                                    None => crate::draw_primitives::ParagraphRunItem::Content(id),
+                                };
+                                if let Some(tc) = canvas.tag_collector.as_mut() {
+                                    tc.record_run(nid, item);
+                                }
+                            }
+                            // Open new region
+                            use krilla::tagging::{ContentTag, SpanTag};
+                            let id = canvas
+                                .surface
+                                .start_tagged(ContentTag::Span(SpanTag::empty()));
+                            cur_region_ptr = Some(new_ptr);
+                            cur_region_id = Some(id);
+                        }
+                    }
                     if !img.visible {
                         continue;
                     }
@@ -771,6 +847,24 @@ pub fn draw_shaped_lines(
         draw_line_decorations(canvas, &line.items, x, baseline_y);
 
         line_top += line.height;
+    }
+    // Close any open per-run tagged region.
+    if let Some(nid) = run_tag_node_id {
+        if cur_region_ptr.is_some() {
+            canvas.surface.end_tagged();
+            let ptr_opt = cur_region_ptr.take().unwrap();
+            let id = cur_region_id.take().unwrap();
+            let item = match ptr_opt {
+                Some(ptr) => crate::draw_primitives::ParagraphRunItem::LinkContent {
+                    span_ptr: ptr,
+                    identifier: id,
+                },
+                None => crate::draw_primitives::ParagraphRunItem::Content(id),
+            };
+            if let Some(tc) = canvas.tag_collector.as_mut() {
+                tc.record_run(nid, item);
+            }
+        }
     }
 }
 

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -551,6 +551,75 @@ pub struct InlineBoxRenderCtx<'a> {
     pub margin_top_pt: Pt,
 }
 
+/// Tracks the currently-open per-run tagged region while `draw_shaped_lines`
+/// walks the line items. Each transition between link spans (or to/from
+/// non-link content) closes the previous region and opens a new one.
+struct RunRegionTracker {
+    /// Paragraph NodeId under which `ParagraphRunItem`s are recorded.
+    node_id: crate::drawables::NodeId,
+    /// `Some(ptr)` while a region is open; `ptr` is `None` for non-link
+    /// content or `Some(arc_ptr)` for content under an `<a>` span.
+    /// `None` means no region is currently open.
+    open_span_ptr: Option<Option<usize>>,
+    /// Identifier returned by the matching `start_tagged` call.
+    open_identifier: Option<krilla::tagging::Identifier>,
+}
+
+impl RunRegionTracker {
+    fn new(node_id: crate::drawables::NodeId) -> Self {
+        Self {
+            node_id,
+            open_span_ptr: None,
+            open_identifier: None,
+        }
+    }
+
+    /// Switch to the region identified by `new_span_ptr`, opening/closing
+    /// `start_tagged` regions as needed and recording closed regions on
+    /// `canvas.tag_collector`.
+    fn transition_to(&mut self, canvas: &mut Canvas<'_, '_>, new_span_ptr: Option<usize>) {
+        if self.open_span_ptr == Some(new_span_ptr) {
+            return;
+        }
+        self.close(canvas);
+        use krilla::tagging::{ContentTag, SpanTag};
+        let id = canvas
+            .surface
+            .start_tagged(ContentTag::Span(SpanTag::empty()));
+        self.open_span_ptr = Some(new_span_ptr);
+        self.open_identifier = Some(id);
+    }
+
+    /// Close the currently-open region (if any) and record it as a
+    /// `ParagraphRunItem` on the tag collector.
+    fn close(&mut self, canvas: &mut Canvas<'_, '_>) {
+        let Some(span_ptr) = self.open_span_ptr.take() else {
+            return;
+        };
+        canvas.surface.end_tagged();
+        let id = self
+            .open_identifier
+            .take()
+            .expect("open_identifier set whenever open_span_ptr is");
+        let item = match span_ptr {
+            Some(ptr) => crate::draw_primitives::ParagraphRunItem::LinkContent {
+                span_ptr: ptr,
+                identifier: id,
+            },
+            None => crate::draw_primitives::ParagraphRunItem::Content(id),
+        };
+        if let Some(tc) = canvas.tag_collector.as_mut() {
+            tc.record_run(self.node_id, item);
+        }
+    }
+}
+
+/// Convert an `Option<&Arc<LinkSpan>>` to its identity pointer used as the
+/// per-run region key.
+fn link_span_ptr(link: Option<&Arc<LinkSpan>>) -> Option<usize> {
+    link.map(|l| Arc::as_ptr(l) as usize)
+}
+
 /// Draw pre-shaped text lines at the given position.
 pub fn draw_shaped_lines(
     canvas: &mut Canvas<'_, '_>,
@@ -566,16 +635,14 @@ pub fn draw_shaped_lines(
     // to derive it from `line.baseline` (which is an absolute baseline offset
     // and does not carry per-line ascent).
     let mut line_top: f32 = 0.0;
-    // Per-run tagging mode is active when canvas.link_run_node_id is set and tagging is enabled.
-    // In this mode each glyph-run or image cluster gets its own start_tagged/end_tagged region.
-    let run_tag_node_id: Option<usize> = if canvas.tag_collector.is_some() {
-        canvas.link_run_node_id
-    } else {
-        None
+    // Per-run tagging mode is active when canvas.link_run_node_id is set and
+    // tagging is enabled. In this mode each glyph-run or inline-image cluster
+    // bounded by `Arc<LinkSpan>` identity gets its own start_tagged/end_tagged
+    // region recorded as a `ParagraphRunItem`.
+    let mut run_region = match (canvas.tag_collector.is_some(), canvas.link_run_node_id) {
+        (true, Some(node_id)) => Some(RunRegionTracker::new(node_id)),
+        _ => None,
     };
-    // None = no region open; Some(None) = non-link region open; Some(Some(ptr)) = link region open.
-    let mut cur_region_ptr: Option<Option<usize>> = None;
-    let mut cur_region_id: Option<krilla::tagging::Identifier> = None;
     for line in lines {
         let line_top_abs = y + line_top;
         let baseline_y = y + line.baseline;
@@ -583,38 +650,8 @@ pub fn draw_shaped_lines(
         for item in &line.items {
             match item {
                 LineItem::Text(run) => {
-                    if let Some(nid) = run_tag_node_id {
-                        let new_ptr = run
-                            .link
-                            .as_ref()
-                            .map(|l| std::sync::Arc::as_ptr(l) as usize);
-                        if cur_region_ptr != Some(new_ptr) {
-                            // Close previous region
-                            if cur_region_ptr.is_some() {
-                                canvas.surface.end_tagged();
-                                let ptr_opt = cur_region_ptr.take().unwrap();
-                                let id = cur_region_id.take().unwrap();
-                                let item = match ptr_opt {
-                                    Some(ptr) => {
-                                        crate::draw_primitives::ParagraphRunItem::LinkContent {
-                                            span_ptr: ptr,
-                                            identifier: id,
-                                        }
-                                    }
-                                    None => crate::draw_primitives::ParagraphRunItem::Content(id),
-                                };
-                                if let Some(tc) = canvas.tag_collector.as_mut() {
-                                    tc.record_run(nid, item);
-                                }
-                            }
-                            // Open new region
-                            use krilla::tagging::{ContentTag, SpanTag};
-                            let id = canvas
-                                .surface
-                                .start_tagged(ContentTag::Span(SpanTag::empty()));
-                            cur_region_ptr = Some(new_ptr);
-                            cur_region_id = Some(id);
-                        }
+                    if let Some(tracker) = run_region.as_mut() {
+                        tracker.transition_to(canvas, link_span_ptr(run.link.as_ref()));
                     }
                     // Create Krilla font from cached data
                     let data: krilla::Data = Arc::clone(&run.font_data).into();
@@ -686,38 +723,8 @@ pub fn draw_shaped_lines(
                     }
                 }
                 LineItem::Image(img) => {
-                    if let Some(nid) = run_tag_node_id {
-                        let new_ptr = img
-                            .link
-                            .as_ref()
-                            .map(|l| std::sync::Arc::as_ptr(l) as usize);
-                        if cur_region_ptr != Some(new_ptr) {
-                            // Close previous region
-                            if cur_region_ptr.is_some() {
-                                canvas.surface.end_tagged();
-                                let ptr_opt = cur_region_ptr.take().unwrap();
-                                let id = cur_region_id.take().unwrap();
-                                let item = match ptr_opt {
-                                    Some(ptr) => {
-                                        crate::draw_primitives::ParagraphRunItem::LinkContent {
-                                            span_ptr: ptr,
-                                            identifier: id,
-                                        }
-                                    }
-                                    None => crate::draw_primitives::ParagraphRunItem::Content(id),
-                                };
-                                if let Some(tc) = canvas.tag_collector.as_mut() {
-                                    tc.record_run(nid, item);
-                                }
-                            }
-                            // Open new region
-                            use krilla::tagging::{ContentTag, SpanTag};
-                            let id = canvas
-                                .surface
-                                .start_tagged(ContentTag::Span(SpanTag::empty()));
-                            cur_region_ptr = Some(new_ptr);
-                            cur_region_id = Some(id);
-                        }
+                    if let Some(tracker) = run_region.as_mut() {
+                        tracker.transition_to(canvas, link_span_ptr(img.link.as_ref()));
                     }
                     if !img.visible {
                         continue;
@@ -848,23 +855,9 @@ pub fn draw_shaped_lines(
 
         line_top += line.height;
     }
-    // Close any open per-run tagged region.
-    if let Some(nid) = run_tag_node_id {
-        if cur_region_ptr.is_some() {
-            canvas.surface.end_tagged();
-            let ptr_opt = cur_region_ptr.take().unwrap();
-            let id = cur_region_id.take().unwrap();
-            let item = match ptr_opt {
-                Some(ptr) => crate::draw_primitives::ParagraphRunItem::LinkContent {
-                    span_ptr: ptr,
-                    identifier: id,
-                },
-                None => crate::draw_primitives::ParagraphRunItem::Content(id),
-            };
-            if let Some(tc) = canvas.tag_collector.as_mut() {
-                tc.record_run(nid, item);
-            }
-        }
+    // Close any open per-run tagged region at end-of-paragraph.
+    if let Some(tracker) = run_region.as_mut() {
+        tracker.close(canvas);
     }
 }
 

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -761,7 +761,17 @@ pub fn draw_shaped_lines(
                     }
                 }
                 LineItem::InlineBox(ib) => {
+                    // Close any open per-run tag region and clear
+                    // `link_run_node_id` before dispatching inline-box
+                    // content. `start_tagged` is non-nestable in Krilla:
+                    // leaving a region open or having `link_run_node_id` set
+                    // while the sub-dispatch also calls `start_tagged` panics.
+                    if let Some(tracker) = run_region.as_mut() {
+                        tracker.close(canvas);
+                    }
+                    let saved_link_run_node_id = canvas.link_run_node_id.take();
                     if !ib.visible {
+                        canvas.link_run_node_id = saved_link_run_node_id;
                         continue;
                     }
                     let ox = x + ib.x_offset;
@@ -846,6 +856,7 @@ pub fn draw_shaped_lines(
                             collector.push_rect(link_span, rect);
                         }
                     }
+                    canvas.link_run_node_id = saved_link_run_node_id;
                 }
             }
         }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -241,9 +241,30 @@ pub fn render_v2(
             );
         }
         let per_page = link_collector.take_page(page_idx);
-        for (ptr, id) in
-            crate::link::emit_link_annotations(&mut page, &per_page, &dest_registry, tagging)
-        {
+        // Build the set of span_ptrs that are wired into the struct tree via
+        // ParagraphRunItem::LinkContent entries.  Only these ptrs should use
+        // add_tagged_annotation; others fall back to add_annotation so that
+        // Krilla's invariant (every tagged annotation appears in the tag tree)
+        // is not violated for link types not yet wired (e.g. InlineBox links).
+        let wired_ptrs: Option<std::collections::BTreeSet<usize>> =
+            tag_collector.as_ref().map(|tc| {
+                use crate::draw_primitives::ParagraphRunItem;
+                tc.run_entries
+                    .values()
+                    .flatten()
+                    .filter_map(|item| match item {
+                        ParagraphRunItem::LinkContent { span_ptr, .. } => Some(*span_ptr),
+                        ParagraphRunItem::Content(_) => None,
+                    })
+                    .collect()
+            });
+        for (ptr, id) in crate::link::emit_link_annotations(
+            &mut page,
+            &per_page,
+            &dest_registry,
+            tagging,
+            wired_ptrs.as_ref(),
+        ) {
             link_annot_ids.insert(ptr, id);
         }
     }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -762,6 +762,19 @@ pub(crate) fn dispatch_inline_box_content(
     }
 }
 
+/// Returns `true` if any line item in `entry` is a text run or inline image
+/// with a non-`None` link. Used to decide whether to activate per-run tagging
+/// mode in `dispatch_fragment` rather than the normal paragraph-level tagging.
+fn para_has_link_runs(entry: &crate::drawables::ParagraphEntry) -> bool {
+    entry.lines.iter().any(|line| {
+        line.items.iter().any(|item| match item {
+            crate::paragraph::LineItem::Text(run) => run.link.is_some(),
+            crate::paragraph::LineItem::Image(img) => img.link.is_some(),
+            crate::paragraph::LineItem::InlineBox(_) => false,
+        })
+    })
+}
+
 /// Start a Krilla tagged content sequence for a paragraph-bearing node when
 /// tagging is enabled and the node has a P / H / Span semantic entry.
 ///
@@ -928,7 +941,13 @@ pub(crate) fn dispatch_fragment(
         let img_for_block = drawables.images.get(&node_id);
         let svg_for_block = drawables.svgs.get(&node_id);
         if para_for_block.is_some() || img_for_block.is_some() || svg_for_block.is_some() {
-            let tag_info = if para_for_block.is_some() {
+            let use_run_tagging = para_for_block
+                .map(|p| canvas.tag_collector.is_some() && para_has_link_runs(p))
+                .unwrap_or(false);
+            let tag_info = if use_run_tagging {
+                canvas.link_run_node_id = Some(node_id);
+                None
+            } else if para_for_block.is_some() {
                 try_start_tagged(canvas, node_id, drawables)
             } else {
                 None
@@ -962,6 +981,9 @@ pub(crate) fn dispatch_fragment(
                 );
             }
             finish_tagged(canvas, tag_info);
+            if use_run_tagging {
+                canvas.link_run_node_id = None;
+            }
             return;
         }
         draw_block_v2(canvas, block, x_pt, y_pt, frag, is_split);
@@ -987,21 +1009,39 @@ pub(crate) fn dispatch_fragment(
         return;
     }
     if let Some(para) = drawables.paragraphs.get(&node_id) {
-        let tag_info = try_start_tagged(canvas, node_id, drawables);
-        draw_paragraph_v2(
-            canvas,
-            para,
-            x_pt,
-            y_pt,
-            &geom.fragments,
-            page_index,
-            is_split,
-            drawables,
-            geometry,
-            margin_left_pt,
-            margin_top_pt,
-        );
-        finish_tagged(canvas, tag_info);
+        if canvas.tag_collector.is_some() && para_has_link_runs(para) {
+            canvas.link_run_node_id = Some(node_id);
+            draw_paragraph_v2(
+                canvas,
+                para,
+                x_pt,
+                y_pt,
+                &geom.fragments,
+                page_index,
+                is_split,
+                drawables,
+                geometry,
+                margin_left_pt,
+                margin_top_pt,
+            );
+            canvas.link_run_node_id = None;
+        } else {
+            let tag_info = try_start_tagged(canvas, node_id, drawables);
+            draw_paragraph_v2(
+                canvas,
+                para,
+                x_pt,
+                y_pt,
+                &geom.fragments,
+                page_index,
+                is_split,
+                drawables,
+                geometry,
+                margin_left_pt,
+                margin_top_pt,
+            );
+            finish_tagged(canvas, tag_info);
+        }
     }
 }
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -115,8 +115,7 @@ pub fn render_v2(
     let mut link_collector = crate::draw_primitives::LinkCollector::new();
 
     let tagging = config.effective_tagging();
-    let mut link_annot_ids: std::collections::BTreeMap<usize, krilla::tagging::Identifier> =
-        std::collections::BTreeMap::new();
+    let mut link_annot_ids: BTreeMap<usize, Vec<krilla::tagging::Identifier>> = BTreeMap::new();
 
     // Build the GCPM margin-box renderer once. Reused across pages so
     // measure / layout / render caches survive between pages and the
@@ -265,7 +264,7 @@ pub fn render_v2(
             tagging,
             wired_ptrs.as_ref(),
         ) {
-            link_annot_ids.insert(ptr, id);
+            link_annot_ids.entry(ptr).or_default().push(id);
         }
     }
 
@@ -3648,7 +3647,7 @@ fn strip_display_none(css: &str) -> String {
 fn build_struct_tree(
     tc: crate::draw_primitives::TagCollector,
     drawables: &Drawables,
-    link_annot_ids: &std::collections::BTreeMap<usize, Identifier>,
+    link_annot_ids: &BTreeMap<usize, Vec<Identifier>>,
     tree: &mut TagTree,
 ) {
     let mut identifiers: BTreeMap<crate::drawables::NodeId, Vec<Identifier>> = BTreeMap::new();
@@ -3700,7 +3699,7 @@ fn build_tag_group(
     heading_titles: &BTreeMap<crate::drawables::NodeId, String>,
     children_map: &BTreeMap<crate::drawables::NodeId, Vec<crate::drawables::NodeId>>,
     run_entries: &BTreeMap<crate::drawables::NodeId, Vec<crate::draw_primitives::ParagraphRunItem>>,
-    link_annot_ids: &std::collections::BTreeMap<usize, Identifier>,
+    link_annot_ids: &BTreeMap<usize, Vec<Identifier>>,
 ) -> TagGroup {
     let entry = &drawables.semantics[&node_id]; // invariant: node_id always derived from drawables.semantics
     let title = heading_titles.get(&node_id).cloned();
@@ -3743,9 +3742,12 @@ fn build_tag_group(
                         }
                         break;
                     }
-                    // Annotation identifier (OBJR) follows content identifiers.
-                    if let Some(&annot_id) = link_annot_ids.get(&ptr) {
-                        link_group.push(Node::Leaf(annot_id));
+                    // Annotation identifiers (OBJR) follow content identifiers.
+                    // A cross-page link produces one identifier per page.
+                    if let Some(annot_ids) = link_annot_ids.get(&ptr) {
+                        for &annot_id in annot_ids {
+                            link_group.push(Node::Leaf(annot_id));
+                        }
                     }
                     group.push(Node::Group(link_group));
                 }
@@ -4010,9 +4012,8 @@ mod tests {
             ],
         );
 
-        let mut link_annot_ids: std::collections::BTreeMap<usize, Identifier> =
-            std::collections::BTreeMap::new();
-        link_annot_ids.insert(99, annot_id);
+        let mut link_annot_ids: BTreeMap<usize, Vec<Identifier>> = BTreeMap::new();
+        link_annot_ids.entry(99).or_default().push(annot_id);
 
         let drawables = drawables_with_para(node_id);
         let identifiers: BTreeMap<crate::drawables::NodeId, Vec<Identifier>> = BTreeMap::new();
@@ -4057,8 +4058,7 @@ mod tests {
             }],
         );
 
-        let link_annot_ids: std::collections::BTreeMap<usize, Identifier> =
-            std::collections::BTreeMap::new(); // empty — no OBJR
+        let link_annot_ids: BTreeMap<usize, Vec<Identifier>> = BTreeMap::new(); // empty — no OBJR
 
         let drawables = drawables_with_para(node_id);
         let identifiers: BTreeMap<crate::drawables::NodeId, Vec<Identifier>> = BTreeMap::new();

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -237,7 +237,7 @@ pub fn render_v2(
             );
         }
         let per_page = link_collector.take_page(page_idx);
-        crate::link::emit_link_annotations(&mut page, &per_page, &dest_registry);
+        crate::link::emit_link_annotations(&mut page, &per_page, &dest_registry, false);
     }
 
     if let Some(tc) = tag_collector {

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -114,6 +114,10 @@ pub fn render_v2(
 
     let mut link_collector = crate::draw_primitives::LinkCollector::new();
 
+    let tagging = config.effective_tagging();
+    let mut link_annot_ids: std::collections::BTreeMap<usize, krilla::tagging::Identifier> =
+        std::collections::BTreeMap::new();
+
     // Build the GCPM margin-box renderer once. Reused across pages so
     // measure / layout / render caches survive between pages and the
     // pre-computed `string_set_states` / `counter_states` /
@@ -237,12 +241,16 @@ pub fn render_v2(
             );
         }
         let per_page = link_collector.take_page(page_idx);
-        crate::link::emit_link_annotations(&mut page, &per_page, &dest_registry, false);
+        for (ptr, id) in
+            crate::link::emit_link_annotations(&mut page, &per_page, &dest_registry, tagging)
+        {
+            link_annot_ids.insert(ptr, id);
+        }
     }
 
     if let Some(tc) = tag_collector {
         let mut tree = TagTree::new().with_lang(config.lang.clone());
-        build_struct_tree(tc, drawables, &mut tree);
+        build_struct_tree(tc, drawables, &link_annot_ids, &mut tree);
         document.set_tag_tree(tree);
     }
 
@@ -3619,11 +3627,16 @@ fn strip_display_none(css: &str) -> String {
 fn build_struct_tree(
     tc: crate::draw_primitives::TagCollector,
     drawables: &Drawables,
+    link_annot_ids: &std::collections::BTreeMap<usize, Identifier>,
     tree: &mut TagTree,
 ) {
     let mut identifiers: BTreeMap<crate::drawables::NodeId, Vec<Identifier>> = BTreeMap::new();
     let mut heading_titles: BTreeMap<crate::drawables::NodeId, String> = BTreeMap::new();
-    for (node_id, _tag, id, heading_title) in tc.into_entries() {
+    // Destructure tc to extract run_entries before consuming tc via
+    // into_entries() — a direct `tc.run_entries` move before calling
+    // tc.into_entries() would be a partial move error.
+    let (tc_entries, run_entries) = tc.into_parts();
+    for (node_id, _tag, id, heading_title) in tc_entries {
         identifiers.entry(node_id).or_default().push(id);
         if let Some(title) = heading_title {
             heading_titles.entry(node_id).or_insert(title);
@@ -3652,6 +3665,8 @@ fn build_struct_tree(
             &identifiers,
             &heading_titles,
             &children_map,
+            &run_entries,
+            link_annot_ids,
         );
         tree.push(Node::Group(group));
     }
@@ -3663,6 +3678,8 @@ fn build_tag_group(
     identifiers: &BTreeMap<crate::drawables::NodeId, Vec<Identifier>>,
     heading_titles: &BTreeMap<crate::drawables::NodeId, String>,
     children_map: &BTreeMap<crate::drawables::NodeId, Vec<crate::drawables::NodeId>>,
+    run_entries: &BTreeMap<crate::drawables::NodeId, Vec<crate::draw_primitives::ParagraphRunItem>>,
+    link_annot_ids: &std::collections::BTreeMap<usize, Identifier>,
 ) -> TagGroup {
     let entry = &drawables.semantics[&node_id]; // invariant: node_id always derived from drawables.semantics
     let title = heading_titles.get(&node_id).cloned();
@@ -3672,7 +3689,48 @@ fn build_tag_group(
         entry.alt_text.clone(),
     ));
 
-    if let Some(ids) = identifiers.get(&node_id) {
+    // Paragraphs with per-run link tagging use run_entries instead of the
+    // single identifiers path.
+    if let Some(run_items) = run_entries.get(&node_id) {
+        let mut i = 0;
+        while i < run_items.len() {
+            use crate::draw_primitives::ParagraphRunItem;
+            match &run_items[i] {
+                ParagraphRunItem::Content(id) => {
+                    group.push(Node::Leaf(*id));
+                    i += 1;
+                }
+                ParagraphRunItem::LinkContent { span_ptr, .. } => {
+                    let ptr = *span_ptr;
+                    let mut link_group = TagGroup::new(crate::tagging::pdf_tag_to_krilla_tag(
+                        &crate::tagging::PdfTag::Link,
+                        None,
+                        None,
+                    ));
+                    // Collect all consecutive items with the same span_ptr.
+                    while i < run_items.len() {
+                        if let ParagraphRunItem::LinkContent {
+                            span_ptr: p,
+                            identifier: id,
+                        } = &run_items[i]
+                        {
+                            if *p == ptr {
+                                link_group.push(Node::Leaf(*id));
+                                i += 1;
+                                continue;
+                            }
+                        }
+                        break;
+                    }
+                    // Annotation identifier (OBJR) follows content identifiers.
+                    if let Some(&annot_id) = link_annot_ids.get(&ptr) {
+                        link_group.push(Node::Leaf(annot_id));
+                    }
+                    group.push(Node::Group(link_group));
+                }
+            }
+        }
+    } else if let Some(ids) = identifiers.get(&node_id) {
         for &id in ids {
             group.push(Node::Leaf(id));
         }
@@ -3686,6 +3744,8 @@ fn build_tag_group(
                 identifiers,
                 heading_titles,
                 children_map,
+                run_entries,
+                link_annot_ids,
             );
             group.push(Node::Group(child));
         }
@@ -3876,5 +3936,133 @@ mod tests {
     #[test]
     fn parse_datetime_invalid_non_numeric_second() {
         assert!(parse_datetime("2024-06-15T10:30:abc").is_none());
+    }
+
+    // --- build_tag_group: LinkContent branch ---
+
+    /// Helper that allocates a real [`Identifier`] from a scratch krilla document.
+    fn make_identifier() -> Identifier {
+        use krilla::tagging::{ContentTag, SpanTag};
+        let mut doc = krilla::Document::new();
+        let settings = krilla::page::PageSettings::from_wh(100.0, 100.0).expect("valid page size");
+        let mut page = doc.start_page_with(settings);
+        let mut surface = page.surface();
+        let id = surface.start_tagged(ContentTag::Span(SpanTag::empty()));
+        surface.end_tagged();
+        id
+    }
+
+    /// Build a minimal [`Drawables`] with a single semantic paragraph node.
+    fn drawables_with_para(node_id: crate::drawables::NodeId) -> Drawables {
+        let mut d = Drawables::new();
+        d.semantics.insert(
+            node_id,
+            crate::tagging::SemanticEntry {
+                tag: crate::tagging::PdfTag::P,
+                parent: None,
+                alt_text: None,
+            },
+        );
+        d
+    }
+
+    #[test]
+    fn build_tag_group_link_content_creates_nested_link_group() {
+        // Paragraph node_id = 1 has one non-link run and one link run (ptr=99).
+        let node_id: crate::drawables::NodeId = 1;
+        let content_id = make_identifier();
+        let link_id = make_identifier();
+        let annot_id = make_identifier();
+
+        let mut run_entries: BTreeMap<
+            crate::drawables::NodeId,
+            Vec<crate::draw_primitives::ParagraphRunItem>,
+        > = BTreeMap::new();
+        run_entries.insert(
+            node_id,
+            vec![
+                crate::draw_primitives::ParagraphRunItem::Content(content_id),
+                crate::draw_primitives::ParagraphRunItem::LinkContent {
+                    span_ptr: 99,
+                    identifier: link_id,
+                },
+            ],
+        );
+
+        let mut link_annot_ids: std::collections::BTreeMap<usize, Identifier> =
+            std::collections::BTreeMap::new();
+        link_annot_ids.insert(99, annot_id);
+
+        let drawables = drawables_with_para(node_id);
+        let identifiers: BTreeMap<crate::drawables::NodeId, Vec<Identifier>> = BTreeMap::new();
+        let heading_titles: BTreeMap<crate::drawables::NodeId, String> = BTreeMap::new();
+        let children_map: BTreeMap<crate::drawables::NodeId, Vec<crate::drawables::NodeId>> =
+            BTreeMap::new();
+
+        let group = build_tag_group(
+            node_id,
+            &drawables,
+            &identifiers,
+            &heading_titles,
+            &children_map,
+            &run_entries,
+            &link_annot_ids,
+        );
+
+        // The group should have two children: one Leaf (Content) and one Group (Link).
+        assert_eq!(group.children.len(), 2, "expected Leaf + Group(Link)");
+        // Second child should be a Group (the Link TagGroup).
+        assert!(
+            matches!(group.children[1], Node::Group(_)),
+            "second child should be a Link Group"
+        );
+    }
+
+    #[test]
+    fn build_tag_group_link_content_no_annot_id_still_builds_group() {
+        // Same as above but no annotation identifier in link_annot_ids.
+        let node_id: crate::drawables::NodeId = 2;
+        let link_id = make_identifier();
+
+        let mut run_entries: BTreeMap<
+            crate::drawables::NodeId,
+            Vec<crate::draw_primitives::ParagraphRunItem>,
+        > = BTreeMap::new();
+        run_entries.insert(
+            node_id,
+            vec![crate::draw_primitives::ParagraphRunItem::LinkContent {
+                span_ptr: 77,
+                identifier: link_id,
+            }],
+        );
+
+        let link_annot_ids: std::collections::BTreeMap<usize, Identifier> =
+            std::collections::BTreeMap::new(); // empty — no OBJR
+
+        let drawables = drawables_with_para(node_id);
+        let identifiers: BTreeMap<crate::drawables::NodeId, Vec<Identifier>> = BTreeMap::new();
+        let heading_titles: BTreeMap<crate::drawables::NodeId, String> = BTreeMap::new();
+        let children_map: BTreeMap<crate::drawables::NodeId, Vec<crate::drawables::NodeId>> =
+            BTreeMap::new();
+
+        let group = build_tag_group(
+            node_id,
+            &drawables,
+            &identifiers,
+            &heading_titles,
+            &children_map,
+            &run_entries,
+            &link_annot_ids,
+        );
+
+        assert_eq!(
+            group.children.len(),
+            1,
+            "link without OBJR should still produce one Link Group"
+        );
+        assert!(
+            matches!(group.children[0], Node::Group(_)),
+            "child should be a Link Group"
+        );
     }
 }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -114,7 +114,6 @@ pub fn render_v2(
 
     let mut link_collector = crate::draw_primitives::LinkCollector::new();
 
-    let tagging = config.effective_tagging();
     let mut link_annot_ids: BTreeMap<usize, Vec<krilla::tagging::Identifier>> = BTreeMap::new();
 
     // Build the GCPM margin-box renderer once. Reused across pages so
@@ -240,28 +239,16 @@ pub fn render_v2(
             );
         }
         let per_page = link_collector.take_page(page_idx);
-        // Build the set of span_ptrs that are wired into the struct tree via
-        // ParagraphRunItem::LinkContent entries.  Only these ptrs should use
-        // add_tagged_annotation; others fall back to add_annotation so that
-        // Krilla's invariant (every tagged annotation appears in the tag tree)
-        // is not violated for link types not yet wired (e.g. InlineBox links).
-        let wired_ptrs: Option<std::collections::BTreeSet<usize>> =
-            tag_collector.as_ref().map(|tc| {
-                use crate::draw_primitives::ParagraphRunItem;
-                tc.run_entries
-                    .values()
-                    .flatten()
-                    .filter_map(|item| match item {
-                        ParagraphRunItem::LinkContent { span_ptr, .. } => Some(*span_ptr),
-                        ParagraphRunItem::Content(_) => None,
-                    })
-                    .collect()
-            });
+        // Only span_ptrs that are wired into the struct tree via
+        // ParagraphRunItem::LinkContent entries should use add_tagged_annotation;
+        // others fall back to add_annotation so that Krilla's invariant
+        // (every tagged annotation appears in the tag tree) is not violated for
+        // link types not yet wired (e.g. InlineBox links).
+        let wired_ptrs = tag_collector.as_ref().map(|tc| tc.wired_link_span_ptrs());
         for (ptr, id) in crate::link::emit_link_annotations(
             &mut page,
             &per_page,
             &dest_registry,
-            tagging,
             wired_ptrs.as_ref(),
         ) {
             link_annot_ids.entry(ptr).or_default().push(id);
@@ -1037,38 +1024,29 @@ pub(crate) fn dispatch_fragment(
         return;
     }
     if let Some(para) = drawables.paragraphs.get(&node_id) {
-        if canvas.tag_collector.is_some() && para_has_link_runs(para) {
+        let use_run_tagging = canvas.tag_collector.is_some() && para_has_link_runs(para);
+        let tag_info = if use_run_tagging {
             canvas.link_run_node_id = Some(node_id);
-            draw_paragraph_v2(
-                canvas,
-                para,
-                x_pt,
-                y_pt,
-                &geom.fragments,
-                page_index,
-                is_split,
-                drawables,
-                geometry,
-                margin_left_pt,
-                margin_top_pt,
-            );
-            canvas.link_run_node_id = None;
+            None
         } else {
-            let tag_info = try_start_tagged(canvas, node_id, drawables);
-            draw_paragraph_v2(
-                canvas,
-                para,
-                x_pt,
-                y_pt,
-                &geom.fragments,
-                page_index,
-                is_split,
-                drawables,
-                geometry,
-                margin_left_pt,
-                margin_top_pt,
-            );
-            finish_tagged(canvas, tag_info);
+            try_start_tagged(canvas, node_id, drawables)
+        };
+        draw_paragraph_v2(
+            canvas,
+            para,
+            x_pt,
+            y_pt,
+            &geom.fragments,
+            page_index,
+            is_split,
+            drawables,
+            geometry,
+            margin_left_pt,
+            margin_top_pt,
+        );
+        finish_tagged(canvas, tag_info);
+        if use_run_tagging {
+            canvas.link_run_node_id = None;
         }
     }
 }
@@ -3652,9 +3630,8 @@ fn build_struct_tree(
 ) {
     let mut identifiers: BTreeMap<crate::drawables::NodeId, Vec<Identifier>> = BTreeMap::new();
     let mut heading_titles: BTreeMap<crate::drawables::NodeId, String> = BTreeMap::new();
-    // Destructure tc to extract run_entries before consuming tc via
-    // into_entries() — a direct `tc.run_entries` move before calling
-    // tc.into_entries() would be a partial move error.
+    // `into_parts` returns `entries` and `run_entries` together so neither
+    // field needs to be borrowed before the other is moved.
     let (tc_entries, run_entries) = tc.into_parts();
     for (node_id, _tag, id, heading_title) in tc_entries {
         identifiers.entry(node_id).or_default().push(id);
@@ -3728,19 +3705,14 @@ fn build_tag_group(
                         None,
                     ));
                     // Collect all consecutive items with the same span_ptr.
-                    while i < run_items.len() {
-                        if let ParagraphRunItem::LinkContent {
-                            span_ptr: p,
-                            identifier: id,
-                        } = &run_items[i]
-                        {
-                            if *p == ptr {
-                                link_group.push(Node::Leaf(*id));
-                                i += 1;
-                                continue;
-                            }
-                        }
-                        break;
+                    while let Some(ParagraphRunItem::LinkContent {
+                        span_ptr: p,
+                        identifier: id,
+                    }) = run_items.get(i)
+                        && *p == ptr
+                    {
+                        link_group.push(Node::Leaf(*id));
+                        i += 1;
                     }
                     // Annotation identifiers (OBJR) follow content identifiers.
                     // A cross-page link produces one identifier per page.
@@ -3963,17 +3935,7 @@ mod tests {
 
     // --- build_tag_group: LinkContent branch ---
 
-    /// Helper that allocates a real [`Identifier`] from a scratch krilla document.
-    fn make_identifier() -> Identifier {
-        use krilla::tagging::{ContentTag, SpanTag};
-        let mut doc = krilla::Document::new();
-        let settings = krilla::page::PageSettings::from_wh(100.0, 100.0).expect("valid page size");
-        let mut page = doc.start_page_with(settings);
-        let mut surface = page.surface();
-        let id = surface.start_tagged(ContentTag::Span(SpanTag::empty()));
-        surface.end_tagged();
-        id
-    }
+    use crate::draw_primitives::run_tag_tests::make_identifier;
 
     /// Build a minimal [`Drawables`] with a single semantic paragraph node.
     fn drawables_with_para(node_id: crate::drawables::NodeId) -> Drawables {

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -790,6 +790,22 @@ fn para_has_link_runs(entry: &crate::drawables::ParagraphEntry) -> bool {
     })
 }
 
+/// Collect the plain-text title from a paragraph's shaped lines.
+///
+/// Returns the concatenated text of all `Text` run items across all lines.
+/// Used to populate the `/T` (Title) attribute on heading tags required by
+/// PDF/UA-1.
+fn extract_heading_title(para: &crate::drawables::ParagraphEntry) -> String {
+    para.lines
+        .iter()
+        .flat_map(|line| line.items.iter())
+        .filter_map(|item| match item {
+            crate::paragraph::LineItem::Text(run) => Some(run.text.as_str()),
+            _ => None,
+        })
+        .collect()
+}
+
 /// Start a Krilla tagged content sequence for a paragraph-bearing node when
 /// tagging is enabled and the node has a P / H / Span semantic entry.
 ///
@@ -819,18 +835,10 @@ fn try_start_tagged(
             Some((node_id, semantic.tag.clone(), id, None))
         }
         crate::tagging::PdfTag::H { .. } => {
-            // For heading tags, extract the plain text so Tag::Hn gets the /T (Title)
-            // attribute that PDF/UA-1 validators require.
-            let heading_title = drawables.paragraphs.get(&node_id).map(|para| {
-                para.lines
-                    .iter()
-                    .flat_map(|line| line.items.iter())
-                    .filter_map(|item| match item {
-                        crate::paragraph::LineItem::Text(run) => Some(run.text.as_str()),
-                        _ => None,
-                    })
-                    .collect::<String>()
-            });
+            let heading_title = drawables
+                .paragraphs
+                .get(&node_id)
+                .map(extract_heading_title);
             use krilla::tagging::{ContentTag, SpanTag};
             let id = canvas
                 .surface
@@ -3637,6 +3645,24 @@ fn build_struct_tree(
         identifiers.entry(node_id).or_default().push(id);
         if let Some(title) = heading_title {
             heading_titles.entry(node_id).or_insert(title);
+        }
+    }
+    // Nodes that use per-run tagging (run_entries) bypass try_start_tagged and
+    // therefore never record a heading_title through tc_entries. Backfill their
+    // titles here so <h1><a href>…</a></h1> still gets the /T attribute.
+    for &node_id in run_entries.keys() {
+        if heading_titles.contains_key(&node_id) {
+            continue;
+        }
+        if let Some(entry) = drawables.semantics.get(&node_id) {
+            if matches!(entry.tag, crate::tagging::PdfTag::H { .. }) {
+                if let Some(para) = drawables.paragraphs.get(&node_id) {
+                    let title = extract_heading_title(para);
+                    if !title.is_empty() {
+                        heading_titles.insert(node_id, title);
+                    }
+                }
+            }
         }
     }
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -160,6 +160,7 @@ pub fn render_v2(
                     bookmark_collector: bookmark_collector.as_mut(),
                     link_collector: Some(&mut link_collector),
                     tag_collector: tag_collector.as_mut(),
+                    link_run_node_id: None,
                 };
                 // Root `<html>` + `<body>` background pre-pass. v1's
                 // `BlockPageable::draw` for these elements paints
@@ -222,6 +223,7 @@ pub fn render_v2(
                 bookmark_collector: None,
                 link_collector: Some(&mut link_collector),
                 tag_collector: None,
+                link_run_node_id: None,
             };
             let page_content_width = page_size.width - resolved_margin.left - resolved_margin.right;
             margin_box_renderer.render_page(

--- a/crates/fulgur/src/svg.rs
+++ b/crates/fulgur/src/svg.rs
@@ -100,6 +100,7 @@ mod tests {
                     bookmark_collector: None,
                     link_collector: None,
                     tag_collector: None,
+                    link_run_node_id: None,
                 };
                 svg.draw(&mut canvas, 10.0, 20.0, 400.0, 400.0);
             }

--- a/crates/fulgur/src/tagging.rs
+++ b/crates/fulgur/src/tagging.rs
@@ -307,10 +307,4 @@ mod tests {
             TagKind::Link(_)
         ));
     }
-
-    #[test]
-    fn pdf_tag_to_krilla_tag_link() {
-        let k = pdf_tag_to_krilla_tag(&PdfTag::Link, None, None);
-        assert!(matches!(k, krilla::tagging::TagKind::Link(_)));
-    }
 }

--- a/crates/fulgur/src/tagging.rs
+++ b/crates/fulgur/src/tagging.rs
@@ -44,6 +44,7 @@ pub enum PdfTag {
         scope: krilla::tagging::TableHeaderScope,
     },
     Td,
+    Link,
 }
 
 /// Per-NodeId semantic record stored in `Drawables.semantics`.
@@ -141,6 +142,7 @@ pub fn pdf_tag_to_krilla_tag(
         PdfTag::Tr => krilla::tagging::Tag::<krilla::tagging::kind::TR>::TR.into(),
         PdfTag::Th { scope } => krilla::tagging::Tag::TH(*scope).into(),
         PdfTag::Td => krilla::tagging::Tag::<krilla::tagging::kind::TD>::TD.into(),
+        PdfTag::Link => krilla::tagging::Tag::<krilla::tagging::kind::Link>::Link.into(),
     }
 }
 
@@ -300,5 +302,15 @@ mod tests {
             pdf_tag_to_krilla_tag(&PdfTag::Td, None, None),
             TagKind::TD(_)
         ));
+        assert!(matches!(
+            pdf_tag_to_krilla_tag(&PdfTag::Link, None, None),
+            TagKind::Link(_)
+        ));
+    }
+
+    #[test]
+    fn pdf_tag_to_krilla_tag_link() {
+        let k = pdf_tag_to_krilla_tag(&PdfTag::Link, None, None);
+        assert!(matches!(k, krilla::tagging::TagKind::Link(_)));
     }
 }

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -2710,3 +2710,79 @@ fn tagged_th_scope_attribute_preserved() {
     );
     assert!(s.contains("/Row"), "must have Row scope for row-scoped TH");
 }
+
+#[test]
+fn tagged_pdf_external_link_produces_link_struct_element() {
+    let html = r#"<!DOCTYPE html><html lang="en"><body>
+        <p>Visit <a href="https://example.com">Example Site</a> for more info.</p>
+    </body></html>"#;
+
+    let pdf = Engine::builder()
+        .tagged(true)
+        .build()
+        .render_html(html)
+        .expect("tagged render with link");
+
+    assert!(!pdf.is_empty());
+    let s = String::from_utf8_lossy(&pdf);
+    assert!(s.contains("/StructTreeRoot"), "must have struct tree root");
+    assert!(s.contains("/Link"), "must have /Link structure element");
+    assert!(s.contains("/Annots"), "must have link annotation on page");
+}
+
+#[test]
+fn tagged_pdf_internal_anchor_link_produces_link_struct_element() {
+    let html = r##"<!DOCTYPE html><html lang="en"><body>
+        <h2 id="section1">Section 1</h2>
+        <p>Go to <a href="#section1">Section 1</a> above.</p>
+    </body></html>"##;
+
+    let pdf = Engine::builder()
+        .tagged(true)
+        .build()
+        .render_html(html)
+        .expect("tagged render with internal link");
+
+    assert!(!pdf.is_empty());
+    let s = String::from_utf8_lossy(&pdf);
+    assert!(s.contains("/Link"), "must have /Link structure element");
+}
+
+#[test]
+fn tagged_pdf_image_link_does_not_panic() {
+    // 1x1 transparent GIF
+    let html = r#"<!DOCTYPE html><html lang="en"><body>
+        <p><a href="https://example.com"><img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" alt="logo" width="10" height="10"></a></p>
+    </body></html>"#;
+
+    let pdf = Engine::builder()
+        .tagged(true)
+        .build()
+        .render_html(html)
+        .expect("image link tagged render must not panic");
+
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn untagged_pdf_with_link_preserves_annotation_no_struct_tree() {
+    let html = r#"<!DOCTYPE html><html><body>
+        <p>Visit <a href="https://example.com">Example</a>.</p>
+    </body></html>"#;
+
+    let pdf = Engine::builder()
+        .build()
+        .render_html(html)
+        .expect("untagged render with link");
+
+    assert!(!pdf.is_empty());
+    let s = String::from_utf8_lossy(&pdf);
+    assert!(
+        !s.contains("/StructTreeRoot"),
+        "untagged PDF must not have struct tree"
+    );
+    assert!(
+        s.contains("/Annots"),
+        "link annotation must be present in untagged PDF"
+    );
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -2752,6 +2752,7 @@ fn tagged_pdf_internal_anchor_link_produces_link_struct_element() {
         s.contains("/S /Link") || s.contains("/S/Link"),
         "must have /Link structure element"
     );
+    assert!(s.contains("/Annots"), "must have link annotation on page");
 }
 
 #[test]

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -2726,7 +2726,10 @@ fn tagged_pdf_external_link_produces_link_struct_element() {
     assert!(!pdf.is_empty());
     let s = String::from_utf8_lossy(&pdf);
     assert!(s.contains("/StructTreeRoot"), "must have struct tree root");
-    assert!(s.contains("/Link"), "must have /Link structure element");
+    assert!(
+        s.contains("/S /Link") || s.contains("/S/Link"),
+        "must have /Link structure element"
+    );
     assert!(s.contains("/Annots"), "must have link annotation on page");
 }
 
@@ -2745,7 +2748,10 @@ fn tagged_pdf_internal_anchor_link_produces_link_struct_element() {
 
     assert!(!pdf.is_empty());
     let s = String::from_utf8_lossy(&pdf);
-    assert!(s.contains("/Link"), "must have /Link structure element");
+    assert!(
+        s.contains("/S /Link") || s.contains("/S/Link"),
+        "must have /Link structure element"
+    );
 }
 
 #[test]
@@ -2760,6 +2766,25 @@ fn tagged_pdf_image_link_does_not_panic() {
         .build()
         .render_html(html)
         .expect("image link tagged render must not panic");
+
+    assert!(!pdf.is_empty());
+    let s = String::from_utf8_lossy(&pdf);
+    assert!(s.contains("/Annots"), "image link must produce annotation");
+}
+
+#[test]
+fn tagged_pdf_inline_box_after_link_does_not_panic() {
+    // Regression: InlineBox was not closing the per-run tag region before
+    // dispatching, causing a non-nestable start_tagged panic in Krilla.
+    let html = r##"<!DOCTYPE html><html lang="en"><body>
+        <p><a href="#x">link text</a><span style="display:inline-block">box</span></p>
+    </body></html>"##;
+
+    let pdf = Engine::builder()
+        .tagged(true)
+        .build()
+        .render_html(html)
+        .expect("inline box after link must not panic");
 
     assert!(!pdf.is_empty());
 }


### PR DESCRIPTION
## 概要

`<a href>` のリンクを Tagged PDF の構造ツリー（StructTree）に関連付ける。PDF/UA-1 準拠のアクセシビリティ対応として、リンク付きテキストが `Link` タググループ（コンテンツ識別子 + OBJR）として StructTree に現れるようになる。

- `PdfTag::Link` バリアントを追加（`tagging.rs`）
- `ParagraphRunItem` enum を導入し、段落内のグリフランを「リンク内」と「リンク外」に区別して記録（`draw_primitives.rs`）
- `LinkOccurrence` に `span_ptr`（`Arc<LinkSpan>` のポインタ値）を追加し、annotation と struct tree エントリの対応付けに使用（`draw_primitives.rs`）
- `draw_shaped_lines` に per-run タギングモードを追加。リンク含む段落では段落レベルではなくランレベルで `start_tagged/end_tagged` を発行（`paragraph.rs`）
- `emit_link_annotations` がタギングモード時に annotation identifier を返すよう変更（`link.rs`）
- `build_struct_tree` / `build_tag_group` で `LinkContent` ランを `Link` TagGroup にアセンブル、OBJR を末尾に追加（`render.rs`）
- 複数ページにまたがるリンクを `link_annot_ids: BTreeMap<usize, Vec<Identifier>>` で正しく蓄積
- `<a><img></a>` のような `LineItem::InlineBox` 経由のリンクは `wired_span_ptrs` ガードで保護（パニック回避）

## テスト

- `render_smoke.rs` に 4 本の E2E テストを追加（外部リンク・内部アンカー・画像リンク・非タグ付き）
- `draw_primitives.rs`・`render.rs` に unit/integration テストを追加
- 全 893 lib テスト通過

## 技術的背景

krilla の `start_tagged` はネスト不可なため、段落レベルのタギングとランレベルのタギングは排他。リンクを含む段落では段落レベルの `start_tagged` を発行せず、`canvas.link_run_node_id` で per-run モードを有効化する設計を採用。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 段落内の実行単位ごとのリンクタグ付けを導入し、同一リンクスパンごとにまとめたLinkタグ群と対応注釈を出力します。
  * リンクタグ種別が追加され、タグ付けされるリンクに対応した注釈IDをページ毎に集約して反映します。

* **不具合修正**
  * リンクが包むインライン〜inline-block 混在ケースでのレンダリング時クラッシュを回避しました。

* **テスト**
  * 外部リンク、内部アンカー、画像リンク等のタグ付き/非タグ付きレンダリング検証テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->