### PR TITLE
test(render): cover Jpeg/Gif image format branches and MarginBoxRenderer non-empty GCPM paths

### DIFF
--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -1319,6 +1319,18 @@ mod tests {
     }
 
     #[test]
+    fn paragraph_with_node_id_stores_value() {
+        let p = ParagraphRender::new(Vec::new()).with_node_id(Some(42));
+        assert_eq!(p.node_id, Some(42));
+    }
+
+    #[test]
+    fn paragraph_with_node_id_none_stores_none() {
+        let p = ParagraphRender::new(Vec::new()).with_node_id(None);
+        assert_eq!(p.node_id, None);
+    }
+
+    #[test]
     fn line_item_inline_box_variant_can_be_constructed() {
         let item = LineItem::InlineBox(InlineBoxItem {
             node_id: Some(42),

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -5326,4 +5326,125 @@ mod tests {
         assert_eq!(tree.children.len(), 1, "one root Group");
         assert!(matches!(tree.children[0], Node::Group(_)));
     }
+
+    // --- decode_image_for_v2: Jpeg and Gif format branches ---
+
+    fn make_image_entry(
+        format: crate::image::ImageFormat,
+        data: Vec<u8>,
+    ) -> crate::drawables::ImageEntry {
+        crate::drawables::ImageEntry {
+            image_data: Arc::new(data),
+            format,
+            width: 10.0,
+            height: 10.0,
+            opacity: 1.0,
+            visible: true,
+        }
+    }
+
+    #[test]
+    fn decode_image_for_v2_jpeg_invalid_data_returns_none() {
+        let entry = make_image_entry(crate::image::ImageFormat::Jpeg, vec![0xFF, 0xD8, 0xFF]);
+        let result = decode_image_for_v2(&entry);
+        assert!(result.is_none(), "invalid JPEG bytes should return None");
+    }
+
+    #[test]
+    fn decode_image_for_v2_gif_invalid_data_returns_none() {
+        let entry = make_image_entry(crate::image::ImageFormat::Gif, b"GIF89a".to_vec());
+        let result = decode_image_for_v2(&entry);
+        assert!(result.is_none(), "invalid GIF bytes should return None");
+    }
+
+    // --- MarginBoxRenderer::new: non-empty GCPM mapping branches ---
+
+    fn empty_geometry() -> crate::pagination_layout::PaginationGeometryTable {
+        BTreeMap::new()
+    }
+
+    #[test]
+    fn margin_box_renderer_new_with_string_set_mappings_takes_else_branch() {
+        // Non-empty string_set_mappings forces the else branch at
+        // `collect_string_set_states(pagination_geometry, &by_node_btree)`.
+        let gcpm = crate::gcpm::GcpmContext {
+            string_set_mappings: vec![crate::gcpm::StringSetMapping {
+                parsed: crate::gcpm::ParsedSelector::Class("hd".to_string()),
+                name: "chapter".to_string(),
+                values: vec![crate::gcpm::StringSetValue::ContentText],
+            }],
+            ..Default::default()
+        };
+        let store = RunningElementStore::default();
+        let geom = empty_geometry();
+        let implicit: BTreeMap<usize, String> = BTreeMap::new();
+        let _mbr = MarginBoxRenderer::new(
+            &gcpm,
+            &store,
+            &[],
+            false,
+            &geom,
+            &HashMap::new(),
+            &BTreeMap::new(),
+            1,
+            &implicit,
+        );
+    }
+
+    #[test]
+    fn margin_box_renderer_new_with_running_mappings_takes_else_branch() {
+        // Non-empty running_mappings forces the else branch at
+        // `collect_running_element_states(pagination_geometry, running_store)`.
+        let gcpm = crate::gcpm::GcpmContext {
+            running_mappings: vec![crate::gcpm::RunningMapping {
+                parsed: crate::gcpm::ParsedSelector::Class("hd".to_string()),
+                running_name: "header".to_string(),
+            }],
+            ..Default::default()
+        };
+        let store = RunningElementStore::default();
+        let geom = empty_geometry();
+        let implicit: BTreeMap<usize, String> = BTreeMap::new();
+        let _mbr = MarginBoxRenderer::new(
+            &gcpm,
+            &store,
+            &[],
+            false,
+            &geom,
+            &HashMap::new(),
+            &BTreeMap::new(),
+            1,
+            &implicit,
+        );
+    }
+
+    #[test]
+    fn margin_box_renderer_new_with_counter_mappings_takes_else_branch() {
+        // Non-empty counter_mappings forces the else branch at
+        // `collect_counter_states(pagination_geometry, counter_ops_by_node)`.
+        let gcpm = crate::gcpm::GcpmContext {
+            counter_mappings: vec![crate::gcpm::CounterMapping {
+                parsed: crate::gcpm::ParsedSelector::Tag("h1".to_string()),
+                ops: vec![crate::gcpm::CounterOp::Reset {
+                    name: "chapter".to_string(),
+                    value: 0,
+                }],
+            }],
+            ..Default::default()
+        };
+        let store = RunningElementStore::default();
+        let geom = empty_geometry();
+        let implicit: BTreeMap<usize, String> = BTreeMap::new();
+        let _mbr = MarginBoxRenderer::new(
+            &gcpm,
+            &store,
+            &[],
+            false,
+            &geom,
+            &HashMap::new(),
+            &BTreeMap::new(),
+            1,
+            &implicit,
+        );
+    }
 }


### PR DESCRIPTION
## 対象モジュールとカバレッジ変化

| ファイル | 変更前 | 変更後 | 増加 |
|---|---|---|---|
| `crates/fulgur/src/render.rs` | 54.78% | 55.99% | +1.21 pp |
| `crates/fulgur/src/paragraph.rs` | 72.80% | 73.38% | +0.58 pp |

`render.rs` は最もカバレッジが低いファイル（3ファイル中1位）として選定。

## 追加テスト一覧

### render.rs

**`decode_image_for_v2`（Jpeg / Gif ブランチ、行 2456–2457）**
- `decode_image_for_v2_jpeg_invalid_data_returns_none` — `ImageFormat::Jpeg` で不正バイト列を渡すと `None` が返ること
- `decode_image_for_v2_gif_invalid_data_returns_none` — `ImageFormat::Gif` で不正バイト列を渡すと `None` が返ること

**`MarginBoxRenderer::new`（非空 GCPM マッピング時の else ブランチ、行 3411–3432）**
- `margin_box_renderer_new_with_string_set_mappings_takes_else_branch` — `string_set_mappings` が非空のとき `collect_string_set_states` を呼ぶパスを通ること
- `margin_box_renderer_new_with_running_mappings_takes_else_branch` — `running_mappings` が非空のとき `collect_running_element_states` を呼ぶパスを通ること
- `margin_box_renderer_new_with_counter_mappings_takes_else_branch` — `counter_mappings` が非空のとき `collect_counter_states` を呼ぶパスを通ること

### paragraph.rs

**`ParagraphRender::with_node_id`（行 219–222）**
- `paragraph_with_node_id_stores_value` — `Some(42)` が正しく格納されること
- `paragraph_with_node_id_none_stores_none` — `None` が正しく格納されること

## 意図的な除外とその理由

- `draw_under_clip`, `draw_under_opacity`, `draw_under_transform`, `render_page` など、canvas 依存の描画関数（合計 1,500+ 行）: Krilla の `Surface` を構築せずには実行不可能なため、`--lib` 単体テストではカバー不能。これらは VRT と `render_smoke.rs` の end-to-end テストで担保されており、lib 側での unit test 追加は設計上困難。
- `build_multicol_stroke` の `ColumnRuleStyle::None => return None` 行（行 2387）: 前段の早期リターン `if rule.width <= 0.0 || rule.style == ColumnRuleStyle::None` で必ずガードされる到達不能コード。LLVM-cov が uncovered と報告するが、これは dead code であり、テストで無理に埋めることはしない。
- `convert/list_item.rs`, `convert/pseudo.rs`: 残存する未カバー行はいずれも Blitz DOM ノードを必要とする関数内にあり、unit test では対応不可。

https://claude.ai/code/session_016RrkyCp7R2n9kVHXmwq6a1

---
_Generated by [Claude Code](https://claude.ai/code/session_016RrkyCp7R2n9kVHXmwq6a1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 画像デコード機能の検証テストを追加しました。
  * レンダリング構成の検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->