### PR TITLE
test(list_item): add coverage for inject_marker shift loop Text/Image arms

### DIFF
--- a/crates/fulgur/src/convert/list_item.rs
+++ b/crates/fulgur/src/convert/list_item.rs
@@ -729,4 +729,177 @@ mod tests {
         assert_eq!(out.block_styles[&10].clip_descendants, vec![11usize]);
         assert!(out.block_styles[&10].opacity_descendants.is_empty());
     }
+
+    // ── inject shift loop: Text and Image existing-item arms ──────────
+
+    fn make_text_run(x_offset: f32) -> LineItem {
+        LineItem::Text(ShapedGlyphRun {
+            font_data: Arc::new(vec![]),
+            font_index: 0,
+            font_size: 12.0,
+            color: [0, 0, 0, 255],
+            decoration: TextDecoration::default(),
+            glyphs: vec![],
+            text: String::new(),
+            x_offset,
+            link: None,
+        })
+    }
+
+    fn make_image_item(width: f32, x_offset: f32) -> LineItem {
+        LineItem::Image(InlineImage {
+            data: Arc::new(vec![]),
+            format: crate::image::ImageFormat::Png,
+            width,
+            height: 10.0,
+            x_offset,
+            vertical_align: VerticalAlign::Baseline,
+            opacity: 1.0,
+            visible: true,
+            computed_y: 0.0,
+            link: None,
+        })
+    }
+
+    #[test]
+    fn inject_shifts_existing_text_run_by_marker_width() {
+        // Existing item in the line is LineItem::Text. The shift loop's Text arm
+        // (`run.x_offset += shift`) must update it when a marker is prepended.
+        let mut out = Drawables::new();
+        out.paragraphs
+            .insert(5, make_para(vec![make_line(vec![make_text_run(5.0)])]));
+        let pre: BTreeSet<usize> = BTreeSet::new();
+        assert!(inject_marker_into_first_paragraph(
+            &mut out,
+            &pre,
+            inline_box(10.0, 0.0)
+        ));
+        // marker InlineBox width = 10 → existing text run shifts from 5 to 15.
+        let LineItem::Text(shifted) = &out.paragraphs[&5].lines[0].items[1] else {
+            panic!("expected Text at index 1");
+        };
+        assert!(
+            (shifted.x_offset - 15.0).abs() < 0.001,
+            "got {}",
+            shifted.x_offset
+        );
+    }
+
+    #[test]
+    fn inject_shifts_existing_inline_image_by_marker_width() {
+        // Existing item in the line is LineItem::Image. The shift loop's Image arm
+        // (`i.x_offset += shift`) must update it when a marker is prepended.
+        let mut out = Drawables::new();
+        out.paragraphs.insert(
+            5,
+            make_para(vec![make_line(vec![make_image_item(20.0, 3.0)])]),
+        );
+        let pre: BTreeSet<usize> = BTreeSet::new();
+        assert!(inject_marker_into_first_paragraph(
+            &mut out,
+            &pre,
+            inline_box(8.0, 0.0)
+        ));
+        // marker width = 8 → existing image shifts from 3 to 11.
+        let LineItem::Image(shifted) = &out.paragraphs[&5].lines[0].items[1] else {
+            panic!("expected Image at index 1");
+        };
+        assert!(
+            (shifted.x_offset - 11.0).abs() < 0.001,
+            "got {}",
+            shifted.x_offset
+        );
+    }
+
+    #[test]
+    fn inject_shifts_all_three_item_types_in_first_line() {
+        // First line has Text + Image + InlineBox. After injection all three must
+        // be shifted by the marker's width; only the first line is affected.
+        let mut out = Drawables::new();
+        let line0 = make_line(vec![
+            make_text_run(1.0),
+            make_image_item(15.0, 2.0),
+            inline_box(5.0, 3.0),
+        ]);
+        let line1 = make_line(vec![inline_box(5.0, 0.0)]); // second line must not shift
+        out.paragraphs.insert(5, make_para(vec![line0, line1]));
+        let pre: BTreeSet<usize> = BTreeSet::new();
+        assert!(inject_marker_into_first_paragraph(
+            &mut out,
+            &pre,
+            inline_box(10.0, 0.0)
+        ));
+        let items = &out.paragraphs[&5].lines[0].items;
+        // Items at indices 1, 2, 3 are the original three (marker inserted at 0).
+        let LineItem::Text(t) = &items[1] else {
+            panic!("expected Text at 1");
+        };
+        assert!(
+            (t.x_offset - 11.0).abs() < 0.001,
+            "text: got {}",
+            t.x_offset
+        );
+        let LineItem::Image(im) = &items[2] else {
+            panic!("expected Image at 2");
+        };
+        assert!(
+            (im.x_offset - 12.0).abs() < 0.001,
+            "image: got {}",
+            im.x_offset
+        );
+        let LineItem::InlineBox(ib) = &items[3] else {
+            panic!("expected InlineBox at 3");
+        };
+        assert!(
+            (ib.x_offset - 13.0).abs() < 0.001,
+            "ib: got {}",
+            ib.x_offset
+        );
+        // Second line must be unchanged.
+        let LineItem::InlineBox(l1_ib) = &out.paragraphs[&5].lines[1].items[0] else {
+            panic!("expected InlineBox in line 1");
+        };
+        assert!(
+            (l1_ib.x_offset - 0.0).abs() < 0.001,
+            "line 1 shifted unexpectedly: {}",
+            l1_ib.x_offset
+        );
+    }
+
+    #[test]
+    fn inject_text_marker_zero_glyphs_inserts_without_shifting() {
+        // A Text marker with no glyphs has advance sum = 0, so existing items
+        // keep their x_offset while the marker is still prepended.
+        let mut out = Drawables::new();
+        out.paragraphs
+            .insert(5, make_para(vec![make_line(vec![inline_box(20.0, 7.0)])]));
+        let pre: BTreeSet<usize> = BTreeSet::new();
+        let zero_glyph_marker = LineItem::Text(ShapedGlyphRun {
+            font_data: Arc::new(vec![]),
+            font_index: 0,
+            font_size: 12.0,
+            color: [0, 0, 0, 255],
+            decoration: TextDecoration::default(),
+            glyphs: vec![],
+            text: String::new(),
+            x_offset: 0.0,
+            link: None,
+        });
+        assert!(inject_marker_into_first_paragraph(
+            &mut out,
+            &pre,
+            zero_glyph_marker
+        ));
+        // shift = 0 → existing InlineBox stays at x_offset=7.
+        let LineItem::InlineBox(ib) = &out.paragraphs[&5].lines[0].items[1] else {
+            panic!("expected InlineBox at index 1");
+        };
+        assert!(
+            (ib.x_offset - 7.0).abs() < 0.001,
+            "expected no shift, got {}",
+            ib.x_offset
+        );
+        // Marker is still inserted at index 0.
+        assert_eq!(out.paragraphs[&5].lines[0].items.len(), 2);
+    }
 }


### PR DESCRIPTION
## 対象モジュール

`crates/fulgur/src/convert/list_item.rs`

## カバレッジ変化

| 指標 | 変更前 | 変更後 |
|------|--------|--------|
| 行カバレッジ | 58.22% | 63.93% |
| ブランチカバレッジ | 65.79% | 70.45% |

## 背景

カバレッジが最も低いファイルのうち、`convert/positioned.rs`（24.77%）と `render.rs`（30.91%）はすべての関数が Blitz/Krilla 依存であり、ユニットテストで直接カバーすることができない。`convert/list_item.rs`（58.22%）は主要関数（`try_convert`・`build_list_item_body`）も Blitz 依存だが、`inject_marker_into_first_paragraph` と `record_li_clip_opacity_descendants` という純粋な helper 関数を含む。本 PR ではその helper 関数の未カバーブランチを埋める。

## 追加したテスト（4件）

| テスト名 | カバーする分岐 |
|----------|---------------|
| `inject_shifts_existing_text_run_by_marker_width` | shift ループの `LineItem::Text` アーム（`run.x_offset += shift`） |
| `inject_shifts_existing_inline_image_by_marker_width` | shift ループの `LineItem::Image` アーム（`i.x_offset += shift`） |
| `inject_shifts_all_three_item_types_in_first_line` | 同一行に Text・Image・InlineBox が混在する場合、全3アームが一度に通ること、かつ **2行目は変化しない**こと |
| `inject_text_marker_zero_glyphs_inserts_without_shifting` | グリフ数ゼロの Text マーカー → advance の sum = 0 → 既存アイテムの x_offset が動かない境界ケース |

また、テスト内で再利用可能な private helper を2つ追加した（`make_text_run`・`make_image_item`）。

## 意図的に除外したブランチ（理由付き）

| 箇所 | 除外理由 |
|------|----------|
| `try_convert` 全体（~265行） | `blitz_dom::BaseDocument` および `Node` を必要とし、Blitz を起動せずに構築する方法がない |
| `build_list_item_body` 全体（~107行） | 同上。`inline_root::extract_paragraph` など Blitz 依存の呼び出しが多数含まれる |
| `let … else { panic!(…) }` の else アーム（テスト内ガード） | テストデータを正しく構築している限り到達しないガードであり、カバーする価値がない |

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2ZCNYEwtVjx9xT5tXivhN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * テスト範囲を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->