### PR TITLE
fix(gcpm): out-specify surviving author rules in CounterPass injection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ callers don't get this guarantee by default — see the tracking issue
   Bash-driven `git worktree add` (used by the `using-git-worktrees` skill)
   doesn't trigger that hook.
 - Use `BTreeMap` (not `HashMap`) for iteration that affects PDF output (determinism)
-- Blitz: `!important` unreliable, `padding-top` on inline roots ignored (use `margin-top`)
+- Blitz: `!important` reliability **unverified** (this note shares commit `7983fab5` with the since-disproven "Blitz not thread-safe" gotcha; no test/issue backing — measure before relying on or avoiding it), `padding-top` on inline roots ignored (use `margin-top`)
 - `cargo fmt --check` enforced by CI
 - **Coverage scope**: CI の coverage job は `cargo llvm-cov nextest --workspace --exclude fulgur-vrt`
   で動いている (`.github/workflows/ci.yml`)。`crates/fulgur-vrt` は別ジョブで実行されるため、

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -1864,6 +1864,27 @@ impl CounterPass {
             None
         };
 
+        // Reconstruct the element's own compound (`tag#id.class`) so the
+        // injected rule out-specifies any author rule that survives in
+        // the DOM and targets the same element — the inline-`<style>`
+        // cascade collision fixed in fulgur-da3u. `[data-fulgur-cid]`
+        // already pins the element uniquely; this prefix only raises
+        // specificity. Computed once: the element's identity does not
+        // change during child traversal, so `::before` and `::after`
+        // share it.
+        //
+        // Order matters: this runs *after* the `attr_value` block set the
+        // `data-fulgur-cid` attribute. That is safe because
+        // `element_specificity_prefix` reads only `id` / `class` — never
+        // `data-fulgur-cid` — so the just-injected attribute does not
+        // leak into the prefix. A future change that widens the prefix to
+        // arbitrary attributes would have to move this above that block.
+        let specificity_prefix = if attr_value.is_some() {
+            element_specificity_prefix(doc.get_node(node_id).and_then(|n| n.element_data()))
+        } else {
+            String::new()
+        };
+
         // Resolve ::before now (before child traversal)
         if let Some(ref cid) = attr_value {
             use std::fmt::Write;
@@ -1874,7 +1895,8 @@ impl CounterPass {
                 let resolved = self.resolve_content(&mapping.content, element);
                 let _ = write!(
                     css,
-                    "[data-fulgur-cid=\"{}\"]::before{{content:\"{}\"}}",
+                    "{}[data-fulgur-cid=\"{}\"]::before{{content:\"{}\"}}",
+                    specificity_prefix,
                     cid,
                     css_escape_string(&resolved)
                 );
@@ -1900,7 +1922,8 @@ impl CounterPass {
                 let resolved = self.resolve_content(&mapping.content, element);
                 let _ = write!(
                     css,
-                    "[data-fulgur-cid=\"{}\"]::after{{content:\"{}\"}}",
+                    "{}[data-fulgur-cid=\"{}\"]::after{{content:\"{}\"}}",
+                    specificity_prefix,
                     cid,
                     css_escape_string(&resolved)
                 );
@@ -2301,6 +2324,86 @@ fn css_escape_string(s: &str) -> String {
         }
     }
     out
+}
+
+/// Serialize a string as a CSS identifier per the CSSOM
+/// [serialize an identifier][algo] algorithm — the same logic as the
+/// JavaScript `CSS.escape()` function.
+///
+/// [algo]: https://drafts.csswg.org/cssom/#serialize-an-identifier
+///
+/// Used by `CounterPass` to embed a DOM element's `id` / `class` token
+/// into a generated selector when reconstructing specificity. The element
+/// is already pinned uniquely by `[data-fulgur-cid="N"]`; the escaped
+/// identifier only has to *match* the element and *carry the right
+/// specificity*. Faithful escaping is therefore required — a mis-escaped
+/// identifier would make the generated rule silently fail to match,
+/// reintroducing the very cascade bug this reconstruction fixes.
+fn css_escape_ident(s: &str) -> String {
+    let mut out = String::new();
+    let chars: Vec<char> = s.chars().collect();
+    for (i, &ch) in chars.iter().enumerate() {
+        match ch {
+            // U+0000 NULL → U+FFFD REPLACEMENT CHARACTER.
+            '\0' => out.push('\u{FFFD}'),
+            // Control characters → `\<hex> `.
+            c if ('\u{1}'..='\u{1F}').contains(&c) || c == '\u{7F}' => {
+                out.push_str(&format!("\\{:x} ", c as u32));
+            }
+            // A leading digit, or a digit right after a leading hyphen,
+            // would start a CSS number — escape it as `\<hex> `.
+            c if c.is_ascii_digit() && (i == 0 || (i == 1 && chars[0] == '-')) => {
+                out.push_str(&format!("\\{:x} ", c as u32));
+            }
+            // A bare `-` identifier would be ambiguous — escape it.
+            '-' if i == 0 && chars.len() == 1 => out.push_str("\\-"),
+            // Identifier-safe code points pass through verbatim.
+            c if c >= '\u{80}'
+                || c == '-'
+                || c == '_'
+                || c.is_ascii_digit()
+                || c.is_ascii_alphabetic() =>
+            {
+                out.push(c);
+            }
+            // Everything else is backslash-escaped literally.
+            c => {
+                out.push('\\');
+                out.push(c);
+            }
+        }
+    }
+    out
+}
+
+/// Reconstruct a CSS selector prefix from an element's own identity —
+/// its tag name, `id`, and every `class` token.
+///
+/// `CounterPass` appends `[data-fulgur-cid="N"]::before/::after` after
+/// this prefix. The `data-fulgur-cid` attribute already pins the element
+/// uniquely, so the prefix never changes *which* element matches; it only
+/// raises the rule's specificity so a surviving author rule on the same
+/// element (the inline-`<style>` case in fulgur-da3u) loses the cascade.
+///
+/// `id` / `class` values come from arbitrary HTML attributes and are
+/// escaped with [`css_escape_ident`]. Tag names from the HTML parser are
+/// already valid identifiers; they are lowercased for good measure.
+fn element_specificity_prefix(element: Option<&blitz_dom::node::ElementData>) -> String {
+    let Some(elem) = element else {
+        return String::new();
+    };
+    let mut prefix = elem.name.local.as_ref().to_ascii_lowercase();
+    if let Some(id) = get_attr(elem, "id").filter(|s| !s.is_empty()) {
+        prefix.push('#');
+        prefix.push_str(&css_escape_ident(id));
+    }
+    if let Some(class) = get_attr(elem, "class") {
+        for token in class.split_whitespace() {
+            prefix.push('.');
+            prefix.push_str(&css_escape_ident(token));
+        }
+    }
+    prefix
 }
 
 fn resolve_string_set_values(
@@ -4204,6 +4307,103 @@ mod tests {
         assert_eq!(escape_css_url("a\nb.css"), r"a\a b.css");
         assert_eq!(escape_css_url("a\rb.css"), r"a\d b.css");
         assert_eq!(escape_css_url("a\x0cb.css"), r"a\c b.css");
+    }
+
+    #[test]
+    fn counter_pass_injected_selector_reconstructs_element_compound() {
+        use crate::gcpm::{ContentCounterMapping, ContentItem, ParsedSelector, PseudoElement};
+
+        // fulgur-da3u: when the original author rule survives in the DOM
+        // (inline `<style>`), the CounterPass-injected rule must out-specify
+        // it. The injected selector therefore reconstructs the target
+        // element's own compound — tag + id + every class — so a surviving
+        // author `#s::after` (specificity 1,0,1) loses to the injection.
+        let html = r#"<html><body><h2 id="s" class="a b">Two</h2></body></html>"#;
+        let mut doc = parse(html, 400.0, &[]);
+        let content_mappings = vec![ContentCounterMapping {
+            parsed: ParsedSelector::Id("s".into()),
+            pseudo: PseudoElement::After,
+            content: vec![ContentItem::String("[x]".into())],
+        }];
+        let pass = CounterPass::new(Vec::new(), content_mappings);
+        let ctx = PassContext { font_data: &[] };
+        pass.apply(&mut doc, &ctx);
+        let css = pass.generated_css();
+
+        assert!(
+            css.contains("h2#s.a.b[data-fulgur-cid=\"0\"]::after"),
+            "injected selector must reconstruct the element's tag+id+classes \
+             to out-specify a surviving author `#s::after` rule, got: {css}"
+        );
+    }
+
+    #[test]
+    fn counter_pass_injected_selector_for_bare_element_uses_tag() {
+        use crate::gcpm::{ContentCounterMapping, ContentItem, ParsedSelector, PseudoElement};
+
+        // An element with no id and no class: no id-based author rule can
+        // target it, so the tag prefix plus `[data-fulgur-cid]` is enough.
+        let html = r#"<html><body><div>x</div></body></html>"#;
+        let mut doc = parse(html, 400.0, &[]);
+        let content_mappings = vec![ContentCounterMapping {
+            parsed: ParsedSelector::Tag("div".into()),
+            pseudo: PseudoElement::Before,
+            content: vec![ContentItem::String("[x]".into())],
+        }];
+        let pass = CounterPass::new(Vec::new(), content_mappings);
+        let ctx = PassContext { font_data: &[] };
+        pass.apply(&mut doc, &ctx);
+        let css = pass.generated_css();
+
+        assert!(
+            css.contains("div[data-fulgur-cid=\"0\"]::before"),
+            "injected selector for a bare element must carry the tag prefix, \
+             got: {css}"
+        );
+    }
+
+    #[test]
+    fn css_escape_ident_passes_through_plain_identifiers() {
+        assert_eq!(css_escape_ident("foo"), "foo");
+        assert_eq!(css_escape_ident("section-2"), "section-2");
+        assert_eq!(css_escape_ident("_private"), "_private");
+        assert_eq!(css_escape_ident("CamelCase"), "CamelCase");
+    }
+
+    #[test]
+    fn css_escape_ident_escapes_leading_digit() {
+        // CSSOM "serialize an identifier": a leading digit is escaped as
+        // its code point in hex followed by a space.
+        assert_eq!(css_escape_ident("2col"), r"\32 col");
+        // A digit in second position is only escaped when the first
+        // code point is a hyphen.
+        assert_eq!(css_escape_ident("-2col"), r"-\32 col");
+        // A non-leading digit is left as-is.
+        assert_eq!(css_escape_ident("col2"), "col2");
+    }
+
+    #[test]
+    fn css_escape_ident_escapes_special_chars() {
+        // Punctuation that is not -, _, digit, or ASCII letter is
+        // backslash-escaped literally.
+        assert_eq!(css_escape_ident("foo:bar"), r"foo\:bar");
+        assert_eq!(css_escape_ident("a.b"), r"a\.b");
+        assert_eq!(css_escape_ident("with space"), r"with\ space");
+        // A bare leading hyphen (the whole identifier is "-") is escaped.
+        assert_eq!(css_escape_ident("-"), r"\-");
+        // A leading hyphen followed by a non-digit is fine as-is.
+        assert_eq!(css_escape_ident("-webkit"), "-webkit");
+    }
+
+    #[test]
+    fn css_escape_ident_handles_control_chars_and_null() {
+        // U+0000 NULL becomes U+FFFD REPLACEMENT CHARACTER.
+        assert_eq!(css_escape_ident("a\0b"), "a\u{FFFD}b");
+        // Control chars are escaped as hex + space.
+        assert_eq!(css_escape_ident("a\x01b"), r"a\1 b");
+        assert_eq!(css_escape_ident("a\x7fb"), r"a\7f b");
+        // Empty identifier stays empty.
+        assert_eq!(css_escape_ident(""), "");
     }
 
     #[test]

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -1786,11 +1786,26 @@ impl CounterPass {
                 }
             }
 
-            Some((matched_ops, matched_content_indices))
+            // Reconstruct the element's own compound (`tag#id.class`) so
+            // an injected `::before` / `::after` rule out-specifies any
+            // author rule that survives in the DOM and targets the same
+            // element — the inline-`<style>` cascade collision fixed in
+            // fulgur-da3u. `[data-fulgur-cid]` already pins the element
+            // uniquely; this prefix only raises specificity. Computed
+            // here, inside the Phase 1 immutable borrow, to reuse `elem`
+            // instead of re-fetching the node later. Empty when no
+            // content mapping matched (no rule will be injected).
+            let specificity_prefix = if matched_content_indices.is_empty() {
+                String::new()
+            } else {
+                element_specificity_prefix(Some(elem))
+            };
+
+            Some((matched_ops, matched_content_indices, specificity_prefix))
         };
         // immutable borrow of doc is now dropped
 
-        let Some((matched_ops, matched_content_indices)) = phase1 else {
+        let Some((matched_ops, matched_content_indices, specificity_prefix)) = phase1 else {
             return;
         };
 
@@ -1864,26 +1879,8 @@ impl CounterPass {
             None
         };
 
-        // Reconstruct the element's own compound (`tag#id.class`) so the
-        // injected rule out-specifies any author rule that survives in
-        // the DOM and targets the same element — the inline-`<style>`
-        // cascade collision fixed in fulgur-da3u. `[data-fulgur-cid]`
-        // already pins the element uniquely; this prefix only raises
-        // specificity. Computed once: the element's identity does not
-        // change during child traversal, so `::before` and `::after`
-        // share it.
-        //
-        // Order matters: this runs *after* the `attr_value` block set the
-        // `data-fulgur-cid` attribute. That is safe because
-        // `element_specificity_prefix` reads only `id` / `class` — never
-        // `data-fulgur-cid` — so the just-injected attribute does not
-        // leak into the prefix. A future change that widens the prefix to
-        // arbitrary attributes would have to move this above that block.
-        let specificity_prefix = if attr_value.is_some() {
-            element_specificity_prefix(doc.get_node(node_id).and_then(|n| n.element_data()))
-        } else {
-            String::new()
-        };
+        // `specificity_prefix` was computed in Phase 1 (above) — reused
+        // verbatim for both `::before` and `::after`.
 
         // Resolve ::before now (before child traversal)
         if let Some(ref cid) = attr_value {
@@ -2340,9 +2337,14 @@ fn css_escape_string(s: &str) -> String {
 /// identifier would make the generated rule silently fail to match,
 /// reintroducing the very cascade bug this reconstruction fixes.
 fn css_escape_ident(s: &str) -> String {
-    let mut out = String::new();
-    let chars: Vec<char> = s.chars().collect();
-    for (i, &ch) in chars.iter().enumerate() {
+    // Single pass over the `char`s — no `Vec<char>` buffer. `index` and
+    // `prev` carry the position-dependent state the CSSOM algorithm
+    // needs; `peek()` covers the bare-`-` look-ahead.
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    let mut index = 0usize;
+    let mut prev: Option<char> = None;
+    while let Some(ch) = chars.next() {
         match ch {
             // U+0000 NULL → U+FFFD REPLACEMENT CHARACTER.
             '\0' => out.push('\u{FFFD}'),
@@ -2352,11 +2354,11 @@ fn css_escape_ident(s: &str) -> String {
             }
             // A leading digit, or a digit right after a leading hyphen,
             // would start a CSS number — escape it as `\<hex> `.
-            c if c.is_ascii_digit() && (i == 0 || (i == 1 && chars[0] == '-')) => {
+            c if c.is_ascii_digit() && (index == 0 || (index == 1 && prev == Some('-'))) => {
                 out.push_str(&format!("\\{:x} ", c as u32));
             }
             // A bare `-` identifier would be ambiguous — escape it.
-            '-' if i == 0 && chars.len() == 1 => out.push_str("\\-"),
+            '-' if index == 0 && chars.peek().is_none() => out.push_str("\\-"),
             // Identifier-safe code points pass through verbatim.
             c if c >= '\u{80}'
                 || c == '-'
@@ -2372,6 +2374,8 @@ fn css_escape_ident(s: &str) -> String {
                 out.push(c);
             }
         }
+        prev = Some(ch);
+        index += 1;
     }
     out
 }

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -3710,33 +3710,25 @@ fn target_text_before_resolves_attr_pseudo() {
     );
 }
 
-/// fulgur-r73p Task 4.2 (regression): exercising the counter-tracked
-/// `collect_pseudo_text` capture path must not panic after Task 2 removed
-/// the `pseudo_text_by_node` plumbing.
+/// fulgur-r73p Task 4.2 / fulgur-da3u: a counter-bearing `::after`
+/// content list selected by an **ID selector inside an inline `<style>`**
+/// must render its resolved value to the PDF text layer.
 ///
 /// `#s::after` uses `counter(c)`, so `CounterPass` + `InjectCssPass`
 /// overlay the resolved value into the cascade; `.r::before { content:
 /// target-text(attr(href), after) }` makes `has_target_references()`
 /// true so `collect_pseudo_text` reads that counter-overlaid computed
-/// content for `#s::after` directly. The regression Task 2 must not
-/// reintroduce is a panic / `None` on that read.
+/// content for `#s::after` directly.
 ///
-/// This stays a no-panic smoke guard, NOT a text-layer assertion.
-/// fulgur-2ykw fixed the multi-item element-pseudo truncation for the
-/// normal path (AssetBundle / `<link>` CSS, and inline `<style>` with
-/// tag/class selectors), so plain `content: "[" "x" "]"` and 3-item
-/// `counter()` lists now render fully (see
-/// `pseudo_multi_item_content_renders_all_items` and
-/// `pseudo_three_item_counter_content_before_and_single_item_unchanged`).
-/// But this test uniquely combines an **inline `<style>` + ID selector**
-/// (`#s::after`): the CounterPass-injected resolved value
-/// (`[data-fulgur-cid]` specificity `0,1,0`) loses the cascade to the
-/// surviving author `#s` rule (`1,0,0`), because inline `<style>` text
-/// is not rewritten to `cleaned_css` (it cannot be — RunningElementPass
-/// and friends depend on the original inline text persisting). That
-/// separate specificity-collision root cause is tracked in fulgur-da3u;
-/// once it lands, this can become a real `[2]` text-layer assertion
-/// (fulgur-2ykw acceptance criterion #4, deferred there).
+/// This was a no-panic-only guard until fulgur-da3u: the inline
+/// `<style>` text stays in the DOM, so the author `#s::after` rule
+/// (`1,0,1`) survived and out-specified `CounterPass`'s bare
+/// `[data-fulgur-cid]::after` injection (`0,1,1`), leaving Blitz to
+/// render the `items[0]`-truncated view (just the leading `[`).
+/// fulgur-da3u reconstructs the element compound into the injected
+/// selector so the injection wins, which is exactly what makes the
+/// real `[2]` text-layer assertion below possible — it discharges
+/// fulgur-2ykw acceptance criterion #4, deferred to fulgur-da3u.
 #[test]
 fn target_text_after_resolves_counter_via_counter_pass() {
     let html = r##"<!doctype html><html><head><style>
@@ -3749,11 +3741,23 @@ fn target_text_after_resolves_counter_via_counter_pass() {
       <h2 id="s">Two</h2>
       <p>Jump to <a class="r" href="#s">section two</a> now.</p>
     </body></html>"##;
-    // collect_pseudo_text reads #s::after's counter-overlaid computed
-    // content during build_anchor_map (gated on the target-text ref
-    // above). Guard: that read must not panic and render must succeed.
     let pdf = tagged_render_with_noto(html);
     assert!(!pdf.is_empty());
+
+    let lower = decompressed_streams_lower(&pdf);
+    // `#s` is the second `h2`, so counter `c` == 2. All three items of
+    // `" [" counter(c) "]"` must render — the contiguous run `[2]` is
+    // present only when the CounterPass injection out-specifies the
+    // surviving inline-`<style>` author `#s::after` rule.
+    let needle = hex_utf16be("[2]");
+    assert!(
+        lower.contains(&needle.to_ascii_lowercase()),
+        "ActualText missing UTF-16BE for the contiguous `[2]` — the \
+         counter-resolved `#s::after` content (selected by an ID selector \
+         in an inline `<style>`) must render ALL items. Looked for \
+         {needle} in {} bytes of decompressed streams.",
+        lower.len()
+    );
 }
 
 /// fulgur-r73p Task 4.3: `target-text(url, first-letter)` must apply the
@@ -3882,6 +3886,46 @@ fn pseudo_three_item_counter_content_before_and_single_item_unchanged() {
         "ActualText missing UTF-16BE for the single-item `.` — \
          single-item pseudo content must keep rendering via Blitz's \
          native path. Looked for {single} in {} bytes.",
+        lower.len()
+    );
+}
+
+/// fulgur-da3u: a multi-item element `::before` content list selected by
+/// an **ID selector inside an inline `<style>`** must render ALL items to
+/// the PDF text layer.
+///
+/// The inline `<style>` text stays in the DOM verbatim, so the author
+/// `#s::before` rule (specificity `1,0,1`) survives the cascade. Before
+/// the fix, `CounterPass`'s injected rule used a bare
+/// `[data-fulgur-cid]::before` selector (`0,1,1`) and lost — Blitz then
+/// rendered its `items[0]`-truncated view of the surviving author rule,
+/// so only the leading `[` reached the text layer. The fix reconstructs
+/// the element's own compound (`h2#s…[data-fulgur-cid]::before`) so the
+/// injection out-specifies the author rule.
+#[test]
+fn pseudo_multi_item_content_via_inline_style_id_selector() {
+    let html = r##"<!doctype html><html><head><style>
+      body { font-family: 'Noto Sans', sans-serif; font-size: 12pt; counter-reset: c; }
+      h2 { counter-increment: c; }
+      #s::before { content: "[" counter(c) "]"; }
+    </style></head><body>
+      <h2>One</h2>
+      <h2 id="s">Two</h2>
+    </body></html>"##;
+    let pdf = tagged_render_with_noto(html);
+    assert!(!pdf.is_empty());
+
+    let lower = decompressed_streams_lower(&pdf);
+    // `#s` is the second `h2`, so counter `c` == 2. All three items must
+    // render contiguously as `[2]`, not the truncated leading `[`.
+    let needle = hex_utf16be("[2]");
+    assert!(
+        lower.contains(&needle.to_ascii_lowercase()),
+        "ActualText missing UTF-16BE for the contiguous `[2]` — a \
+         multi-item `::before` content list selected by an ID selector in \
+         an inline `<style>` must render ALL items. The CounterPass \
+         injected rule must out-specify the surviving author `#s::before` \
+         rule. Looked for {needle} in {} bytes of decompressed streams.",
         lower.len()
     );
 }

--- a/docs/plans/2026-05-23-fulgur-da3u-counterpass-selector-specificity-design.md
+++ b/docs/plans/2026-05-23-fulgur-da3u-counterpass-selector-specificity-design.md
@@ -1,0 +1,153 @@
+# fulgur-da3u: CounterPass 注入セレクタの specificity 再構成
+
+## 背景
+
+`fulgur-2ykw` で、複数アイテムの要素 `::before`/`::after` generated content
+を `CounterPass` 経由でレンダリングするゲートを修正した。これにより
+AssetBundle / `<link>` CSS と、タグ / クラスセレクタを使う inline `<style>`
+は全アイテムが描画されるようになった。
+
+しかし inline `<style>` ブロックには別の、先行して存在する根本原因が残る。
+
+## 根本原因
+
+`CounterPass` は解決済みの擬似要素 content を
+`[data-fulgur-cid="N"]::before/::after{content:"..."}` という形で注入する。
+属性セレクタの specificity は `(0,1,0)`、擬似要素を足して `(0,1,1)`。
+
+- **AssetBundle / `<link>` CSS**: 元の author 宣言は DOM に文字列として
+  入らない（`engine::render_pass` が `parse_gcpm().cleaned_css` を
+  `InjectCssPass` で注入する）。カスケード競合は発生しない。
+- **inline `<style>`**: `extract_gcpm_from_inline_styles` は mapping を
+  **抽出するだけ**で、`<style>` テキストは DOM に残り Stylo がそのまま
+  パースする。これは意図的で、`RunningElementPass`（`position:running()`）
+  など他パスが元の inline `<style>` テキストの残存に依存しているため。
+
+結果、生き残った author ルールが注入ルールとカスケード競合する。タグ
+セレクタ `(0,0,1)` は注入 `(0,1,1)` に負ける（正常動作）が、ID セレクタ
+`(1,0,0)` — もしくは specificity が `(0,1,0)` 以上の任意の author
+セレクタ、あるいは `!important` — は注入に**勝ち**、Blitz が
+items[0] 切り詰め版をレンダリングしてしまう。
+
+### 検証済みエビデンス（fulgur-2ykw 調査より）
+
+`{h2, #s} × {::before, ::after}` のマトリクスで
+`content:"[" counter(c) "]"` を inline `<style>` に置く。タグセレクタは
+`[1]`/`[2]` を完全描画。ID セレクタは先頭の `[` のみ描画。
+
+### 不採用となった先行案
+
+各 inline `<style>` を `parse_gcpm().cleaned_css` + Blitz
+`upsert_stylesheet_for_node` で書き換える実装は、狙ったケースは直るが
+`gcpm_snapshot` テスト（`gcpm_running_element_via_inline_style`,
+`gcpm_element_policy_first/last`）を回帰させた。`cleaned_css` は
+`position:running()` / `@page` も除去し、`RunningElementPass` は元の
+inline `<style>` テキストの残存に依存するため。AssetBundle と
+inline-`<style>` の経路は設計上非対称（DOM presence・パス順序が異なる）で、
+一括書き換えは不可。
+
+## 採用方針: セレクタ再構成
+
+注入セレクタに**対象要素自身の compound を前置**して specificity を
+引き上げる。`!important` も CSS テキスト編集も使わない。
+
+```css
+/* 現状 */   [data-fulgur-cid="3"]::after{content:"[1][2]"}
+/* 変更後 */ h2#s[data-fulgur-cid="3"]::after{content:"[1][2]"}
+```
+
+### なぜマッチ対象が変わらないか
+
+`data-fulgur-cid` は `CounterPass` が content mapping にマッチした要素
+ごとに採番する一意属性。`[data-fulgur-cid="N"]` 単独で対象要素を確定
+させる。前置する `tag#id.class` は「その同じ要素について真である事実」
+を足すだけなので、マッチする要素は変わらず specificity だけが上がる。
+
+### specificity 効果
+
+- `h2#s[data-fulgur-cid="N"]::after` = `(1,1,2)` は author `#s::after`
+  `(1,0,1)` に勝つ。
+- 全クラスを盛り込むことで `.a.b.c::after` `(0,3,1)` のような
+  クラス多用ルールも被覆する。根本原因が挙げる「specificity が
+  `(0,1,0)` 以上の任意の author セレクタ」全般をカバーする。
+- specificity が同点の場合は source order で決まる。`InjectCssPass`
+  が生成する `<style>` ノードは DOM パース後に作られ最大の node_id を
+  持つため、`add_stylesheet_for_node` のオーダリング（node_id 昇順）で
+  最後に置かれ、同点は注入側が勝つ。
+
+### 既知の限界（文書化する）
+
+`#main #s::after` のような **ID 持ち祖先セレクタ** `(2,0,2)` には
+負けうる。要素自身の compound からは祖先の specificity を再現できない
+ため。acceptance criteria は単一 compound `#id` をスコープとしており
+対象外。実ケースが出たら follow-up issue で扱う。
+
+## 実装
+
+変更は `CounterPass::walk_tree`（`crates/fulgur/src/blitz_adapter.rs`）
+内に閉じる。
+
+### 1. `element_specificity_prefix`
+
+新ヘルパー。要素の `tag` + `#id`（あれば）+ `.class`（全クラス、属性
+トークン順）を連結して返す。cid 割り当て直後に一度だけ計算し、
+`::before` / `::after` 両方の解決ブロックで再利用する（要素の id/class
+は子要素再帰の間に変化しないため安全）。
+
+### 2. `css_escape_ident`
+
+新ヘルパー。id を `#<ident>` で出すには CSS identifier エスケープが
+必須。既存の `css_escape_string` は文字列リテラル用で別物。CSSOM
+`CSS.escape` 相当のアルゴリズムを実装し、id と各クラスに適用する。
+タグ名は HTML タグ名なのでエスケープ不要。
+
+### 3. 注入箇所
+
+`::before` / `::after` の `write!` で、`[data-fulgur-cid="{cid}"]` の
+前にプレフィックスを差し込む。
+
+### AssetBundle 経路への影響
+
+`CounterPass` は両経路で共有される。AssetBundle 経路では注入セレクタが
+`#id[data-fulgur-cid]::before` に変わるが、`data-fulgur-cid` は一意な
+ので依然として対象要素のみにマッチし、競合相手も存在しない（cleaned_css
+が author ルールを除去済み）。よって correctness は変わらず、CSS が
+わずかに長くなるだけ。経路ごとの特別扱いは不要。
+
+## テスト
+
+### ユニットテスト（`blitz_adapter.rs` の `#[cfg(test)] mod tests`）
+
+- 新規: id 持ち要素の content mapping を `CounterPass` に与え、
+  `generated_css()` が `#s[data-fulgur-cid=` を含むことを assert。
+- 新規: `css_escape_ident` の境界テスト（数字始まり・特殊文字・空文字
+  など CSSOM アルゴリズムのエッジ）。
+- 既存修正: `generated_css` を exact 比較するテスト群は、対象要素に
+  id/class があれば期待値が変わる。期待文字列を更新する。
+
+### end-to-end smoke テスト（`crates/fulgur/tests/render_smoke.rs`）
+
+- 新規: inline `<style>` の `#id::before { content: <multi-item> }`
+  をレンダリングし、全アイテムが PDF テキストレイヤに出ることを
+  `hex_utf16be` で assert。
+- ガードテスト昇格: `target_text_after_resolves_counter_via_counter_pass`
+  を no-panic ガードから実 `[2]` テキストレイヤ assertion へ格上げ。
+  fulgur-2ykw の acceptance criterion #4 をここで満たす。
+
+### 回帰防止
+
+- `cargo test -p fulgur --test gcpm_snapshot` の running-element 系
+  （`gcpm_running_element_via_inline_style`,
+  `gcpm_element_policy_first/last`）が green のまま。本案は inline
+  `<style>` テキストを一切触らないので原理上影響しないが、失敗実装で
+  踏んだ地雷なので明示的に確認する。
+- `cargo test -p fulgur` 全体 + `cargo clippy` + `cargo fmt --check`。
+
+## Acceptance
+
+- inline `<style>` の `#id::before/::after { content: <multi-item> }`
+  が全アイテムを PDF テキストレイヤへ描画する。
+- `gcpm_snapshot` の running-element テストが green のまま。
+- `target_text_after_resolves_counter_via_counter_pass` を no-panic
+  ガードから実 `[2]` テキストレイヤ assertion へ昇格できる
+  （fulgur-2ykw acceptance criterion #4、ここへ deferred）。

--- a/docs/plans/2026-05-23-fulgur-da3u-counterpass-selector-specificity-design.md
+++ b/docs/plans/2026-05-23-fulgur-da3u-counterpass-selector-specificity-design.md
@@ -68,8 +68,8 @@ inline-`<style>` の経路は設計上非対称（DOM presence・パス順序が
 - `h2#s[data-fulgur-cid="N"]::after` = `(1,1,2)` は author `#s::after`
   `(1,0,1)` に勝つ。
 - 全クラスを盛り込むことで `.a.b.c::after` `(0,3,1)` のような
-  クラス多用ルールも被覆する。根本原因が挙げる「specificity が
-  `(0,1,0)` 以上の任意の author セレクタ」全般をカバーする。
+  クラス多用ルールも被覆する。要素を直接対象とする単一 compound の
+  author ルールは（後述の「既知の限界」を除き）被覆できる。
 - specificity が同点の場合は source order で決まる。`InjectCssPass`
   が生成する `<style>` ノードは DOM パース後に作られ最大の node_id を
   持つため、`add_stylesheet_for_node` のオーダリング（node_id 昇順）で

--- a/docs/plans/2026-05-23-fulgur-da3u-counterpass-selector-specificity-design.md
+++ b/docs/plans/2026-05-23-fulgur-da3u-counterpass-selector-specificity-design.md
@@ -79,8 +79,10 @@ inline-`<style>` の経路は設計上非対称（DOM presence・パス順序が
 
 `#main #s::after` のような **ID 持ち祖先セレクタ** `(2,0,2)` には
 負けうる。要素自身の compound からは祖先の specificity を再現できない
-ため。acceptance criteria は単一 compound `#id` をスコープとしており
-対象外。実ケースが出たら follow-up issue で扱う。
+ため。同じバケツに、疑似クラスを積み重ねた単一 compound
+（`#s:not(.x):not(.y)::after` = `(1,2,1)`）も入る — 再構成した
+`(1,1,2)` を上回る。いずれも acceptance criteria のスコープ（単一
+compound `#id`）外。実ケースが出たら follow-up issue で扱う。
 
 ## 実装
 


### PR DESCRIPTION
## 概要

inline `<style>` 内の id セレクタ擬似要素 content が `CounterPass` の注入ルールにカスケードで勝ってしまい、複数アイテムの generated content が items[0] 切り詰めでレンダリングされる問題（**fulgur-da3u**）を修正します。

## 根本原因

`CounterPass` は解決済みの擬似要素 content を `[data-fulgur-cid="N"]::before/::after{content:"..."}`（specificity `(0,1,1)`）として注入します。

- **AssetBundle / `<link>` CSS**: 元の author 宣言は `cleaned_css` 注入のため DOM に入らず、競合なし。
- **inline `<style>`**: `extract_gcpm_from_inline_styles` は mapping を抽出するだけで `<style>` テキストは DOM に残り Stylo がパースする（`RunningElementPass` 等が元テキストの残存に依存するため意図的）。

結果、生き残った author の `#id::before/::after` ルール `(1,0,1)` — specificity が `(0,1,0)` 以上の任意のセレクタ — が注入に勝ち、Blitz が items[0] 切り詰め版を描画していました。

## 修正方針

注入セレクタに**対象要素自身の compound（`tag#id.class`）を前置**して specificity を引き上げます。`[data-fulgur-cid]` は要素ごとに一意なので**マッチ対象は変わらず**、specificity だけが上がり、同一要素を狙う単一 compound の author ルールに必ず勝ちます。

- `!important` 不使用、inline `<style>` テキストの書き換えなし → `RunningElementPass` / `@page` 処理は無変更
- 変更は `CounterPass::walk_tree` 内に閉じる
- 新ヘルパー: `css_escape_ident`（CSSOM "serialize an identifier"）, `element_specificity_prefix`

不採用とした「inline `<style>` を `cleaned_css` に一括書き換え」案（`gcpm_snapshot` の running-element テストを回帰させる）の経緯は設計ドキュメント参照。

### 既知の限界

`#main #s::after` のような id 持ち祖先セレクタ、疑似クラスを積み重ねた単一 compound には依然負けうる（acceptance スコープ外、follow-up 候補）。

## テスト

- ユニット: `css_escape_ident` の境界テスト、`generated_css` のセレクタ再構成テスト（id+class / bare element）
- end-to-end smoke: inline `<style>` `#id::before` multi-item が全アイテム描画されることを PDF テキストレイヤで検証
- ガードテスト昇格: `target_text_after_resolves_counter_via_counter_pass` を no-panic ガードから実 `[2]` テキストレイヤ assertion へ（fulgur-2ykw acceptance criterion #4 を discharge）
- 回帰確認: `cargo test -p fulgur`（lib 1149 + integration）/ `gcpm_snapshot` 19件 / `fulgur-vrt`（PDF byte 比較）/ `fulgur-cli`（examples determinism）/ `clippy --workspace --all-targets` / `fmt --check` すべて green

## 関連

- 設計ドキュメント: `docs/plans/2026-05-23-fulgur-da3u-counterpass-selector-specificity-design.md`
- Closes fulgur-da3u
- fulgur-2ykw acceptance criterion #4 をここで満たす

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * インラインスタイルのIDセレクタと競合していたカウンター要素（::before/::after）が優先度調整によりPDF上で正しく表示されない問題を解消しました。

* **テスト**
  * PDFテキスト層でカウンター表示が連続して正しく出力されることを検証するスモークテストを強化し、識別子エスケープや要素特異性の境界ケースを確認するユニットテストを追加しました。

* **ドキュメント**
  * 注入セレクタの特異性方針、既知の制限、および運用上の注意点をまとめた設計メモと補足を追加・更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fulgur-rs/fulgur/pull/434?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->