### PR TITLE
fix(deps): bump pyo3 to 0.29 and smallbitvec to 2.6.1 for security advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,9 +2669,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "libc",
  "once_cell",
@@ -2683,18 +2683,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2702,9 +2702,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2714,13 +2714,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -3336,9 +3335,9 @@ dependencies = [
 
 [[package]]
 name = "smallbitvec"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d31d263dd118560e1a492922182ab6ca6dc1d03a3bf54e7699993f31a4150e3f"
+checksum = "9b0e903ee191d8f7a8fbf0d712c3a1699d19e04ceba5ad1eb673053c7d938a09"
 
 [[package]]
 name = "smallvec"

--- a/crates/pyfulgur/Cargo.toml
+++ b/crates/pyfulgur/Cargo.toml
@@ -21,7 +21,7 @@ extension-module = ["dep:pyo3", "pyo3/extension-module"]
 
 [dependencies]
 fulgur = { path = "../fulgur" }
-pyo3 = { version = "0.28", optional = true, features = ["abi3-py39"] }
+pyo3 = { version = "0.29", optional = true, features = ["abi3-py39"] }
 
 [dev-dependencies]
 static_assertions = "1.1"


### PR DESCRIPTION
## 概要

Dependabot セキュリティアラートのトリアージと対応。14 件のうち未解決（open）は 5 件で、いずれもこの PR で解消する。残り 9 件は既に lockfile が修正版を含んでおり `state=fixed`（対応不要）。

## 対応内容

| アラート | パッケージ | 重大度 | 対応 |
|---|---|---|---|
| #13 #12 GHSA-36hh-v3qg-5jq4 | pyo3 | high | `PyList`/`PyTuple` の `nth`/`nth_back` での OOB read。0.29.0 で修正 |
| #15 #14 GHSA-chgr-c6px-7xpp | pyo3 | medium | `PyCFunction::new_closure` の `Sync` bound 欠落。0.29.0 で修正 |
| #7 GHSA-97wc-2hqc-cjgr | smallbitvec | high | `buffer_len` の整数オーバーフローによる heap buffer overflow。2.6.1 で修正 |

- **pyo3 0.28.3 → 0.29.0**: `crates/pyfulgur/Cargo.toml` の制約を `0.28` → `0.29` に更新 + lockfile 更新。
- **smallbitvec 2.6.0 → 2.6.1**: stylo 経由の推移的依存。lockfile のみ更新。

## smallbitvec について

Dependabot の advisory は `patched: null`（脆弱性レンジ `<= 2.6.0`）と表示するが、これは advisory DB の遅延で、**2.6.1 が修正版**。2.6.1 の `buffer_len` を確認したところ、脆弱な `cap + bits_per_storage() - 1` が `cap.checked_add(bits - 1).expect("capacity overflow")` に置き換わっており、修正が実際に含まれていることを確認済み。レンジ `<= 2.6.0` 外なので push で #7 は自動クローズされる。

## 検証

```text
cargo clippy -p pyfulgur --features extension-module --all-targets -- -D warnings
```

CI ゲート（`ci.yml:337`）相当のコマンドで pyo3 0.29 へのアップグレードがクリーンに通ることを確認（`from_py_object` pyclass 属性含む）。このビルドで smallbitvec 2.6.1 も同時に引き込まれるため、両 fix を一括検証。

determinism への影響: smallbitvec は stylo の CSS パス内のみで使われ、通常レンダリングでは `usize::MAX` 近傍のオーバーフロー経路を通らないため VRT golden は変化しない（CI の VRT ジョブで担保）。

Closes #fulgur-qjry
