### PR TITLE
test(convert/positioned): add coverage for cb_padding_box and resolve_cb_for_absolute

### DIFF
--- a/crates/fulgur/src/convert/positioned.rs
+++ b/crates/fulgur/src/convert/positioned.rs
@@ -875,9 +875,16 @@ mod tests {
         let span_node = doc.get_node(span_id).unwrap();
         let result = resolve_cb_for_absolute(doc.deref(), span_node, false, Some((595.0, 842.0)));
         // All ancestors are static → body fallback must be returned.
+        let cb = result.expect(
+            "body fallback should always produce Some when the document has a body element",
+        );
+        // Body is viewport-wide (~579px after default margins), which is wider
+        // than the 200px div. Asserting > 200 proves the function used the body
+        // CB and did not stop at the static div ancestor.
         assert!(
-            result.is_some(),
-            "body fallback should always produce Some when the document has a body element"
+            cb.padding_box_size.0 > 200.0,
+            "body padding-box width should exceed the 200px static div, confirming body fallback was used; got {}",
+            cb.padding_box_size.0
         );
     }
 
@@ -897,9 +904,15 @@ mod tests {
         let div_node = doc.get_node(div_id).unwrap();
         let result = resolve_cb_for_absolute(doc.deref(), div_node, true, Some((595.0, 842.0)));
         // is_fixed=true → relative section is skipped → body fallback returned.
+        let cb = result
+            .expect("fixed: body fallback should be returned even when a relative parent exists");
+        // Body is viewport-wide (~579px after default margins), which is wider
+        // than the 200px section. Asserting > 200 proves the function skipped
+        // the relative section and used the body CB instead.
         assert!(
-            result.is_some(),
-            "fixed: body fallback should be returned even when a relative parent exists"
+            cb.padding_box_size.0 > 200.0,
+            "fixed: body padding-box width should exceed the 200px relative section, confirming it was skipped; got {}",
+            cb.padding_box_size.0
         );
     }
 
@@ -953,9 +966,10 @@ mod tests {
 
         walk_absolute_children(doc.deref(), section_node, &mut ctx, 0, &mut out);
 
+        let abs_div_id = find_tag(&doc, "div");
         assert!(
-            !out.block_styles.is_empty() || !out.paragraphs.is_empty(),
-            "abs-positioned child must be registered by walk_absolute_children"
+            out.block_styles.contains_key(&abs_div_id) || out.paragraphs.contains_key(&abs_div_id),
+            "abs-positioned div must be registered by walk_absolute_children"
         );
     }
 }

--- a/crates/fulgur/src/convert/positioned.rs
+++ b/crates/fulgur/src/convert/positioned.rs
@@ -727,4 +727,235 @@ mod tests {
             "abs child must be excluded by walk_children_into_drawables"
         );
     }
+
+    #[test]
+    fn walk_children_into_drawables_skips_non_visual_elements() {
+        // A section that contains a <script> (non-visual) child and a <div>
+        // child with text. The script should be filtered out; the div must
+        // produce at least one draw entry.
+        let mut doc = crate::blitz_adapter::parse_and_layout(
+            r#"<!doctype html><html><body>
+              <section>
+                <script>/* noise */</script>
+                <div>content</div>
+              </section>
+            </body></html>"#,
+            595.0,
+            842.0,
+            &[],
+            false,
+        );
+        let running_store = RunningElementStore::new();
+        let mut ctx = make_ctx(&mut doc, &running_store);
+        let mut out = crate::drawables::Drawables::new();
+
+        let section_id = find_tag(&doc, "section");
+        let child_ids: Vec<usize> = doc
+            .get_node(section_id)
+            .map(|n| n.children.clone())
+            .unwrap_or_default();
+
+        walk_children_into_drawables(doc.deref(), &child_ids, &mut ctx, 0, &mut out);
+
+        // Script node (if present in the DOM) must not have been registered.
+        // Div with "content" should produce at least one draw entry.
+        if let Some(script_id) = find_first_by_tag(doc.deref(), doc.root_element().id, "script") {
+            assert!(
+                !out.block_styles.contains_key(&script_id)
+                    && !out.paragraphs.contains_key(&script_id),
+                "script element must be skipped by walk_children_into_drawables"
+            );
+        }
+        // At a minimum the div with text should produce a paragraph entry.
+        assert!(
+            !out.block_styles.is_empty() || !out.paragraphs.is_empty(),
+            "div child must produce at least one draw entry"
+        );
+    }
+
+    // ── cb_padding_box ────────────────────────────────────────────────
+
+    #[test]
+    fn cb_padding_box_no_border_returns_full_layout_size_and_zero_offsets() {
+        // A div with explicit size but no border. The padding box should equal
+        // the Taffy layout size (sz.width, sz.height) and border_top_left = (0, 0).
+        let doc = parse_doc(
+            r#"<!doctype html><html><body>
+                <div style="width:100px;height:50px;">x</div>
+            </body></html>"#,
+        );
+        let div_id = find_tag(&doc, "div");
+        let node = doc.get_node(div_id).unwrap();
+        let ((pb_w, pb_h), (bl, bt)) = cb_padding_box(node);
+        let sz = node.final_layout.size;
+        // No border → pb_w == sz.width, pb_h == sz.height.
+        assert!(
+            (pb_w - sz.width).abs() < 0.01,
+            "no border: pb_w should equal layout width; pb_w={pb_w} sz.width={sz_w}",
+            sz_w = sz.width
+        );
+        assert!(
+            (pb_h - sz.height).abs() < 0.01,
+            "no border: pb_h should equal layout height; pb_h={pb_h} sz.height={sz_h}",
+            sz_h = sz.height
+        );
+        assert!(
+            bl.abs() < 0.001,
+            "no border: left offset should be 0; got {bl}"
+        );
+        assert!(
+            bt.abs() < 0.001,
+            "no border: top offset should be 0; got {bt}"
+        );
+    }
+
+    #[test]
+    fn cb_padding_box_with_border_reduces_padding_box_and_gives_nonzero_offsets() {
+        // A div with a 10px uniform border. The padding box must be strictly
+        // smaller than the border-box and border_top_left must be > 0.
+        let doc = parse_doc(
+            r#"<!doctype html><html><body>
+                <div style="width:100px;height:100px;border:10px solid black;">x</div>
+            </body></html>"#,
+        );
+        let div_id = find_tag(&doc, "div");
+        let node = doc.get_node(div_id).unwrap();
+        let ((pb_w, _pb_h), (bl, bt)) = cb_padding_box(node);
+        let sz = node.final_layout.size;
+        // With 10px border on each side, the border-box is 120×120px and the
+        // padding box (content) is 100×100px.
+        assert!(
+            pb_w < sz.width,
+            "10px border: padding box width must be less than border-box; pb_w={pb_w} sz.width={sz_w}",
+            sz_w = sz.width
+        );
+        assert!(bl > 0.0, "10px border: left offset must be > 0; got {bl}");
+        assert!(bt > 0.0, "10px border: top offset must be > 0; got {bt}");
+    }
+
+    // ── resolve_cb_for_absolute ───────────────────────────────────────
+
+    #[test]
+    fn resolve_cb_for_absolute_returns_some_for_positioned_ancestor() {
+        // Pass the div child of a position:relative section. The function
+        // must walk up, find the relative section, and return Some immediately.
+        let doc = parse_doc(
+            r#"<!doctype html><html><body>
+                <section style="position:relative;width:200px;height:100px;">
+                    <div>text</div>
+                </section>
+            </body></html>"#,
+        );
+        let div_id = find_tag(&doc, "div");
+        let div_node = doc.get_node(div_id).unwrap();
+        let result = resolve_cb_for_absolute(doc.deref(), div_node, false, None);
+        assert!(
+            result.is_some(),
+            "position:relative section should be found as containing block"
+        );
+        let cb = result.unwrap();
+        assert!(
+            cb.padding_box_size.0 > 0.0,
+            "CB padding-box width should be > 0 (section has explicit width)"
+        );
+    }
+
+    #[test]
+    fn resolve_cb_for_absolute_uses_body_fallback_when_all_ancestors_static() {
+        // The span's parent div is static, so resolve_cb_for_absolute should
+        // walk all the way up to body and return the body fallback.
+        let doc = parse_doc(
+            r#"<!doctype html><html><body>
+                <div style="width:200px;height:100px;">
+                    <span>text</span>
+                </div>
+            </body></html>"#,
+        );
+        let span_id = find_tag(&doc, "span");
+        let span_node = doc.get_node(span_id).unwrap();
+        let result = resolve_cb_for_absolute(doc.deref(), span_node, false, Some((595.0, 842.0)));
+        // All ancestors are static → body fallback must be returned.
+        assert!(
+            result.is_some(),
+            "body fallback should always produce Some when the document has a body element"
+        );
+    }
+
+    #[test]
+    fn resolve_cb_for_absolute_fixed_skips_positioned_ancestors_and_uses_body_fallback() {
+        // With is_fixed=true the `!is_fixed && !is_position_static(cur)` check
+        // short-circuits to false, so even a position:relative parent is ignored
+        // and the body fallback is used.
+        let doc = parse_doc(
+            r#"<!doctype html><html><body>
+                <section style="position:relative;width:200px;height:100px;">
+                    <div>text</div>
+                </section>
+            </body></html>"#,
+        );
+        let div_id = find_tag(&doc, "div");
+        let div_node = doc.get_node(div_id).unwrap();
+        let result = resolve_cb_for_absolute(doc.deref(), div_node, true, Some((595.0, 842.0)));
+        // is_fixed=true → relative section is skipped → body fallback returned.
+        assert!(
+            result.is_some(),
+            "fixed: body fallback should be returned even when a relative parent exists"
+        );
+    }
+
+    #[test]
+    fn resolve_cb_for_absolute_positioned_node_passed_directly_returns_some() {
+        // When we pass a node that is itself non-static, the function returns
+        // Some on the very first iteration (cur == parent, is_position_static=false).
+        let doc = parse_doc(
+            r#"<!doctype html><html><body>
+                <div style="position:relative;width:150px;height:80px;">x</div>
+            </body></html>"#,
+        );
+        let div_id = find_tag(&doc, "div");
+        let div_node = doc.get_node(div_id).unwrap();
+        let result = resolve_cb_for_absolute(doc.deref(), div_node, false, None);
+        assert!(result.is_some(), "non-static node passed directly → Some");
+        let cb = result.unwrap();
+        // parent_offset_in_cb_bp should be (0,0) since the loop fires immediately
+        // (no offset accumulated yet).
+        assert!(
+            (cb.parent_offset_in_cb_bp.0).abs() < 0.001,
+            "no offset accumulated on first iteration"
+        );
+    }
+
+    // ── walk_absolute_children ────────────────────────────────────────
+
+    #[test]
+    fn walk_absolute_children_registers_abs_positioned_child() {
+        // walk_absolute_children is the combined entry that calls both
+        // walk_absolute_pseudo_children and walk_absolute_non_pseudo_children.
+        // Verify that an abs-positioned non-pseudo child is registered via the
+        // non-pseudo path.
+        let mut doc = crate::blitz_adapter::parse_and_layout(
+            r#"<!doctype html><html><body>
+              <section style="position:relative;">
+                <div style="position:absolute;width:20px;height:20px;">abs</div>
+              </section>
+            </body></html>"#,
+            595.0,
+            842.0,
+            &[],
+            false,
+        );
+        let running_store = RunningElementStore::new();
+        let mut ctx = make_ctx(&mut doc, &running_store);
+        let mut out = crate::drawables::Drawables::new();
+
+        let section_id = find_tag(&doc, "section");
+        let section_node = doc.get_node(section_id).unwrap();
+
+        walk_absolute_children(doc.deref(), section_node, &mut ctx, 0, &mut out);
+
+        assert!(
+            !out.block_styles.is_empty() || !out.paragraphs.is_empty(),
+            "abs-positioned child must be registered by walk_absolute_children"
+        );
+    }
 }


### PR DESCRIPTION
## 対象モジュール

`crates/fulgur/src/convert/positioned.rs`

## カバレッジ変化

| 指標 | 変更前 | 変更後 |
|------|--------|--------|
| ライン カバレッジ | 56.22% | 75.39% |
| リージョン カバレッジ | 57.76% | 76.01% |
| 関数カバレッジ | 73.81% | 82.35% |

全体 (TOTAL) も 85.16% → 85.39% に微増。

## 追加テスト一覧

### `cb_padding_box` 系

| テスト名 | 概要 |
|----------|------|
| `cb_padding_box_no_border_returns_full_layout_size_and_zero_offsets` | ボーダーなし div → padding-box = レイアウトサイズ、border_top_left = (0, 0) |
| `cb_padding_box_with_border_reduces_padding_box_and_gives_nonzero_offsets` | 10px ボーダー付き div → padding-box < border-box、オフセット > 0 |

### `resolve_cb_for_absolute` 系

| テスト名 | 概要 |
|----------|------|
| `resolve_cb_for_absolute_returns_some_for_positioned_ancestor` | `position:relative` の section の子 div を渡す → 祖先を上昇して Some を返す |
| `resolve_cb_for_absolute_uses_body_fallback_when_all_ancestors_static` | 全祖先が static → body フォールバックで Some を返す |
| `resolve_cb_for_absolute_fixed_skips_positioned_ancestors_and_uses_body_fallback` | `is_fixed=true` → `position:relative` 親を無視して body フォールバックを返す |
| `resolve_cb_for_absolute_positioned_node_passed_directly_returns_some` | 非 static ノードを直接渡す → 初回ループで即 Some を返す (parent_offset = 0) |

### `walk_children_into_drawables` 系

| テスト名 | 概要 |
|----------|------|
| `walk_children_into_drawables_skips_non_visual_elements` | section 内の `<script>` が `is_non_visual_element` によりスキップされる |

### `walk_absolute_children`

| テスト名 | 概要 |
|----------|------|
| `walk_absolute_children_registers_abs_positioned_child` | abs-positioned 子が非 pseudo パスを通じて登録される (thin wrapper のオーケストレーションを確認) |

## 意図的にカバーしなかったブランチ

| ブランチ / 関数 | 省略理由 |
|----------------|----------|
| `walk_children_into_drawables` の `depth >= MAX_DOM_DEPTH` ガード (line 25) | MAX_DOM_DEPTH = 512 のため、自然なテスト用 HTML で再現するにはネストが深すぎる。実用上の影響は軽微。 |
| `walk_children_into_drawables` の `NodeData::Comment` skip (line 31) | Blitz が `<!-- ... -->` を `NodeData::Comment` としてリストするかどうかが未確認のため保留。 |
| `resolve_cb_for_absolute` の `padding_box_size <= 0.0` ビューポート補完 (lines 125-130) | 通常の HTML では body に Taffy がビューポート幅を割り当てるため、この分岐は発生しにくい。 |
| `resolve_inset_px` (lines 165-175) | Stylo の `GenericInset::LengthPercentage` を直接構築する安全な方法がないため除外。 |
| `maybe_apply_abs_pseudo_inset_correction` (lines 197-314) | abs pseudo + `content:url()` + `right`/`bottom` inset という組み合わせは既存の結合テスト (`pseudo_absolute_content_url`) でカバー済みであり、単体テストの追加コストが高い。 |
| `walk_absolute_pseudo_children` の pseudo 経路 (lines 336-386) | `::before`/`::after` に `position:absolute` を設定した Blitz ノードをテスト内で確実に得る方法が複雑なため除外。 |
| `try_build_absolute_pseudo_image` の visual_style ガード / cb=None 経路 (lines 442-455) | `extract_content_image_url` が Some を返す擬似要素ノードを構築するには Blitz のフル解析が必要で、統合テストの領域に属する。 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01XrfgLa4QsLAUxsNn8s5oM9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * レイアウト/配置のテストカバレッジを拡張。
  * 非表示・非ビジュアル要素のスキップと、テキストを持つ要素の登録を検証。
  * パディングボックス計算の境界条件（ボーダー有無によるサイズ/オフセット差）を確認。
  * 包含ブロックの解決や祖先の振る舞い、絶対配置要素の登録動作を複数シナリオで検証。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->