### PR TITLE
test(convert/replaced): add coverage for DOM-dependent replaced-element paths

### DIFF
--- a/crates/fulgur/src/convert/replaced.rs
+++ b/crates/fulgur/src/convert/replaced.rs
@@ -228,6 +228,11 @@ fn convert_svg(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::asset::AssetBundle;
+    use crate::drawables::Drawables;
+    use crate::gcpm::running::RunningElementStore;
+    use blitz_html::HtmlDocument;
+    use std::ops::{Deref, DerefMut};
 
     // Minimal 1x1 red PNG.
     const TEST_PNG_1X1: &[u8] = &[
@@ -301,5 +306,243 @@ mod tests {
         assert_eq!(img.height, 1.0);
         assert_eq!(img.opacity, 0.5);
         assert!(!img.visible);
+    }
+
+    // ── resolve_image_dimensions: additional edge cases ─────────────
+
+    #[test]
+    fn resolve_image_dimensions_invalid_data_falls_back_to_1x1_intrinsic() {
+        // Corrupt bytes → decode_dimensions returns Err → unwrap_or((1,1))
+        // With css_w=None, css_h=None the intrinsic size (1,1) is returned.
+        let (w, h) =
+            resolve_image_dimensions(b"not-a-png", crate::image::ImageFormat::Png, None, None);
+        assert_eq!(w, 1.0);
+        assert_eq!(h, 1.0);
+    }
+
+    #[test]
+    fn resolve_image_dimensions_invalid_data_width_only_uses_fallback_aspect() {
+        // Corrupt bytes → intrinsic (1,1) → aspect 1.0 → height == width.
+        let (w, h) =
+            resolve_image_dimensions(b"junk", crate::image::ImageFormat::Png, Some(20.0), None);
+        assert_eq!(w, 20.0);
+        assert_eq!(h, 20.0);
+    }
+
+    // ── DOM-based helpers ────────────────────────────────────────────
+
+    fn parse_doc(html: &str) -> HtmlDocument {
+        crate::blitz_adapter::parse_and_layout(html, 595.0, 842.0, &[], false)
+    }
+
+    fn find_by_tag_inner(doc: &BaseDocument, id: usize, tag: &str) -> Option<usize> {
+        let n = doc.get_node(id)?;
+        if n.element_data()
+            .is_some_and(|e| e.name.local.as_ref() == tag)
+        {
+            return Some(id);
+        }
+        for &c in &n.children {
+            if let Some(f) = find_by_tag_inner(doc, c, tag) {
+                return Some(f);
+            }
+        }
+        None
+    }
+
+    fn find_tag(doc: &HtmlDocument, tag: &str) -> usize {
+        let root = doc.root_element();
+        find_by_tag_inner(doc.deref(), root.id, tag)
+            .unwrap_or_else(|| panic!("<{tag}> not found in document"))
+    }
+
+    fn make_ctx<'a>(
+        doc: &mut HtmlDocument,
+        store: &'a RunningElementStore,
+        assets: Option<&'a AssetBundle>,
+    ) -> ConvertContext<'a> {
+        let column_styles = crate::blitz_adapter::extract_column_style_table(doc);
+        let multicol_geometry = crate::multicol_layout::run_pass(doc.deref_mut(), &column_styles);
+        let pagination_geometry = crate::pagination_layout::run_pass(doc.deref_mut(), 842.0);
+        ConvertContext {
+            running_store: store,
+            assets,
+            font_cache: Default::default(),
+            string_set_by_node: Default::default(),
+            counter_ops_by_node: Default::default(),
+            bookmark_by_node: Default::default(),
+            column_styles,
+            multicol_geometry,
+            pagination_geometry,
+            link_cache: Default::default(),
+            viewport_size_px: Some((595.0, 842.0)),
+        }
+    }
+
+    // ── try_convert: non-replaced element ────────────────────────────
+
+    #[test]
+    fn try_convert_plain_div_returns_false() {
+        let mut doc = parse_doc(r#"<!doctype html><html><body><div>hello</div></body></html>"#);
+        let store = RunningElementStore::new();
+        let mut ctx = make_ctx(&mut doc, &store, None);
+        let mut out = Drawables::new();
+        let div_id = find_tag(&doc, "div");
+        assert!(!try_convert(doc.deref(), div_id, &mut ctx, &mut out));
+        assert!(out.images.is_empty());
+        assert!(out.svgs.is_empty());
+    }
+
+    // ── try_convert: <img> without asset bundle ───────────────────────
+
+    #[test]
+    fn try_convert_img_without_bundle_returns_false() {
+        let mut doc =
+            parse_doc(r#"<!doctype html><html><body><img src="photo.png"></body></html>"#);
+        let store = RunningElementStore::new();
+        let mut ctx = make_ctx(&mut doc, &store, None);
+        let mut out = Drawables::new();
+        let img_id = find_tag(&doc, "img");
+        assert!(!try_convert(doc.deref(), img_id, &mut ctx, &mut out));
+        assert!(out.images.is_empty());
+    }
+
+    // ── try_convert: <img> with matching bundle entry ─────────────────
+
+    #[test]
+    fn try_convert_img_with_bundle_inserts_image_entry() {
+        let mut doc = parse_doc(
+            r#"<!doctype html><html><body>
+              <img src="icon.png" style="width:30px;height:20px;">
+            </body></html>"#,
+        );
+        let mut bundle = AssetBundle::new();
+        bundle.add_image("icon.png", TEST_PNG_1X1.to_vec());
+        let store = RunningElementStore::new();
+        let mut ctx = make_ctx(&mut doc, &store, Some(&bundle));
+        let mut out = Drawables::new();
+        let img_id = find_tag(&doc, "img");
+        assert!(
+            try_convert(doc.deref(), img_id, &mut ctx, &mut out),
+            "must return true when image is found in bundle"
+        );
+        assert!(
+            out.images.contains_key(&img_id),
+            "ImageEntry must be registered for the <img> node"
+        );
+    }
+
+    // ── try_convert: <img> with missing src attribute ─────────────────
+
+    #[test]
+    fn try_convert_img_missing_src_returns_false() {
+        let mut doc = parse_doc(r#"<!doctype html><html><body><img></body></html>"#);
+        let mut bundle = AssetBundle::new();
+        bundle.add_image("something.png", TEST_PNG_1X1.to_vec());
+        let store = RunningElementStore::new();
+        let mut ctx = make_ctx(&mut doc, &store, Some(&bundle));
+        let mut out = Drawables::new();
+        let img_id = find_tag(&doc, "img");
+        // No src attribute → convert_image returns false
+        assert!(!try_convert(doc.deref(), img_id, &mut ctx, &mut out));
+        assert!(out.images.is_empty());
+    }
+
+    // ── try_convert: <img> src not in bundle ──────────────────────────
+
+    #[test]
+    fn try_convert_img_src_not_in_bundle_returns_false() {
+        let mut doc =
+            parse_doc(r#"<!doctype html><html><body><img src="missing.png"></body></html>"#);
+        let bundle = AssetBundle::new(); // empty bundle
+        let store = RunningElementStore::new();
+        let mut ctx = make_ctx(&mut doc, &store, Some(&bundle));
+        let mut out = Drawables::new();
+        let img_id = find_tag(&doc, "img");
+        assert!(!try_convert(doc.deref(), img_id, &mut ctx, &mut out));
+        assert!(out.images.is_empty());
+    }
+
+    // ── maybe_insert_block_for_replaced: no visual style ─────────────
+
+    #[test]
+    fn maybe_insert_block_no_visual_style_omits_block_entry() {
+        // A plain <img> with no border/background has no visual style.
+        let doc = parse_doc(
+            r#"<!doctype html><html><body><img src="x.png" style="width:40px;height:25px;"></body></html>"#,
+        );
+        let img_id = find_tag(&doc, "img");
+        let node = doc.get_node(img_id).unwrap();
+        let mut out = Drawables::new();
+        let (_w, _h, opacity, visible) = maybe_insert_block_for_replaced(node, None, &mut out);
+        assert!(
+            out.block_styles.is_empty(),
+            "no BlockEntry for unstyled img"
+        );
+        assert_eq!(opacity, 1.0);
+        assert!(visible);
+    }
+
+    // ── maybe_insert_block_for_replaced: visual style (border) ────────
+
+    #[test]
+    fn maybe_insert_block_with_border_inserts_block_entry_and_shrinks_content() {
+        // A 4px border on each side subtracts from content dimensions.
+        let doc = parse_doc(
+            r#"<!doctype html><html><body>
+              <img src="x.png" style="width:60px;height:40px;border:4px solid black;">
+            </body></html>"#,
+        );
+        let img_id = find_tag(&doc, "img");
+        let node = doc.get_node(img_id).unwrap();
+        let (layout_w, layout_h) = size_in_pt(node.final_layout.size);
+        let mut out = Drawables::new();
+        let (content_w, content_h, _opacity, _visible) =
+            maybe_insert_block_for_replaced(node, None, &mut out);
+        assert!(
+            out.block_styles.contains_key(&img_id),
+            "BlockEntry must be inserted for img with border"
+        );
+        // Content box must be smaller than the layout box (border is consumed).
+        // Only assert when layout gave non-zero dimensions.
+        if layout_w > 0.0 {
+            assert!(
+                content_w <= layout_w,
+                "content_w {content_w} > layout_w {layout_w}"
+            );
+        }
+        if layout_h > 0.0 {
+            assert!(
+                content_h <= layout_h,
+                "content_h {content_h} > layout_h {layout_h}"
+            );
+        }
+    }
+
+    // ── try_convert: inline SVG ───────────────────────────────────────
+
+    #[test]
+    fn try_convert_inline_svg_registers_svg_entry_when_parsed() {
+        // Blitz parses inline SVG elements and stores the tree as ImageData::Svg.
+        // If parsing succeeds, try_convert must insert an SvgEntry.
+        let mut doc = parse_doc(
+            r#"<!doctype html><html><body>
+              <svg width="50" height="50" xmlns="http://www.w3.org/2000/svg">
+                <rect fill="red" width="50" height="50"/>
+              </svg>
+            </body></html>"#,
+        );
+        let store = RunningElementStore::new();
+        let mut ctx = make_ctx(&mut doc, &store, None);
+        let mut out = Drawables::new();
+        let svg_id = find_tag(&doc, "svg");
+        let result = try_convert(doc.deref(), svg_id, &mut ctx, &mut out);
+        if result {
+            assert!(
+                out.svgs.contains_key(&svg_id),
+                "SvgEntry must be registered when try_convert returns true for <svg>"
+            );
+        }
+        // If Blitz did not materialise the SVG tree (returns false) — acceptable.
     }
 }

--- a/crates/fulgur/src/convert/replaced.rs
+++ b/crates/fulgur/src/convert/replaced.rs
@@ -503,28 +503,27 @@ mod tests {
             out.block_styles.contains_key(&img_id),
             "BlockEntry must be inserted for img with border"
         );
-        // Content box must be smaller than the layout box (border is consumed).
-        // Only assert when layout gave non-zero dimensions.
-        if layout_w > 0.0 {
-            assert!(
-                content_w <= layout_w,
-                "content_w {content_w} > layout_w {layout_w}"
-            );
-        }
-        if layout_h > 0.0 {
-            assert!(
-                content_h <= layout_h,
-                "content_h {content_h} > layout_h {layout_h}"
-            );
-        }
+        // content_w / content_h must not exceed the layout box (border is consumed).
+        // `.max(0.0)` in the production code guarantees content ≤ layout even when
+        // Taffy gives (0, 0) to an unsized element, so the assertions hold always.
+        assert!(
+            content_w <= layout_w,
+            "content_w {content_w} > layout_w {layout_w}"
+        );
+        assert!(
+            content_h <= layout_h,
+            "content_h {content_h} > layout_h {layout_h}"
+        );
     }
 
-    // ── try_convert: inline SVG ───────────────────────────────────────
+    // ── try_convert: inline SVG (smoke) ──────────────────────────────
 
     #[test]
-    fn try_convert_inline_svg_registers_svg_entry_when_parsed() {
-        // Blitz parses inline SVG elements and stores the tree as ImageData::Svg.
-        // If parsing succeeds, try_convert must insert an SvgEntry.
+    fn try_convert_inline_svg_does_not_panic() {
+        // Blitz may or may not materialise the SVG tree in a test environment
+        // (inline SVG parsing depends on system fonts via fontdb). We verify
+        // only that try_convert completes without panicking and that any
+        // registered SvgEntry is consistent with the return value.
         let mut doc = parse_doc(
             r#"<!doctype html><html><body>
               <svg width="50" height="50" xmlns="http://www.w3.org/2000/svg">
@@ -537,12 +536,7 @@ mod tests {
         let mut out = Drawables::new();
         let svg_id = find_tag(&doc, "svg");
         let result = try_convert(doc.deref(), svg_id, &mut ctx, &mut out);
-        if result {
-            assert!(
-                out.svgs.contains_key(&svg_id),
-                "SvgEntry must be registered when try_convert returns true for <svg>"
-            );
-        }
-        // If Blitz did not materialise the SVG tree (returns false) — acceptable.
+        // Invariant: if try_convert returned true, the SvgEntry must be present.
+        assert_eq!(result, out.svgs.contains_key(&svg_id));
     }
 }

--- a/crates/fulgur/src/convert/replaced.rs
+++ b/crates/fulgur/src/convert/replaced.rs
@@ -232,7 +232,7 @@ mod tests {
     use crate::drawables::Drawables;
     use crate::gcpm::running::RunningElementStore;
     use blitz_html::HtmlDocument;
-    use std::ops::{Deref, DerefMut};
+    use std::ops::Deref;
 
     // Minimal 1x1 red PNG.
     const TEST_PNG_1X1: &[u8] = &[
@@ -352,7 +352,7 @@ mod tests {
 
     fn find_tag(doc: &HtmlDocument, tag: &str) -> usize {
         let root = doc.root_element();
-        find_by_tag_inner(doc.deref(), root.id, tag)
+        find_by_tag_inner(doc, root.id, tag)
             .unwrap_or_else(|| panic!("<{tag}> not found in document"))
     }
 
@@ -362,8 +362,8 @@ mod tests {
         assets: Option<&'a AssetBundle>,
     ) -> ConvertContext<'a> {
         let column_styles = crate::blitz_adapter::extract_column_style_table(doc);
-        let multicol_geometry = crate::multicol_layout::run_pass(doc.deref_mut(), &column_styles);
-        let pagination_geometry = crate::pagination_layout::run_pass(doc.deref_mut(), 842.0);
+        let multicol_geometry = crate::multicol_layout::run_pass(doc, &column_styles);
+        let pagination_geometry = crate::pagination_layout::run_pass(doc, 842.0);
         ConvertContext {
             running_store: store,
             assets,


### PR DESCRIPTION
## 対象モジュール

`crates/fulgur/src/convert/replaced.rs`

## カバレッジ変化

| 指標 | 変更前 | 変更後 |
|------|--------|--------|
| Regions | 64.44% (174/270) | **92.09%** (547/594) |
| Lines | 68.50% (137/200) | **92.88%** (339/365) |
| Functions | 91.67% (11/12) | **96.43%** (27/28) |

## 追加したテスト一覧

### 純関数（`resolve_image_dimensions`）の追加ケース

- `resolve_image_dimensions_invalid_data_falls_back_to_1x1_intrinsic` — 不正なバイト列を渡すと `decode_dimensions` が失敗し、フォールバックの (1,1) が使われることを確認
- `resolve_image_dimensions_invalid_data_width_only_uses_fallback_aspect` — 不正データ時のアスペクト比フォールバック（aspect=1.0 → height==width）を確認

### DOM ベーステスト（`try_convert` / `convert_image`）

- `try_convert_plain_div_returns_false` — 非置換要素（`<div>`）は `false` を返し、`images` / `svgs` が空のまま
- `try_convert_img_without_bundle_returns_false` — AssetBundle なしの `<img>` は `false`
- `try_convert_img_with_bundle_inserts_image_entry` — 有効な AssetBundle を渡すと `true` かつ `images` にエントリが登録される
- `try_convert_img_missing_src_returns_false` — `src` 属性なし `<img>` は `false`
- `try_convert_img_src_not_in_bundle_returns_false` — `src` に対応する画像がバンドルにない場合は `false`

### DOM ベーステスト（`maybe_insert_block_for_replaced`）

- `maybe_insert_block_no_visual_style_omits_block_entry` — ボーダー・背景なしの `<img>` は `BlockEntry` を挿入しない
- `maybe_insert_block_with_border_inserts_block_entry_and_shrinks_content` — `border: 4px solid black` ありの要素は `BlockEntry` を挿入し、コンテンツ寸法がレイアウト寸法より小さくなる

### DOM ベーステスト（`convert_svg`）

- `try_convert_inline_svg_registers_svg_entry_when_parsed` — Blitz が inline `<svg>` を `ImageData::Svg` として materialise した場合、`svgs` にエントリが登録される（SVG parse が失敗した場合は `false` を許容）

## 意図的にカバーしなかったブランチ

| ブランチ | 理由 |
|----------|------|
| `resolve_image_dimensions` 内の `else { 1.0 }` (ih≤0) および `else { w }` (aspect≤0) | `decode_dimensions` の `unwrap_or((1,1))` フォールバックにより ih=0 は到達不可能なデッドコード |
| `convert_content_url` の本体 | 通常要素の `content: url(...)` は Blitz 0.2.4 がレイアウトに materialise しないため、テスト可能な DOM 構成が確立できない |
| `convert_svg` で `extract_inline_svg_tree` が成功する経路 | Blitz の SVG parse が環境依存（システムフォント読み込み）で deterministic でないため、成功を assert せず条件付きにした |

https://claude.ai/code/session_017uUgaKS6P4C5UJtj867LR3

---
_Generated by [Claude Code](https://claude.ai/code/session_017uUgaKS6P4C5UJtj867LR3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * 置換要素の変換処理に関する包括的なテストスイートを追加しました。
  * 画像の壊れたデータ時の1×1フォールバックや、幅のみ指定時にアスペクト比から高さが導出される挙動を検証するテストを追加しました。
  * DOM解析・レイアウト補助を用いて、div/img/svgの変換結果やSVG登録、ボーダー等の有無によるブロック挿入と表示領域計算の動作を確認するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->