### PR TITLE
test(gcpm/running): add coverage for escape_attribute_value and Default impl

### DIFF
--- a/crates/fulgur/src/gcpm/running.rs
+++ b/crates/fulgur/src/gcpm/running.rs
@@ -180,4 +180,62 @@ mod tests {
         assert!(store.get_html(999).is_none());
         assert!(store.name_of(999).is_none());
     }
+
+    #[test]
+    fn default_gives_empty_store() {
+        let store = RunningElementStore::default();
+        assert_eq!(store.instance_count(), 0);
+        assert_eq!(store.instance_for_node(0), None);
+    }
+
+    #[test]
+    fn instance_count_tracks_registrations() {
+        let mut store = RunningElementStore::new();
+        assert_eq!(store.instance_count(), 0);
+        store.register(1, "header".to_string(), "<h1>A</h1>".to_string());
+        assert_eq!(store.instance_count(), 1);
+        store.register(2, "header".to_string(), "<h1>B</h1>".to_string());
+        assert_eq!(store.instance_count(), 2);
+    }
+
+    // --- escape_attribute_value ---
+
+    fn escape(s: &str) -> String {
+        let mut out = String::new();
+        escape_attribute_value(s, &mut out);
+        out
+    }
+
+    #[test]
+    fn escape_attribute_value_ampersand() {
+        assert_eq!(escape("a&b"), "a&amp;b");
+        assert_eq!(escape("&&"), "&amp;&amp;");
+    }
+
+    #[test]
+    fn escape_attribute_value_double_quote() {
+        assert_eq!(escape("say \"hi\""), "say &quot;hi&quot;");
+    }
+
+    #[test]
+    fn escape_attribute_value_angle_brackets() {
+        assert_eq!(escape("a<b>c"), "a&lt;b&gt;c");
+        assert_eq!(escape("<>"), "&lt;&gt;");
+    }
+
+    #[test]
+    fn escape_attribute_value_passthrough_regular_chars() {
+        assert_eq!(escape("hello world!"), "hello world!");
+        assert_eq!(escape("abc123"), "abc123");
+    }
+
+    #[test]
+    fn escape_attribute_value_empty() {
+        assert_eq!(escape(""), "");
+    }
+
+    #[test]
+    fn escape_attribute_value_all_specials_combined() {
+        assert_eq!(escape("&\"<>"), "&amp;&quot;&lt;&gt;");
+    }
 }


### PR DESCRIPTION
## 対象モジュール

`crates/fulgur/src/gcpm/running.rs` — CSS Generated Content for Paged Media の running element 管理モジュール。

## カバレッジ改善

| 指標 | 変更前 | 変更後 |
|------|--------|--------|
| Regions | 91.28% | 98.19% |
| Lines | 89.00% | 94.96% |

## 追加テスト一覧

| テスト名 | カバーする挙動 |
|----------|---------------|
| `escape_attribute_value_ampersand` | `&` → `&amp;` への変換（単体・連続） |
| `escape_attribute_value_double_quote` | `"` → `&quot;` への変換 |
| `escape_attribute_value_angle_brackets` | `<` → `&lt;`、`>` → `&gt;` への変換 |
| `escape_attribute_value_passthrough_regular_chars` | 特殊文字を含まない入力はそのまま通過 |
| `escape_attribute_value_empty` | 空文字入力でパニックしない・空出力 |
| `escape_attribute_value_all_specials_combined` | 4種の特殊文字を含む文字列を一括エスケープ |
| `default_gives_empty_store` | `Default` トレイト実装が `new()` と同等の空ストアを返す |
| `instance_count_tracks_registrations` | `register()` を呼ぶたびに `instance_count()` が増加する |

## 意図的に外したブランチと理由

- `serialize_node` / `write_node` の `depth >= MAX_DOM_DEPTH` ガード — `blitz_dom::BaseDocument` を構築する必要があり、Blitz API を経由しないと DOM ノードが生成できない。このルーティンはテスト専用であるため、Blitz を起動するエンドツーエンドテストは追加しなかった。
- `write_node` の `_ => { // Document, Comment, AnonymousBlock }` アーム — 同上の理由で Blitz DOM が必要。

## 変更範囲

テストのみ。プロダクションコードへの変更なし。

---
_Generated by [Claude Code](https://claude.ai/code/session_016BvtV9PZvCE4UASQFosYci)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 属性値のエスケープ処理について、`&`、引用符、`<`/`>`、空文字、通常文字などのケースを追加で確認するテストを拡充しました。
  * 初期状態やインスタンス数の追跡に関する動作を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->