### PR TITLE
fix(gcpm): render all items of multi-item element pseudo content

### DIFF
--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -1998,6 +1998,17 @@ impl CounterPass {
                         None => out.push(' '),
                     }
                 }
+                // `attr(<name>)` in pseudo content. Now that multi-item
+                // lists route through here (fulgur-2ykw), `[" attr(x) "]`
+                // must resolve the attribute rather than drop it. Missing
+                // attributes resolve to the empty string (CSS Values 3
+                // §attr() fallback grammar is not parsed by
+                // `parse_content_value`, so there is no author fallback).
+                ContentItem::Attr(name) => {
+                    if let Some(v) = element.and_then(|el| get_attr(el, name)) {
+                        out.push_str(v);
+                    }
+                }
                 _ => {}
             }
         }

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -728,13 +728,26 @@ impl<'i, 'a> DeclarationParser<'i> for StyleRuleParser<'a> {
                         | ContentItem::TargetText { .. }
                 )
             });
+            // blitz-dom 0.2.4's `flush_pseudo_elements`
+            // (`construct.rs:367`) materializes only `items[0]` of a
+            // pseudo element's multi-item `Content::Items` list, so a
+            // plain `content: "[" "x" "]"` would render just the leading
+            // `[`. Route ANY multi-item content (not only counter-bearing
+            // lists) through CounterPass, which flattens every item into
+            // a single resolved string and injects it as a synthetic
+            // single-item rule Blitz can render in full (fulgur-2ykw).
+            // Single-item plain content stays on Blitz's native path —
+            // `items[0]` IS the whole value there, so no truncation and
+            // no behavior change.
+            let route_via_counter_pass = has_counter || items.len() > 1;
             // Last-declaration-wins: always update content_items (clear when
-            // the new content has no counter()).
-            if has_counter {
+            // the new content needs no CounterPass handling).
+            if route_via_counter_pass {
                 *self.content_items = Some(items);
-                // Strip the original `content: counter(...)` from cleaned CSS
-                // because Blitz cannot evaluate counter() — CounterPass injects
-                // a synthetic ::before/::after rule with the resolved value.
+                // Strip the original `content: ...` from cleaned CSS so
+                // Blitz does not also render its (truncated) view —
+                // CounterPass injects a synthetic ::before/::after rule
+                // with the fully resolved value.
                 let start = decl_start.position().byte_index();
                 let end = input.position().byte_index();
                 self.edits.push(CssEdit::Replace {

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -3721,20 +3721,22 @@ fn target_text_before_resolves_attr_pseudo() {
 /// content for `#s::after` directly. The regression Task 2 must not
 /// reintroduce is a panic / `None` on that read.
 ///
-/// This is a no-panic smoke guard, not a text-layer assertion, and that
-/// is deliberate: the *text-layer* behaviour of counter-tracked
-/// `target-text` is already verified by
-/// `target_text_second_arg_resolves_target_fragments` (which renders the
-/// captured counter-tracked value through an `@page` margin box and
-/// asserts `AfterFrag1` via `pdftotext`). A text assertion *here* is not
-/// possible because fulgur's *element* `::before`/`::after` renderer has
-/// a pre-existing, unrelated limitation: multi-item generated content
-/// only emits its first item (reproduces with plain
-/// `content: "[" "x" "]"` — no `counter()`, no `target-*` — so it cannot
-/// originate in Tasks 2-3's read-only, `has_target_references`-gated
-/// capture). That element-pseudo truncation is out of scope for this PR
-/// and tracked separately. The capture itself (Tasks 2-3) is text-layer
-/// proven by tests #1/#3/#4 below and by `..._second_arg...`.
+/// This stays a no-panic smoke guard, NOT a text-layer assertion.
+/// fulgur-2ykw fixed the multi-item element-pseudo truncation for the
+/// normal path (AssetBundle / `<link>` CSS, and inline `<style>` with
+/// tag/class selectors), so plain `content: "[" "x" "]"` and 3-item
+/// `counter()` lists now render fully (see
+/// `pseudo_multi_item_content_renders_all_items` and
+/// `pseudo_three_item_counter_content_before_and_single_item_unchanged`).
+/// But this test uniquely combines an **inline `<style>` + ID selector**
+/// (`#s::after`): the CounterPass-injected resolved value
+/// (`[data-fulgur-cid]` specificity `0,1,0`) loses the cascade to the
+/// surviving author `#s` rule (`1,0,0`), because inline `<style>` text
+/// is not rewritten to `cleaned_css` (it cannot be — RunningElementPass
+/// and friends depend on the original inline text persisting). That
+/// separate specificity-collision root cause is tracked in fulgur-da3u;
+/// once it lands, this can become a real `[2]` text-layer assertion
+/// (fulgur-2ykw acceptance criterion #4, deferred there).
 #[test]
 fn target_text_after_resolves_counter_via_counter_pass() {
     let html = r##"<!doctype html><html><head><style>
@@ -3810,6 +3812,76 @@ fn target_text_empty_for_missing_pseudo() {
          missing `::before` should resolve target-text to the empty \
          string, leaving the surrounding brackets adjacent (`[]`, not \
          `[X]`). Looked for {needle} in {} bytes of decompressed streams.",
+        lower.len()
+    );
+}
+
+/// fulgur-2ykw: a multi-item element `::after` content list — pure
+/// strings, NO `counter()` / `target-*` so the GCPM scan does not route
+/// it through the `CounterPass` flattening workaround — must render ALL
+/// items in order to the PDF text layer, not just the first. Before the
+/// fix, blitz-dom 0.2.4's `flush_pseudo_elements` materialized only
+/// `items[0]`, so only the leading `[` reached the text layer.
+#[test]
+fn pseudo_multi_item_content_renders_all_items() {
+    let html = r##"<!doctype html><html><head><style>
+      body { font-family: 'Noto Sans', sans-serif; font-size: 12pt; }
+      p::after { content: "[" "x" "]"; }
+    </style></head><body>
+      <p>Body text</p>
+    </body></html>"##;
+    let pdf = tagged_render_with_noto(html);
+    assert!(!pdf.is_empty());
+
+    let lower = decompressed_streams_lower(&pdf);
+    let needle = hex_utf16be("[x]");
+    assert!(
+        lower.contains(&needle.to_ascii_lowercase()),
+        "ActualText missing UTF-16BE for the contiguous `[x]` — a \
+         multi-item `::after` content list must render ALL items, not \
+         just the first `[`. Looked for {needle} in {} bytes of \
+         decompressed streams.",
+        lower.len()
+    );
+}
+
+/// fulgur-2ykw: the canonical 3-item case — open-bracket string +
+/// `counter()` + close-bracket string — on `::before` (the spec sibling
+/// of the `::after` path; both go through blitz-dom's shared
+/// `flush_pseudo_elements`). All three items must reach the text layer
+/// contiguously as `[1]`, and single-item content elsewhere on the page
+/// must stay unchanged.
+#[test]
+fn pseudo_three_item_counter_content_before_and_single_item_unchanged() {
+    let html = r##"<!doctype html><html><head><style>
+      body { font-family: 'Noto Sans', sans-serif; font-size: 12pt; counter-reset: c; }
+      h2 { counter-increment: c; }
+      h2::before { content: "[" counter(c) "]"; }
+      p::after { content: "."; }
+    </style></head><body>
+      <h2>Section</h2>
+      <p>Body</p>
+    </body></html>"##;
+    let pdf = tagged_render_with_noto(html);
+    assert!(!pdf.is_empty());
+
+    let lower = decompressed_streams_lower(&pdf);
+    let three_item = hex_utf16be("[1]");
+    assert!(
+        lower.contains(&three_item.to_ascii_lowercase()),
+        "ActualText missing UTF-16BE for the contiguous `[1]` — a 3-item \
+         `::before` content list (string + counter() + string) must \
+         render ALL items in order. Looked for {three_item} in {} bytes.",
+        lower.len()
+    );
+    // Single-item plain `::after` content still renders (Blitz native
+    // path, unchanged): the lone `.` is present.
+    let single = hex_utf16be(".");
+    assert!(
+        lower.contains(&single.to_ascii_lowercase()),
+        "ActualText missing UTF-16BE for the single-item `.` — \
+         single-item pseudo content must keep rendering via Blitz's \
+         native path. Looked for {single} in {} bytes.",
         lower.len()
     );
 }


### PR DESCRIPTION
## 概要

`fulgur-2ykw`: 要素の `::before`/`::after` の `content` がマルチアイテムリストのとき、**最初のアイテムだけ**しか PDF にレンダリングされないバグを修正する。

## 根本原因

blitz-dom 0.2.4 の `flush_pseudo_elements`（`construct.rs:367`）が擬似要素のマルチアイテム `Content::Items` のうち **`items[0]` のみ** materialize する。fulgur 側の GCPM gate（`gcpm/parser.rs`）は `counter()`/`target-*` を含む content のみ CounterPass の flatten 回避経路に流していたため、`p::after { content: "[" "x" "]" }` のような純粋なマルチ文字列は blitz にそのまま渡り、先頭の `[` だけがレンダリングされていた。

## 修正

- **`gcpm/parser.rs`**: gate を `route_via_counter_pass = has_counter || items.len() > 1` に拡張。マルチアイテム `Content::Items` は CounterPass が全項目を 1 つの解決済み文字列に flatten し、合成した単一アイテムルールとして注入する → blitz が完全にレンダリングする。単一アイテムのプレーン content は従来どおり blitz ネイティブ経路（`items[0]` がそのまま全体なので truncate なし・挙動不変）。
- **`blitz_adapter.rs` `resolve_content`**: `ContentItem::Attr` arm を追加。新たに routed されるマルチアイテム内の `attr()` を drop せず解決する。
- **`render_smoke.rs`**: 回帰テスト追加（純文字列・3項目 counter の `::before`/`::after`・単一アイテム不変ガード）。

## 受け入れ条件

- ✅ #1〜#3: マルチアイテム `::before`/`::after`（文字列 + `counter()` + 文字列）が全項目順序通りにレンダリングされる。単一アイテム挙動は不変。
- ⏸️ #4: `target_text_after_resolves_counter_via_counter_pass` の text-layer assertion 格上げは **`fulgur-da3u` へ分割**。このテストは inline `<style>` + ID セレクタという別の既存バグ（CounterPass の属性セレクタ注入 `0,1,0` が、strip されず DOM に残る inline `<style>` の著者 `#id` ルール `1,0,0` にカスケードで負ける）を踏むため。inline `<style>` と AssetBundle の GCPM 経路は設計上非対称（inline は元テキストが DOM に残ることに `RunningElementPass` 等が依存）で、`cleaned_css` 全体書き換えは不可。完全な診断と候補アプローチは `fulgur-da3u` に記録済み。

## 検証

- `cargo test -p fulgur` 全 green（lib 1131 / render_smoke 138 / gcpm_snapshot 19 / gcpm_integration 13 / 全 integration）
- `cargo fmt --check` clean、`cargo clippy` 警告なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * CSS疑似要素（::before/::after）の content プロパティで attr() 関数を使用して要素の属性値を挿入できるようになりました

* **改善**
  * CSS疑似要素の複数項目から成るコンテンツプロパティの処理精度が向上しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fulgur-rs/fulgur/pull/431?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->