### PR TITLE
feat(tagged): wire link_run_node_id in clip/opacity/list/multicol dispatch paths

### DIFF
--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -1671,7 +1671,15 @@ fn draw_under_clip(
         if let Some(p) = para_for_block {
             let use_run_tagging = canvas.tag_collector.is_some() && para_has_link_runs(p);
             let tag_info = if use_run_tagging {
-                canvas.link_run_node_id = Some(node_id);
+                let run_tag_node_id = if drawables.list_items.contains_key(&node_id) {
+                    *drawables
+                        .li_lbody_ids
+                        .get(&node_id)
+                        .expect("list-item paragraph must have an LBody id")
+                } else {
+                    node_id
+                };
+                canvas.link_run_node_id = Some(run_tag_node_id);
                 None
             } else {
                 try_start_tagged(canvas, node_id, drawables)
@@ -2951,7 +2959,11 @@ fn draw_list_item_with_block(
             // inline-root li の段落コンテンツを LBody 配下に記録する
             let use_run_tagging = canvas.tag_collector.is_some() && para_has_link_runs(p);
             let tag_info = if use_run_tagging {
-                canvas.link_run_node_id = Some(node_id);
+                let lbody_id = *drawables
+                    .li_lbody_ids
+                    .get(&node_id)
+                    .expect("list-item paragraph must have an LBody id");
+                canvas.link_run_node_id = Some(lbody_id);
                 None
             } else {
                 try_start_tagged(canvas, node_id, drawables)

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -1181,6 +1181,14 @@ fn paint_multicol_paragraph_slices(
     // so `is_split() == fragments.len() > 1` for any valid input here.
     // Using the predicate documents the intent.
     let needs_partition = container_geom.is_split();
+    let use_run_tagging = canvas.tag_collector.is_some()
+        && drawables
+            .paragraphs
+            .get(&source_node_id)
+            .is_some_and(para_has_link_runs);
+    if use_run_tagging {
+        canvas.link_run_node_id = Some(source_node_id);
+    }
     draw_with_opacity(canvas, opacity, |canvas| {
         for slice in &slices_entry.slices {
             let slice_top = slice.origin_pt.1 - consumed;
@@ -1207,6 +1215,9 @@ fn paint_multicol_paragraph_slices(
             crate::paragraph::draw_shaped_lines(canvas, &slice.lines, abs_x, abs_y, None);
         }
     });
+    if use_run_tagging {
+        canvas.link_run_node_id = None;
+    }
 }
 
 /// Push the transform onto the surface + link collector, dispatch the
@@ -1658,7 +1669,13 @@ fn draw_under_clip(
         let inner_x = x_pt + inner_inset.0;
         let inner_y = y_pt + inner_inset.1;
         if let Some(p) = para_for_block {
-            let tag_info = try_start_tagged(canvas, node_id, drawables);
+            let use_run_tagging = canvas.tag_collector.is_some() && para_has_link_runs(p);
+            let tag_info = if use_run_tagging {
+                canvas.link_run_node_id = Some(node_id);
+                None
+            } else {
+                try_start_tagged(canvas, node_id, drawables)
+            };
             draw_paragraph_inner_paint(
                 canvas,
                 p,
@@ -1673,6 +1690,9 @@ fn draw_under_clip(
                 margin_top_pt,
             );
             finish_tagged(canvas, tag_info);
+            if use_run_tagging {
+                canvas.link_run_node_id = None;
+            }
         }
         if let Some(i) = img_for_block {
             draw_image_inner_paint(canvas, i, inner_x, inner_y);
@@ -2010,6 +2030,13 @@ fn draw_under_opacity(
             let inner_x = x_pt + inner_inset.0;
             let inner_y = y_pt + inner_inset.1;
             if let Some(p) = para_for_block {
+                let use_run_tagging = canvas.tag_collector.is_some() && para_has_link_runs(p);
+                let tag_info = if use_run_tagging {
+                    canvas.link_run_node_id = Some(node_id);
+                    None
+                } else {
+                    try_start_tagged(canvas, node_id, drawables)
+                };
                 draw_paragraph_inner_paint(
                     canvas,
                     p,
@@ -2023,6 +2050,10 @@ fn draw_under_opacity(
                     margin_left_pt,
                     margin_top_pt,
                 );
+                finish_tagged(canvas, tag_info);
+                if use_run_tagging {
+                    canvas.link_run_node_id = None;
+                }
             }
             if let Some(i) = img_for_block {
                 draw_image_inner_paint(canvas, i, inner_x, inner_y);
@@ -2918,7 +2949,13 @@ fn draw_list_item_with_block(
         }
         if let Some(p) = paragraph {
             // inline-root li の段落コンテンツを LBody 配下に記録する
-            let tag_info = try_start_tagged(canvas, node_id, drawables);
+            let use_run_tagging = canvas.tag_collector.is_some() && para_has_link_runs(p);
+            let tag_info = if use_run_tagging {
+                canvas.link_run_node_id = Some(node_id);
+                None
+            } else {
+                try_start_tagged(canvas, node_id, drawables)
+            };
             draw_paragraph_inner_paint(
                 canvas,
                 p,
@@ -2933,6 +2970,9 @@ fn draw_list_item_with_block(
                 margin_top_pt,
             );
             finish_tagged(canvas, tag_info);
+            if use_run_tagging {
+                canvas.link_run_node_id = None;
+            }
         }
     });
 }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -1671,15 +1671,7 @@ fn draw_under_clip(
         if let Some(p) = para_for_block {
             let use_run_tagging = canvas.tag_collector.is_some() && para_has_link_runs(p);
             let tag_info = if use_run_tagging {
-                let run_tag_node_id = if drawables.list_items.contains_key(&node_id) {
-                    *drawables
-                        .li_lbody_ids
-                        .get(&node_id)
-                        .expect("list-item paragraph must have an LBody id")
-                } else {
-                    node_id
-                };
-                canvas.link_run_node_id = Some(run_tag_node_id);
+                canvas.link_run_node_id = Some(node_id);
                 None
             } else {
                 try_start_tagged(canvas, node_id, drawables)

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -2819,7 +2819,7 @@ fn tagged_pdf_link_in_overflow_hidden_does_not_panic() {
     // causing a non-nestable start_tagged panic. Should use use_run_tagging instead.
     let html = r#"<!DOCTYPE html><html lang="en"><body>
         <div style="overflow:hidden;width:200px;height:50px">
-            <p>Visit <a href="https://example.com">clipped link</a> here.</p>
+            Visit <a href="https://example.com">clipped link</a> here.
         </div>
     </body></html>"#;
 
@@ -2883,7 +2883,7 @@ fn tagged_pdf_link_in_opacity_block_does_not_panic() {
     // no /Link entry in StructTree. The fix adds the full use_run_tagging chain.
     let html = r#"<!DOCTYPE html><html lang="en"><body>
         <div style="opacity:0.8">
-            <p>Visit <a href="https://example.com">opacity link</a> here.</p>
+            Visit <a href="https://example.com">opacity link</a> here.
         </div>
     </body></html>"#;
 

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -2901,3 +2901,35 @@ fn tagged_pdf_link_in_opacity_block_does_not_panic() {
     );
     assert!(s.contains("/Annots"), "must have link annotation on page");
 }
+
+#[test]
+fn tagged_pdf_link_in_opacity_block_with_inline_box_child() {
+    // Exercises the `use_run_tagging` branch inside `draw_under_opacity`
+    // (render.rs L2035/2036/2055) which is reached only when the opacity-
+    // scoped node is ALSO an inline root (has a ParagraphDraw at the same
+    // node_id) AND has `opacity_descendants` non-empty (i.e. it contains
+    // inline-box children that register their own drawable entries during
+    // `extract_paragraph`). The combination: visual-style + opacity +
+    // inline-box child + link run.
+    let html = r#"<!DOCTYPE html><html lang="en"><body>
+        <div style="opacity:0.8;background:#fff;padding:4px">
+            Visit <a href="https://example.com">opacity link</a>
+            <span style="display:inline-block;width:10px;height:10px;background:#aaa;"></span>
+            here.
+        </div>
+    </body></html>"#;
+
+    let pdf = Engine::builder()
+        .tagged(true)
+        .build()
+        .render_html(html)
+        .expect("opacity inline-root with inline-box child and link in tagged PDF must not panic");
+
+    assert!(!pdf.is_empty());
+    let s = String::from_utf8_lossy(&pdf);
+    assert!(
+        s.contains("/S /Link") || s.contains("/S/Link"),
+        "must have /Link structure element"
+    );
+    assert!(s.contains("/Annots"), "must have link annotation on page");
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -2812,3 +2812,92 @@ fn untagged_pdf_with_link_preserves_annotation_no_struct_tree() {
         "link annotation must be present in untagged PDF"
     );
 }
+
+#[test]
+fn tagged_pdf_link_in_overflow_hidden_does_not_panic() {
+    // Regression: draw_under_clip used try_start_tagged for para with link runs,
+    // causing a non-nestable start_tagged panic. Should use use_run_tagging instead.
+    let html = r#"<!DOCTYPE html><html lang="en"><body>
+        <div style="overflow:hidden;width:200px;height:50px">
+            <p>Visit <a href="https://example.com">clipped link</a> here.</p>
+        </div>
+    </body></html>"#;
+
+    let pdf = Engine::builder()
+        .tagged(true)
+        .build()
+        .render_html(html)
+        .expect("overflow:hidden link in tagged PDF must not panic");
+
+    assert!(!pdf.is_empty());
+    let s = String::from_utf8_lossy(&pdf);
+    assert!(
+        s.contains("/S /Link") || s.contains("/S/Link"),
+        "must have /Link structure element"
+    );
+    assert!(s.contains("/Annots"), "must have link annotation on page");
+}
+
+#[test]
+fn tagged_pdf_link_in_list_item_produces_link_struct_element() {
+    // Regression: draw_list_item_with_block used try_start_tagged for para with
+    // link runs, causing a non-nestable start_tagged panic.
+    let html = r#"<!DOCTYPE html><html lang="en"><body>
+        <ul>
+            <li>Visit <a href="https://example.com">list item link</a>.</li>
+        </ul>
+    </body></html>"#;
+
+    let pdf = tagged_render_with_noto(html);
+    let s = String::from_utf8_lossy(&pdf);
+    assert!(
+        s.contains("/S /Link") || s.contains("/S/Link"),
+        "must have /Link structure element"
+    );
+    assert!(s.contains("/Annots"), "must have link annotation on page");
+}
+
+#[test]
+fn tagged_pdf_link_in_multicol_produces_link_struct_element() {
+    // Regression: paint_multicol_paragraph_slices never set link_run_node_id,
+    // so links in multicol blocks had no /Link StructTree entries.
+    let html = r#"<!DOCTYPE html><html lang="en"><body>
+        <div style="columns:2;column-gap:20px;width:400px">
+            <p>Visit <a href="https://example.com">multicol link</a> here.</p>
+        </div>
+    </body></html>"#;
+
+    let pdf = tagged_render_with_noto(html);
+    let s = String::from_utf8_lossy(&pdf);
+    assert!(
+        s.contains("/S /Link") || s.contains("/S/Link"),
+        "must have /Link structure element"
+    );
+    assert!(s.contains("/Annots"), "must have link annotation on page");
+}
+
+#[test]
+fn tagged_pdf_link_in_opacity_block_does_not_panic() {
+    // Regression: draw_under_opacity had no tagging at all — para with link runs
+    // would invoke draw_shaped_lines while link_run_node_id was not set, meaning
+    // no /Link entry in StructTree. The fix adds the full use_run_tagging chain.
+    let html = r#"<!DOCTYPE html><html lang="en"><body>
+        <div style="opacity:0.8">
+            <p>Visit <a href="https://example.com">opacity link</a> here.</p>
+        </div>
+    </body></html>"#;
+
+    let pdf = Engine::builder()
+        .tagged(true)
+        .build()
+        .render_html(html)
+        .expect("opacity block with link in tagged PDF must not panic");
+
+    assert!(!pdf.is_empty());
+    let s = String::from_utf8_lossy(&pdf);
+    assert!(
+        s.contains("/S /Link") || s.contains("/S/Link"),
+        "must have /Link structure element"
+    );
+    assert!(s.contains("/Annots"), "must have link annotation on page");
+}


### PR DESCRIPTION
## 概要

Tagged PDF の4つのレンダリング経路で `link_run_node_id` が未設定のまま `draw_paragraph_inner_paint` を呼んでいたため、各コンテキスト内のリンクが StructTree に `/Link` エントリを生成しない問題 (fulgur-liu8) を修正する。

- **`draw_under_clip`**: `overflow:hidden` ブロック内のリンク段落。`try_start_tagged` を `use_run_tagging` パターン（`dispatch_fragment` と同じ）に置き換え
- **`draw_under_opacity`**: `opacity` ブロック内の段落。タギング処理が**完全に欠落**していたため、`try_start_tagged` / `use_run_tagging` チェーンを全面追加（fulgur-liu8 スコープ外のボーナス修正）
- **`draw_list_item_with_block`**: `<li>` のインラインルート段落。`draw_under_clip` と同様の置き換え
- **`paint_multicol_paragraph_slices`**: `columns:` を使う multicol コンテナ内段落。`draw_with_opacity` の前後で `link_run_node_id` を set/clear

## テスト

smoke test を4本追加（各経路1本ずつ）:

- `tagged_pdf_link_in_overflow_hidden_does_not_panic`
- `tagged_pdf_link_in_list_item_produces_link_struct_element`（`/S /Link` + `/Annots` を assert）
- `tagged_pdf_link_in_multicol_produces_link_struct_element`（`/S /Link` + `/Annots` を assert）
- `tagged_pdf_link_in_opacity_block_does_not_panic`

全テスト通過確認済み (`cargo test -p fulgur`: 0 failed)。

## チェックリスト

- [x] `cargo test -p fulgur` — all pass
- [x] `cargo clippy -p fulgur` — clean
- [x] `cargo fmt --check` — 未実行（下記）

Closes fulgur-liu8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * マルチカラム、リスト、overflow:hidden、opacity スコープなど複数のレイアウト文脈で、リンクを含む段落のラン単位のタグ付けを有効化・改善し、描画後に正しくクリアするようにしました。

* **テスト**
  * 上記シナリオをカバーするタグ付きPDFレンダリングの回帰テストを5件追加し、タグ構造と注釈の存在を検証。既存の未タグ化リンクテストの期待値も調整しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->