### PR TITLE
test(convert/list_item): add coverage for try_convert and build_list_item_body

### DIFF
--- a/crates/fulgur/src/convert/list_item.rs
+++ b/crates/fulgur/src/convert/list_item.rs
@@ -902,4 +902,161 @@ mod tests {
         // Marker is still inserted at index 0.
         assert_eq!(out.paragraphs[&5].lines[0].items.len(), 2);
     }
+
+    // ── smoke tests via Engine::render_html (Blitz-dependent paths) ──────────
+    //
+    // These exercises cover branches in `try_convert` and `build_list_item_body`
+    // that cannot be reached without a live Blitz document.  They mirror the
+    // pattern used in render.rs `#[cfg(test)]` smoke helpers.
+
+    fn render_list_html(html: &str) -> Vec<u8> {
+        crate::engine::Engine::builder()
+            .build()
+            .render_html(html)
+            .expect("render failed")
+    }
+
+    const RED_1X1_PNG: &[u8] = &[
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90,
+        0x77, 0x53, 0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0xF8,
+        0xCF, 0xC0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00, 0xC9, 0xFE, 0x92, 0xEF, 0x00, 0x00, 0x00,
+        0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+    ];
+
+    // try_convert branch 1 (outside marker): opacity < 1.0 on the <li> activates
+    // the `opacity_scope` snapshot path (line 62-63).
+    #[test]
+    fn smoke_outside_marker_with_opacity_scope() {
+        let pdf = render_list_html(
+            r#"<!doctype html><html><body>
+            <ul><li style="opacity:0.5">Faded item</li></ul>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // try_convert branch 1 (outside marker): overflow:hidden on the <li>
+    // activates the `clipping` snapshot path (line 61-63).
+    #[test]
+    fn smoke_outside_marker_with_overflow_clip() {
+        let pdf = render_list_html(
+            r#"<!doctype html><html><body>
+            <ul><li style="overflow:hidden;height:30px">
+                <div style="height:200px">Clipped content</div>
+            </li></ul>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // try_convert branch 3 (inside marker, non-inline-root): a numeric
+    // `line-height` multiplier → `LineHeight::Number` arm (line 138).
+    #[test]
+    fn smoke_inside_marker_line_height_number() {
+        let pdf = render_list_html(
+            r#"<!doctype html><html><body>
+            <ul style="list-style-position:inside;line-height:1.5">
+                <li><p>Block child so non-inline-root</p></li>
+            </ul>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // try_convert branch 3 (inside marker, non-inline-root): an absolute-length
+    // `line-height` → `LineHeight::Length` arm (line 139).
+    #[test]
+    fn smoke_inside_marker_line_height_length() {
+        let pdf = render_list_html(
+            r#"<!doctype html><html><body>
+            <ul style="list-style-position:inside;line-height:24px">
+                <li><p>Block child so non-inline-root</p></li>
+            </ul>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // try_convert branch 3 (inside marker, non-inline-root): empty <li> with no
+    // children forces the standalone marker-paragraph path (lines 172-203).
+    #[test]
+    fn smoke_inside_empty_li_with_marker() {
+        let pdf = render_list_html(
+            r#"<!doctype html><html><body>
+            <ul style="list-style-position:inside">
+                <li></li>
+                <li>Normal item</li>
+            </ul>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // build_list_item_body (outside marker): <li> whose only child is a block
+    // element.  The <li> is NOT an inline-root, so the non-inline-root walk
+    // (lines 423-427) is exercised.
+    #[test]
+    fn smoke_outside_marker_with_block_children() {
+        let pdf = render_list_html(
+            r#"<!doctype html><html><body>
+            <ul><li><div style="background:#cef;height:20px">Block child</div></li></ul>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // build_list_item_body (outside marker, inline-root): a ::before pseudo whose
+    // `content` is an image URL and display is NOT block-outside injects an
+    // InlineImage *before* the paragraph text (lines 336-387).
+    #[test]
+    fn smoke_outside_marker_with_inline_before_image() {
+        let mut bundle = crate::asset::AssetBundle::default();
+        bundle.add_image("dot.png", RED_1X1_PNG.to_vec());
+        bundle.add_css(r#"li::before { content: url("dot.png"); width: 8px; height: 8px; }"#);
+        let pdf = crate::engine::Engine::builder()
+            .assets(bundle)
+            .build()
+            .render_html(
+                r#"<!doctype html><html><body>
+                <ul><li>Item with before image</li></ul>
+                </body></html>"#,
+            )
+            .expect("render failed");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // build_list_item_body (outside marker, inline-root): empty <li> with an
+    // inline ::before image but no text.  `extract_paragraph` returns None so
+    // the `before_inline.is_some()` branch at line 392 is taken.
+    #[test]
+    fn smoke_outside_marker_empty_li_with_inline_before_image() {
+        let mut bundle = crate::asset::AssetBundle::default();
+        bundle.add_image("dot.png", RED_1X1_PNG.to_vec());
+        bundle.add_css(r#"li::before { content: url("dot.png"); width: 8px; height: 8px; }"#);
+        let pdf = crate::engine::Engine::builder()
+            .assets(bundle)
+            .build()
+            .render_html(
+                r#"<!doctype html><html><body>
+                <ul><li></li></ul>
+                </body></html>"#,
+            )
+            .expect("render failed");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // build_list_item_body (outside marker, inline-root): empty <li> with no
+    // text and no inline pseudo images.  Both `paragraph_opt` and
+    // `before_inline`/`after_inline` are None, so the final `else` branch at
+    // line 415 (fall-through to non-inline-root child walk) is exercised.
+    #[test]
+    fn smoke_outside_marker_empty_li_no_pseudos() {
+        let pdf = render_list_html(
+            r#"<!doctype html><html><body>
+            <ul><li></li><li>Next item</li></ul>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
 }


### PR DESCRIPTION
## 対象モジュール

`crates/fulgur/src/convert/list_item.rs`

## カバレッジ変化

| 指標 | 変更前 | 変更後 |
|------|--------|--------|
| 行カバレッジ | 67.77% (471/695 行) | 84.75% (667/787 行) |
| 関数カバレッジ | 72.73% (32/44) | 90.74% (49/54) |
| **改善幅** | — | **+17pp** |

## 追加したテスト一覧

`#[cfg(test)] mod tests` ブロック内に、`crate::engine::Engine::render_html` を使った smoke テストを 9 件追加した。いずれも Blitz DOM を必要とする `try_convert` / `build_list_item_body` の経路をカバーする。

| テスト名 | カバーする経路 |
|----------|--------------|
| `smoke_outside_marker_with_opacity_scope` | try_convert branch 1: `opacity < 1.0` → `opacity_scope` スナップショット (line 62–63) |
| `smoke_outside_marker_with_overflow_clip` | try_convert branch 1: `overflow:hidden` → `clipping` スナップショット (line 61–63) |
| `smoke_inside_marker_line_height_number` | try_convert branch 3: `LineHeight::Number` アーム (line 138) |
| `smoke_inside_marker_line_height_length` | try_convert branch 3: `LineHeight::Length` アーム (line 139) |
| `smoke_inside_empty_li_with_marker` | try_convert branch 3: 子なし `<li>` → スタンドアロンマーカー段落 (lines 172–203) |
| `smoke_outside_marker_with_block_children` | build_list_item_body: 非 inline-root の子ウォーク (lines 423–427) |
| `smoke_outside_marker_with_inline_before_image` | build_list_item_body inline-root: `::before` インライン疑似画像 + テキストあり (lines 336–387) |
| `smoke_outside_marker_empty_li_with_inline_before_image` | build_list_item_body inline-root: `::before` 画像あり・テキストなし (lines 392–414) |
| `smoke_outside_marker_empty_li_no_pseudos` | build_list_item_body inline-root: テキストも疑似画像もなし → else フォールスルー (lines 415–421) |

## 意図的にカバーしなかった箇所

- **try_convert branch 2 (fallback, lines 70–118)**: `display: list-item` かつ `list_item_data` が `None` というケース。Blitz が現在この組み合わせを生成する CSS 構文が特定できなかったため保留。
- **`build_list_item_body` inline-root + `::after` のみ / `::before` + `::after` 両方**: 単一の `::before` ケースで injection ロジックは十分にカバーされるため省略。
- **`try_convert` の `false` リターン後の各フォールスルー経路**: これらは `convert/mod.rs` 側で処理されるため、`list_item.rs` 単体のカバレッジには寄与しない。

## テスト方針

プロダクションコードの変更はなし。テストのみ追加。CLAUDE.md の "Coverage scope" ガイドラインに従い、Blitz を必要とするレンダリング経路は `Engine::render_html` 経由の smoke test として `#[cfg(test)]` ブロックに配置した。

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgVVTtAQEdbqKUEizKphUB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * リスト項目のHTML レンダリングに関する包括的なスモークテストを追加。複数のレンダリング経路をカバーし、出力の正確性を検証。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->