### PR TITLE
perf(convert): eliminate residual O(N²) in pseudo content snapshot (fulgur-vrkv)

### DIFF
--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -262,6 +262,23 @@ pub(super) fn collect_drawables_node_ids(
     ids
 }
 
+/// O(1) probe answering "did *any* per-NodeId map grow?" — sums `.len()`
+/// across the same six maps `collect_drawables_node_ids` unions. Callers
+/// that only need the boolean "produced anything?" answer (not the
+/// descendant set) should compare this value before/after a recursion
+/// instead of constructing two `BTreeSet<usize>`s. Convert never removes
+/// entries from these maps, so the sum is monotonic and a strict
+/// inequality is exactly equivalent to set-difference being non-empty.
+/// (fulgur-vrkv)
+pub(super) fn drawables_total_len(out: &crate::drawables::Drawables) -> usize {
+    out.block_styles.len()
+        + out.paragraphs.len()
+        + out.images.len()
+        + out.svgs.len()
+        + out.tables.len()
+        + out.list_items.len()
+}
+
 /// Build the bookmark anchor map. The `bookmark_by_node` map on
 /// `ConvertContext` is populated upstream (`engine.rs` runs
 /// `BookmarkPass` before `dom_to_drawables`); we only project it into

--- a/crates/fulgur/src/convert/pseudo.rs
+++ b/crates/fulgur/src/convert/pseudo.rs
@@ -61,10 +61,18 @@ pub(super) fn register_pseudo_content(
         out.images.insert(pseudo_id, entry);
         produced = true;
     }
-    let before_keys = collect_drawables_node_ids(out);
+    // Probe with O(1) `drawables_total_len` instead of constructing a
+    // 6-map `BTreeSet<usize>` snapshot before and after — the snapshot
+    // was the dominant residual O(N²) factor inside the per-cell
+    // convert walk (`register_pseudo_content` fires once per block-level
+    // node, and the snapshot is O(K) where K = total drawables already
+    // recorded). Convert never removes entries from these maps, so the
+    // length sum is monotonic and a strict inequality is exactly
+    // equivalent to "the BTreeSet diff would be non-empty".
+    // (fulgur-vrkv)
+    let before_total = super::drawables_total_len(out);
     walk_absolute_children(doc, node, ctx, depth, out);
-    let after_keys = collect_drawables_node_ids(out);
-    if after_keys.len() > before_keys.len() {
+    if super::drawables_total_len(out) > before_total {
         produced = true;
     }
     produced

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -3272,21 +3272,23 @@ fn bookmark_label_string_appears_in_outline() {
     assert_eq!(titles, vec!["Alpha".to_string(), "Beta".to_string()]);
 }
 
-/// Regression test for fulgur-v1cm: render time must not blow up
-/// quadratically with section/table count.
+/// Regression test for fulgur-v1cm + fulgur-vrkv: render time must not
+/// blow up quadratically with section/table count.
 ///
-/// Pre-fix a 100-section × 100-table doc rendered ~410ms while a
-/// 10-section × 10-table doc was ~10ms — a 41x ratio, well past the
-/// 10x linear baseline (textbook O(N²) signature). The fix moved the
-/// page-independent skip sets and per-page geometry buckets out of the
-/// per-page loop and gated `convert_node`'s document-wide drawables
-/// snapshot on `node_has_transform`.
+/// Pre-fulgur-v1cm a 100-section doc rendered ~410ms while a 10-section
+/// doc was ~10ms — a 41x ratio, well past the 10x linear baseline
+/// (textbook O(N²) signature). v1cm moved the page-independent skip
+/// sets and per-page geometry buckets out of the per-page loop and
+/// gated `convert_node`'s document-wide drawables snapshot on
+/// `node_has_transform`. fulgur-vrkv then replaced the remaining
+/// unconditional `BTreeSet<usize>` snapshot in
+/// `pseudo::register_pseudo_content` with an O(1) length-sum probe,
+/// dropping the t100/t10 ratio from ~4.5x to ~2.6x.
 ///
 /// We assert ratio (not absolute time) to stay robust against CI
-/// variance. 30x is loose enough to tolerate sub-linear startup
-/// amortisation at small N and the residual sub-quadratic factor
-/// in the cell walk (tracked in a follow-up), but still fails loudly
-/// if a future change reintroduces a per-page document-wide walk.
+/// variance. 15x is tight enough to fail loudly if a future change
+/// reintroduces a per-node document-wide snapshot, while still
+/// tolerating sub-linear startup amortisation at small N.
 #[test]
 fn render_table_pagebreak_does_not_scale_quadratically() {
     fn build(n: usize) -> String {
@@ -3322,9 +3324,9 @@ fn render_table_pagebreak_does_not_scale_quadratically() {
 
     let ratio = t100.as_secs_f64() / t10.as_secs_f64();
     assert!(
-        ratio < 30.0,
+        ratio < 15.0,
         "render time scaling regressed: t10={:?} t100={:?} ratio={:.1}x \
-         (expected < 30x — see fulgur-v1cm)",
+         (expected < 15x — see fulgur-v1cm + fulgur-vrkv)",
         t10,
         t100,
         ratio,


### PR DESCRIPTION
## 概要

fulgur-v1cm 修正後に残っていた per-cell convert walk の残余 O(N²) を解消します。

`crates/fulgur/src/convert/pseudo.rs` の `register_pseudo_content` が、block-level node 毎に `collect_drawables_node_ids(out)` を **無条件で 2 回** 呼んでおり、これが N×M 規模の文書で支配的でした。スナップショットは 6 つの per-NodeId map を統合した `BTreeSet<usize>` を構築する O(K) 操作(K = 既に記録された drawables 総数)で、`register_pseudo_content` は block node 毎に発火するため累積コストは N²/2 inserts に達します。

## 変更内容

- `crate::convert::drawables_total_len(out)` を追加: 同じ 6 map の `.len()` 和を返す O(1) probe。
- `register_pseudo_content` の snapshot 2 回を `drawables_total_len` の前後比較に置換。convert 経路は map から要素を削除しないため `len` 和は monotonic で、`>` 比較は `BTreeSet` 差分が空でないことと厳密に等価。
- 既存 scaling regression test (`render_table_pagebreak_does_not_scale_quadratically`) の閾値を **30x → 15x** に強化。

## 合成シナリオ計測 (AMD Ryzen AI 9 HX 370 / release)

| シナリオ | before | after | 改善率 |
| --- | ---: | ---: | ---: |
| simple 100 page-section × 1 table each | 33.96ms | 16.72ms | 2.0x |
| simple t100 / t10 比 | 4.47x | 2.60x | — |
| heavy 100 page-section × 100 tables | 139,250ms | 666ms | **209x** |
| heavy t100 / t10 比 | 144.5x | 10.5x | — |

受け入れ基準(`t-100 < 100ms`、`t100/t10 < 15x`、PDF byte equality)すべて達成。

## benchmark.py 実文書計測 (同環境)

| Document | pages | before | after | 改善率 |
| --- | ---: | ---: | ---: | ---: |
| small | 1 | 8ms | 9ms | 誤差範囲 |
| medium | 10 | 18ms | 17ms | -6% |
| large | 101 | 191ms | 108ms | **-43% (-83ms)** |
| xlarge | 201 | 637ms | 209ms | **-67% (-428ms)** |

長文書(101p / 201p)の改善率が大きく、長尺の帳票・レポート用途で効きます。

## Test plan

- [x] `cargo test -p fulgur --lib` (953 tests pass)
- [x] `cargo test -p fulgur --release --test render_smoke` (127 tests pass)
- [x] `cargo test -p fulgur-vrt --release` — VRT byte-wise PDF 比較 (8 tests pass)
- [x] `cargo test -p fulgur-cli --release --test examples_determinism` — CLI byte-wise 比較 (11 tests pass)
- [x] `cargo clippy -p fulgur --release` clean
- [x] `cargo fmt --check` clean
- [x] 強化した scaling regression test (`< 15x`) が pass