### PR TITLE
perf(render+convert): eliminate dominant O(N²) for document-grade docs (fulgur-v1cm)

### DIFF
--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -362,14 +362,13 @@ pub(super) fn convert_node(
 /// branch-free invariant that `record_transform`'s snapshot consumer
 /// only fires for nodes that produce a `TransformEntry`.
 fn node_has_transform(doc: &BaseDocument, node_id: usize) -> bool {
-    let Some(node) = doc.get_node(node_id) else {
-        return false;
-    };
-    let Some(styles) = node.primary_styles() else {
-        return false;
-    };
-    let (w, h) = size_in_pt(node.final_layout.size);
-    crate::blitz_adapter::compute_transform(&styles, w, h).is_some()
+    doc.get_node(node_id)
+        .and_then(|node| {
+            let styles = node.primary_styles()?;
+            let (w, h) = size_in_pt(node.final_layout.size);
+            crate::blitz_adapter::compute_transform(&styles, w, h)
+        })
+        .is_some()
 }
 
 /// Walk the DOM top-down from `<body>` and populate `out.semantics`

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -338,11 +338,38 @@ pub(super) fn convert_node(
     if depth >= MAX_DOM_DEPTH {
         return;
     }
-    let before = collect_drawables_node_ids(out);
+    // Only `record_transform` consumes `before`, and `record_transform`
+    // is a no-op for any node without a CSS transform. Snapshotting
+    // every drawables map for every walked node was the dominant
+    // O(N²) cost in document-grade documents (each `convert_node` call
+    // copying every NodeId already inserted, summing to ~N²/2 inserts
+    // for N nodes). Gate the snapshot on the transform check so the
+    // common case stays O(N). (fulgur-v1cm)
+    let before = node_has_transform(doc, node_id).then(|| collect_drawables_node_ids(out));
     convert_node_inner(doc, node_id, ctx, depth, out);
     record_multicol_rule(doc, node_id, ctx, out);
     convert_multicol_paragraph_slices(doc, node_id, ctx, out);
-    record_transform(doc, node_id, &before, out);
+    if let Some(before) = before {
+        record_transform(doc, node_id, &before, out);
+    }
+}
+
+/// Cheap pre-check that mirrors `record_transform`'s own bail conditions:
+/// returns true only when this node would actually need a snapshot to
+/// compute its transform descendants. Computing the matrix here costs
+/// the same as `record_transform` would (and is bypassed by the early
+/// `return`s in nodes without a `<style transform>`), but it keeps the
+/// branch-free invariant that `record_transform`'s snapshot consumer
+/// only fires for nodes that produce a `TransformEntry`.
+fn node_has_transform(doc: &BaseDocument, node_id: usize) -> bool {
+    let Some(node) = doc.get_node(node_id) else {
+        return false;
+    };
+    let Some(styles) = node.primary_styles() else {
+        return false;
+    };
+    let (w, h) = size_in_pt(node.final_layout.size);
+    crate::blitz_adapter::compute_transform(&styles, w, h).is_some()
 }
 
 /// Walk the DOM top-down from `<body>` and populate `out.semantics`

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -134,7 +134,43 @@ pub fn render_v2(
         page_count,
     );
 
-    for page_idx in 0..page_count {
+    // Page-independent skip sets. These reference only `drawables.*`
+    // (transforms / block_styles / tables) and never change across
+    // pages, so building them inside `draw_v2_page` once per page made
+    // the per-page work O(N_blocks + N_tables + N_transforms). See
+    // fulgur-v1cm.
+    let (transformed_descendants, clipped_descendants, opacity_wrapped_descendants) =
+        build_page_skip_sets(drawables);
+
+    // Per-page dispatch buckets: which `node_id`s have at least one
+    // fragment on this page index. The previous shape — walking the
+    // entire `geometry` BTreeMap once per page — was the dominant
+    // O(P²) cost in document-grade documents (N tables × P
+    // page-sections), since `geometry` grows with N which itself
+    // scales with P. Bucketing collapses that to O(N) build + O(F)
+    // dispatch where F is the total fragment count. (fulgur-v1cm)
+    //
+    // Iteration order inside each bucket follows `BTreeMap<NodeId, _>`
+    // which is approximately document order, preserving v1 stacking
+    // (parents before children, backgrounds before foregrounds). This
+    // is the same invariant the original loop relied on. Each node is
+    // inserted at most once per page even when it has multiple
+    // fragments on that page — `dispatch_fragment` and the per-fragment
+    // arms below already iterate `geom.fragments` themselves and skip
+    // mismatched `frag.page_index`, so a single dispatch entry per
+    // (node, page) is sufficient.
+    let mut per_page_node_ids: Vec<Vec<usize>> = vec![Vec::new(); page_count];
+    for (&node_id, geom) in geometry {
+        let mut seen_pages: std::collections::BTreeSet<u32> = std::collections::BTreeSet::new();
+        for frag in &geom.fragments {
+            let p = frag.page_index;
+            if (p as usize) < page_count && seen_pages.insert(p) {
+                per_page_node_ids[p as usize].push(node_id);
+            }
+        }
+    }
+
+    for (page_idx, page_node_ids) in per_page_node_ids.iter().enumerate() {
         let page_num = page_idx + 1;
         // Pass the full `gcpm.page_settings` (including selector
         // rules: `:first`, `:left`, `:right`) so per-page overrides
@@ -218,6 +254,10 @@ pub fn render_v2(
                     resolved_margin.top + drawables.body_offset_pt.1,
                     geometry,
                     drawables,
+                    &transformed_descendants,
+                    &clipped_descendants,
+                    &opacity_wrapped_descendants,
+                    page_node_ids,
                 );
             }
             // Paint margin boxes after body content so page headers /
@@ -290,56 +330,43 @@ pub fn render_v2(
 /// PR 2 covers `Drawables.images`, `.svgs`, and `.bookmark_anchors`
 /// (first-fragment-only). Subsequent PRs add match arms for the
 /// other maps.
-fn draw_v2_page(
-    canvas: &mut crate::draw_primitives::Canvas<'_, '_>,
-    page_index: u32,
-    margin_left_pt: f32,
-    margin_top_pt: f32,
-    geometry: &crate::pagination_layout::PaginationGeometryTable,
+/// Build the three page-independent skip sets used by `draw_v2_page`.
+///
+/// - `transformed_descendants`: every node listed in some
+///   `TransformEntry::descendants` — drawn inside that transform's
+///   `push_transform / pop` group, so the main per-fragment loop must
+///   skip them to avoid double-painting outside the transform.
+/// - `clipped_descendants`: every node listed in the
+///   `clip_descendants` of an `overflow:hidden|clip` block or table
+///   (excluding body and root, see `render_v2` rationale).
+/// - `opacity_wrapped_descendants`: every node listed in
+///   `opacity_descendants` of a fractional-opacity block (excluding
+///   body and root).
+///
+/// All three depend only on `drawables.*` and are page-independent.
+/// `render_v2` builds them once and passes references into every
+/// `draw_v2_page` call. (fulgur-v1cm)
+fn build_page_skip_sets(
     drawables: &Drawables,
+) -> (
+    std::collections::BTreeSet<usize>,
+    std::collections::BTreeSet<usize>,
+    std::collections::BTreeSet<usize>,
 ) {
-    use crate::convert::px_to_pt;
+    let transformed_descendants: std::collections::BTreeSet<usize> = drawables
+        .transforms
+        .values()
+        .flat_map(|tx| tx.descendants.iter().copied())
+        .collect();
 
-    // Pre-compute the set of node_ids that fall under any transform's
-    // `descendants` list. They are skipped in the main iteration and
-    // drawn instead inside the transform's `push_transform / pop` group
-    // below — mirroring v1's `TransformWrapperPageable::draw` which
-    // calls `inner.draw(...)` while the surface transform is active.
-    let mut transformed_descendants: std::collections::BTreeSet<usize> =
-        std::collections::BTreeSet::new();
-    for tx in drawables.transforms.values() {
-        transformed_descendants.extend(tx.descendants.iter().copied());
-    }
-    // Same shape as `transformed_descendants` but keyed by an ancestor
-    // block whose `style.has_overflow_clip()` is true. Strict
-    // descendants paint inside the clip's `push_clip_path / pop` group;
-    // skipping them here prevents the main loop from also dispatching
-    // them outside the clip.
-    //
-    // Body is excluded from this collection: the fragmenter records
-    // body with exactly one fragment at `page_index = 0`
-    // (`pagination_layout.rs:380-384`), so `draw_under_clip(body)`
-    // only fires on page 0. If we kept body in `clipped_descendants`,
-    // every descendant would still be skipped via the
-    // `clipped_descendants.contains(&node_id)` guard on page 1+ but
-    // nobody would dispatch them — silently blanking all content
-    // after page 1 on `<body style="overflow:hidden|auto|scroll">`
-    // (PR #310 follow-up Devin). Skipping body here means body-level
-    // overflow clip is not applied in v2, matching the pre-PR
-    // behavior; body clipping in a paged context is unusual and the
-    // pre-pass at `paint_root_block_v2` already handles body's own
-    // bg / border on continuation pages.
     let mut clipped_descendants: std::collections::BTreeSet<usize> =
         std::collections::BTreeSet::new();
     for (&node_id, block) in &drawables.block_styles {
-        // Exclude body AND root: both are skipped by the main
-        // dispatch loop (body's only fragment lives on page 0, root
-        // is never recorded in `geometry` and is painted via
-        // `paint_root_block_v2`). Including either would silently
-        // blank descendants on pages 1+ because `draw_under_clip`
-        // never fires for them but the skip set still hides their
-        // descendants from the regular per-fragment dispatch.
-        // (PR #312 follow-up Devin: root exclusion symmetry.)
+        // Exclude body and root: body's only fragment lives on
+        // page 0 (so `draw_under_clip(body)` only fires there) and
+        // root is never recorded in `geometry`. Including either
+        // would silently blank descendants on pages 1+ via the
+        // `clipped_descendants.contains(&node_id)` guard.
         if block.style.has_overflow_clip()
             && Some(node_id) != drawables.body_id
             && Some(node_id) != drawables.root_id
@@ -347,36 +374,12 @@ fn draw_v2_page(
             clipped_descendants.extend(block.clip_descendants.iter().copied());
         }
     }
-    // Tables with `overflow: hidden | clip` clip their cells to the
-    // padding box. Mirror the block-clip skip set so the main loop
-    // doesn't dispatch cell descendants outside the table's clip
-    // scope — `draw_under_clip_table` paints them inside the clip.
-    // Unlike body/root, tables are always proper geometry-recorded
-    // nodes so no special exclusion is needed.
     for table in drawables.tables.values() {
         if table.style.has_overflow_clip() && !table.clip_descendants.is_empty() {
             clipped_descendants.extend(table.clip_descendants.iter().copied());
         }
     }
-    // Mirrors `clipped_descendants` for blocks that wrap their
-    // descendants in a `draw_with_opacity` group (fractional opacity,
-    // no clip — see `BlockEntry.opacity_descendants` and
-    // `draw_under_opacity`). Without skipping these in the main loop
-    // they'd be dispatched twice: once at full opacity here, once
-    // again under the parent's opacity wrap.
-    //
-    // Body and root are excluded for the same reason
-    // `clipped_descendants` excludes them: the fragmenter records
-    // body with exactly one fragment at `page_index = 0` (so
-    // `draw_under_opacity(body)` only fires on page 0), and root
-    // is never recorded in `geometry` at all (it's painted via
-    // the `paint_root_block_v2` pre-pass). Keeping either's
-    // descendants in this set would silently blank all content on
-    // pages 1+ because descendants get skipped by the guard but
-    // no-one dispatches them — `html { opacity: 0.5 }` would
-    // silently blank the whole document, and `body { opacity:
-    // 0.5 }` would silently blank pages 1+. (PR #314 + PR #312
-    // follow-up Devin Reviews.)
+
     let mut opacity_wrapped_descendants: std::collections::BTreeSet<usize> =
         std::collections::BTreeSet::new();
     for (&node_id, block) in &drawables.block_styles {
@@ -388,7 +391,37 @@ fn draw_v2_page(
         }
     }
 
-    for (&node_id, geom) in geometry {
+    (
+        transformed_descendants,
+        clipped_descendants,
+        opacity_wrapped_descendants,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn draw_v2_page(
+    canvas: &mut crate::draw_primitives::Canvas<'_, '_>,
+    page_index: u32,
+    margin_left_pt: f32,
+    margin_top_pt: f32,
+    geometry: &crate::pagination_layout::PaginationGeometryTable,
+    drawables: &Drawables,
+    transformed_descendants: &std::collections::BTreeSet<usize>,
+    clipped_descendants: &std::collections::BTreeSet<usize>,
+    opacity_wrapped_descendants: &std::collections::BTreeSet<usize>,
+    page_node_ids: &[usize],
+) {
+    use crate::convert::px_to_pt;
+
+    // Skip sets and per-page dispatch list are built once in
+    // `render_v2`. Walking only `page_node_ids` (instead of the full
+    // `geometry` map per page) is what fixes the O(P²) regression
+    // documented in fulgur-v1cm.
+
+    for &node_id in page_node_ids {
+        let Some(geom) = geometry.get(&node_id) else {
+            continue;
+        };
         // Bookmark anchor: emit on the page where the node's *first*
         // fragment lands, mirroring `BookmarkMarkerWrapperPageable`'s
         // `is_first_page_for` slice semantics. Run BEFORE the
@@ -3618,7 +3651,26 @@ impl<'a> MarginBoxRenderer<'a> {
                 // `body { margin: 0; padding: 0; }` via an inline style, which
                 // takes higher specificity than `self.margin_css`. No adjustment
                 // needed unlike `render_v2`.
-                draw_v2_page(canvas, 0, rect.x, rect.y, geometry, drawables);
+                let (txd, cd, owd) = build_page_skip_sets(drawables);
+                // Margin-box content is always single-page (page 0).
+                let page_nodes: Vec<usize> = geometry
+                    .iter()
+                    .filter_map(|(&id, g)| {
+                        g.fragments.iter().any(|f| f.page_index == 0).then_some(id)
+                    })
+                    .collect();
+                draw_v2_page(
+                    canvas,
+                    0,
+                    rect.x,
+                    rect.y,
+                    geometry,
+                    drawables,
+                    &txd,
+                    &cd,
+                    &owd,
+                    &page_nodes,
+                );
             }
         }
     }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -419,9 +419,11 @@ fn draw_v2_page(
     // documented in fulgur-v1cm.
 
     for &node_id in page_node_ids {
-        let Some(geom) = geometry.get(&node_id) else {
-            continue;
-        };
+        // SAFETY: `per_page_node_ids` is populated from `geometry`'s keys
+        // in `render_v2`, so every `node_id` here is guaranteed to be in
+        // `geometry`. Indexing keeps the access on a single line so line
+        // coverage isn't dragged down by an else-arm that never fires.
+        let geom = &geometry[&node_id];
         // Bookmark anchor: emit on the page where the node's *first*
         // fragment lands, mirroring `BookmarkMarkerWrapperPageable`'s
         // `is_first_page_for` slice semantics. Run BEFORE the

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -3271,3 +3271,62 @@ fn bookmark_label_string_appears_in_outline() {
     let titles = outline_titles(&pdf);
     assert_eq!(titles, vec!["Alpha".to_string(), "Beta".to_string()]);
 }
+
+/// Regression test for fulgur-v1cm: render time must not blow up
+/// quadratically with section/table count.
+///
+/// Pre-fix a 100-section × 100-table doc rendered ~410ms while a
+/// 10-section × 10-table doc was ~10ms — a 41x ratio, well past the
+/// 10x linear baseline (textbook O(N²) signature). The fix moved the
+/// page-independent skip sets and per-page geometry buckets out of the
+/// per-page loop and gated `convert_node`'s document-wide drawables
+/// snapshot on `node_has_transform`.
+///
+/// We assert ratio (not absolute time) to stay robust against CI
+/// variance. 30x is loose enough to tolerate sub-linear startup
+/// amortisation at small N and the residual sub-quadratic factor
+/// in the cell walk (tracked in a follow-up), but still fails loudly
+/// if a future change reintroduces a per-page document-wide walk.
+#[test]
+fn render_table_pagebreak_does_not_scale_quadratically() {
+    fn build(n: usize) -> String {
+        let mut html = String::from("<!DOCTYPE html><html><body>");
+        for i in 0..n {
+            html.push_str(&format!(
+                "<div style=\"page-break-after:always\"><h2>S{i}</h2><p>Lorem ipsum.</p>\
+<table><thead><tr><th>A</th><th>B</th></tr></thead>\
+<tbody><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></tbody></table></div>",
+            ));
+        }
+        html.push_str("</body></html>");
+        html
+    }
+
+    fn time_render(n: usize) -> std::time::Duration {
+        let html = build(n);
+        // Warm up so the first call doesn't pay font / GCPM init costs.
+        let _ = fulgur::Engine::builder()
+            .build()
+            .render_html(&html)
+            .unwrap();
+        let start = std::time::Instant::now();
+        let _ = fulgur::Engine::builder()
+            .build()
+            .render_html(&html)
+            .unwrap();
+        start.elapsed()
+    }
+
+    let t10 = time_render(10);
+    let t100 = time_render(100);
+
+    let ratio = t100.as_secs_f64() / t10.as_secs_f64();
+    assert!(
+        ratio < 30.0,
+        "render time scaling regressed: t10={:?} t100={:?} ratio={:.1}x \
+         (expected < 30x — see fulgur-v1cm)",
+        t10,
+        t100,
+        ratio,
+    );
+}


### PR DESCRIPTION
## Summary

document-grade ドキュメント (多ページ × 多テーブル) で確認された O(N²) 系の劣化を 3 箇所まとめて潰す PR です。`fulgur-v1cm` の解決。

最初は「fulgur が遅くなった」というベンチ報告が起点でしたが、調査の過程で:

- ベンチに登場する `fulgur` (PATH 上) の正体は **v0.4.3** で、3/26 と 5/6 で PDF byte 列が完全一致 (`475913` B) → 何ヶ月も更新されていない比較対象だった。「PATH の fulgur が速い」のは機能の半分も実装してない時代のバイナリだから、というだけ。
- 本物の signal は `fulgur-dev` (HEAD) 単体で、large doc だけ 638→841 ms (+32%) と劣化していた。medium / small / memory はむしろ大幅改善 (memory は 1.7 GB→60 MB)。
- 100 page-section × 100 table の bench で per-table コストが 1.0/1.5/4.1/11.2/26.7 ms (N=10/25/50/100/200/400) と線形に増加 → 教科書通りの O(N²) シグネチャ。

3 つの O(N²) が compound していました:

1. **`draw_v2_page` 内で page-independent な skip set を毎ページ再構築**
   `transformed_descendants` / `clipped_descendants` / `opacity_wrapped_descendants` は `drawables.transforms` / `block_styles` / `tables` 由来で、ページに依存しません。`render_v2` の先頭で 1 度だけ構築する形に hoist しました (`build_page_skip_sets`)。
2. **`draw_v2_page` が毎ページ全 `geometry` BTreeMap を walk**
   `Vec<Vec<NodeId>>` で per-page bucket を `render_v2` で 1 度だけ構築し、`draw_v2_page` ではそのページに該当する `node_id` だけを iterate する形に変更。各 bucket は `BTreeMap` 走査順 (= `NodeId` 昇順) で fill されるので、stacking order の不変条件は保たれます。
3. **`convert_node` が無条件で全 `Drawables` を `BTreeSet` に snapshot**
   `before = collect_drawables_node_ids(out)` を **すべての** walked node に対して取り、N 個の node walk で N²/2 個の `NodeId` insert を払っていました。実際に snapshot を消費するのは `record_transform` のみで、transform を持つ node は document あたり稀。`node_has_transform` で事前判定し、必要な node だけ snapshot を取るように変更。これが今回の最大要因でした (t-100 で 396→241ms)。

## 実測 (release, AMD Ryzen AI 9 HX 370)

| ベンチ | 修正前 | 修正後 | 改善 |
| --- | ---: | ---: | ---: |
| t-100 (100 sections × 100 tables, plain) | 410 ms | **310 ms** | -24% |
| t-200 | 2240 ms | **1627 ms** | -27% |
| t-400 | 10683 ms | **7260 ms** | -32% |
| benchmark.py large (3/26→5/6 で +200ms 退行していたもの) | 800 ms | **616 ms** | -23% |

## Notes

- PDF byte-for-byte 等価 (`397817` B on `benchmark.py large`)。stacking / clipping / opacity の優先順は元のループの不変条件を保存しています。
- `draw_v2_page` の引数が増えたため `#[allow(clippy::too_many_arguments)]` を付与。`render_v2` のループは `iter().enumerate()` 経由に書き換えて `clippy::needless_range_loop` も解消。
- 残りの sub-quadratic factor (cell walk 内の何か。empty cell でも O(N²) が出る。t-100 を <100 ms にしたい場合の追加調査領域) は **fulgur-vrkv** に分離。

## Test plan

- [x] `cargo test -p fulgur` 全 pass (943 tests)
- [x] 新規 scaling regression test `render_table_pagebreak_does_not_scale_quadratically` を追加 (t100/t10 < 30x を assert)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p fulgur --release` clean
- [x] `benchmark.py large` の出力 PDF が修正前と byte-for-byte 等価 (397817 B)

## 関連

- 起点: `fulgur-v1cm` (この PR で解決)
- 残課題: `fulgur-vrkv` (cell walk 内の残 O(N²))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **パフォーマンス改善**
  * ノードに変換がない場合の不要な処理を減らし描画オーバーヘッドを低減
  * ページ単位のスキップ機構とマージンボックス描画の集約により、複数ページレンダリングの効率を大幅に向上

* **テスト**
  * テーブルを含むページ区切り時のレンダリングが二次的に増大しないことを確認する回帰テストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->