### PR TITLE
refactor(multicol): type column-rule pt carrier with units::Pt (fulgur-2map.2 spike)

### DIFF
--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -20,6 +20,7 @@ use crate::paragraph::{
     InlineImage, LineFontMetrics, LineItem, LinkSpan, LinkTarget, ShapedGlyph, ShapedGlyphRun,
     ShapedLine, TextDecoration, TextDecorationLine, TextDecorationStyle, VerticalAlign,
 };
+use crate::units::F32Units;
 use blitz_html::HtmlDocument;
 use skrifa::MetadataProvider;
 use std::collections::HashMap;
@@ -666,27 +667,29 @@ fn record_multicol_rule(
     let Some(geometry) = ctx.multicol_geometry.get(&node_id) else {
         return;
     };
-    // `ColumnGroupGeometry` is recorded in CSS px; convert to pt so
-    // downstream paint matches every other Drawables entry's units.
-    let groups_pt: Vec<crate::multicol_layout::ColumnGroupGeometry> = geometry
+    // `ColumnGroupGeometry` is recorded in CSS px; convert to the pt-typed
+    // ColumnRuleGeometry carrier so downstream paint matches every other
+    // Drawables entry's units. Each conversion is one multiply (byte-neutral).
+    let groups: Vec<crate::drawables::ColumnRuleGeometry> = geometry
         .groups
         .iter()
-        .map(|g| crate::multicol_layout::ColumnGroupGeometry {
-            x_offset: px_to_pt(g.x_offset),
-            y_offset: px_to_pt(g.y_offset),
-            col_w: px_to_pt(g.col_w),
-            gap: px_to_pt(g.gap),
+        .map(|g| crate::drawables::ColumnRuleGeometry {
+            x_offset: g.x_offset.px().in_pt(),
+            y_offset: g.y_offset.px().in_pt(),
+            col_w: g.col_w.px().in_pt(),
+            gap: g.gap.px().in_pt(),
             n: g.n,
-            col_heights: g.col_heights.iter().copied().map(px_to_pt).collect(),
-            paragraph_splits: Vec::new(),
+            col_heights: g
+                .col_heights
+                .iter()
+                .copied()
+                .map(|h| h.px().in_pt())
+                .collect(),
         })
         .collect();
     out.multicol_rules.insert(
         node_id,
-        crate::drawables::MulticolRuleEntry {
-            rule,
-            groups: groups_pt,
-        },
+        crate::drawables::MulticolRuleEntry { rule, groups },
     );
 }
 

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -199,6 +199,26 @@ impl std::fmt::Debug for ListItemEntry {
     }
 }
 
+/// Per-column-group geometry for painting a multicol `column-rule`, in PDF
+/// pt (already converted from `multicol_layout::ColumnGroupGeometry`'s CSS
+/// px by `convert::record_multicol_rule`). A distinct pt-typed carrier so
+/// the px source struct is no longer reused across two unit spaces.
+#[derive(Debug, Clone)]
+pub struct ColumnRuleGeometry {
+    /// Horizontal offset from the container border-box left to column 0.
+    pub x_offset: crate::units::Pt,
+    /// Vertical offset from the container content-box top to this group.
+    pub y_offset: crate::units::Pt,
+    /// Width of a single column.
+    pub col_w: crate::units::Pt,
+    /// Gap between adjacent columns.
+    pub gap: crate::units::Pt,
+    /// Number of columns this group balances across.
+    pub n: u32,
+    /// Per-column filled height; length == `n`.
+    pub col_heights: Vec<crate::units::Pt>,
+}
+
 /// Multicol column-rule paint spec + per-column-group geometry.
 /// Mirrors the fields `MulticolRulePageable` carries — render at the
 /// container's location after children paint, partitioning `groups`
@@ -206,7 +226,7 @@ impl std::fmt::Debug for ListItemEntry {
 #[derive(Debug, Clone)]
 pub struct MulticolRuleEntry {
     pub rule: crate::column_css::ColumnRuleSpec,
-    pub groups: Vec<crate::multicol_layout::ColumnGroupGeometry>,
+    pub groups: Vec<ColumnRuleGeometry>,
 }
 
 /// One source paragraph distributed across columns of a multicol

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -207,7 +207,8 @@ impl std::fmt::Debug for ListItemEntry {
 pub struct ColumnRuleGeometry {
     /// Horizontal offset from the container border-box left to column 0.
     pub x_offset: crate::units::Pt,
-    /// Vertical offset from the container content-box top to this group.
+    /// Vertical offset from the container border-box top (incl. padding-top
+    /// + border-top) to this group.
     pub y_offset: crate::units::Pt,
     /// Width of a single column.
     pub col_w: crate::units::Pt,

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -2321,19 +2321,18 @@ fn paint_multicol_rule_for_page(
 
     let x_base = margin_left_pt.pt() + target_frag.x.px().in_pt();
     let y_base = margin_top_pt.pt() + target_frag.y.px().in_pt();
-    let zero = 0.0_f32.pt();
 
     for group in &entry.groups {
         if group.n < 2 || group.col_heights.len() != group.n as usize {
             continue;
         }
         let group_top = group.y_offset - consumed;
-        let max_h = group.col_heights.iter().copied().fold(zero, Pt::max);
+        let max_h = group.col_heights.iter().copied().fold(Pt::ZERO, Pt::max);
         let group_bottom = group_top + max_h;
-        if group_bottom <= zero || group_top >= cutoff {
+        if group_bottom <= Pt::ZERO || group_top >= cutoff {
             continue;
         }
-        let visible_top = group_top.max(zero);
+        let visible_top = group_top.max(Pt::ZERO);
         let y_top = y_base + visible_top;
         // Mirror `MulticolRulePageable::slice_for_page`
         // (`pageable.rs:3221-3223`): subtract the portion of each
@@ -2341,16 +2340,16 @@ fn paint_multicol_rule_for_page(
         // the visible strip on this page. Without this, a column rule
         // segment whose group straddles a page boundary extends past
         // the actual visible column content.
-        let consumed_above = (visible_top - group_top).max(zero);
-        let visible_h = (group_bottom.min(cutoff) - visible_top).max(zero);
+        let consumed_above = (visible_top - group_top).max(Pt::ZERO);
+        let visible_h = (group_bottom.min(cutoff) - visible_top).max(Pt::ZERO);
         for i in 0..(group.n as usize - 1) {
             let h_left = (group.col_heights[i] - consumed_above)
-                .max(zero)
+                .max(Pt::ZERO)
                 .min(visible_h);
             let h_right = (group.col_heights[i + 1] - consumed_above)
-                .max(zero)
+                .max(Pt::ZERO)
                 .min(visible_h);
-            if h_left <= zero || h_right <= zero {
+            if h_left <= Pt::ZERO || h_right <= Pt::ZERO {
                 continue;
             }
             let rule_x = x_base

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -2295,7 +2295,6 @@ fn paint_multicol_rule_for_page(
     margin_top_pt: f32,
     page_index: u32,
 ) {
-    use crate::convert::px_to_pt;
     use crate::draw_primitives::stroke_line;
 
     let Some(stroke) = build_multicol_stroke(&entry.rule) else {
@@ -2311,16 +2310,19 @@ fn paint_multicol_rule_for_page(
     };
     let target_frag = &container_geom.fragments[target_pos];
 
-    let consumed: f32 = px_to_pt(
-        container_geom.fragments[..target_pos]
-            .iter()
-            .map(|f| f.height)
-            .sum::<f32>(),
-    );
-    let cutoff = px_to_pt(target_frag.height);
+    use crate::units::F32Units;
 
-    let x_base = margin_left_pt + px_to_pt(target_frag.x);
-    let y_base = margin_top_pt + px_to_pt(target_frag.y);
+    let consumed = container_geom.fragments[..target_pos]
+        .iter()
+        .map(|f| f.height)
+        .sum::<f32>()
+        .px()
+        .in_pt();
+    let cutoff = target_frag.height.px().in_pt();
+
+    let x_base = margin_left_pt.pt() + target_frag.x.px().in_pt();
+    let y_base = margin_top_pt.pt() + target_frag.y.px().in_pt();
+    let zero = 0.0_f32.pt();
 
     for group in &entry.groups {
         if group.n < 2 || group.col_heights.len() != group.n as usize {
@@ -2331,12 +2333,12 @@ fn paint_multicol_rule_for_page(
             .col_heights
             .iter()
             .copied()
-            .fold(0.0_f32, |acc, h| acc.max(h));
+            .fold(zero, crate::units::Pt::max);
         let group_bottom = group_top + max_h;
-        if group_bottom <= 0.0 || group_top >= cutoff {
+        if group_bottom <= zero || group_top >= cutoff {
             continue;
         }
-        let visible_top = group_top.max(0.0);
+        let visible_top = group_top.max(zero);
         let y_top = y_base + visible_top;
         // Mirror `MulticolRulePageable::slice_for_page`
         // (`pageable.rs:3221-3223`): subtract the portion of each
@@ -2344,16 +2346,16 @@ fn paint_multicol_rule_for_page(
         // the visible strip on this page. Without this, a column rule
         // segment whose group straddles a page boundary extends past
         // the actual visible column content.
-        let consumed_above = (visible_top - group_top).max(0.0);
-        let visible_h = (group_bottom.min(cutoff) - visible_top).max(0.0);
+        let consumed_above = (visible_top - group_top).max(zero);
+        let visible_h = (group_bottom.min(cutoff) - visible_top).max(zero);
         for i in 0..(group.n as usize - 1) {
             let h_left = (group.col_heights[i] - consumed_above)
-                .max(0.0)
+                .max(zero)
                 .min(visible_h);
             let h_right = (group.col_heights[i + 1] - consumed_above)
-                .max(0.0)
+                .max(zero)
                 .min(visible_h);
-            if h_left <= 0.0 || h_right <= 0.0 {
+            if h_left <= zero || h_right <= zero {
                 continue;
             }
             let rule_x = x_base
@@ -2362,7 +2364,14 @@ fn paint_multicol_rule_for_page(
                 + i as f32 * group.gap
                 + group.gap / 2.0;
             let y_bot = y_top + h_left.min(h_right);
-            stroke_line(canvas, rule_x, y_top, rule_x, y_bot, stroke.clone());
+            stroke_line(
+                canvas,
+                rule_x.to_f32(),
+                y_top.to_f32(),
+                rule_x.to_f32(),
+                y_bot.to_f32(),
+                stroke.clone(),
+            );
         }
     }
     canvas.surface.set_stroke(None);

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -2296,6 +2296,7 @@ fn paint_multicol_rule_for_page(
     page_index: u32,
 ) {
     use crate::draw_primitives::stroke_line;
+    use crate::units::{F32Units, Pt};
 
     let Some(stroke) = build_multicol_stroke(&entry.rule) else {
         return;
@@ -2309,8 +2310,6 @@ fn paint_multicol_rule_for_page(
         return;
     };
     let target_frag = &container_geom.fragments[target_pos];
-
-    use crate::units::F32Units;
 
     let consumed = container_geom.fragments[..target_pos]
         .iter()
@@ -2329,11 +2328,7 @@ fn paint_multicol_rule_for_page(
             continue;
         }
         let group_top = group.y_offset - consumed;
-        let max_h = group
-            .col_heights
-            .iter()
-            .copied()
-            .fold(zero, crate::units::Pt::max);
+        let max_h = group.col_heights.iter().copied().fold(zero, Pt::max);
         let group_bottom = group_top + max_h;
         if group_bottom <= zero || group_top >= cutoff {
             continue;

--- a/crates/fulgur/src/units.rs
+++ b/crates/fulgur/src/units.rs
@@ -160,6 +160,19 @@ impl Pt {
     pub fn in_px(self) -> Px {
         Px(self.0 / PX_TO_PT)
     }
+
+    /// Larger of two lengths. Mirrors `f32::max` (same NaN handling) so a
+    /// migrated `x.max(y)` stays byte-identical.
+    #[inline]
+    pub fn max(self, other: Pt) -> Pt {
+        Pt(self.0.max(other.0))
+    }
+
+    /// Smaller of two lengths. Mirrors `f32::min`.
+    #[inline]
+    pub fn min(self, other: Pt) -> Pt {
+        Pt(self.0.min(other.0))
+    }
 }
 
 /// Constructor sugar so `value.px()` / `value.pt()` reads naturally and the
@@ -209,6 +222,20 @@ mod tests {
         assert_eq!(a, Pt(1.0));
         let s: Pt = [Pt(1.0), Pt(2.0), Pt(3.0)].into_iter().sum();
         assert_eq!(s, Pt(6.0));
+    }
+
+    #[test]
+    fn pt_max_min_mirror_f32() {
+        assert_eq!(Pt(1.0).max(Pt(2.0)), Pt(2.0));
+        assert_eq!(Pt(1.0).min(Pt(2.0)), Pt(1.0));
+        // identical to f32::max/min, including the 0.0 clamp idiom
+        assert_eq!(Pt(-3.0).max(Pt(0.0)), Pt(0.0));
+        assert_eq!(
+            [Pt(0.0), Pt(2.0), Pt(1.0)]
+                .into_iter()
+                .fold(Pt(0.0), Pt::max),
+            Pt(2.0)
+        );
     }
 
     #[test]

--- a/crates/fulgur/src/units.rs
+++ b/crates/fulgur/src/units.rs
@@ -149,6 +149,11 @@ impl Px {
 }
 
 impl Pt {
+    /// The zero length. Use instead of `0.0_f32.pt()` for clamp idioms
+    /// (`x.max(Pt::ZERO)`); the private field means `Pt(0.0)` is not
+    /// constructible outside this module.
+    pub const ZERO: Pt = Pt(0.0);
+
     /// Raw `f32` value. Use only at FFI boundaries.
     #[inline]
     pub const fn to_f32(self) -> f32 {
@@ -226,6 +231,7 @@ mod tests {
 
     #[test]
     fn pt_max_min_mirror_f32() {
+        assert_eq!(Pt::ZERO, Pt(0.0));
         assert_eq!(Pt(1.0).max(Pt(2.0)), Pt(2.0));
         assert_eq!(Pt(1.0).min(Pt(2.0)), Pt(1.0));
         // identical to f32::max/min, including the 0.0 clamp idiom

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -4707,3 +4707,20 @@ fn pathological_tall_block_render_is_bounded() {
         .expect("render must terminate and succeed");
     assert!(!pdf.is_empty(), "expected a non-empty bounded PDF");
 }
+
+/// fulgur-2map.2: the multicol column-rule pt carrier (units::Pt) renders
+/// end-to-end through record_multicol_rule + paint_multicol_rule_for_page.
+#[test]
+fn multicol_column_rule_renders() {
+    let html = r#"<!doctype html><html><body>
+      <div style="column-count:3; column-gap:20px; column-rule:2px solid #333;">
+        <p>alpha beta gamma delta epsilon zeta eta theta iota kappa
+        lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega</p>
+      </div>
+    </body></html>"#;
+    let pdf = fulgur::Engine::builder()
+        .build()
+        .render_html(html)
+        .expect("render multicol column-rule");
+    assert!(!pdf.is_empty());
+}

--- a/docs/plans/2026-06-27-engine-layout-api-design.md
+++ b/docs/plans/2026-06-27-engine-layout-api-design.md
@@ -1,0 +1,275 @@
+# `Engine::layout()` 公開 API と座標 newtype 基盤 — 設計
+
+- Status: Draft
+- Date: 2026-06-27
+- Related: PR #459 (feat: HTML to image output), maintainer comment
+  <https://github.com/fulgur-rs/fulgur/pull/459#issuecomment-4612646966>
+- Coordinate rules: `.claude/rules/coordinate-system.md`
+
+## 1. 背景と目的
+
+fulgur のレイアウトエンジン（parse → style → layout → `Drawables`）を、コアを
+lean に保ったまま外部 crate から再利用可能にする。PR #459 が画像出力をコアに
+取り込もうとしたのに対し、メンテナは「コアは `layout()` を公開し、ラスタライズは
+コア外」という crate レベルの分離（`wkhtmltopdf` / `wkhtmltoimage` と同じ思想）を
+選んだ。
+
+公開 `layout()` の想定 consumer は 2 つ:
+
+1. **PDF→画像**: page-0 `Drawables` を SVG 化 → resvg/tiny-skia でラスタライズ →
+   PNG / lossless WebP エンコード（PR #459 の `image_export/*` がほぼそのまま移植
+   可能）。
+2. **OCR 学習データ生成**: fulgur は各グリフの配置を正確に知っているため、
+   **ピクセル完全なラベル（テキスト＋bbox）付きの合成画像**を生成できる。画像
+   エンコードではなく、ラスタライズのテンソル（生ピクセル）とラベルを直接得る。
+   これは fulgur 固有の強み。
+
+両 consumer が必要とする公開面は実質 `(Drawables, PaginationGeometryTable)` のみ。
+`gcpm` / `running_store` などは PDF 側 `render_v2` 専用で、margin box / running
+element は render-side のため画像・OCR では**自動的に落ちる**（特別扱い不要）。
+
+## 2. 決定事項サマリ
+
+| 論点 | 決定 |
+|---|---|
+| 返り値の形 | 名前付き struct `LayoutOutput { drawables, geometry }`（タプルではなく。非破壊でフィールド追加可能） |
+| `target-*` 2-pass | 公開 `layout()` は内部で 2-pass を回し、解決済み Drawables を返す（PDF と忠実一致） |
+| シグネチャ | `pub fn layout(&self, html: &str) -> Result<LayoutOutput>`。canvas/page サイズは builder 経由 |
+| 座標系 | **`Px`/`Pt` newtype 単位系**（演算子 impl ＋ ctor 糖衣 ＋ FFI 境界 `.to_f32()`）をコアに据える |
+| 順序 | **newtype 先行**（型移行を private のうちに完了 → 公開は一度きり）。理由: §7 |
+| ラスタライズ / エンコード / テンソル生成 | **すべて外部 crate**。コアは関与しない |
+| OCR ラベル抽出（合成・グリフ配置） | **consumer（外部 crate）が所有**。コアは「単位変換」を所有し、「合成（配置）」は consumer |
+
+設計原則の一行: **コアは「単位変換（pt↔px）」を所有する。consumer は「合成
+（配置＝どこに置くか、グリフ配置）」を所有する。**
+
+## 3. 公開 API
+
+```rust
+/// parse → style → layout → Drawables の成果物。
+/// PDF 描画にも画像描画にも OCR にも使える、レンダラ非依存のレイアウト結果。
+pub struct LayoutOutput {
+    pub drawables: Drawables,
+    pub geometry: PaginationGeometryTable,
+}
+
+impl Engine {
+    /// HTML をレイアウトし、描画用の per-node ペイロードを返す。
+    /// ページ形状（canvas サイズ・余白）は builder の設定を使う。
+    /// target-* がある文書では内部で 2-pass を回し、解決済み Drawables を返す。
+    pub fn layout(&self, html: &str) -> Result<LayoutOutput>;
+}
+```
+
+`lib.rs` で `pub use engine::LayoutOutput;` を再エクスポート。
+
+consumer（fulgur-image / OCR）の典型形:
+
+```rust
+let out = Engine::builder()
+    .page_size(canvas)            // 画像 canvas = layout の page size
+    .margin(Margin::uniform(Pt(0.0)))
+    .landscape(false)
+    .build()
+    .layout(html)?;
+// 以降は外部 crate が out.drawables / out.geometry を合成してラスタライズ or ラベル化
+```
+
+## 4. 内部リファクタ（PR #459 から流用）
+
+PR が既に抽出済みの private ヘルパをそのまま採用する:
+
+```rust
+fn layout_to_drawables(&self, html, config, anchor_map) -> Result<LayoutArtifacts>
+```
+
+- `render_pass` は従来どおり `layout_to_drawables` → **無改変の** `render_v2`
+  （PDF byte-identical）。
+- 公開 `layout()` は**同じ** `layout_to_drawables` を呼ぶ薄いラッパ。`render_html`
+  と同じ 2-pass ループ（pass1 → `needs_anchor_map_for_pass_two` なら pass2）を回し、
+  最終 artifacts から `{ drawables, geometry }` だけ取り出す。
+- → レイアウト経路は**1本**。PDF と画像/OCR でロジックが分岐しない。
+
+`LayoutArtifacts`（private, 10 フィールド）は `render_v2` を駆動するための全
+side-channel を持つが、公開 `LayoutOutput` はその部分集合（drawables, geometry）
+のみを露出する。`gcpm` / `running_store` 等は非公開のまま。
+
+## 5. 座標基盤: `Px` / `Pt` newtype 単位系
+
+### 5.1 動機
+
+現状、公開到達型は単位が混在している:
+
+- `Drawables` の座標は **PDF pt**（`ParagraphSlice.origin_pt` 等、一部は suffix 済）。
+- `PaginationGeometry::Fragment` は **CSS px**（Taffy ネイティブ、doc コメントに明記）。
+
+混在自体は設計（Krilla=pt / Taffy=px）。これまでは `_pt`/`_px` の**命名規約**を
+単位契約としてきたが、**未移行のフィールドが多く**、命名契約は穴だらけ。公開した
+瞬間にこの不完全な契約が固定化される。
+
+PR #459 の `svg_emit` は `const PX_TO_PT = 0.75` を**ローカル再定義**し、合成式
+（`body_offset + frag * PX_TO_PT`）とグリフ配置（`baseline + advance*font_size`）を
+**外部で再実装**していた。これは fulgur が最も恐れる 4/3・baseline 系バグの温床。
+
+### 5.2 採用する型
+
+```rust
+#[repr(transparent)] #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
+pub struct Px(f32);
+#[repr(transparent)] #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
+pub struct Pt(f32);
+
+// 単位内の算術は演算子で（.0 不要）
+impl core::ops::Add for Pt { type Output = Pt; fn add(self, o: Pt) -> Pt { Pt(self.0 + o.0) } }
+impl core::ops::Sub for Pt { type Output = Pt; fn sub(self, o: Pt) -> Pt { Pt(self.0 - o.0) } }
+impl core::ops::Mul<f32> for Pt { type Output = Pt; fn mul(self, s: f32) -> Pt { Pt(self.0 * s) } }
+impl core::ops::Neg for Pt { type Output = Pt; fn neg(self) -> Pt { Pt(-self.0) } }
+// Px も同様。Px + Pt は impl しない → 混ぜたらコンパイルエラー（=安全性）
+
+// 変換（コアが所有する唯一の 0.75 定義）
+pub const PX_TO_PT: f32 = 0.75;
+impl Px { pub fn in_pt(self) -> Pt { Pt(self.0 * PX_TO_PT) } }
+impl Pt { pub fn in_px(self) -> Px { Px(self.0 / PX_TO_PT) } }
+
+// コンストラクタ糖衣（Px(..) を書かない）
+pub trait F32Units { fn px(self) -> Px; fn pt(self) -> Pt; }
+impl F32Units for f32 { fn px(self) -> Px { Px(self) } fn pt(self) -> Pt { Pt(self) } }
+
+// FFI 脱出口（resvg / tiny-skia / krilla が f32 を要求する境界だけ）
+impl Px { pub fn to_f32(self) -> f32 { self.0 } }
+impl Pt { pub fn to_f32(self) -> f32 { self.0 } }
+```
+
+### 5.3 性質
+
+- **実行時ゼロコスト**: `#[repr(transparent)]` で `f32` と同一レイアウト・ABI。演算子は
+  monomorphize＋inline で消え、最適化後の機械語は素の `f32` 演算と同一。`.0` /
+  `.to_f32()` はコンパイル時の見た目のみ。
+- **決定性**: newtype 自体は値を変えないが、byte-neutral は**自動保証ではない**。
+  演算子へ移行する際に `(a + b) * 0.75` を `a * 0.75 + b * 0.75` のように**再結合
+  すると f32 の丸めが変わる**。演算順序の保存は各 call site の義務であり、§8 の
+  per-Phase golden 再検証で担保する。
+- **エルゴノミクス**: 演算子で `.0` は call site から消える。`.to_f32()` が出るのは
+  FFI 境界だけ。
+- **ラベリング完全性**: 単位が型なので、単位の無い座標フィールドは**構造的に存在
+  し得ない**。命名規約の穴を恒久的に塞ぐ。
+- **安全性**: `Px + Pt` 等の取り違えはコンパイルエラー。
+
+### 5.4 call site 比較（PR svg_emit の合成）
+
+```rust
+// 現状（PR・ハードコード）: px+pt 取り違えを止める物が無い
+let x = bx + frag.x * 0.75;
+
+// 採用（newtype＋演算子）: Pt+Pt=Pt、px+pt はコンパイル不可
+let x: Pt = drawables.body_offset.x + frag.x_px.in_pt();
+emit_rect(x.to_f32(), ...);   // FFI 境界だけ .to_f32()
+```
+
+## 6. 公開到達性の前提（layout() 公開とセットで直す）
+
+| ギャップ | 現状 | 対応 |
+|---|---|---|
+| 単位変換 | `convert::{px_to_pt,pt_to_px}` が `pub(crate)`、`PX_TO_PT` ローカル定義 | `Px::in_pt` / `Pt::in_px` として公開。0.75 はコア 1 箇所に集約 |
+| `ColumnRuleSpec` | `column_css` が `pub(crate) mod` で公開フィールド `Drawables.multicol_rules` の型が外部から名前で呼べない（`private_interfaces` リーク） | `column_css` を `pub mod` 化、または型を re-export |
+| `usvg::Tree` | `SvgEntry.tree: Arc<usvg::Tree>` が外部依存型 | consumer は同一 `usvg` バージョンに pin（要文書化） |
+
+## 7. 順序（フェーズ分割）— newtype 先行（確定）
+
+### なぜ newtype 先行か
+
+これまで fulgur の公開面は **入力（HTML / CSS / アセット）と出力（PDF bytes）だけ**
+で、`Drawables` / `geometry` は公開契約の外だった。`layout()` でこれらを公開する
+瞬間、`Drawables` 配下の座標型**そのものが公開契約**になる。ここで newtype 移行を
+後回しにすると、移行の各ステップが**公開済み `Drawables` への breaking change の
+連発**になる。
+
+移行 churn は**型が private のうちはタダ**（外部 consumer が存在しない）で、公開後は
+破壊的。したがって **newtype 移行を private のうちに済ませ、公開は一度きり**にする。
+クレート規模だが段階化する。
+
+### フェーズ
+
+- **Phase 0**: `Px`/`Pt` 型 ＋ 演算子 / ctor 糖衣 / FFI `.to_f32()` / 変換を
+  `draw_primitives`（または新 `units` モジュール）に導入。移行はまだしない。
+- **Phase 1**: 公開到達座標型（`Fragment`、`Drawables` 配下の座標、
+  `ShapedLine` / `ShapedGlyphRun` の座標）と、それらを**生成・消費する内部経路**
+  （convert / 各 fragmenter / render_v2 の座標扱い）を `Px`/`Pt` へ移行。
+  byte-neutral（演算順序を保存）。
+- **Phase 2**: 残りの内部 math を演算子へ移行し、f32↔newtype の一時境界を解消。
+- **Phase 3（最後）**: 公開到達性ギャップ修正（§6）＋ `layout()` / `LayoutOutput`
+  公開 ＋ `render_smoke.rs` に lib smoke test。**公開時点で公開座標契約は完全
+  型付き**で、以後の単位移行による breaking change は発生しない。
+
+### 不採用
+
+- **公開面先行 / bare-f32 先行**: `Drawables` を公開してから newtype 化すると、
+  公開契約への breaking change が連発するため不採用（上記理由）。ZeroVer で破壊は
+  許容されるが、公開直後の API を壊し続けるのは consumer 体験として避ける。
+
+### Spike outcome (fulgur-2map.2) — validated per-phase byte-neutral pattern
+
+Migrated the multicol column-rule **pt carrier** end-to-end as the P0.5 spike
+(PR/branch `fulgur-2map.2-multicol-px-pt`). Established recipe for P1a–P1d:
+
+1. **Type the converted (pt) side with a dedicated carrier.** Do not reuse the
+   px source struct for pt values. `drawables::ColumnRuleGeometry` (Pt fields)
+   replaced the second `ColumnGroupGeometry` that held pt — closing the
+   one-struct-two-units hole on the pt side.
+2. **Convert at the boundary, one multiply.** `px_to_pt(v)` → `v.px().in_pt()`.
+   Never distribute across `+` (no reassociation). `margin + px_to_pt(v)` →
+   `margin.pt() + v.px().in_pt()`. Convert a sum once (`sum.px().in_pt()`), not
+   per-term.
+3. **`to_f32()` only at FFI** (the `stroke_line` krilla call).
+4. **Clamps/folds need unit-preserving helpers** — added `Pt::max` / `Pt::min`
+   mirroring `f32` exactly; `Pt(0.0)` is unconstructable outside `units`, so use
+   `0.0_f32.pt()`.
+5. **Proof = unchanged goldens.** `examples_determinism` + VRT stayed
+   byte-identical; never `FULGUR_VRT_UPDATE=1`. Note `examples_determinism` is a
+   run-twice self-comparison (catches nondeterminism, not value drift); the VRT
+   golden-vs-baseline comparison is the load-bearing byte-neutrality proof.
+
+Deferred to P1d (`fulgur-2map.6`): typing the px source
+`multicol_layout::ColumnGroupGeometry` to `Px`, and
+`column_css::ColumnRuleSpec.width` to `Pt`.
+
+## 8. 決定性 / 受け入れ条件
+
+- `layout_to_drawables` 抽出後・newtype 移行後とも `examples_determinism` golden と
+  VRT golden が **byte-identical**（PR は branch で byte-neutral を主張 → 各 Phase で
+  **再検証必須**）。
+- 公開 `layout()` の lib smoke test を `render_smoke.rs` に追加
+  （`Engine::builder().build().layout(html)` で `drawables`/`geometry` 非空。
+  CLAUDE.md のカバレッジ方針）。
+- newtype の単位混在（`Px + Pt` 等）がコンパイルエラーになることの型テスト
+  （`trybuild` 等、任意）。
+
+## 9. スコープ外 / 下流（別作業）
+
+- `fulgur-image` crate 本体: SVG-emit → resvg → encode、`ImageOptions`。PR #459 の
+  `image_export/*` がほぼそのまま移植可能。**rasterize → `Pixmap`（生ピクセル）を
+  公開層として持ち、encode はその上の薄い層**にすると、OCR consumer が `Pixmap` を
+  直接テンソル化でき、ラスタライザを共有できる。
+- CLI `fulgur rasterize` サブコマンド（`render` を拡張しない。format 固有オプション
+  の爆発を避ける）。
+- OCR 学習データ crate: 公開 `LayoutOutput` ＋ 公開 `Px`/`Pt` 変換 API を使い、
+  グリフ／単語／行レベルの bbox＋テキストを合成（consumer 所有）。device px =
+  CSS px × scale（scale=1 で 1:1）。
+- 画像での margin box / running element / target-* 対応（render-side のため画像では
+  自動的に落ちる）。
+
+## 10. リスク / 未決
+
+- newtype 移行の波及範囲（特に Phase 1/2 の内部 call site 数）の見積りが必要。
+  公開は Phase 3（最後）なので、この見積りが `layout()` 公開までのリードタイムを
+  決める。
+- builder の `PageSize` / `Margin` も型付き（`Pt`）にするか — config 層の単位整合と
+  併せて Phase 1/2 で扱うか別途か。
+- **グリフ合成は single-source 制約**（OCR の正しさに load-bearing）: OCR の価値は
+  *ピクセル完全なラベル*。ラスタライズが画像 crate、ラベルが OCR crate に分かれる
+  以上、グリフ配置（baseline + advance×font_size）の合成ルーチンは**両者で共有
+  （single-source）されねばならない**。consumer ごとに再実装すると**ラベルがピクセル
+  からずれ、学習データが静かに壊れる**。→ 「コア=変換 / consumer=合成」の線は保ちつつ、
+  グリフ合成だけは薄い純関数ヘルパ（`glyph_boxes_px(&ShapedLine, origin) -> Vec<(Range, RectPx)>`
+  等、Drawables を太らせない自由関数）をコアに置いて両 consumer で共有する案を有力
+  候補とする（OCR 研究が固まり次第確定）。

--- a/docs/plans/2026-06-27-multicol-px-pt-spike.md
+++ b/docs/plans/2026-06-27-multicol-px-pt-spike.md
@@ -22,7 +22,7 @@ existing `examples_determinism` and VRT goldens (incl. `multicol-rule-solid`)
 must stay byte-identical, proven by preserving f32 operation order (no
 reassociation).
 
-**Tech Stack:** Rust, `units::{Px, Pt, F32Units}` newtypes
+**Tech Stack:** Rust, `units::{Px, Pt}` newtypes + `F32Units` conversion trait
 (`crates/fulgur/src/units.rs`), krilla draw layer, VRT PDF byte comparison
 (`crates/fulgur-vrt`), `examples_determinism` (`crates/fulgur-cli`).
 

--- a/docs/plans/2026-06-27-multicol-px-pt-spike.md
+++ b/docs/plans/2026-06-27-multicol-px-pt-spike.md
@@ -1,0 +1,488 @@
+# Multicol column-rule Px/Pt Validation Spike — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (or
+> superpowers:subagent-driven-development) to implement this plan task-by-task.
+
+**Goal:** Migrate the multicol column-rule **pt carrier** (the geometry that
+`Drawables::multicol_rules` hands to the draw layer) from bare `f32` to the
+`units::Pt` newtype, end-to-end from the px→pt conversion site to the krilla
+FFI boundary, proving the per-phase byte-neutral pattern for the
+`fulgur-2map` epic (beads issue `fulgur-2map.2`).
+
+**Architecture:** Today `convert::record_multicol_rule` converts a px-native
+`multicol_layout::ColumnGroupGeometry` into a *second* `ColumnGroupGeometry`
+holding pt values (`groups_pt`) — one struct naming two unit spaces, the
+"naming-contract hole" the epic closes. This spike introduces a dedicated
+`Pt`-typed carrier (`drawables::ColumnRuleGeometry`) for the pt side, so the
+producer (`record_multicol_rule`) converts with `Px::in_pt`, the carrier
+fields are `Pt`, and the single consumer (`render::paint_multicol_rule_for_page`)
+does `Pt` arithmetic and drops to `f32` with `to_f32()` only at the
+`stroke_line` FFI call. **Byte-neutrality is the acceptance test:** the
+existing `examples_determinism` and VRT goldens (incl. `multicol-rule-solid`)
+must stay byte-identical, proven by preserving f32 operation order (no
+reassociation).
+
+**Tech Stack:** Rust, `units::{Px, Pt, F32Units}` newtypes
+(`crates/fulgur/src/units.rs`), krilla draw layer, VRT PDF byte comparison
+(`crates/fulgur-vrt`), `examples_determinism` (`crates/fulgur-cli`).
+
+## Scope
+
+**In scope (the pt carrier path):**
+
+- `units::Pt` gains `max` / `min` helpers (unit-preserving, mirror `f32::max`).
+- New `drawables::ColumnRuleGeometry` with `Pt` coordinate fields; becomes the
+  element type of `MulticolRuleEntry.groups`.
+- `convert::record_multicol_rule` builds the `Pt` carrier via `.px().in_pt()`.
+- `render::paint_multicol_rule_for_page` consumes the `Pt` carrier, does `Pt`
+  arithmetic, `to_f32()` only at `stroke_line`.
+
+**Out of scope (left for `fulgur-2map.6` / P1d proper):**
+
+- Typing the *px source* struct `multicol_layout::ColumnGroupGeometry` to `Px`
+  (ripples into 2 construction sites, `col_heights: Vec<f32>`, the
+  `fold(0.0, f32::max)` readers, `convert_multicol_paragraph_slices`, and
+  ~20 multicol_layout unit-test assertions — its own bounded task, not needed
+  to prove the conversion pattern here).
+- Typing `column_css::ColumnRuleSpec.width` to `Pt` (pt-only relabel, no
+  px→pt conversion to validate; pulls in the CSS length parser + ~15 parser
+  test assertions).
+- `Engine::layout()` public exposure and the `draw_primitives::Pt = f32` alias
+  replacement (later epic phases).
+
+## The byte-neutral rule (read before every edit)
+
+`px_to_pt(v)` is exactly `v * 0.75` (`PX_TO_PT`). Its newtype equivalent is
+`v.px().in_pt()` which is `Pt(v * 0.75)` — **one** multiply, identical f32
+rounding. NEVER distribute the multiply across an addition: `px_to_pt(a + b)`
+must become `(a + b).px().in_pt()`, **not** `a.px().in_pt() + b.px().in_pt()`.
+Preserve the exact left-to-right operand order of every converted expression.
+The proof is the unchanged goldens; if a golden flips, a reassociation crept
+in — fix the code, **never** run `FULGUR_VRT_UPDATE=1`.
+
+## Verification commands (used at the end of every task)
+
+Always export the pinned fontconfig first (determinism — see CLAUDE.md):
+
+```bash
+export FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf"
+```
+
+- Build: `cargo build` → Expected: `Finished`
+- Lint: `cargo clippy -p fulgur -- -D warnings` → Expected: no warnings
+- Format: `cargo fmt --check` → Expected: clean
+- Unit: `cargo test -p fulgur --lib` → Expected: all pass
+- Byte-identity 1: `cargo test -p fulgur-cli --test examples_determinism`
+  → Expected: `11 passed; 0 failed`
+- Byte-identity 2: `cargo test -p fulgur-vrt` → Expected: `run_fulgur_vrt ... ok`
+  (NO golden regeneration)
+
+**Baseline already captured GREEN** in this worktree before any edit
+(`examples_determinism` 11/0, VRT `run_fulgur_vrt` ok), so any later red is
+attributable to the change, not font drift.
+
+---
+
+### Task 1: Add unit-preserving `max` / `min` to `units::Pt`
+
+The consumer clamps lengths with `.max(0.0)` / `.min(cutoff)` and
+`fold(0.0, f32::max)`. `Pt` derives `PartialOrd` (comparisons already work) but
+has no `max`/`min`. Add them mirroring `f32::max`/`f32::min` exactly so bytes
+do not move.
+
+**Files:**
+
+- Modify: `crates/fulgur/src/units.rs` (in the `impl Pt { ... }` block, near
+  `in_px`)
+- Test: `crates/fulgur/src/units.rs` (`#[cfg(test)] mod tests`)
+
+**Step 1: Write the failing test**
+
+Add to `mod tests` in `units.rs`:
+
+```rust
+#[test]
+fn pt_max_min_mirror_f32() {
+    assert_eq!(Pt(1.0).max(Pt(2.0)), Pt(2.0));
+    assert_eq!(Pt(1.0).min(Pt(2.0)), Pt(1.0));
+    // identical to f32::max/min, including the 0.0 clamp idiom
+    assert_eq!(Pt(-3.0).max(Pt(0.0)), Pt(0.0));
+    assert_eq!([Pt(0.0), Pt(2.0), Pt(1.0)].into_iter().fold(Pt(0.0), Pt::max), Pt(2.0));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p fulgur --lib units::tests::pt_max_min_mirror_f32`
+Expected: FAIL — `no method named max found for struct Pt`
+
+**Step 3: Write minimal implementation**
+
+In `impl Pt { ... }` (add after `in_px`):
+
+```rust
+/// Larger of two lengths. Mirrors `f32::max` (same NaN handling) so a
+/// migrated `x.max(y)` stays byte-identical.
+#[inline]
+pub fn max(self, other: Pt) -> Pt {
+    Pt(self.0.max(other.0))
+}
+
+/// Smaller of two lengths. Mirrors `f32::min`.
+#[inline]
+pub fn min(self, other: Pt) -> Pt {
+    Pt(self.0.min(other.0))
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p fulgur --lib units::tests::pt_max_min_mirror_f32`
+Expected: PASS
+
+**Step 5: Build + lint + commit**
+
+```bash
+cargo clippy -p fulgur -- -D warnings
+cargo fmt
+git add crates/fulgur/src/units.rs
+git commit -m "feat(units): add unit-preserving Pt::max/Pt::min (multicol spike prep)"
+```
+
+---
+
+### Task 2: Introduce the `Pt`-typed `ColumnRuleGeometry` carrier and thread it producer→consumer
+
+This is one atomic change: switching `MulticolRuleEntry.groups` to a new
+`Pt`-typed struct breaks both the producer (`convert::record_multicol_rule`)
+and the consumer (`render::paint_multicol_rule_for_page`) at once, so all three
+edits land together to keep the crate compiling. Byte-neutrality is verified by
+the goldens at the end.
+
+**Files:**
+
+- Modify: `crates/fulgur/src/drawables.rs` (add `ColumnRuleGeometry`, retype
+  `MulticolRuleEntry.groups` ~line 207-210)
+- Modify: `crates/fulgur/src/convert/mod.rs` (`record_multicol_rule`,
+  ~line 668-693)
+- Modify: `crates/fulgur/src/render.rs` (`paint_multicol_rule_for_page`,
+  ~line 2290-2375)
+
+**Step 1: Add the carrier type in `drawables.rs`**
+
+Replace the `MulticolRuleEntry` struct (currently `groups:
+Vec<crate::multicol_layout::ColumnGroupGeometry>`) with:
+
+```rust
+/// Per-column-group geometry for painting a multicol `column-rule`, in PDF
+/// pt (already converted from `multicol_layout::ColumnGroupGeometry`'s CSS
+/// px by `convert::record_multicol_rule`). A distinct pt-typed carrier so
+/// the px source struct is no longer reused across two unit spaces.
+#[derive(Debug, Clone)]
+pub struct ColumnRuleGeometry {
+    /// Horizontal offset from the container border-box left to column 0.
+    pub x_offset: crate::units::Pt,
+    /// Vertical offset from the container border-box top (incl. padding-top
+    /// + border-top) to this group.
+    pub y_offset: crate::units::Pt,
+    /// Width of a single column.
+    pub col_w: crate::units::Pt,
+    /// Gap between adjacent columns.
+    pub gap: crate::units::Pt,
+    /// Number of columns this group balances across.
+    pub n: u32,
+    /// Per-column filled height; length == `n`.
+    pub col_heights: Vec<crate::units::Pt>,
+}
+
+/// Multicol column-rule paint spec + per-column-group geometry.
+/// Mirrors the fields `MulticolRulePageable` carries — render at the
+/// container's location after children paint, partitioning `groups`
+/// per page based on the container's fragment cumulative heights.
+#[derive(Debug, Clone)]
+pub struct MulticolRuleEntry {
+    pub rule: crate::column_css::ColumnRuleSpec,
+    pub groups: Vec<ColumnRuleGeometry>,
+}
+```
+
+**Step 2: Update the producer `record_multicol_rule` in `convert/mod.rs`**
+
+Replace the `groups_pt` builder (the `.map(|g| ColumnGroupGeometry { ... })`
+block, ~line 671-684) with a builder for the new carrier. Each
+`px_to_pt(g.field)` becomes `g.field.px().in_pt()` (one multiply, byte-neutral;
+`g.field` is still bare-f32 px from the source struct, so tag it with `.px()`):
+
+```rust
+// `ColumnGroupGeometry` is recorded in CSS px; convert to the pt-typed
+// ColumnRuleGeometry carrier so downstream paint matches every other
+// Drawables entry's units. Each conversion is one multiply (byte-neutral).
+let groups: Vec<crate::drawables::ColumnRuleGeometry> = geometry
+    .groups
+    .iter()
+    .map(|g| crate::drawables::ColumnRuleGeometry {
+        x_offset: g.x_offset.px().in_pt(),
+        y_offset: g.y_offset.px().in_pt(),
+        col_w: g.col_w.px().in_pt(),
+        gap: g.gap.px().in_pt(),
+        n: g.n,
+        col_heights: g.col_heights.iter().copied().map(|h| h.px().in_pt()).collect(),
+    })
+    .collect();
+out.multicol_rules.insert(
+    node_id,
+    crate::drawables::MulticolRuleEntry { rule, groups },
+);
+```
+
+Add `use crate::units::F32Units;` at the top of `convert/mod.rs` if not already
+imported (needed for `.px()`). The old `use crate::convert::px_to_pt;` /
+`px_to_pt` call in this function is removed for the geometry conversion (it may
+still be used elsewhere in the file — leave those).
+
+**Step 3: Update the consumer `paint_multicol_rule_for_page` in `render.rs`**
+
+The carrier fields are now `Pt`. Make the page-partition scalars `Pt` and keep
+the **exact operand order** of every expression. `Pt(0.0)` can't be written
+outside `units` (private field) — use `0.0_f32.pt()`. Drop to `f32` only at
+`stroke_line`.
+
+Replace the body from `let consumed` through the inner `stroke_line` call with:
+
+```rust
+    use crate::units::F32Units;
+
+    let consumed = container_geom.fragments[..target_pos]
+        .iter()
+        .map(|f| f.height)
+        .sum::<f32>()
+        .px()
+        .in_pt();
+    let cutoff = target_frag.height.px().in_pt();
+
+    let x_base = margin_left_pt.pt() + target_frag.x.px().in_pt();
+    let y_base = margin_top_pt.pt() + target_frag.y.px().in_pt();
+    let zero = 0.0_f32.pt();
+
+    for group in &entry.groups {
+        if group.n < 2 || group.col_heights.len() != group.n as usize {
+            continue;
+        }
+        let group_top = group.y_offset - consumed;
+        let max_h = group
+            .col_heights
+            .iter()
+            .copied()
+            .fold(zero, crate::units::Pt::max);
+        let group_bottom = group_top + max_h;
+        if group_bottom <= zero || group_top >= cutoff {
+            continue;
+        }
+        let visible_top = group_top.max(zero);
+        let y_top = y_base + visible_top;
+        let consumed_above = (visible_top - group_top).max(zero);
+        let visible_h = (group_bottom.min(cutoff) - visible_top).max(zero);
+        for i in 0..(group.n as usize - 1) {
+            let h_left = (group.col_heights[i] - consumed_above)
+                .max(zero)
+                .min(visible_h);
+            let h_right = (group.col_heights[i + 1] - consumed_above)
+                .max(zero)
+                .min(visible_h);
+            if h_left <= zero || h_right <= zero {
+                continue;
+            }
+            let rule_x = x_base
+                + group.x_offset
+                + (i as f32 + 1.0) * group.col_w
+                + i as f32 * group.gap
+                + group.gap / 2.0;
+            let y_bot = y_top + h_left.min(h_right);
+            stroke_line(
+                canvas,
+                rule_x.to_f32(),
+                y_top.to_f32(),
+                rule_x.to_f32(),
+                y_bot.to_f32(),
+                stroke.clone(),
+            );
+        }
+    }
+    canvas.surface.set_stroke(None);
+```
+
+Notes on byte-neutrality of the rewrite (verify each as you type):
+
+- `consumed`/`cutoff`/`x_base`/`y_base`: `px_to_pt(v)` → `v.px().in_pt()`;
+  `margin_*_pt + px_to_pt(v)` → `margin_*_pt.pt() + v.px().in_pt()` — same
+  order, one multiply.
+- `(i as f32 + 1.0) * group.col_w`: `f32 * Pt` uses the commutative
+  `Mul<Pt> for f32` impl = `(i+1.0) * col_w.0` — identical. Same for
+  `i as f32 * group.gap` and `group.gap / 2.0` (`Pt / f32`).
+- `.max(0.0)`/`.min(...)`/`fold(0.0, f32::max)` → `.max(zero)`/`.min(...)`/
+  `fold(zero, Pt::max)` — `Pt::max`/`min` mirror `f32` exactly (Task 1).
+- comparisons (`<= 0.0`, `>= cutoff`) → vs `zero`/`cutoff`; `PartialOrd`
+  compares the inner `f32`.
+- The `use crate::convert::px_to_pt;` at the top of the function is now unused
+  for geometry — remove it **only if** nothing else in the function still uses
+  it (it is used for `target_frag` scalars above, which we just migrated, so it
+  becomes unused — remove it and rely on `.px().in_pt()`). Confirm with clippy.
+
+**Step 4: Build**
+
+Run: `cargo build`
+Expected: `Finished` (no type errors — producer and consumer both updated)
+
+**Step 5: Lint + format**
+
+```bash
+cargo clippy -p fulgur -- -D warnings
+cargo fmt --check
+```
+
+Expected: clean (no unused `px_to_pt` import warning).
+
+**Step 6: Byte-identity proof (the real acceptance test)**
+
+```bash
+export FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf"
+cargo test -p fulgur --lib
+cargo test -p fulgur-cli --test examples_determinism
+cargo test -p fulgur-vrt
+```
+
+Expected: `fulgur --lib` all pass; `examples_determinism` 11 passed / 0 failed;
+VRT `run_fulgur_vrt ... ok` (the `multicol-rule-solid` / `multicol-2` /
+`multicol-span-all` goldens stay byte-identical). If VRT goes red, a
+reassociation crept in — diff the offending expression, fix operand order, do
+NOT regenerate the golden.
+
+**Step 7: Commit**
+
+```bash
+git add crates/fulgur/src/drawables.rs crates/fulgur/src/convert/mod.rs crates/fulgur/src/render.rs
+git commit -m "refactor(multicol): type column-rule pt carrier with units::Pt (byte-neutral spike)"
+```
+
+---
+
+### Task 3: Lib-side smoke test for the migrated render path (codecov patch coverage)
+
+Per CLAUDE.md coverage policy, the VRT-only path is excluded from codecov; the
+changed `convert`/`render` lines need a lib-side test reachable via
+`Engine::render_html`. Add an end-to-end smoke test that renders a multicol
+container with a `column-rule` so the migrated producer + consumer execute.
+
+**Files:**
+
+- Test: `crates/fulgur/tests/render_smoke.rs` (append a new `#[test]`)
+
+**Step 1: Write the test**
+
+```rust
+/// fulgur-2map.2: the multicol column-rule pt carrier (units::Pt) renders
+/// end-to-end through record_multicol_rule + paint_multicol_rule_for_page.
+#[test]
+fn multicol_column_rule_renders() {
+    let html = r#"<!doctype html><html><body>
+      <div style="column-count:3; column-gap:20px; column-rule:2px solid #333;">
+        <p>alpha beta gamma delta epsilon zeta eta theta iota kappa
+        lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega</p>
+      </div>
+    </body></html>"#;
+    let pdf = fulgur::Engine::builder()
+        .build()
+        .render_html(html)
+        .expect("render multicol column-rule");
+    assert!(!pdf.is_empty());
+}
+```
+
+**Step 2: Run it**
+
+Run: `cargo test -p fulgur --test render_smoke multicol_column_rule_renders`
+Expected: PASS (non-empty PDF; exercises the migrated path)
+
+**Step 3: Commit**
+
+```bash
+git add crates/fulgur/tests/render_smoke.rs
+git commit -m "test(multicol): lib smoke test for column-rule pt-carrier render path"
+```
+
+---
+
+### Task 4: Document the established per-phase pattern + close out
+
+The spike's deliverable is a *reusable pattern*. Record it so P1a–P1d follow it.
+
+**Files:**
+
+- Modify: `docs/plans/2026-06-27-engine-layout-api-design.md` (append a short
+  "Spike outcome (fulgur-2map.2)" note under §7 or §8)
+
+**Step 1: Append the pattern note**
+
+Add a subsection capturing the validated recipe:
+
+```markdown
+### Spike outcome (fulgur-2map.2) — validated per-phase byte-neutral pattern
+
+Migrated the multicol column-rule **pt carrier** end-to-end as the P0.5 spike:
+
+1. **Type the converted (pt) side with a dedicated carrier.** Do not reuse the
+   px source struct for pt values. `drawables::ColumnRuleGeometry` (Pt fields)
+   replaced the second `ColumnGroupGeometry` that held pt — closing the
+   one-struct-two-units hole on the pt side.
+2. **Convert at the boundary, one multiply.** `px_to_pt(v)` → `v.px().in_pt()`.
+   Never distribute across `+` (no reassociation). `margin + px_to_pt(v)` →
+   `margin.pt() + v.px().in_pt()`.
+3. **`to_f32()` only at FFI** (the `stroke_line` krilla call).
+4. **Clamps/folds need unit-preserving helpers** — added `Pt::max`/`Pt::min`
+   mirroring `f32` exactly; `Pt(0.0)` is unconstructable outside `units`, use
+   `0.0_f32.pt()`.
+5. **Proof = unchanged goldens.** `examples_determinism` + VRT stayed
+   byte-identical; never `FULGUR_VRT_UPDATE=1`.
+
+Deferred to P1d (`fulgur-2map.6`): typing the px source
+`multicol_layout::ColumnGroupGeometry` to `Px`, and
+`column_css::ColumnRuleSpec.width` to `Pt`.
+```
+
+**Step 2: Markdown lint**
+
+Run: `npx markdownlint-cli2 'docs/plans/2026-06-27-*.md'`
+Expected: no errors
+
+**Step 3: Final full verification**
+
+```bash
+export FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf"
+cargo build && cargo clippy -p fulgur -- -D warnings && cargo fmt --check \
+  && cargo test -p fulgur --lib \
+  && cargo test -p fulgur-cli --test examples_determinism \
+  && cargo test -p fulgur-vrt
+```
+
+Expected: all green, goldens byte-identical.
+
+**Step 4: Commit**
+
+```bash
+git add docs/plans/2026-06-27-engine-layout-api-design.md
+git commit -m "docs(2map): record multicol Px/Pt spike outcome + per-phase pattern"
+```
+
+---
+
+## Done criteria (maps to `fulgur-2map.2` acceptance)
+
+- [ ] `MulticolRuleEntry.groups` carries a `Pt`-typed `ColumnRuleGeometry`.
+- [ ] Conversion uses `Px::in_pt` (one multiply); `to_f32()` only at the
+      `stroke_line` FFI boundary.
+- [ ] `examples_determinism` + VRT goldens **byte-identical** (no
+      `FULGUR_VRT_UPDATE`).
+- [ ] `cargo build`, `cargo clippy -p fulgur -- -D warnings`,
+      `cargo fmt --check`, `cargo test -p fulgur --lib` all clean.
+- [ ] Lib smoke test covers the migrated render path.
+- [ ] Per-phase byte-neutral pattern documented for P1a–P1d.


### PR DESCRIPTION
## 概要

`fulgur-2map` エピック（`Engine::layout()` を Px/Pt newtype 座標基盤で公開）の **P0.5 検証スパイク**（beads `fulgur-2map.2`）。最小 blast radius の leaf サブシステムとして **multicol column-rule の pt geometry** を 1 つだけ `units::Pt` newtype へ end-to-end 移行し、後続フェーズ P1a–P1d が踏襲する **per-phase byte-neutral パターン**を実証・確立する。

## 背景

現状 `convert::record_multicol_rule` は px-native な `multicol_layout::ColumnGroupGeometry` を **同じ型の pt 版**（`groups_pt`）へ写しており、1 つの構造体が 2 つの単位空間を名乗る「naming-contract hole」になっていた。これがエピックの解消対象。

## 変更内容

- **`units::Pt` に `max` / `min` を追加**（`f32::max`/`min` へ委譲＝同一 NaN 挙動、unit 保存）。consumer の clamp / fold に必要。
- **`drawables::ColumnRuleGeometry`（Pt フィールドの専用 carrier）を新設**し、`MulticolRuleEntry.groups` の要素型を px 流用の `ColumnGroupGeometry` から差し替え。pt 側の二重利用を解消。
- **producer** `convert::record_multicol_rule`: `px_to_pt(g.field)` → `g.field.px().in_pt()`（1 乗算、再結合なし）。
- **consumer** `render::paint_multicol_rule_for_page`: 全演算を `Pt` で実施し、演算子順序を厳密に保存。`to_f32()` は krilla FFI（`stroke_line`）境界のみ。
- lib-side smoke test（`render_smoke::multicol_column_rule_renders`）を追加（VRT は codecov 対象外のため patch coverage 用）。
- エピック設計ドキュメントに **Spike outcome** セクション（確立したパターン）を追記。

## byte-neutrality（受け入れの核心）

`px_to_pt(v)` ≡ `v * 0.75` ≡ `v.px().in_pt()`（同一の単一 f32 乗算。`PX_TO_PT = 0.75` はクレート唯一）。和は一度だけ変換（`sum.px().in_pt()`）し、加算をまたいで乗算を分配しない（再結合禁止）。証明は **既存 golden の byte 一致**。`FULGUR_VRT_UPDATE=1` は不使用。

- VRT `run_fulgur_vrt` ✅（`multicol-rule-solid` / `multicol-2` / `multicol-span-all` 含む 64 fixtures、golden 変更なし）
- `examples_determinism` ✅ 11 passed / 0 failed
- `cargo test -p fulgur --lib` ✅ 1485 passed / 0 failed
- `cargo build` / `clippy -p fulgur -D warnings` / `fmt --check` ✅ clean

## スコープ（意図的に P1d へ繰り延べ）

- px 源 `multicol_layout::ColumnGroupGeometry` 自体の `Px` 化（構築箇所・`fold(f32::max)` 読み手・約 20 の unit-test アサーションへ波及）
- `column_css::ColumnRuleSpec.width` の `Pt` 化（px→pt 変換を含まない pt-only relabel、CSS パーサと約 15 テストへ波及）

## 注記

エピック設計ドキュメント `docs/plans/2026-06-27-engine-layout-api-design.md` は **元々 git 未追跡**で main 作業ツリーにのみ存在していたため、本ブランチでスパイク成果追記とあわせて初めてコミットされている（VCS 取り込みとしては妥当）。merge 時に main 側の未追跡コピーとの整合に注意。

## フォローアップ候補（本 PR スコープ外）

- ページまたぎ column-rule の VRT golden を追加し、cross-page partition 算術（`consumed > 0` / `cutoff` clamp など）を byte レベルでも担保する（現状は型と推論で byte-neutral、既存の coverage gap）。

## Test Plan

- [x] `cargo build` / `cargo clippy -p fulgur -- -D warnings` / `cargo fmt --check`
- [x] `cargo test -p fulgur --lib`（1485 passed）
- [x] `cargo test -p fulgur-cli --test examples_determinism`（11 passed）
- [x] `cargo test -p fulgur-vrt`（golden byte 一致、再生成なし）

Closes beads `fulgur-2map.2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * マルチカラムの `column-rule` 描画が、単位を明確に扱う仕組みに更新されました。
  * 列ルールの幾何情報をより安全に扱えるようになり、描画精度と一貫性が向上しました。

* **Bug Fixes**
  * ページごとの列ルール描画で、単位変換に起因するズレや不整合を起こしにくくしました。

* **Tests**
  * マルチカラムの `column-rule` を含むレンダリングのスモークテストを追加しました。

* **Documentation**
  * 将来のレイアウト API に関する設計メモを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->