### PR TITLE
test(render): assert every nested-ol marker renders exactly once

### DIFF
--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -4185,16 +4185,30 @@ fn cjk_glyphs_copy_correct_characters() {
     assert_eq!(all_clusters, vec!["你", "好", "世", "界"]);
 }
 
-/// Regression for the multi-GlyphRun duplication bug: when a single Parley
-/// `Run` is split across multiple `GlyphRun`s (as `counters(item, ".")` list
-/// markers produce — one GlyphRun for "1." and another for "Alpha"), iterating
-/// `glyph_run.run().visual_clusters()` emits ALL clusters of the parent Run for
-/// EACH GlyphRun, causing each glyph to appear once per GlyphRun rather than
-/// once total.
+/// Regression for the multi-GlyphRun duplication bug (fulgur-tt91): when a
+/// single Parley `Run` is split across multiple `GlyphRun`s (as the
+/// `counters(item, ".")` generated `::before` content here produces — one
+/// GlyphRun for the counter prefix and another for the body text, both in the
+/// same shaping Run), iterating `glyph_run.run().visual_clusters()` once per
+/// GlyphRun emits ALL clusters of the parent Run for EACH GlyphRun, so every
+/// glyph is drawn once per GlyphRun rather than once total.
 ///
-/// The correct output is "1.Alpha" exactly once per list item. The buggy output
-/// renders "1.Alpha" twice — overlapping at slightly different x positions —
-/// which pdftotext extracts as two occurrences.
+/// With `list-style: none` the prefix comes from `::before` generated content,
+/// so this fixture exercises the inline-root paragraph path
+/// (`convert/inline_root.rs::extract_paragraph`). The structurally identical
+/// loop also lives in `convert/mod.rs`, `paragraph.rs`, and
+/// `convert/list_marker.rs`; this fixture does NOT route through those, so a
+/// regression reintroduced there would slip past this test — covering them
+/// needs separate fixtures and is out of scope for fulgur-tt91.
+///
+/// Each marker must appear exactly once. We assert on whole `pdftotext -raw`
+/// lines rather than `text.matches(marker).count()`: a bare substring count is
+/// unsound because shorter markers are substrings of longer ones — e.g.
+/// `"2.Beta"` occurs inside the `"2.2.Beta-two"` line, so
+/// `matches("2.Beta").count()` is 2 even in correct output. Full-line equality
+/// also catches the duplication whether pdftotext emits the doubled glyphs as a
+/// second line (`"1.Alpha"` twice → count 2) or merges them on one line
+/// (`"1.Alpha1.Alpha"` → count 0); both differ from the required 1.
 #[test]
 fn multi_glyph_run_marker_renders_without_duplication() {
     let html = r#"<!doctype html>
@@ -4227,12 +4241,27 @@ body { font-family: 'Noto Sans', sans-serif; }
         return;
     };
 
-    let occurrences = text.matches("1.Alpha").count();
-    assert_eq!(
-        occurrences, 1,
-        "marker \"1.Alpha\" rendered {occurrences}× — multi-GlyphRun duplication regression; \
-         extracted text: {text:?}"
-    );
+    // pdftotext -raw flattens each marker + its body label onto its own line.
+    let lines: Vec<&str> = text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .collect();
+
+    for marker in [
+        "1.Alpha",
+        "2.Beta",
+        "2.1.Beta-one",
+        "2.2.Beta-two",
+        "3.Gamma",
+    ] {
+        let occurrences = lines.iter().filter(|&&l| l == marker).count();
+        assert_eq!(
+            occurrences, 1,
+            "marker {marker:?} appeared on {occurrences} line(s), expected 1 — \
+             multi-GlyphRun duplication regression; extracted lines: {lines:?}"
+        );
+    }
 }
 
 /// Exercises `clear_subtree_cache` for codecov coverage.

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -4242,9 +4242,14 @@ body { font-family: 'Noto Sans', sans-serif; }
     };
 
     // pdftotext -raw flattens each marker + its body label onto its own line.
-    let lines: Vec<&str> = text
+    // Strip all whitespace per line so the comparison is robust against
+    // platform-specific spacing extraction: the marker content is `"N. "` with
+    // a trailing space, and some Poppler versions reconstruct it as "1. Alpha"
+    // rather than the "1.Alpha" seen here. Whole-(stripped-)line equality keeps
+    // the substring-safety property ("2.Beta" never equals "2.2.Beta-two").
+    let lines: Vec<String> = text
         .lines()
-        .map(str::trim)
+        .map(|l| l.chars().filter(|c| !c.is_whitespace()).collect::<String>())
         .filter(|l| !l.is_empty())
         .collect();
 
@@ -4255,7 +4260,7 @@ body { font-family: 'Noto Sans', sans-serif; }
         "2.2.Beta-two",
         "3.Gamma",
     ] {
-        let occurrences = lines.iter().filter(|&&l| l == marker).count();
+        let occurrences = lines.iter().filter(|l| l.as_str() == marker).count();
         assert_eq!(
             occurrences, 1,
             "marker {marker:?} appeared on {occurrences} line(s), expected 1 — \


### PR DESCRIPTION
## 概要

list marker の multi-GlyphRun 重複描画回帰テスト (`multi_glyph_run_marker_renders_without_duplication`) を強化する。fulgur-tt91 対応。

- 既存テストは `"1.Alpha"` 1マーカーしかチェックしておらず、より深いマーカー (`2.1.` / `2.2.`) だけが重複する部分回帰を取りこぼす。全5マーカー (`1.Alpha` / `2.Beta` / `2.1.Beta-one` / `2.2.Beta-two` / `3.Gamma`) を検証するよう拡張した。
- issue 本文が指定する素朴な `text.matches(marker).count() == 1` は **不健全**: `"2.Beta"` は `"2.2.Beta-two"` 行の部分文字列なので、正しい出力でも count が 2 になる。`pdftotext -raw` の **行単位完全一致** に変更した。これは重複が「2行目として出る」(count 2) でも「1行に連結される」(count 0) でも検出できる。

## 背景

PR #442 の duplication regression は、snapshot test（壊れた出力で再生成され byte-equal で通過）と `text.contains()` ベースの assert（重複に透過）を素通りした。本テストはそのクラスの silent regression を防ぐ。

なお調査の結果、`list-style: none` + `::before` 生成コンテンツのため、この fixture が踏む真の経路は **inline-root paragraph 経路** (`convert/inline_root.rs::extract_paragraph`) であり、list_marker 経路ではないことを実証で確認した（docstring に明記）。同型ループは `convert/mod.rs` / `paragraph.rs` / `convert/list_marker.rs` にも存在するが、この fixture はそれらを通らない（別 fixture が必要、本 issue スコープ外）。

## 検証

- **RED**: PR #442 以前のバグ版ループ（各 GlyphRun で `glyph_run.run().visual_clusters()` を取り直す）を `extract_paragraph` に再現すると、全5マーカーが2行に重複してテストが FAIL することを確認。
- **GREEN**: 修正済み `extract_paragraph` で PASS。
- `cargo test -p fulgur` 全件 green / `cargo fmt --check` / `cargo clippy -p fulgur --tests` いずれも通過。
- 変更はテストファイル1本のみ（src/ 変更なし）。

snapshot サブ項目（"2+5 グリフ TJ 構造の復元"）は PR #442 で対応済みのため本 PR には含めない。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * マーカーの重複レンダリング検証テストを改善しました。説明コメントを明確化し、PDF抽出テキストを行ごとに整形して空白を除去したうえで、各マーカー（1.Alpha〜3.Gamma）が「行単位で完全一致」してちょうど1回出現することを厳密に検証するように変更し、部分文字列カウントを置き換えました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->