### PR TITLE
build(wasm): cut fulgur-wasm bundle 37MB->7MB via size-optimised build

### DIFF
--- a/crates/fulgur-wasm/Cargo.toml
+++ b/crates/fulgur-wasm/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib", "rlib"]
 # env vars (see the mise `wasm-build` task) so the CLI's native release profile
 # keeps its speed-first tuning untouched.
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ['-Oz', '--enable-bulk-memory', '--enable-mutable-globals', '--enable-nontrapping-float-to-int', '--enable-sign-ext', '--enable-reference-types']
+wasm-opt = ["-Oz", "--enable-bulk-memory", "--enable-mutable-globals", "--enable-nontrapping-float-to-int", "--enable-sign-ext", "--enable-reference-types"]
 
 [dependencies]
 fulgur = { path = "../fulgur" }

--- a/crates/fulgur-wasm/Cargo.toml
+++ b/crates/fulgur-wasm/Cargo.toml
@@ -12,6 +12,18 @@ publish = false
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+# wasm-opt flags applied by `wasm-pack build --release`. `-Oz` optimises
+# aggressively for size (over speed). The `--enable-*` flags re-declare the
+# WebAssembly features that rustc emits when the release profile is overridden
+# to opt-level="z"/strip=true (those emit `memory.copy`/`memory.fill` and drop
+# the `target_features` section); the bundled binaryen (v117) otherwise rejects
+# them with a "Bulk memory operations require bulk memory" validator error.
+# The size-optimised rustc knobs are passed per-build as CARGO_PROFILE_RELEASE_*
+# env vars (see the mise `wasm-build` task) so the CLI's native release profile
+# keeps its speed-first tuning untouched.
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ['-Oz', '--enable-bulk-memory', '--enable-mutable-globals', '--enable-nontrapping-float-to-int', '--enable-sign-ext', '--enable-reference-types']
+
 [dependencies]
 fulgur = { path = "../fulgur" }
 wasm-bindgen = "0.2"

--- a/examples/wasm-demo/README.md
+++ b/examples/wasm-demo/README.md
@@ -40,12 +40,27 @@ local font / CSS / image assets served alongside it.
 Requires [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/).
 
 ```bash
-wasm-pack build crates/fulgur-wasm --target web --dev \
-  --out-dir ../../examples/wasm-demo/pkg
+# Size-optimised build (~7 MB). Wraps the CARGO_PROFILE_RELEASE_* overrides
+# and wasm-opt flags; see mise.toml.
+mise run wasm-build
 ```
 
 This populates `examples/wasm-demo/pkg/` with `fulgur_wasm.js`,
 `fulgur_wasm_bg.wasm`, and TypeScript declarations.
+
+If you don't use mise, run the underlying command from the repo root:
+
+```bash
+CARGO_PROFILE_RELEASE_OPT_LEVEL=z \
+CARGO_PROFILE_RELEASE_PANIC=abort \
+CARGO_PROFILE_RELEASE_LTO=fat \
+CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 \
+CARGO_PROFILE_RELEASE_STRIP=true \
+wasm-pack build crates/fulgur-wasm --target web --release \
+  --out-dir ../../examples/wasm-demo/pkg
+```
+
+For a quick iteration build (no size tuning, ~37 MB), use `--dev` instead.
 
 ## Run
 
@@ -66,10 +81,14 @@ pdf.js. (No file download — see notes below if you need bytes.)
 
 ## Notes
 
-- `--dev` builds produce a ~37 MB `.wasm`. `wasm-pack build … --release` (no
-  flag = release) shrinks it but currently still ships every fulgur dependency.
-  Aggressive size reduction (`wasm-opt`, dead-code analysis) is part of the
-  later B-3 / scope C work.
+- Bundle sizes: `--dev` ≈ 37 MB and the size-optimised `mise run wasm-build`
+  ≈ 7 MB (≈ 2.8 MB gzipped). The size-optimised build adds `opt-level=z` /
+  `lto=fat` / `panic=abort` (via per-build `CARGO_PROFILE_RELEASE_*` env vars,
+  so the CLI's native release profile is untouched) on top of the
+  `wasm-opt -Oz` that the Cargo metadata applies to every `--release` build. A
+  plain `wasm-pack build --release` (no env vars) keeps `opt-level=3` and lands
+  between the two. Further dead-code analysis / feature-gating (dropping SVG or
+  system-font fallback) is tracked in `fulgur-0xuy`.
 - The first call after page load incurs a one-time WASM compile cost on top
   of the render itself; subsequent calls reuse the instance.
 - WOFF2 payloads work too — `Engine.add_font` decodes them in-process via

--- a/mise.toml
+++ b/mise.toml
@@ -33,6 +33,27 @@ for dir in examples/*/; do
 done
 """
 
+[tasks.wasm-build]
+description = "Build the size-optimised fulgur-wasm bundle into examples/wasm-demo/pkg"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+# Size-optimised WASM build (~7 MB vs ~11 MB for a plain --release and ~37 MB
+# for --dev). The CARGO_PROFILE_RELEASE_* env vars override the shared release
+# profile for THIS invocation only, so the CLI's native release tuning is never
+# touched (cargo reads these env vars; the wasm-opt flags live in
+# crates/fulgur-wasm/Cargo.toml under [package.metadata.wasm-pack.profile.release]).
+# panic=abort is safe here: fulgur-wasm returns errors via Result<_, JsError>
+# and uses no catch_unwind, and wasm32-unknown-unknown cannot unwind anyway.
+export CARGO_PROFILE_RELEASE_OPT_LEVEL=z
+export CARGO_PROFILE_RELEASE_PANIC=abort
+export CARGO_PROFILE_RELEASE_LTO=fat
+export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
+export CARGO_PROFILE_RELEASE_STRIP=true
+wasm-pack build crates/fulgur-wasm --target web --release \\
+  --out-dir ../../examples/wasm-demo/pkg
+"""
+
 [tasks."wpt:fetch"]
 description = "Fetch WPT sources into target/wpt/ (pinned SHA)"
 run = "scripts/wpt/fetch.sh"


### PR DESCRIPTION
## 概要

`examples/wasm-demo/pkg/fulgur_wasm_bg.wasm` が **37.3MB** と肥大化していた問題を解消する。根本原因は pkg が `--dev` ビルド（デバッグ情報込み・最適化なし）で生成されていたこと。サイズ最適化したリリースビルド経路を追加し、**7.04MB（gzip 2.8MB、81%削減）** にした。

## サイズ比較

| ビルド | 生サイズ | gzip |
|---|---|---|
| `--dev`（従来の pkg） | 37.3 MB | 8.7 MB |
| `--release`（wasm-opt 既定 -O） | 10.9 MB | 3.9 MB |
| **size-optimised（本PR）** | **7.04 MB** | **2.8 MB** |

## 変更内容

- **`crates/fulgur-wasm/Cargo.toml`**: `[package.metadata.wasm-pack.profile.release]` に `wasm-opt -Oz` を設定。`--enable-*` フラグは、`strip` で `target_features` セクションが落ちると binaryen v117 が `bulk-memory`（`memory.copy`/`memory.fill`）を auto-detect できず validator error になるため明示的に再宣言している。
- **`mise.toml`**: `wasm-build` タスクを新設。`CARGO_PROFILE_RELEASE_*` env var（`opt-level=z` / `lto=fat` / `panic=abort` / `strip`）を**ビルド毎に**上書きするため、**CLI のネイティブ release プロファイルは無変更**で速度優先チューニングを維持する。
- **`examples/wasm-demo/README.md`**: ビルド手順を `mise run wasm-build` に更新、サイズ記述を刷新。

## 設計上のポイント

- wasm-pack 0.14 は custom profile (`--profile <name>`) の `wasm-opt` metadata を**無視する**（`unknown key` warning）。そのため標準 `release` プロファイルの metadata + env var 上書きという構成にした。
- `panic=abort` は本ターゲットでは安全: fulgur-wasm は `catch_unwind` を使わず全エラーを `Result<_, JsError>` で返し、かつ wasm32-unknown-unknown は元々 unwind 不可。

## 検証（すべて実測）

- ✅ render 3パターン: bare HTML / Engine builder / **実配布パス（font + CSS + `<img>`）** — いずれも有効な `%PDF-`…`%%EOF` を生成
- ✅ `cargo check --target wasm32-unknown-unknown -p fulgur -p fulgur-wasm` green
- ✅ markdownlint 0 errors

## 備考

`pkg/` は gitignore 済みのためコミット対象外（ローカル再生成）。さらなる構造的削減（SVG / system-font fallback の feature-gating、blitz upstream の `load_system_fonts` 切離し）は `fulgur-0xuy` で追跡継続。

Refs: fulgur-0xuy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * WebAssembly本番ビルド向けの最適化設定を強化し、成果物のサイズ削減を狙えるようにしました。
  * `mise` の新しいタスクで、サイズ最適化ビルドを手軽に実行できるようになりました。

* **Documentation**
  * `wasm-demo` のビルド手順を更新し、`--dev` とサイズ最適化 `--release` の違い（サイズ目安や最適化方針）を明確化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->