### PR TITLE
docs+config(beads): modernize for bd 1.0.3 (bd dolt push, sync.remote)

### DIFF
--- a/.beads/README.md
+++ b/.beads/README.md
@@ -26,8 +26,8 @@ bd show <issue-id>
 bd update <issue-id> --status in_progress
 bd update <issue-id> --status done
 
-# Sync with git remote
-bd sync
+# Sync with Dolt remote
+bd dolt push
 ```
 
 ### Working with Issues

--- a/.beads/README.md
+++ b/.beads/README.md
@@ -26,7 +26,7 @@ bd show <issue-id>
 bd update <issue-id> --status in_progress
 bd update <issue-id> --status done
 
-# Sync with Dolt remote
+# Push to Dolt remote
 bd dolt push
 ```
 

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -65,3 +65,5 @@ sync-branch: "beads-sync"
 # - linear.api-key
 # - github.org
 # - github.repo
+
+sync.remote: "https://github.com/fulgur-rs/beads-fulgur.git"


### PR DESCRIPTION
## 概要

bd 1.0.3 移行に追従する2点をまとめる小さな PR。

### 1. README サンプル更新 (af8e44c3)

```diff
-# Sync with git remote
-bd sync
+# Sync with Dolt remote
+bd dolt push
```

bd 1.0.3 で legacy の `bd sync` サブコマンドは廃止され、Dolt backend 利用時は `bd dolt push/pull` を明示的に呼ぶ形に変更された。新しい contributor が README をそのまま叩いて `unknown command "sync"` に当たらないよう、サンプルを現行コマンドに更新する。

### 2. .beads/config.yaml に sync.remote 宣言 (45007250)

`bd hooks install` 実行時に bd が自動追記した `sync.remote: "https://github.com/fulgur-rs/beads-fulgur.git"` をコミットして永続化。次の contributor が `bd dolt push` した時に remote が未設定で失敗しないようにする。

## 動作確認

- `bd dolt push` が実コマンドであることは `bd dolt --help` で確認
- pre-commit hook (beads integration v1.0.3) を介したコミット成功

## 関連

- 直接の親 issue なし（fulgur-d6om "blitz 0.3 prep" 作業中に副次的に発見）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * クイックスタートの同期手順を bd sync から bd dolt push に更新しました。

* **Chores**
  * リモート同期設定（sync.remote）を追加し、既定のリモートを指定しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fulgur-rs/fulgur/pull/449?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->