### PR TITLE
feat(gcpm): cascade-safe capture of pseudo content for target-text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,6 +1145,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml",
+ "unicode-properties",
  "unicode-segmentation",
  "usvg",
  "woff2-patched",

--- a/crates/fulgur/Cargo.toml
+++ b/crates/fulgur/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1"
 log = "0.4"
 lopdf = "0.40.0"
 unicode-segmentation = "1.13"
+unicode-properties = "0.1"
 # Force-enable `image`'s `png` feature so PNG decoding (used by blitz-dom for
 # `<img>` tags and CSS background-image) works consistently across every fulgur
 # build target. Without this, `blitz-dom-0.2.4`'s `image = { default-features =

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -1644,9 +1644,6 @@ pub struct CounterPass {
     counter_id: RefCell<usize>,
     /// Counter ops keyed by node_id, for later use in Pageable markers.
     ops_by_node: RefCell<Vec<(usize, Vec<CounterOp>)>>,
-    /// Resolved `::before` / `::after` text keyed by node_id. Pass 1 uses
-    /// this to populate `AnchorMap` for `target-text(..., before|after)`.
-    pseudo_text_by_node: RefCell<BTreeMap<usize, crate::gcpm::target_ref::AnchorPseudoText>>,
     /// Counter-state snapshot taken at each visited element after the
     /// element's own `counter-reset` / `counter-increment` / `counter-set`
     /// operations have been applied (Phase 2). Consumed by `BookmarkPass`
@@ -1683,7 +1680,6 @@ impl CounterPass {
             generated_css: RefCell::new(String::new()),
             counter_id: RefCell::new(0),
             ops_by_node: RefCell::new(Vec::new()),
-            pseudo_text_by_node: RefCell::new(BTreeMap::new()),
             node_snapshots: RefCell::new(BTreeMap::new()),
             record_node_snapshots: false,
             anchor_map: None,
@@ -1726,10 +1722,6 @@ impl CounterPass {
     /// Subsequent calls return an empty map (the snapshot is moved out).
     pub fn take_node_snapshots(&self) -> BTreeMap<usize, BTreeMap<String, Vec<i32>>> {
         std::mem::take(&mut *self.node_snapshots.borrow_mut())
-    }
-
-    pub fn take_pseudo_texts(&self) -> BTreeMap<usize, crate::gcpm::target_ref::AnchorPseudoText> {
-        std::mem::take(&mut *self.pseudo_text_by_node.borrow_mut())
     }
 
     /// Consume self and return (ops_by_node for Pageable markers, generated CSS for body).
@@ -1880,11 +1872,6 @@ impl CounterPass {
             for idx in &before_indices {
                 let mapping = &self.content_mappings[*idx];
                 let resolved = self.resolve_content(&mapping.content, element);
-                self.pseudo_text_by_node
-                    .borrow_mut()
-                    .entry(node_id)
-                    .or_default()
-                    .before_text = resolved.clone();
                 let _ = write!(
                     css,
                     "[data-fulgur-cid=\"{}\"]::before{{content:\"{}\"}}",
@@ -1911,11 +1898,6 @@ impl CounterPass {
             for idx in &after_indices {
                 let mapping = &self.content_mappings[*idx];
                 let resolved = self.resolve_content(&mapping.content, element);
-                self.pseudo_text_by_node
-                    .borrow_mut()
-                    .entry(node_id)
-                    .or_default()
-                    .after_text = resolved.clone();
                 let _ = write!(
                     css,
                     "[data-fulgur-cid=\"{}\"]::after{{content:\"{}\"}}",

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -878,10 +878,13 @@ fn walk_anchors(
 /// than substituting it at computed time; both the resolved-`String` and
 /// the deferred-`Attr` shapes are handled (the latter resolved against
 /// `parent_elem`, falling back to `a.fallback`). Counter / Counters /
-/// Image / quote items are skipped — text items only, then
-/// whitespace-normalized to match `collect_text_content`. A `counter()`
-/// pseudo that GCPM did not counter-track has no injected `String`
-/// overlay and therefore captures as empty here.
+/// Image / quote items are skipped — text items only, then internal
+/// whitespace runs are collapsed while leading/trailing whitespace is
+/// preserved (CSS string literals such as `content: attr(x) ": "` keep
+/// their separator space; HTML whitespace collapsing does not apply to
+/// generated content). A `counter()` pseudo that GCPM did not
+/// counter-track has no injected `String` overlay and therefore captures
+/// as empty here.
 fn collect_pseudo_text(
     doc: &BaseDocument,
     pseudo_id: Option<usize>,
@@ -917,7 +920,37 @@ fn collect_pseudo_text(
             _ => {}
         }
     }
-    out.split_whitespace().collect::<Vec<_>>().join(" ")
+    collapse_ws_keep_edges(&out)
+}
+
+/// Collapse internal whitespace runs to a single space while preserving a
+/// single leading/trailing space if the original had any. Unlike
+/// `split_whitespace().join(" ")` (used by `collect_text_content` for HTML
+/// text, where boundary whitespace is collapsed away by HTML rules), CSS
+/// generated content keeps author-written separator spaces — e.g.
+/// `content: attr(data-tag) ": "` must yield `APP: ` so a referencing
+/// `target-text(..., before)` does not jam against following text.
+fn collapse_ws_keep_edges(s: &str) -> String {
+    let leading = s.chars().next().is_some_and(char::is_whitespace);
+    let trailing = s.chars().next_back().is_some_and(char::is_whitespace);
+    let core = s.split_whitespace().collect::<Vec<_>>().join(" ");
+    if core.is_empty() {
+        // All-whitespace (or empty) input: a lone space if any ws was present.
+        return if leading || trailing {
+            " ".to_string()
+        } else {
+            String::new()
+        };
+    }
+    let mut r = String::with_capacity(core.len() + 2);
+    if leading {
+        r.push(' ');
+    }
+    r.push_str(&core);
+    if trailing {
+        r.push(' ');
+    }
+    r
 }
 
 fn collect_text_content(doc: &BaseDocument, node_id: usize) -> String {

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -874,9 +874,10 @@ fn walk_anchors(
 /// path covers cascade-only and counter-tracked pseudo content; no CSS is
 /// injected and Blitz rendering is never overridden.
 ///
-/// Stylo 0.8 keeps `attr()` deferred as `ContentItem::Attr` (it is NOT
-/// substituted at computed time), so this resolves it against
-/// `parent_elem` and falls back to `a.fallback`. Counter / Counters /
+/// Stylo 0.8 may keep `attr()` deferred as `ContentItem::Attr` rather
+/// than substituting it at computed time; both the resolved-`String` and
+/// the deferred-`Attr` shapes are handled (the latter resolved against
+/// `parent_elem`, falling back to `a.fallback`). Counter / Counters /
 /// Image / quote items are skipped — text items only, then
 /// whitespace-normalized to match `collect_text_content`. A `counter()`
 /// pseudo that GCPM did not counter-track has no injected `String`

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -878,7 +878,9 @@ fn walk_anchors(
 /// substituted at computed time), so this resolves it against
 /// `parent_elem` and falls back to `a.fallback`. Counter / Counters /
 /// Image / quote items are skipped — text items only, then
-/// whitespace-normalized to match `collect_text_content`.
+/// whitespace-normalized to match `collect_text_content`. A `counter()`
+/// pseudo that GCPM did not counter-track has no injected `String`
+/// overlay and therefore captures as empty here.
 fn collect_pseudo_text(
     doc: &BaseDocument,
     pseudo_id: Option<usize>,

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -283,7 +283,7 @@ impl Engine {
         // value is the full nesting chain (`Vec<i32>`, outer-to-inner)
         // per CSS Lists 3 §4.5, so both `counter()` (innermost) and
         // `counters()` (joined) can resolve directly.
-        let (counter_ops_by_node_vec, counter_css, counter_snapshots, pseudo_texts) =
+        let (counter_ops_by_node_vec, counter_css, counter_snapshots) =
             if !gcpm.counter_mappings.is_empty() || !gcpm.content_counter_mappings.is_empty() {
                 let mut pass = crate::blitz_adapter::CounterPass::new(
                     gcpm.counter_mappings.clone(),
@@ -297,11 +297,10 @@ impl Engine {
                 }
                 crate::blitz_adapter::apply_single_pass(&pass, &mut doc, &ctx);
                 let snapshots = pass.take_node_snapshots();
-                let pseudo_texts = pass.take_pseudo_texts();
                 let (ops, css) = pass.into_parts();
-                (ops, css, snapshots, pseudo_texts)
+                (ops, css, snapshots)
             } else {
-                (Vec::new(), String::new(), BTreeMap::new(), BTreeMap::new())
+                (Vec::new(), String::new(), BTreeMap::new())
             };
 
         // Inject counter-resolved CSS for ::before/::after. Must happen
@@ -497,12 +496,7 @@ impl Engine {
         // `walk_anchors` short-circuits on `MAX_DOM_DEPTH`.
         let needs_anchor_map_for_pass_two = anchor_map.is_none() && has_target_refs;
         let collected_anchor_map = if needs_anchor_map_for_pass_two {
-            build_anchor_map(
-                &doc,
-                &pagination_geometry,
-                &counter_snapshots_for_anchor,
-                &pseudo_texts,
-            )
+            build_anchor_map(&doc, &pagination_geometry, &counter_snapshots_for_anchor)
         } else {
             AnchorMap::default()
         };
@@ -804,9 +798,7 @@ impl Engine {
 }
 
 use crate::blitz_adapter::get_attr;
-use crate::gcpm::target_ref::{
-    AnchorEntry, AnchorMap, AnchorPseudoText, fragment_id_from_href, page_for_node,
-};
+use crate::gcpm::target_ref::{AnchorEntry, AnchorMap, fragment_id_from_href, page_for_node};
 use crate::pagination_layout::PaginationGeometryTable;
 use blitz_dom::BaseDocument;
 
@@ -814,7 +806,6 @@ fn build_anchor_map(
     doc: &BaseDocument,
     pagination_geometry: &PaginationGeometryTable,
     counter_snapshots: &BTreeMap<usize, BTreeMap<String, Vec<i32>>>,
-    pseudo_texts: &BTreeMap<usize, AnchorPseudoText>,
 ) -> AnchorMap {
     let mut map = AnchorMap::new();
     walk_anchors(
@@ -823,7 +814,6 @@ fn build_anchor_map(
         0,
         pagination_geometry,
         counter_snapshots,
-        pseudo_texts,
         &mut map,
     );
     map
@@ -835,7 +825,6 @@ fn walk_anchors(
     depth: usize,
     geometry: &PaginationGeometryTable,
     snapshots: &BTreeMap<usize, BTreeMap<String, Vec<i32>>>,
-    pseudo_texts: &BTreeMap<usize, AnchorPseudoText>,
     out: &mut AnchorMap,
 ) {
     if depth >= crate::MAX_DOM_DEPTH {
@@ -855,22 +844,77 @@ fn walk_anchors(
     {
         let counters = snapshots.get(&node_id).cloned().unwrap_or_default();
         let text = collect_text_content(doc, node_id);
-        let pseudo_text = pseudo_texts.get(&node_id).cloned().unwrap_or_default();
+        let before_text = collect_pseudo_text(doc, node.before, elem);
+        let after_text = collect_pseudo_text(doc, node.after, elem);
         out.insert(
             frag.to_string(),
             AnchorEntry {
                 page_num,
                 counters,
                 text,
-                before_text: pseudo_text.before_text,
-                after_text: pseudo_text.after_text,
+                before_text,
+                after_text,
             },
         );
     }
     let children: Vec<usize> = node.children.clone();
     for c in children {
-        walk_anchors(doc, c, depth + 1, geometry, snapshots, pseudo_texts, out);
+        walk_anchors(doc, c, depth + 1, geometry, snapshots, out);
     }
+}
+
+/// Capture the resolved text of a `::before` / `::after` pseudo node for
+/// `target-text(url, before|after)`.
+///
+/// Read-only post-cascade read via `primary_styles().get_counters().content`
+/// (cf. `blitz_adapter::extract_content_image_url`). Runs at `walk_anchors`
+/// time — after CounterPass + InjectCssPass + pagination — so the cascade
+/// carries both fulgur-left-to-Blitz `attr()`/string content and
+/// CounterPass's injected resolved-counter overlay (a `String` item). One
+/// path covers cascade-only and counter-tracked pseudo content; no CSS is
+/// injected and Blitz rendering is never overridden.
+///
+/// Stylo 0.8 keeps `attr()` deferred as `ContentItem::Attr` (it is NOT
+/// substituted at computed time), so this resolves it against
+/// `parent_elem` and falls back to `a.fallback`. Counter / Counters /
+/// Image / quote items are skipped — text items only, then
+/// whitespace-normalized to match `collect_text_content`.
+fn collect_pseudo_text(
+    doc: &BaseDocument,
+    pseudo_id: Option<usize>,
+    parent_elem: &blitz_dom::node::ElementData,
+) -> String {
+    use style::values::generics::counters::{Content, ContentItem as Sci};
+    let Some(pid) = pseudo_id else {
+        return String::new();
+    };
+    let Some(node) = doc.get_node(pid) else {
+        return String::new();
+    };
+    let Some(styles) = node.primary_styles() else {
+        return String::new();
+    };
+    let content = &styles.get_counters().content;
+    let Content::Items(item_data) = content else {
+        return String::new();
+    };
+    let mut out = String::new();
+    // Only the "main" items (before `alt_start`); content after is
+    // alt-text in CSS Level 3 Content.
+    for item in &item_data.items[..item_data.alt_start] {
+        match item {
+            Sci::String(s) => out.push_str(s.as_ref()),
+            Sci::Attr(a) => {
+                let name = a.attribute.as_ref();
+                match get_attr(parent_elem, name) {
+                    Some(v) => out.push_str(v),
+                    None => out.push_str(a.fallback.as_ref()),
+                }
+            }
+            _ => {}
+        }
+    }
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 fn collect_text_content(doc: &BaseDocument, node_id: usize) -> String {
@@ -1085,6 +1129,23 @@ impl EngineBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn collect_pseudo_text_resolves_string_and_attr() {
+        // `walk_anchors` (and therefore `collect_pseudo_text`) only runs
+        // when GCPM has an active `target-*` reference, so the CSS must
+        // include a real `target-text(...)` or this exercises nothing.
+        let html = r##"<!doctype html><html><head><style>
+          #t::before { content: attr(data-x) " "; }
+          #t::after  { content: "AFT"; }
+          .ref::after { content: target-text(attr(href), before); }
+        </style></head><body>
+          <p><a class="ref" href="#t"></a></p>
+          <h2 id="t" data-x="DX">Title</h2>
+        </body></html>"##;
+        let pdf = Engine::builder().build().render_html(html).unwrap();
+        assert!(!pdf.is_empty());
+    }
 
     #[test]
     fn builder_bookmarks_defaults_to_false() {

--- a/crates/fulgur/src/gcpm/target_ref.rs
+++ b/crates/fulgur/src/gcpm/target_ref.rs
@@ -9,7 +9,6 @@ use crate::gcpm::counter::{format_counter, format_counter_chain};
 use crate::gcpm::{CounterStyle, TargetTextKind};
 use crate::pagination_layout::PaginationGeometryTable;
 use std::collections::BTreeMap;
-use unicode_segmentation::UnicodeSegmentation;
 
 #[derive(Debug, Clone, Default)]
 pub struct AnchorMap {
@@ -117,8 +116,67 @@ pub fn resolve_target_text(href: &str, kind: TargetTextKind, map: &AnchorMap) ->
         TargetTextKind::Content => entry.text.clone(),
         TargetTextKind::Before => entry.before_text.clone(),
         TargetTextKind::After => entry.after_text.clone(),
-        TargetTextKind::FirstLetter => entry.text.graphemes(true).next().unwrap_or("").to_string(),
+        TargetTextKind::FirstLetter => compute_first_letter(&entry.text),
     }
+}
+
+/// First-letter per CSS Pseudo-Elements 4 §3.2: optional leading
+/// typographic punctuation, the first typographic letter/digit
+/// (grapheme cluster), then optional trailing typographic punctuation.
+/// Whitespace before the first letter (after fully-trimmed leading
+/// whitespace) terminates the run. Returns `""` when there is no letter.
+fn compute_first_letter(text: &str) -> String {
+    use unicode_properties::{GeneralCategory as GC, UnicodeGeneralCategory};
+    use unicode_segmentation::UnicodeSegmentation;
+
+    fn is_punct(g: &str) -> bool {
+        g.chars().all(|c| {
+            matches!(
+                c.general_category(),
+                GC::OpenPunctuation
+                    | GC::ClosePunctuation
+                    | GC::InitialPunctuation
+                    | GC::FinalPunctuation
+                    | GC::OtherPunctuation
+                    | GC::ConnectorPunctuation
+                    | GC::DashPunctuation
+                    | GC::MathSymbol
+                    | GC::OtherSymbol
+                    | GC::CurrencySymbol
+                    | GC::ModifierSymbol
+            )
+        })
+    }
+    fn is_letter(g: &str) -> bool {
+        g.chars().any(|c| {
+            matches!(
+                c.general_category(),
+                GC::UppercaseLetter
+                    | GC::LowercaseLetter
+                    | GC::TitlecaseLetter
+                    | GC::ModifierLetter
+                    | GC::OtherLetter
+                    | GC::DecimalNumber
+                    | GC::LetterNumber
+                    | GC::OtherNumber
+            )
+        })
+    }
+
+    let trimmed = text.trim_start_matches(char::is_whitespace);
+    let gs: Vec<&str> = trimmed.graphemes(true).collect();
+    let mut i = 0;
+    while i < gs.len() && is_punct(gs[i]) {
+        i += 1;
+    }
+    if i >= gs.len() || !is_letter(gs[i]) {
+        return String::new();
+    }
+    let mut j = i + 1;
+    while j < gs.len() && is_punct(gs[j]) {
+        j += 1;
+    }
+    gs[..j].concat()
 }
 
 /// Return the **1-based** page number for a DOM node, derived from
@@ -270,6 +328,33 @@ mod tests {
             resolve_target_text("#sec-1-2", TargetTextKind::FirstLetter, &m),
             "A\u{0301}"
         );
+    }
+
+    #[test]
+    fn first_letter_ascii() {
+        assert_eq!(compute_first_letter("Hello world"), "H");
+    }
+    #[test]
+    fn first_letter_skips_leading_punct_and_keeps_trailing() {
+        assert_eq!(compute_first_letter("「『Hello』"), "「『H");
+    }
+    #[test]
+    fn first_letter_digit_counts_as_letter() {
+        assert_eq!(compute_first_letter("123abc"), "1");
+    }
+    #[test]
+    fn first_letter_empty_and_all_punct() {
+        assert_eq!(compute_first_letter(""), "");
+        assert_eq!(compute_first_letter("   "), "");
+        assert_eq!(compute_first_letter("...!?"), "");
+    }
+    #[test]
+    fn first_letter_space_before_letter_yields_nothing() {
+        assert_eq!(compute_first_letter("『 H"), "");
+    }
+    #[test]
+    fn first_letter_grapheme_cluster() {
+        assert_eq!(compute_first_letter("e\u{0301}tude"), "e\u{0301}");
     }
 
     #[test]

--- a/crates/fulgur/src/gcpm/target_ref.rs
+++ b/crates/fulgur/src/gcpm/target_ref.rs
@@ -27,12 +27,6 @@ pub struct AnchorEntry {
     pub after_text: String,
 }
 
-#[derive(Debug, Clone, Default)]
-pub struct AnchorPseudoText {
-    pub before_text: String,
-    pub after_text: String,
-}
-
 impl AnchorMap {
     pub fn new() -> Self {
         Self::default()

--- a/crates/fulgur/src/gcpm/target_ref.rs
+++ b/crates/fulgur/src/gcpm/target_ref.rs
@@ -120,11 +120,19 @@ pub fn resolve_target_text(href: &str, kind: TargetTextKind, map: &AnchorMap) ->
     }
 }
 
-/// First-letter per CSS Pseudo-Elements 4 §3.2: optional leading
+/// First-letter, based on CSS Pseudo-Elements 4 §3.2: optional leading
 /// typographic punctuation, the first typographic letter/digit
 /// (grapheme cluster), then optional trailing typographic punctuation.
-/// Whitespace before the first letter (after fully-trimmed leading
-/// whitespace) terminates the run. Returns `""` when there is no letter.
+/// This is **extended beyond the literal §3.2 category set** (which is
+/// punctuation-only: Pc Pd Ps Pe Pi Pf Po): leading and trailing runs
+/// also include currency, math, and modifier/other symbols (e.g. `$`,
+/// `¥`, `+`, `©`), so `$Hello` yields `$H`. The symbol inclusion is an
+/// intentional design extension, not a consequence of the spec.
+/// Whitespace appearing between the leading punctuation/symbol run and
+/// the first letter (after fully-trimmed leading whitespace) terminates
+/// the first-letter, yielding `""` — an intentional interpretation of
+/// the spec's ambiguous contiguity wording. Returns `""` when there is
+/// no letter.
 fn compute_first_letter(text: &str) -> String {
     use unicode_properties::{GeneralCategory as GC, UnicodeGeneralCategory};
     use unicode_segmentation::UnicodeSegmentation;
@@ -163,7 +171,7 @@ fn compute_first_letter(text: &str) -> String {
         })
     }
 
-    let trimmed = text.trim_start_matches(char::is_whitespace);
+    let trimmed = text.trim_start();
     let gs: Vec<&str> = trimmed.graphemes(true).collect();
     let mut i = 0;
     while i < gs.len() && is_punct(gs[i]) {
@@ -355,6 +363,21 @@ mod tests {
     #[test]
     fn first_letter_grapheme_cluster() {
         assert_eq!(compute_first_letter("e\u{0301}tude"), "e\u{0301}");
+    }
+    #[test]
+    fn first_letter_includes_leading_currency_symbol() {
+        // Intentional extension beyond literal §3.2 (P*-only): leading
+        // currency/math/symbol clusters ride with the first letter.
+        assert_eq!(compute_first_letter("$Hello"), "$H");
+    }
+    #[test]
+    fn first_letter_trailing_punct_then_more_letters() {
+        // Exercises the trailing-punct (`j`) advance: stop at the next letter.
+        assert_eq!(compute_first_letter("H!Hello"), "H!");
+    }
+    #[test]
+    fn first_letter_trailing_punct_then_nonletter() {
+        assert_eq!(compute_first_letter("「Hello」 world"), "「H");
     }
 
     #[test]

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -3684,7 +3684,7 @@ fn target_text_before_resolves_attr_pseudo() {
     let html = r##"<!doctype html><html><head><style>
       body { font-family: 'Noto Sans', sans-serif; font-size: 12pt; }
       #sec::before { content: attr(data-tag) ": "; }
-      .ref::after  { content: target-text(attr(href), before); }
+      .ref::after  { content: "[" target-text(attr(href), before) "]"; }
     </style></head><body>
       <p>See <a class="ref" href="#sec">the appendix</a> for details.</p>
       <h2 id="sec" data-tag="APP">Appendix</h2>
@@ -3693,14 +3693,19 @@ fn target_text_before_resolves_attr_pseudo() {
     assert!(!pdf.is_empty());
 
     let lower = decompressed_streams_lower(&pdf);
-    let needle = hex_utf16be("APP: ");
+    // Sentinel-wrapped: the trailing `]` immediately follows the captured
+    // text, so a hit proves the trailing separator space of `APP: ` is part
+    // of the captured pseudo content — not borrowed from following page
+    // text. A trim-everything normalization would yield `[APP:]` and fail.
+    let needle = hex_utf16be("[APP: ]");
     assert!(
         lower.contains(&needle.to_ascii_lowercase()),
-        "ActualText missing UTF-16BE for `APP: ` — collect_pseudo_text did \
-         not capture the cascade-only attr() `::before` of #sec into the \
-         AnchorMap, so `.ref::after {{ content: target-text(attr(href), \
-         before) }}` rendered nothing. Looked for {needle} in {} bytes of \
-         decompressed streams.",
+        "ActualText missing UTF-16BE for `[APP: ]` — collect_pseudo_text did \
+         not capture the cascade-only attr() `::before` of #sec (with its \
+         trailing separator space) into the AnchorMap, so `.ref::after {{ \
+         content: \"[\" target-text(attr(href), before) \"]\" }}` rendered \
+         the wrong text. Looked for {needle} in {} bytes of decompressed \
+         streams.",
         lower.len()
     );
 }

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -3646,3 +3646,163 @@ fn target_text_second_arg_resolves_target_fragments() {
         "target-text second-argument payload missing from extracted PDF text: {text:?}"
     );
 }
+
+/// Concatenate every decompressed content/object stream of `pdf` so a
+/// test can grep for the UTF-16BE `/ActualText` payloads Krilla writes
+/// into tagged-PDF `/Span` markers (mirrors the technique in
+/// `target_counter_in_link_loaded_css_triggers_pass_two` and
+/// `target_text_in_top_center_resolves_via_implicit_href`). lopdf 0.40
+/// cannot decode the CID-encoded `TJ` strings, so ActualText is the
+/// portable signal that resolved generated content reached pass 2.
+fn decompressed_streams_lower(pdf: &[u8]) -> String {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("grep.pdf");
+    std::fs::write(&path, pdf).expect("write pdf");
+    let doc = lopdf::Document::load(&path).expect("load pdf");
+    let mut decompressed = String::new();
+    for (_id, obj) in doc.objects.iter() {
+        if let lopdf::Object::Stream(s) = obj {
+            let mut clone = s.clone();
+            let _ = clone.decompress();
+            decompressed.push_str(&String::from_utf8_lossy(&clone.content));
+        }
+    }
+    decompressed.to_ascii_lowercase()
+}
+
+/// fulgur-r73p Task 4.1: `target-text(attr(href), before)` must reflect a
+/// target element's *cascade-only* `::before` content. `#sec::before`
+/// here uses `attr(data-tag)` + a literal string — content with no
+/// `counter()` / `target-*`, which the GCPM parser deliberately routes to
+/// Blitz's normal cascade and which the old plumbing never captured into
+/// `AnchorMap`. The read-only `collect_pseudo_text` capture added in
+/// Task 2 must pick `APP: ` up so the referencing `.ref::after` renders
+/// it into pass 2. The `<a>` carries visible text so the inline host is
+/// not culled before its generated `::after` is drawn.
+#[test]
+fn target_text_before_resolves_attr_pseudo() {
+    let html = r##"<!doctype html><html><head><style>
+      body { font-family: 'Noto Sans', sans-serif; font-size: 12pt; }
+      #sec::before { content: attr(data-tag) ": "; }
+      .ref::after  { content: target-text(attr(href), before); }
+    </style></head><body>
+      <p>See <a class="ref" href="#sec">the appendix</a> for details.</p>
+      <h2 id="sec" data-tag="APP">Appendix</h2>
+    </body></html>"##;
+    let pdf = tagged_render_with_noto(html);
+    assert!(!pdf.is_empty());
+
+    let lower = decompressed_streams_lower(&pdf);
+    let needle = hex_utf16be("APP: ");
+    assert!(
+        lower.contains(&needle.to_ascii_lowercase()),
+        "ActualText missing UTF-16BE for `APP: ` — collect_pseudo_text did \
+         not capture the cascade-only attr() `::before` of #sec into the \
+         AnchorMap, so `.ref::after {{ content: target-text(attr(href), \
+         before) }}` rendered nothing. Looked for {needle} in {} bytes of \
+         decompressed streams.",
+        lower.len()
+    );
+}
+
+/// fulgur-r73p Task 4.2 (regression): exercising the counter-tracked
+/// `collect_pseudo_text` capture path must not panic after Task 2 removed
+/// the `pseudo_text_by_node` plumbing.
+///
+/// `#s::after` uses `counter(c)`, so `CounterPass` + `InjectCssPass`
+/// overlay the resolved value into the cascade; `.r::before { content:
+/// target-text(attr(href), after) }` makes `has_target_references()`
+/// true so `collect_pseudo_text` reads that counter-overlaid computed
+/// content for `#s::after` directly. The regression Task 2 must not
+/// reintroduce is a panic / `None` on that read.
+///
+/// This is a no-panic smoke guard, not a text-layer assertion, and that
+/// is deliberate: the *text-layer* behaviour of counter-tracked
+/// `target-text` is already verified by
+/// `target_text_second_arg_resolves_target_fragments` (which renders the
+/// captured counter-tracked value through an `@page` margin box and
+/// asserts `AfterFrag1` via `pdftotext`). A text assertion *here* is not
+/// possible because fulgur's *element* `::before`/`::after` renderer has
+/// a pre-existing, unrelated limitation: multi-item generated content
+/// only emits its first item (reproduces with plain
+/// `content: "[" "x" "]"` — no `counter()`, no `target-*` — so it cannot
+/// originate in Tasks 2-3's read-only, `has_target_references`-gated
+/// capture). That element-pseudo truncation is out of scope for this PR
+/// and tracked separately. The capture itself (Tasks 2-3) is text-layer
+/// proven by tests #1/#3/#4 below and by `..._second_arg...`.
+#[test]
+fn target_text_after_resolves_counter_via_counter_pass() {
+    let html = r##"<!doctype html><html><head><style>
+      body { font-family: 'Noto Sans', sans-serif; font-size: 12pt; counter-reset: c; }
+      h2 { counter-increment: c; }
+      #s::after { content: " [" counter(c) "]"; }
+      .r::before { content: target-text(attr(href), after); }
+    </style></head><body>
+      <h2>One</h2>
+      <h2 id="s">Two</h2>
+      <p>Jump to <a class="r" href="#s">section two</a> now.</p>
+    </body></html>"##;
+    // collect_pseudo_text reads #s::after's counter-overlaid computed
+    // content during build_anchor_map (gated on the target-text ref
+    // above). Guard: that read must not panic and render must succeed.
+    let pdf = tagged_render_with_noto(html);
+    assert!(!pdf.is_empty());
+}
+
+/// fulgur-r73p Task 4.3: `target-text(url, first-letter)` must apply the
+/// CSS Pseudo-Elements 4 §3.2 algorithm from Task 3 — leading
+/// typographic punctuation (`「`) is included with the first letter, so
+/// the result is `「H`, not `「` or `H`.
+#[test]
+fn target_text_first_letter_typographic() {
+    let html = r##"<!doctype html><html><head><style>
+      body { font-family: 'Noto Sans', sans-serif; font-size: 12pt; }
+      .r::after { content: target-text(attr(href), first-letter); }
+    </style></head><body>
+      <p>Open <a class="r" href="#h">the heading</a> reference.</p>
+      <h2 id="h">「Hello」</h2>
+    </body></html>"##;
+    let pdf = tagged_render_with_noto(html);
+    assert!(!pdf.is_empty());
+
+    let lower = decompressed_streams_lower(&pdf);
+    let needle = hex_utf16be("「H");
+    assert!(
+        lower.contains(&needle.to_ascii_lowercase()),
+        "ActualText missing UTF-16BE for `「H` — compute_first_letter did \
+         not fold the leading typographic punctuation into the first \
+         letter per CSS Pseudo-Elements 4 §3.2. Looked for {needle} in {} \
+         bytes of decompressed streams.",
+        lower.len()
+    );
+}
+
+/// fulgur-r73p Task 4.4: a `target-text(url, before)` whose target has
+/// no `::before` must resolve to the empty string — no panic, render
+/// still succeeds, and the surrounding literal `[` / `]` brackets still
+/// render (with nothing captured between them).
+#[test]
+fn target_text_empty_for_missing_pseudo() {
+    let html = r##"<!doctype html><html><head><style>
+      body { font-family: 'Noto Sans', sans-serif; font-size: 12pt; }
+      .r::after { content: "[" target-text(attr(href), before) "]"; }
+    </style></head><body>
+      <p>Check <a class="r" href="#h">this link</a> here.</p>
+      <h2 id="h">No pseudo here</h2>
+    </body></html>"##;
+    let pdf = tagged_render_with_noto(html);
+    assert!(!pdf.is_empty()); // resolves to "[]" — no panic, empty capture
+
+    // The literal brackets must survive (capture is empty, not erroring).
+    let lower = decompressed_streams_lower(&pdf);
+    let open = hex_utf16be("[");
+    let close = hex_utf16be("]");
+    assert!(
+        lower.contains(&open.to_ascii_lowercase()) && lower.contains(&close.to_ascii_lowercase()),
+        "ActualText missing UTF-16BE for the `[` / `]` literals — a \
+         missing `::before` should resolve target-text to empty, not \
+         suppress the surrounding generated content. Looked for {open} \
+         and {close} in {} bytes of decompressed streams.",
+        lower.len()
+    );
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -3793,16 +3793,18 @@ fn target_text_empty_for_missing_pseudo() {
     let pdf = tagged_render_with_noto(html);
     assert!(!pdf.is_empty()); // resolves to "[]" — no panic, empty capture
 
-    // The literal brackets must survive (capture is empty, not erroring).
+    // The literal brackets must be adjacent (`[]`, not `[X]`): a missing
+    // `::before` resolves the inner target-text to EMPTY, so nothing is
+    // captured between them. Two separate `[`/`]` presence checks cannot
+    // distinguish `[]` from `[X]`; assert the contiguous UTF-16BE run.
     let lower = decompressed_streams_lower(&pdf);
-    let open = hex_utf16be("[");
-    let close = hex_utf16be("]");
+    let needle = hex_utf16be("[]");
     assert!(
-        lower.contains(&open.to_ascii_lowercase()) && lower.contains(&close.to_ascii_lowercase()),
-        "ActualText missing UTF-16BE for the `[` / `]` literals — a \
-         missing `::before` should resolve target-text to empty, not \
-         suppress the surrounding generated content. Looked for {open} \
-         and {close} in {} bytes of decompressed streams.",
+        lower.contains(&needle.to_ascii_lowercase()),
+        "ActualText missing UTF-16BE for the contiguous `[]` literal — a \
+         missing `::before` should resolve target-text to the empty \
+         string, leaving the surrounding brackets adjacent (`[]`, not \
+         `[X]`). Looked for {needle} in {} bytes of decompressed streams.",
         lower.len()
     );
 }

--- a/docs/plans/2026-05-16-target-text-pseudo-cascade-capture.md
+++ b/docs/plans/2026-05-16-target-text-pseudo-cascade-capture.md
@@ -1,0 +1,588 @@
+# target-text pseudo cascade-safe capture Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make `target-text(attr(href), before|after|first-letter)` reflect the
+target element's resolved `::before` / `::after` content — including
+cascade-only generated content such as `attr(data-x)` and plain strings that
+fulgur currently leaves to Blitz and never captures into `AnchorMap`.
+
+**Architecture:** The GCPM parser deliberately routes pseudo content **without**
+`counter()` / `target-*` to Blitz's normal cascade (`parser.rs:721-749`:
+`has_counter == false` ⇒ `content_items = None` ⇒ `CounterPass` never visits it
+⇒ `before_text` / `after_text` stay empty). The fix adds a **read-only** capture
+in `walk_anchors` (engine.rs) that reads each id-bearing element's pseudo node
+resolved computed value directly via `primary_styles().get_counters().content`
+— the same pattern as `blitz_adapter::extract_content_image_url` — and resolves
+the text items. This runs after `CounterPass` + `InjectCssPass` + pagination, so
+the cascade already carries both the original `attr()`/string values *and*
+`CounterPass`'s injected resolved-counter overlay. One capture path therefore
+covers both the cascade-only case and the counter-tracked case; no CSS is
+injected and Blitz rendering is never overridden (cascade-safe).
+
+**Tech Stack:** Rust, stylo (`style::values::generics::counters`), blitz-dom
+0.2.4, `unicode-segmentation`, `unicode-properties` (new direct dep).
+
+**Scope reconciliation (design memo is partially stale):** The issue's design
+field predates work that already landed. Already implemented — **do NOT redo**:
+`TargetTextKind` enum (`Content`/`Before`/`After`/`FirstLetter`,
+`gcpm/mod.rs:333-345`); parser arm for `before|after|first-letter|content`
+(`parser.rs:1121-1158`); `AnchorEntry.before_text`/`after_text` as `String`
+(`target_ref.rs`); `resolve_target_text` kind dispatch
+(`target_ref.rs:115-128`); `TargetText { url, kind }` variant. Deliberately
+dropped from the memo (YAGNI): the new `TargetTextSource` enum + ~25 callsite
+migration, the `Option<String>` field migration, a separate
+`first_letter` `AnchorEntry` field (compute on-the-fly in the resolver instead),
+and parser/drop-test rework. Net: ~4 commits, not 6.
+
+---
+
+## Task 1: Spike — confirm what Stylo exposes at `walk_anchors` time
+
+This is the one assumption that breaks the whole approach if wrong:
+**does `doc.get_node(node.before).primary_styles()` return the resolved pseudo
+content at the point `walk_anchors` runs (after CounterPass + InjectCssPass +
+pagination)?** And does Stylo 0.8 resolve `attr()` at computed time
+(`Content::Items[String("...")]`) or defer it (`ContentItem::Attr(name)`)?
+
+**Files:**
+
+- Temp test in: `crates/fulgur/tests/render_smoke.rs`
+
+**Step 1: Write a throwaway probe test**
+
+Add to `crates/fulgur/tests/render_smoke.rs`:
+
+```rust
+#[test]
+fn spike_pseudo_content_shape() {
+    // Not a permanent test — deleted in Step 4 once findings are recorded.
+    let html = r##"<!doctype html><html><head><style>
+      #t::before { content: attr(data-x); }
+      #t::after  { content: "lit-after"; }
+    </style></head><body>
+      <p>see <a href="#t">ref</a></p>
+      <h2 id="t" data-x="ATTRVAL">Heading</h2>
+    </body></html>"##;
+    let pdf = fulgur::Engine::builder()
+        .build()
+        .render_html(html)
+        .expect("render");
+    assert!(!pdf.is_empty());
+}
+```
+
+Then add a temporary `eprintln!` inside `walk_anchors`
+(`crates/fulgur/src/engine.rs`, in the `if let Some(elem) = node.element_data()`
+block, after `let text = collect_text_content(...)`):
+
+```rust
+for pid in [node.before, node.after].into_iter().flatten() {
+    if let Some(pn) = doc.get_node(pid) {
+        if let Some(st) = pn.primary_styles() {
+            eprintln!("SPIKE pseudo {pid}: {:?}", st.get_counters().content);
+        } else {
+            eprintln!("SPIKE pseudo {pid}: NO primary_styles");
+        }
+    }
+}
+```
+
+**Step 2: Run the probe**
+
+Run: `cargo test -p fulgur --test render_smoke spike_pseudo_content_shape -- --nocapture 2>&1 | grep SPIKE`
+
+Expected: lines showing the `Content` enum shape for the `attr()` and the
+string pseudo. Record (in the commit message of Task 2, and below):
+
+- Does `primary_styles()` return `Some` for the pseudo node here? (must be Yes)
+- Is `attr(data-x)` `Content::Items[String("ATTRVAL")]` (resolved) or
+  `Content::Items[Attr("data-x")]` (deferred)?
+- Is the string `Content::Items[String("lit-after")]`?
+
+**Step 3: Record findings, revert the probe**
+
+Write the three answers into a code comment you will place above
+`collect_pseudo_text` in Task 2. Remove the `eprintln!` and the
+`spike_pseudo_content_shape` test (revert engine.rs, delete the test fn).
+
+Run: `git diff --stat` — Expected: clean (no residual spike code).
+
+**Step 4: No commit** (spike leaves no tracked change). Proceed to Task 2 with
+findings in hand. If `primary_styles()` returned `None` for the pseudo, STOP and
+escalate — the read-only-at-walk_anchors approach is invalid and the plan needs
+rework (fallback: keep the `CounterPass` plumbing and additionally force
+attr-only pseudo into `content_counter_mappings`).
+
+---
+
+## Task 2: `collect_pseudo_text` capture helper + rewire `walk_anchors`
+
+**Files:**
+
+- Modify: `crates/fulgur/src/engine.rs` (add `collect_pseudo_text`; call it in
+  `walk_anchors` ~`engine.rs:852-869`)
+- Modify: `crates/fulgur/src/engine.rs` (drop the now-redundant `pseudo_texts`
+  parameter threading — see Step 5)
+- Modify: `crates/fulgur/src/blitz_adapter.rs` (remove `pseudo_text_by_node`
+  field, `take_pseudo_texts`, and the two `.before_text =` / `.after_text =`
+  writes at ~1883/1914 — **only if** Task 1 confirmed the direct read covers the
+  counter-tracked case; otherwise keep them and have `collect_pseudo_text` win
+  only when non-empty)
+- Test: `crates/fulgur/src/engine.rs` `#[cfg(test)] mod tests` (unit test for
+  `collect_pseudo_text`)
+
+**Step 1: Write the failing unit test**
+
+In `engine.rs` test module (create one if absent, mirroring existing
+module-level test convention):
+
+```rust
+#[test]
+fn collect_pseudo_text_resolves_string_and_attr() {
+    // Drives Engine end-to-end and asserts the captured AnchorEntry.
+    // collect_pseudo_text has no pure-fn seam (needs a real pseudo node),
+    // so exercise it through build_anchor_map via render.
+    let html = r##"<!doctype html><html><head><style>
+      #t::before { content: attr(data-x) " "; }
+      #t::after  { content: "AFT"; }
+    </style></head><body>
+      <p>x <a href="#t">L</a></p>
+      <h2 id="t" data-x="DX">Title</h2>
+    </body></html>"##;
+    let pdf = crate::Engine::builder().build().render_html(html).unwrap();
+    assert!(!pdf.is_empty());
+    // Behavioural assertion lives in the integration tests (Task 4);
+    // here we only guard that render does not panic with the new path.
+}
+```
+
+> Note: `collect_pseudo_text` reads a live `BaseDocument` pseudo node, so it has
+> no clean pure-function seam. The real behavioural coverage is the integration
+> tests in Task 4 (which assert resolved text appears in the PDF text layer).
+> This unit test is a panic/compile guard only. Keep it minimal.
+
+**Step 2: Run it to verify it fails**
+
+Run: `cargo test -p fulgur --lib engine::tests::collect_pseudo_text_resolves_string_and_attr`
+Expected: FAIL — test fn references nothing new yet *or* compile error once
+Step 3 signature changes land; that's the red.
+
+**Step 3: Implement `collect_pseudo_text`**
+
+Add to `crates/fulgur/src/engine.rs` (near `collect_text_content`,
+~`engine.rs:876`). Use the findings from Task 1 in the doc comment. Handle
+**both** `String` and `Attr` items (Attr is the safety net for the deferred
+case; harmless if Stylo resolves eagerly):
+
+```rust
+/// Capture the resolved text of a `::before` / `::after` pseudo node for
+/// `target-text(url, before|after)`.
+///
+/// Read-only: reads the post-cascade computed value via
+/// `primary_styles().get_counters().content` (same pattern as
+/// `blitz_adapter::extract_content_image_url`). Runs at `walk_anchors`
+/// time — after CounterPass + InjectCssPass + pagination — so the cascade
+/// already carries (a) original `attr()` / string values that fulgur
+/// leaves to Blitz, and (b) CounterPass's injected resolved-counter
+/// overlay. One path therefore covers cascade-only and counter-tracked
+/// pseudo content without injecting CSS or overriding Blitz.
+///
+/// Stylo 0.8 behaviour observed in Task 1 spike: <RECORD: String vs Attr,
+/// primary_styles Some/None>.
+///
+/// `parent_elem` supplies `attr()` resolution when Stylo defers it
+/// (`ContentItem::Attr`). Counter / Counters / Image / target-* /
+/// leader items are skipped — text items only, joined and
+/// whitespace-normalized to match `collect_text_content`.
+fn collect_pseudo_text(
+    doc: &BaseDocument,
+    pseudo_id: Option<usize>,
+    parent_elem: &blitz_dom::node::ElementData,
+) -> String {
+    use style::values::generics::counters::{Content, ContentItem as Sci};
+    let Some(pid) = pseudo_id else {
+        return String::new();
+    };
+    let Some(pnode) = doc.get_node(pid) else {
+        return String::new();
+    };
+    let Some(styles) = pnode.primary_styles() else {
+        return String::new();
+    };
+    let Content::Items(item_data) = &styles.get_counters().content else {
+        return String::new();
+    };
+    let main = &item_data.items[..item_data.alt_start];
+    let mut out = String::new();
+    for item in main {
+        match item {
+            Sci::String(s) => out.push_str(s.as_ref()),
+            Sci::Attr(a) => {
+                // stylo's Attr carries the attribute name; resolve against
+                // the *element*, not the pseudo (pseudo has no attrs).
+                if let Some(v) = crate::blitz_adapter::get_attr(parent_elem, a.attribute.as_ref())
+                {
+                    out.push_str(v);
+                }
+            }
+            _ => {}
+        }
+    }
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+```
+
+> **Verify the `Sci::Attr` field path against Task 1 / the stylo source**
+> before finalizing — the exact field (`a.attribute` vs `a.name` vs tuple) and
+> `get_attr`'s expected name form (lower-cased?) must match. If Task 1 showed
+> Stylo always resolves `attr()` eagerly to `String`, the `Sci::Attr` arm is
+> dead-but-safe; keep it as documented defense and do not over-invest in its
+> field plumbing (a `_ => {}`-style fallthrough is acceptable if the field
+> shape is awkward — note it in the comment).
+
+**Step 4: Wire into `walk_anchors`**
+
+In `crates/fulgur/src/engine.rs` `walk_anchors`, replace the
+`pseudo_texts`-sourced lines (~`engine.rs:858-867`):
+
+```rust
+let before_text = collect_pseudo_text(doc, node.before, elem);
+let after_text = collect_pseudo_text(doc, node.after, elem);
+out.insert(
+    frag.to_string(),
+    AnchorEntry {
+        page_num,
+        counters,
+        text,
+        before_text,
+        after_text,
+    },
+);
+```
+
+(`elem` is already bound in the enclosing `if let Some(elem) = node.element_data()`.)
+
+**Step 5: Remove the dead `pseudo_texts` plumbing**
+
+Only if Task 1 confirmed the direct read also covers counter-tracked pseudo
+(InjectCssPass overlay visible in `primary_styles()`):
+
+- `engine.rs`: drop `pseudo_texts` from `build_anchor_map` /`walk_anchors`
+  signatures and the `take_pseudo_texts()` call (~`engine.rs:300`); collapse the
+  4-tuple at ~`engine.rs:286` to a 3-tuple.
+- `blitz_adapter.rs`: remove the `pseudo_text_by_node` field (~1649), its init
+  (~1686), `take_pseudo_texts` (~1731-1732), and the two pseudo-text writes
+  inside the before/after resolve blocks (~1883-1887, ~1914-1918). Leave the
+  rest of those blocks (the `write!(css, ...)` overlay) intact — that overlay is
+  what makes the counter-resolved value visible to Step 3's read.
+- Delete `AnchorPseudoText` from `target_ref.rs` (~31-36) and its
+  `engine.rs:808` import if no longer referenced.
+
+If Task 1 did **not** confirm uniform coverage: keep the plumbing, and in Step 4
+make `collect_pseudo_text` the source only when it returns non-empty, else fall
+back to `pseudo_texts.get(&node_id)`. Document the divergence in the commit.
+
+**Step 6: Run the targeted + lib tests**
+
+Run: `cargo test -p fulgur --lib 2>&1 | tail -5`
+Expected: PASS, count ≥ baseline 1121 (1 new), 0 failed. Fix any fallout from
+the signature changes in Step 5 before proceeding.
+
+**Step 7: Commit**
+
+```bash
+git add crates/fulgur/src/engine.rs crates/fulgur/src/blitz_adapter.rs crates/fulgur/src/gcpm/target_ref.rs
+git commit -m "feat(gcpm): cascade-safe capture of pseudo content for target-text"
+```
+
+---
+
+## Task 3: CSS Pseudo-Elements 4 `first-letter` algorithm
+
+Replace the simplistic `entry.text.graphemes(true).next()` in the resolver
+(`target_ref.rs:126`) with the spec-conformant first-letter (leading
+typographic punctuation + first letter/digit + trailing typographic
+punctuation, CSS Pseudo-Elements 4 §3.2).
+
+**Files:**
+
+- Modify: `crates/fulgur/Cargo.toml` (add `unicode-properties`)
+- Modify: `crates/fulgur/src/gcpm/target_ref.rs` (add `compute_first_letter`;
+  use it in `resolve_target_text`)
+- Test: `crates/fulgur/src/gcpm/target_ref.rs` `mod tests`
+
+**Step 1: Add the dependency**
+
+In `crates/fulgur/Cargo.toml`, after the `unicode-segmentation = "1.13"` line:
+
+```toml
+unicode-properties = "0.1"
+```
+
+Run: `cargo build -p fulgur 2>&1 | tail -2` — Expected: resolves (it is already
+transitive in `Cargo.lock`; adding it as a direct dep is the only change).
+
+**Step 2: Write the failing unit tests**
+
+Add to the `tests` module in `crates/fulgur/src/gcpm/target_ref.rs`:
+
+```rust
+#[test]
+fn first_letter_ascii() {
+    assert_eq!(compute_first_letter("Hello world"), "H");
+}
+#[test]
+fn first_letter_skips_leading_punct_and_keeps_trailing() {
+    assert_eq!(compute_first_letter("「『Hello』"), "「『H");
+}
+#[test]
+fn first_letter_digit_counts_as_letter() {
+    assert_eq!(compute_first_letter("123abc"), "1");
+}
+#[test]
+fn first_letter_empty_and_all_punct() {
+    assert_eq!(compute_first_letter(""), "");
+    assert_eq!(compute_first_letter("   "), "");
+    assert_eq!(compute_first_letter("...!?"), "");
+}
+#[test]
+fn first_letter_space_before_letter_yields_nothing() {
+    // Leading whitespace is trimmed, but a space *between* the leading
+    // punctuation run and the letter terminates the first-letter per spec.
+    assert_eq!(compute_first_letter("『 H"), "");
+}
+#[test]
+fn first_letter_grapheme_cluster() {
+    // Combining sequence stays one unit.
+    assert_eq!(compute_first_letter("e\u{0301}tude"), "e\u{0301}");
+}
+```
+
+**Step 3: Run to verify they fail**
+
+Run: `cargo test -p fulgur --lib gcpm::target_ref::tests::first_letter`
+Expected: FAIL — `compute_first_letter` not defined.
+
+**Step 4: Implement `compute_first_letter`**
+
+Add to `crates/fulgur/src/gcpm/target_ref.rs` (near `resolve_target_text`):
+
+```rust
+/// First-letter per CSS Pseudo-Elements 4 §3.2: optional leading
+/// typographic punctuation, the first typographic letter/digit
+/// (grapheme cluster), then optional trailing typographic punctuation.
+/// Whitespace before the first letter (other than fully-trimmed leading
+/// whitespace) terminates the run. Returns `""` when there is no letter.
+fn compute_first_letter(text: &str) -> String {
+    use unicode_properties::{GeneralCategory as GC, UnicodeGeneralCategory};
+    use unicode_segmentation::UnicodeSegmentation;
+
+    fn is_punct(g: &str) -> bool {
+        g.chars().all(|c| {
+            matches!(
+                c.general_category(),
+                GC::OpenPunctuation
+                    | GC::ClosePunctuation
+                    | GC::InitialPunctuation
+                    | GC::FinalPunctuation
+                    | GC::OtherPunctuation
+                    | GC::ConnectorPunctuation
+                    | GC::DashPunctuation
+                    | GC::MathSymbol
+                    | GC::OtherSymbol
+                    | GC::CurrencySymbol
+                    | GC::ModifierSymbol
+            )
+        })
+    }
+    fn is_letter(g: &str) -> bool {
+        g.chars().any(|c| {
+            matches!(
+                c.general_category(),
+                GC::UppercaseLetter
+                    | GC::LowercaseLetter
+                    | GC::TitlecaseLetter
+                    | GC::ModifierLetter
+                    | GC::OtherLetter
+                    | GC::DecimalNumber
+                    | GC::LetterNumber
+                    | GC::OtherNumber
+            )
+        })
+    }
+
+    let trimmed = text.trim_start_matches(char::is_whitespace);
+    let gs: Vec<&str> = trimmed.graphemes(true).collect();
+    let mut i = 0;
+    while i < gs.len() && is_punct(gs[i]) {
+        i += 1;
+    }
+    if i >= gs.len() || !is_letter(gs[i]) {
+        return String::new();
+    }
+    let mut j = i + 1;
+    while j < gs.len() && is_punct(gs[j]) {
+        j += 1;
+    }
+    gs[..j].concat()
+}
+```
+
+In `resolve_target_text`, replace the `FirstLetter` arm:
+
+```rust
+TargetTextKind::FirstLetter => compute_first_letter(&entry.text),
+```
+
+If `entry.text.graphemes(...)` was the only `UnicodeSegmentation` use in the
+file, the import may now be unused at module scope — keep it inside
+`compute_first_letter` only and remove the stale top-level `use`.
+
+**Step 5: Run to verify pass**
+
+Run: `cargo test -p fulgur --lib gcpm::target_ref::tests 2>&1 | tail -5`
+Expected: PASS, including the pre-existing
+`target_text_first_letter_is_grapheme_cluster` /
+`target_text_returns_before_after_and_first_letter`. If a pre-existing
+first-letter test asserted the old single-grapheme behaviour and now conflicts
+with spec output, update it to the spec-correct expectation and note why in the
+commit (the old behaviour was a known simplification).
+
+**Step 6: Commit**
+
+```bash
+git add crates/fulgur/Cargo.toml crates/fulgur/Cargo.lock crates/fulgur/src/gcpm/target_ref.rs
+git commit -m "feat(gcpm): CSS Pseudo-Elements 4 conformant target-text first-letter"
+```
+
+---
+
+## Task 4: Integration smoke tests
+
+End-to-end coverage that resolved pseudo text reaches pass 2 render. Per
+CLAUDE.md coverage policy, render-path logic needs a `render_smoke.rs`
+end-to-end test (codecov patch coverage does not see VRT-only paths).
+
+**Files:**
+
+- Test: `crates/fulgur/tests/render_smoke.rs`
+
+**Step 1: Write the tests**
+
+Append to `crates/fulgur/tests/render_smoke.rs`. If the harness exposes a PDF
+text-extraction helper (check existing tests in the file for a
+`extract_text` / `pdf_text` util — fulgur has `inspect.rs`), assert the
+resolved string is present; otherwise assert non-empty PDF + no panic and rely
+on Task 2/3 unit coverage for correctness.
+
+```rust
+#[test]
+fn target_text_before_resolves_attr_pseudo() {
+    let html = r##"<!doctype html><html><head><style>
+      #sec::before { content: attr(data-tag) ": "; }
+      .ref::after  { content: target-text(attr(href), before); }
+    </style></head><body>
+      <p><a class="ref" href="#sec"></a></p>
+      <h2 id="sec" data-tag="APP">Appendix</h2>
+    </body></html>"##;
+    let pdf = fulgur::Engine::builder().build().render_html(html).unwrap();
+    assert!(!pdf.is_empty());
+    // If a text extractor is available:
+    // assert!(pdf_text(&pdf).contains("APP:"));
+}
+
+#[test]
+fn target_text_after_resolves_counter_via_counter_pass() {
+    // Regression: counter-tracked pseudo still captured after the
+    // pseudo_text_by_node removal (InjectCssPass overlay must be visible
+    // to collect_pseudo_text).
+    let html = r##"<!doctype html><html><head><style>
+      body { counter-reset: c; }
+      h2 { counter-increment: c; }
+      #s::after { content: " [" counter(c) "]"; }
+      .r::before { content: target-text(attr(href), after); }
+    </style></head><body>
+      <h2>One</h2>
+      <h2 id="s">Two</h2>
+      <p><a class="r" href="#s"></a></p>
+    </body></html>"##;
+    let pdf = fulgur::Engine::builder().build().render_html(html).unwrap();
+    assert!(!pdf.is_empty());
+    // assert!(pdf_text(&pdf).contains("[2]"));
+}
+
+#[test]
+fn target_text_first_letter_typographic() {
+    let html = r##"<!doctype html><html><head><style>
+      .r::after { content: target-text(attr(href), first-letter); }
+    </style></head><body>
+      <p><a class="r" href="#h"></a></p>
+      <h2 id="h">「Hello」</h2>
+    </body></html>"##;
+    let pdf = fulgur::Engine::builder().build().render_html(html).unwrap();
+    assert!(!pdf.is_empty());
+    // assert!(pdf_text(&pdf).contains("「H"));
+}
+
+#[test]
+fn target_text_empty_for_missing_pseudo() {
+    let html = r##"<!doctype html><html><head><style>
+      .r::after { content: "[" target-text(attr(href), before) "]"; }
+    </style></head><body>
+      <p><a class="r" href="#h"></a></p>
+      <h2 id="h">No pseudo here</h2>
+    </body></html>"##;
+    let pdf = fulgur::Engine::builder().build().render_html(html).unwrap();
+    assert!(!pdf.is_empty()); // resolves to "[]" — no panic, empty capture
+}
+```
+
+**Step 2: Run**
+
+Run: `cargo test -p fulgur --test render_smoke target_text 2>&1 | tail -8`
+Expected: PASS, 0 failed.
+
+**Step 3: Decide on text-layer assertions**
+
+Check `crates/fulgur/src/inspect.rs` / existing `render_smoke.rs` tests for a
+reusable PDF-text extractor. If one exists, upgrade the `// assert!(...)`
+comments to real assertions and re-run. If not, leave the non-empty assertions
+and rely on Task 2/3 units — note the limitation in the commit message.
+
+**Step 4: Commit**
+
+```bash
+git add crates/fulgur/tests/render_smoke.rs
+git commit -m "test(gcpm): integration coverage for target-text pseudo capture"
+```
+
+---
+
+## Final verification
+
+Run before declaring done (REQUIRED SUB-SKILL:
+superpowers:verification-before-completion):
+
+```bash
+cargo test -p fulgur --lib 2>&1 | tail -3
+cargo test -p fulgur --test render_smoke 2>&1 | tail -3
+cargo clippy -p fulgur --all-targets 2>&1 | tail -3
+cargo fmt --check
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur-vrt 2>&1 | tail -3
+```
+
+Expected: all green; lib count ≥ 1121 + new tests; clippy clean; fmt clean; VRT
+no regressions (this change must not alter PDF output for any document that does
+**not** use `target-text(url, before|after|first-letter)` — the capture path is
+read-only and gated behind `has_target_refs`).
+
+## Acceptance (from fulgur-r73p)
+
+- [ ] `target-text(attr(href), before|after|first-letter)` parse → variant
+      (already done; covered by existing parser tests — confirm green)
+- [ ] pass 2 reflects target's `::before`/`::after` resolved text including
+      `attr()` / string / `counter()` (Task 2 + Task 4)
+- [ ] first-letter is CSS Pseudo-Elements 4 conformant (Task 3)
+- [ ] existing `target-text(attr(href))` (Content default) unchanged
+      (VRT + existing target_ref tests green)


### PR DESCRIPTION
## 概要

GCPM `target-text(attr(href), before|after|first-letter)` が対象要素の解決済み `::before` / `::after` 内容を 2nd render pass に反映できるようにする (fulgur-r73p)。

これまで `counter()` / `target-*` を含まない pseudo content (`content: attr(data-x)` やプレーン文字列) は CSS cascade を保持するため Blitz レンダリングに委ね、`AnchorMap` に取り込まれず `before_text` / `after_text` が空のままだった (`gcpm/parser.rs` の `has_counter == false` 経路)。本 PR は **読み取り専用** のキャプチャ経路を追加し、CSS を二重に走らせず override もせずに解決済み pseudo テキストを取り込む (cascade-safe)。

## 変更点

- **`collect_pseudo_text` (engine.rs)**: `walk_anchors` 時点 (CounterPass + InjectCssPass + pagination 後) で id 付き要素の pseudo node の `primary_styles().get_counters().content` を直接読む。`extract_content_image_url` と同じパターン。cascade-only な `attr()` / 文字列と、CounterPass が overlay した `String`（counter 解決値）の両方を 1 経路でカバー。Stylo 0.8 は `attr()` を computed time に解決しないため、`ContentItem::Attr` を host 要素属性 + `a.fallback` から解決。
- **旧 plumbing 削除**: `pseudo_text_by_node` / `take_pseudo_texts` / `AnchorPseudoText` を撤去 (engine.rs / blitz_adapter.rs / target_ref.rs)。InjectCssPass の `write!` overlay は新読み取り経路の前提として保持。
- **`compute_first_letter` (target_ref.rs)**: 素朴な単一書記素取得を CSS Pseudo-Elements 4 §3.2 ベースの実装に置換 (先頭/末尾の typographic punctuation + 先頭 letter/digit、書記素クラスタ単位)。通貨/数学/修飾記号も先頭/末尾 run に含める意図的拡張で、docstring で「§3.2 そのものではなく拡張」と明記。`unicode-properties` を direct dep 化。

## 決定論

`AnchorMap` / `AnchorEntry.counters` は `BTreeMap` のまま、新 HashMap / system-font 依存なし。新経路は `needs_anchor_map_for_pass_two = anchor_map.is_none() && has_target_refs` で gate され、`target-text` 不使用の文書は byte 同一。

## テスト

- lib unit: `compute_first_letter` 9 ケース (ASCII / CJK punctuation / 数字 / 空 / 全 punct / 空白境界 / 書記素クラスタ / 通貨記号 / 末尾 punct)、`collect_pseudo_text` panic guard
- 結合 (`render_smoke.rs`, ActualText テキストレイヤ検証): attr()-before → `APP:`、first-letter → `「H`、missing pseudo → 隣接 `[]`、counter-after (no-panic guard; テキストレイヤ被覆は既存 `target_text_second_arg_resolves_target_fragments` に存置)
- 既知の別件: 要素 `::before`/`::after` の multi-item generated content が先頭 item しか出力しない既存制約を発見 (本 PR の read-only 経路とは無関係、別 issue 候補)

## Test Plan

- [x] `cargo test -p fulgur --lib` (1131 passed, 0 failed)
- [x] `cargo test -p fulgur --test render_smoke` (136 passed, 0 failed)
- [x] `cargo clippy -p fulgur --all-targets` clean
- [x] `cargo fmt --check` clean
- [ ] CI の VRT job (gate 経路のため別文書への回帰は構造上不可、CI で確認)

Closes fulgur-r73p

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * target-text() が疑似要素（::before/::after）の解決済みテキストをより正確に取得するよう改善されました。
  * first-letter の抽出ロジックを強化し、先頭の句読点や記号の扱いを仕様準拠で改善しました。

* **バグ修正**
  * 疑似要素テキストのキャッシュ処理を廃止し、解決をオンデマンド化して信頼性を向上しました。

* **テスト**
  * target-text() 関連の回帰／スモークテストを追加しました。

* **ドキュメント**
  * target-text に関する実装計画書を追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fulgur-rs/fulgur/pull/425?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->