### PR TITLE
fix(pagination): nested-abs page generation + end-side margin (fulgur-puml)

### DIFF
--- a/crates/fulgur-wpt/expectations/css-page.txt
+++ b/crates/fulgur-wpt/expectations/css-page.txt
@@ -31,9 +31,9 @@ SKIP  css/css-page/cssom/page-002.html  # NoMatch
 PASS  css/css-page/fixedpos-001-print.html
 PASS  css/css-page/fixedpos-002-print.html
 PASS  css/css-page/fixedpos-003-print.html
-FAIL  css/css-page/fixedpos-004-print.html  # page count mismatch: test=2 ref=3
-FAIL  css/css-page/fixedpos-005-print.html  # page count mismatch: test=3 ref=5
-FAIL  css/css-page/fixedpos-006-print.html  # page count mismatch: test=3 ref=5
+PASS  css/css-page/fixedpos-004-print.html  # fulgur-puml: nested-abs pagination + end-side margin fix
+FAIL  css/css-page/fixedpos-005-print.html  # fulgur-xa9q: page count test=3 ref=5 (abs page extension with in-flow content)
+FAIL  css/css-page/fixedpos-006-print.html  # fulgur-xa9q: page count test=1 ref=3 (abs page extension with in-flow content)
 FAIL  css/css-page/fixedpos-007-print.html  # page 1 diff: 1765/891662 pixels exceed tol (max_ch=255)
 PASS  css/css-page/fixedpos-008-print.html
 FAIL  css/css-page/fixedpos-009-print.html  # page 1 diff: 216/891662 pixels exceed tol (max_ch=149) — §10.3.7 shrink-to-fit now correct (pencil at bottom-right per spec, was 2738 px wrong); residual is sub-pixel anti-aliasing on the 36×36 mask edge between the test (position:fixed root) and ref (position:absolute inside relative .fakepage) y rounding

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -3063,37 +3063,49 @@ fn record_subtree_fragments_at_offset(
             //     abs root anchor; viewport-relative (`vh`) insets are
             //     CB-independent, so the CB dims only affect percentage
             //     insets.
-            if is_out_of_flow_positioned(child) {
+            {
                 use ::style::properties::longhands::position::computed_value::T as Pos;
-                let is_abs = child
-                    .primary_styles()
-                    .is_some_and(|s| matches!(s.get_box().clone_position(), Pos::Absolute));
-                if !is_abs {
-                    continue;
+                match child.primary_styles().map(|s| s.get_box().clone_position()) {
+                    // Fixed is handled by its own pass; skip here.
+                    Some(Pos::Fixed) => continue,
+                    Some(Pos::Absolute) => {
+                        let (child_w, child_h) = (
+                            child.final_layout.size.width,
+                            child.final_layout.size.height,
+                        );
+                        // `final_layout.size` is the child's border box; the CSS
+                        // containing block for an abs descendant is the positioned
+                        // ancestor's *padding* box. Harmless for `vh` insets (CB-
+                        // independent); only a minor error for `%` insets when the
+                        // CB has non-zero borders.
+                        let (cb_w, cb_h) =
+                            (node.final_layout.size.width, node.final_layout.size.height);
+                        let (rel_x, rel_y) =
+                            resolve_viewport_cb_location(child, child_w, child_h, cb_w, cb_h)
+                                .unwrap_or((
+                                    child.final_layout.location.x,
+                                    child.final_layout.location.y,
+                                ));
+                        let nested_offset =
+                            (offset_in_subtree.0 + rel_x, offset_in_subtree.1 + rel_y);
+                        walk(
+                            geometry,
+                            doc,
+                            child_id,
+                            nested_offset,
+                            root_xy_for_paging,
+                            body_offset,
+                            page_h_px,
+                            page_stride_px,
+                            descendant_total_pages,
+                            may_extend_pages,
+                            depth + 1,
+                        );
+                        continue;
+                    }
+                    // In-flow (or unstyled): fall through to the normal path below.
+                    _ => {}
                 }
-                let (child_w, child_h) = (
-                    child.final_layout.size.width,
-                    child.final_layout.size.height,
-                );
-                let (cb_w, cb_h) = (node.final_layout.size.width, node.final_layout.size.height);
-                let (rel_x, rel_y) =
-                    resolve_viewport_cb_location(child, child_w, child_h, cb_w, cb_h)
-                        .unwrap_or((child.final_layout.location.x, child.final_layout.location.y));
-                let nested_offset = (offset_in_subtree.0 + rel_x, offset_in_subtree.1 + rel_y);
-                walk(
-                    geometry,
-                    doc,
-                    child_id,
-                    nested_offset,
-                    root_xy_for_paging,
-                    body_offset,
-                    page_h_px,
-                    page_stride_px,
-                    descendant_total_pages,
-                    may_extend_pages,
-                    depth + 1,
-                );
-                continue;
             }
             // Skip whitespace-only text (matches fragmenter).
             if let Some(text) = child.text_data()

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -3048,10 +3048,51 @@ fn record_subtree_fragments_at_offset(
             let Some(child) = doc.get_node(child_id) else {
                 continue;
             };
-            // Skip out-of-flow descendants (handled by their own
-            // pass — `append_position_fixed_fragments` for fixed,
-            // separate body-direct walk for abs).
+            // Out-of-flow descendants:
+            //   - `position: fixed` is a repeat element handled by
+            //     `append_position_fixed_fragments`; skip it here so it
+            //     does not contribute to extent (it would otherwise be
+            //     double-counted).
+            //   - `position: absolute` (fulgur-puml #1): a nested abs's
+            //     height/offset must still drive the page count. Resolve
+            //     its location against ITS containing block (the nearest
+            //     positioned ancestor = the current `node`'s box) via
+            //     `resolve_viewport_cb_location`, fold that CB-relative
+            //     (x, y) into the accumulated `offset_in_subtree`, and
+            //     recurse. `root_xy_for_paging` stays the body-direct
+            //     abs root anchor; viewport-relative (`vh`) insets are
+            //     CB-independent, so the CB dims only affect percentage
+            //     insets.
             if is_out_of_flow_positioned(child) {
+                use ::style::properties::longhands::position::computed_value::T as Pos;
+                let is_abs = child
+                    .primary_styles()
+                    .is_some_and(|s| matches!(s.get_box().clone_position(), Pos::Absolute));
+                if !is_abs {
+                    continue;
+                }
+                let (child_w, child_h) = (
+                    child.final_layout.size.width,
+                    child.final_layout.size.height,
+                );
+                let (cb_w, cb_h) = (node.final_layout.size.width, node.final_layout.size.height);
+                let (rel_x, rel_y) =
+                    resolve_viewport_cb_location(child, child_w, child_h, cb_w, cb_h)
+                        .unwrap_or((child.final_layout.location.x, child.final_layout.location.y));
+                let nested_offset = (offset_in_subtree.0 + rel_x, offset_in_subtree.1 + rel_y);
+                walk(
+                    geometry,
+                    doc,
+                    child_id,
+                    nested_offset,
+                    root_xy_for_paging,
+                    body_offset,
+                    page_h_px,
+                    page_stride_px,
+                    descendant_total_pages,
+                    may_extend_pages,
+                    depth + 1,
+                );
                 continue;
             }
             // Skip whitespace-only text (matches fragmenter).

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -3227,7 +3227,11 @@ fn resolve_viewport_cb_location(
     // these into `final_layout.margin`; without subtracting them an abs with
     // `bottom:0; margin-bottom:2em` collapses onto `bottom:0`. This is a
     // distinct end-side-margin bug from nested-abs pagination — see the
-    // `abs_bottom_margin_offsets_above_sibling` regression test.
+    // `abs_bottom_margin_offsets_above_sibling` regression test. NOTE: this
+    // helper resolves `position: fixed` elements too (all three callers), so
+    // the margin term corrects fixed end-anchoring as well as abs. The margin
+    // is subtracted unrounded between the two rounded terms; fixedpos-004's
+    // pixel-exact reftest is the validator for this rounding choice.
     let margin = node.final_layout.margin;
     let x = if let Some(l) = left {
         l

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -3221,12 +3221,20 @@ fn resolve_viewport_cb_location(
     // back to Taffy's static position (`final_layout.location`). Caller
     // unwraps the returned tuple against that fallback, so we surface
     // only the axes that have an explicit inset.
+    // End-side (right / bottom) anchoring positions the element's *margin
+    // box* edge against the CB edge, so the border-box origin must back off
+    // by the used end-side margin (CSS 2.1 §10.3.7 / §10.6.4). Taffy resolves
+    // these into `final_layout.margin`; without subtracting them an abs with
+    // `bottom:0; margin-bottom:2em` collapses onto `bottom:0`. This is a
+    // distinct end-side-margin bug from nested-abs pagination — see the
+    // `abs_bottom_margin_offsets_above_sibling` regression test.
+    let margin = node.final_layout.margin;
     let x = if let Some(l) = left {
         l
     } else if let Some(r) = right {
         // To mirror Taffy's internal end-side layout, collapse viewport
         // edge before subtracting element width.
-        (cb_w_px - r).round() - el_w_px.round()
+        (cb_w_px - r).round() - margin.right - el_w_px.round()
     } else {
         node.final_layout.location.x
     };
@@ -3237,7 +3245,7 @@ fn resolve_viewport_cb_location(
         // first round viewport location, then subtract rounded element
         // height. This keeps fixed/abs reference paths aligned to one
         // px boundary when cb height / element size are sub-pixel.
-        (cb_h_px - b).round() - el_h_px.round()
+        (cb_h_px - b).round() - margin.bottom - el_h_px.round()
     } else {
         node.final_layout.location.y
     };

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -2962,15 +2962,27 @@ fn record_subtree_fragments_at_offset(
         // inherited nearest-positioned ancestor (`cb_anchor`/`cb_size`). A
         // `position: static` element does not establish a CB, so an abs child
         // beneath it anchors to the same ancestor its static parent does.
+        //
+        // The CB is the positioned ancestor's *padding box* (CSS 2.1
+        // §10.1.4): the anchor backs in by its top/left border and the size
+        // drops both borders. `offset_in_subtree` is `node`'s border-box
+        // origin, so add the border to reach the padding edge.
         let node_positioned = {
             use ::style::properties::longhands::position::computed_value::T as Pos;
             node.primary_styles()
                 .is_some_and(|s| !matches!(s.get_box().clone_position(), Pos::Static))
         };
         let (child_cb_anchor, child_cb_size) = if node_positioned {
+            let border = node.final_layout.border;
             (
-                offset_in_subtree,
-                (node.final_layout.size.width, node.final_layout.size.height),
+                (
+                    offset_in_subtree.0 + border.left,
+                    offset_in_subtree.1 + border.top,
+                ),
+                (
+                    node.final_layout.size.width - border.left - border.right,
+                    node.final_layout.size.height - border.top - border.bottom,
+                ),
             )
         } else {
             (cb_anchor, cb_size)
@@ -3099,12 +3111,9 @@ fn record_subtree_fragments_at_offset(
                             child.final_layout.size.height,
                         );
                         // Resolve against the nearest positioned ancestor's
-                        // box (`child_cb_*`), NOT the immediate DOM parent —
-                        // a `position: static` parent does not establish a CB
-                        // (CSS 2.1 §10.1.4). `child_cb_size` is that ancestor's
-                        // border box; the spec CB is its padding box — harmless
-                        // for `vh` insets (CB-independent), a minor error for
-                        // `%` insets only when the CB has non-zero borders.
+                        // padding box (`child_cb_*`), NOT the immediate DOM
+                        // parent — a `position: static` parent does not
+                        // establish a CB (CSS 2.1 §10.1.4).
                         let (rel_x, rel_y) = resolve_viewport_cb_location(
                             child,
                             child_w,
@@ -5378,6 +5387,42 @@ h2 { string-set: chapter-title content(text); }
             None
         }
         walk(base, root_id, tag)
+    }
+
+    /// fulgur-puml: `explicit_inset_axes` must classify each axis as
+    /// explicit (length/percentage inset present) vs auto, since the nested-
+    /// abs base selection depends on it. A silent regression here would
+    /// mis-anchor abs descendants across a static intermediate.
+    #[test]
+    fn explicit_inset_axes_classifies_per_axis() {
+        use std::ops::Deref;
+        // (fragment, (x_explicit, y_explicit))
+        let cases: &[(&str, (bool, bool))] = &[
+            ("<div style=\"position:absolute\"></div>", (false, false)),
+            (
+                "<div style=\"position:absolute; top:10px\"></div>",
+                (false, true),
+            ),
+            (
+                "<div style=\"position:absolute; right:0\"></div>",
+                (true, false),
+            ),
+            (
+                "<div style=\"position:absolute; left:0; right:0\"></div>",
+                (true, false),
+            ),
+            (
+                "<div style=\"position:absolute; top:0; left:0\"></div>",
+                (true, true),
+            ),
+        ];
+        for (frag, expected) in cases {
+            let html = format!("<html><body>{frag}</body></html>");
+            let doc = parse(&html, 600.0);
+            let id = find_node_by_local_name(&doc, "div").expect("div present");
+            let node = doc.deref().get_node(id).expect("node present");
+            assert_eq!(explicit_inset_axes(node), *expected, "fragment: {frag}");
+        }
     }
 
     /// coderabbit: body containing only a `position: running()` element

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -2928,6 +2928,13 @@ fn record_subtree_fragments_at_offset(
         page_stride_px: f32,
         total_pages: u32,
         may_extend_pages: bool,
+        // Subtree-offset and border-box size of the nearest positioned
+        // ancestor of `node_id` — the containing block that `node_id`'s
+        // out-of-flow children resolve their explicit insets against (CSS
+        // 2.1 §10.1.4). The body-direct abs at the subtree root is itself
+        // positioned, so it overrides these on the first frame.
+        cb_anchor: (f32, f32),
+        cb_size: (f32, f32),
         depth: usize,
     ) {
         if depth >= crate::MAX_DOM_DEPTH {
@@ -2949,6 +2956,24 @@ fn record_subtree_fragments_at_offset(
             } else {
                 node.children.clone()
             }
+        };
+        // The containing block for THIS node's out-of-flow children is
+        // `node` itself when `node` is positioned (non-static), otherwise the
+        // inherited nearest-positioned ancestor (`cb_anchor`/`cb_size`). A
+        // `position: static` element does not establish a CB, so an abs child
+        // beneath it anchors to the same ancestor its static parent does.
+        let node_positioned = {
+            use ::style::properties::longhands::position::computed_value::T as Pos;
+            node.primary_styles()
+                .is_some_and(|s| !matches!(s.get_box().clone_position(), Pos::Static))
+        };
+        let (child_cb_anchor, child_cb_size) = if node_positioned {
+            (
+                offset_in_subtree,
+                (node.final_layout.size.width, node.final_layout.size.height),
+            )
+        } else {
+            (cb_anchor, cb_size)
         };
         // Page assignment is based on the un-compensated viewport-CB
         // resolved position (the actual paint location). Storage is
@@ -3073,21 +3098,41 @@ fn record_subtree_fragments_at_offset(
                             child.final_layout.size.width,
                             child.final_layout.size.height,
                         );
-                        // `final_layout.size` is the child's border box; the CSS
-                        // containing block for an abs descendant is the positioned
-                        // ancestor's *padding* box. Harmless for `vh` insets (CB-
-                        // independent); only a minor error for `%` insets when the
-                        // CB has non-zero borders.
-                        let (cb_w, cb_h) =
-                            (node.final_layout.size.width, node.final_layout.size.height);
-                        let (rel_x, rel_y) =
-                            resolve_viewport_cb_location(child, child_w, child_h, cb_w, cb_h)
-                                .unwrap_or((
-                                    child.final_layout.location.x,
-                                    child.final_layout.location.y,
-                                ));
-                        let nested_offset =
-                            (offset_in_subtree.0 + rel_x, offset_in_subtree.1 + rel_y);
+                        // Resolve against the nearest positioned ancestor's
+                        // box (`child_cb_*`), NOT the immediate DOM parent —
+                        // a `position: static` parent does not establish a CB
+                        // (CSS 2.1 §10.1.4). `child_cb_size` is that ancestor's
+                        // border box; the spec CB is its padding box — harmless
+                        // for `vh` insets (CB-independent), a minor error for
+                        // `%` insets only when the CB has non-zero borders.
+                        let (rel_x, rel_y) = resolve_viewport_cb_location(
+                            child,
+                            child_w,
+                            child_h,
+                            child_cb_size.0,
+                            child_cb_size.1,
+                        )
+                        .unwrap_or((child.final_layout.location.x, child.final_layout.location.y));
+                        // Per-axis anchor: an explicit inset is relative to the
+                        // CB origin (`child_cb_anchor`); an `auto` inset keeps
+                        // the static position, i.e. the flow offset relative to
+                        // the immediate parent (`offset_in_subtree`). For a
+                        // directly-nested abs the immediate parent IS the
+                        // positioned ancestor, so both bases coincide and this
+                        // is a no-op; they diverge only across a static
+                        // intermediate.
+                        let (explicit_x, explicit_y) = explicit_inset_axes(child);
+                        let base_x = if explicit_x {
+                            child_cb_anchor.0
+                        } else {
+                            offset_in_subtree.0
+                        };
+                        let base_y = if explicit_y {
+                            child_cb_anchor.1
+                        } else {
+                            offset_in_subtree.1
+                        };
+                        let nested_offset = (base_x + rel_x, base_y + rel_y);
                         walk(
                             geometry,
                             doc,
@@ -3099,6 +3144,8 @@ fn record_subtree_fragments_at_offset(
                             page_stride_px,
                             descendant_total_pages,
                             may_extend_pages,
+                            child_cb_anchor,
+                            child_cb_size,
                             depth + 1,
                         );
                         continue;
@@ -3128,6 +3175,8 @@ fn record_subtree_fragments_at_offset(
                 page_stride_px,
                 descendant_total_pages,
                 may_extend_pages,
+                child_cb_anchor,
+                child_cb_size,
                 depth + 1,
             );
             if has_contain_size(child) {
@@ -3147,8 +3196,34 @@ fn record_subtree_fragments_at_offset(
         page_stride_px,
         total_pages,
         may_extend_pages,
+        // Initial CB: the subtree root is the body-direct abs (positioned),
+        // so it overrides these on the first frame — seed with the root's own
+        // anchor/size for correctness if that ever changes.
+        (0.0, 0.0),
+        (0.0, 0.0),
         0,
     );
+}
+
+/// Which axes of an out-of-flow element carry an explicit (length /
+/// percentage) inset, as `(x, y)`. An explicit inset is resolved against the
+/// containing block; an `auto` inset falls back to the static (flow) position.
+/// Mirrors the per-axis idiom in [`resolve_viewport_cb_location`].
+fn explicit_inset_axes(node: &blitz_dom::Node) -> (bool, bool) {
+    use ::style::values::generics::position::GenericInset;
+
+    fn is_length_percentage(inset: &::style::values::computed::position::Inset) -> bool {
+        matches!(inset, GenericInset::LengthPercentage(_))
+    }
+
+    let Some(styles) = node.primary_styles() else {
+        return (false, false);
+    };
+    let pos = styles.get_position();
+    (
+        is_length_percentage(&pos.left) || is_length_percentage(&pos.right),
+        is_length_percentage(&pos.top) || is_length_percentage(&pos.bottom),
+    )
 }
 
 fn is_out_of_flow_positioned(node: &blitz_dom::Node) -> bool {

--- a/crates/fulgur/tests/abs_positioned_pagination.rs
+++ b/crates/fulgur/tests/abs_positioned_pagination.rs
@@ -188,3 +188,82 @@ fn abs_positioned_does_not_force_extra_pages_for_short_flow() {
         "300pt-tall abs div must not force extra pages when in-flow content fits a single page; got {pages}"
     );
 }
+
+/// fulgur-puml 原因①: nested abs (abs 内 abs) の高さがページ数を駆動する。
+#[test]
+fn nested_abs_height_drives_page_count() {
+    let html = r#"<!doctype html><html><head><style>
+        @page { size: 100pt 100pt; margin: 0; }
+        body { margin: 0; }
+    </style></head><body>
+      <div style="position:absolute;">
+        outer
+        <div style="position:absolute; top:0; height:300vh; width:50px;"></div>
+      </div>
+    </body></html>"#;
+    let engine = Engine::builder()
+        .page_size(PageSize {
+            width: 100.0,
+            height: 100.0,
+        })
+        .margin(Margin::uniform(0.0))
+        .build();
+    let pdf = engine.render_html(html).expect("render");
+    assert_eq!(
+        page_count(&pdf),
+        3,
+        "nested abs height:300vh must drive 3 pages"
+    );
+}
+
+/// fulgur-puml 原因②: in-flow があっても abs はページ拡張できる (Fix #2 で green になる想定)。
+#[test]
+fn abs_extends_pages_despite_in_flow_content() {
+    let html = r#"<!doctype html><html><head><style>
+        @page { size: 100pt 100pt; margin: 0; }
+        body { margin: 0; }
+    </style></head><body>
+      in-flow text here
+      <div style="position:absolute; bottom:-200vh;">x</div>
+    </body></html>"#;
+    let engine = Engine::builder()
+        .page_size(PageSize {
+            width: 100.0,
+            height: 100.0,
+        })
+        .margin(Margin::uniform(0.0))
+        .build();
+    let pdf = engine.render_html(html).expect("render");
+    assert_eq!(
+        page_count(&pdf),
+        3,
+        "abs bottom:-200vh must extend to 3 pages even with in-flow content"
+    );
+}
+
+/// fulgur-puml trap A: nested abs の offset は CB 基準で解決される。
+#[test]
+fn nested_abs_offset_resolves_against_cb_not_flow() {
+    let html = r#"<!doctype html><html><head><style>
+        @page { size: 100pt 100pt; margin: 0; }
+        body { margin: 0; }
+    </style></head><body>
+      <div style="position:absolute; top:100vh;">
+        outer on page 2
+        <div style="position:absolute; top:300vh;">inner on page 5</div>
+      </div>
+    </body></html>"#;
+    let engine = Engine::builder()
+        .page_size(PageSize {
+            width: 100.0,
+            height: 100.0,
+        })
+        .margin(Margin::uniform(0.0))
+        .build();
+    let pdf = engine.render_html(html).expect("render");
+    assert_eq!(
+        page_count(&pdf),
+        5,
+        "inner abs top:300vh under outer top:100vh must land on page 5 (400vh)"
+    );
+}

--- a/crates/fulgur/tests/abs_positioned_pagination.rs
+++ b/crates/fulgur/tests/abs_positioned_pagination.rs
@@ -274,6 +274,42 @@ fn nested_abs_offset_resolves_against_cb_not_flow() {
     );
 }
 
+/// fulgur-puml (CB = nearest positioned ancestor, addressing coderabbit/gemini
+/// review): when a nested abs's immediate parent is `position:static`, its
+/// containing block is the nearest POSITIONED ancestor, not the static parent
+/// (CSS 2.1 §10.1.4). Here B's `top:0` is relative to A (the abs), so B starts
+/// on page 1 and its `height:300vh` drives exactly 3 pages — even though a
+/// 200pt spacer pushes B's static wrapper down. The buggy immediate-parent
+/// anchoring would start B at 200pt and inflate the page count to 5.
+#[test]
+fn nested_abs_cb_is_nearest_positioned_ancestor_not_static_parent() {
+    let html = r#"<!doctype html><html><head><style>
+        @page { size: 100pt 100pt; margin: 0; }
+        body { margin: 0; }
+    </style></head><body>
+      <div style="position:absolute; top:0;">
+        <div style="height:200pt;"></div>
+        <div>
+          <div style="position:absolute; top:0; height:300vh; width:10px;"></div>
+        </div>
+      </div>
+    </body></html>"#;
+    let engine = Engine::builder()
+        .page_size(PageSize {
+            width: 100.0,
+            height: 100.0,
+        })
+        .margin(Margin::uniform(0.0))
+        .build();
+    let pdf = engine.render_html(html).expect("render");
+    assert_eq!(
+        page_count(&pdf),
+        3,
+        "nested abs under a static parent must anchor to the positioned ancestor (A, top:0), \
+         not the static parent's 200pt flow offset"
+    );
+}
+
 /// fulgur-puml (end-side margin fix C): an end-anchored absolute element
 /// positions its *margin box* against the CB edge, so `bottom:0;
 /// margin-bottom:N` must sit N above a plain `bottom:0` sibling. Before the

--- a/crates/fulgur/tests/abs_positioned_pagination.rs
+++ b/crates/fulgur/tests/abs_positioned_pagination.rs
@@ -5,6 +5,9 @@
 //! CSS 2.1 §10.6.4: the height of an absolutely-positioned element does not
 //! contribute to the height of its containing block's normal flow.
 
+mod support;
+use support::content_stream::text_matrix_ys;
+
 use fulgur::{Engine, Margin, PageSize};
 
 fn page_count(pdf: &[u8]) -> usize {
@@ -216,9 +219,11 @@ fn nested_abs_height_drives_page_count() {
     );
 }
 
-/// fulgur-puml 原因②: in-flow があっても abs はページ拡張できる (Fix #2 で green になる想定)。
+/// fulgur-xa9q: in-flow があっても abs はページ拡張できるべき (Chrome 準拠)。
+/// fulgur-puml では未対応 — naive な may_extend 緩和は fixedpos-008 /
+/// page-background-003 を regress させると bisect で判明したため別 issue に分離。
 #[test]
-#[ignore = "green after fulgur-puml #2 (may_extend_pages relaxation)"]
+#[ignore = "tracked by fulgur-xa9q: abs page extension with in-flow content"]
 fn abs_extends_pages_despite_in_flow_content() {
     let html = r#"<!doctype html><html><head><style>
         @page { size: 100pt 100pt; margin: 0; }
@@ -266,5 +271,45 @@ fn nested_abs_offset_resolves_against_cb_not_flow() {
         page_count(&pdf),
         5,
         "inner abs top:300vh under outer top:100vh must land on page 5 (400vh)"
+    );
+}
+
+/// fulgur-puml (end-side margin fix C): an end-anchored absolute element
+/// positions its *margin box* against the CB edge, so `bottom:0;
+/// margin-bottom:N` must sit N above a plain `bottom:0` sibling. Before the
+/// fix `resolve_viewport_cb_location` dropped the end-side margin and both
+/// collapsed onto the same baseline (the fixedpos-004/005/006 ref-side
+/// overlap that blocked promotion). This is a distinct bug from nested-abs
+/// pagination — assert the vertical offset directly via the text matrices.
+#[test]
+fn abs_bottom_margin_offsets_above_sibling() {
+    let html = r#"<!doctype html><html><head><style>
+        @page { size: 100pt 100pt; margin: 0; }
+        body { margin: 0; }
+    </style></head><body>
+      <div style="position:absolute; bottom:0; margin-bottom:30pt;">A</div>
+      <div style="position:absolute; bottom:0;">B</div>
+    </body></html>"#;
+    let engine = Engine::builder()
+        .page_size(PageSize {
+            width: 100.0,
+            height: 100.0,
+        })
+        .margin(Margin::uniform(0.0))
+        .build();
+    let pdf = engine.render_html(html).expect("render");
+
+    let Some(ys) = text_matrix_ys(&pdf) else {
+        eprintln!("qpdf not installed — skipping");
+        return;
+    };
+    // Exactly the two single-glyph runs "A" and "B".
+    assert_eq!(ys.len(), 2, "expected two text runs, got {ys:?}");
+    let gap = (ys[0] - ys[1]).abs();
+    // margin-bottom:30pt must separate the two baselines by ~30pt. The bug
+    // (margin dropped) collapses them to gap ~= 0.
+    assert!(
+        (29.0..=31.0).contains(&gap),
+        "bottom:0 + margin-bottom:30pt must sit ~30pt above a bottom:0 sibling; got baselines {ys:?} (gap {gap})"
     );
 }

--- a/crates/fulgur/tests/abs_positioned_pagination.rs
+++ b/crates/fulgur/tests/abs_positioned_pagination.rs
@@ -310,6 +310,59 @@ fn nested_abs_cb_is_nearest_positioned_ancestor_not_static_parent() {
     );
 }
 
+/// fulgur-puml (CB = positioned ancestor's PADDING box, addressing coderabbit
+/// re-review): a nested abs `top:0` sits at the ancestor's padding edge, so a
+/// top border on the ancestor pushes it down by the border width. Compare
+/// with vs without the border — the nested text baseline must shift by ~the
+/// border (a border-box CB would leave it unmoved). 40px border = 30pt.
+#[test]
+fn nested_abs_cb_uses_positioned_ancestor_padding_box() {
+    let render = |border: &str| -> Vec<u8> {
+        let html = format!(
+            r#"<!doctype html><html><head><style>
+            @page {{ size: 200pt 200pt; margin: 0; }}
+            body {{ margin: 0; }}
+        </style></head><body>
+          <div style="position:absolute; top:0; {border} width:100px; height:100px;">
+            <div style="position:absolute; top:0;">X</div>
+          </div>
+        </body></html>"#
+        );
+        let engine = Engine::builder()
+            .page_size(PageSize {
+                width: 200.0,
+                height: 200.0,
+            })
+            .margin(Margin::uniform(0.0))
+            .build();
+        engine.render_html(&html).expect("render")
+    };
+    let pdf_plain = render("");
+    let pdf_border = render("border-top: 40px solid black;");
+    let (Some(ys_plain), Some(ys_border)) =
+        (text_matrix_ys(&pdf_plain), text_matrix_ys(&pdf_border))
+    else {
+        eprintln!("qpdf not installed — skipping");
+        return;
+    };
+    assert_eq!(ys_plain.len(), 1, "one text run expected, got {ys_plain:?}");
+    assert_eq!(
+        ys_border.len(),
+        1,
+        "one text run expected, got {ys_border:?}"
+    );
+    let delta = ys_border[0] - ys_plain[0];
+    // 40px top border = 30pt; the padding-box CB pushes the nested abs down by
+    // it. A border-box CB would give delta ~= 0.
+    assert!(
+        (28.0..=32.0).contains(&delta),
+        "padding-box CB must shift the nested abs down by ~30pt (40px border); \
+         got delta {delta} (plain={}, border={})",
+        ys_plain[0],
+        ys_border[0]
+    );
+}
+
 /// fulgur-puml (end-side margin fix C): an end-anchored absolute element
 /// positions its *margin box* against the CB edge, so `bottom:0;
 /// margin-bottom:N` must sit N above a plain `bottom:0` sibling. Before the

--- a/crates/fulgur/tests/abs_positioned_pagination.rs
+++ b/crates/fulgur/tests/abs_positioned_pagination.rs
@@ -218,6 +218,7 @@ fn nested_abs_height_drives_page_count() {
 
 /// fulgur-puml 原因②: in-flow があっても abs はページ拡張できる (Fix #2 で green になる想定)。
 #[test]
+#[ignore = "green after fulgur-puml #2 (may_extend_pages relaxation)"]
 fn abs_extends_pages_despite_in_flow_content() {
     let html = r#"<!doctype html><html><head><style>
         @page { size: 100pt 100pt; margin: 0; }

--- a/crates/fulgur/tests/support/content_stream.rs
+++ b/crates/fulgur/tests/support/content_stream.rs
@@ -1,3 +1,8 @@
+// Shared test-support module: each integration-test binary that does
+// `mod support;` pulls in the whole module but uses only a subset of these
+// helpers, so unused items here are expected per-binary.
+#![allow(dead_code)]
+
 use std::process::Command;
 
 /// Counts of PDF content-stream operators after a qpdf `--qdf` expansion.
@@ -73,4 +78,56 @@ pub fn count_ops(pdf_bytes: &[u8]) -> Option<OpCounts> {
         }
     }
     Some(c)
+}
+
+/// Extract the `f` (vertical translate) operand of every text matrix
+/// (`a b c d e f Tm`) in `pdf_bytes`, in document order. Krilla emits one
+/// `Tm` per text run, so each returned value is a text run's baseline y in
+/// PDF user space. Returns `None` only when qpdf is not installed (skip);
+/// any other failure panics so bugs don't masquerade as skips.
+///
+/// Used to assert vertical placement (e.g. that an end-side margin actually
+/// offsets a `bottom:0` absolute element) without rasterizing.
+pub fn text_matrix_ys(pdf_bytes: &[u8]) -> Option<Vec<f32>> {
+    match Command::new("qpdf").arg("--version").status() {
+        Ok(status) if status.success() => {}
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return None,
+        Ok(status) => panic!("qpdf --version failed: {:?}", status),
+        Err(err) => panic!("failed to execute qpdf --version: {err}"),
+    }
+
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let tmp = dir.path().join("input.pdf");
+    let out = dir.path().join("output.qdf.pdf");
+    std::fs::write(&tmp, pdf_bytes).expect("write tmp pdf");
+
+    let status = Command::new("qpdf")
+        .args(["--qdf", "--object-streams=disable"])
+        .arg(&tmp)
+        .arg(&out)
+        .status()
+        .expect("spawn qpdf");
+    assert!(status.success(), "qpdf --qdf failed: {:?}", status);
+
+    let qdf = std::fs::read(&out).expect("read qdf output");
+    let mut ys = Vec::new();
+    for raw in qdf.split(|&b| b == b'\n') {
+        let line: &[u8] = if raw.last() == Some(&b'\r') {
+            &raw[..raw.len() - 1]
+        } else {
+            raw
+        };
+        if line.ends_with(b" Tm") {
+            // `a b c d e f Tm` — the f operand is the 6th number.
+            let text = String::from_utf8_lossy(line);
+            let nums: Vec<f32> = text
+                .split_whitespace()
+                .filter_map(|t| t.parse::<f32>().ok())
+                .collect();
+            if nums.len() == 6 {
+                ys.push(nums[5]);
+            }
+        }
+    }
+    Some(ys)
 }

--- a/docs/plans/2026-06-09-fulgur-puml-nested-abs-pagination.md
+++ b/docs/plans/2026-06-09-fulgur-puml-nested-abs-pagination.md
@@ -157,8 +157,8 @@ for child_id in children {
         // fulgur-puml 原因①: nested abs を訪問する。位置は CB (= 現 node の box) 基準で解決し、
         // root 空間 offset に変換してから recurse する (trap A)。
         let (cw, ch) = (child.final_layout.size.width, child.final_layout.size.height);
-        let (cb_w, ch_h) = (node.final_layout.size.width, node.final_layout.size.height);
-        let (rel_x, rel_y) = resolve_viewport_cb_location(child, cw, ch, cb_w, ch_h)
+        let (cb_w, cb_h) = (node.final_layout.size.width, node.final_layout.size.height);
+        let (rel_x, rel_y) = resolve_viewport_cb_location(child, cw, ch, cb_w, cb_h)
             .unwrap_or((child.final_layout.location.x, child.final_layout.location.y));
         let nested_offset = (offset_in_subtree.0 + rel_x, offset_in_subtree.1 + rel_y);
         walk(geometry, doc, child_id, nested_offset, root_xy_for_paging, body_offset,

--- a/docs/plans/2026-06-09-fulgur-puml-nested-abs-pagination.md
+++ b/docs/plans/2026-06-09-fulgur-puml-nested-abs-pagination.md
@@ -1,0 +1,339 @@
+# Nested abs-driven pagination (fulgur-puml) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** `position:absolute` 要素（特に abs 内 abs = nested abs）が height/offset で
+ページ領域を超えるとき、CSS Paged Media のフラグメント化に従って追加ページを生成し、
+それを fixed-repeat 要素にも伝播させる。WPT `fixedpos-004/005/006-print` を PASS にする。
+
+**Architecture:** 現状 `pagination_layout::append_position_absolute_body_direct_fragments` は
+body 直下 abs のみを `record_subtree_fragments_at_offset` で walk するが、内側 walk が
+OOF 子孫を `continue` で skip するため nested abs が処理されない（原因①）。また
+`may_extend_pages = !body_has_in_flow_content` のため in-flow 併存時に abs がページ拡張
+できない（原因②）。engine.rs はすでに abs パス後に `implied_page_count` を再読して
+`append_position_fixed_fragments` を再実行する拡張ループを持つので、abs パスが
+`implied_page_count` を正しく伸ばせば fixed-repeat への伝播（trap B）は自動で成立する。
+
+**Tech Stack:** Rust, Stylo (computed position insets), `pagination_layout.rs` の
+`walk()` 再帰 + `Fragment` / `descendant_total_pages` / `may_extend_pages`。
+
+---
+
+## 背景 (実測済の事実 — 着手前に再確認不要)
+
+- 原因① 最小再現: `<body><div style="position:absolute"><div style="position:absolute;height:300vh">x</div></div></body>` → 1 ページ (期待 3)
+- 原因② 最小再現: `<body>text<div style="position:absolute;bottom:-200vh">x</div></body>` → 1 ページ (期待 3)。in-flow 無し版は 3 ページ
+- 既存 PASS (regression guard): `monolithic-overflow-013`, `fixedpos-001/002/003/008-print`
+- vh は viewport 相対 (CB 非依存)。`top:300vh` は常に 3×viewport
+- nested abs の root 空間 y = 外側 abs の解決 y + 内側 abs の CB 相対解決 y
+- ページ数 assert は `crates/fulgur/tests/abs_positioned_pagination.rs` の `page_count(&pdf)` ヘルパー
+  (`/Type /Page` カウント) を流用。`@page { size: 100pt 100pt; margin:0 }` で 100vh = 1 ページ
+
+## 検証ラダー (原因帰属のため順守)
+
+1. Fix #1 単独 → fixedpos-004 と nested 最小再現が green になるはず (004 body は in-flow 無し →
+   may_extend は既に true)。ここで lib suite + WPT regression guard 確認
+2. その後 Fix #2 追加 → fixedpos-005/006 と in-flow+abs 最小再現が green。full WPT + lib suite 確認
+
+---
+
+### Task 1: RED — nested abs と in-flow+abs のページ数特性テスト
+
+**Files:**
+
+- Modify (append): `crates/fulgur/tests/abs_positioned_pagination.rs`
+
+**Step 1: Write the failing tests**
+
+`abs_positioned_pagination.rs` 末尾に追加（`page_count` / `Engine` / `PageSize` / `Margin` は既存 import）:
+
+```rust
+/// fulgur-puml 原因①: nested abs (abs 内 abs) の高さがページ数を駆動する。
+/// 内側 abs `height:300vh` → 3 ページ。外側 abs は in-flow を持たない。
+#[test]
+fn nested_abs_height_drives_page_count() {
+    let html = r#"<!doctype html><html><head><style>
+        @page { size: 100pt 100pt; margin: 0; }
+        body { margin: 0; }
+    </style></head><body>
+      <div style="position:absolute;">
+        outer
+        <div style="position:absolute; top:0; height:300vh; width:50px;"></div>
+      </div>
+    </body></html>"#;
+    let engine = Engine::builder()
+        .page_size(PageSize { width: 100.0, height: 100.0 })
+        .margin(Margin::uniform(0.0))
+        .build();
+    let pdf = engine.render_html(html).expect("render");
+    assert_eq!(page_count(&pdf), 3, "nested abs height:300vh must drive 3 pages");
+}
+
+/// fulgur-puml 原因②: in-flow コンテンツがあっても abs はページを拡張できる。
+/// abs `bottom:-200vh` → 3 ページ (in-flow は 1 ページ分の text)。
+#[test]
+fn abs_extends_pages_despite_in_flow_content() {
+    let html = r#"<!doctype html><html><head><style>
+        @page { size: 100pt 100pt; margin: 0; }
+        body { margin: 0; }
+    </style></head><body>
+      in-flow text here
+      <div style="position:absolute; bottom:-200vh;">x</div>
+    </body></html>"#;
+    let engine = Engine::builder()
+        .page_size(PageSize { width: 100.0, height: 100.0 })
+        .margin(Margin::uniform(0.0))
+        .build();
+    let pdf = engine.render_html(html).expect("render");
+    assert_eq!(page_count(&pdf), 3, "abs bottom:-200vh must extend to 3 pages even with in-flow content");
+}
+
+/// fulgur-puml trap A: nested abs の offset は CB 基準で解決される。
+/// 外側 abs `top:100vh` + 内側 abs `top:300vh` → 内側は 400vh (page 5) に着地。
+#[test]
+fn nested_abs_offset_resolves_against_cb_not_flow() {
+    let html = r#"<!doctype html><html><head><style>
+        @page { size: 100pt 100pt; margin: 0; }
+        body { margin: 0; }
+    </style></head><body>
+      <div style="position:absolute; top:100vh;">
+        outer on page 2
+        <div style="position:absolute; top:300vh;">inner on page 5</div>
+      </div>
+    </body></html>"#;
+    let engine = Engine::builder()
+        .page_size(PageSize { width: 100.0, height: 100.0 })
+        .margin(Margin::uniform(0.0))
+        .build();
+    let pdf = engine.render_html(html).expect("render");
+    assert_eq!(page_count(&pdf), 5, "inner abs top:300vh under outer top:100vh must land on page 5 (400vh)");
+}
+```
+
+**Step 2: Run to verify they fail**
+
+Run: `cargo test -p fulgur --test abs_positioned_pagination nested_abs_height_drives_page_count abs_extends_pages_despite_in_flow_content nested_abs_offset_resolves_against_cb_not_flow 2>&1 | tail -20`
+Expected: 3 つとも FAIL（おそらく page_count=1）。期待値とのズレを記録。
+
+**Step 3: Commit (red)**
+
+```bash
+git add crates/fulgur/tests/abs_positioned_pagination.rs
+git commit -m "test(pagination): red tests for nested-abs and in-flow+abs page extension"
+```
+
+---
+
+### Task 2: Fix #1 — nested abs を訪問し CB 基準 offset で extent を集計
+
+**Files:**
+
+- Modify: `crates/fulgur/src/pagination_layout.rs`
+  - `record_subtree_fragments_at_offset` の内側 `walk`（OOF skip する `if is_out_of_flow_positioned(child) { continue; }` ≈ L3050-3055）
+
+**Step 1: 設計メモ（trap A 厳守）**
+
+内側 walk が nested abs 子に出会ったとき、in-flow 子のように `offset_in_subtree += child.final_layout.location`
+で単純加算してはいけない。nested abs の位置は **その CB（最寄り positioned 祖先 = 現在の subtree root の box）**
+に対して `resolve_viewport_cb_location(child, child_w, child_h, cb_w, cb_h)` で解決する。
+
+- `cb_w` / `cb_h` = nested abs の CB box の寸法。第一候補は外側 abs（= 現 walk の `node`）の
+  `final_layout.size`。ただし vh ベース inset (`top:300vh`) は CB 非依存なのでこの寸法は
+  パーセンテージ inset のみに効く。
+- 解決した CB 相対 (x, y) に、現在の accumulated root-space offset（= この nested abs の親 = `node` の
+  root 空間位置）を足して root 空間位置を得る。
+- その root 空間位置を新しい `root_xy_for_paging`（または `offset_in_subtree`）として nested abs subtree を
+  walk し直す（フラグメント emit と `descendant_total_pages` 更新は既存ロジックを再利用）。
+
+**実装は TDD で確定する。** 単純加算では `nested_abs_offset_resolves_against_cb_not_flow` が
+page 4 等で落ちるはず。落ちたら CB 基準解決へ寄せる。off-by-one (page 4 vs 5) を必ず潰す。
+
+候補実装スケッチ（exact code は test を回しながら調整）:
+
+```rust
+for child_id in children {
+    let Some(child) = doc.get_node(child_id) else { continue; };
+    if is_out_of_flow_positioned(child) {
+        // fulgur-puml 原因①: nested abs を訪問する。位置は CB (= 現 node の box) 基準で解決し、
+        // root 空間 offset に変換してから recurse する (trap A)。
+        let (cw, ch) = (child.final_layout.size.width, child.final_layout.size.height);
+        let (cb_w, ch_h) = (node.final_layout.size.width, node.final_layout.size.height);
+        let (rel_x, rel_y) = resolve_viewport_cb_location(child, cw, ch, cb_w, ch_h)
+            .unwrap_or((child.final_layout.location.x, child.final_layout.location.y));
+        let nested_offset = (offset_in_subtree.0 + rel_x, offset_in_subtree.1 + rel_y);
+        walk(geometry, doc, child_id, nested_offset, root_xy_for_paging, body_offset,
+             page_h_px, page_stride_px, total_pages, may_extend_pages, depth + 1);
+        continue;
+    }
+    // ... 既存 in-flow 子の処理（whitespace skip, monolithic_y_adjust 等）
+}
+```
+
+注意: nested abs が `position:fixed` の場合（fixedpos-004/005/006 の最内 fixed）は別パス
+(`append_position_fixed_fragments`) が扱う。fixed は repeat 要素なのでこの walk で extent に
+加算してはいけない。`is_out_of_flow_positioned` は abs/fixed 両方 true なので、nested 訪問は
+**abs のみ**に限定する（fixed は従来どおり continue で skip）。
+
+**Step 2-4: テストを回しながら実装 → green を確認**
+
+Run: `cargo test -p fulgur --test abs_positioned_pagination nested_abs_height_drives_page_count nested_abs_offset_resolves_against_cb_not_flow 2>&1 | tail -20`
+Expected: この 2 つ PASS。`abs_extends_pages_despite_in_flow_content` はまだ FAIL でよい
+（in-flow 併存なので Fix #2 待ち）。
+
+**Step 5: regression guard（lib + 該当 WPT）**
+
+```bash
+cargo test -p fulgur --lib 2>&1 | tail -5
+cargo test -p fulgur --test abs_positioned_pagination 2>&1 | tail -10
+```
+
+WPT 該当のみ（regression 早期検知）:
+
+```bash
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" \
+  cargo test -p fulgur-wpt 2>&1 | grep -iE "fixedpos|monolithic-overflow-013" | tail -20
+```
+
+Expected: fixedpos-004 が test=3/ref=3 で PASS 方向。monolithic-013, fixedpos-001/002/003/008 が
+依然 PASS。fixedpos-005/006 はまだ FAIL でよい。
+
+**Step 6: Commit**
+
+```bash
+git add crates/fulgur/src/pagination_layout.rs
+git commit -m "fix(pagination): visit nested abs and resolve offset against CB (fulgur-puml #1)"
+```
+
+---
+
+### Task 3: Fix #2 — in-flow 併存時も abs がページ拡張できるようにする
+
+**Files:**
+
+- Modify: `crates/fulgur/src/pagination_layout.rs`
+  - `append_position_absolute_body_direct_fragments` の
+    `record_subtree_fragments_at_offset(..., !body_has_in_flow_content)` 呼び出し（≈ L2895）
+
+**Step 1: 変更**
+
+abs パスは in-flow の有無に関わらずページ拡張を許可する。最小変更:
+
+```rust
+// fulgur-puml 原因②: abs は in-flow 併存でもページを拡張できる (Chrome 準拠)。
+// 旧 `!body_has_in_flow_content` は abs が pagination_geometry から落ちる問題
+// (fixedpos-001/002/008) とは無関係で、拡張可否を不当に制限していた。
+record_subtree_fragments_at_offset(
+    geometry, doc, child_id, (resolved_x, resolved_y), body_offset_xy,
+    viewport_h_px, page_stride_px, pages,
+    /* may_extend_pages */ true,
+);
+```
+
+`body_has_in_flow_content` が他で使われていなければ dead code 警告が出る。使われていなければ
+当該ローカルを削除する（`#[allow(unused)]` で誤魔化さない）。
+
+**Step 2-4: テスト green 確認**
+
+Run: `cargo test -p fulgur --test abs_positioned_pagination 2>&1 | tail -10`
+Expected: `abs_extends_pages_despite_in_flow_content` を含む全テスト PASS。
+
+**Step 5: full WPT + lib suite（regression 全面確認）**
+
+```bash
+cargo test -p fulgur --lib 2>&1 | tail -5
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur-wpt 2>&1 | tail -30
+```
+
+Expected: fixedpos-004/005/006 が PASS 方向。**新規 FAIL（regression）が出たら、その test が
+「abs を clip すべき（paginate でない）」ケースを名指ししている** → may_extend を無条件 true ではなく
+条件付き（例: abs の resolved extent が実在 inset 由来のときのみ）に絞る。先回り実装はしない。
+
+**Step 6: Commit**
+
+```bash
+git add crates/fulgur/src/pagination_layout.rs
+git commit -m "fix(pagination): allow abs to extend page count with in-flow content (fulgur-puml #2)"
+```
+
+---
+
+### Task 4: WPT expectations を PASS に昇格
+
+**Files:**
+
+- Modify: `crates/fulgur-wpt/expectations/css-page.txt`（L34-36 の fixedpos-004/005/006）
+
+**Step 1: 実 PASS を確認してから昇格**
+
+`/wpt-promote` の流儀に従い、まず該当テストが実際に PASS することを確認:
+
+```bash
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" \
+  cargo test -p fulgur-wpt 2>&1 | grep -iE "fixedpos-00[456]"
+```
+
+**Step 2: expectations 編集**
+
+`crates/fulgur-wpt/expectations/css-page.txt` の以下 3 行を `FAIL ... # page count mismatch...`
+から `PASS` に変更し、行末に `# fulgur-puml` 参照を付す:
+
+```text
+PASS  css/css-page/fixedpos-004-print.html  # fulgur-puml
+PASS  css/css-page/fixedpos-005-print.html  # fulgur-puml
+PASS  css/css-page/fixedpos-006-print.html  # fulgur-puml
+```
+
+**Step 3: 昇格後の expectation で全 WPT green 確認**
+
+```bash
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur-wpt 2>&1 | tail -15
+```
+
+Expected: expectation mismatch 0。
+
+**Step 4: Commit**
+
+```bash
+git add crates/fulgur-wpt/expectations/css-page.txt
+git commit -m "test(wpt): promote fixedpos-004/005/006-print to PASS (fulgur-puml)"
+```
+
+---
+
+### Task 5: 最終検証 + clippy/fmt
+
+**Step 1: 全体検証**
+
+```bash
+cargo fmt --check
+cargo clippy -p fulgur --all-targets 2>&1 | tail -15
+cargo test -p fulgur 2>&1 | tail -5
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur-wpt 2>&1 | tail -10
+```
+
+Expected: fmt OK、clippy 警告なし、全テスト green。
+
+**Step 2: 受け入れ基準の確認（design 参照）**
+
+- [ ] fixedpos-004/005/006-print PASS
+- [ ] monolithic-overflow-013, fixedpos-001/002/003/008-print 引き続き PASS
+- [ ] 既存 fulgur テスト全緑
+- [ ] nested abs / in-flow+abs / CB 解決の再現テスト追加済（Task 1）
+
+**Step 3: 必要なら fmt commit**
+
+```bash
+cargo fmt
+git add -A && git commit -m "style: cargo fmt"
+```
+
+---
+
+## 留意
+
+- DRY: `resolve_viewport_cb_location` を再利用（新規解決ロジックを書かない）
+- YAGNI: may_extend は無条件 true から始め、regression が出た test に応じてのみ条件を足す
+- trap B（fixed-repeat 伝播）は engine.rs の既存「abs パス後に implied_page_count 再読 →
+  fixed 再実行」ループで自動成立。abs パスが implied_page_count を伸ばすことだけ保証すればよい
+- nested 訪問は **abs のみ**。fixed は `append_position_fixed_fragments` の担当（repeat 要素なので
+  extent 加算してはいけない）


### PR DESCRIPTION
## 概要

`fulgur-puml`: tall な `position:absolute` 要素（特に **nested abs = abs 内 abs**）が
height/offset でページ領域を超えてもページ生成を駆動しない問題を修正します。

着手時に design の scope 表が `fulgur-sbw2` の修正で陳腐化していたため再計測し、残課題が
nested abs 3件（fixedpos-004/005/006）に絞られていることを確認。実装中にさらに原因を
分離しました。

## 変更内容

- **Fix #1 — nested abs の訪問** (`206295ff`): `record_subtree_fragments_at_offset` の walk が
  OOF 子孫を無条件 skip していたため、abs 内 abs がどのパスからも処理されなかった。nested abs を
  CB（最寄り positioned 祖先）基準で解決した offset で訪問し、`descendant_total_pages` に
  寄与させる。`position:fixed` 子孫は従来どおり別パス担当なので skip 維持。
- **Fix C — end-side margin** (`1c887605`): `resolve_viewport_cb_location` が bottom/right
  anchor 時に `margin-bottom`/`margin-right` を無視していた**既存バグ**（nested-abs とは無関係）。
  fixedpos-004/005/006 の ref は `margin-bottom` で repeat 行を分離する設計のため、これが
  promotion をブロックしていた。Taffy 解決済みの end-side margin を減算。3 callers
  （fixed/abs body-direct/nested 再帰）に効くため `position:fixed` の end-anchor も同時に修正。
- **WPT** (`ca649d21`): `fixedpos-004-print` を PASS に昇格。

## スコープ判断（重要）

当初 design の受け入れ基準は「004/005/006 全 promote」でしたが、実装中の **bisect** で、
in-flow 併存時に abs をページ拡張させる素朴な `may_extend_pages` 緩和が
**`fixedpos-008` と `page-background-003` を regress させる**ことが判明しました。
そのため当該 commit を **drop** し、005/006（abs の in-flow 併存ページ拡張を要する）は
follow-up issue **`fulgur-xa9q`** に分離しています。本 PR では **004 のみ** を promote します。
（`fixedpos-003` は当初 in-scope でしたが `fulgur-sbw2` で既に PASS 済）

## テスト

- 追加 lib テスト: `nested_abs_height_drives_page_count`,
  `nested_abs_offset_resolves_against_cb_not_flow`（trap A: 内側 `top:300vh` が
  page 5 = 400vh に着地）, `abs_bottom_margin_offsets_above_sibling`（Fix C を Tm 抽出で検証）
- `cargo test -p fulgur`: 全緑
- `cargo test -p fulgur-vrt`（byte-wise golden）: 全緑（C は既存 golden を動かさない）
- WPT 全フェーズ: 新規 regression 0（css-page の pre-existing page-name 2件のみ）
- 保護セット維持: `monolithic-overflow-013`, `fixedpos-001/002/003/008`,
  `page-background-002/003` 全 PASS
- `cargo fmt --check` / `cargo clippy`: クリーン

Closes fulgur-puml


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 絶対配置要素のページ分割と位置解決を改善し、複数ページにまたがる配置がより正確になります（端辺マージンの扱いも修正）。

* **Tests**
  * ネストした絶対配置やページ拡張動作を含む回帰テスト群を追加し、PDF上のベースライン差などを直接検証します。
  * テスト用のPDFテキスト抽出ユーティリティを追加しました。

* **Documentation**
  * ネストした絶対配置とページネーションに関する実装計画ドキュメントを追加しました。

* **Chores**
  * 外部テスト期待結果を更新しました（印刷関連の期待が見直し済み）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->