### PR TITLE
test(render): add coverage for pure helper functions

### DIFF
--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -4473,17 +4473,17 @@ mod tests {
         }
     }
 
-    fn make_line(height_pt: f32) -> crate::paragraph::ShapedLine {
+    fn make_line(height_pt: f32, baseline_pt: f32) -> crate::paragraph::ShapedLine {
         crate::paragraph::ShapedLine {
             height: height_pt,
-            baseline: height_pt * 0.75,
+            baseline: baseline_pt,
             items: vec![],
         }
     }
 
     #[test]
     fn paragraph_lines_for_page_no_matching_fragment_returns_none() {
-        let lines = vec![make_line(16.0)];
+        let lines = vec![make_line(16.0, 12.0)];
         let fragments = vec![make_fragment(0, 16.0)];
         // Ask for page 1, which has no fragment.
         let result = paragraph_lines_for_page(&lines, &fragments, 1, false);
@@ -4492,21 +4492,30 @@ mod tests {
 
     #[test]
     fn paragraph_lines_for_page_not_split_returns_all_lines() {
-        let lines = vec![make_line(16.0), make_line(16.0), make_line(16.0)];
-        let fragments = vec![make_fragment(0, 48.0)];
-        // px_to_pt conversion: fragment height in px, lines in pt.
-        // paragraph_lines_for_page works with pt throughout since ShapedLine.height is in pt
-        // and Fragment.height is in px (converted by px_to_pt inside the function).
+        // px_to_pt(64px) ≈ 48pt (3 × 16pt lines). Non-split path returns
+        // all lines unchanged — baseline values are preserved as-is.
+        let lines = vec![
+            make_line(16.0, 12.0),
+            make_line(16.0, 28.0),
+            make_line(16.0, 44.0),
+        ];
+        let fragments = vec![make_fragment(0, 64.0)];
         let result = paragraph_lines_for_page(&lines, &fragments, 0, false);
         assert!(result.is_some());
-        assert_eq!(result.unwrap().len(), 3);
+        let sliced = result.unwrap();
+        assert_eq!(sliced.len(), 3);
+        assert!(
+            (sliced[0].baseline - 12.0).abs() < 0.01,
+            "baseline unchanged on non-split"
+        );
     }
 
     #[test]
     fn paragraph_lines_for_page_split_first_page_returns_first_lines() {
         // Lines are 12pt each. Fragment heights are in CSS px;
         // px_to_pt(16px) = 12pt (PX_TO_PT = 0.75), so 16px per line.
-        let lines = vec![make_line(12.0), make_line(12.0)];
+        // Page 0: consumed = 0, baseline unchanged.
+        let lines = vec![make_line(12.0, 9.0), make_line(12.0, 21.0)];
         let fragments = vec![
             make_fragment(0, 16.0), // 16px = 12pt → first line
             make_fragment(1, 16.0),
@@ -4515,11 +4524,17 @@ mod tests {
         assert!(result.is_some());
         let sliced = result.unwrap();
         assert_eq!(sliced.len(), 1, "page 0 should contain exactly one line");
+        assert!(
+            (sliced[0].baseline - 9.0).abs() < 0.01,
+            "page 0 baseline unchanged (consumed=0)"
+        );
     }
 
     #[test]
     fn paragraph_lines_for_page_split_second_page_returns_remaining_lines() {
-        let lines = vec![make_line(12.0), make_line(12.0)];
+        // Page 1: consumed = 12pt (one line). The function subtracts consumed
+        // from baseline, so paragraph-absolute 21pt → fragment-local 9pt.
+        let lines = vec![make_line(12.0, 9.0), make_line(12.0, 21.0)];
         let fragments = vec![
             make_fragment(0, 16.0), // 16px = 12pt → first line
             make_fragment(1, 16.0),
@@ -4528,12 +4543,16 @@ mod tests {
         assert!(result.is_some());
         let sliced = result.unwrap();
         assert_eq!(sliced.len(), 1, "page 1 should contain exactly one line");
+        assert!(
+            (sliced[0].baseline - 9.0).abs() < 0.01,
+            "baseline rebased: 21pt - 12pt consumed = 9pt"
+        );
     }
 
     #[test]
     fn paragraph_lines_for_page_split_empty_range_returns_none() {
         // Fragment height is 0px → no lines fit.
-        let lines = vec![make_line(12.0)];
+        let lines = vec![make_line(12.0, 9.0)];
         let fragments = vec![
             make_fragment(0, 100.0), // page 0 gets the line
             make_fragment(1, 0.0),   // page 1 has zero height
@@ -4545,8 +4564,10 @@ mod tests {
     // --- build_page_skip_sets ---
 
     fn block_entry_with_overflow_clip(descendants: Vec<usize>) -> crate::drawables::BlockEntry {
-        let mut style = crate::draw_primitives::BlockStyle::default();
-        style.overflow_x = crate::draw_primitives::Overflow::Clip;
+        let style = crate::draw_primitives::BlockStyle {
+            overflow_x: crate::draw_primitives::Overflow::Clip,
+            ..Default::default()
+        };
         crate::drawables::BlockEntry {
             style,
             opacity: 1.0,
@@ -4652,8 +4673,10 @@ mod tests {
     #[test]
     fn build_page_skip_sets_table_overflow_clip_collects_descendants() {
         let mut d = Drawables::new();
-        let mut style = crate::draw_primitives::BlockStyle::default();
-        style.overflow_x = crate::draw_primitives::Overflow::Clip;
+        let style = crate::draw_primitives::BlockStyle {
+            overflow_x: crate::draw_primitives::Overflow::Clip,
+            ..Default::default()
+        };
         d.tables.insert(
             40,
             crate::drawables::TableEntry {

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -4254,4 +4254,421 @@ mod tests {
             "child should be a Link Group"
         );
     }
+
+    // --- para_has_link_runs ---
+
+    fn make_glyph_run(
+        text: &str,
+        link: Option<std::sync::Arc<crate::paragraph::LinkSpan>>,
+    ) -> crate::paragraph::ShapedGlyphRun {
+        crate::paragraph::ShapedGlyphRun {
+            font_data: std::sync::Arc::new(vec![]),
+            font_index: 0,
+            font_size: 12.0,
+            color: [0, 0, 0, 255],
+            decoration: crate::paragraph::TextDecoration::default(),
+            glyphs: vec![],
+            text: text.to_string(),
+            x_offset: 0.0,
+            link,
+        }
+    }
+
+    fn make_shaped_line(items: Vec<crate::paragraph::LineItem>) -> crate::paragraph::ShapedLine {
+        crate::paragraph::ShapedLine {
+            height: 16.0,
+            baseline: 12.0,
+            items,
+        }
+    }
+
+    fn make_para(lines: Vec<crate::paragraph::ShapedLine>) -> crate::drawables::ParagraphEntry {
+        crate::drawables::ParagraphEntry {
+            lines,
+            opacity: 1.0,
+            visible: true,
+            id: None,
+        }
+    }
+
+    #[test]
+    fn para_has_link_runs_empty_paragraph_returns_false() {
+        let para = make_para(vec![]);
+        assert!(!para_has_link_runs(&para));
+    }
+
+    #[test]
+    fn para_has_link_runs_text_without_link_returns_false() {
+        let run = make_glyph_run("hello", None);
+        let line = make_shaped_line(vec![crate::paragraph::LineItem::Text(run)]);
+        let para = make_para(vec![line]);
+        assert!(!para_has_link_runs(&para));
+    }
+
+    #[test]
+    fn para_has_link_runs_text_with_link_returns_true() {
+        let span = std::sync::Arc::new(crate::paragraph::LinkSpan {
+            target: crate::paragraph::LinkTarget::External(std::sync::Arc::new(
+                "https://example.com".to_string(),
+            )),
+            alt_text: None,
+        });
+        let run = make_glyph_run("click me", Some(span));
+        let line = make_shaped_line(vec![crate::paragraph::LineItem::Text(run)]);
+        let para = make_para(vec![line]);
+        assert!(para_has_link_runs(&para));
+    }
+
+    #[test]
+    fn para_has_link_runs_inline_box_returns_false() {
+        let item = crate::paragraph::InlineBoxItem {
+            node_id: None,
+            width: 10.0,
+            height: 10.0,
+            x_offset: 0.0,
+            computed_y: 0.0,
+            link: None,
+            opacity: 1.0,
+            visible: true,
+        };
+        let line = make_shaped_line(vec![crate::paragraph::LineItem::InlineBox(item)]);
+        let para = make_para(vec![line]);
+        assert!(!para_has_link_runs(&para));
+    }
+
+    #[test]
+    fn para_has_link_runs_image_with_link_returns_true() {
+        let span = std::sync::Arc::new(crate::paragraph::LinkSpan {
+            target: crate::paragraph::LinkTarget::Internal(std::sync::Arc::new(
+                "section".to_string(),
+            )),
+            alt_text: None,
+        });
+        let img = crate::paragraph::InlineImage {
+            data: std::sync::Arc::new(vec![]),
+            format: crate::image::ImageFormat::Png,
+            width: 20.0,
+            height: 20.0,
+            x_offset: 0.0,
+            vertical_align: crate::paragraph::VerticalAlign::Baseline,
+            opacity: 1.0,
+            visible: true,
+            computed_y: 0.0,
+            link: Some(span),
+        };
+        let line = make_shaped_line(vec![crate::paragraph::LineItem::Image(img)]);
+        let para = make_para(vec![line]);
+        assert!(para_has_link_runs(&para));
+    }
+
+    #[test]
+    fn para_has_link_runs_image_without_link_returns_false() {
+        let img = crate::paragraph::InlineImage {
+            data: std::sync::Arc::new(vec![]),
+            format: crate::image::ImageFormat::Png,
+            width: 10.0,
+            height: 10.0,
+            x_offset: 0.0,
+            vertical_align: crate::paragraph::VerticalAlign::Baseline,
+            opacity: 1.0,
+            visible: true,
+            computed_y: 0.0,
+            link: None,
+        };
+        let line = make_shaped_line(vec![crate::paragraph::LineItem::Image(img)]);
+        let para = make_para(vec![line]);
+        assert!(!para_has_link_runs(&para));
+    }
+
+    #[test]
+    fn para_has_link_runs_link_in_second_line_returns_true() {
+        let plain_line = make_shaped_line(vec![crate::paragraph::LineItem::Text(make_glyph_run(
+            "first", None,
+        ))]);
+        let span = std::sync::Arc::new(crate::paragraph::LinkSpan {
+            target: crate::paragraph::LinkTarget::External(std::sync::Arc::new(
+                "https://example.com".to_string(),
+            )),
+            alt_text: None,
+        });
+        let link_line = make_shaped_line(vec![crate::paragraph::LineItem::Text(make_glyph_run(
+            "second",
+            Some(span),
+        ))]);
+        let para = make_para(vec![plain_line, link_line]);
+        assert!(para_has_link_runs(&para));
+    }
+
+    // --- extract_heading_title ---
+
+    #[test]
+    fn extract_heading_title_empty_paragraph_returns_empty() {
+        let para = make_para(vec![]);
+        assert_eq!(extract_heading_title(&para), "");
+    }
+
+    #[test]
+    fn extract_heading_title_single_text_run() {
+        let line = make_shaped_line(vec![crate::paragraph::LineItem::Text(make_glyph_run(
+            "Hello", None,
+        ))]);
+        let para = make_para(vec![line]);
+        assert_eq!(extract_heading_title(&para), "Hello");
+    }
+
+    #[test]
+    fn extract_heading_title_multiple_runs_across_lines() {
+        let line1 = make_shaped_line(vec![crate::paragraph::LineItem::Text(make_glyph_run(
+            "Foo", None,
+        ))]);
+        let line2 = make_shaped_line(vec![crate::paragraph::LineItem::Text(make_glyph_run(
+            "Bar", None,
+        ))]);
+        let para = make_para(vec![line1, line2]);
+        assert_eq!(extract_heading_title(&para), "FooBar");
+    }
+
+    #[test]
+    fn extract_heading_title_skips_image_and_inline_box() {
+        let img = crate::paragraph::InlineImage {
+            data: std::sync::Arc::new(vec![]),
+            format: crate::image::ImageFormat::Png,
+            width: 10.0,
+            height: 10.0,
+            x_offset: 0.0,
+            vertical_align: crate::paragraph::VerticalAlign::Baseline,
+            opacity: 1.0,
+            visible: true,
+            computed_y: 0.0,
+            link: None,
+        };
+        let inline_box = crate::paragraph::InlineBoxItem {
+            node_id: None,
+            width: 10.0,
+            height: 10.0,
+            x_offset: 0.0,
+            computed_y: 0.0,
+            link: None,
+            opacity: 1.0,
+            visible: true,
+        };
+        let line = make_shaped_line(vec![
+            crate::paragraph::LineItem::Image(img),
+            crate::paragraph::LineItem::Text(make_glyph_run("text", None)),
+            crate::paragraph::LineItem::InlineBox(inline_box),
+        ]);
+        let para = make_para(vec![line]);
+        assert_eq!(extract_heading_title(&para), "text");
+    }
+
+    // --- paragraph_lines_for_page ---
+
+    fn make_fragment(page_index: u32, height: f32) -> crate::pagination_layout::Fragment {
+        crate::pagination_layout::Fragment {
+            page_index,
+            x: 0.0,
+            y: 0.0,
+            width: 100.0,
+            height,
+        }
+    }
+
+    fn make_line(height_pt: f32) -> crate::paragraph::ShapedLine {
+        crate::paragraph::ShapedLine {
+            height: height_pt,
+            baseline: height_pt * 0.75,
+            items: vec![],
+        }
+    }
+
+    #[test]
+    fn paragraph_lines_for_page_no_matching_fragment_returns_none() {
+        let lines = vec![make_line(16.0)];
+        let fragments = vec![make_fragment(0, 16.0)];
+        // Ask for page 1, which has no fragment.
+        let result = paragraph_lines_for_page(&lines, &fragments, 1, false);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn paragraph_lines_for_page_not_split_returns_all_lines() {
+        let lines = vec![make_line(16.0), make_line(16.0), make_line(16.0)];
+        let fragments = vec![make_fragment(0, 48.0)];
+        // px_to_pt conversion: fragment height in px, lines in pt.
+        // paragraph_lines_for_page works with pt throughout since ShapedLine.height is in pt
+        // and Fragment.height is in px (converted by px_to_pt inside the function).
+        let result = paragraph_lines_for_page(&lines, &fragments, 0, false);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().len(), 3);
+    }
+
+    #[test]
+    fn paragraph_lines_for_page_split_first_page_returns_first_lines() {
+        // Lines are 12pt each. Fragment heights are in CSS px;
+        // px_to_pt(16px) = 12pt (PX_TO_PT = 0.75), so 16px per line.
+        let lines = vec![make_line(12.0), make_line(12.0)];
+        let fragments = vec![
+            make_fragment(0, 16.0), // 16px = 12pt → first line
+            make_fragment(1, 16.0),
+        ];
+        let result = paragraph_lines_for_page(&lines, &fragments, 0, true);
+        assert!(result.is_some());
+        let sliced = result.unwrap();
+        assert_eq!(sliced.len(), 1, "page 0 should contain exactly one line");
+    }
+
+    #[test]
+    fn paragraph_lines_for_page_split_second_page_returns_remaining_lines() {
+        let lines = vec![make_line(12.0), make_line(12.0)];
+        let fragments = vec![
+            make_fragment(0, 16.0), // 16px = 12pt → first line
+            make_fragment(1, 16.0),
+        ];
+        let result = paragraph_lines_for_page(&lines, &fragments, 1, true);
+        assert!(result.is_some());
+        let sliced = result.unwrap();
+        assert_eq!(sliced.len(), 1, "page 1 should contain exactly one line");
+    }
+
+    #[test]
+    fn paragraph_lines_for_page_split_empty_range_returns_none() {
+        // Fragment height is 0px → no lines fit.
+        let lines = vec![make_line(12.0)];
+        let fragments = vec![
+            make_fragment(0, 100.0), // page 0 gets the line
+            make_fragment(1, 0.0),   // page 1 has zero height
+        ];
+        let result = paragraph_lines_for_page(&lines, &fragments, 1, true);
+        assert!(result.is_none());
+    }
+
+    // --- build_page_skip_sets ---
+
+    fn block_entry_with_overflow_clip(descendants: Vec<usize>) -> crate::drawables::BlockEntry {
+        let mut style = crate::draw_primitives::BlockStyle::default();
+        style.overflow_x = crate::draw_primitives::Overflow::Clip;
+        crate::drawables::BlockEntry {
+            style,
+            opacity: 1.0,
+            visible: true,
+            id: None,
+            layout_size: None,
+            clip_descendants: descendants,
+            opacity_descendants: vec![],
+        }
+    }
+
+    fn block_entry_with_opacity_descendants(
+        descendants: Vec<usize>,
+    ) -> crate::drawables::BlockEntry {
+        crate::drawables::BlockEntry {
+            style: crate::draw_primitives::BlockStyle::default(),
+            opacity: 0.5,
+            visible: true,
+            id: None,
+            layout_size: None,
+            clip_descendants: vec![],
+            opacity_descendants: descendants,
+        }
+    }
+
+    #[test]
+    fn build_page_skip_sets_empty_drawables_returns_empty_sets() {
+        let d = Drawables::new();
+        let (tx, clip, opacity) = build_page_skip_sets(&d);
+        assert!(tx.is_empty());
+        assert!(clip.is_empty());
+        assert!(opacity.is_empty());
+    }
+
+    #[test]
+    fn build_page_skip_sets_transform_descendants_collected() {
+        let mut d = Drawables::new();
+        d.transforms.insert(
+            10,
+            crate::drawables::TransformEntry {
+                matrix: crate::draw_primitives::Affine2D::translation(0.0, 0.0),
+                origin: crate::draw_primitives::Point2 { x: 0.0, y: 0.0 },
+                descendants: vec![11, 12],
+            },
+        );
+        let (tx, clip, opacity) = build_page_skip_sets(&d);
+        assert!(tx.contains(&11));
+        assert!(tx.contains(&12));
+        assert!(!tx.contains(&10), "wrapper itself is not a descendant");
+        assert!(clip.is_empty());
+        assert!(opacity.is_empty());
+    }
+
+    #[test]
+    fn build_page_skip_sets_overflow_clip_block_collects_descendants() {
+        let mut d = Drawables::new();
+        let node_id: usize = 20;
+        d.block_styles
+            .insert(node_id, block_entry_with_overflow_clip(vec![21, 22]));
+        let (_, clip, _) = build_page_skip_sets(&d);
+        assert!(clip.contains(&21));
+        assert!(clip.contains(&22));
+    }
+
+    #[test]
+    fn build_page_skip_sets_body_excluded_from_clip_descendants() {
+        let mut d = Drawables::new();
+        let body_id: usize = 5;
+        d.body_id = Some(body_id);
+        d.block_styles
+            .insert(body_id, block_entry_with_overflow_clip(vec![6, 7]));
+        let (_, clip, _) = build_page_skip_sets(&d);
+        assert!(!clip.contains(&6), "body clip descendants must be excluded");
+        assert!(!clip.contains(&7));
+    }
+
+    #[test]
+    fn build_page_skip_sets_opacity_descendants_collected() {
+        let mut d = Drawables::new();
+        let node_id: usize = 30;
+        d.block_styles
+            .insert(node_id, block_entry_with_opacity_descendants(vec![31, 32]));
+        let (_, _, opacity) = build_page_skip_sets(&d);
+        assert!(opacity.contains(&31));
+        assert!(opacity.contains(&32));
+    }
+
+    #[test]
+    fn build_page_skip_sets_body_excluded_from_opacity_descendants() {
+        let mut d = Drawables::new();
+        let body_id: usize = 3;
+        d.body_id = Some(body_id);
+        d.block_styles
+            .insert(body_id, block_entry_with_opacity_descendants(vec![4, 5]));
+        let (_, _, opacity) = build_page_skip_sets(&d);
+        assert!(
+            !opacity.contains(&4),
+            "body opacity descendants must be excluded"
+        );
+        assert!(!opacity.contains(&5));
+    }
+
+    #[test]
+    fn build_page_skip_sets_table_overflow_clip_collects_descendants() {
+        let mut d = Drawables::new();
+        let mut style = crate::draw_primitives::BlockStyle::default();
+        style.overflow_x = crate::draw_primitives::Overflow::Clip;
+        d.tables.insert(
+            40,
+            crate::drawables::TableEntry {
+                style,
+                opacity: 1.0,
+                visible: true,
+                id: None,
+                layout_size: None,
+                width: 200.0,
+                cached_height: 100.0,
+                clip_descendants: vec![41, 42],
+            },
+        );
+        let (_, clip, _) = build_page_skip_sets(&d);
+        assert!(clip.contains(&41));
+        assert!(clip.contains(&42));
+    }
 }


### PR DESCRIPTION
## 対象モジュール

`crates/fulgur/src/render.rs`

## カバレッジ変化

| 測定方法 | 変化前 | 変化後 |
|---------|--------|--------|
| `cargo llvm-cov --package fulgur --lib` | 31.6% | 41.1% |

## 追加したテスト

### `para_has_link_runs` (7件)

- `para_has_link_runs_empty_paragraph_returns_false` — 空の段落
- `para_has_link_runs_text_without_link_returns_false` — リンクなし Text ラン
- `para_has_link_runs_text_with_link_returns_true` — リンクあり Text ラン
- `para_has_link_runs_inline_box_returns_false` — InlineBox 項目（リンク判定対象外）
- `para_has_link_runs_image_with_link_returns_true` — リンクあり Image 項目
- `para_has_link_runs_image_without_link_returns_false` — リンクなし Image 項目
- `para_has_link_runs_link_in_second_line_returns_true` — 2行目にリンクあり

### `extract_heading_title` (4件)

- `extract_heading_title_empty_paragraph_returns_empty` — 空の段落
- `extract_heading_title_single_text_run` — 単一 Text ラン
- `extract_heading_title_multiple_runs_across_lines` — 複数行にわたる Text ランの結合
- `extract_heading_title_skips_image_and_inline_box` — Image / InlineBox をスキップして Text のみ抽出

### `paragraph_lines_for_page` (5件)

- `paragraph_lines_for_page_no_matching_fragment_returns_none` — 指定ページのフラグメントなし → None
- `paragraph_lines_for_page_not_split_returns_all_lines` — 非分割時は全行を返す
- `paragraph_lines_for_page_split_first_page_returns_first_lines` — 分割：1ページ目の行を正しく抽出
- `paragraph_lines_for_page_split_second_page_returns_remaining_lines` — 分割：2ページ目の行を正しく抽出
- `paragraph_lines_for_page_split_empty_range_returns_none` — 分割：ページ高さ 0 → 対象行なし → None

### `build_page_skip_sets` (7件)

- `build_page_skip_sets_empty_drawables_returns_empty_sets` — 空の Drawables
- `build_page_skip_sets_transform_descendants_collected` — TransformEntry の descendants 収集
- `build_page_skip_sets_overflow_clip_block_collects_descendants` — overflow clip ブロックの clip\_descendants 収集
- `build_page_skip_sets_body_excluded_from_clip_descendants` — body\_id はクリップ除外対象から外す
- `build_page_skip_sets_opacity_descendants_collected` — opacity\_descendants 収集
- `build_page_skip_sets_body_excluded_from_opacity_descendants` — body\_id は opacity 除外対象から外す
- `build_page_skip_sets_table_overflow_clip_collects_descendants` — テーブルの overflow clip 時の descendants 収集

## 意図的に除外したブランチ

| 対象 | 理由 |
|------|------|
| `render_v2` / `draw_v2_page` 本体 | Krilla の `Document` / `Surface` を構築するには `Engine::render_html` が必要。インライン単体テストでは構築不可。integration test (`render_smoke.rs`) が既に多数カバー済み |
| `try_start_tagged` / `finish_tagged` | `Canvas` が `Surface` の可変参照を保持しており、単体で構築できない |
| `build_metadata` | 返値が `krilla::metadata::Metadata` で内部フィールドにアクセサがなく、結果を検証できない |

https://claude.ai/code/session_011UHpHT692EtxTwGBZbDvso

---
_Generated by [Claude Code](https://claude.ai/code/session_011UHpHT692EtxTwGBZbDvso)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * 段落のリンク検出（空段落、テキスト/画像の有無、行跨ぎケース、インライン要素除外）に関する包括的なユニットテストを追加しました。
  * 見出しタイトル抽出（空、複数行、非テキスト要素無視）を検証するテストを追加しました。
  * ページ分割・行抽出処理（分割/非分割、断片欠損、ページごとの切り出し、高さゼロの扱い）を追加しました。
  * 描画スキップセット構築（変換・オーバーフロー・不透明度の子孫収集挙動含む）を拡充しました。
  * テスト用ヘルパーを導入し保守性を向上させました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->