### PR TITLE
test(convert/style/shadow): add coverage for all apply_to branches

### DIFF
--- a/crates/fulgur/src/convert/style/shadow.rs
+++ b/crates/fulgur/src/convert/style/shadow.rs
@@ -47,38 +47,73 @@ mod tests {
     }
 
     /// Non-inset shadow with partial alpha exercises the main push path.
+    /// The shadow is actually drawn, so the PDF must differ from the no-shadow baseline.
     #[test]
     fn non_inset_shadow_is_pushed() {
+        let baseline = render_with_shadow("none");
         let pdf = render_with_shadow("5px 5px 10px rgba(0,0,0,0.5)");
         assert!(pdf.starts_with(b"%PDF"), "expected PDF header");
+        assert_ne!(
+            pdf.len(),
+            baseline.len(),
+            "non-inset shadow should add content to PDF"
+        );
     }
 
     /// `inset` keyword exercises the `shadow.inset` branch (skipped with log::warn!).
+    /// Skipped shadows leave no trace — output must match the no-shadow baseline.
     #[test]
     fn inset_shadow_is_skipped() {
+        let baseline = render_with_shadow("none");
         let pdf = render_with_shadow("inset 5px 5px 10px red");
         assert!(pdf.starts_with(b"%PDF"), "expected PDF header");
+        assert_eq!(
+            pdf.len(),
+            baseline.len(),
+            "inset shadow should not affect output"
+        );
     }
 
     /// Fully transparent color exercises the `rgba[3] == 0` early-continue branch.
+    /// Skipped shadows leave no trace — output must match the no-shadow baseline.
     #[test]
     fn transparent_shadow_is_skipped() {
+        let baseline = render_with_shadow("none");
         let pdf = render_with_shadow("5px 5px 10px transparent");
         assert!(pdf.starts_with(b"%PDF"), "expected PDF header");
+        assert_eq!(
+            pdf.len(),
+            baseline.len(),
+            "transparent shadow should not affect output"
+        );
     }
 
     /// Multiple shadows: inset + transparent + normal in one list.
-    /// Only the opaque non-inset shadow reaches the push path.
+    /// Only the opaque non-inset shadow reaches the push path;
+    /// output must match the equivalent single-shadow render.
     #[test]
     fn mixed_shadow_list_skips_inset_and_transparent() {
+        let single = render_with_shadow("3px 3px 0px black");
         let pdf = render_with_shadow("inset 2px 2px red, 5px 5px transparent, 3px 3px 0px black");
         assert!(pdf.starts_with(b"%PDF"), "expected PDF header");
+        assert_eq!(
+            pdf.len(),
+            single.len(),
+            "only the valid shadow should be included"
+        );
     }
 
     /// Non-zero spread radius is stored via `px_to_pt(shadow.spread.px())`.
+    /// The shadow is actually drawn, so the PDF must differ from the no-shadow baseline.
     #[test]
     fn shadow_with_spread_radius() {
+        let baseline = render_with_shadow("none");
         let pdf = render_with_shadow("2px 2px 5px 8px rgba(255,0,0,0.8)");
         assert!(pdf.starts_with(b"%PDF"), "expected PDF header");
+        assert_ne!(
+            pdf.len(),
+            baseline.len(),
+            "shadow with spread should add content to PDF"
+        );
     }
 }

--- a/crates/fulgur/src/convert/style/shadow.rs
+++ b/crates/fulgur/src/convert/style/shadow.rs
@@ -31,3 +31,54 @@ pub(super) fn apply_to(style: &mut BlockStyle, ctx: &StyleContext<'_>) {
         });
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Engine;
+
+    fn render_with_shadow(shadow_css: &str) -> Vec<u8> {
+        let html = format!(
+            r#"<html><body><div style="width:100px;height:100px;box-shadow:{shadow_css}"></div></body></html>"#
+        );
+        Engine::builder()
+            .build()
+            .render_html(&html)
+            .expect("render should succeed")
+    }
+
+    /// Non-inset shadow with partial alpha exercises the main push path.
+    #[test]
+    fn non_inset_shadow_is_pushed() {
+        let pdf = render_with_shadow("5px 5px 10px rgba(0,0,0,0.5)");
+        assert!(pdf.starts_with(b"%PDF"), "expected PDF header");
+    }
+
+    /// `inset` keyword exercises the `shadow.inset` branch (skipped with log::warn!).
+    #[test]
+    fn inset_shadow_is_skipped() {
+        let pdf = render_with_shadow("inset 5px 5px 10px red");
+        assert!(pdf.starts_with(b"%PDF"), "expected PDF header");
+    }
+
+    /// Fully transparent color exercises the `rgba[3] == 0` early-continue branch.
+    #[test]
+    fn transparent_shadow_is_skipped() {
+        let pdf = render_with_shadow("5px 5px 10px transparent");
+        assert!(pdf.starts_with(b"%PDF"), "expected PDF header");
+    }
+
+    /// Multiple shadows: inset + transparent + normal in one list.
+    /// Only the opaque non-inset shadow reaches the push path.
+    #[test]
+    fn mixed_shadow_list_skips_inset_and_transparent() {
+        let pdf = render_with_shadow("inset 2px 2px red, 5px 5px transparent, 3px 3px 0px black");
+        assert!(pdf.starts_with(b"%PDF"), "expected PDF header");
+    }
+
+    /// Non-zero spread radius is stored via `px_to_pt(shadow.spread.px())`.
+    #[test]
+    fn shadow_with_spread_radius() {
+        let pdf = render_with_shadow("2px 2px 5px 8px rgba(255,0,0,0.8)");
+        assert!(pdf.starts_with(b"%PDF"), "expected PDF header");
+    }
+}


### PR DESCRIPTION
## Summary

- `convert/style/shadow.rs` に `#[cfg(test)] mod tests` を追加
- `apply_to` 関数内の3つの分岐（push・inset-skip・transparent-skip）すべてをカバー
- スキップケースはベースラインとの PDF サイズ比較で退行検知を強化

## Changes

`crates/fulgur/src/convert/style/shadow.rs` に5つのインラインユニットテストを追加（prod コード変更なし）。

## Test plan

- [x] `cargo test -p fulgur --lib convert::style::shadow` — 5 tests pass
- [x] `cargo clippy -p fulgur -- -D warnings` — clean
- [x] `cargo fmt --check -p fulgur` — clean
- [x] `cargo llvm-cov --package fulgur --lib --summary-only` — shadow.rs 17% → 100%

---

## 対象モジュール

`crates/fulgur/src/convert/style/shadow.rs` — `box-shadow` プロパティの抽出ロジック。

## カバレッジ変化

| 指標 | 変更前 | 変更後 |
|------|--------|--------|
| 行カバレッジ | 19.05% (4/21 lines) | **100%** |
| リージョン | 17.14% (6/35 regions) | **100%** |

総合ライン（fulgur --lib）: 92.53% → 93.44%

## 原因分析

`apply_to` 関数自体は既存テストで入口まで到達していたが、`box-shadow` を指定する `--lib` 対象インラインテストが存在しなかった。そのため for ループ本体（3つの分岐すべて）が未到達だった。

## 追加したテスト

| テスト名 | 対象ブランチ | 検証内容 |
|----------|-------------|---------|
| `non_inset_shadow_is_pushed` | 非 inset・不透明シャドウ → push | PDF サイズがベースライン（no-shadow）と異なる |
| `inset_shadow_is_skipped` | `shadow.inset == true` → skip | PDF サイズがベースラインと一致 |
| `transparent_shadow_is_skipped` | `rgba[3] == 0` → skip | PDF サイズがベースラインと一致 |
| `mixed_shadow_list_skips_inset_and_transparent` | 混合リスト | PDF サイズが単一有効シャドウケースと一致 |
| `shadow_with_spread_radius` | spread フィールドの px→pt 変換 | PDF サイズがベースラインと異なる |

## 意図的に除外したブランチ

なし。`apply_to` 内の到達可能なブランチはすべてカバーされた。