### PR TITLE
feat(gcpm): support target-text fragments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ bd ready              # Find available work
 bd show <id>          # View issue details
 bd update <id> --status in_progress  # Claim work
 bd close <id>         # Complete work
-bd sync               # Sync with git
+bd dolt push          # Sync with git
 ```
 
 ## Landing the Plane (Session Completion)
@@ -25,7 +25,7 @@ bd sync               # Sync with git
 
    ```bash
    git pull --rebase
-   bd sync
+   bd dolt push
    git push
    git status  # MUST show "up to date with origin"
    ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,6 +1139,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml",
+ "unicode-segmentation",
  "usvg",
  "woff2-patched",
 ]

--- a/crates/fulgur/Cargo.toml
+++ b/crates/fulgur/Cargo.toml
@@ -29,6 +29,7 @@ minijinja = { version = "=2.19.0", features = ["unstable_machinery"] }
 serde_json = "1"
 log = "0.4"
 lopdf = "0.40.0"
+unicode-segmentation = "1.13"
 # Force-enable `image`'s `png` feature so PNG decoding (used by blitz-dom for
 # `<img>` tags and CSS background-image) works consistently across every fulgur
 # build target. Without this, `blitz-dom-0.2.4`'s `image = { default-features =

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -1644,6 +1644,9 @@ pub struct CounterPass {
     counter_id: RefCell<usize>,
     /// Counter ops keyed by node_id, for later use in Pageable markers.
     ops_by_node: RefCell<Vec<(usize, Vec<CounterOp>)>>,
+    /// Resolved `::before` / `::after` text keyed by node_id. Pass 1 uses
+    /// this to populate `AnchorMap` for `target-text(..., before|after)`.
+    pseudo_text_by_node: RefCell<BTreeMap<usize, crate::gcpm::target_ref::AnchorPseudoText>>,
     /// Counter-state snapshot taken at each visited element after the
     /// element's own `counter-reset` / `counter-increment` / `counter-set`
     /// operations have been applied (Phase 2). Consumed by `BookmarkPass`
@@ -1680,6 +1683,7 @@ impl CounterPass {
             generated_css: RefCell::new(String::new()),
             counter_id: RefCell::new(0),
             ops_by_node: RefCell::new(Vec::new()),
+            pseudo_text_by_node: RefCell::new(BTreeMap::new()),
             node_snapshots: RefCell::new(BTreeMap::new()),
             record_node_snapshots: false,
             anchor_map: None,
@@ -1722,6 +1726,10 @@ impl CounterPass {
     /// Subsequent calls return an empty map (the snapshot is moved out).
     pub fn take_node_snapshots(&self) -> BTreeMap<usize, BTreeMap<String, Vec<i32>>> {
         std::mem::take(&mut *self.node_snapshots.borrow_mut())
+    }
+
+    pub fn take_pseudo_texts(&self) -> BTreeMap<usize, crate::gcpm::target_ref::AnchorPseudoText> {
+        std::mem::take(&mut *self.pseudo_text_by_node.borrow_mut())
     }
 
     /// Consume self and return (ops_by_node for Pageable markers, generated CSS for body).
@@ -1872,6 +1880,11 @@ impl CounterPass {
             for idx in &before_indices {
                 let mapping = &self.content_mappings[*idx];
                 let resolved = self.resolve_content(&mapping.content, element);
+                self.pseudo_text_by_node
+                    .borrow_mut()
+                    .entry(node_id)
+                    .or_default()
+                    .before_text = resolved.clone();
                 let _ = write!(
                     css,
                     "[data-fulgur-cid=\"{}\"]::before{{content:\"{}\"}}",
@@ -1898,6 +1911,11 @@ impl CounterPass {
             for idx in &after_indices {
                 let mapping = &self.content_mappings[*idx];
                 let resolved = self.resolve_content(&mapping.content, element);
+                self.pseudo_text_by_node
+                    .borrow_mut()
+                    .entry(node_id)
+                    .or_default()
+                    .after_text = resolved.clone();
                 let _ = write!(
                     css,
                     "[data-fulgur-cid=\"{}\"]::after{{content:\"{}\"}}",
@@ -1987,14 +2005,14 @@ impl CounterPass {
                         None => out.push_str("00"),
                     }
                 }
-                ContentItem::TargetText { url } => {
+                ContentItem::TargetText { url, kind } => {
                     let Some(href) = target_href(url, element) else {
                         continue;
                     };
                     match self.anchor_map.as_ref() {
-                        Some(map) => {
-                            out.push_str(&crate::gcpm::target_ref::resolve_target_text(href, map))
-                        }
+                        Some(map) => out.push_str(&crate::gcpm::target_ref::resolve_target_text(
+                            href, *kind, map,
+                        )),
                         None => out.push(' '),
                     }
                 }
@@ -2829,6 +2847,7 @@ pub(crate) fn apply_link_media_rewrites(doc: &mut HtmlDocument, rewrites: &[Link
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::gcpm::TargetTextKind;
 
     /// `relayout_position_fixed` must reshape every `position: fixed`
     /// subtree against the supplied viewport, not against the nearest
@@ -3541,6 +3560,8 @@ mod tests {
                 page_num: 3,
                 counters,
                 text: String::new(),
+                before_text: String::new(),
+                after_text: String::new(),
             },
         );
 
@@ -3582,6 +3603,8 @@ mod tests {
                 page_num: 4,
                 counters,
                 text: String::new(),
+                before_text: String::new(),
+                after_text: String::new(),
             },
         );
 
@@ -3639,6 +3662,7 @@ mod tests {
         let mut doc = parse(html, 400.0, &[]);
         let content = vec![ContentItem::TargetText {
             url: TargetUrl::Attr("href".into()),
+            kind: TargetTextKind::Content,
         }];
         let mappings = vec![ContentCounterMapping {
             parsed: ParsedSelector::Class("ref".into()),
@@ -3653,6 +3677,8 @@ mod tests {
                 page_num: 0,
                 counters: BTreeMap::new(),
                 text: "Hello".into(),
+                before_text: String::new(),
+                after_text: String::new(),
             },
         );
 
@@ -3697,6 +3723,8 @@ mod tests {
                 page_num: 0,
                 counters,
                 text: String::new(),
+                before_text: String::new(),
+                after_text: String::new(),
             },
         );
 
@@ -3750,6 +3778,7 @@ mod tests {
         let mut doc = parse(html, 400.0, &[]);
         let content = vec![ContentItem::TargetText {
             url: TargetUrl::Attr("href".into()),
+            kind: TargetTextKind::Content,
         }];
         let mappings = vec![ContentCounterMapping {
             parsed: ParsedSelector::Class("ref".into()),
@@ -3787,6 +3816,7 @@ mod tests {
             },
             ContentItem::TargetText {
                 url: TargetUrl::Attr("href".into()),
+                kind: TargetTextKind::Content,
             },
         ];
         let mappings = vec![ContentCounterMapping {
@@ -3838,6 +3868,7 @@ mod tests {
             },
             ContentItem::TargetText {
                 url: TargetUrl::Attr("data-ref".into()),
+                kind: TargetTextKind::Content,
             },
         ];
         let mappings = vec![ContentCounterMapping {
@@ -3856,6 +3887,8 @@ mod tests {
                 page_num: 3,
                 counters,
                 text: "should-not-appear".into(),
+                before_text: String::new(),
+                after_text: String::new(),
             },
         );
 

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -283,7 +283,7 @@ impl Engine {
         // value is the full nesting chain (`Vec<i32>`, outer-to-inner)
         // per CSS Lists 3 §4.5, so both `counter()` (innermost) and
         // `counters()` (joined) can resolve directly.
-        let (counter_ops_by_node_vec, counter_css, counter_snapshots) =
+        let (counter_ops_by_node_vec, counter_css, counter_snapshots, pseudo_texts) =
             if !gcpm.counter_mappings.is_empty() || !gcpm.content_counter_mappings.is_empty() {
                 let mut pass = crate::blitz_adapter::CounterPass::new(
                     gcpm.counter_mappings.clone(),
@@ -297,10 +297,11 @@ impl Engine {
                 }
                 crate::blitz_adapter::apply_single_pass(&pass, &mut doc, &ctx);
                 let snapshots = pass.take_node_snapshots();
+                let pseudo_texts = pass.take_pseudo_texts();
                 let (ops, css) = pass.into_parts();
-                (ops, css, snapshots)
+                (ops, css, snapshots, pseudo_texts)
             } else {
-                (Vec::new(), String::new(), BTreeMap::new())
+                (Vec::new(), String::new(), BTreeMap::new(), BTreeMap::new())
             };
 
         // Inject counter-resolved CSS for ::before/::after. Must happen
@@ -496,7 +497,12 @@ impl Engine {
         // `walk_anchors` short-circuits on `MAX_DOM_DEPTH`.
         let needs_anchor_map_for_pass_two = anchor_map.is_none() && has_target_refs;
         let collected_anchor_map = if needs_anchor_map_for_pass_two {
-            build_anchor_map(&doc, &pagination_geometry, &counter_snapshots_for_anchor)
+            build_anchor_map(
+                &doc,
+                &pagination_geometry,
+                &counter_snapshots_for_anchor,
+                &pseudo_texts,
+            )
         } else {
             AnchorMap::default()
         };
@@ -798,7 +804,9 @@ impl Engine {
 }
 
 use crate::blitz_adapter::get_attr;
-use crate::gcpm::target_ref::{AnchorEntry, AnchorMap, fragment_id_from_href, page_for_node};
+use crate::gcpm::target_ref::{
+    AnchorEntry, AnchorMap, AnchorPseudoText, fragment_id_from_href, page_for_node,
+};
 use crate::pagination_layout::PaginationGeometryTable;
 use blitz_dom::BaseDocument;
 
@@ -806,6 +814,7 @@ fn build_anchor_map(
     doc: &BaseDocument,
     pagination_geometry: &PaginationGeometryTable,
     counter_snapshots: &BTreeMap<usize, BTreeMap<String, Vec<i32>>>,
+    pseudo_texts: &BTreeMap<usize, AnchorPseudoText>,
 ) -> AnchorMap {
     let mut map = AnchorMap::new();
     walk_anchors(
@@ -814,6 +823,7 @@ fn build_anchor_map(
         0,
         pagination_geometry,
         counter_snapshots,
+        pseudo_texts,
         &mut map,
     );
     map
@@ -825,6 +835,7 @@ fn walk_anchors(
     depth: usize,
     geometry: &PaginationGeometryTable,
     snapshots: &BTreeMap<usize, BTreeMap<String, Vec<i32>>>,
+    pseudo_texts: &BTreeMap<usize, AnchorPseudoText>,
     out: &mut AnchorMap,
 ) {
     if depth >= crate::MAX_DOM_DEPTH {
@@ -844,18 +855,21 @@ fn walk_anchors(
     {
         let counters = snapshots.get(&node_id).cloned().unwrap_or_default();
         let text = collect_text_content(doc, node_id);
+        let pseudo_text = pseudo_texts.get(&node_id).cloned().unwrap_or_default();
         out.insert(
             frag.to_string(),
             AnchorEntry {
                 page_num,
                 counters,
                 text,
+                before_text: pseudo_text.before_text,
+                after_text: pseudo_text.after_text,
             },
         );
     }
     let children: Vec<usize> = node.children.clone();
     for c in children {
-        walk_anchors(doc, c, depth + 1, geometry, snapshots, out);
+        walk_anchors(doc, c, depth + 1, geometry, snapshots, pseudo_texts, out);
     }
 }
 

--- a/crates/fulgur/src/gcpm/counter.rs
+++ b/crates/fulgur/src/gcpm/counter.rs
@@ -133,12 +133,14 @@ pub fn resolve_content_to_string_with_anchor(
                     ));
                 }
             }
-            ContentItem::TargetText { url } => {
+            ContentItem::TargetText { url, kind } => {
                 let Some(href) = target_href(url, implicit_href) else {
                     continue;
                 };
                 if let Some(map) = anchor_map {
-                    out.push_str(&crate::gcpm::target_ref::resolve_target_text(href, map));
+                    out.push_str(&crate::gcpm::target_ref::resolve_target_text(
+                        href, *kind, map,
+                    ));
                 }
             }
             ContentItem::ContentText
@@ -291,14 +293,14 @@ pub fn resolve_content_to_html_with_anchor(
                         );
                     }
                 }
-                ContentItem::TargetText { url } => {
+                ContentItem::TargetText { url, kind } => {
                     let Some(href) = target_href(url, implicit_href) else {
                         continue;
                     };
                     if let Some(map) = anchor_map {
                         push_escaped_html_text(
                             &mut out,
-                            &crate::gcpm::target_ref::resolve_target_text(href, map),
+                            &crate::gcpm::target_ref::resolve_target_text(href, *kind, map),
                         );
                     }
                 }
@@ -412,14 +414,14 @@ pub fn resolve_content_to_html_with_anchor(
                             );
                         }
                     }
-                    ContentItem::TargetText { url } => {
+                    ContentItem::TargetText { url, kind } => {
                         let Some(href) = target_href(url, implicit_href) else {
                             continue;
                         };
                         if let Some(map) = anchor_map {
                             push_escaped_html_text(
                                 &mut inner,
-                                &crate::gcpm::target_ref::resolve_target_text(href, map),
+                                &crate::gcpm::target_ref::resolve_target_text(href, *kind, map),
                             );
                         }
                     }
@@ -782,6 +784,7 @@ impl CounterState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::gcpm::TargetTextKind;
 
     #[test]
     fn test_resolve_counters() {
@@ -1844,6 +1847,8 @@ mod tests {
                 page_num: 5,
                 counters,
                 text: "Hello".into(),
+                before_text: String::new(),
+                after_text: String::new(),
             },
         );
         let items = vec![ContentItem::TargetCounter {
@@ -1876,6 +1881,8 @@ mod tests {
                 page_num: 7,
                 counters,
                 text: "Hello & <world>".into(),
+                before_text: "Before".into(),
+                after_text: "After".into(),
             },
         );
         map
@@ -1907,6 +1914,7 @@ mod tests {
         let map = make_anchor_map_for_target_tests();
         let items = vec![ContentItem::TargetText {
             url: TargetUrl::Attr("href".into()),
+            kind: TargetTextKind::Content,
         }];
         let out = resolve_content_to_string_with_anchor(
             &items,
@@ -2014,6 +2022,7 @@ mod tests {
         let map = make_anchor_map_for_target_tests();
         let items = vec![ContentItem::TargetText {
             url: TargetUrl::Attr("href".into()),
+            kind: TargetTextKind::Content,
         }];
         let store = RunningElementStore::new();
         let out = resolve_content_to_html_with_anchor(
@@ -2038,6 +2047,7 @@ mod tests {
         let map = make_anchor_map_for_target_tests();
         let items = vec![ContentItem::TargetText {
             url: TargetUrl::Literal("#sec".into()),
+            kind: TargetTextKind::Content,
         }];
         let store = RunningElementStore::new();
         let out = resolve_content_to_html_with_anchor(
@@ -2072,6 +2082,7 @@ mod tests {
             },
             ContentItem::TargetText {
                 url: TargetUrl::Attr("data-ref".into()),
+                kind: TargetTextKind::Content,
             },
         ];
         let store = RunningElementStore::new();
@@ -2197,6 +2208,7 @@ mod tests {
         let items = vec![
             ContentItem::TargetText {
                 url: TargetUrl::Attr("href".into()),
+                kind: TargetTextKind::Content,
             },
             ContentItem::Leader {
                 style: super::super::LeaderStyle::Dotted,
@@ -2241,6 +2253,7 @@ mod tests {
             },
             ContentItem::TargetText {
                 url: TargetUrl::Attr("data-ref".into()),
+                kind: TargetTextKind::Content,
             },
             ContentItem::Leader {
                 style: super::super::LeaderStyle::Dotted,

--- a/crates/fulgur/src/gcpm/mod.rs
+++ b/crates/fulgur/src/gcpm/mod.rs
@@ -313,9 +313,12 @@ pub enum ContentItem {
         separator: String,
         style: CounterStyle,
     },
-    /// `target-text(<url>)` — resolves to the text content of the
-    /// target element. Only the default `content` form is implemented.
-    TargetText { url: TargetUrl },
+    /// `target-text(<url>[, <kind>])` — resolves text associated with
+    /// the target element.
+    TargetText {
+        url: TargetUrl,
+        kind: TargetTextKind,
+    },
 }
 
 /// URL source accepted by GCPM `target-*` functions.
@@ -325,6 +328,20 @@ pub enum TargetUrl {
     Attr(String),
     /// A string literal or `url()` literal supplies the URL directly.
     Literal(String),
+}
+
+/// Which text fragment of the target element `target-text()` resolves to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum TargetTextKind {
+    /// `target-text(<url>)` or `target-text(<url>, content)`.
+    #[default]
+    Content,
+    /// `target-text(<url>, before)` — text from `::before` pseudo-element.
+    Before,
+    /// `target-text(<url>, after)` — text from `::after` pseudo-element.
+    After,
+    /// `target-text(<url>, first-letter)` — first grapheme cluster of content.
+    FirstLetter,
 }
 
 impl ContentItem {
@@ -639,6 +656,7 @@ mod content_item_target_tests {
             position: MarginBoxPosition::TopCenter,
             content: vec![ContentItem::TargetText {
                 url: TargetUrl::Attr("href".into()),
+                kind: TargetTextKind::Content,
             }],
             declarations: String::new(),
         });

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -728,18 +728,13 @@ impl<'i, 'a> DeclarationParser<'i> for StyleRuleParser<'a> {
                         | ContentItem::TargetText { .. }
                 )
             });
-            let is_plain_text = !items.is_empty()
-                && items
-                    .iter()
-                    .all(|item| matches!(item, ContentItem::String(_)));
             // Last-declaration-wins: always update content_items (clear when
-            // the new content cannot be represented by CounterPass).
-            if has_counter || is_plain_text {
+            // the new content has no counter()).
+            if has_counter {
                 *self.content_items = Some(items);
-                // Strip the original declaration. CounterPass injects a
-                // synthetic ::before/::after rule with the resolved value;
-                // leaving the original in place would duplicate plain text
-                // pseudos and Blitz cannot evaluate target/counter content.
+                // Strip the original `content: counter(...)` from cleaned CSS
+                // because Blitz cannot evaluate counter() — CounterPass injects
+                // a synthetic ::before/::after rule with the resolved value.
                 let start = decl_start.position().byte_index();
                 let end = input.position().byte_index();
                 self.edits.push(CssEdit::Replace {
@@ -748,8 +743,8 @@ impl<'i, 'a> DeclarationParser<'i> for StyleRuleParser<'a> {
                     replacement: String::new(),
                 });
             } else {
-                // Unsupported forms (e.g. content: url(...)) stay in cleaned
-                // CSS so Blitz can render what it supports directly.
+                // Plain `content: "..."` stays in cleaned CSS so Blitz can
+                // render it directly.
                 *self.content_items = None;
             }
         } else {
@@ -1947,22 +1942,17 @@ mod tests {
 
     #[test]
     fn test_parse_pseudo_content_without_counter_kept_in_cleaned_css() {
-        // Plain string content is routed through CounterPass so pass 1 can
-        // record it for `target-text(..., before|after)`. The original
-        // declaration is stripped to avoid duplicate pseudo rendering.
+        // Plain string content (no counter()) must remain in cleaned CSS so
+        // Blitz can render it directly. Stripping it would break authors who
+        // use ::before/::after for purely decorative literals.
         let css = r#".note::before { content: "Note: "; font-weight: bold; }"#;
         let ctx = parse_gcpm(css);
         assert!(
-            !ctx.cleaned_css.contains(r#"content: "Note: ""#),
-            "literal content must be injected by CounterPass only: {:?}",
+            ctx.cleaned_css.contains(r#"content: "Note: ""#),
+            "literal content must survive in cleaned_css: {:?}",
             ctx.cleaned_css
         );
         assert!(ctx.cleaned_css.contains("font-weight: bold"));
-        assert_eq!(ctx.content_counter_mappings.len(), 1);
-        assert_eq!(
-            ctx.content_counter_mappings[0].content,
-            vec![ContentItem::String("Note: ".into())]
-        );
     }
 
     #[test]
@@ -2609,6 +2599,25 @@ mod tests {
                 .flat_map(|m| m.content.iter())
                 .any(|i| matches!(i, ContentItem::TargetText { .. }));
             assert!(any_target, "2nd arg `{form}` should parse as target-text");
+        }
+    }
+
+    #[test]
+    fn parse_target_text_with_unknown_or_trailing_2nd_arg_drops_item() {
+        for css in [
+            r#"a::after { content: target-text(attr(href), unknown); }"#,
+            r#"a::after { content: target-text(attr(href), before, extra); }"#,
+        ] {
+            let g = parse_gcpm(css);
+            let any_target = g
+                .content_counter_mappings
+                .iter()
+                .flat_map(|m| m.content.iter())
+                .any(|i| matches!(i, ContentItem::TargetText { .. }));
+            assert!(
+                !any_target,
+                "unsupported form should drop target-text: {css}"
+            );
         }
     }
 

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -9,7 +9,7 @@ use super::{
     ContentCounterMapping, ContentItem, CounterMapping, CounterOp, CounterStyle, ElementPolicy,
     GcpmContext, LeaderStyle, MarginBoxRule, PageSettingsRule, PageSizeDecl, ParsedSelector,
     PartialMargin, PseudoElement, RunningMapping, StringPolicy, StringSetMapping, StringSetValue,
-    TargetUrl,
+    TargetTextKind, TargetUrl,
 };
 
 // ---------------------------------------------------------------------------
@@ -728,13 +728,18 @@ impl<'i, 'a> DeclarationParser<'i> for StyleRuleParser<'a> {
                         | ContentItem::TargetText { .. }
                 )
             });
+            let is_plain_text = !items.is_empty()
+                && items
+                    .iter()
+                    .all(|item| matches!(item, ContentItem::String(_)));
             // Last-declaration-wins: always update content_items (clear when
-            // the new content has no counter()).
-            if has_counter {
+            // the new content cannot be represented by CounterPass).
+            if has_counter || is_plain_text {
                 *self.content_items = Some(items);
-                // Strip the original `content: counter(...)` from cleaned CSS
-                // because Blitz cannot evaluate counter() — CounterPass injects
-                // a synthetic ::before/::after rule with the resolved value.
+                // Strip the original declaration. CounterPass injects a
+                // synthetic ::before/::after rule with the resolved value;
+                // leaving the original in place would duplicate plain text
+                // pseudos and Blitz cannot evaluate target/counter content.
                 let start = decl_start.position().byte_index();
                 let end = input.position().byte_index();
                 self.edits.push(CssEdit::Replace {
@@ -743,8 +748,8 @@ impl<'i, 'a> DeclarationParser<'i> for StyleRuleParser<'a> {
                     replacement: String::new(),
                 });
             } else {
-                // Plain `content: "..."` stays in cleaned CSS so Blitz can
-                // render it directly.
+                // Unsupported forms (e.g. content: url(...)) stay in cleaned
+                // CSS so Blitz can render what it supports directly.
                 *self.content_items = None;
             }
         } else {
@@ -1123,16 +1128,23 @@ fn parse_content_value(input: &mut Parser<'_, '_>) -> Vec<ContentItem> {
                                 Some(url) => url,
                                 None => return Ok(()),
                             };
-                            // Only the default `content` form is
-                            // implemented. Other forms
-                            // (`target-text(url, before|after|first-letter)`)
-                            // are not yet supported; if a 2nd argument is
-                            // present at all, drop the item rather than
-                            // silently treating it as the default form.
+                            let kind = input
+                                .try_parse(|input| -> Result<TargetTextKind, ParseError<'_, ()>> {
+                                    input.expect_comma()?;
+                                    let ident = input.expect_ident()?.clone();
+                                    match ident.to_ascii_lowercase().as_str() {
+                                        "content" => Ok(TargetTextKind::Content),
+                                        "before" => Ok(TargetTextKind::Before),
+                                        "after" => Ok(TargetTextKind::After),
+                                        "first-letter" => Ok(TargetTextKind::FirstLetter),
+                                        _ => Err(input.new_custom_error(())),
+                                    }
+                                })
+                                .unwrap_or_default();
                             if !input.is_exhausted() {
                                 return Ok(());
                             }
-                            items.push(ContentItem::TargetText { url });
+                            items.push(ContentItem::TargetText { url, kind });
                             return Ok(());
                         }
                         let arg = input.expect_ident()?.clone();
@@ -1935,17 +1947,22 @@ mod tests {
 
     #[test]
     fn test_parse_pseudo_content_without_counter_kept_in_cleaned_css() {
-        // Plain string content (no counter()) must remain in cleaned CSS so
-        // Blitz can render it directly. Stripping it would break authors who
-        // use ::before/::after for purely decorative literals.
+        // Plain string content is routed through CounterPass so pass 1 can
+        // record it for `target-text(..., before|after)`. The original
+        // declaration is stripped to avoid duplicate pseudo rendering.
         let css = r#".note::before { content: "Note: "; font-weight: bold; }"#;
         let ctx = parse_gcpm(css);
         assert!(
-            ctx.cleaned_css.contains(r#"content: "Note: ""#),
-            "literal content must survive in cleaned_css: {:?}",
+            !ctx.cleaned_css.contains(r#"content: "Note: ""#),
+            "literal content must be injected by CounterPass only: {:?}",
             ctx.cleaned_css
         );
         assert!(ctx.cleaned_css.contains("font-weight: bold"));
+        assert_eq!(ctx.content_counter_mappings.len(), 1);
+        assert_eq!(
+            ctx.content_counter_mappings[0].content,
+            vec![ContentItem::String("Note: ".into())]
+        );
     }
 
     #[test]
@@ -2415,7 +2432,8 @@ mod tests {
         assert_eq!(
             mapping.content,
             vec![ContentItem::TargetText {
-                url: TargetUrl::Attr("href".into())
+                url: TargetUrl::Attr("href".into()),
+                kind: TargetTextKind::Content,
             }]
         );
     }
@@ -2505,7 +2523,8 @@ mod tests {
         assert_eq!(
             mapping.content,
             vec![ContentItem::TargetText {
-                url: TargetUrl::Literal("#sec1".into())
+                url: TargetUrl::Literal("#sec1".into()),
+                kind: TargetTextKind::Content,
             }]
         );
     }
@@ -2518,7 +2537,8 @@ mod tests {
         assert_eq!(
             mapping.content,
             vec![ContentItem::TargetText {
-                url: TargetUrl::Literal("#sec1".into())
+                url: TargetUrl::Literal("#sec1".into()),
+                kind: TargetTextKind::Content,
             }]
         );
     }
@@ -2579,12 +2599,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_target_text_with_unsupported_2nd_arg_drops_item() {
-        // `target-text(url, before|after|first-letter)` is not yet
-        // implemented. If a 2nd argument is present at all, drop the
-        // item rather than silently aliasing it to the default
-        // `content` form (which would surface a wrong text fragment in
-        // the rendered PDF).
+    fn parse_target_text_with_supported_2nd_arg() {
         for form in ["before", "after", "first-letter", "content"] {
             let css = format!(r##"a::after {{ content: target-text(attr(href), {form}); }}"##);
             let g = parse_gcpm(&css);
@@ -2593,7 +2608,7 @@ mod tests {
                 .iter()
                 .flat_map(|m| m.content.iter())
                 .any(|i| matches!(i, ContentItem::TargetText { .. }));
-            assert!(!any_target, "2nd arg `{form}` should drop the item");
+            assert!(any_target, "2nd arg `{form}` should parse as target-text");
         }
     }
 

--- a/crates/fulgur/src/gcpm/target_ref.rs
+++ b/crates/fulgur/src/gcpm/target_ref.rs
@@ -5,8 +5,8 @@
 //! assigned each DOM element a page) and consumed by pass 2 via the
 //! resolver helpers below.
 
-use crate::gcpm::CounterStyle;
 use crate::gcpm::counter::{format_counter, format_counter_chain};
+use crate::gcpm::{CounterStyle, TargetTextKind};
 use crate::pagination_layout::PaginationGeometryTable;
 use std::collections::BTreeMap;
 
@@ -22,6 +22,14 @@ pub struct AnchorEntry {
     /// element. Mirrors `CounterState::chain_snapshot`.
     pub counters: BTreeMap<String, Vec<i32>>,
     pub text: String,
+    pub before_text: String,
+    pub after_text: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct AnchorPseudoText {
+    pub before_text: String,
+    pub after_text: String,
 }
 
 impl AnchorMap {
@@ -103,11 +111,24 @@ pub fn resolve_target_counters(
     format_counter_chain(chain, separator, style)
 }
 
-pub fn resolve_target_text(href: &str, map: &AnchorMap) -> String {
+pub fn resolve_target_text(href: &str, kind: TargetTextKind, map: &AnchorMap) -> String {
     let Some(frag) = fragment_id_from_href(href) else {
         return String::new();
     };
-    map.get(frag).map(|e| e.text.clone()).unwrap_or_default()
+    let Some(entry) = map.get(frag) else {
+        return String::new();
+    };
+    match kind {
+        TargetTextKind::Content => entry.text.clone(),
+        TargetTextKind::Before => entry.before_text.clone(),
+        TargetTextKind::After => entry.after_text.clone(),
+        TargetTextKind::FirstLetter => entry
+            .text
+            .chars()
+            .next()
+            .map(|c| c.to_string())
+            .unwrap_or_default(),
+    }
 }
 
 /// Return the **1-based** page number for a DOM node, derived from
@@ -135,6 +156,8 @@ mod tests {
                 page_num: 7,
                 counters,
                 text: "Introduction".into(),
+                before_text: "Before".into(),
+                after_text: "After".into(),
             },
         );
         m
@@ -177,6 +200,8 @@ mod tests {
                 page_num: 5,
                 counters,
                 text: String::new(),
+                before_text: String::new(),
+                after_text: String::new(),
             },
         );
         assert_eq!(
@@ -224,13 +249,36 @@ mod tests {
     #[test]
     fn target_text_returns_text() {
         let m = make_map();
-        assert_eq!(resolve_target_text("#sec-1-2", &m), "Introduction");
+        assert_eq!(
+            resolve_target_text("#sec-1-2", TargetTextKind::Content, &m),
+            "Introduction"
+        );
+    }
+
+    #[test]
+    fn target_text_returns_before_after_and_first_letter() {
+        let m = make_map();
+        assert_eq!(
+            resolve_target_text("#sec-1-2", TargetTextKind::Before, &m),
+            "Before"
+        );
+        assert_eq!(
+            resolve_target_text("#sec-1-2", TargetTextKind::After, &m),
+            "After"
+        );
+        assert_eq!(
+            resolve_target_text("#sec-1-2", TargetTextKind::FirstLetter, &m),
+            "I"
+        );
     }
 
     #[test]
     fn target_text_missing_returns_empty() {
         let m = make_map();
-        assert_eq!(resolve_target_text("#nope", &m), "");
+        assert_eq!(
+            resolve_target_text("#nope", TargetTextKind::Content, &m),
+            ""
+        );
     }
 
     #[test]
@@ -337,6 +385,9 @@ mod tests {
     #[test]
     fn target_text_external_href_returns_empty() {
         let m = make_map();
-        assert_eq!(resolve_target_text("https://example.com/", &m), "");
+        assert_eq!(
+            resolve_target_text("https://example.com/", TargetTextKind::Content, &m),
+            ""
+        );
     }
 }

--- a/crates/fulgur/src/gcpm/target_ref.rs
+++ b/crates/fulgur/src/gcpm/target_ref.rs
@@ -9,6 +9,7 @@ use crate::gcpm::counter::{format_counter, format_counter_chain};
 use crate::gcpm::{CounterStyle, TargetTextKind};
 use crate::pagination_layout::PaginationGeometryTable;
 use std::collections::BTreeMap;
+use unicode_segmentation::UnicodeSegmentation;
 
 #[derive(Debug, Clone, Default)]
 pub struct AnchorMap {
@@ -122,12 +123,7 @@ pub fn resolve_target_text(href: &str, kind: TargetTextKind, map: &AnchorMap) ->
         TargetTextKind::Content => entry.text.clone(),
         TargetTextKind::Before => entry.before_text.clone(),
         TargetTextKind::After => entry.after_text.clone(),
-        TargetTextKind::FirstLetter => entry
-            .text
-            .chars()
-            .next()
-            .map(|c| c.to_string())
-            .unwrap_or_default(),
+        TargetTextKind::FirstLetter => entry.text.graphemes(true).next().unwrap_or("").to_string(),
     }
 }
 
@@ -269,6 +265,16 @@ mod tests {
         assert_eq!(
             resolve_target_text("#sec-1-2", TargetTextKind::FirstLetter, &m),
             "I"
+        );
+    }
+
+    #[test]
+    fn target_text_first_letter_is_grapheme_cluster() {
+        let mut m = make_map();
+        m.entries.get_mut("sec-1-2").expect("target fixture").text = "A\u{0301}BC".to_string();
+        assert_eq!(
+            resolve_target_text("#sec-1-2", TargetTextKind::FirstLetter, &m),
+            "A\u{0301}"
         );
     }
 

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -3563,7 +3563,7 @@ fn target_text_in_top_center_resolves_via_implicit_href() {
     let html = r##"
 <!doctype html>
 <html><head><style>
-  body { font-family: 'Noto Sans', sans-serif; font-size: 12pt; }
+  body { counter-reset: chapter; font-family: 'Noto Sans', sans-serif; font-size: 12pt; }
   @page { margin: 1in; @top-center { content: "Header: " target-text(attr(href)); } }
   h2 { page-break-before: always; }
 </style></head>
@@ -3616,8 +3616,9 @@ fn target_text_second_arg_resolves_target_fragments() {
                " First: " target-text(attr(href), first-letter);
     }
   }
-  h2::before { content: "BeforeFrag"; }
-  h2::after { content: "AfterFrag"; }
+  h2 { counter-increment: chapter; }
+  h2::before { content: "BeforeFrag" counter(chapter); }
+  h2::after { content: "AfterFrag" counter(chapter); }
 </style></head>
 <body>
   <p><a href="#sec1">Jump</a></p>
@@ -3641,7 +3642,7 @@ fn target_text_second_arg_resolves_target_fragments() {
     };
     let text = String::from_utf8_lossy(&output.stdout);
     assert!(
-        text.contains("Before: BeforeFrag After: AfterFrag First: M"),
+        text.contains("Before: BeforeFrag1 After: AfterFrag1 First: M"),
         "target-text second-argument payload missing from extracted PDF text: {text:?}"
     );
 }

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -3601,3 +3601,47 @@ fn target_text_in_top_center_resolves_via_implicit_href() {
         lower.len()
     );
 }
+
+#[test]
+fn target_text_second_arg_resolves_target_fragments() {
+    let html = r##"
+<!doctype html>
+<html><head><style>
+  body { font-family: 'Noto Sans', sans-serif; font-size: 12pt; }
+  @page {
+    margin: 1in;
+    @top-center {
+      content: "Before: " target-text(attr(href), before)
+               " After: " target-text(attr(href), after)
+               " First: " target-text(attr(href), first-letter);
+    }
+  }
+  h2::before { content: "BeforeFrag"; }
+  h2::after { content: "AfterFrag"; }
+</style></head>
+<body>
+  <p><a href="#sec1">Jump</a></p>
+  <h2 id="sec1">My Section Title</h2>
+</body></html>"##;
+
+    let pdf = tagged_render_with_noto(html);
+    assert!(!pdf.is_empty());
+
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("target-text-second-arg.pdf");
+    std::fs::write(&path, &pdf).expect("write pdf");
+
+    let output = std::process::Command::new("pdftotext")
+        .arg(&path)
+        .arg("-")
+        .output();
+    let Ok(output) = output else {
+        eprintln!("pdftotext not available; skipping text assertion");
+        return;
+    };
+    let text = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        text.contains("Before: BeforeFrag After: AfterFrag First: M"),
+        "target-text second-argument payload missing from extracted PDF text: {text:?}"
+    );
+}

--- a/docs/superpowers/plans/2026-05-07-target-text-second-arg.md
+++ b/docs/superpowers/plans/2026-05-07-target-text-second-arg.md
@@ -37,7 +37,7 @@ Accept `content`, `before`, `after`, and `first-letter`; drop unknown arguments 
 
 - [ ] **Step 5: Extend target text resolution**
 
-Resolve `Content` from `AnchorEntry.text`, `Before` from `AnchorEntry.before_text`, `After` from `AnchorEntry.after_text`, and `FirstLetter` from the first Unicode scalar of normalized text.
+Resolve `Content` from `AnchorEntry.text`, `Before` from `AnchorEntry.before_text`, `After` from `AnchorEntry.after_text`, and `FirstLetter` from the first grapheme cluster of normalized text.
 
 ### Task 2: Pseudo Text Capture
 

--- a/docs/superpowers/plans/2026-05-07-target-text-second-arg.md
+++ b/docs/superpowers/plans/2026-05-07-target-text-second-arg.md
@@ -1,0 +1,87 @@
+# Target Text Second Argument Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add GCPM `target-text(attr(href), before|after|first-letter)` support while preserving existing default `content` behavior.
+
+**Architecture:** Extend `ContentItem::TargetText` with a small mode enum, parse the optional second argument, and resolve it through `AnchorEntry`. Reuse `CounterPass`'s already-resolved pseudo content for target `::before`/`::after`, and derive `first-letter` from normalized target text.
+
+**Tech Stack:** Rust workspace, `cssparser`, existing GCPM two-pass render pipeline, `cargo test`.
+
+---
+
+### Task 1: Parser And Resolver Model
+
+**Files:**
+- Modify: `crates/fulgur/src/gcpm/mod.rs`
+- Modify: `crates/fulgur/src/gcpm/parser.rs`
+- Modify: `crates/fulgur/src/gcpm/target_ref.rs`
+
+- [ ] **Step 1: Write failing parser/resolver tests**
+
+Add tests proving `target-text(attr(href), before|after|first-letter|content)` parses into a target-text item and resolves different text forms.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+Run: `cargo test -p fulgur gcpm::parser::tests::parse_target_text_with_supported_2nd_arg --lib`
+
+Expected: FAIL because supported second arguments are currently dropped.
+
+- [ ] **Step 3: Add `TargetTextKind` and extend `ContentItem::TargetText`**
+
+Use variants `Content`, `Before`, `After`, and `FirstLetter` with `Content` as default.
+
+- [ ] **Step 4: Parse optional second argument**
+
+Accept `content`, `before`, `after`, and `first-letter`; drop unknown arguments or trailing tokens.
+
+- [ ] **Step 5: Extend target text resolution**
+
+Resolve `Content` from `AnchorEntry.text`, `Before` from `AnchorEntry.before_text`, `After` from `AnchorEntry.after_text`, and `FirstLetter` from the first Unicode scalar of normalized text.
+
+### Task 2: Pseudo Text Capture
+
+**Files:**
+- Modify: `crates/fulgur/src/blitz_adapter.rs`
+- Modify: `crates/fulgur/src/engine.rs`
+
+- [ ] **Step 1: Write failing CounterPass/engine tests**
+
+Add tests showing resolved `::before` and `::after` content is captured per node and made available in `AnchorMap`.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+Run: `cargo test -p fulgur blitz_adapter::tests::counter_pass_records_target_text_pseudo_content --lib`
+
+Expected: FAIL because CounterPass currently only emits CSS, not reusable pseudo text.
+
+- [ ] **Step 3: Record pseudo text in CounterPass**
+
+Add a per-node pseudo text map populated at the same point generated CSS is written.
+
+- [ ] **Step 4: Pass pseudo text into `build_anchor_map`**
+
+Populate `AnchorEntry.before_text` and `AnchorEntry.after_text` when pass 1 builds the map.
+
+### Task 3: End-To-End Verification
+
+**Files:**
+- Modify: `crates/fulgur/tests/render_smoke.rs`
+
+- [ ] **Step 1: Write failing smoke test**
+
+Add an HTML render test where a reference emits `target-text(attr(href), before)`, `after`, and `first-letter` and assert extracted PDF text contains the expected fragments.
+
+- [ ] **Step 2: Run focused test and verify RED**
+
+Run: `cargo test -p fulgur --test render_smoke target_text_second_arg_resolves_target_fragments`
+
+Expected: FAIL before implementation is complete.
+
+- [ ] **Step 3: Run focused and full quality gates**
+
+Run: `cargo fmt --check`, `cargo test -p fulgur gcpm::parser::tests::parse_target_text_with_supported_2nd_arg --lib`, `cargo test -p fulgur --test render_smoke target_text_second_arg_resolves_target_fragments`, and `cargo test --workspace`.
+
+- [ ] **Step 4: Commit and push**
+
+Commit the implementation and push the feature branch per project session completion rules.


### PR DESCRIPTION
## Summary
- Add `target-text()` second-argument parsing for `content`, `before`, `after`, and `first-letter`.
- Carry CounterPass-resolved pseudo text into `AnchorMap` so pass-2 `target-text(..., before|after)` can resolve target fragments.
- Preserve plain pseudo-content cascade behavior and add parser/smoke coverage for supported and unsupported forms.

## Test Plan
- [x] cargo fmt --check
- [x] cargo test -p fulgur gcpm::parser::tests::parse_target_text_with_supported_2nd_arg --lib
- [x] cargo test -p fulgur gcpm::parser::tests::parse_target_text_with_unknown_or_trailing_2nd_arg_drops_item --lib
- [x] cargo test -p fulgur --test render_smoke target_text_second_arg_resolves_target_fragments
- [x] cargo test --workspace

## Notes
- `fulgur-x70n` is closed.
- Follow-up `fulgur-r73p` tracks cascade-safe capture for non-CounterPass pseudo content such as `attr()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * target-text() の第2引数（content/before/after/first-letter）をサポートし、参照先の特定フラグメントを取得可能に。
* **Improvements**
  * 参照先テキストの擬似要素（before/after）をノード単位で収集・伝搬し、target-text 解決がより正確に。
* **Tests**
  * 単体・統合テストを追加・更新して各モードと境界ケースを検証。
* **Documentation**
  * 実装計画と手順を追記。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->