### PR TITLE
test(schema): add coverage for FilterBlock, AutoEscape, SetBlock, UnaryOp, IfExpr, BinOp, Map, value_to_schema edge cases

### DIFF
--- a/crates/fulgur/src/schema.rs
+++ b/crates/fulgur/src/schema.rs
@@ -792,4 +792,132 @@ mod tests {
         assert_eq!(schema["properties"]["title"]["type"], "string");
         assert_eq!(schema["properties"]["subtitle"]["type"], "string");
     }
+
+    // ── FilterBlock ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn filter_block_collects_body_variables() {
+        let schema =
+            extract_schema("{% filter upper %}{{ name }}{% endfilter %}", "test.html").unwrap();
+        assert_eq!(schema["properties"]["name"]["type"], "string");
+    }
+
+    // ── AutoEscape ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn autoescape_block_collects_body_variables() {
+        let schema = extract_schema(
+            r#"{% autoescape true %}{{ name }}{% endautoescape %}"#,
+            "test.html",
+        )
+        .unwrap();
+        assert_eq!(schema["properties"]["name"]["type"], "string");
+    }
+
+    // ── SetBlock ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn setblock_body_is_walked_and_target_does_not_leak() {
+        // {% set x %}...{% endset %} walks the block body but x itself
+        // is a locally-captured string and must not appear as a top-level
+        // schema property.
+        let schema =
+            extract_schema("{% set content %}{{ source_var }}{% endset %}", "test.html").unwrap();
+        assert_eq!(schema["properties"]["source_var"]["type"], "string");
+        assert!(schema["properties"]["content"].is_null());
+    }
+
+    // ── UnaryOp ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn unary_op_collects_operand_variable() {
+        let schema = extract_schema("{{ not flag }}", "test.html").unwrap();
+        assert_eq!(schema["properties"]["flag"]["type"], "string");
+    }
+
+    // ── IfExpr (inline ternary) ───────────────────────────────────────────────
+
+    #[test]
+    fn inline_if_with_else_collects_all_three_parts() {
+        let schema = extract_schema("{{ title if show else fallback }}", "test.html").unwrap();
+        assert_eq!(schema["properties"]["title"]["type"], "string");
+        assert_eq!(schema["properties"]["show"]["type"], "string");
+        assert_eq!(schema["properties"]["fallback"]["type"], "string");
+    }
+
+    #[test]
+    fn inline_if_without_else_collects_value_and_test() {
+        let schema = extract_schema("{{ title if show }}", "test.html").unwrap();
+        assert_eq!(schema["properties"]["title"]["type"], "string");
+        assert_eq!(schema["properties"]["show"]["type"], "string");
+    }
+
+    // ── Test expression (is defined / is …) ──────────────────────────────────
+
+    #[test]
+    fn test_expression_collects_subject_variable() {
+        let schema = extract_schema("{{ value is defined }}", "test.html").unwrap();
+        assert_eq!(schema["properties"]["value"]["type"], "string");
+    }
+
+    // ── BinOp ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn bin_op_collects_both_operands() {
+        let schema = extract_schema("{{ first ~ last }}", "test.html").unwrap();
+        assert_eq!(schema["properties"]["first"]["type"], "string");
+        assert_eq!(schema["properties"]["last"]["type"], "string");
+    }
+
+    // ── Map literal ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn map_literal_collects_value_variables() {
+        let schema =
+            extract_schema(r#"{{ {"label": title, "id": page_id} }}"#, "test.html").unwrap();
+        assert_eq!(schema["properties"]["title"]["type"], "string");
+        assert_eq!(schema["properties"]["page_id"]["type"], "string");
+    }
+
+    // ── value_to_schema edge cases ────────────────────────────────────────────
+
+    #[test]
+    fn schema_with_data_boolean_maps_to_boolean_type() {
+        let data = json!({"active": true});
+        let schema = extract_schema_with_data("{{ active }}", "test.html", &data).unwrap();
+        assert_eq!(schema["properties"]["active"]["type"], "boolean");
+    }
+
+    #[test]
+    fn schema_with_data_null_maps_to_null_type() {
+        let data = json!({"val": null});
+        let schema = extract_schema_with_data("{{ val }}", "test.html", &data).unwrap();
+        assert_eq!(schema["properties"]["val"]["type"], "null");
+    }
+
+    #[test]
+    fn schema_with_data_object_includes_all_nested_properties() {
+        let data = json!({
+            "user": {"name": "Alice", "age": 30, "active": true}
+        });
+        let schema = extract_schema_with_data("{{ user.name }}", "test.html", &data).unwrap();
+        let user = &schema["properties"]["user"];
+        assert_eq!(user["type"], "object");
+        assert_eq!(user["properties"]["name"]["type"], "string");
+        assert_eq!(user["properties"]["age"]["type"], "number");
+        assert_eq!(user["properties"]["active"]["type"], "boolean");
+    }
+
+    #[test]
+    fn schema_with_data_empty_array_omits_items_schema() {
+        // When the sample array is empty, value_to_schema cannot infer an
+        // items schema, so the "items" key must be absent.
+        let data = json!({"tags": []});
+        let schema =
+            extract_schema_with_data("{% for t in tags %}{{ t }}{% endfor %}", "test.html", &data)
+                .unwrap();
+        let tags = &schema["properties"]["tags"];
+        assert_eq!(tags["type"], "array");
+        assert!(tags.get("items").is_none() || tags["items"].is_null());
+    }
 }


### PR DESCRIPTION
## 対象モジュール

`crates/fulgur/src/schema.rs` — MiniJinja テンプレートの AST を走査して JSON Schema を生成するモジュール。Blitz / Krilla に依存しない純粋なロジックで構成されており、ユニットテストが追加しやすい。

## カバレッジ変化

| 指標 | 変更前 | 変更後 | 差分 |
|------|--------|--------|------|
| リージョンカバレッジ | 83.33% | 92.54% | +9.21 pp |
| ラインカバレッジ | 85.56% | 93.49% | +7.93 pp |

## 追加したテスト（13 件）

| テスト名 | カバーする経路 |
|---------|--------------|
| `filter_block_collects_body_variables` | `ast::Stmt::FilterBlock` の body 走査 |
| `autoescape_block_collects_body_variables` | `ast::Stmt::AutoEscape` の body 走査 |
| `setblock_body_is_walked_and_target_does_not_leak` | `ast::Stmt::SetBlock` の body 走査 + ターゲット変数がスキーマに漏れないこと |
| `unary_op_collects_operand_variable` | `ast::Expr::UnaryOp` のオペランド再帰 |
| `inline_if_with_else_collects_all_three_parts` | `ast::Expr::IfExpr` の test/true/false 三部すべて |
| `inline_if_without_else_collects_value_and_test` | `ast::Expr::IfExpr` の false_expr が `None` のケース |
| `test_expression_collects_subject_variable` | `ast::Expr::Test` のサブジェクト再帰 |
| `bin_op_collects_both_operands` | `ast::Expr::BinOp` の left/right 再帰 |
| `map_literal_collects_value_variables` | `ast::Expr::Map` の value 再帰 |
| `schema_with_data_boolean_maps_to_boolean_type` | `value_to_schema(Value::Bool)` |
| `schema_with_data_null_maps_to_null_type` | `value_to_schema(Value::Null)` |
| `schema_with_data_object_includes_all_nested_properties` | `value_to_schema(Value::Object)` のネストされたプロパティ |
| `schema_with_data_empty_array_omits_items_schema` | `value_to_schema(Value::Array([]))` — `arr.first()` が `None` のブランチ |

## 意図的にスキップした未カバーブランチ

- **`PosSplat` / `KwargSplat` in `collect_from_call_arg`**: MiniJinja のテンプレート構文では splat 引数 (`*args`, `**kwargs`) を記述する方法が存在しないため、テンプレート文字列経由で到達させることが不可能。プロダクションコード側の変更なしに網羅する手段がない。
- **`ast::Expr::GetAttr` の `resolve_expr_path` が `None` を返すブランチ**: フィルタ式の戻り値に `.attr` アクセスするケース（例: `{{ (x | filter).attr }}`）。MiniJinja がこのパターンを AST レベルで `GetAttr` に変換するか不明であり、現時点では安全にテストケースを構築できない。
- **`extract_var_names` の `_ => vec[]` ブランチ**: `for` ループのターゲットが `Var` でも `List` でもない AST ノードになるケース。実際のテンプレート構文ではこのパスに到達しない。

---
_Generated by [Claude Code](https://claude.ai/code/session_018pf4YEgRCxk4zjiNQZ1Xeg)_