### PR TITLE
feat(engine): add render_batch; optional rayon parallel feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
       - name: Run tests with coverage
         if: matrix.coverage
         run: |
+          cargo llvm-cov clean --workspace
           cargo llvm-cov nextest --workspace --exclude fulgur-vrt --profile ci --no-report
           cargo llvm-cov nextest --workspace --exclude fulgur-vrt --features fulgur/parallel --profile ci --no-report
           cargo llvm-cov report --lcov --output-path lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         run: cargo nextest run --workspace --exclude fulgur-vrt
       - name: Run tests with coverage
         if: matrix.coverage
-        run: cargo llvm-cov nextest --workspace --exclude fulgur-vrt --profile ci --lcov --output-path lcov.info
+        run: cargo llvm-cov nextest --workspace --exclude fulgur-vrt --features fulgur/parallel --profile ci --lcov --output-path lcov.info
       - name: Upload coverage artifact
         if: matrix.coverage
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,10 @@ jobs:
         run: cargo nextest run --workspace --exclude fulgur-vrt
       - name: Run tests with coverage
         if: matrix.coverage
-        run: cargo llvm-cov nextest --workspace --exclude fulgur-vrt --features fulgur/parallel --profile ci --lcov --output-path lcov.info
+        run: |
+          cargo llvm-cov nextest --workspace --exclude fulgur-vrt --profile ci --no-report
+          cargo llvm-cov nextest --workspace --exclude fulgur-vrt --features fulgur/parallel --profile ci --no-report
+          cargo llvm-cov report --lcov --output-path lcov.info
       - name: Upload coverage artifact
         if: matrix.coverage
         uses: actions/upload-artifact@v7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,6 +1118,7 @@ dependencies = [
  "lopdf",
  "minijinja",
  "parley",
+ "rayon",
  "serde",
  "serde_json",
  "skrifa 0.42.1",

--- a/crates/fulgur/Cargo.toml
+++ b/crates/fulgur/Cargo.toml
@@ -11,7 +11,12 @@ readme = "../../README.md"
 keywords = ["pdf", "html", "css", "converter"]
 categories = ["text-processing", "command-line-utilities"]
 
+[features]
+## Enable rayon-based thread parallelism in `Engine::render_batch`.
+parallel = ["dep:rayon"]
+
 [dependencies]
+rayon = { version = "1", optional = true }
 cssparser = "0.37"
 krilla = "0.7.0"
 krilla-svg = "0.7.0"

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -18,6 +18,11 @@ pub struct Engine {
     system_fonts: bool,
 }
 
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<Engine>();
+};
+
 /// Result of a single render pass.
 ///
 /// - `pdf`: serialized PDF bytes for this pass.
@@ -631,6 +636,23 @@ impl Engine {
             .map_or_else(|| serde_json::json!({}), Clone::clone);
         let html = crate::template::render_template(name, content, &data)?;
         self.render(&html)
+    }
+
+    /// Render multiple HTML strings to PDFs, sharing this engine's parsed fonts.
+    ///
+    /// Returns one `Result<Vec<u8>>` per input in the same order. A failure in one
+    /// item does not abort the rest. With the `parallel` feature enabled the items
+    /// are processed concurrently via rayon; without it they run sequentially.
+    pub fn render_batch<S: AsRef<str> + Sync>(&self, htmls: &[S]) -> Vec<Result<Vec<u8>>> {
+        #[cfg(feature = "parallel")]
+        {
+            use rayon::prelude::*;
+            htmls.par_iter().map(|h| self.render(h.as_ref())).collect()
+        }
+        #[cfg(not(feature = "parallel"))]
+        {
+            htmls.iter().map(|h| self.render(h.as_ref())).collect()
+        }
     }
 
     /// Renamed to [`render`](Engine::render).

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -640,9 +640,13 @@ impl Engine {
 
     /// Render multiple HTML strings to PDFs, sharing this engine's parsed fonts.
     ///
-    /// Returns one `Result<Vec<u8>>` per input in the same order. A failure in one
-    /// item does not abort the rest. With the `parallel` feature enabled the items
-    /// are processed concurrently via rayon; without it they run sequentially.
+    /// Returns one `Result<Vec<u8>>` per input in the same order as the input
+    /// slice. A failure in one item does not abort the rest.
+    ///
+    /// With the `parallel` feature enabled the items are processed concurrently
+    /// via rayon's global thread pool. Callers managing many concurrent batches
+    /// should consider [`rayon::ThreadPoolBuilder`] to bound concurrency.
+    /// Without the feature items run sequentially.
     pub fn render_batch<S: AsRef<str> + Sync>(&self, htmls: &[S]) -> Vec<Result<Vec<u8>>> {
         #[cfg(feature = "parallel")]
         {

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -18,11 +18,6 @@ pub struct Engine {
     system_fonts: bool,
 }
 
-const _: fn() = || {
-    fn assert_send_sync<T: Send + Sync>() {}
-    assert_send_sync::<Engine>();
-};
-
 /// Result of a single render pass.
 ///
 /// - `pdf`: serialized PDF bytes for this pass.

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -4694,6 +4694,22 @@ fn multicol_column_rule_renders() {
     assert!(!pdf.is_empty());
 }
 
+/// fulgur-5biq: Engine is Send + Sync — can be shared across threads.
+///
+/// If `Engine` ever stops being `Send + Sync` this test will fail to compile.
+#[test]
+fn engine_is_send_and_sync() {
+    let engine = fulgur::Engine::builder().build();
+    std::thread::scope(|s| {
+        s.spawn(|| {
+            let pdf = engine
+                .render("<!doctype html><html><body><p>ok</p></body></html>")
+                .expect("render in spawned thread");
+            assert!(pdf.starts_with(b"%PDF"));
+        });
+    });
+}
+
 /// fulgur-5biq: render_batch returns one valid PDF per input.
 ///
 /// Output length equals input length and each element is a valid PDF.

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -4693,3 +4693,22 @@ fn multicol_column_rule_renders() {
         .expect("render multicol column-rule");
     assert!(!pdf.is_empty());
 }
+
+/// fulgur-5biq: render_batch returns one result per input in order, all valid PDFs.
+#[test]
+fn render_batch_returns_ordered_results() {
+    let htmls = [
+        r#"<!doctype html><html><body><p>first</p></body></html>"#,
+        r#"<!doctype html><html><body><p>second</p></body></html>"#,
+        r#"<!doctype html><html><body><p>third</p></body></html>"#,
+    ];
+    let results = Engine::builder().build().render_batch(&htmls);
+    assert_eq!(results.len(), htmls.len());
+    for (i, result) in results.iter().enumerate() {
+        let pdf = result
+            .as_ref()
+            .unwrap_or_else(|e| panic!("item {i} failed: {e}"));
+        assert!(!pdf.is_empty(), "item {i} produced empty PDF");
+        assert!(pdf.starts_with(b"%PDF"), "item {i} not a PDF");
+    }
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -4694,9 +4694,13 @@ fn multicol_column_rule_renders() {
     assert!(!pdf.is_empty());
 }
 
-/// fulgur-5biq: render_batch returns one result per input in order, all valid PDFs.
+/// fulgur-5biq: render_batch returns one valid PDF per input.
+///
+/// Output length equals input length and each element is a valid PDF.
+/// Ordering is guaranteed by rayon's `IndexedParallelIterator`: `par_iter()`
+/// on a slice is indexed, so `.collect::<Vec<_>>()` preserves the original order.
 #[test]
-fn render_batch_returns_ordered_results() {
+fn render_batch_returns_one_pdf_per_input() {
     let htmls = [
         r#"<!doctype html><html><body><p>first</p></body></html>"#,
         r#"<!doctype html><html><body><p>second</p></body></html>"#,
@@ -4711,4 +4715,30 @@ fn render_batch_returns_ordered_results() {
         assert!(!pdf.is_empty(), "item {i} produced empty PDF");
         assert!(pdf.starts_with(b"%PDF"), "item {i} not a PDF");
     }
+}
+
+/// fulgur-5biq: a failing item in render_batch does not abort its siblings.
+/// pdf_ua(true) without a document title reliably triggers Err (NoDocumentTitle).
+/// A batch mixing titled and untitled HTML must return Ok for the titled item
+/// even when adjacent items fail.
+#[test]
+fn render_batch_failure_does_not_abort_siblings() {
+    let engine = Engine::builder().pdf_ua(true).lang("en").build();
+    // item 0: no <title> → Err (NoDocumentTitle)
+    // item 1: has <title>  → Ok
+    // item 2: no <title> → Err
+    let htmls = [
+        "<!doctype html><html lang=\"en\"><body><h1>no title</h1></body></html>",
+        "<!doctype html><html lang=\"en\"><head><title>T</title></head><body><h1>Heading</h1><p>ok</p></body></html>",
+        "<!doctype html><html lang=\"en\"><body><h1>no title either</h1></body></html>",
+    ];
+    let results = engine.render_batch(&htmls);
+    assert_eq!(results.len(), 3);
+    assert!(results[0].is_err(), "item 0 (no title) should fail");
+    assert!(
+        results[1].is_ok(),
+        "item 1 (has title) should succeed, got: {:?}",
+        results[1]
+    );
+    assert!(results[2].is_err(), "item 2 (no title) should fail");
 }


### PR DESCRIPTION
## Summary

- `Engine::render_batch<S: AsRef<str> + Sync>(&self, &[S]) -> Vec<Result<Vec<u8>>>` を追加
- `[features] parallel = ["dep:rayon"]` を新設。有効化すると rayon で並列処理
- `Engine: Send + Sync` を静的アサーション (`const _: fn() = ...`) で保証
- smoke test `render_batch_returns_ordered_results` で順序保持・全件 PDF 出力を検証

## Background

kagutsuchi（OCR 訓練データパイプライン）は HTML → PDF を逐次処理する際に毎回 `Engine::builder().build()` を呼び、フォント解析を繰り返している。`render_batch` により Engine（フォント解析済み）を N 件で共有し、セットアップコストを償却できる。

## Test Plan

- [x] `cargo test -p fulgur --test render_smoke render_batch`（sequential モード）
- [x] `cargo build -p fulgur --features parallel`（rayon feature ビルド確認）
- [x] `cargo fmt --check --all`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 複数のHTMLをまとめてPDFに変換するバッチ処理（入力ごとに個別結果を返す）を追加しました。
  * `parallel` 機能により、対応環境ではバッチ処理を並列実行して高速化できます。
* **Tests**
  * 入力数に応じて結果が返り、各PDFが正しく生成されることを確認するテストを追加しました。
  * 途中で失敗が発生しても、他の入力の結果収集が中断されないことを検証するテストを追加しました。
* **Chores**
  * カバレッジ生成手順を改善し、レポート出力を確実にしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->