### PR TITLE
test(render): add coverage for rendering pipeline

### DIFF
--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -5200,3 +5200,126 @@ mod tests {
         assert!(clip.is_empty(), "empty clip_descendants → nothing added");
     }
 }
+
+/// Smoke tests that drive the rendering pipeline end-to-end.
+///
+/// These cover `draw_v2_page`, `draw_block_v2`, `draw_paragraph_v2`,
+/// `draw_list_item_with_block`, `draw_table_v2`, `draw_svg_v2`,
+/// `draw_under_transform`, `draw_under_clip`, `draw_under_opacity`,
+/// `paint_multicol_paragraph_slices`, and related tagged-render paths
+/// that cannot be reached from pure-data unit tests.
+///
+/// Each test asserts `!pdf.is_empty()` — the goal is to catch panics
+/// and ensure coverage attribution fires for each render arm.
+#[cfg(test)]
+mod smoke_tests {
+    fn render(html: &str) -> Vec<u8> {
+        crate::engine::Engine::builder()
+            .build()
+            .render_html(html)
+            .expect("smoke render")
+    }
+
+    fn render_tagged(html: &str) -> Vec<u8> {
+        crate::engine::Engine::builder()
+            .tagged(true)
+            .build()
+            .render_html(html)
+            .expect("smoke render (tagged)")
+    }
+
+    #[test]
+    fn smoke_basic_paragraph() {
+        assert!(!render("<p>Hello, world!</p>").is_empty());
+    }
+
+    #[test]
+    fn smoke_nested_blocks() {
+        assert!(!render("<div><p>outer</p><div><p>inner</p></div></div>").is_empty());
+    }
+
+    #[test]
+    fn smoke_unordered_list() {
+        assert!(!render("<ul><li>apple</li><li>banana</li></ul>").is_empty());
+    }
+
+    #[test]
+    fn smoke_ordered_list() {
+        assert!(!render("<ol><li>first</li><li>second</li></ol>").is_empty());
+    }
+
+    #[test]
+    fn smoke_table() {
+        assert!(
+            !render(
+                "<table><thead><tr><th>H1</th><th>H2</th></tr></thead>\
+             <tbody><tr><td>A</td><td>B</td></tr></tbody></table>"
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn smoke_inline_svg() {
+        assert!(
+            !render(
+                r#"<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40">
+                <circle cx="20" cy="20" r="15"/>
+            </svg>"#
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn smoke_css_transform() {
+        assert!(
+            !render(r#"<div style="transform: translateX(10px)">shifted text</div>"#).is_empty()
+        );
+    }
+
+    #[test]
+    fn smoke_overflow_clip() {
+        assert!(
+            !render(
+                r#"<div style="overflow: clip; width: 100px; height: 40px">clipped content</div>"#
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn smoke_opacity_wrapper() {
+        assert!(!render(r#"<div style="opacity: 0.5"><p>faded</p></div>"#).is_empty());
+    }
+
+    #[test]
+    fn smoke_multicolumn() {
+        assert!(
+            !render(r#"<div style="column-count: 2">alpha beta gamma delta epsilon zeta</div>"#)
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn smoke_multicolumn_with_rule() {
+        assert!(
+            !render(
+                r#"<div style="column-count: 2; column-rule: 2px solid black">
+                alpha beta gamma delta
+            </div>"#
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn smoke_tagged_heading() {
+        assert!(!render_tagged("<h1>Title</h1><p>Body text.</p>").is_empty());
+    }
+
+    #[test]
+    fn smoke_tagged_list() {
+        assert!(!render_tagged("<ul><li>Item A</li><li>Item B</li></ul>").is_empty());
+    }
+}

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -5296,7 +5296,7 @@ mod smoke_tests {
     #[test]
     fn smoke_multicolumn() {
         assert!(
-            !render(r#"<div style="column-count: 2">alpha beta gamma delta epsilon zeta</div>"#)
+            !render(r#"<div style="column-count: 2; width: 50pt">alpha beta gamma delta epsilon zeta</div>"#)
                 .is_empty()
         );
     }
@@ -5305,7 +5305,7 @@ mod smoke_tests {
     fn smoke_multicolumn_with_rule() {
         assert!(
             !render(
-                r#"<div style="column-count: 2; column-rule: 2px solid black">
+                r#"<div style="column-count: 2; column-rule: 2px solid black; width: 50pt">
                 alpha beta gamma delta
             </div>"#
             )


### PR DESCRIPTION
## 対象モジュール

`crates/fulgur/src/render.rs`

## カバレッジの変化

| 指標 | 変更前 | 変更後 |
|------|--------|--------|
| ライン | 50.18% | 73.01% |
| リージョン | 52.56% | 73.77% |
| 関数 | 54.84% | 71.86% |

ワークスペース全体のライン カバレッジも 84.87% → 87.86% に向上した。

## 追加したテスト一覧

`render::smoke_tests` モジュールに以下 13 テストを追加。いずれも `Engine::render_html(html)` を呼び出して `!pdf.is_empty()` を検証する。

| テスト名 | カバーされた主な関数 |
|----------|---------------------|
| `smoke_basic_paragraph` | `draw_v2_page`, `draw_block_v2`, `draw_paragraph_v2` |
| `smoke_nested_blocks` | `draw_block_with_inner_content` |
| `smoke_unordered_list` | `draw_list_item_with_block`, `draw_list_item_marker` |
| `smoke_ordered_list` | 順序付きリストマーカー描画パス |
| `smoke_table` | `draw_table_v2`, `paint_table_outer_frame` |
| `smoke_inline_svg` | `draw_svg_v2` |
| `smoke_css_transform` | `draw_under_transform` |
| `smoke_overflow_clip` | `draw_under_clip` |
| `smoke_opacity_wrapper` | `draw_under_opacity` |
| `smoke_multicolumn` | `paint_multicol_paragraph_slices` |
| `smoke_multicolumn_with_rule` | `paint_multicol_rule_for_page`, `build_multicol_stroke` |
| `smoke_tagged_heading` | タグ付き描画パス (`try_start_tagged`, `finish_tagged`) |
| `smoke_tagged_list` | `draw_list_item_marker_tagged` |

## 意図的にカバーしなかった箇所

| 箇所 | 理由 |
|------|------|
| `build_page_skip_sets` / `table_box_size` 等の純粋関数 | 既存の 79 個のユニットテストが網羅済み |
| `render_v2` の一部分岐（GCPM margin-box 描画、pass-2 レンダリング等） | GCPM や running element が絡む複雑なセットアップが必要。VRT / integration テストの範囲 |
| `draw_image_v2` / `decode_image_for_v2` | バイナリ画像アセットのバンドルが必要。`tests/image_test.rs` で既に integration 側でカバー済み |
| `get_body_child_dimension` | Blitz の DOM 取得が必要 |

## 備考

`render.rs` は元々カバレッジ下位 3 ファイルの 2 位（50.18%）に位置していた。最も低い `convert/positioned.rs`（26.41%）と 3 位の `convert/list_item.rs`（66.91%）はどちらも Blitz DOM に強く依存しており、純粋な unit test を追加しにくい。`render.rs` は純粋関数テスト（既存 79 件）に加えてレンダリング smoke test が有効であり、最も tractable と判断して選択した。


---
_Generated by [Claude Code](https://claude.ai/code/session_01HLxhV1CueDjUGFnKta8nmu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * レンダリングパイプラインの包括的なスモークテストを追加。タグ付き/非タグ付きの出力を含め、段落、ネストブロック、箇条書き、表、インラインSVG、CSS変形、overflowクリップ、opacity、マルチカラムやルール付きマルチカラムなど多岐にわたるレンダリングを検証し、生成PDFが空でないことを確認します。既存テストは維持。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->