### PR TITLE
test(schema): add coverage for expression types, stmt kinds, and ensure_array_at_path

### DIFF
--- a/crates/fulgur/src/schema.rs
+++ b/crates/fulgur/src/schema.rs
@@ -1024,6 +1024,14 @@ mod tests {
             schema["properties"]["user"]["properties"]["items"]["type"],
             "array"
         );
+        assert_eq!(
+            schema["properties"]["user"]["properties"]["items"]["items"]["type"],
+            "object"
+        );
+        assert_eq!(
+            schema["properties"]["user"]["properties"]["items"]["items"]["properties"]["val"]["type"],
+            "string"
+        );
     }
 
     // ── ensure_array_at_path: Array arms (lines 529–547) ─────────────────────
@@ -1033,13 +1041,28 @@ mod tests {
         // First for loop marks "data" as Array(String).
         // Second for loop calls ensure_array_at_path(root, ["data","sub"]):
         //   → entry at "data" is Array(String) → inner match `other` arm (lines 535-540):
-        //     upgrades inner from String to Object.
+        //     upgrades inner from String to Object({"sub": Array(String)}).
+        // `{{ x.v }}` then sets sub's items to Object({"v": String}).
         let schema = extract_schema(
             "{% for x in data %}{% endfor %}{% for x in data.sub %}{{ x.v }}{% endfor %}",
             "t.html",
         )
         .unwrap();
         assert_eq!(schema["properties"]["data"]["type"], "array");
+        assert_eq!(schema["properties"]["data"]["items"]["type"], "object");
+        assert_eq!(
+            schema["properties"]["data"]["items"]["properties"]["sub"]["type"],
+            "array"
+        );
+        assert_eq!(
+            schema["properties"]["data"]["items"]["properties"]["sub"]["items"]["type"],
+            "object"
+        );
+        assert_eq!(
+            schema["properties"]["data"]["items"]["properties"]["sub"]["items"]["properties"]["v"]
+                ["type"],
+            "string"
+        );
     }
 
     #[test]
@@ -1048,7 +1071,7 @@ mod tests {
         //  1. `{% for x in a %}` → a = Array(String)
         //  2. `{% for x in a.b %}` → upgrades a's inner to Object({"b": Array(String)})
         //  3. `{% for x in a.b.c %}` → a = Array(Object({"b":...})) → inner match Object arm
-        //                              (lines 531-533) → descends into children.
+        //                              (lines 531-533) → descends into b's children.
         let schema = extract_schema(
             "{% for x in a %}{% endfor %}\
              {% for x in a.b %}{% endfor %}\
@@ -1057,5 +1080,23 @@ mod tests {
         )
         .unwrap();
         assert_eq!(schema["properties"]["a"]["type"], "array");
+        assert_eq!(schema["properties"]["a"]["items"]["type"], "object");
+        assert_eq!(
+            schema["properties"]["a"]["items"]["properties"]["b"]["type"],
+            "array"
+        );
+        assert_eq!(
+            schema["properties"]["a"]["items"]["properties"]["b"]["items"]["type"],
+            "object"
+        );
+        assert_eq!(
+            schema["properties"]["a"]["items"]["properties"]["b"]["items"]["properties"]["c"]["type"],
+            "array"
+        );
+        assert_eq!(
+            schema["properties"]["a"]["items"]["properties"]["b"]["items"]["properties"]["c"]["items"]
+                ["type"],
+            "string"
+        );
     }
 }

--- a/crates/fulgur/src/schema.rs
+++ b/crates/fulgur/src/schema.rs
@@ -1032,6 +1032,14 @@ mod tests {
             schema["properties"]["user"]["properties"]["items"]["items"]["properties"]["val"]["type"],
             "string"
         );
+        assert_eq!(
+            schema["properties"]["user"]["properties"]["items"]["items"]["type"],
+            "object"
+        );
+        assert_eq!(
+            schema["properties"]["user"]["properties"]["items"]["items"]["properties"]["val"]["type"],
+            "string"
+        );
     }
 
     // ── ensure_array_at_path: Array arms (lines 529–547) ─────────────────────

--- a/crates/fulgur/src/schema.rs
+++ b/crates/fulgur/src/schema.rs
@@ -792,4 +792,270 @@ mod tests {
         assert_eq!(schema["properties"]["title"]["type"], "string");
         assert_eq!(schema["properties"]["subtitle"]["type"], "string");
     }
+
+    // ── error paths ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn extract_schema_parse_error_returns_err() {
+        let result = extract_schema("{% if %}", "t.html");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn extract_schema_with_data_parse_error_returns_err() {
+        let result = extract_schema_with_data("{% if %}", "t.html", &json!({}));
+        assert!(result.is_err());
+    }
+
+    // ── value_to_schema coverage (via extract_schema_with_data) ──────────────
+
+    #[test]
+    fn value_to_schema_bool_inferred_from_data() {
+        let data = json!({"flag": true});
+        let schema = extract_schema_with_data("{{ flag }}", "t.html", &data).unwrap();
+        assert_eq!(schema["properties"]["flag"]["type"], "boolean");
+    }
+
+    #[test]
+    fn value_to_schema_null_inferred_from_data() {
+        let data = json!({"val": null});
+        let schema = extract_schema_with_data("{{ val }}", "t.html", &data).unwrap();
+        assert_eq!(schema["properties"]["val"]["type"], "null");
+    }
+
+    #[test]
+    fn value_to_schema_empty_array_inferred_from_data() {
+        let data = json!({"items": []});
+        let schema = extract_schema_with_data("{{ items }}", "t.html", &data).unwrap();
+        assert_eq!(schema["properties"]["items"]["type"], "array");
+        // Empty array → no "items" key on the array schema
+        assert!(schema["properties"]["items"]["items"].is_null());
+    }
+
+    #[test]
+    fn extract_schema_with_data_non_object_data_yields_empty_properties() {
+        // data is not a JSON object → the `if let Value::Object` branch is skipped
+        let schema = extract_schema_with_data("{{ x }}", "t.html", &json!([1, 2, 3])).unwrap();
+        assert!(schema["properties"]["x"].is_null());
+    }
+
+    // ── SetBlock statement ({% set x %}...{% endset %}) ───────────────────────
+
+    #[test]
+    fn set_block_body_variables_collected_and_var_not_leaked() {
+        // SetBlock: the var "x" should be local; "name" from the body must appear.
+        let schema = extract_schema("{% set x %}{{ name }}{% endset %}", "t.html").unwrap();
+        assert_eq!(schema["properties"]["name"]["type"], "string");
+        assert!(schema["properties"]["x"].is_null());
+    }
+
+    // ── FilterBlock statement ({% filter ... %}...{% endfilter %}) ────────────
+
+    #[test]
+    fn filter_block_body_variables_collected() {
+        let schema =
+            extract_schema("{% filter upper %}{{ greeting }}{% endfilter %}", "t.html").unwrap();
+        assert_eq!(schema["properties"]["greeting"]["type"], "string");
+    }
+
+    // ── AutoEscape statement ({% autoescape %}...{% endautoescape %}) ─────────
+
+    #[test]
+    fn autoescape_block_body_variables_collected() {
+        let schema = extract_schema(
+            "{% autoescape true %}{{ content }}{% endautoescape %}",
+            "t.html",
+        )
+        .unwrap();
+        assert_eq!(schema["properties"]["content"]["type"], "string");
+    }
+
+    // ── BinOp expression ──────────────────────────────────────────────────────
+
+    #[test]
+    fn binop_concat_collects_both_operands() {
+        // `a ~ b` is string-concatenation BinOp; both variables must appear.
+        let schema = extract_schema("{{ first ~ last }}", "t.html").unwrap();
+        assert_eq!(schema["properties"]["first"]["type"], "string");
+        assert_eq!(schema["properties"]["last"]["type"], "string");
+    }
+
+    #[test]
+    fn binop_in_if_condition_collects_variables() {
+        let schema = extract_schema("{% if a == b %}{{ c }}{% endif %}", "t.html").unwrap();
+        assert_eq!(schema["properties"]["a"]["type"], "string");
+        assert_eq!(schema["properties"]["b"]["type"], "string");
+        assert_eq!(schema["properties"]["c"]["type"], "string");
+    }
+
+    // ── UnaryOp expression ────────────────────────────────────────────────────
+
+    #[test]
+    fn unaryop_not_collects_inner_variable() {
+        let schema = extract_schema("{% if not flag %}{{ result }}{% endif %}", "t.html").unwrap();
+        assert_eq!(schema["properties"]["flag"]["type"], "string");
+        assert_eq!(schema["properties"]["result"]["type"], "string");
+    }
+
+    // ── IfExpr (ternary) ──────────────────────────────────────────────────────
+
+    #[test]
+    fn ternary_if_expr_collects_all_three_parts() {
+        // `a if cond else b` — test_expr, true_expr, false_expr all collected.
+        let schema = extract_schema("{{ a if cond else b }}", "t.html").unwrap();
+        assert_eq!(schema["properties"]["a"]["type"], "string");
+        assert_eq!(schema["properties"]["cond"]["type"], "string");
+        assert_eq!(schema["properties"]["b"]["type"], "string");
+    }
+
+    #[test]
+    fn ternary_if_expr_without_else_collects_test_and_true() {
+        let schema = extract_schema("{{ a if cond }}", "t.html").unwrap();
+        assert_eq!(schema["properties"]["a"]["type"], "string");
+        assert_eq!(schema["properties"]["cond"]["type"], "string");
+    }
+
+    // ── Test expression ({% if x is ... %}) ───────────────────────────────────
+
+    #[test]
+    fn is_test_expression_collects_subject_variable() {
+        let schema =
+            extract_schema("{% if value is string %}{{ value }}{% endif %}", "t.html").unwrap();
+        assert_eq!(schema["properties"]["value"]["type"], "string");
+    }
+
+    #[test]
+    fn is_test_with_arg_collects_subject() {
+        // `is divisibleby(n)` — the arg is a literal, but the subject is a variable.
+        let schema =
+            extract_schema("{% if count is divisibleby(2) %}even{% endif %}", "t.html").unwrap();
+        assert_eq!(schema["properties"]["count"]["type"], "string");
+    }
+
+    // ── Map expression (dict literal) ─────────────────────────────────────────
+
+    #[test]
+    fn map_expression_value_variables_collected() {
+        // `{"key": user}` — "user" (a variable value) must appear; "key" (literal key) must not.
+        let schema = extract_schema(r#"{{ {"label": name} }}"#, "t.html").unwrap();
+        assert_eq!(schema["properties"]["name"]["type"], "string");
+    }
+
+    // ── Built-in keyword guard in resolve_expr_path (line 436) ───────────────
+
+    #[test]
+    fn loop_builtin_not_collected_as_schema_property() {
+        // `loop` is a built-in variable; it must not appear in the schema.
+        let schema = extract_schema(
+            "{% for item in items %}{{ loop.index }}{% endfor %}",
+            "t.html",
+        )
+        .unwrap();
+        assert!(schema["properties"]["loop"].is_null());
+        assert_eq!(schema["properties"]["items"]["type"], "array");
+    }
+
+    #[test]
+    fn none_builtin_not_collected_as_schema_property() {
+        let schema = extract_schema("{% if x == none %}{% endif %}", "t.html").unwrap();
+        assert!(schema["properties"]["none"].is_null());
+        assert_eq!(schema["properties"]["x"]["type"], "string");
+    }
+
+    // ── IfCond at end of sibling list — scope merge (lines 205–209) ──────────
+
+    #[test]
+    fn if_at_end_of_body_set_scopes_merged_back() {
+        // The if-block is the last sibling: remaining.is_empty() → both branch scopes
+        // are merged back into the parent scope rather than being used to re-process
+        // trailing siblings.  We verify that the RHS of the inner `set` (i.e. "val"
+        // and "other") appear in the schema, and that the set variables ("x", "y")
+        // do not.
+        let schema = extract_schema(
+            r#"{% if cond %}{% set x = val %}{% else %}{% set y = other %}{% endif %}"#,
+            "t.html",
+        )
+        .unwrap();
+        assert_eq!(schema["properties"]["cond"]["type"], "string");
+        assert_eq!(schema["properties"]["val"]["type"], "string");
+        assert_eq!(schema["properties"]["other"]["type"], "string");
+        assert!(schema["properties"]["x"].is_null());
+        assert!(schema["properties"]["y"].is_null());
+    }
+
+    // ── ForLoop with non-resolvable iter path (lines 259–261) ────────────────
+
+    #[test]
+    fn for_loop_with_filter_iter_loop_var_is_local() {
+        // `items | first` is a Filter expr → resolve_expr_path returns None →
+        // the loop variable "item" is inserted with an empty path (local).
+        // Attribute accesses on "item" should NOT leak to the schema.
+        let schema = extract_schema(
+            "{% for item in items | first %}{{ item.name }}{% endfor %}",
+            "t.html",
+        )
+        .unwrap();
+        // "items" is collected from the filter base expression
+        assert_eq!(schema["properties"]["items"]["type"], "string");
+        // "item" is local — must not appear
+        assert!(schema["properties"]["item"].is_null());
+        // "item.name" must not leak as a top-level "name"
+        assert!(schema["properties"]["name"].is_null());
+    }
+
+    // ── ensure_array_at_path: Object arm (lines 525–527) ─────────────────────
+
+    #[test]
+    fn ensure_array_at_nested_path_traverses_object() {
+        // `{{ user.name }}` first creates user as Object.
+        // `{% for item in user.items %}` then calls ensure_array_at_path(root, ["user","items"]):
+        //   → entry at "user" is Object → Object arm (lines 525-527).
+        let schema = extract_schema(
+            "{{ user.name }}{% for item in user.items %}{{ item.val }}{% endfor %}",
+            "t.html",
+        )
+        .unwrap();
+        assert_eq!(schema["properties"]["user"]["type"], "object");
+        assert_eq!(
+            schema["properties"]["user"]["properties"]["name"]["type"],
+            "string"
+        );
+        assert_eq!(
+            schema["properties"]["user"]["properties"]["items"]["type"],
+            "array"
+        );
+    }
+
+    // ── ensure_array_at_path: Array arms (lines 529–547) ─────────────────────
+
+    #[test]
+    fn ensure_array_at_nested_path_through_existing_array_string_inner() {
+        // First for loop marks "data" as Array(String).
+        // Second for loop calls ensure_array_at_path(root, ["data","sub"]):
+        //   → entry at "data" is Array(String) → inner match `other` arm (lines 535-540):
+        //     upgrades inner from String to Object.
+        let schema = extract_schema(
+            "{% for x in data %}{% endfor %}{% for x in data.sub %}{{ x.v }}{% endfor %}",
+            "t.html",
+        )
+        .unwrap();
+        assert_eq!(schema["properties"]["data"]["type"], "array");
+    }
+
+    #[test]
+    fn ensure_array_at_path_triple_nested_covers_object_inner_arm() {
+        // Three levels:
+        //  1. `{% for x in a %}` → a = Array(String)
+        //  2. `{% for x in a.b %}` → upgrades a's inner to Object({"b": Array(String)})
+        //  3. `{% for x in a.b.c %}` → a = Array(Object({"b":...})) → inner match Object arm
+        //                              (lines 531-533) → descends into children.
+        let schema = extract_schema(
+            "{% for x in a %}{% endfor %}\
+             {% for x in a.b %}{% endfor %}\
+             {% for x in a.b.c %}{% endfor %}",
+            "t.html",
+        )
+        .unwrap();
+        assert_eq!(schema["properties"]["a"]["type"], "array");
+    }
 }


### PR DESCRIPTION
## Summary

- `crates/fulgur/src/schema.rs` に 24 件のユニットテストを追加し、MiniJinja AST ウォーカーのカバレッジを 83% から 96% に向上させる
- プロダクションコードの変更なし — テストのみ

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `crates/fulgur/src/schema.rs` | `#[cfg(test)] mod tests` に 24 件のテスト追加（+266 行） |

## Test plan

- [x] `cargo test -p fulgur --lib` — 全 44 テスト（既存 20 + 新規 24）がパス
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — フォーマット差分なし
- [x] カバレッジ再測定: Lines 83.33% → 96.24%、Regions 85.56% → 96.78%

## Related issues

なし

---

## 対象モジュール

`crates/fulgur/src/schema.rs` — MiniJinja テンプレートの AST を走査して JSON Schema を推論するモジュール。

## カバレッジ推移

| 指標 | Before | After |
|------|--------|-------|
| Lines | 83.33% (158 missed) | 96.24% (46 missed) |
| Regions | 85.56% (82 missed) | 96.78% (23 missed) |

全体プロジェクト (fulgur crate): 90.19% → 90.47% (lines)

## 追加したテスト（24 件）

### エラーパス（lines 14, 44）
- `extract_schema_parse_error_returns_err` — 不正なテンプレート構文で `Err` が返ることを確認
- `extract_schema_with_data_parse_error_returns_err` — 同上、`extract_schema_with_data` 版

### `value_to_schema` の未カバー分岐（lines 76, 77, 59）
- `value_to_schema_bool_inferred_from_data` — データに bool 値が含まれる場合 `"type": "boolean"` が推論される
- `value_to_schema_null_inferred_from_data` — null 値に対して `"type": "null"` が推論される
- `value_to_schema_empty_array_inferred_from_data` — 空配列に対して `"type": "array"` かつ `items` キーなし
- `extract_schema_with_data_non_object_data_yields_empty_properties` — data が JSON Object でない場合の `if let Value::Object` false 分岐

### `SetBlock` / `FilterBlock` / `AutoEscape` ステートメント（lines 152–154, 302–319）
- `set_block_body_variables_collected_and_var_not_leaked`
- `filter_block_body_variables_collected`
- `autoescape_block_body_variables_collected`

### 式ノード（lines 356–399）
- `binop_concat_collects_both_operands`
- `binop_in_if_condition_collects_variables`
- `unaryop_not_collects_inner_variable`
- `ternary_if_expr_collects_all_three_parts`
- `ternary_if_expr_without_else_collects_test_and_true`
- `is_test_expression_collects_subject_variable`
- `is_test_with_arg_collects_subject`
- `map_expression_value_variables_collected`

### 組み込み変数ガード（line 436）
- `loop_builtin_not_collected_as_schema_property`
- `none_builtin_not_collected_as_schema_property`

### `collect_from_stmts` — IfCond 末尾スコープマージ（lines 205–209）
- `if_at_end_of_body_set_scopes_merged_back`

### ForLoop の非解決イテレータパス（lines 259–261）
- `for_loop_with_filter_iter_loop_var_is_local`

### `ensure_array_at_path` ネスト分岐（lines 525–547）
- `ensure_array_at_nested_path_traverses_object`
- `ensure_array_at_nested_path_through_existing_array_string_inner`
- `ensure_array_at_path_triple_nested_covers_object_inner_arm`

## 意図的に省略したブランチとその理由

| ブランチ | 省略理由 |
|---------|---------|
| `extract_var_names` の `ast::Expr::List` アーム (line 139) | MiniJinja の for ループはタプルターゲットに `List` ノードを使用しないため、公開 API からは到達不可 |
| `collect_if_cond_scopes` else 分岐 (line 172) / `collect_from_stmt` の IfCond アーム (lines 272–278) | `collect_from_stmts` が IfCond を先にインターセプトするため事実上デッドコード |
| `WithBlock` タプル展開 (lines 295–297) | MiniJinja の `with` ブロックは単一変数代入のみサポートし、タプル代入は構文エラー |
| `resolve_path` / `ensure_array_at_path` 空パスガード (lines 465, 508) | 呼び出し元が `!path.is_empty()` をガードしており、再帰経路でも空パスは渡されない |
| `ensure_array_at_path` 上書き変換 (line 519) | `or_insert_with` で `Array` として初期挿入されるため、単一パスで非 Array になる経路が存在しない |
| `collect_from_call_arg` の PosSplat / KwargSplat アーム (line 416) | MiniJinja 2.x はテンプレート関数呼び出しで `*args` / `**kwargs` をサポートしない |

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGTNEMVtbF8K48ymFZu9Ln)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * スキーマ推論機能の信頼性と正確性を検証するための包括的なユニットテストスイートを追加しました。様々なシナリオと境界ケースをカバーし、機能の堅牢性を向上させています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->