### PR TITLE
refactor(engine): rename render_html→render, render→render_template

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ use fulgur::config::{PageSize, Margin};
 
 // Basic conversion
 let engine = Engine::builder().build();
-let pdf = engine.render_html("<h1>Hello</h1>")?;
+let pdf = engine.render("<h1>Hello</h1>")?;
 
 // With page options
 let engine = Engine::builder()
@@ -148,8 +148,8 @@ let engine = Engine::builder()
     .title("My Document")
     .build();
 
-let pdf = engine.render_html(html)?;
-engine.render_html_to_file(html, "output.pdf")?;
+let pdf = engine.render(html)?;
+engine.render_file(html, "output.pdf")?;
 
 // Template + JSON
 let engine = Engine::builder()
@@ -160,7 +160,7 @@ let engine = Engine::builder()
     }))
     .build();
 
-let pdf = engine.render()?;
+let pdf = engine.render_template()?;
 
 // Tagged PDF (accessibility / PDF/UA-1)
 let engine = Engine::builder()
@@ -168,7 +168,7 @@ let engine = Engine::builder()
     .build();
 // or: .pdf_ua(true) for full PDF/UA-1 conformance (implies tagged + bookmarks)
 
-let pdf = engine.render_html(html)?;
+let pdf = engine.render(html)?;
 ```
 
 ## Tagged PDF

--- a/crates/fulgur-cli/src/main.rs
+++ b/crates/fulgur-cli/src/main.rs
@@ -526,9 +526,9 @@ fn main() {
             };
 
             let pdf = if data.is_some() {
-                engine.render()
+                engine.render_template()
             } else {
-                engine.render_html(&input_content)
+                engine.render(&input_content)
             }
             .unwrap_or_else(|e| {
                 eprintln!("Error: {e}");

--- a/crates/fulgur-ruby/src/engine.rs
+++ b/crates/fulgur-ruby/src/engine.rs
@@ -168,7 +168,7 @@ impl RbEngine {
             // pointer。`without_gvl` は呼び出し元を block しているため、
             // この closure が走っている間 `self` は生存している。
             let engine: &Engine = unsafe { &*a.engine };
-            engine.render_html(&a.html)
+            engine.render(&a.html)
         });
 
         let ruby = Ruby::get().expect("ruby vm");
@@ -201,7 +201,7 @@ impl RbEngine {
             // SAFETY: `a.engine` は呼び出し元の `&self.inner` から作った
             // pointer。`without_gvl` の block 中は self が生存している。
             let engine: &Engine = unsafe { &*a.engine };
-            engine.render_html_to_file(&a.html, &a.path)
+            engine.render_file(&a.html, &a.path)
         });
 
         let ruby = Ruby::get().expect("ruby vm");

--- a/crates/fulgur-vrt/src/pdf_render.rs
+++ b/crates/fulgur-vrt/src/pdf_render.rs
@@ -40,7 +40,7 @@ pub fn render_html_to_pdf(html: &str, spec: RenderSpec<'_>) -> anyhow::Result<Ve
     let engine = builder.build();
 
     engine
-        .render_html(html)
+        .render(html)
         .map_err(|e| anyhow::anyhow!("fulgur render_html failed: {e}"))
 }
 

--- a/crates/fulgur-vrt/src/pdf_render.rs
+++ b/crates/fulgur-vrt/src/pdf_render.rs
@@ -41,7 +41,7 @@ pub fn render_html_to_pdf(html: &str, spec: RenderSpec<'_>) -> anyhow::Result<Ve
 
     engine
         .render(html)
-        .map_err(|e| anyhow::anyhow!("fulgur render_html failed: {e}"))
+        .map_err(|e| anyhow::anyhow!("fulgur render failed: {e}"))
 }
 
 /// Render `html` through fulgur, write the PDF into `work_dir`, rasterize

--- a/crates/fulgur-wasm/src/lib.rs
+++ b/crates/fulgur-wasm/src/lib.rs
@@ -511,7 +511,7 @@ mod tests {
     #[test]
     fn render_html_standalone_still_works() {
         let pdf = render_html(r#"<div style="background:red; width:100px; height:100px"></div>"#)
-            .expect("render_html should succeed");
+            .expect("render_html standalone should succeed");
         assert_eq!(&pdf[..4], b"%PDF");
     }
 

--- a/crates/fulgur-wasm/src/lib.rs
+++ b/crates/fulgur-wasm/src/lib.rs
@@ -232,7 +232,7 @@ impl Engine {
         if let Some(b) = self.bookmarks {
             builder = builder.bookmarks(b);
         }
-        builder.build().render_html(html)
+        builder.build().render(html)
     }
 }
 

--- a/crates/fulgur-wpt/src/render.rs
+++ b/crates/fulgur-wpt/src/render.rs
@@ -45,7 +45,7 @@ pub fn render_test(
     let engine = builder.build();
     let pdf_bytes = engine
         .render(&html)
-        .map_err(|e| anyhow::anyhow!("fulgur render_html failed for {}: {e}", abs.display()))?;
+        .map_err(|e| anyhow::anyhow!("fulgur render failed for {}: {e}", abs.display()))?;
 
     // Remove stale page PNGs from prior runs so page count is accurate.
     let prefix = work_dir.join("page");

--- a/crates/fulgur-wpt/src/render.rs
+++ b/crates/fulgur-wpt/src/render.rs
@@ -44,7 +44,7 @@ pub fn render_test(
     }
     let engine = builder.build();
     let pdf_bytes = engine
-        .render_html(&html)
+        .render(&html)
         .map_err(|e| anyhow::anyhow!("fulgur render_html failed for {}: {e}", abs.display()))?;
 
     // Remove stale page PNGs from prior runs so page count is accurate.

--- a/crates/fulgur-wpt/tests/fonts_integration.rs
+++ b/crates/fulgur-wpt/tests/fonts_integration.rs
@@ -41,12 +41,12 @@ fn ahem_bundle_differs_from_no_bundle() {
 
     let pdf_none = Engine::builder()
         .build()
-        .render_html(HTML)
+        .render(HTML)
         .expect("render without bundle");
     let pdf_with = Engine::builder()
         .assets(bundle)
         .build()
-        .render_html(HTML)
+        .render(HTML)
         .expect("render with bundle");
 
     assert_ne!(

--- a/crates/fulgur/src/convert/inline_root.rs
+++ b/crates/fulgur/src/convert/inline_root.rs
@@ -1324,7 +1324,7 @@ mod tests {
         // This exercises the pre_snapshot + clip_descendants tracking path.
         let pdf = crate::engine::Engine::builder()
             .build()
-            .render_html(
+            .render(
                 r#"<!doctype html><html><body>
                 <p style="overflow:hidden;height:30px;background:#abc">Clipped text</p>
                 </body></html>"#,
@@ -1340,7 +1340,7 @@ mod tests {
         // The pre_snapshot + opacity_descendants path is exercised.
         let pdf = crate::engine::Engine::builder()
             .build()
-            .render_html(
+            .render(
                 r#"<!doctype html><html><body>
                 <p style="opacity:0.5;background:#def">Faded paragraph</p>
                 </body></html>"#,

--- a/crates/fulgur/src/convert/list_item.rs
+++ b/crates/fulgur/src/convert/list_item.rs
@@ -1071,7 +1071,7 @@ mod tests {
         let pdf = crate::engine::Engine::builder()
             .assets(bundle)
             .build()
-            .render_html(
+            .render(
                 r#"<!doctype html><html><body>
                 <ul><li>Item with after image</li></ul>
                 </body></html>"#,
@@ -1104,7 +1104,7 @@ mod tests {
         let pdf = crate::engine::Engine::builder()
             .assets(bundle)
             .build()
-            .render_html(
+            .render(
                 r#"<!doctype html><html><body>
                 <ul style="list-style-position:inside">
                     <li><div style="height:20px;background:#eee"></div></li>
@@ -1127,7 +1127,7 @@ mod tests {
         let pdf = crate::engine::Engine::builder()
             .assets(bundle)
             .build()
-            .render_html(
+            .render(
                 r#"<!doctype html><html><body>
                 <div class="li-item">Fallback list item</div>
                 </body></html>"#,
@@ -1152,7 +1152,7 @@ mod tests {
         let pdf = crate::engine::Engine::builder()
             .assets(bundle)
             .build()
-            .render_html(
+            .render(
                 r#"<!doctype html><html><body>
                 <div class="li-item">Fallback item numeric lh</div>
                 </body></html>"#,
@@ -1177,7 +1177,7 @@ mod tests {
         let pdf = crate::engine::Engine::builder()
             .assets(bundle)
             .build()
-            .render_html(
+            .render(
                 r#"<!doctype html><html><body>
                 <div class="li-item">Fallback item length lh</div>
                 </body></html>"#,

--- a/crates/fulgur/src/convert/list_item.rs
+++ b/crates/fulgur/src/convert/list_item.rs
@@ -912,7 +912,7 @@ mod tests {
     fn render_list_html(html: &str) -> Vec<u8> {
         crate::engine::Engine::builder()
             .build()
-            .render_html(html)
+            .render(html)
             .expect("render failed")
     }
 
@@ -1017,7 +1017,7 @@ mod tests {
         let pdf = crate::engine::Engine::builder()
             .assets(bundle)
             .build()
-            .render_html(
+            .render(
                 r#"<!doctype html><html><body>
                 <ul><li>Item with before image</li></ul>
                 </body></html>"#,
@@ -1037,7 +1037,7 @@ mod tests {
         let pdf = crate::engine::Engine::builder()
             .assets(bundle)
             .build()
-            .render_html(
+            .render(
                 r#"<!doctype html><html><body>
                 <ul><li></li></ul>
                 </body></html>"#,

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -1159,7 +1159,7 @@ mod bookmark_outline_tests {
             .page_size(PageSize::A4)
             .bookmarks(true)
             .build();
-        let pdf = engine.render_html(html).expect("render v2");
+        let pdf = engine.render(html).expect("render v2");
         let pdf_str = String::from_utf8_lossy(&pdf);
         assert!(
             pdf_str.contains("/Outlines"),

--- a/crates/fulgur/src/convert/positioned.rs
+++ b/crates/fulgur/src/convert/positioned.rs
@@ -1376,7 +1376,7 @@ mod tests {
         crate::engine::Engine::builder()
             .assets(bundle)
             .build()
-            .render_html(html)
+            .render(html)
             .expect("render failed")
     }
 

--- a/crates/fulgur/src/convert/style/background.rs
+++ b/crates/fulgur/src/convert/style/background.rs
@@ -617,7 +617,7 @@ mod tests {
         );
         Engine::builder()
             .build()
-            .render_html(&html)
+            .render(&html)
             .expect("render should succeed")
     }
 
@@ -629,7 +629,7 @@ mod tests {
         let html = format!(r#"<html><body><div style="{style}"></div></body></html>"#);
         let pdf = Engine::builder()
             .build()
-            .render_html(&html)
+            .render(&html)
             .unwrap_or_else(|_| panic!("render failed for {label}"));
         assert!(pdf.starts_with(b"%PDF"), "{label}: expected PDF");
     }
@@ -919,7 +919,7 @@ mod tests {
         let pdf = Engine::builder()
             .assets(bundle)
             .build()
-            .render_html(html)
+            .render(html)
             .expect("render raster bg");
         assert!(pdf.starts_with(b"%PDF"));
     }
@@ -934,7 +934,7 @@ mod tests {
         let pdf = Engine::builder()
             .assets(bundle)
             .build()
-            .render_html(html)
+            .render(html)
             .expect("render svg bg");
         assert!(pdf.starts_with(b"%PDF"));
     }
@@ -949,7 +949,7 @@ mod tests {
         let pdf = Engine::builder()
             .assets(bundle)
             .build()
-            .render_html(html)
+            .render(html)
             .expect("render broken-svg bg");
         assert!(pdf.starts_with(b"%PDF"));
     }
@@ -963,7 +963,7 @@ mod tests {
         let pdf = Engine::builder()
             .assets(bundle)
             .build()
-            .render_html(html)
+            .render(html)
             .expect("render unknown-asset bg");
         assert!(pdf.starts_with(b"%PDF"));
     }
@@ -975,7 +975,7 @@ mod tests {
         let html = r#"<html><body><div style="width:80px;height:80px;background:url(img.png)"></div></body></html>"#;
         let pdf = Engine::builder()
             .build()
-            .render_html(html)
+            .render(html)
             .expect("render missing-bundle bg");
         assert!(pdf.starts_with(b"%PDF"));
     }

--- a/crates/fulgur/src/convert/style/shadow.rs
+++ b/crates/fulgur/src/convert/style/shadow.rs
@@ -42,7 +42,7 @@ mod tests {
         );
         Engine::builder()
             .build()
-            .render_html(&html)
+            .render(&html)
             .expect("render should succeed")
     }
 

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -28,7 +28,7 @@ pub struct Engine {
 ///   skipped to avoid `element_text` cost on every id'd subtree on the
 ///   fast path.
 /// - `needs_pass_two`: mirrors that gate; `true` only for pass 1 of a
-///   2-pass render so `render_html` can decide whether to call
+///   2-pass render so `render` can decide whether to call
 ///   `render_pass` again with the populated map.
 struct RenderPassOutput {
     pdf: Vec<u8>,
@@ -752,12 +752,12 @@ impl Engine {
             &column_styles,
         );
 
-        // Mirror the production `render_html` path so test callers that
+        // Mirror the production `render` path so test callers that
         // consult the returned geometry as a placement oracle see the
         // same `position: fixed` per-page repetition that the real
         // render emits (see the `append_position_fixed_fragments` block
-        // in `render_html`). Without this, the helper would diverge
-        // from `render_html` for documents with `position: fixed`.
+        // in `render`). Without this, the helper would diverge
+        // from `render` for documents with `position: fixed`.
         let content_w_px = crate::convert::pt_to_px(self.config.content_width());
         let content_h_px = crate::convert::pt_to_px(self.config.content_height());
         let total_pages = crate::pagination_layout::implied_page_count(&pagination_geometry).max(1);
@@ -810,7 +810,7 @@ impl Engine {
         // those corrections from tests that drive
         // `pseudo_absolute_content_url::
         // absolute_pseudo_with_right_bottom_offsets_by_image_size`.
-        // The production `render_html` path already passes
+        // The production `render` path already passes
         // `&convert_ctx.pagination_geometry` to `render_v2` after
         // convert, so this matches the production read order.
         (drawables, convert_ctx.pagination_geometry)

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -611,8 +611,15 @@ impl Engine {
     }
 
     /// Render a template with data to PDF bytes.
-    /// The template is expanded via MiniJinja, then passed to render().
+    ///
+    /// The template is expanded via MiniJinja, then passed to [`render`](Engine::render).
     /// Returns an error if no template was set via the builder.
+    ///
+    /// **Migration note:** This method was previously named `render()` (no arguments).
+    /// Because the new [`render`](Engine::render) method occupies that name with a
+    /// different signature, no `#[deprecated]` alias can be provided — existing calls
+    /// to `engine.render()` with no arguments will produce a compile error and must be
+    /// updated to `engine.render_template()`.
     pub fn render_template(&self) -> Result<Vec<u8>> {
         let (name, content) = self
             .template

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -74,7 +74,7 @@ impl Engine {
     /// `gcpm::counter::resolve_content_to_*_with_anchor` and
     /// `CounterPass::with_anchor_map` substitute real values instead of
     /// fixed-width placeholders.
-    pub fn render_html(&self, html: &str) -> Result<Vec<u8>> {
+    pub fn render(&self, html: &str) -> Result<Vec<u8>> {
         // Pass 1: render once. `render_pass` parses the full GCPM context
         // (AssetBundle, <link>-loaded stylesheets, inline <style> blocks)
         // and reports `needs_pass_two` based on that parsed view, so
@@ -603,17 +603,17 @@ impl Engine {
         })
     }
 
-    /// Render HTML string to a PDF file.
-    pub fn render_html_to_file(&self, html: &str, path: impl AsRef<Path>) -> Result<()> {
-        let pdf = self.render_html(html)?;
+    /// Render an HTML string to a PDF file.
+    pub fn render_file(&self, html: &str, path: impl AsRef<Path>) -> Result<()> {
+        let pdf = self.render(html)?;
         std::fs::write(path, pdf)?;
         Ok(())
     }
 
     /// Render a template with data to PDF bytes.
-    /// The template is expanded via MiniJinja, then passed to render_html().
+    /// The template is expanded via MiniJinja, then passed to render().
     /// Returns an error if no template was set via the builder.
-    pub fn render(&self) -> Result<Vec<u8>> {
+    pub fn render_template(&self) -> Result<Vec<u8>> {
         let (name, content) = self
             .template
             .as_ref()
@@ -623,7 +623,19 @@ impl Engine {
             .as_ref()
             .map_or_else(|| serde_json::json!({}), Clone::clone);
         let html = crate::template::render_template(name, content, &data)?;
-        self.render_html(&html)
+        self.render(&html)
+    }
+
+    /// Renamed to [`render`](Engine::render).
+    #[deprecated(since = "0.19.0", note = "renamed to `render`")]
+    pub fn render_html(&self, html: &str) -> Result<Vec<u8>> {
+        self.render(html)
+    }
+
+    /// Renamed to [`render_file`](Engine::render_file).
+    #[deprecated(since = "0.19.0", note = "renamed to `render_file`")]
+    pub fn render_html_to_file(&self, html: &str, path: impl AsRef<Path>) -> Result<()> {
+        self.render_file(html, path)
     }
 
     /// Build a `Drawables` map from HTML for integration tests.
@@ -1187,7 +1199,7 @@ mod tests {
           <p><a class="ref" href="#t"></a></p>
           <h2 id="t" data-x="DX">Title</h2>
         </body></html>"##;
-        let pdf = Engine::builder().build().render_html(html).unwrap();
+        let pdf = Engine::builder().build().render(html).unwrap();
         assert!(!pdf.is_empty());
     }
 
@@ -1221,14 +1233,14 @@ mod tests {
             .template("test.html", "<h1>{{ title }}</h1>")
             .data(serde_json::json!({"title": "Hello"}))
             .build();
-        let result = engine.render();
+        let result = engine.render_template();
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_engine_render_without_template_errors() {
         let engine = Engine::builder().build();
-        let result = engine.render();
+        let result = engine.render_template();
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Template"));
     }
@@ -1238,7 +1250,7 @@ mod tests {
         let engine = Engine::builder()
             .template("test.html", "<p>static</p>")
             .build();
-        let result = engine.render();
+        let result = engine.render_template();
         assert!(result.is_ok());
     }
 
@@ -1340,7 +1352,7 @@ mod tests {
         let path = dir.path().join("out.pdf");
         Engine::builder()
             .build()
-            .render_html_to_file("<html><body><p>test</p></body></html>", &path)
+            .render_file("<html><body><p>test</p></body></html>", &path)
             .unwrap();
         let bytes = std::fs::read(&path).unwrap();
         assert!(bytes.starts_with(b"%PDF"));

--- a/crates/fulgur/src/inspect.rs
+++ b/crates/fulgur/src/inspect.rs
@@ -521,7 +521,7 @@ mod tests {
     fn render_test_pdf(html: &str) -> Vec<u8> {
         crate::engine::Engine::builder()
             .build()
-            .render_html(html)
+            .render(html)
             .unwrap()
     }
 
@@ -543,7 +543,7 @@ mod tests {
         let pdf = crate::engine::Engine::builder()
             .title("Test Title".to_string())
             .build()
-            .render_html("<html><body><p>Hi</p></body></html>")
+            .render("<html><body><p>Hi</p></body></html>")
             .unwrap();
         let result = inspect_bytes(&pdf);
         assert_eq!(result.metadata.title.as_deref(), Some("Test Title"));
@@ -605,7 +605,7 @@ mod tests {
             .authors(vec!["Alice".to_string()])
             .creator("TestApp".to_string())
             .build()
-            .render_html("<html><body><p>x</p></body></html>")
+            .render("<html><body><p>x</p></body></html>")
             .unwrap();
         let result = inspect_bytes(&pdf);
         assert_eq!(result.metadata.title.as_deref(), Some("My Title"));
@@ -628,7 +628,7 @@ mod tests {
         let pdf = crate::engine::Engine::builder()
             .assets(bundle)
             .build()
-            .render_html(r#"<html><body><img src="test.png" width="50" height="50"></body></html>"#)
+            .render(r#"<html><body><img src="test.png" width="50" height="50"></body></html>"#)
             .unwrap();
         let result = inspect_bytes(&pdf);
         assert!(!result.images.is_empty(), "expected at least one image");

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -70,5 +70,5 @@ pub use outline::build_outline;
 /// Convert HTML to PDF with default settings.
 pub fn convert_html(html: &str) -> Result<Vec<u8>> {
     let engine = Engine::builder().build();
-    engine.render_html(html)
+    engine.render(html)
 }

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -1885,7 +1885,7 @@ mod render_smoke_tests {
     fn render_html(html: &str) -> Vec<u8> {
         crate::engine::Engine::builder()
             .build()
-            .render_html(html)
+            .render(html)
             .expect("render failed")
     }
 
@@ -1894,7 +1894,7 @@ mod render_smoke_tests {
             .tagged(true)
             .lang("en")
             .build()
-            .render_html(html)
+            .render(html)
             .expect("tagged render failed")
     }
 
@@ -2065,7 +2065,7 @@ mod render_smoke_tests {
         let pdf = crate::engine::Engine::builder()
             .assets(assets)
             .build()
-            .render_html(
+            .render(
                 r#"<!doctype html><html><body>
                 <ul style="list-style-position: inside; list-style-image: url(bullet.png)">
                     <li>item with image marker</li>
@@ -2087,7 +2087,7 @@ mod render_smoke_tests {
         let pdf = crate::engine::Engine::builder()
             .assets(assets)
             .build()
-            .render_html(
+            .render(
                 r#"<!doctype html><html><body>
                 <p><a href="https://example.com"><img src="pixel.png"
                    width="20" height="20"></a> caption text</p>

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -5460,7 +5460,7 @@ mod tests {
     fn render_html(html: &str) -> Vec<u8> {
         crate::engine::Engine::builder()
             .build()
-            .render_html(html)
+            .render(html)
             .expect("render failed")
     }
 
@@ -5561,7 +5561,7 @@ mod tests {
         let pdf = crate::engine::Engine::builder()
             .assets(bundle)
             .build()
-            .render_html(
+            .render(
                 r#"<!doctype html><html><body>
                 <img src="img.png" style="width:64px;height:64px;">
                 </body></html>"#,
@@ -5675,7 +5675,7 @@ mod tests {
             .tagged(true)
             .lang("en")
             .build()
-            .render_html(
+            .render(
                 r#"<!doctype html><html><body>
                 <h1>Heading One</h1>
                 <p>A paragraph of text.</p>
@@ -5763,7 +5763,7 @@ mod tests {
         let pdf = crate::engine::Engine::builder()
             .assets(bundle)
             .build()
-            .render_html(
+            .render(
                 r#"<!doctype html><html><body style="margin:0">
                 <div style="background:url(red.png);width:80px;height:80px"></div>
                 </body></html>"#,
@@ -5782,7 +5782,7 @@ mod tests {
         let pdf = crate::engine::Engine::builder()
             .bookmarks(true)
             .build()
-            .render_html(
+            .render(
                 r#"<!doctype html><html><body>
                 <h1>Chapter One</h1>
                 <p>Body content for chapter one.</p>
@@ -5809,7 +5809,7 @@ mod tests {
             .lang("en")
             .title("PDF/UA Test Document")
             .build()
-            .render_html(
+            .render(
                 r#"<!doctype html><html><body>
                 <h1>Title</h1>
                 <p>A paragraph of body text.</p>
@@ -5831,7 +5831,7 @@ mod tests {
             .tagged(true)
             .lang("en")
             .build()
-            .render_html(
+            .render(
                 r#"<!doctype html><html><body>
                 <ul>
                   <li>First item</li>
@@ -5856,7 +5856,7 @@ mod tests {
             .tagged(true)
             .lang("en")
             .build()
-            .render_html(
+            .render(
                 r#"<!doctype html><html><body>
                 <p>Visit <a href="https://example.com">our website</a> for more info.</p>
                 <p>Another <a href="https://other.example.com">link here</a> too.</p>
@@ -5931,7 +5931,7 @@ mod tests {
         let pdf = crate::engine::Engine::builder()
             .assets(bundle)
             .build()
-            .render_html(
+            .render(
                 r#"<!doctype html><html><body>
                 <div style="width:60px;height:40px;overflow:hidden">
                   <img src="red.png" style="width:100px;height:100px">

--- a/crates/fulgur/tests/abs_positioned_pagination.rs
+++ b/crates/fulgur/tests/abs_positioned_pagination.rs
@@ -51,7 +51,7 @@ fn abs_positioned_div_is_out_of_flow_in_pagination() {
         })
         .margin(Margin::uniform(0.0))
         .build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     let pages = page_count(&pdf);
     assert_eq!(
         pages, 3,
@@ -157,7 +157,7 @@ fn break_after_on_last_in_flow_with_trailing_abs_sibling_does_not_split() {
         })
         .margin(Margin::uniform(0.0))
         .build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     let pages = page_count(&pdf);
     assert_eq!(
         pages, 1,
@@ -184,7 +184,7 @@ fn abs_positioned_does_not_force_extra_pages_for_short_flow() {
         })
         .margin(Margin::uniform(0.0))
         .build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     let pages = page_count(&pdf);
     assert_eq!(
         pages, 1,
@@ -211,7 +211,7 @@ fn nested_abs_height_drives_page_count() {
         })
         .margin(Margin::uniform(0.0))
         .build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert_eq!(
         page_count(&pdf),
         3,
@@ -238,7 +238,7 @@ fn abs_extends_pages_despite_in_flow_content() {
         })
         .margin(Margin::uniform(0.0))
         .build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert_eq!(
         page_count(&pdf),
         3,
@@ -265,7 +265,7 @@ fn nested_abs_offset_resolves_against_cb_not_flow() {
         })
         .margin(Margin::uniform(0.0))
         .build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert_eq!(
         page_count(&pdf),
         5,
@@ -300,7 +300,7 @@ fn nested_abs_cb_is_nearest_positioned_ancestor_not_static_parent() {
         })
         .margin(Margin::uniform(0.0))
         .build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert_eq!(
         page_count(&pdf),
         3,
@@ -334,7 +334,7 @@ fn nested_abs_cb_uses_positioned_ancestor_padding_box() {
             })
             .margin(Margin::uniform(0.0))
             .build();
-        engine.render_html(&html).expect("render")
+        engine.render(&html).expect("render")
     };
     let pdf_plain = render("");
     let pdf_border = render("border-top: 40px solid black;");
@@ -385,7 +385,7 @@ fn abs_bottom_margin_offsets_above_sibling() {
         })
         .margin(Margin::uniform(0.0))
         .build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
 
     let Some(ys) = text_matrix_ys(&pdf) else {
         eprintln!("qpdf not installed — skipping");
@@ -423,7 +423,7 @@ fn nested_abs_text_renders_cleanly_on_extended_page() {
       </div>
     </body></html>"#;
     let engine = Engine::builder().build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
 
     // in-flow 200vh = pages 1-2; nested abs at 100vh+200vh = 300vh extends to
     // the 4th page (its start is the top of page 4).

--- a/crates/fulgur/tests/background_test.rs
+++ b/crates/fulgur/tests/background_test.rs
@@ -35,9 +35,7 @@ fn test_background_image_renders_to_pdf() {
         .page_size(PageSize::A4)
         .margin(Margin::uniform(72.0))
         .build()
-        .render(
-            r#"<html><body><div style="width:200px;height:200px">Hello</div></body></html>"#,
-        )
+        .render(r#"<html><body><div style="width:200px;height:200px">Hello</div></body></html>"#)
         .unwrap();
     assert!(
         pdf.len() > pdf_no_bg.len(),

--- a/crates/fulgur/tests/background_test.rs
+++ b/crates/fulgur/tests/background_test.rs
@@ -27,7 +27,7 @@ fn test_background_image_renders_to_pdf() {
     let html = r#"<html><body>
         <div style="width:200px;height:200px;background-image:url(bg.png)">Hello</div>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
 
     // PDF with background image should be larger than without (verifies image is embedded)
@@ -35,7 +35,7 @@ fn test_background_image_renders_to_pdf() {
         .page_size(PageSize::A4)
         .margin(Margin::uniform(72.0))
         .build()
-        .render_html(
+        .render(
             r#"<html><body><div style="width:200px;height:200px">Hello</div></body></html>"#,
         )
         .unwrap();
@@ -53,7 +53,7 @@ fn test_background_no_repeat() {
     let html = r#"<html><body>
         <div style="width:200px;height:200px;background-image:url(bg.png);background-repeat:no-repeat">Content</div>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
 }
 
@@ -63,7 +63,7 @@ fn test_background_size_cover() {
     let html = r#"<html><body>
         <div style="width:200px;height:200px;background-image:url(bg.png);background-size:cover;background-repeat:no-repeat">Content</div>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
 }
 
@@ -73,7 +73,7 @@ fn test_background_position_center() {
     let html = r#"<html><body>
         <div style="width:200px;height:200px;background-image:url(bg.png);background-position:center;background-repeat:no-repeat">Content</div>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
 }
 
@@ -90,7 +90,7 @@ fn test_background_multiple_layers() {
     let html = r#"<html><body>
         <div style="width:200px;height:200px;background-image:url(bg1.png),url(bg2.png);background-repeat:no-repeat">Content</div>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
 }
 
@@ -100,7 +100,7 @@ fn test_background_clip_padding_box() {
     let html = r#"<html><body>
         <div style="width:200px;height:200px;padding:20px;border:5px solid black;background-image:url(bg.png);background-clip:padding-box;background-repeat:no-repeat">Content</div>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
 }
 
@@ -118,7 +118,7 @@ fn test_background_image_svg_renders() {
     let html = r#"<html><body>
         <div style="width:100px;height:100px;background-image:url(circle.svg);background-size:contain;background-repeat:no-repeat"></div>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"), "output should be a PDF");
 
     // PDF with SVG background should be larger than without (verifies SVG is embedded)
@@ -126,7 +126,7 @@ fn test_background_image_svg_renders() {
         .page_size(PageSize::A4)
         .margin(Margin::uniform(72.0))
         .build()
-        .render_html(r#"<html><body><div style="width:100px;height:100px"></div></body></html>"#)
+        .render(r#"<html><body><div style="width:100px;height:100px"></div></body></html>"#)
         .unwrap();
     assert!(
         pdf.len() > pdf_no_bg.len(),

--- a/crates/fulgur/tests/bookmarks_integration.rs
+++ b/crates/fulgur/tests/bookmarks_integration.rs
@@ -8,7 +8,7 @@ fn render_with_bookmarks(html: &str, bookmarks: bool) -> Vec<u8> {
         .page_size(PageSize::A4)
         .bookmarks(bookmarks)
         .build();
-    engine.render_html(html).expect("render ok")
+    engine.render(html).expect("render ok")
 }
 
 /// Permissive substring check for an outline title in a PDF byte stream.
@@ -87,7 +87,7 @@ fn engine_with_css(css: &str) -> Engine {
 fn author_css_can_suppress_h1_bookmark() {
     let engine = engine_with_css("h1 { bookmark-level: none; }");
     let html = r#"<html><body><h1>Hidden</h1></body></html>"#;
-    let pdf = engine.render_html(html).expect("render ok");
+    let pdf = engine.render(html).expect("render ok");
     assert!(
         !pdf_contains_outline_entry(&pdf, "Hidden"),
         "expected 'Hidden' to be suppressed by bookmark-level: none"
@@ -105,7 +105,7 @@ fn custom_css_bookmarks_arbitrary_element() {
         <div class="ch" data-num="1">first</div>
         <div class="ch" data-num="2">second</div>
     </body></html>"#;
-    let pdf = engine.render_html(html).expect("render ok");
+    let pdf = engine.render(html).expect("render ok");
     assert!(
         pdf_contains_outline_entry(&pdf, "Ch. 1"),
         "expected outline entry 'Ch. 1' resolved from attr(data-num)"
@@ -126,7 +126,7 @@ fn mixed_h1_and_custom_aside_produce_nested_outline() {
         <h1>Chapter</h1>
         <div class="aside" data-title="Note">body</div>
     </body></html>"#;
-    let pdf = engine.render_html(html).expect("render ok");
+    let pdf = engine.render(html).expect("render ok");
     assert!(
         pdf_contains_outline_entry(&pdf, "Chapter"),
         "expected UA-driven h1 'Chapter' in outline"
@@ -144,7 +144,7 @@ fn mixed_h1_and_custom_aside_produce_nested_outline() {
 fn counter_in_bookmark_label_does_not_panic() {
     let engine = engine_with_css(r#"h1 { bookmark-label: counter(chapter) " " content(); }"#);
     let html = r#"<html><body><h1>Intro</h1></body></html>"#;
-    let pdf = engine.render_html(html).expect("render ok");
+    let pdf = engine.render(html).expect("render ok");
     // counter(chapter) resolves to empty; " " content() yields " Intro".
     // The substring helper still matches on the trailing "Intro" portion.
     assert!(
@@ -162,7 +162,7 @@ fn level_only_falls_back_to_element_text() {
     let html = r#"<html><body>
         <div class="aside">Text Content</div>
     </body></html>"#;
-    let pdf = engine.render_html(html).expect("render ok");
+    let pdf = engine.render(html).expect("render ok");
     assert!(
         pdf_contains_outline_entry(&pdf, "Text Content"),
         "label-less rule should fall back to element's text content"
@@ -183,7 +183,7 @@ fn bookmarks_via_inline_style_block() {
     </body></html>"#;
 
     let engine = Engine::builder().bookmarks(true).build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert!(
         pdf_contains_outline_entry(&pdf, "Sidebar"),
         "expected 'Sidebar' bookmark entry — bookmark-label via inline <style> not working"

--- a/crates/fulgur/tests/border_radius_test.rs
+++ b/crates/fulgur/tests/border_radius_test.rs
@@ -9,7 +9,7 @@ fn make_engine() -> Engine {
 fn border_radius_uniform_renders() {
     let engine = make_engine();
     let html = r#"<div style="border: 2px solid black; border-radius: 10px; padding: 10px;">Rounded box</div>"#;
-    let pdf = engine.render_html(html).expect("render should succeed");
+    let pdf = engine.render(html).expect("render should succeed");
     assert!(!pdf.is_empty(), "PDF should not be empty");
 }
 
@@ -17,7 +17,7 @@ fn border_radius_uniform_renders() {
 fn border_radius_individual_corners_renders() {
     let engine = make_engine();
     let html = r#"<div style="border: 2px solid black; border-top-left-radius: 20px; border-bottom-right-radius: 20px; padding: 10px;">Diagonal rounded</div>"#;
-    let pdf = engine.render_html(html).expect("render should succeed");
+    let pdf = engine.render(html).expect("render should succeed");
     assert!(!pdf.is_empty(), "PDF should not be empty");
 }
 
@@ -25,7 +25,7 @@ fn border_radius_individual_corners_renders() {
 fn border_radius_with_background_renders() {
     let engine = make_engine();
     let html = r#"<div style="background-color: #3498db; border-radius: 15px; padding: 20px; color: white;">Rounded background</div>"#;
-    let pdf = engine.render_html(html).expect("render should succeed");
+    let pdf = engine.render(html).expect("render should succeed");
     assert!(!pdf.is_empty(), "PDF should not be empty");
 }
 
@@ -33,7 +33,7 @@ fn border_radius_with_background_renders() {
 fn border_radius_elliptical_renders() {
     let engine = make_engine();
     let html = r#"<div style="border: 1px solid gray; border-radius: 20px / 10px; padding: 10px;">Elliptical radius</div>"#;
-    let pdf = engine.render_html(html).expect("render should succeed");
+    let pdf = engine.render(html).expect("render should succeed");
     assert!(!pdf.is_empty(), "PDF should not be empty");
 }
 
@@ -41,6 +41,6 @@ fn border_radius_elliptical_renders() {
 fn border_radius_circle_renders() {
     let engine = make_engine();
     let html = r#"<div style="width: 50px; height: 50px; border-radius: 50%; background-color: red;"></div>"#;
-    let pdf = engine.render_html(html).expect("render should succeed");
+    let pdf = engine.render(html).expect("render should succeed");
     assert!(!pdf.is_empty(), "PDF should not be empty");
 }

--- a/crates/fulgur/tests/box_shadow_test.rs
+++ b/crates/fulgur/tests/box_shadow_test.rs
@@ -13,7 +13,7 @@ fn renders_basic_offset_shadow_without_error() {
       <div style="width:100px;height:100px;background:#eee;
                   box-shadow: 4px 4px 0 #888;">hi</div>
     </body></html>"#;
-    let pdf = make_engine().render_html(html).expect("render ok");
+    let pdf = make_engine().render(html).expect("render ok");
     assert!(!pdf.is_empty());
 }
 
@@ -24,7 +24,7 @@ fn renders_multiple_shadows() {
       <div style="width:100px;height:100px;
                   box-shadow: 2px 2px 0 red, 4px 4px 0 blue;"></div>
     </body></html>"#;
-    let pdf = make_engine().render_html(html).expect("render ok");
+    let pdf = make_engine().render(html).expect("render ok");
     assert!(!pdf.is_empty());
 }
 
@@ -35,7 +35,7 @@ fn renders_shadow_with_rgba_alpha() {
       <div style="width:100px;height:100px;
                   box-shadow: 2px 2px 0 rgba(0,0,0,0.5);"></div>
     </body></html>"#;
-    let pdf = make_engine().render_html(html).expect("render ok");
+    let pdf = make_engine().render(html).expect("render ok");
     assert!(!pdf.is_empty());
 }
 
@@ -46,7 +46,7 @@ fn renders_shadow_with_spread() {
       <div style="width:100px;height:100px;
                   box-shadow: 0 0 0 4px red;"></div>
     </body></html>"#;
-    let pdf = make_engine().render_html(html).expect("render ok");
+    let pdf = make_engine().render(html).expect("render ok");
     assert!(!pdf.is_empty());
 }
 
@@ -57,7 +57,7 @@ fn renders_shadow_with_negative_spread() {
       <div style="width:100px;height:100px;
                   box-shadow: 0 0 0 -2px red;"></div>
     </body></html>"#;
-    let pdf = make_engine().render_html(html).expect("render ok");
+    let pdf = make_engine().render(html).expect("render ok");
     assert!(!pdf.is_empty());
 }
 
@@ -68,6 +68,6 @@ fn renders_shadow_with_border_radius() {
       <div style="width:100px;height:100px;border-radius:20px;
                   box-shadow: 4px 4px 0 2px #888;"></div>
     </body></html>"#;
-    let pdf = make_engine().render_html(html).expect("render ok");
+    let pdf = make_engine().render(html).expect("render ok");
     assert!(!pdf.is_empty());
 }

--- a/crates/fulgur/tests/break_inside_avoid.rs
+++ b/crates/fulgur/tests/break_inside_avoid.rs
@@ -36,7 +36,7 @@ fn avoid_block_straddling_boundary_promotes_to_next_page() {
         // 200pt × 200pt expressed in mm (PageSize::custom_pt not yet available)
         .page_size(PageSize::custom(70.5556, 70.5556))
         .build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert!(
         page_count(&pdf) >= 2,
         "expected avoid block to promote to page 2, got {} pages",
@@ -72,7 +72,7 @@ fn avoid_block_taller_than_page_falls_back_to_split() {
         // 200pt × 200pt expressed in mm (PageSize::custom_pt not yet available)
         .page_size(PageSize::custom(70.5556, 70.5556))
         .build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert!(
         page_count(&pdf) >= 2,
         "expected oversized avoid block to still paginate, got {} pages",
@@ -101,7 +101,7 @@ fn avoid_child_inside_multicol_fits_whole_column() {
         // 300pt × 400pt expressed in mm (PageSize::custom_pt not yet available)
         .page_size(PageSize::custom(105.8333, 141.1111))
         .build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert!(page_count(&pdf) >= 1);
     assert!(page_count(&pdf) <= 2);
     assert!(pdf.len() > 500, "PDF looks truncated");

--- a/crates/fulgur/tests/column_rule_rendering.rs
+++ b/crates/fulgur/tests/column_rule_rendering.rs
@@ -128,7 +128,7 @@ fn column_rule_solid_red_is_visible_between_columns() {
         })
         .margin(Margin::uniform(10.0))
         .build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
 
     let tmp = tempfile::tempdir().expect("tempdir");
     let rgba = pdf_to_rgba(&pdf, 200, tmp.path());
@@ -201,7 +201,7 @@ fn column_fill_auto_leaves_second_column_empty_for_short_content() {
         })
         .margin(Margin::uniform(20.0))
         .build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
 
     let tmp = tempfile::tempdir().expect("tempdir");
     let rgba = pdf_to_rgba(&pdf, 200, tmp.path());

--- a/crates/fulgur/tests/font_bundle_test.rs
+++ b/crates/fulgur/tests/font_bundle_test.rs
@@ -24,7 +24,7 @@ fn test_bundled_font() {
         <p>株式会社フルグル — バンドルフォントテスト</p>
     </body></html>"#;
 
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     // Bundled font should make the PDF larger
     assert!(pdf.len() > 5000);

--- a/crates/fulgur/tests/gcpm_integration.rs
+++ b/crates/fulgur/tests/gcpm_integration.rs
@@ -25,7 +25,7 @@ fn test_counter_margin_box_values_correct() {
         <h2>Two</h2><p>Content for chapter two.</p>
         <h2>Three</h2><p>Content for chapter three.</p>
     "#;
-    let result = engine.render_html(html);
+    let result = engine.render(html);
     assert!(
         result.is_ok(),
         "Counter values should reach margin boxes: {:?}",
@@ -51,7 +51,7 @@ fn test_gcpm_no_gcpm_css_works_as_before() {
 </html>"#;
 
     let engine = Engine::builder().build();
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
 
     assert!(!pdf.is_empty(), "PDF output should not be empty");
     assert!(
@@ -80,12 +80,12 @@ fn test_deterministic_output() {
     let mut assets = AssetBundle::new();
     assets.add_css(css);
     let engine = Engine::builder().assets(assets).build();
-    let pdf1 = engine.render_html(html).unwrap();
+    let pdf1 = engine.render(html).unwrap();
 
     let mut assets2 = AssetBundle::new();
     assets2.add_css(css);
     let engine2 = Engine::builder().assets(assets2).build();
-    let pdf2 = engine2.render_html(html).unwrap();
+    let pdf2 = engine2.render(html).unwrap();
 
     assert_eq!(pdf1, pdf2, "Same input must produce identical PDF output");
 }
@@ -118,7 +118,7 @@ fn test_element_policy_multiple_chapters_last() {
 
     let engine = Engine::builder().assets(assets).build();
     let pdf = engine
-        .render_html(html)
+        .render(html)
         .expect("render should succeed with element(title, last) across multiple chapters");
 
     assert!(
@@ -155,7 +155,7 @@ fn test_element_policy_first_except() {
 
     let engine = Engine::builder().assets(assets).build();
     let pdf = engine
-        .render_html(html)
+        .render(html)
         .expect("render should succeed with element(title, first-except)");
 
     assert!(
@@ -200,7 +200,7 @@ fn test_element_policy_start() {
 
     let engine = Engine::builder().assets(assets).build();
     let pdf = engine
-        .render_html(html)
+        .render(html)
         .expect("render should succeed with element(title, start)");
 
     assert!(
@@ -238,7 +238,7 @@ fn test_element_default_policy_still_works() {
 
     let engine = Engine::builder().assets(assets).build();
     let pdf = engine
-        .render_html(html)
+        .render(html)
         .expect("render should succeed with default element() policy");
 
     assert!(
@@ -262,7 +262,7 @@ fn test_counter_chapter_before_pseudo() {
 
     let engine = Engine::builder().assets(assets).build();
     let html = "<h2>Introduction</h2><p>Some text here</p><h2>Methods</h2><p>More text</p>";
-    let result = engine.render_html(html);
+    let result = engine.render(html);
     assert!(
         result.is_ok(),
         "PDF generation with counter in ::before should succeed: {:?}",
@@ -287,7 +287,7 @@ fn test_counter_in_margin_box() {
 
     let engine = Engine::builder().assets(assets).build();
     let html = "<h2>One</h2><p>Some text</p><h2>Two</h2><p>More text</p>";
-    let result = engine.render_html(html);
+    let result = engine.render(html);
     assert!(
         result.is_ok(),
         "PDF with counter in margin box should succeed: {:?}",
@@ -308,7 +308,7 @@ fn test_counter_upper_roman_style() {
 
     let engine = Engine::builder().assets(assets).build();
     let html = "<h2>A</h2><h2>B</h2><h2>C</h2><h2>D</h2>";
-    let result = engine.render_html(html);
+    let result = engine.render(html);
     assert!(
         result.is_ok(),
         "PDF with upper-roman counter should succeed: {:?}",
@@ -330,7 +330,7 @@ fn test_counter_set() {
 
     let engine = Engine::builder().assets(assets).build();
     let html = r#"<h2>One</h2><div class="reset"></div><h2>Eleven</h2>"#;
-    let result = engine.render_html(html);
+    let result = engine.render(html);
     assert!(
         result.is_ok(),
         "PDF with counter-set should succeed: {:?}",
@@ -356,7 +356,7 @@ fn test_counter_body_and_margin_box() {
 
     let engine = Engine::builder().assets(assets).build();
     let html = "<h2>Intro</h2><p>text</p><h2>Body</h2><p>text</p><h2>End</h2><p>text</p>";
-    let result = engine.render_html(html);
+    let result = engine.render(html);
     assert!(
         result.is_ok(),
         "PDF with counter in both body and margin box should succeed: {:?}",
@@ -379,7 +379,7 @@ fn test_counter_page_still_works() {
 
     let engine = Engine::builder().assets(assets).build();
     let html = "<p>Hello World</p>";
-    let result = engine.render_html(html);
+    let result = engine.render(html);
     assert!(
         result.is_ok(),
         "counter(page) should still work: {:?}",

--- a/crates/fulgur/tests/gcpm_snapshot.rs
+++ b/crates/fulgur/tests/gcpm_snapshot.rs
@@ -71,7 +71,7 @@ fn gcpm_counter_via_inline_style_snapshot() {
         .assets(noto_assets())
         .serialize_settings(snapshot_settings())
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render");
 
     check_snapshot("gcpm_counter_via_inline_style", &pdf);
@@ -93,7 +93,7 @@ fn gcpm_running_element_via_inline_style_snapshot() {
         .assets(noto_assets())
         .serialize_settings(snapshot_settings())
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render");
 
     check_snapshot("gcpm_running_element_via_inline_style", &pdf);
@@ -126,7 +126,7 @@ fn gcpm_element_policy_first_snapshot() {
         .assets(noto_assets())
         .serialize_settings(snapshot_settings())
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render");
 
     check_snapshot("gcpm_element_policy_first", &pdf);
@@ -158,7 +158,7 @@ fn gcpm_element_policy_last_snapshot() {
         .assets(noto_assets())
         .serialize_settings(snapshot_settings())
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render");
 
     check_snapshot("gcpm_element_policy_last", &pdf);
@@ -180,7 +180,7 @@ fn gcpm_string_set_via_inline_style_snapshot() {
         .assets(noto_assets())
         .serialize_settings(snapshot_settings())
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render");
 
     check_snapshot("gcpm_string_set_via_inline_style", &pdf);
@@ -213,7 +213,7 @@ fn gcpm_header_footer_snapshot() {
         .assets(assets)
         .serialize_settings(snapshot_settings())
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render");
 
     check_snapshot("gcpm_header_footer", &pdf);
@@ -246,7 +246,7 @@ fn gcpm_multipage_counter_snapshot() {
         .assets(assets)
         .serialize_settings(snapshot_settings())
         .build()
-        .render_html(&html)
+        .render(&html)
         .expect("render");
 
     check_snapshot("gcpm_multipage_counter", &pdf);
@@ -271,7 +271,7 @@ fn gcpm_counter_only_no_running_snapshot() {
         .assets(assets)
         .serialize_settings(snapshot_settings())
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render");
 
     check_snapshot("gcpm_counter_only_no_running", &pdf);
@@ -296,7 +296,7 @@ fn gcpm_id_selector_running_element_snapshot() {
         .assets(assets)
         .serialize_settings(snapshot_settings())
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render");
 
     check_snapshot("gcpm_id_selector_running_element", &pdf);
@@ -321,7 +321,7 @@ fn gcpm_tag_selector_running_element_snapshot() {
         .assets(assets)
         .serialize_settings(snapshot_settings())
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render");
 
     check_snapshot("gcpm_tag_selector_running_element", &pdf);
@@ -348,7 +348,7 @@ fn gcpm_left_right_margin_boxes_snapshot() {
         .assets(assets)
         .serialize_settings(snapshot_settings())
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render");
 
     check_snapshot("gcpm_left_right_margin_boxes", &pdf);
@@ -381,7 +381,7 @@ fn gcpm_all_side_margin_boxes_snapshot() {
         .assets(assets)
         .serialize_settings(snapshot_settings())
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render");
 
     check_snapshot("gcpm_all_side_margin_boxes", &pdf);
@@ -410,7 +410,7 @@ fn gcpm_left_right_with_running_element_snapshot() {
         .assets(assets)
         .serialize_settings(snapshot_settings())
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render");
 
     check_snapshot("gcpm_left_right_with_running_element", &pdf);
@@ -444,7 +444,7 @@ fn gcpm_side_boxes_asymmetric_margins_snapshot() {
         .assets(assets)
         .serialize_settings(snapshot_settings())
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render");
 
     check_snapshot("gcpm_side_boxes_asymmetric_margins", &pdf);
@@ -487,7 +487,7 @@ fn gcpm_string_set_chapter_title_snapshot() {
         .assets(assets)
         .serialize_settings(snapshot_settings())
         .build()
-        .render_html(&html)
+        .render(&html)
         .expect("render");
 
     check_snapshot("gcpm_string_set_chapter_title", &pdf);
@@ -514,7 +514,7 @@ fn gcpm_string_set_with_attr_snapshot() {
         .assets(assets)
         .serialize_settings(snapshot_settings())
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render");
 
     check_snapshot("gcpm_string_set_with_attr", &pdf);
@@ -541,7 +541,7 @@ fn gcpm_string_set_with_literal_concat_snapshot() {
         .assets(assets)
         .serialize_settings(snapshot_settings())
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render");
 
     check_snapshot("gcpm_string_set_with_literal_concat", &pdf);
@@ -573,7 +573,7 @@ fn gcpm_string_set_with_policies_snapshot() {
         .assets(assets)
         .serialize_settings(snapshot_settings())
         .build()
-        .render_html(&html)
+        .render(&html)
         .expect("render");
 
     check_snapshot("gcpm_string_set_with_policies", &pdf);
@@ -613,7 +613,7 @@ li::before { content: counters(item, ".") ". "; }
         .assets(noto_assets())
         .serialize_settings(snapshot_settings())
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render");
 
     check_snapshot("gcpm_counters_function_nested_ol", &pdf);

--- a/crates/fulgur/tests/gradient_test.rs
+++ b/crates/fulgur/tests/gradient_test.rs
@@ -24,7 +24,7 @@ fn render(css_background: &str) -> Vec<u8> {
         .page_size(PageSize::A4)
         .margin(Margin::uniform(72.0))
         .build()
-        .render_html(&html)
+        .render(&html)
         .expect("render gradient")
 }
 

--- a/crates/fulgur/tests/html_test.rs
+++ b/crates/fulgur/tests/html_test.rs
@@ -9,7 +9,7 @@ fn test_render_simple_html() {
         .build();
 
     let html = "<html><body><h1>Hello World</h1><p>This is a test.</p></body></html>";
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     assert!(pdf.len() > 100);
 }

--- a/crates/fulgur/tests/image_test.rs
+++ b/crates/fulgur/tests/image_test.rs
@@ -32,11 +32,11 @@ fn build_engine_no_assets() -> Engine {
 fn test_img_renders_to_pdf() {
     let engine = build_engine_with_image("logo.png");
     let html = r#"<html><body><div><img src="logo.png" style="display:block;width:100px;height:100px"></div></body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
 
     // Verify image data is embedded: PDF with image should be larger than without
-    let pdf_no_img = build_engine_no_assets().render_html(html).unwrap();
+    let pdf_no_img = build_engine_no_assets().render(html).unwrap();
     assert!(
         pdf.len() > pdf_no_img.len(),
         "PDF with image ({} bytes) should be larger than without ({} bytes)",
@@ -49,10 +49,10 @@ fn test_img_renders_to_pdf() {
 fn test_img_with_dot_slash_prefix() {
     let engine = build_engine_with_image("logo.png");
     let html = r#"<html><body><div><img src="./logo.png" style="display:block;width:50px;height:50px"></div></body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
 
     // Verify ./logo.png resolves to same image as logo.png
-    let pdf_no_img = build_engine_no_assets().render_html(html).unwrap();
+    let pdf_no_img = build_engine_no_assets().render(html).unwrap();
     assert!(
         pdf.len() > pdf_no_img.len(),
         "PDF with ./logo.png ({} bytes) should be larger than without ({} bytes)",
@@ -74,7 +74,7 @@ fn test_img_missing_image_no_error() {
 
     let html =
         r#"<html><body><img src="missing.png" style="width:50px;height:50px"></body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
 }
 
@@ -82,6 +82,6 @@ fn test_img_missing_image_no_error() {
 fn test_img_no_assets_no_error() {
     let engine = build_engine_no_assets();
     let html = r#"<html><body><img src="logo.png" style="width:50px;height:50px"></body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
 }

--- a/crates/fulgur/tests/in_flow_pagination_regression.rs
+++ b/crates/fulgur/tests/in_flow_pagination_regression.rs
@@ -32,7 +32,7 @@ fn in_flow_300vh_paginates_to_three_pages() {
 <body style="margin:0">
 <div style="height:300vh">x</div>
 </body>"#;
-    let pdf = Engine::builder().build().render_html(html).expect("render");
+    let pdf = Engine::builder().build().render(html).expect("render");
     let pages = page_count(&pdf);
     assert_eq!(pages, 3, "expected 3 pages, got {pages}");
 }

--- a/crates/fulgur/tests/inline_box_render_test.rs
+++ b/crates/fulgur/tests/inline_box_render_test.rs
@@ -4,7 +4,7 @@ use fulgur::engine::Engine;
 
 fn render(html: &str) -> Vec<u8> {
     let engine = Engine::builder().build();
-    engine.render_html(html).expect("render ok")
+    engine.render(html).expect("render ok")
 }
 
 #[test]

--- a/crates/fulgur/tests/link_integration.rs
+++ b/crates/fulgur/tests/link_integration.rs
@@ -25,7 +25,7 @@ fn engine_with_png(name: &str) -> Engine {
 #[test]
 fn external_link_produces_uri_action_in_pdf() {
     let html = r#"<html><body><p><a href="https://example.com">click</a></p></body></html>"#;
-    let bytes = engine().render_html(html).expect("render");
+    let bytes = engine().render(html).expect("render");
     assert!(bytes.starts_with(b"%PDF"));
     let text = String::from_utf8_lossy(&bytes);
     assert!(text.contains("/Link"), "missing /Link annotation subtype");
@@ -43,7 +43,7 @@ fn internal_anchor_produces_destination() {
         <div style="height:1500px"></div>
         <h2 id="section">Target</h2>
     </body></html>"##;
-    let bytes = engine().render_html(html).expect("render");
+    let bytes = engine().render(html).expect("render");
     assert!(bytes.starts_with(b"%PDF"));
     let text = String::from_utf8_lossy(&bytes);
     assert!(text.contains("/Link"), "missing /Link annotation");
@@ -59,7 +59,7 @@ fn internal_anchor_produces_destination() {
 #[test]
 fn unresolved_internal_anchor_is_ignored_not_error() {
     let html = r##"<html><body><p><a href="#nope">dangling</a></p></body></html>"##;
-    let bytes = engine().render_html(html).expect("render should not fail");
+    let bytes = engine().render(html).expect("render should not fail");
     assert!(bytes.starts_with(b"%PDF"));
 }
 
@@ -72,7 +72,7 @@ fn multiline_link_merges_into_single_annotation_with_multiple_quads() {
         r##"<html><body><div style="width:200px"><p><a href="https://multiline.test">{}</a></p></div></body></html>"##,
         long
     );
-    let bytes = engine().render_html(&html).unwrap();
+    let bytes = engine().render(&html).unwrap();
     let text = String::from_utf8_lossy(&bytes);
     // Single <a> with text broken across multiple lines → one LinkAnnotation
     // that carries multiple QuadPoints. PDF writer emits /QuadPoints array
@@ -100,7 +100,7 @@ fn link_spanning_page_break_emits_annotation_on_each_page() {
         <div style="width:120pt;font-size:40pt;line-height:1.2"><a href="https://cross.test">{link_text}</a></div>
     </body></html>"##
     );
-    let bytes = engine().render_html(&html).unwrap();
+    let bytes = engine().render(&html).unwrap();
     let text = String::from_utf8_lossy(&bytes);
     // Page-crossing links must produce ONE annotation per page (can't share across pages).
     // Expect the URI to appear at least twice in the PDF byte stream (once per /URI entry).
@@ -118,7 +118,7 @@ fn link_works_through_gcpm_render_path() {
         <head><style>@page { margin: 2cm; @top-center { content: "Header"; } }</style></head>
         <body><p><a href="https://gcpm.test">click</a></p></body>
     </html>"##;
-    let bytes = engine().render_html(html).unwrap();
+    let bytes = engine().render(html).unwrap();
     let text = String::from_utf8_lossy(&bytes);
     assert!(text.contains("/Link"), "GCPM path missing /Link");
     assert!(text.contains("https://gcpm.test"), "GCPM path missing URI");
@@ -136,7 +136,7 @@ fn margin_box_running_element_link_keeps_pdf_annotation() {
             <p>body</p>
         </body>
     </html>"##;
-    let bytes = engine().render_html(html).unwrap();
+    let bytes = engine().render(html).unwrap();
     let text = String::from_utf8_lossy(&bytes);
     assert!(
         text.contains("/Link"),
@@ -185,7 +185,7 @@ fn margin_box_running_element_link_keeps_pdf_annotation() {
 #[ignore = "blocked on InlineBox → InlineImage materialisation in extract_paragraph; see TODO above"]
 fn anchor_wrapping_inline_image_is_clickable() {
     let html = r##"<html><body><p><a href="https://img.test"><img src="pixel.png" width="100" height="50"/></a></p></body></html>"##;
-    let bytes = engine_with_png("pixel.png").render_html(html).unwrap();
+    let bytes = engine_with_png("pixel.png").render(html).unwrap();
     let text = String::from_utf8_lossy(&bytes);
     assert!(
         text.contains("/Link"),

--- a/crates/fulgur/tests/link_media_attribute.rs
+++ b/crates/fulgur/tests/link_media_attribute.rs
@@ -17,7 +17,7 @@ fn render_contains_red(html: &str, base: &Path) -> Option<bool> {
         .page_size(PageSize::A4)
         .base_path(base.to_path_buf())
         .build();
-    let pdf = engine.render_html(html).expect("render must succeed");
+    let pdf = engine.render(html).expect("render must succeed");
 
     let work = tempdir().unwrap();
     let pdf_path = work.path().join("fixture.pdf");
@@ -204,7 +204,7 @@ fn link_media_print_does_not_duplicate_gcpm_context() {
         .page_size(PageSize::A4)
         .base_path(root.to_path_buf())
         .build();
-    let pdf = engine.render_html(html).expect("render must succeed");
+    let pdf = engine.render(html).expect("render must succeed");
     assert!(!pdf.is_empty());
     // TODO (fulgur-owa): assert margin-box "HDR" appears exactly once in
     // the rendered page margin, not twice.

--- a/crates/fulgur/tests/link_stylesheet_url_resolution.rs
+++ b/crates/fulgur/tests/link_stylesheet_url_resolution.rs
@@ -45,7 +45,7 @@ fn css_internal_url_resolves_against_stylesheet_directory() {
         .page_size(PageSize::A4)
         .base_path(root)
         .build();
-    let pdf = engine.render_html(html).expect("render must succeed");
+    let pdf = engine.render(html).expect("render must succeed");
     // Note: fulgur does not fail when an image resource is unreachable,
     // so this is a soft pin: it catches "renderer panics on CSS-relative
     // url()" regressions but NOT "url resolved against the wrong base"

--- a/crates/fulgur/tests/list_style_image_test.rs
+++ b/crates/fulgur/tests/list_style_image_test.rs
@@ -34,7 +34,7 @@ fn test_list_style_image_png_embeds_xobject() {
             <li>Item two</li>
         </ul>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     // A rendered raster image marker causes krilla to emit an Image XObject.
     assert!(
@@ -46,7 +46,7 @@ fn test_list_style_image_png_embeds_xobject() {
         .page_size(PageSize::A4)
         .margin(Margin::uniform(72.0))
         .build()
-        .render_html(r#"<html><body><ul><li>Item one</li><li>Item two</li></ul></body></html>"#)
+        .render(r#"<html><body><ul><li>Item one</li><li>Item two</li></ul></body></html>"#)
         .unwrap();
     assert!(
         !pdf_contains(&text_only, b"/Subtype /Image")
@@ -64,7 +64,7 @@ fn test_list_style_image_unresolved_url_falls_back_to_text() {
         </ul>
     </body></html>"#;
     // Must not panic — falls through to text marker silently.
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
 }
 
@@ -77,7 +77,7 @@ fn test_list_style_none_with_image_url_embeds_xobject() {
             <li>Item two</li>
         </ul>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     assert!(
         pdf_contains(&pdf, b"/Subtype /Image") || pdf_contains(&pdf, b"/Subtype/Image"),
@@ -93,7 +93,7 @@ fn test_list_style_image_only_embeds_xobject() {
             <li style="list-style-image: url(bullet.png)">Item</li>
         </ul>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     assert!(
         pdf_contains(&pdf, b"/Subtype /Image") || pdf_contains(&pdf, b"/Subtype/Image"),
@@ -117,14 +117,14 @@ fn test_list_style_image_svg_renders() {
             <li>SVG bullet item</li>
         </ul>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
 
     let text_only = Engine::builder()
         .page_size(PageSize::A4)
         .margin(Margin::uniform(72.0))
         .build()
-        .render_html(r#"<html><body><ul><li>SVG bullet item</li></ul></body></html>"#)
+        .render(r#"<html><body><ul><li>SVG bullet item</li></ul></body></html>"#)
         .unwrap();
     // When the SVG branch of resolve_list_marker actually fires, the bullet
     // glyph (U+2022) is replaced by a vector draw and the font subset for the

--- a/crates/fulgur/tests/list_style_inside_test.rs
+++ b/crates/fulgur/tests/list_style_inside_test.rs
@@ -32,7 +32,7 @@ fn test_list_style_position_inside_text_marker_renders() {
             <li>Item three</li>
         </ul>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     assert!(
         pdf.len() > 500,
@@ -51,7 +51,7 @@ fn test_list_style_position_inside_ordered_list() {
             <li>Third item</li>
         </ol>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     assert!(
         pdf.len() > 500,
@@ -74,7 +74,7 @@ fn test_list_style_position_inside_image_marker() {
             <li>Image inside</li>
         </ul>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"), "output should be a valid PDF");
     assert!(
         pdf_contains(&pdf, b"/Subtype /Image") || pdf_contains(&pdf, b"/Subtype/Image"),
@@ -92,7 +92,7 @@ fn test_outside_markers_still_work_after_inside_changes() {
             <li>Outside three</li>
         </ul>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     assert!(
         pdf.len() > 500,
@@ -120,7 +120,7 @@ fn test_inside_marker_with_block_child_does_not_crash() {
             <li><p>Nested paragraph</p></li>
         </ul>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
 }
 
@@ -133,7 +133,7 @@ fn test_inside_empty_li_does_not_crash() {
             <li>Not empty</li>
         </ul>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
 }
 
@@ -159,7 +159,7 @@ fn test_inside_image_marker_with_before_pseudo_does_not_crash() {
             <li>Item with pseudo</li>
         </ul>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     // Both the marker image and the ::before image should be embedded.
     assert!(
@@ -181,7 +181,7 @@ fn test_inside_and_outside_in_same_document() {
             <li>Inside item B</li>
         </ul>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     assert!(
         pdf.len() > 500,

--- a/crates/fulgur/tests/list_test.rs
+++ b/crates/fulgur/tests/list_test.rs
@@ -20,7 +20,7 @@ fn test_unordered_list_renders() {
             </ul>
         </body></html>
     "#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     assert!(pdf.len() > 100);
 }
@@ -37,7 +37,7 @@ fn test_ordered_list_renders() {
             </ol>
         </body></html>
     "#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     assert!(pdf.len() > 100);
 }
@@ -56,7 +56,7 @@ fn test_nested_list_renders() {
             </ul>
         </body></html>
     "#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     assert!(pdf.len() > 100);
 }
@@ -75,7 +75,7 @@ fn test_mixed_list_styles_render() {
             </ul>
         </body></html>
     "#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     assert!(pdf.len() > 100);
 }

--- a/crates/fulgur/tests/multicol_integration.rs
+++ b/crates/fulgur/tests/multicol_integration.rs
@@ -42,7 +42,7 @@ fn multicol_basic_2col_renders() {
         <div class="b"></div><div class="b"></div>
       </div>
     </body></html>"#;
-    let pdf = Engine::builder().build().render_html(html).expect("render");
+    let pdf = Engine::builder().build().render(html).expect("render");
     assert!(!pdf.is_empty());
     assert_eq!(page_count(&pdf), 1);
 }
@@ -61,7 +61,7 @@ fn multicol_column_width_resolution_renders() {
         <div class="b"></div>
       </div>
     </body></html>"#;
-    let pdf = Engine::builder().build().render_html(html).expect("render");
+    let pdf = Engine::builder().build().render(html).expect("render");
     assert!(!pdf.is_empty());
 }
 
@@ -79,7 +79,7 @@ fn multicol_balance_renders() {
         <div class="b"></div><div class="b"></div>
       </div>
     </body></html>"#;
-    let pdf = Engine::builder().build().render_html(html).expect("render");
+    let pdf = Engine::builder().build().render(html).expect("render");
     assert!(!pdf.is_empty());
     assert_eq!(page_count(&pdf), 1);
 }
@@ -108,6 +108,6 @@ fn multicol_page_spanning_renders_without_panic() {
         <div class="b"></div><div class="b"></div>
       </div>
     </body></html>"#;
-    let pdf = Engine::builder().build().render_html(html).expect("render");
+    let pdf = Engine::builder().build().render(html).expect("render");
     assert!(!pdf.is_empty());
 }

--- a/crates/fulgur/tests/multicol_span_all.rs
+++ b/crates/fulgur/tests/multicol_span_all.rs
@@ -60,7 +60,7 @@ fn span_all_subtree_that_exceeds_one_page_splits_across_pages() {
     let engine = Engine::builder()
         .page_size(PageSize::custom(105.0, 148.0))
         .build();
-    let pdf = engine.render_html(&html).expect("render");
+    let pdf = engine.render(&html).expect("render");
     assert!(
         page_count(&pdf) >= 2,
         "expected >=2 pages from oversized SpanAll, got {}",
@@ -82,6 +82,6 @@ fn span_all_fits_single_page_for_short_content() {
     </body></html>"#;
 
     let engine = Engine::builder().page_size(PageSize::A4).build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert_eq!(page_count(&pdf), 1, "short content should fit one A4 page");
 }

--- a/crates/fulgur/tests/opacity_visibility_test.rs
+++ b/crates/fulgur/tests/opacity_visibility_test.rs
@@ -15,7 +15,7 @@ fn test_opacity_half() {
             <p>This text should be semi-transparent</p>
         </div>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     assert!(
         has_transparency_group(&pdf),
@@ -31,7 +31,7 @@ fn test_opacity_zero() {
             <p>This text should be invisible but preserve layout</p>
         </div>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     // opacity: 0 skips drawing entirely, so no transparency group needed
     assert!(
@@ -48,7 +48,7 @@ fn test_visibility_hidden() {
             <p>This text should be hidden</p>
         </div>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     // visibility: hidden skips drawing, so no transparency group
     assert!(
@@ -64,7 +64,7 @@ fn test_opacity_on_div_placeholder() {
         <div style="opacity: 0.7; width: 100px; height: 100px; background-color: blue;">
         </div>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     assert!(
         has_transparency_group(&pdf),
@@ -83,7 +83,7 @@ fn test_nested_opacity() {
             </div>
         </div>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     assert!(
         has_transparency_group(&pdf),
@@ -99,7 +99,7 @@ fn test_opacity_with_background() {
             <p>Semi-transparent red background</p>
         </div>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     assert!(
         has_transparency_group(&pdf),
@@ -118,7 +118,7 @@ fn test_visibility_hidden_preserves_layout() {
             <p>This should appear below the hidden element</p>
         </div>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     assert!(pdf.len() > 1000);
 }
@@ -134,7 +134,7 @@ fn test_visibility_hidden_styled_inline_root() {
             Hidden text with styled background
         </p>
     </body></html>"#;
-    let pdf_hidden = engine.render_html(html_hidden).unwrap();
+    let pdf_hidden = engine.render(html_hidden).unwrap();
     assert!(pdf_hidden.starts_with(b"%PDF"));
     // visibility:hidden should not produce a transparency group
     assert!(
@@ -155,7 +155,7 @@ fn test_visibility_hidden_list_item() {
             <li>Visible list item</li>
         </ul>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     assert!(pdf.len() > 500);
     // Neither hidden nor visible list items (with default opacity) should produce transparency groups

--- a/crates/fulgur/tests/page_break_wiring.rs
+++ b/crates/fulgur/tests/page_break_wiring.rs
@@ -49,7 +49,7 @@ fn page_break_after_always_splits_pages() {
         .page_size(PageSize::custom(70.5556, 70.5556))
         .margin(Margin::uniform(0.0))
         .build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert!(
         page_count(&pdf) >= 3,
         "expected page-break-after: always to force >= 3 pages, got {}",
@@ -76,7 +76,7 @@ fn break_after_page_splits_pages() {
         .page_size(PageSize::custom(70.5556, 70.5556))
         .margin(Margin::uniform(0.0))
         .build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert!(
         page_count(&pdf) >= 3,
         "expected break-after: page to force >= 3 pages, got {}",
@@ -107,7 +107,7 @@ fn page_break_before_always_splits_pages() {
         .page_size(PageSize::custom(70.5556, 70.5556))
         .margin(Margin::uniform(0.0))
         .build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert!(
         page_count(&pdf) >= 3,
         "expected page-break-before: always to force >= 3 pages, got {}",
@@ -134,7 +134,7 @@ fn break_before_page_splits_pages() {
         .page_size(PageSize::custom(70.5556, 70.5556))
         .margin(Margin::uniform(0.0))
         .build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert!(
         page_count(&pdf) >= 3,
         "expected break-before: page to force >= 3 pages, got {}",
@@ -158,7 +158,7 @@ fn no_break_property_stays_on_one_page() {
         .page_size(PageSize::custom(70.5556, 70.5556))
         .margin(Margin::uniform(0.0))
         .build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert_eq!(
         page_count(&pdf),
         1,
@@ -189,7 +189,7 @@ fn page_break_after_forces_split_when_both_fit_on_one_page() {
         .page_size(PageSize::custom(70.5556, 70.5556))
         .margin(Margin::uniform(0.0))
         .build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert!(
         page_count(&pdf) >= 2,
         "page-break-after: always should force a split even when both divs fit on one page, got {} pages",

--- a/crates/fulgur/tests/page_size_from_css.rs
+++ b/crates/fulgur/tests/page_size_from_css.rs
@@ -22,7 +22,7 @@ fn page_size_landscape_from_inline_style_block() {
     </head><body>test</body></html>"#;
 
     let engine = Engine::builder().build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert!(
         has_landscape_a4_mediabox(&pdf),
         "expected A4 landscape (841 × 595) from inline <style>"
@@ -50,7 +50,7 @@ fn page_size_landscape_from_link_stylesheet() {
     let html = std::fs::read_to_string(&html_path).expect("html read");
 
     let engine = Engine::builder().base_path(dir.path()).build();
-    let pdf = engine.render_html(&html).expect("render");
+    let pdf = engine.render(&html).expect("render");
     assert!(
         has_landscape_a4_mediabox(&pdf),
         "expected A4 landscape from <link> stylesheet"

--- a/crates/fulgur/tests/pseudo_only_break_before.rs
+++ b/crates/fulgur/tests/pseudo_only_break_before.rs
@@ -63,7 +63,7 @@ fn pseudo_only_inline_root_honours_break_before_page() {
         .page_size(PageSize::custom(70.5556, 70.5556))
         .assets(make_bundle_with_image())
         .build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert!(
         page_count(&pdf) >= 2,
         "pseudo-only element with break-before:page should force new page, got {} pages",
@@ -89,7 +89,7 @@ fn empty_leaf_div_honours_break_before_page() {
     let engine = Engine::builder()
         .page_size(PageSize::custom(70.5556, 70.5556))
         .build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert!(
         page_count(&pdf) >= 2,
         "empty leaf <div> with break-before:page should force new page, got {} pages",
@@ -116,7 +116,7 @@ fn bare_img_honours_break_before_page() {
         .page_size(PageSize::custom(70.5556, 70.5556))
         .assets(make_bundle_with_image())
         .build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert!(
         page_count(&pdf) >= 2,
         "bare <img> with break-before:page should force new page, got {} pages",
@@ -145,7 +145,7 @@ fn pseudo_only_list_item_honours_break_before_page() {
         .page_size(PageSize::custom(70.5556, 70.5556))
         .assets(make_bundle_with_image())
         .build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert!(
         page_count(&pdf) >= 2,
         "pseudo-only <li> with break-before:page should force new page, got {} pages",

--- a/crates/fulgur/tests/rect_borders_test.rs
+++ b/crates/fulgur/tests/rect_borders_test.rs
@@ -21,7 +21,7 @@ fn render_example(name: &str) -> Vec<u8> {
         .build();
 
     engine
-        .render_html(&html)
+        .render(&html)
         .expect("render_html should succeed")
 }
 
@@ -60,7 +60,7 @@ fn dashed_uniform_border_keeps_per_edge_phase() {
     "#;
 
     let engine = Engine::builder().page_size(PageSize::A4).build();
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
 
     let Some(counts) = count_ops(&pdf) else {
         eprintln!("qpdf not installed — skipping");
@@ -84,7 +84,7 @@ fn double_uniform_border_uses_two_rects() {
     "#;
 
     let engine = Engine::builder().page_size(PageSize::A4).build();
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
 
     let Some(counts) = count_ops(&pdf) else {
         eprintln!("qpdf not installed — skipping");
@@ -120,7 +120,7 @@ fn double_uniform_border_below_3px_falls_back_to_solid() {
     "#;
 
     let engine = Engine::builder().page_size(PageSize::A4).build();
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
 
     let Some(counts) = count_ops(&pdf) else {
         eprintln!("qpdf not installed — skipping");
@@ -157,7 +157,7 @@ fn double_per_edge_below_3px_falls_back_to_solid() {
     "#;
 
     let engine = Engine::builder().page_size(PageSize::A4).build();
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
 
     let Some(counts) = count_ops(&pdf) else {
         eprintln!("qpdf not installed — skipping");

--- a/crates/fulgur/tests/rect_borders_test.rs
+++ b/crates/fulgur/tests/rect_borders_test.rs
@@ -20,9 +20,7 @@ fn render_example(name: &str) -> Vec<u8> {
         .base_path(root)
         .build();
 
-    engine
-        .render(&html)
-        .expect("render should succeed")
+    engine.render(&html).expect("render should succeed")
 }
 
 #[test]

--- a/crates/fulgur/tests/rect_borders_test.rs
+++ b/crates/fulgur/tests/rect_borders_test.rs
@@ -22,7 +22,7 @@ fn render_example(name: &str) -> Vec<u8> {
 
     engine
         .render(&html)
-        .expect("render_html should succeed")
+        .expect("render should succeed")
 }
 
 #[test]

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -4648,3 +4648,31 @@ fn pathological_tall_block_render_is_bounded() {
         .expect("render must terminate and succeed");
     assert!(!pdf.is_empty(), "expected a non-empty bounded PDF");
 }
+
+/// fulgur-2qpt: deprecated aliases `render_html` and `render_html_to_file`
+/// must delegate to the renamed methods and produce valid PDFs.
+#[test]
+#[allow(deprecated)]
+fn deprecated_render_html_alias_delegates() {
+    let html = r#"<!doctype html><html><body><p>compat</p></body></html>"#;
+    let pdf = Engine::builder()
+        .build()
+        .render_html(html)
+        .expect("render_html must succeed");
+    assert!(!pdf.is_empty());
+    assert!(pdf.starts_with(b"%PDF"));
+}
+
+#[test]
+#[allow(deprecated)]
+fn deprecated_render_html_to_file_alias_delegates() {
+    let html = r#"<!doctype html><html><body><p>compat</p></body></html>"#;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("compat.pdf");
+    Engine::builder()
+        .build()
+        .render_html_to_file(html, &path)
+        .expect("render_html_to_file must succeed");
+    assert!(path.exists());
+    assert!(std::fs::metadata(&path).unwrap().len() > 0);
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -951,9 +951,7 @@ fn render_v2_smoke_body_overflow_hidden_multi_page_content_survives() {
     let without_clip = r##"<!DOCTYPE html><html><head><style>html,body{margin:0;padding:0;background:#fff}.tall{height:1500px;background:#cef}</style></head><body><div class="tall"></div></body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
     let pdf_clip = engine.render(with_clip).expect("v2 render w/ clip");
-    let pdf_plain = engine
-        .render(without_clip)
-        .expect("v2 render w/o clip");
+    let pdf_plain = engine.render(without_clip).expect("v2 render w/o clip");
     let ratio = pdf_clip.len() as f32 / pdf_plain.len() as f32;
     assert!(
         ratio > 0.95 && ratio < 1.05,
@@ -1495,10 +1493,7 @@ fn render_v2_smoke_inline_block_css_transform_branch() {
         <p>text <span style="display:inline-block;width:60px;height:30px;background:red;
                              transform:rotate(15deg)">rotated</span> text</p>
     </body></html>"#;
-    let pdf = Engine::builder()
-        .build()
-        .render(html)
-        .expect("v2 render");
+    let pdf = Engine::builder().build().render(html).expect("v2 render");
     assert!(!pdf.is_empty());
     assert!(pdf.starts_with(b"%PDF"));
 }
@@ -1511,10 +1506,7 @@ fn render_v2_smoke_inline_block_overflow_hidden_clip_branch() {
             <span style="margin-left:100px">clipped</span>
         </span> text</p>
     </body></html>"#;
-    let pdf = Engine::builder()
-        .build()
-        .render(html)
-        .expect("v2 render");
+    let pdf = Engine::builder().build().render(html).expect("v2 render");
     assert!(!pdf.is_empty());
     assert!(pdf.starts_with(b"%PDF"));
 }
@@ -1529,10 +1521,7 @@ fn render_v2_smoke_inline_block_opacity_descendant_branch() {
             </span>
         </span> text</p>
     </body></html>"#;
-    let pdf = Engine::builder()
-        .build()
-        .render(html)
-        .expect("v2 render");
+    let pdf = Engine::builder().build().render(html).expect("v2 render");
     assert!(!pdf.is_empty());
     assert!(pdf.starts_with(b"%PDF"));
 }
@@ -1606,10 +1595,7 @@ fn render_v2_smoke_border_groove_and_ridge() {
         <div class="grv">grooved box</div>
         <div class="rdg">ridge box</div>
     </body></html>"#;
-    let pdf = Engine::builder()
-        .build()
-        .render(html)
-        .expect("v2 render");
+    let pdf = Engine::builder().build().render(html).expect("v2 render");
     assert!(!pdf.is_empty());
     assert!(pdf.starts_with(b"%PDF"));
 }
@@ -1625,10 +1611,7 @@ fn render_v2_smoke_border_inset_and_outset() {
         <div class="ins">inset box</div>
         <div class="ots">outset box</div>
     </body></html>"#;
-    let pdf = Engine::builder()
-        .build()
-        .render(html)
-        .expect("v2 render");
+    let pdf = Engine::builder().build().render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -1640,10 +1623,7 @@ fn render_v2_smoke_border_radius_with_style_rounded_path() {
     let html = r#"<!DOCTYPE html><html><head><style>
         .rnd { border: 4pt solid #444; border-radius: 12pt; padding: 8pt; }
     </style></head><body><div class="rnd">rounded</div></body></html>"#;
-    let pdf = Engine::builder()
-        .build()
-        .render(html)
-        .expect("v2 render");
+    let pdf = Engine::builder().build().render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -1658,10 +1638,7 @@ fn render_v2_smoke_overflow_hidden_with_border_radius() {
     </style></head><body>
         <div class="clipped"><div class="inner">overflow content</div></div>
     </body></html>"#;
-    let pdf = Engine::builder()
-        .build()
-        .render(html)
-        .expect("v2 render");
+    let pdf = Engine::builder().build().render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -1674,10 +1651,7 @@ fn render_v2_smoke_inline_block_with_background_and_text() {
     let html = r#"<!DOCTYPE html><html><body>
         <p>before <span style="display:inline-block; background:#fce; padding:4pt; border:1pt solid #888;">inline-block with background</span> after</p>
     </body></html>"#;
-    let pdf = Engine::builder()
-        .build()
-        .render(html)
-        .expect("v2 render");
+    let pdf = Engine::builder().build().render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -1689,10 +1663,7 @@ fn render_v2_smoke_inline_block_with_overflow_clip_and_text() {
     let html = r#"<!DOCTYPE html><html><body>
         <p>x <span style="display:inline-block; overflow:hidden; width:60pt; height:20pt; background:#cef;">overflow inline-block text</span> y</p>
     </body></html>"#;
-    let pdf = Engine::builder()
-        .build()
-        .render(html)
-        .expect("v2 render");
+    let pdf = Engine::builder().build().render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -1706,10 +1677,7 @@ fn render_v2_smoke_empty_li_inside_position_marker_paragraph() {
     </style></head><body>
         <ul><li></li><li>second</li></ul>
     </body></html>"#;
-    let pdf = Engine::builder()
-        .build()
-        .render(html)
-        .expect("v2 render");
+    let pdf = Engine::builder().build().render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -1725,10 +1693,7 @@ fn render_v2_smoke_li_inside_with_block_child_synthesizes_marker_paragraph() {
     </style></head><body>
         <ul><li><div class="blk"></div></li></ul>
     </body></html>"#;
-    let pdf = Engine::builder()
-        .build()
-        .render(html)
-        .expect("v2 render");
+    let pdf = Engine::builder().build().render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -1845,10 +1810,7 @@ fn render_v2_smoke_li_with_opacity_records_opacity_descendants() {
     </style></head><body>
         <ul><li><div class="blk">child</div></li></ul>
     </body></html>"#;
-    let pdf = Engine::builder()
-        .build()
-        .render(html)
-        .expect("v2 render");
+    let pdf = Engine::builder().build().render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -3115,11 +3077,10 @@ fn tagged_pdf_link_in_opacity_block_with_inline_box_child() {
         </div>
     </body></html>"#;
 
-    let pdf = Engine::builder()
-        .tagged(true)
-        .build()
-        .render(html)
-        .expect("opacity inline-root with inline-box child and link in tagged PDF must not panic");
+    let pdf =
+        Engine::builder().tagged(true).build().render(html).expect(
+            "opacity inline-root with inline-box child and link in tagged PDF must not panic",
+        );
 
     assert!(!pdf.is_empty());
     let s = String::from_utf8_lossy(&pdf);
@@ -3364,15 +3325,9 @@ fn render_table_pagebreak_does_not_scale_quadratically() {
     fn time_render(n: usize) -> std::time::Duration {
         let html = build(n);
         // Warm up so the first call doesn't pay font / GCPM init costs.
-        let _ = fulgur::Engine::builder()
-            .build()
-            .render(&html)
-            .unwrap();
+        let _ = fulgur::Engine::builder().build().render(&html).unwrap();
         let start = std::time::Instant::now();
-        let _ = fulgur::Engine::builder()
-            .build()
-            .render(&html)
-            .unwrap();
+        let _ = fulgur::Engine::builder().build().render(&html).unwrap();
         start.elapsed()
     }
 
@@ -4325,9 +4280,7 @@ fn table_caption_text_renders_in_pdf() {
           <tbody><tr><td>cellone</td><td>celltwo</td></tr></tbody>
         </table>
     </body></html>"#;
-    let pdf = noto_engine()
-        .render(html)
-        .expect("render must succeed");
+    let pdf = noto_engine().render(html).expect("render must succeed");
     assert!(!pdf.is_empty());
 
     let Some(text) = extract_pdf_text(&pdf) else {
@@ -4364,9 +4317,7 @@ fn caption_and_cell_ys(caption_side: &str) -> (f32, f32, f32) {
           </table>
         </body></html>"#
     );
-    let pdf = noto_engine()
-        .render(&html)
-        .expect("render must succeed");
+    let pdf = noto_engine().render(&html).expect("render must succeed");
     let dir = tempdir().expect("tempdir");
     let path = dir.path().join("caption-side.pdf");
     std::fs::write(&path, &pdf).expect("write pdf");
@@ -4425,9 +4376,7 @@ fn table_caption_with_nested_inline_renders() {
           <tbody><tr><td>cellone</td></tr></tbody>
         </table>
     </body></html>"#;
-    let pdf = noto_engine()
-        .render(html)
-        .expect("render must succeed");
+    let pdf = noto_engine().render(html).expect("render must succeed");
     let Some(text) = extract_pdf_text(&pdf) else {
         eprintln!("pdftotext not available; skipping text assertion");
         return;
@@ -4450,9 +4399,7 @@ fn table_with_two_captions_does_not_panic() {
           <tbody><tr><td>cellone</td></tr></tbody>
         </table>
     </body></html>"#;
-    let pdf = noto_engine()
-        .render(html)
-        .expect("render must succeed");
+    let pdf = noto_engine().render(html).expect("render must succeed");
     assert!(!pdf.is_empty());
     assert!(pdf.starts_with(b"%PDF"));
 }
@@ -4473,9 +4420,7 @@ fn caption_big_text_count(extra_css: &str) -> usize {
           </table>
         </body></html>"#
     );
-    let pdf = noto_engine()
-        .render(&html)
-        .expect("render must succeed");
+    let pdf = noto_engine().render(&html).expect("render must succeed");
     let dir = tempdir().expect("tempdir");
     let path = dir.path().join("caption-display.pdf");
     std::fs::write(&path, &pdf).expect("write pdf");
@@ -4564,9 +4509,7 @@ fn table_caption_side_ignored_for_non_table_caption_display() {
             <tbody><tr><td>cellone</td></tr><tr><td>celltwo</td></tr></tbody>
           </table>
         </body></html>"#;
-    let pdf = noto_engine()
-        .render(html)
-        .expect("render must succeed");
+    let pdf = noto_engine().render(html).expect("render must succeed");
     let dir = tempdir().expect("tempdir");
     let path = dir.path().join("caption-block-bottom.pdf");
     std::fs::write(&path, &pdf).expect("write pdf");
@@ -4662,9 +4605,7 @@ fn full_width_table_max_cell_x(with_caption: bool) -> f32 {
           </table>
         </body></html>"#
     );
-    let pdf = noto_engine()
-        .render(&html)
-        .expect("render must succeed");
+    let pdf = noto_engine().render(&html).expect("render must succeed");
     let dir = tempdir().expect("tempdir");
     let path = dir.path().join("fullwidth.pdf");
     std::fs::write(&path, &pdf).expect("write pdf");

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -3301,7 +3301,7 @@ fn bookmark_label_counter_appears_in_outline() {
         .bookmarks(true)
         .build()
         .render(html)
-        .expect("render_html");
+        .expect("render");
     let titles = outline_titles(&pdf);
     assert!(
         titles.iter().any(|t| t == "1. Intro"),
@@ -3324,7 +3324,7 @@ fn bookmark_label_string_appears_in_outline() {
         .bookmarks(true)
         .build()
         .render(html)
-        .expect("render_html");
+        .expect("render");
     let titles = outline_titles(&pdf);
     assert_eq!(titles, vec!["Alpha".to_string(), "Beta".to_string()]);
 }

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -59,7 +59,7 @@ fn tagged_render_with_noto(html: &str) -> Vec<u8> {
         .lang("en")
         .assets(assets)
         .build()
-        .render_html(html)
+        .render(html)
         .expect("tagged render")
 }
 
@@ -99,7 +99,7 @@ fn test_render_html_resolves_link_stylesheet() {
     let html = r#"<html><head><link rel="stylesheet" href="test.css"></head><body><p>Hello</p></body></html>"#;
 
     let engine = Engine::builder().base_path(dir.path()).build();
-    let result = engine.render_html(html);
+    let result = engine.render(html);
     assert!(result.is_ok());
 }
 
@@ -130,7 +130,7 @@ fn test_render_html_link_stylesheet_with_gcpm() {
 </body></html>"#;
 
     let engine = Engine::builder().base_path(dir.path()).build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
 
     // Crude check: the PDF should have at least one page and not be
     // empty. A more thorough comparison would require pdf parsing in
@@ -170,7 +170,7 @@ fn test_render_html_link_stylesheet_with_import() {
 </body></html>"#;
 
     let engine = Engine::builder().base_path(dir.path()).build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert!(!pdf.is_empty());
     assert!(pdf.starts_with(b"%PDF"));
 }
@@ -191,7 +191,7 @@ fn test_render_html_link_stylesheet_rejects_path_traversal() {
 <body><p>Hi</p></body></html>"#;
 
     let engine = Engine::builder().base_path(&base).build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert!(!pdf.is_empty());
 }
 
@@ -203,7 +203,7 @@ li::marker { content: url("bullet.png"); }
 </style></head>
 <body><ul><li>Item</li></ul></body></html>"#;
     let engine = Engine::builder().build();
-    let pdf = engine.render_html(html).expect("render should not panic");
+    let pdf = engine.render(html).expect("render should not panic");
     assert!(!pdf.is_empty());
 }
 
@@ -227,7 +227,7 @@ fn test_render_html_marker_content_url_with_image() {
 
     let engine = Engine::builder().assets(bundle).build();
     let pdf = engine
-        .render_html(html)
+        .render(html)
         .expect("render should succeed with marker image");
     assert!(!pdf.is_empty(), "PDF should be non-empty");
 }
@@ -244,7 +244,7 @@ fn test_render_repeating_linear_gradient_smoke() {
 </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render repeating-linear-gradient");
     assert!(!pdf.is_empty());
 }
@@ -259,7 +259,7 @@ fn test_render_repeating_radial_gradient_smoke() {
 </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render repeating-radial-gradient");
     assert!(!pdf.is_empty());
 }
@@ -276,7 +276,7 @@ fn test_render_linear_gradient_corner_direction_smoke() {
 </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render corner-direction linear gradient");
     assert!(!pdf.is_empty());
 }
@@ -292,7 +292,7 @@ fn test_render_linear_gradient_tiled_smoke() {
 </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render tiled linear gradient");
     assert!(!pdf.is_empty());
 }
@@ -311,7 +311,7 @@ fn test_render_html_conic_gradient_pie_chart() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render conic pie chart");
     assert!(!pdf.is_empty());
 }
@@ -326,7 +326,7 @@ fn test_render_html_conic_gradient_smooth() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render smooth conic");
     assert!(!pdf.is_empty());
 }
@@ -341,7 +341,7 @@ fn test_render_html_repeating_conic_gradient() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render repeating conic");
     assert!(!pdf.is_empty());
 }
@@ -357,7 +357,7 @@ fn test_render_html_conic_gradient_from_angle() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render conic with from angle");
     assert!(!pdf.is_empty());
 }
@@ -376,7 +376,7 @@ fn test_render_html_conic_gradient_at_position() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render conic with offset center");
     assert!(!pdf.is_empty());
 }
@@ -392,7 +392,7 @@ fn test_render_html_shadow_inset_logged_and_skipped() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render inset shadow");
     assert!(!pdf.is_empty());
 }
@@ -406,7 +406,7 @@ fn test_render_html_shadow_blur_warning_path() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render blurred shadow");
     assert!(!pdf.is_empty());
 }
@@ -420,7 +420,7 @@ fn test_render_html_shadow_blur_gradient_path() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render blurred shadow with offset and spread");
     assert!(!pdf.is_empty());
 }
@@ -434,7 +434,7 @@ fn test_render_html_shadow_blur_rounded() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render blurred shadow with border-radius");
     assert!(!pdf.is_empty());
 }
@@ -448,7 +448,7 @@ fn test_render_html_shadow_blur_non_white_background() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render blurred shadow on dark background");
     assert!(!pdf.is_empty());
 }
@@ -462,7 +462,7 @@ fn test_render_html_shadow_fully_transparent_skipped() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render transparent shadow");
     assert!(!pdf.is_empty());
 }
@@ -486,7 +486,7 @@ fn test_render_html_bg_image_unknown_asset() {
     let pdf = Engine::builder()
         .assets(bundle)
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render unknown-asset bg");
     assert!(!pdf.is_empty());
 }
@@ -510,7 +510,7 @@ fn test_render_html_bg_image_invalid_svg_logs_and_falls_back() {
     let pdf = Engine::builder()
         .assets(bundle)
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render broken-svg bg");
     assert!(!pdf.is_empty());
 }
@@ -526,7 +526,7 @@ fn test_render_html_linear_gradient_keyword_directions() {
         <div style="width:80px;height:80px;background:linear-gradient(to left, red, blue);"></div>
         <div style="width:80px;height:80px;background:linear-gradient(to right, red, blue);"></div>
     </body></html>"#;
-    let pdf = Engine::builder().build().render_html(html).expect("render");
+    let pdf = Engine::builder().build().render(html).expect("render");
     assert!(!pdf.is_empty());
 }
 
@@ -539,7 +539,7 @@ fn test_render_html_linear_gradient_corner_directions() {
         <div style="width:80px;height:80px;background:linear-gradient(to bottom left, red, blue);"></div>
         <div style="width:80px;height:80px;background:linear-gradient(to bottom right, red, blue);"></div>
     </body></html>"#;
-    let pdf = Engine::builder().build().render_html(html).expect("render");
+    let pdf = Engine::builder().build().render(html).expect("render");
     assert!(!pdf.is_empty());
 }
 
@@ -555,7 +555,7 @@ fn test_render_html_radial_gradient_shape_variants() {
         <div style="width:120px;height:80px;background:radial-gradient(circle 30px, red, blue);"></div>
         <div style="width:120px;height:80px;background:radial-gradient(ellipse 40px 30px, red, blue);"></div>
     </body></html>"#;
-    let pdf = Engine::builder().build().render_html(html).expect("render");
+    let pdf = Engine::builder().build().render(html).expect("render");
     assert!(!pdf.is_empty());
 }
 
@@ -584,7 +584,7 @@ fn test_render_html_bg_repeat_origin_clip_variants() {
     let pdf = Engine::builder()
         .assets(bundle)
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render bg repeat/origin/clip variants");
     assert!(!pdf.is_empty());
 }
@@ -595,7 +595,7 @@ fn linear_gradient_with_interpolation_hint_renders_via_engine() {
     // (fulgur-2zam). VRT は codecov 対象外なので draw branch 起動の証拠を
     // ここに残す (CLAUDE.md "Coverage scope" Gotcha).
     let html = r#"<html><body><div style="width:200px;height:100px;background:linear-gradient(red, 30%, blue)">x</div></body></html>"#;
-    let pdf = Engine::builder().build().render_html(html).expect("render");
+    let pdf = Engine::builder().build().render(html).expect("render");
     assert!(!pdf.is_empty());
     assert!(pdf.starts_with(b"%PDF"));
 }
@@ -603,7 +603,7 @@ fn linear_gradient_with_interpolation_hint_renders_via_engine() {
 #[test]
 fn radial_gradient_with_interpolation_hint_renders_via_engine() {
     let html = r#"<html><body><div style="width:200px;height:100px;background:radial-gradient(red, 30%, blue)">x</div></body></html>"#;
-    let pdf = Engine::builder().build().render_html(html).expect("render");
+    let pdf = Engine::builder().build().render(html).expect("render");
     assert!(!pdf.is_empty());
 }
 
@@ -611,7 +611,7 @@ fn radial_gradient_with_interpolation_hint_renders_via_engine() {
 fn repeating_linear_gradient_with_hint_renders_via_engine() {
     // hint expansion + repeating 周期展開の組み合わせ経路.
     let html = r#"<html><body><div style="width:200px;height:100px;background:repeating-linear-gradient(red, 30%, blue 50%, red 100%)">x</div></body></html>"#;
-    let pdf = Engine::builder().build().render_html(html).expect("render");
+    let pdf = Engine::builder().build().render(html).expect("render");
     assert!(!pdf.is_empty());
 }
 
@@ -627,7 +627,7 @@ fn position_absolute_pseudo_at_body_resolves_initial_cb() {
 <style>body::before { content: "x"; position: absolute; bottom: 0; }</style>
 <p>filler</p>
 </body></html>"#;
-    let pdf = Engine::builder().build().render_html(html).expect("render");
+    let pdf = Engine::builder().build().render(html).expect("render");
     assert!(!pdf.is_empty());
     assert!(pdf.starts_with(b"%PDF"));
 }
@@ -661,7 +661,7 @@ fn position_fixed_inside_absolute_relayouts_against_viewport() {
 </div>
 </body></html>"#;
     let engine = Engine::builder().build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert!(pdf.starts_with(b"%PDF"));
 
     let drawables = engine.build_drawables_for_testing_no_gcpm(html);
@@ -714,7 +714,7 @@ fn position_fixed_repeats_on_every_page() {
                       width: 200px; height: 50px">FXFXFX</div>
         </body></html>"#;
     let engine = Engine::builder().page_size(PageSize::A4).build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
 
     // We do not have an inline PDF text extractor; pdftotext is the
     // canonical "did this glyph render on this page" probe used in
@@ -770,7 +770,7 @@ fn page_counter_footer_paints_above_body_background() {
         .page { height: 100vh; background: #fff; }
       </style></head><body><div class="page">body</div></body></html>"#;
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
 
     let dir = tempfile::tempdir().expect("tempdir");
     let pdf_path = dir.path().join("out.pdf");
@@ -846,7 +846,7 @@ fn page_counter_footer_paints_above_body_background() {
 fn render_v2_smoke_transform_translate() {
     let html = r##"<!DOCTYPE html><html><head><style>body{margin:0}.box{width:80px;height:60px;background:#cef;transform:translate(10px,5px)}</style></head><body><div class="box"></div></body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf = engine.render_html(html).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -857,7 +857,7 @@ fn render_v2_smoke_nested_transforms() {
     // matrices must compose.
     let html = r##"<!DOCTYPE html><html><head><style>body{margin:0}.outer{width:120px;height:80px;background:#cef;transform:rotate(10deg)}.inner{width:60px;height:40px;background:#fce;transform:translate(8px,4px)}</style></head><body><div class="outer"><div class="inner"></div></div></body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf = engine.render_html(html).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -867,7 +867,7 @@ fn render_v2_smoke_multicol_with_column_rule() {
     // declare `column-rule` so this path needs an explicit smoke test.
     let html = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:8pt}.cols{column-count:2;column-rule:1pt solid #888;column-gap:12pt;height:80pt}.cell{height:30pt;background:#cef;margin-bottom:6pt}</style></head><body><div class="cols"><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div></body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf = engine.render_html(html).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -877,7 +877,7 @@ fn render_v2_smoke_html_body_bg_multi_page() {
     // every page) and `<body>` (pre-pass on continuation pages).
     let html = r##"<!DOCTYPE html><html><head><style>html,body{margin:0;background:#fafafa}.tall{height:1500px;background:#cef}</style></head><body><div class="tall"></div></body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf = engine.render_html(html).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -896,7 +896,7 @@ fn render_v2_smoke_rtl_page_left_right_selectors() {
         <div class="tall"></div>
     </body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf = engine.render_html(html).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -906,7 +906,7 @@ fn render_v2_smoke_block_with_inline_root_padding() {
     // the `padding: 6px` shift fix that landed in PR 6.
     let html = r##"<!DOCTYPE html><html><head><style>body{margin:0}p{margin:0;padding:6px;background:#cef}</style></head><body><p>hello</p></body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf = engine.render_html(html).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -916,7 +916,7 @@ fn render_v2_smoke_bookmarks_under_transform() {
     // before `transformed_descendants` skip) added in PR 6 Devin fix.
     let html = r##"<!DOCTYPE html><html><head><style>body{margin:0}div{transform:rotate(5deg)}h1{margin:0;font-size:14px}</style></head><body><div><h1>Heading</h1></div></body></html>"##;
     let engine = fulgur::engine::Engine::builder().bookmarks(true).build();
-    let pdf = engine.render_html(html).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -928,7 +928,7 @@ fn render_v2_smoke_transform_inside_overflow_clip() {
     // pre-skips `clipped_descendants` before the transform check.
     let html = r##"<!DOCTYPE html><html><head><style>body{margin:0}.outer{width:120px;height:80px;overflow:hidden;background:#cef}.inner{width:60px;height:40px;background:#fce;transform:rotate(10deg)}</style></head><body><div class="outer"><div class="inner"></div></div></body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf = engine.render_html(html).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -950,9 +950,9 @@ fn render_v2_smoke_body_overflow_hidden_multi_page_content_survives() {
     let with_clip = r##"<!DOCTYPE html><html><head><style>html,body{margin:0;padding:0;background:#fff}body{overflow:hidden}.tall{height:1500px;background:#cef}</style></head><body><div class="tall"></div></body></html>"##;
     let without_clip = r##"<!DOCTYPE html><html><head><style>html,body{margin:0;padding:0;background:#fff}.tall{height:1500px;background:#cef}</style></head><body><div class="tall"></div></body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf_clip = engine.render_html(with_clip).expect("v2 render w/ clip");
+    let pdf_clip = engine.render(with_clip).expect("v2 render w/ clip");
     let pdf_plain = engine
-        .render_html(without_clip)
+        .render(without_clip)
         .expect("v2 render w/o clip");
     let ratio = pdf_clip.len() as f32 / pdf_plain.len() as f32;
     assert!(
@@ -974,7 +974,7 @@ fn render_v2_smoke_list_item_overflow_clip_with_opacity() {
     // must paint before `push_clip_path`.
     let html = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}ul{margin:0;padding:0 0 0 24px}li{background:#cef;overflow:hidden;opacity:0.5}.inner{height:30px;background:#fce}</style></head><body><ul><li><div class="inner"></div></li></ul></body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf = engine.render_html(html).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -987,7 +987,7 @@ fn render_v2_smoke_overflow_clip_inside_transform() {
     // clip path fired, leaking content past the boundary.
     let html = r##"<!DOCTYPE html><html><head><style>body{margin:0}.outer{width:140px;height:80px;background:#cef;transform:translate(8px,4px)}.inner{width:60px;height:40px;background:#fce;overflow:hidden}.leaf{width:120px;height:20px;background:#ffd}</style></head><body><div class="outer"><div class="inner"><div class="leaf"></div></div></div></body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf = engine.render_html(html).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -1000,7 +1000,7 @@ fn render_v2_smoke_nested_overflow_clip_blocks() {
     // boundary while overflowing content escaped through it.
     let html = r##"<!DOCTYPE html><html><head><style>body{margin:0}.outer{width:120px;height:80px;overflow:hidden;background:#cef}.inner{width:60px;height:40px;overflow:hidden;background:#fce}.leaf{width:200px;height:20px;background:#ffd}</style></head><body><div class="outer"><div class="inner"><div class="leaf"></div></div></div></body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf = engine.render_html(html).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -1013,8 +1013,8 @@ fn render_v2_smoke_multicol_dashed_and_dotted_column_rule() {
     let html_dashed = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:8pt}.cols{column-count:2;column-rule:1pt dashed #888;column-gap:12pt;height:80pt}.cell{height:30pt;background:#cef;margin-bottom:6pt}</style></head><body><div class="cols"><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div></body></html>"##;
     let html_dotted = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:8pt}.cols{column-count:2;column-rule:1pt dotted #888;column-gap:12pt;height:80pt}.cell{height:30pt;background:#cef;margin-bottom:6pt}</style></head><body><div class="cols"><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div></body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf_dashed = engine.render_html(html_dashed).expect("dashed render");
-    let pdf_dotted = engine.render_html(html_dotted).expect("dotted render");
+    let pdf_dashed = engine.render(html_dashed).expect("dashed render");
+    let pdf_dotted = engine.render(html_dotted).expect("dotted render");
     assert!(!pdf_dashed.is_empty());
     assert!(!pdf_dotted.is_empty());
 }
@@ -1035,7 +1035,7 @@ fn render_v2_smoke_paragraph_multi_fragment_slice() {
         r##"<!DOCTYPE html><html><head><style>html,body{{margin:0;padding:0}}p{{margin:0;font-size:14pt;line-height:1.4}}</style></head><body><p>{paragraph_text}</p></body></html>"##
     );
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf = engine.render_html(&html).expect("v2 render");
+    let pdf = engine.render(&html).expect("v2 render");
     assert!(!pdf.is_empty());
     // Multi-page sanity check: multiple `Type /Page` entries (one per
     // page object) — without slicing, only the first fragment would
@@ -1067,7 +1067,7 @@ fn render_v2_smoke_list_item_image_marker() {
     let html =
         r##"<!doctype html><html><body><ul><li>Item 1</li><li>Item 2</li></ul></body></html>"##;
     let engine = Engine::builder().assets(bundle).build();
-    let pdf = engine.render_html(html).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -1080,7 +1080,7 @@ fn render_v2_smoke_multicol_rule_inside_transform() {
     // Otherwise the rules render in untransformed page coordinates.
     let html = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.tx{transform:translate(8px,4px)}.cols{column-count:2;column-rule:1pt solid #888;column-gap:12pt;height:80pt}.cell{height:30pt;background:#cef;margin-bottom:6pt}</style></head><body><div class="tx"><div class="cols"><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div></div></body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf = engine.render_html(html).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -1097,7 +1097,7 @@ fn render_v2_smoke_opacity_descendants_block_with_svg() {
     // chain.
     let html = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.faded{opacity:0.4}</style></head><body><div class="faded"><svg xmlns="http://www.w3.org/2000/svg" width="40" height="40"><rect width="40" height="40" fill="#1a6faa"/></svg></div></body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf = engine.render_html(html).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -1112,7 +1112,7 @@ fn render_v2_smoke_opacity_inside_overflow_clip() {
     // wrap).
     let html = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.clip{overflow:hidden;width:120pt;height:80pt}.faded{opacity:0.5}</style></head><body><div class="clip"><div class="faded"><svg xmlns="http://www.w3.org/2000/svg" width="60" height="60"><circle cx="30" cy="30" r="25" fill="#e74c3c"/></svg></div></div></body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf = engine.render_html(html).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -1124,7 +1124,7 @@ fn render_v2_smoke_opacity_inside_transform() {
     // `draw_under_opacity` arm in the recursive descend.
     let html = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.tx{transform:rotate(5deg)}.faded{opacity:0.6}</style></head><body><div class="tx"><div class="faded"><svg xmlns="http://www.w3.org/2000/svg" width="40" height="40"><rect width="40" height="40" fill="#27ae60"/></svg></div></div></body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf = engine.render_html(html).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -1150,8 +1150,8 @@ fn render_v2_smoke_anonymous_block_inline_level_sibling() {
     let html = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.card{padding:8pt}.label{display:inline-block;background:#cef;padding:2pt 6pt}</style></head><body><div class="card"><div>block child</div><span class="label">BADGE</span></div></body></html>"##;
     let html_no_badge = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:0}.card{padding:8pt}</style></head><body><div class="card"><div>block child</div></div></body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf = engine.render_html(html).expect("v2 render");
-    let pdf_no_badge = engine.render_html(html_no_badge).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
+    let pdf_no_badge = engine.render(html_no_badge).expect("v2 render");
     assert!(!pdf.is_empty());
     assert!(
         pdf.len() > pdf_no_badge.len(),
@@ -1187,7 +1187,7 @@ fn render_v2_smoke_split_block_uses_per_slice_height() {
         <div class="box"></div>
     </body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf = engine.render_html(html).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
     assert!(!pdf.is_empty());
     // Sanity: must produce a multi-page PDF (the box straddles page
     // bottom).
@@ -1217,8 +1217,8 @@ fn render_v2_smoke_body_layout_children_for_form_siblings() {
     let html = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:8pt;font-size:10pt}label{margin-right:8pt}input{padding:2pt;border:1pt solid #888;width:120pt}</style></head><body><h1>Form sample</h1><label>Name:</label><input type="text" value="hello"></body></html>"##;
     let html_no_inline = r##"<!DOCTYPE html><html><head><style>body{margin:0;padding:8pt;font-size:10pt}</style></head><body><h1>Form sample</h1></body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf = engine.render_html(html).expect("v2 render");
-    let pdf_no_inline = engine.render_html(html_no_inline).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
+    let pdf_no_inline = engine.render(html_no_inline).expect("v2 render");
     assert!(!pdf.is_empty());
     // Sanity: body with inline-level form siblings produces a
     // larger PDF than h1-only baseline. Without the body-level
@@ -1259,7 +1259,7 @@ fn render_v2_smoke_body_opacity_multi_page_content_survives() {
         <div class="tail">tail content on page 2</div>
     </body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf = engine.render_html(html).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
     assert!(!pdf.is_empty());
     // Sanity: must be multi-page (filler 800pt + tail 132pt > A4
     // content height of ~842pt).
@@ -1283,7 +1283,7 @@ fn render_v2_smoke_body_opacity_multi_page_content_survives() {
         <div class="filler"></div>
         <div class="tail">tail content on page 2</div>
     </body></html>"##;
-    let pdf_baseline = engine.render_html(html_baseline).expect("v2 render");
+    let pdf_baseline = engine.render(html_baseline).expect("v2 render");
     // Allow some room for the opacity group XObject overhead but
     // require at least 90% of the baseline content survives. A real
     // regression (silent page-2 blanking) drops the size by far more
@@ -1325,7 +1325,7 @@ fn render_v2_smoke_split_opacity_block_uses_per_slice_height() {
         </div>
     </body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf = engine.render_html(html).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
     assert!(!pdf.is_empty());
     // Multi-page sanity.
     let pdf_str = String::from_utf8_lossy(&pdf);
@@ -1361,7 +1361,7 @@ fn render_v2_smoke_split_overflow_clip_block_uses_per_slice_height() {
         <div class="clip"><div class="inner">clipped content</div></div>
     </body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf = engine.render_html(html).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
     assert!(!pdf.is_empty());
     // Multi-page sanity (filler 600pt + clip 300pt + 12pt margin
     // = 912pt > A4 ~842pt content height).
@@ -1400,7 +1400,7 @@ fn render_v2_smoke_html_opacity_multi_page_content_survives() {
         <div class="tail">tail content on page 2</div>
     </body></html>"##;
     let engine = fulgur::engine::Engine::builder().build();
-    let pdf = engine.render_html(html).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
     assert!(!pdf.is_empty());
     // Multi-page sanity.
     let pdf_str = String::from_utf8_lossy(&pdf);
@@ -1422,7 +1422,7 @@ fn render_v2_smoke_html_opacity_multi_page_content_survives() {
         <div class="filler"></div>
         <div class="tail">tail content on page 2</div>
     </body></html>"##;
-    let pdf_baseline = engine.render_html(html_baseline).expect("v2 render");
+    let pdf_baseline = engine.render(html_baseline).expect("v2 render");
     assert!(
         pdf.len() * 100 >= pdf_baseline.len() * 85,
         "with-html-opacity PDF lost too much content vs baseline \
@@ -1481,7 +1481,7 @@ fn render_v2_smoke_positioned_child_height_field_paths() {
         <img src="dot.png" style="width: 32pt; height: 32pt; border: 2pt solid #888; padding: 4pt;">
     </body></html>"##;
     let engine = Engine::builder().assets(bundle).bookmarks(true).build();
-    let pdf = engine.render_html(html).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
     assert!(!pdf.is_empty());
     assert!(pdf.starts_with(b"%PDF"));
 }
@@ -1497,7 +1497,7 @@ fn render_v2_smoke_inline_block_css_transform_branch() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("v2 render");
     assert!(!pdf.is_empty());
     assert!(pdf.starts_with(b"%PDF"));
@@ -1513,7 +1513,7 @@ fn render_v2_smoke_inline_block_overflow_hidden_clip_branch() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("v2 render");
     assert!(!pdf.is_empty());
     assert!(pdf.starts_with(b"%PDF"));
@@ -1531,7 +1531,7 @@ fn render_v2_smoke_inline_block_opacity_descendant_branch() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("v2 render");
     assert!(!pdf.is_empty());
     assert!(pdf.starts_with(b"%PDF"));
@@ -1558,7 +1558,7 @@ fn render_v2_smoke_inline_block_image_child_via_dispatch_fragment() {
     let pdf = Engine::builder()
         .assets(bundle)
         .build()
-        .render_html(html)
+        .render(html)
         .expect("v2 render");
     assert!(!pdf.is_empty());
     assert!(pdf.starts_with(b"%PDF"));
@@ -1574,7 +1574,7 @@ fn render_v2_smoke_list_item_svg_marker() {
     bundle.add_image("bullet.svg", svg_data.to_vec());
     let html = r##"<!doctype html><html><body><ul><li>Alpha</li><li>Beta</li></ul></body></html>"##;
     let engine = Engine::builder().assets(bundle).build();
-    let pdf = engine.render_html(html).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -1588,7 +1588,7 @@ fn render_v2_smoke_margin_box_renderer() {
         p { height: 500pt; background: #eee; }
     </style></head><body><p>Page 1</p><p>Page 2</p></body></html>"##;
     let engine = Engine::builder().build();
-    let pdf = engine.render_html(html).expect("v2 render");
+    let pdf = engine.render(html).expect("v2 render");
     assert!(!pdf.is_empty());
 }
 
@@ -1608,7 +1608,7 @@ fn render_v2_smoke_border_groove_and_ridge() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("v2 render");
     assert!(!pdf.is_empty());
     assert!(pdf.starts_with(b"%PDF"));
@@ -1627,7 +1627,7 @@ fn render_v2_smoke_border_inset_and_outset() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("v2 render");
     assert!(!pdf.is_empty());
 }
@@ -1642,7 +1642,7 @@ fn render_v2_smoke_border_radius_with_style_rounded_path() {
     </style></head><body><div class="rnd">rounded</div></body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("v2 render");
     assert!(!pdf.is_empty());
 }
@@ -1660,7 +1660,7 @@ fn render_v2_smoke_overflow_hidden_with_border_radius() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("v2 render");
     assert!(!pdf.is_empty());
 }
@@ -1676,7 +1676,7 @@ fn render_v2_smoke_inline_block_with_background_and_text() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("v2 render");
     assert!(!pdf.is_empty());
 }
@@ -1691,7 +1691,7 @@ fn render_v2_smoke_inline_block_with_overflow_clip_and_text() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("v2 render");
     assert!(!pdf.is_empty());
 }
@@ -1708,7 +1708,7 @@ fn render_v2_smoke_empty_li_inside_position_marker_paragraph() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("v2 render");
     assert!(!pdf.is_empty());
 }
@@ -1727,7 +1727,7 @@ fn render_v2_smoke_li_inside_with_block_child_synthesizes_marker_paragraph() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("v2 render");
     assert!(!pdf.is_empty());
 }
@@ -1751,7 +1751,7 @@ fn render_v2_smoke_content_url_on_non_replaced_element() {
     let pdf = Engine::builder()
         .assets(bundle)
         .build()
-        .render_html(html)
+        .render(html)
         .expect("v2 render");
     assert!(!pdf.is_empty());
 }
@@ -1781,7 +1781,7 @@ fn render_v2_smoke_inline_root_after_pseudo_image_with_link() {
     let pdf = Engine::builder()
         .assets(bundle)
         .build()
-        .render_html(html)
+        .render(html)
         .expect("v2 render");
     assert!(!pdf.is_empty());
 }
@@ -1806,7 +1806,7 @@ fn render_v2_smoke_inline_root_pseudo_only_with_background() {
     let pdf = Engine::builder()
         .assets(bundle)
         .build()
-        .render_html(html)
+        .render(html)
         .expect("v2 render");
     assert!(!pdf.is_empty());
 }
@@ -1827,7 +1827,7 @@ fn render_v2_smoke_li_pseudo_image_outside_marker_no_text() {
     let pdf = Engine::builder()
         .assets(bundle)
         .build()
-        .render_html(html)
+        .render(html)
         .expect("v2 render");
     assert!(!pdf.is_empty());
 }
@@ -1847,7 +1847,7 @@ fn render_v2_smoke_li_with_opacity_records_opacity_descendants() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("v2 render");
     assert!(!pdf.is_empty());
 }
@@ -1875,7 +1875,7 @@ fn render_v2_smoke_inside_list_style_image_with_image_child() {
     let pdf = Engine::builder()
         .assets(bundle)
         .build()
-        .render_html(html)
+        .render(html)
         .expect("v2 render");
     assert!(!pdf.is_empty());
 }
@@ -1896,7 +1896,7 @@ fn render_v2_smoke_li_inside_marker_with_inline_box_in_line() {
     let pdf = Engine::builder()
         .assets(bundle)
         .build()
-        .render_html(html)
+        .render(html)
         .expect("v2 render");
     assert!(!pdf.is_empty());
 }
@@ -1922,7 +1922,7 @@ fn render_v2_smoke_content_url_on_replaced_with_visual_style() {
     let pdf = Engine::builder()
         .assets(bundle)
         .build()
-        .render_html(html)
+        .render(html)
         .expect("v2 render");
     assert!(!pdf.is_empty());
 }
@@ -1941,7 +1941,7 @@ fn page_property_induces_implicit_break_between_named_siblings() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("page-named siblings render");
     assert!(!pdf.is_empty());
 }
@@ -1969,7 +1969,7 @@ fn page_property_propagates_through_block_subtree() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("page-propagation render");
     assert!(!pdf.is_empty());
 }
@@ -1991,7 +1991,7 @@ fn page_property_on_orthogonal_block_with_own_page_drives_outer_break() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("orthogonal-with-own-page render");
     assert!(!pdf.is_empty());
 }
@@ -2007,7 +2007,7 @@ fn page_property_on_inline_canvas_is_ignored() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("inline-canvas page render");
     assert!(!pdf.is_empty());
 }
@@ -2035,7 +2035,7 @@ fn vh_resolves_against_at_page_content_area() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("vh-with-page-margin render");
     assert!(!pdf.is_empty());
 }
@@ -2056,7 +2056,7 @@ fn page_property_inside_flex_container_does_not_propagate_outward() {
     </body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("flex page render");
     assert!(!pdf.is_empty());
 }
@@ -2196,7 +2196,7 @@ fn multicol_inline_root_split_renders_both_columns_in_pdf_case_b() {
             height: 600.0,
         })
         .build();
-    let pdf = engine.render_html(html).expect("render must succeed");
+    let pdf = engine.render(html).expect("render must succeed");
     assert!(!pdf.is_empty());
 
     let dir = tempdir().expect("tempdir");
@@ -2247,7 +2247,7 @@ fn multicol_inline_root_split_renders_both_columns_in_pdf_case_a() {
             height: 600.0,
         })
         .build();
-    let pdf = engine.render_html(html).expect("render must succeed");
+    let pdf = engine.render(html).expect("render must succeed");
     assert!(!pdf.is_empty());
 
     let dir = tempdir().expect("tempdir");
@@ -2414,7 +2414,7 @@ fn multicol_with_inline_box_paragraph_falls_back_to_atomic() {
     // Sanity: rendering still succeeds (the container falls back to
     // atomic placement and renders the text at full container width via
     // the standard inline-root path).
-    let pdf = engine.render_html(html).expect("render must succeed");
+    let pdf = engine.render(html).expect("render must succeed");
     assert!(pdf.starts_with(b"%PDF"));
 }
 
@@ -2494,7 +2494,7 @@ fn multicol_inline_root_split_skips_slices_outside_current_page() {
         })
         .margin(fulgur::config::Margin::uniform(0.0))
         .build();
-    let pdf = engine.render_html(html).expect("render must succeed");
+    let pdf = engine.render(html).expect("render must succeed");
     assert!(!pdf.is_empty(), "render produced empty PDF");
     assert!(pdf.starts_with(b"%PDF"));
 
@@ -2587,7 +2587,7 @@ fn tagged_render_produces_pdf() {
     let pdf = Engine::builder()
         .tagged(true)
         .build()
-        .render_html("<html><body><p>hello tagged</p></body></html>")
+        .render("<html><body><p>hello tagged</p></body></html>")
         .expect("render tagged");
     assert!(!pdf.is_empty());
     let s = String::from_utf8_lossy(&pdf);
@@ -2610,7 +2610,7 @@ fn tagged_pdf_headings_and_paragraphs_produce_struct_tree() {
         .tagged(true)
         .lang("en")
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render tagged headings");
 
     assert!(!pdf.is_empty());
@@ -2632,7 +2632,7 @@ fn tagged_pdf_multipage_does_not_panic() {
     let pdf = Engine::builder()
         .tagged(true)
         .build()
-        .render_html(&html)
+        .render(&html)
         .expect("render multi-page tagged");
 
     assert!(!pdf.is_empty());
@@ -2654,7 +2654,7 @@ fn tagged_pdf_multipage_does_not_panic() {
 fn untagged_pdf_has_no_struct_tree_root() {
     let pdf = Engine::builder()
         .build()
-        .render_html("<html><body><h1>Hello</h1><p>World</p></body></html>")
+        .render("<html><body><h1>Hello</h1><p>World</p></body></html>")
         .expect("render untagged");
 
     let s = String::from_utf8_lossy(&pdf);
@@ -2673,7 +2673,7 @@ fn pdf_ua_without_title_returns_error() {
         .pdf_ua(true)
         .lang("en")
         .build()
-        .render_html("<html><body><h1>Hello</h1><p>World</p></body></html>");
+        .render("<html><body><h1>Hello</h1><p>World</p></body></html>");
     assert!(
         result.is_err(),
         "pdf_ua without title must return Err (NoDocumentTitle)"
@@ -2699,7 +2699,7 @@ fn pdf_ua_with_html_title_succeeds() {
         .pdf_ua(true)
         .lang("en")
         .build()
-        .render_html(html)
+        .render(html)
         .expect("pdf_ua with <title> must succeed");
 
     assert!(!pdf.is_empty(), "pdf must be non-empty");
@@ -2732,7 +2732,7 @@ fn pdf_ua_with_explicit_title_succeeds() {
         .title("Explicit Title")
         .lang("en")
         .build()
-        .render_html(html)
+        .render(html)
         .expect("pdf_ua with explicit title must succeed");
 
     assert!(!pdf.is_empty());
@@ -2753,7 +2753,7 @@ fn pdf_ua_without_lang_succeeds() {
     let pdf = Engine::builder()
         .pdf_ua(true)
         .build()
-        .render_html(html)
+        .render(html)
         .expect("pdf_ua without lang must succeed");
 
     assert!(!pdf.is_empty());
@@ -2768,7 +2768,7 @@ fn html_title_appears_in_untagged_pdf_metadata() {
 
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("untagged render with title");
 
     let text = String::from_utf8_lossy(&pdf);
@@ -2791,7 +2791,7 @@ fn tagged_struct_tree_reflects_dom_nesting() {
         .tagged(true)
         .lang("en")
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render");
 
     let s = String::from_utf8_lossy(&pdf);
@@ -2835,7 +2835,7 @@ fn tagged_figure_alt_text_appears_in_pdf() {
         .tagged(true)
         .lang("en")
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render");
 
     let s = String::from_utf8_lossy(&pdf);
@@ -2916,7 +2916,7 @@ fn tagged_pdf_external_link_produces_link_struct_element() {
     let pdf = Engine::builder()
         .tagged(true)
         .build()
-        .render_html(html)
+        .render(html)
         .expect("tagged render with link");
 
     assert!(!pdf.is_empty());
@@ -2939,7 +2939,7 @@ fn tagged_pdf_internal_anchor_link_produces_link_struct_element() {
     let pdf = Engine::builder()
         .tagged(true)
         .build()
-        .render_html(html)
+        .render(html)
         .expect("tagged render with internal link");
 
     assert!(!pdf.is_empty());
@@ -2961,7 +2961,7 @@ fn tagged_pdf_image_link_does_not_panic() {
     let pdf = Engine::builder()
         .tagged(true)
         .build()
-        .render_html(html)
+        .render(html)
         .expect("image link tagged render must not panic");
 
     assert!(!pdf.is_empty());
@@ -2980,7 +2980,7 @@ fn tagged_pdf_inline_box_after_link_does_not_panic() {
     let pdf = Engine::builder()
         .tagged(true)
         .build()
-        .render_html(html)
+        .render(html)
         .expect("inline box after link must not panic");
 
     assert!(!pdf.is_empty());
@@ -2994,7 +2994,7 @@ fn untagged_pdf_with_link_preserves_annotation_no_struct_tree() {
 
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("untagged render with link");
 
     assert!(!pdf.is_empty());
@@ -3022,7 +3022,7 @@ fn tagged_pdf_link_in_overflow_hidden_does_not_panic() {
     let pdf = Engine::builder()
         .tagged(true)
         .build()
-        .render_html(html)
+        .render(html)
         .expect("overflow:hidden link in tagged PDF must not panic");
 
     assert!(!pdf.is_empty());
@@ -3086,7 +3086,7 @@ fn tagged_pdf_link_in_opacity_block_does_not_panic() {
     let pdf = Engine::builder()
         .tagged(true)
         .build()
-        .render_html(html)
+        .render(html)
         .expect("opacity block with link in tagged PDF must not panic");
 
     assert!(!pdf.is_empty());
@@ -3118,7 +3118,7 @@ fn tagged_pdf_link_in_opacity_block_with_inline_box_child() {
     let pdf = Engine::builder()
         .tagged(true)
         .build()
-        .render_html(html)
+        .render(html)
         .expect("opacity inline-root with inline-box child and link in tagged PDF must not panic");
 
     assert!(!pdf.is_empty());
@@ -3149,7 +3149,7 @@ p { margin: 8pt 0; }
 <body>
 <p>Leader smoke test. This page should have a dot leader in the top-right margin box.</p>
 </body></html>"#;
-    let pdf = Engine::builder().build().render_html(html).expect("render");
+    let pdf = Engine::builder().build().render(html).expect("render");
     assert!(!pdf.is_empty());
     assert!(pdf.starts_with(b"%PDF"));
 }
@@ -3168,7 +3168,7 @@ fn render_v2_smoke_gcpm_leader_custom_string() {
 }
 body { font-family: sans-serif; }
 </style></head><body><p>Custom leader test.</p></body></html>"#;
-    let pdf = Engine::builder().build().render_html(html).expect("render");
+    let pdf = Engine::builder().build().render(html).expect("render");
     assert!(!pdf.is_empty());
 }
 
@@ -3215,7 +3215,7 @@ fn content_url_resolves_image_when_base_path_set() {
         .base_path(dir.path())
         .assets(bundle)
         .build()
-        .render_html(&html)
+        .render(&html)
         .unwrap();
 
     assert!(!pdf.is_empty(), "PDF must be generated");
@@ -3300,7 +3300,7 @@ fn bookmark_label_counter_appears_in_outline() {
     let pdf = Engine::builder()
         .bookmarks(true)
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render_html");
     let titles = outline_titles(&pdf);
     assert!(
@@ -3323,7 +3323,7 @@ fn bookmark_label_string_appears_in_outline() {
     let pdf = Engine::builder()
         .bookmarks(true)
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render_html");
     let titles = outline_titles(&pdf);
     assert_eq!(titles, vec!["Alpha".to_string(), "Beta".to_string()]);
@@ -3366,12 +3366,12 @@ fn render_table_pagebreak_does_not_scale_quadratically() {
         // Warm up so the first call doesn't pay font / GCPM init costs.
         let _ = fulgur::Engine::builder()
             .build()
-            .render_html(&html)
+            .render(&html)
             .unwrap();
         let start = std::time::Instant::now();
         let _ = fulgur::Engine::builder()
             .build()
-            .render_html(&html)
+            .render(&html)
             .unwrap();
         start.elapsed()
     }
@@ -3437,7 +3437,7 @@ fn target_counter_in_toc_renders_page_number() {
         .tagged(true)
         .assets(assets)
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render");
     assert!(!pdf.is_empty());
 
@@ -3521,7 +3521,7 @@ fn target_counter_in_link_loaded_css_triggers_pass_two() {
         .assets(assets)
         .base_path(dir.path())
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render");
     assert!(!pdf.is_empty());
 
@@ -3758,7 +3758,7 @@ fn target_text_first_letter_typographic() {
         .lang("en")
         .assets(assets)
         .build()
-        .render_html(html)
+        .render(html)
         .expect("tagged render");
     assert!(!pdf.is_empty());
 
@@ -4233,7 +4233,7 @@ body { font-family: 'Noto Sans', sans-serif; }
 </body>
 </html>"#;
 
-    let pdf = noto_engine().render_html(html).expect("render");
+    let pdf = noto_engine().render(html).expect("render");
     assert!(!pdf.is_empty());
 
     let Some(text) = extract_pdf_text(&pdf) else {
@@ -4308,7 +4308,7 @@ fn multicol_table_with_text_content_renders() {
 </div>
 </body></html>"#;
     let engine = Engine::builder().build();
-    let pdf = engine.render_html(html).expect("render must not fail");
+    let pdf = engine.render(html).expect("render must not fail");
     assert!(!pdf.is_empty());
 }
 
@@ -4326,7 +4326,7 @@ fn table_caption_text_renders_in_pdf() {
         </table>
     </body></html>"#;
     let pdf = noto_engine()
-        .render_html(html)
+        .render(html)
         .expect("render must succeed");
     assert!(!pdf.is_empty());
 
@@ -4365,7 +4365,7 @@ fn caption_and_cell_ys(caption_side: &str) -> (f32, f32, f32) {
         </body></html>"#
     );
     let pdf = noto_engine()
-        .render_html(&html)
+        .render(&html)
         .expect("render must succeed");
     let dir = tempdir().expect("tempdir");
     let path = dir.path().join("caption-side.pdf");
@@ -4426,7 +4426,7 @@ fn table_caption_with_nested_inline_renders() {
         </table>
     </body></html>"#;
     let pdf = noto_engine()
-        .render_html(html)
+        .render(html)
         .expect("render must succeed");
     let Some(text) = extract_pdf_text(&pdf) else {
         eprintln!("pdftotext not available; skipping text assertion");
@@ -4451,7 +4451,7 @@ fn table_with_two_captions_does_not_panic() {
         </table>
     </body></html>"#;
     let pdf = noto_engine()
-        .render_html(html)
+        .render(html)
         .expect("render must succeed");
     assert!(!pdf.is_empty());
     assert!(pdf.starts_with(b"%PDF"));
@@ -4474,7 +4474,7 @@ fn caption_big_text_count(extra_css: &str) -> usize {
         </body></html>"#
     );
     let pdf = noto_engine()
-        .render_html(&html)
+        .render(&html)
         .expect("render must succeed");
     let dir = tempdir().expect("tempdir");
     let path = dir.path().join("caption-display.pdf");
@@ -4565,7 +4565,7 @@ fn table_caption_side_ignored_for_non_table_caption_display() {
           </table>
         </body></html>"#;
     let pdf = noto_engine()
-        .render_html(html)
+        .render(html)
         .expect("render must succeed");
     let dir = tempdir().expect("tempdir");
     let path = dir.path().join("caption-block-bottom.pdf");
@@ -4618,7 +4618,7 @@ fn table_caption_side_bottom_via_injected_css() {
           </tbody>
         </table>
     </body></html>"#;
-    let pdf = engine.render_html(html).expect("render must succeed");
+    let pdf = engine.render(html).expect("render must succeed");
     let dir = tempdir().expect("tempdir");
     let path = dir.path().join("caption-injected.pdf");
     std::fs::write(&path, &pdf).expect("write pdf");
@@ -4663,7 +4663,7 @@ fn full_width_table_max_cell_x(with_caption: bool) -> f32 {
         </body></html>"#
     );
     let pdf = noto_engine()
-        .render_html(&html)
+        .render(&html)
         .expect("render must succeed");
     let dir = tempdir().expect("tempdir");
     let path = dir.path().join("fullwidth.pdf");
@@ -4703,7 +4703,7 @@ fn pathological_tall_block_render_is_bounded() {
     let html = r#"<!doctype html><html><body><div style="height:50000px"></div></body></html>"#;
     let pdf = Engine::builder()
         .build()
-        .render_html(html)
+        .render(html)
         .expect("render must terminate and succeed");
     assert!(!pdf.is_empty(), "expected a non-empty bounded PDF");
 }

--- a/crates/fulgur/tests/style_test.rs
+++ b/crates/fulgur/tests/style_test.rs
@@ -9,7 +9,7 @@ fn test_render_styled_html() {
             <h1>Styled Content</h1>
         </div>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     // Styled PDF should be larger due to graphics commands
     assert!(pdf.len() > 1000);
@@ -26,7 +26,7 @@ fn test_render_colored_background() {
             <p>Green background</p>
         </div>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
 }
 
@@ -42,7 +42,7 @@ fn test_overflow_hidden_produces_different_pdf_than_visible() {
             <div style="width:300px;height:300px;background:red"></div>
         </div>
     </body></html>"#;
-    let pdf_hidden = engine.render_html(html_hidden).unwrap();
+    let pdf_hidden = engine.render(html_hidden).unwrap();
     assert!(pdf_hidden.starts_with(b"%PDF"));
 
     let html_visible = r#"<html><body>
@@ -50,7 +50,7 @@ fn test_overflow_hidden_produces_different_pdf_than_visible() {
             <div style="width:300px;height:300px;background:red"></div>
         </div>
     </body></html>"#;
-    let pdf_visible = engine.render_html(html_visible).unwrap();
+    let pdf_visible = engine.render(html_visible).unwrap();
     assert!(pdf_visible.starts_with(b"%PDF"));
 
     // overflow:hidden emits a clip path in the content stream, so the PDF
@@ -71,7 +71,7 @@ fn test_overflow_clip_keyword_renders() {
             <div style="width:300px;height:300px;background:blue"></div>
         </div>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
 }
 
@@ -86,7 +86,7 @@ fn test_overflow_scroll_and_auto_also_clip() {
             <div style="width:300px;height:300px;background:green"></div>
         </div>
     </body></html>"#;
-    let pdf_scroll = engine.render_html(html_scroll).unwrap();
+    let pdf_scroll = engine.render(html_scroll).unwrap();
     assert!(pdf_scroll.starts_with(b"%PDF"));
 
     let html_auto = r#"<html><body>
@@ -94,7 +94,7 @@ fn test_overflow_scroll_and_auto_also_clip() {
             <div style="width:300px;height:300px;background:green"></div>
         </div>
     </body></html>"#;
-    let pdf_auto = engine.render_html(html_auto).unwrap();
+    let pdf_auto = engine.render(html_auto).unwrap();
     assert!(pdf_auto.starts_with(b"%PDF"));
 
     let html_visible = r#"<html><body>
@@ -102,7 +102,7 @@ fn test_overflow_scroll_and_auto_also_clip() {
             <div style="width:300px;height:300px;background:green"></div>
         </div>
     </body></html>"#;
-    let pdf_visible = engine.render_html(html_visible).unwrap();
+    let pdf_visible = engine.render(html_visible).unwrap();
 
     assert_ne!(
         pdf_scroll, pdf_visible,
@@ -128,7 +128,7 @@ fn test_overflow_hidden_on_bare_block_without_visual_style() {
             <div style="width:300px;height:300px;background:red"></div>
         </div>
     </body></html>"#;
-    let pdf_hidden = engine.render_html(html_hidden).unwrap();
+    let pdf_hidden = engine.render(html_hidden).unwrap();
     assert!(pdf_hidden.starts_with(b"%PDF"));
 
     let html_visible = r#"<html><body>
@@ -136,7 +136,7 @@ fn test_overflow_hidden_on_bare_block_without_visual_style() {
             <div style="width:300px;height:300px;background:red"></div>
         </div>
     </body></html>"#;
-    let pdf_visible = engine.render_html(html_visible).unwrap();
+    let pdf_visible = engine.render(html_visible).unwrap();
 
     assert_ne!(
         pdf_hidden, pdf_visible,
@@ -156,7 +156,7 @@ fn test_overflow_hidden_on_table_clips() {
             <tr><td style="width:300px;height:300px;background:orange">cell</td></tr>
         </table>
     </body></html>"#;
-    let pdf_hidden = engine.render_html(html_hidden).unwrap();
+    let pdf_hidden = engine.render(html_hidden).unwrap();
     assert!(pdf_hidden.starts_with(b"%PDF"));
 
     let html_visible = r#"<html><body>
@@ -164,7 +164,7 @@ fn test_overflow_hidden_on_table_clips() {
             <tr><td style="width:300px;height:300px;background:orange">cell</td></tr>
         </table>
     </body></html>"#;
-    let pdf_visible = engine.render_html(html_visible).unwrap();
+    let pdf_visible = engine.render(html_visible).unwrap();
 
     assert_ne!(
         pdf_hidden, pdf_visible,
@@ -182,7 +182,7 @@ fn test_overflow_x_only_renders() {
             <div style="width:300px;height:300px;background:purple"></div>
         </div>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
 
     let html_visible = r#"<html><body>
@@ -190,7 +190,7 @@ fn test_overflow_x_only_renders() {
             <div style="width:300px;height:300px;background:purple"></div>
         </div>
     </body></html>"#;
-    let pdf_visible = engine.render_html(html_visible).unwrap();
+    let pdf_visible = engine.render(html_visible).unwrap();
     assert_ne!(
         pdf, pdf_visible,
         "overflow-x:hidden should emit a clip path different from default"
@@ -218,7 +218,7 @@ fn test_overflow_hidden_page_spanning_clip() {
             <div style="width:200pt;height:80pt;background:purple"></div>
         </div>
     </body></html>"#;
-    let pdf_hidden = engine.render_html(html_hidden).unwrap();
+    let pdf_hidden = engine.render(html_hidden).unwrap();
     assert!(pdf_hidden.starts_with(b"%PDF"));
 
     // Count pages using /Type /Page (exclude /Type /Pages)
@@ -251,7 +251,7 @@ fn test_overflow_hidden_page_spanning_clip() {
             <div style="width:200pt;height:80pt;background:purple"></div>
         </div>
     </body></html>"#;
-    let pdf_visible = engine.render_html(html_visible).unwrap();
+    let pdf_visible = engine.render(html_visible).unwrap();
 
     assert_ne!(
         pdf_hidden, pdf_visible,

--- a/crates/fulgur/tests/svg_test.rs
+++ b/crates/fulgur/tests/svg_test.rs
@@ -17,13 +17,13 @@ fn test_inline_svg_renders_to_pdf() {
         </svg>
     </body></html>"#;
 
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"), "output should be a PDF");
     assert!(!pdf.is_empty());
 
     // A page that successfully drew the SVG is larger than an empty page:
     let empty_html = r#"<html><body></body></html>"#;
-    let empty_pdf = engine.render_html(empty_html).unwrap();
+    let empty_pdf = engine.render(empty_html).unwrap();
     assert!(
         pdf.len() > empty_pdf.len(),
         "PDF with SVG ({} bytes) must be larger than empty PDF ({} bytes)",
@@ -48,8 +48,8 @@ fn test_svg_with_border_and_padding_renders() {
         </svg>
     </body></html>"#;
 
-    let styled_pdf = engine.render_html(styled_html).unwrap();
-    let plain_pdf = engine.render_html(plain_html).unwrap();
+    let styled_pdf = engine.render(styled_html).unwrap();
+    let plain_pdf = engine.render(plain_html).unwrap();
 
     assert!(styled_pdf.starts_with(b"%PDF"));
     assert!(plain_pdf.starts_with(b"%PDF"));
@@ -79,7 +79,7 @@ fn test_multiple_svgs_on_same_page() {
         </svg>
     </body></html>"#;
 
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
 
     // Two SVGs should produce a larger PDF than one
@@ -88,7 +88,7 @@ fn test_multiple_svgs_on_same_page() {
             <circle cx="25" cy="25" r="20" fill="red"/>
         </svg>
     </body></html>"#;
-    let single_pdf = engine.render_html(single_html).unwrap();
+    let single_pdf = engine.render(single_html).unwrap();
     assert!(
         pdf.len() > single_pdf.len(),
         "PDF with 2 SVGs ({} bytes) should exceed PDF with 1 SVG ({} bytes)",
@@ -110,7 +110,7 @@ fn test_svg_does_not_split_across_pages() {
         </svg>
     </body></html>"#;
 
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     // PDF should contain at least 2 pages.
     assert!(
@@ -130,7 +130,7 @@ fn test_svg_with_parent_opacity() {
         </div>
     </body></html>"#;
 
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     // Smoke test: opacity propagation should not panic and should emit a valid PDF.
     // Byte-level opacity detection is fragile; the main goal here is to exercise
@@ -152,8 +152,8 @@ fn test_svg_with_visibility_hidden_is_skipped() {
         </svg>
     </body></html>"#;
 
-    let visible_pdf = engine.render_html(visible_html).unwrap();
-    let hidden_pdf = engine.render_html(hidden_html).unwrap();
+    let visible_pdf = engine.render(visible_html).unwrap();
+    let hidden_pdf = engine.render(hidden_html).unwrap();
     assert!(visible_pdf.starts_with(b"%PDF"));
     assert!(hidden_pdf.starts_with(b"%PDF"));
 

--- a/crates/fulgur/tests/table_header_test.rs
+++ b/crates/fulgur/tests/table_header_test.rs
@@ -2,7 +2,7 @@ use fulgur::{Engine, PageSize};
 
 fn render(html: &str) -> Vec<u8> {
     let engine = Engine::builder().page_size(PageSize::A4).build();
-    engine.render_html(html).expect("render should succeed")
+    engine.render(html).expect("render should succeed")
 }
 
 #[test]

--- a/crates/fulgur/tests/template_integration.rs
+++ b/crates/fulgur/tests/template_integration.rs
@@ -26,7 +26,7 @@ fn test_template_to_pdf() {
 #[test]
 fn test_html_mode_still_works() {
     let html = "<html><body><p>Hello</p></body></html>";
-    let pdf = Engine::builder().build().render_html(html).unwrap();
+    let pdf = Engine::builder().build().render(html).unwrap();
     assert!(!pdf.is_empty());
     assert!(pdf.starts_with(b"%PDF-"));
 }

--- a/crates/fulgur/tests/template_integration.rs
+++ b/crates/fulgur/tests/template_integration.rs
@@ -15,7 +15,7 @@ fn test_template_to_pdf() {
         .template("invoice.html", template)
         .data(data)
         .build()
-        .render()
+        .render_template()
         .unwrap();
 
     assert!(!pdf.is_empty());
@@ -37,14 +37,14 @@ fn test_template_syntax_error_propagates() {
         .template("bad.html", "{% if %}")
         .data(json!({}))
         .build()
-        .render();
+        .render_template();
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("Template error"));
 }
 
 #[test]
 fn test_render_without_template_errors() {
-    let result = Engine::builder().build().render();
+    let result = Engine::builder().build().render_template();
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("no template set"));
 }
@@ -55,7 +55,7 @@ fn test_invalid_filter_propagates() {
         .template("test.html", "{{ x | bogus }}")
         .data(json!({"x": 1}))
         .build()
-        .render();
+        .render_template();
     assert!(result.is_err());
 }
 
@@ -72,7 +72,7 @@ fn test_template_with_assets() {
         .data(data)
         .assets(assets)
         .build()
-        .render()
+        .render_template()
         .unwrap();
 
     assert!(!pdf.is_empty());

--- a/crates/fulgur/tests/text_decoration_test.rs
+++ b/crates/fulgur/tests/text_decoration_test.rs
@@ -9,7 +9,7 @@ fn make_engine() -> Engine {
 fn text_decoration_underline_renders() {
     let engine = make_engine();
     let html = r#"<p style="text-decoration: underline">underlined text</p>"#;
-    let pdf = engine.render_html(html).expect("render should succeed");
+    let pdf = engine.render(html).expect("render should succeed");
     assert!(!pdf.is_empty(), "PDF should not be empty");
 }
 
@@ -17,7 +17,7 @@ fn text_decoration_underline_renders() {
 fn text_decoration_line_through_renders() {
     let engine = make_engine();
     let html = r#"<p style="text-decoration: line-through">struck text</p>"#;
-    let pdf = engine.render_html(html).expect("render should succeed");
+    let pdf = engine.render(html).expect("render should succeed");
     assert!(!pdf.is_empty(), "PDF should not be empty");
 }
 
@@ -25,7 +25,7 @@ fn text_decoration_line_through_renders() {
 fn text_decoration_overline_renders() {
     let engine = make_engine();
     let html = r#"<p style="text-decoration: overline">overlined text</p>"#;
-    let pdf = engine.render_html(html).expect("render should succeed");
+    let pdf = engine.render(html).expect("render should succeed");
     assert!(!pdf.is_empty(), "PDF should not be empty");
 }
 
@@ -33,7 +33,7 @@ fn text_decoration_overline_renders() {
 fn text_decoration_combined_renders() {
     let engine = make_engine();
     let html = r#"<p style="text-decoration: underline line-through">both</p>"#;
-    let pdf = engine.render_html(html).expect("render should succeed");
+    let pdf = engine.render(html).expect("render should succeed");
     assert!(!pdf.is_empty(), "PDF should not be empty");
 }
 
@@ -41,7 +41,7 @@ fn text_decoration_combined_renders() {
 fn text_decoration_color_renders() {
     let engine = make_engine();
     let html = r#"<p style="text-decoration: underline; text-decoration-color: red">colored underline</p>"#;
-    let pdf = engine.render_html(html).expect("render should succeed");
+    let pdf = engine.render(html).expect("render should succeed");
     assert!(!pdf.is_empty(), "PDF should not be empty");
 }
 
@@ -53,7 +53,7 @@ fn text_decoration_styles_render() {
             r#"<p style="text-decoration: underline; text-decoration-style: {style}">styled</p>"#
         );
         let pdf = engine
-            .render_html(&html)
+            .render(&html)
             .unwrap_or_else(|_| panic!("render with style={style} should succeed"));
         assert!(
             !pdf.is_empty(),

--- a/crates/fulgur/tests/text_test.rs
+++ b/crates/fulgur/tests/text_test.rs
@@ -9,7 +9,7 @@ fn test_render_html_with_text() {
         .build();
 
     let html = "<html><body><h1>Hello World</h1><p>This is fulgur.</p></body></html>";
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
     // PDF should be larger than empty doc due to font embedding
     assert!(pdf.len() > 1000);
@@ -27,6 +27,6 @@ fn test_render_multiline_text() {
         <p>Line two of the paragraph.</p>
         <p>Line three of the paragraph.</p>
     </body></html>"#;
-    let pdf = engine.render_html(html).unwrap();
+    let pdf = engine.render(html).unwrap();
     assert!(pdf.starts_with(b"%PDF"));
 }

--- a/crates/fulgur/tests/transform_integration.rs
+++ b/crates/fulgur/tests/transform_integration.rs
@@ -208,7 +208,7 @@ fn transformed_element_produces_expected_pagination() {
         })
         .margin(Margin::uniform(10.0))
         .build();
-    let pdf = engine.render_html(html).expect("render should succeed");
+    let pdf = engine.render(html).expect("render should succeed");
     assert!(pdf.starts_with(b"%PDF-"), "PDF header missing");
 
     // Count `/Type /Page` occurrences, excluding `/Type /Pages`. Match the

--- a/crates/fulgur/tests/unit_semantics.rs
+++ b/crates/fulgur/tests/unit_semantics.rs
@@ -9,7 +9,7 @@ fn width_percent_renders() {
     let html =
         r#"<html><body><div style="width:100%;height:10pt;background:red"></div></body></html>"#;
     let engine = Engine::builder().build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert!(pdf.len() > 100);
 }
 
@@ -18,7 +18,7 @@ fn width_cm_renders() {
     let html =
         r#"<html><body><div style="width:10cm;height:1cm;background:red"></div></body></html>"#;
     let engine = Engine::builder().build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert!(pdf.len() > 100);
 }
 
@@ -27,6 +27,6 @@ fn width_px_renders() {
     let html =
         r#"<html><body><div style="width:360px;height:10px;background:red"></div></body></html>"#;
     let engine = Engine::builder().build();
-    let pdf = engine.render_html(html).expect("render");
+    let pdf = engine.render(html).expect("render");
     assert!(pdf.len() > 100);
 }

--- a/crates/fulgur/tests/v2_table_overflow_clip.rs
+++ b/crates/fulgur/tests/v2_table_overflow_clip.rs
@@ -24,7 +24,7 @@ fn v2_overflow_hidden_table_inside_transform_keeps_clip() {
             </table>
         </div>
     </body></html>"#;
-    let pdf_hidden = engine.render_html(html_hidden).expect("render v2");
+    let pdf_hidden = engine.render(html_hidden).expect("render v2");
     assert!(pdf_hidden.starts_with(b"%PDF"));
 
     let html_visible = r#"<html><body>
@@ -34,7 +34,7 @@ fn v2_overflow_hidden_table_inside_transform_keeps_clip() {
             </table>
         </div>
     </body></html>"#;
-    let pdf_visible = engine.render_html(html_visible).expect("render v2");
+    let pdf_visible = engine.render(html_visible).expect("render v2");
 
     assert_ne!(
         pdf_hidden, pdf_visible,
@@ -56,7 +56,7 @@ fn v2_table_clip_with_inner_cell_clip_keeps_inner_boundary() {
             </td></tr>
         </table>
     </body></html>"#;
-    let pdf_inner_hidden = engine.render_html(html_inner_hidden).expect("render v2");
+    let pdf_inner_hidden = engine.render(html_inner_hidden).expect("render v2");
     assert!(pdf_inner_hidden.starts_with(b"%PDF"));
 
     let html_inner_visible = r#"<html><body>
@@ -66,7 +66,7 @@ fn v2_table_clip_with_inner_cell_clip_keeps_inner_boundary() {
             </td></tr>
         </table>
     </body></html>"#;
-    let pdf_inner_visible = engine.render_html(html_inner_visible).expect("render v2");
+    let pdf_inner_visible = engine.render(html_inner_visible).expect("render v2");
 
     assert_ne!(
         pdf_inner_hidden, pdf_inner_visible,

--- a/crates/fulgur/tests/woff2_integration.rs
+++ b/crates/fulgur/tests/woff2_integration.rs
@@ -20,7 +20,7 @@ fn woff2_font_renders_to_pdf() {
         <p>Hello — WOFF2 fixture rendering via AssetBundle.</p>
     </body></html>"#;
 
-    let pdf = engine.render_html(html).expect("PDF render must succeed");
+    let pdf = engine.render(html).expect("PDF render must succeed");
     assert!(
         pdf.starts_with(b"%PDF"),
         "output must start with %PDF magic"

--- a/crates/pyfulgur/src/engine.rs
+++ b/crates/pyfulgur/src/engine.rs
@@ -204,7 +204,7 @@ impl PyEngineBuilder {
 ///     ```python
 ///     from pyfulgur import Engine, PageSize
 ///     engine = Engine(page_size=PageSize.A4, title="Hello")
-///     engine.render_html_to_file("<h1>Hi</h1>", "out.pdf")
+///     engine.render_file("<h1>Hi</h1>", "out.pdf")
 ///     ```
 #[pyclass(name = "Engine", module = "pyfulgur")]
 pub struct PyEngine {
@@ -305,7 +305,7 @@ impl PyEngine {
         // assert_impl_all! で compile time に検査している。Python スレッドから
         // 並列で render できるよう、GIL を解放してから呼ぶ。
         let bytes = py
-            .detach(|| self.inner.render_html(&html))
+            .detach(|| self.inner.render(&html))
             .map_err(crate::error::map_fulgur_error)?;
         Ok(PyBytes::new(py, &bytes))
     }
@@ -322,7 +322,7 @@ impl PyEngine {
     ///     RenderError: When rendering or writing fails.
     ///     FileNotFoundError: When the parent directory does not exist.
     fn render_html_to_file(&self, py: Python<'_>, html: String, path: PathBuf) -> PyResult<()> {
-        py.detach(|| self.inner.render_html_to_file(&html, &path))
+        py.detach(|| self.inner.render_file(&html, &path))
             .map_err(crate::error::map_fulgur_error)
     }
 }

--- a/crates/pyfulgur/src/engine.rs
+++ b/crates/pyfulgur/src/engine.rs
@@ -204,7 +204,7 @@ impl PyEngineBuilder {
 ///     ```python
 ///     from pyfulgur import Engine, PageSize
 ///     engine = Engine(page_size=PageSize.A4, title="Hello")
-///     engine.render_file("<h1>Hi</h1>", "out.pdf")
+///     engine.render_html_to_file("<h1>Hi</h1>", "out.pdf")
 ///     ```
 #[pyclass(name = "Engine", module = "pyfulgur")]
 pub struct PyEngine {


### PR DESCRIPTION
## 概要

`Engine` の公開 API を出力フォーマットに即した名前に整理しました。

- `render_html(&str)` → `render(&str)` — HTML→PDF のメインメソッド
- `render_html_to_file(html, path)` → `render_file(html, path)`
- `render()` (テンプレート用) → `render_template()`

旧名は `#[deprecated(since = "0.19.0")]` のデリゲートとして残してあります。外部ユーザー（crab-js 等）は既存コードのままビルドが通り、コンパイラの deprecated 警告で移行を促す形です。

## 変更内容

- `crates/fulgur/src/engine.rs` — 新メソッド名に改名、旧名を deprecated スタブとして追加
- `crates/fulgur-cli/src/main.rs` — `render_template()` / `render()` に更新
- `crates/fulgur/tests/`, `crates/fulgur-*/` — ワークスペース全体 (54 ファイル、376 箇所) を一括更新
- エラーメッセージ・`.expect()` 文字列・doc comment の旧名参照も修正

Ruby / Python バインディングは公開 API 側の識別子として `render_html` を維持しています（バインディング層の deprecation は別 PR）。

## テスト計画

- [x] `cargo test -p fulgur --lib` — 1450 tests passed
- [x] `cargo build --workspace` — エラー 0、deprecated 警告 0
- [x] `cargo clippy -p fulgur` — エラーなし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTML から PDF を生成する呼び出し方法が整理され、テンプレート処理と通常の HTML レンダリングを使い分けられるようになりました。
  * ファイル出力や各種バインディングでも、新しいレンダリング呼び出しに対応しました。

* **Bug Fixes**
  * レンダリング経路とエラーメッセージが統一され、PDF生成時の挙動がより一貫して扱えるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->