### PR TITLE
build(python): add musllinux wheels for Alpine (x86_64, aarch64)

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -32,6 +32,14 @@ jobs:
             runner: ubuntu-24.04-arm
             manylinux: "2014"
             rustflags: ""
+          - target: x86_64-unknown-linux-musl
+            runner: ubuntu-latest
+            manylinux: musllinux_1_2
+            rustflags: ""
+          - target: aarch64-unknown-linux-musl
+            runner: ubuntu-24.04-arm
+            manylinux: musllinux_1_2
+            rustflags: ""
           - target: x86_64-apple-darwin
             runner: macos-15-intel
             rustflags: ""
@@ -167,6 +175,44 @@ jobs:
           print(f'OK: {len(pdf)} bytes')
           "
 
+  smoke-test-musl:
+    # Verify musllinux wheels on an actual Alpine (musl) environment.
+    # Alpine runs via `docker run` rather than `container:` because JavaScript
+    # actions (download-artifact) inside Alpine containers are only supported
+    # on x64 runners — the arm64 runner fails with "JavaScript Actions in
+    # Alpine containers are only supported on x64 Linux runners". Alpine's
+    # Python is PEP 668 externally-managed, so the wheel installs into a venv.
+    name: Smoke test (Alpine / ${{ matrix.target }})
+    needs: [build-wheels]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            runner: ubuntu-latest
+          - target: aarch64-unknown-linux-musl
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: wheels-${{ matrix.target }}
+          path: dist
+      - name: Smoke test in Alpine container
+        run: |
+          docker run --rm -v "$PWD/dist:/dist" alpine:3.24 sh -ec '
+          apk add --no-cache python3 py3-pip
+          python3 -m venv /tmp/venv
+          /tmp/venv/bin/pip install /dist/*.whl
+          /tmp/venv/bin/python -c "
+          import pyfulgur
+          engine = pyfulgur.Engine()
+          pdf = engine.render_html(\"<p>hi</p>\")
+          assert isinstance(pdf, (bytes, bytearray)), type(pdf)
+          assert len(pdf) > 100, len(pdf)
+          print(f\"OK: {len(pdf)} bytes\")
+          "'
+
   # release-prepare.yml が release PR に `release:skip-bindings` ラベルを付けて
   # いれば bindings publish を丸ごと skip する。release event は PR コンテキストを
   # 持たないため、tag → commit → associated PR の順に逆引きしてラベルを参照する。
@@ -202,7 +248,7 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    needs: [build-wheels, build-sdist, smoke-test, smoke-test-sdist, check-skip-label]
+    needs: [build-wheels, build-sdist, smoke-test, smoke-test-sdist, smoke-test-musl, check-skip-label]
     # 本番 PyPI publish は release イベント (release.yml がタグから発火) のみ。
     # workflow_dispatch からは任意の ref を publish できないようにする (security)。
     # 手動検証は publish-testpypi (dry_run=true) を使う。
@@ -220,7 +266,7 @@ jobs:
 
   publish-testpypi:
     name: Publish to TestPyPI
-    needs: [build-wheels, build-sdist, smoke-test, smoke-test-sdist]
+    needs: [build-wheels, build-sdist, smoke-test, smoke-test-sdist, smoke-test-musl]
     if: github.event_name == 'workflow_dispatch' && inputs.dry_run
     runs-on: ubuntu-latest
     environment: testpypi


### PR DESCRIPTION
## Summary

Adds `musllinux_1_2` abi3 wheels for `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` to the Python release workflow, so `pip install pyfulgur` works on Alpine-based images (musl libc) without a Rust toolchain. Today those users fall back to the sdist, which requires a full Rust build.

## Changes (release-python.yml only)

- Two new `build-wheels` matrix entries (`manylinux: musllinux_1_2`); maturin-action builds musl targets in its standard `rust-musl-cross` images and bundles the one shared library (`libgcc_s.so.1`) into the wheel, so no step changes were needed.
- New `smoke-test-musl` job: installs the built wheel inside an `alpine:3.24` container (venv, since Alpine's Python is PEP 668 externally-managed) and runs the same `render_html` assertion as the existing smoke tests. The container runs via `docker run` rather than `container:` because JavaScript actions inside Alpine containers are only supported on x64 runners — on `ubuntu-24.04-arm` the runner fails with "JavaScript Actions in Alpine containers are only supported on x64 Linux runners".
- Both publish jobs now also gate on `smoke-test-musl`.

## Why this is safe

The musl build graph has no link-time C dependencies: the only Linux C library involved is fontconfig, which `fontique` loads via `dlopen` at runtime (`yeslogic-fontconfig-sys` with the `dlopen` feature). Verified with `cargo tree --target x86_64-unknown-linux-musl`.

## Verification

- Full `workflow_dispatch` run (`dry_run=false`: all build + smoke jobs, publish skipped) on my fork: https://github.com/cristi-boboc/fulgur/actions/runs/27327575369 — all 7 wheel targets, sdist, and all smoke tests green, including the new Alpine container tests on both architectures.
- Also reproduced locally on arm64: wheel built in `rust-musl-cross:aarch64-musl`, installed and smoke-tested in `alpine:3.24` (`OK: 1575 bytes`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * musllinuxプラットフォーム（x86_64およびaarch64）向けのパッケージ配布対応を新規実装しました

* **Tests**
  * Alpineコンテナ環境でのスモークテストジョブを新規追加し、ビルド成果物の品質確認テストを実装しました
  * パッケージ公開前にテスト完了を必須要件として組み込みました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->