### PR TITLE
refactor(multicol): type multicol/column geometry with units::Px/Pt (fulgur-2map.6 / P1d)

### DIFF
--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -5126,7 +5126,7 @@ mod tests {
         // inline `column-rule` beats the stylesheet's rule declaration.
         let b_props = table.get(&b).expect("b in table");
         let b_rule = b_props.rule.expect("b rule");
-        assert!((b_rule.width - 2.0).abs() < 1e-3);
+        assert!((b_rule.width.to_f32() - 2.0).abs() < 1e-3);
         assert_eq!(b_rule.style, crate::column_css::ColumnRuleStyle::Dashed);
         assert_eq!(b_rule.color, [255, 0, 0, 255]); // inline red beats stylesheet blue
         // Inline `column-rule` overrides only the rule field — `column-fill`

--- a/crates/fulgur/src/column_css.rs
+++ b/crates/fulgur/src/column_css.rs
@@ -46,6 +46,7 @@ use cssparser::{
 };
 
 use crate::draw_primitives::{BreakAfter, BreakBefore, BreakInside};
+use crate::units::F32Units;
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -68,7 +69,7 @@ pub enum ColumnRuleStyle {
 /// A fully-resolved `column-rule` specification. Width is in PDF points.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ColumnRuleSpec {
-    pub width: f32,
+    pub width: crate::units::Pt,
     pub style: ColumnRuleStyle,
     /// RGBA colour, matching the `[u8; 4]` convention used by
     /// `paragraph::TextRun` and `draw_primitives::BlockStyle::border_color`.
@@ -78,7 +79,7 @@ pub struct ColumnRuleSpec {
 impl Default for ColumnRuleSpec {
     fn default() -> Self {
         Self {
-            width: 1.0,
+            width: 1.0_f32.pt(),
             style: ColumnRuleStyle::None,
             color: [0, 0, 0, 255],
         }
@@ -567,7 +568,7 @@ impl<'i, 'a> DeclarationParser<'i> for ColumnDeclParser<'a> {
         } else if name.eq_ignore_ascii_case("column-rule-width") {
             if let Ok(w) = input.parse_entirely(parse_length) {
                 let mut spec = self.props.rule.unwrap_or_default();
-                spec.width = w;
+                spec.width = w.pt();
                 self.props.rule = Some(spec);
             }
         } else if name.eq_ignore_ascii_case("column-rule-style") {
@@ -706,7 +707,7 @@ fn parse_column_rule_shorthand(input: &mut Parser<'_, '_>) -> Option<ColumnRuleS
 
     let mut spec = ColumnRuleSpec::default();
     if let Some(w) = width {
-        spec.width = w;
+        spec.width = w.pt();
     }
     if let Some(s) = style {
         spec.style = s;
@@ -1040,7 +1041,7 @@ mod tests {
         let css = "column-rule-width: 2pt; column-rule-style: solid; column-rule-color: red;";
         let props = parse_declaration_block(css);
         let rule = props.rule.expect("rule");
-        assert!((rule.width - 2.0).abs() < 1e-3);
+        assert!((rule.width.to_f32() - 2.0).abs() < 1e-3);
         assert_eq!(rule.style, ColumnRuleStyle::Solid);
         assert_eq!(rule.color, [255, 0, 0, 255]);
     }
@@ -1049,7 +1050,7 @@ mod tests {
     fn parses_column_rule_shorthand() {
         let props = parse_declaration_block("column-rule: 1px dashed #0a0;");
         let rule = props.rule.expect("rule");
-        assert!((rule.width - 0.75).abs() < 1e-2); // 1px → 0.75pt
+        assert!((rule.width.to_f32() - 0.75).abs() < 1e-2); // 1px → 0.75pt
         assert_eq!(rule.style, ColumnRuleStyle::Dashed);
         assert_eq!(rule.color, [0x00, 0xAA, 0x00, 0xFF]);
     }
@@ -1058,7 +1059,7 @@ mod tests {
     fn parses_column_rule_shorthand_any_order() {
         let props = parse_declaration_block("column-rule: red 3pt dotted;");
         let rule = props.rule.expect("rule");
-        assert!((rule.width - 3.0).abs() < 1e-3);
+        assert!((rule.width.to_f32() - 3.0).abs() < 1e-3);
         assert_eq!(rule.style, ColumnRuleStyle::Dotted);
         assert_eq!(rule.color, [255, 0, 0, 255]);
     }
@@ -1069,7 +1070,7 @@ mod tests {
         let rule = props.rule.expect("rule");
         assert_eq!(rule.style, ColumnRuleStyle::Dashed);
         // Defaults: 1pt, black.
-        assert!((rule.width - 1.0).abs() < 1e-3);
+        assert!((rule.width.to_f32() - 1.0).abs() < 1e-3);
         assert_eq!(rule.color, [0, 0, 0, 255]);
     }
 
@@ -1130,7 +1131,7 @@ mod tests {
     #[test]
     fn px_length_converts_to_pt() {
         let props = parse_declaration_block("column-rule-width: 4px;");
-        let w = props.rule.expect("rule").width;
+        let w = props.rule.expect("rule").width.to_f32();
         assert!((w - 3.0).abs() < 1e-3); // 4px * 72/96 = 3pt
     }
 
@@ -1140,9 +1141,9 @@ mod tests {
         let props = parse_declaration_block("column-rule-width: 1em;");
         let rule = props.rule.expect("rule");
         assert!(
-            (rule.width - 12.0).abs() < 1e-3,
+            (rule.width.to_f32() - 12.0).abs() < 1e-3,
             "1em expected 12pt (16px × 72/96), got {}",
-            rule.width
+            rule.width.to_f32()
         );
     }
 
@@ -1152,9 +1153,9 @@ mod tests {
         let props = parse_declaration_block("column-rule-width: 0.25rem;");
         let rule = props.rule.expect("rule");
         assert!(
-            (rule.width - 3.0).abs() < 1e-3,
+            (rule.width.to_f32() - 3.0).abs() < 1e-3,
             "0.25rem expected 3pt (4px × 72/96), got {}",
-            rule.width
+            rule.width.to_f32()
         );
     }
 
@@ -1164,9 +1165,9 @@ mod tests {
         let rule = props.rule.expect("rule");
         // 0.1em × 16 px × 72/96 = 1.2pt
         assert!(
-            (rule.width - 1.2).abs() < 1e-3,
+            (rule.width.to_f32() - 1.2).abs() < 1e-3,
             "0.1em expected 1.2pt, got {}",
-            rule.width
+            rule.width.to_f32()
         );
         assert_eq!(rule.style, ColumnRuleStyle::Solid);
         assert_eq!(rule.color, [255, 0, 0, 255]);
@@ -1184,7 +1185,7 @@ mod tests {
         let css = "column-rule-width: 5pt; column-rule-color: blue;";
         let props = parse_declaration_block(css);
         let rule = props.rule.expect("rule");
-        assert!((rule.width - 5.0).abs() < 1e-3);
+        assert!((rule.width.to_f32() - 5.0).abs() < 1e-3);
         assert_eq!(rule.color, [0, 0, 255, 255]);
         // No `column-rule-style` — default `None` applies.
         assert_eq!(rule.style, ColumnRuleStyle::None);
@@ -1482,7 +1483,7 @@ mod tests {
 
         let b = table.get(&b_id).expect("b entry");
         let b_rule = b.rule.expect("b rule");
-        assert!((b_rule.width - 2.0).abs() < 1e-3);
+        assert!((b_rule.width.to_f32() - 2.0).abs() < 1e-3);
         assert_eq!(b_rule.style, ColumnRuleStyle::Dashed);
         assert_eq!(b_rule.color, [255, 0, 0, 255]);
     }

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -674,17 +674,12 @@ fn record_multicol_rule(
         .groups
         .iter()
         .map(|g| crate::drawables::ColumnRuleGeometry {
-            x_offset: g.x_offset.px().in_pt(),
-            y_offset: g.y_offset.px().in_pt(),
-            col_w: g.col_w.px().in_pt(),
-            gap: g.gap.px().in_pt(),
+            x_offset: g.x_offset.in_pt(),
+            y_offset: g.y_offset.in_pt(),
+            col_w: g.col_w.in_pt(),
+            gap: g.gap.in_pt(),
             n: g.n,
-            col_heights: g
-                .col_heights
-                .iter()
-                .copied()
-                .map(|h| h.px().in_pt())
-                .collect(),
+            col_heights: g.col_heights.iter().copied().map(|h| h.in_pt()).collect(),
         })
         .collect();
     out.multicol_rules.insert(
@@ -740,9 +735,9 @@ fn convert_multicol_paragraph_slices(
         if group.paragraph_splits.is_empty() {
             continue;
         }
-        let group_x_pt = px_to_pt(group.x_offset);
-        let group_y_pt = px_to_pt(group.y_offset);
-        let col_w_pt = px_to_pt(group.col_w);
+        let group_x_pt = group.x_offset.in_pt().to_f32();
+        let group_y_pt = group.y_offset.in_pt().to_f32();
+        let col_w_pt = group.col_w.in_pt().to_f32();
 
         for split in &group.paragraph_splits {
             let source_id = split.source_node_id;
@@ -785,9 +780,9 @@ fn convert_multicol_paragraph_slices(
                     .map(|s| css_text_align_to_parley_alignment(s.clone_text_align()))
                     .unwrap_or(parley::Alignment::Start);
                 let mut cloned = text_layout.layout.clone();
-                cloned.break_all_lines(Some(group.col_w));
+                cloned.break_all_lines(Some(group.col_w.to_f32()));
                 cloned.align(
-                    Some(group.col_w),
+                    Some(group.col_w.to_f32()),
                     alignment,
                     parley::AlignmentOptions::default(),
                 );

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -660,7 +660,9 @@ fn record_multicol_rule(
         .column_styles
         .get(&node_id)
         .and_then(|props| props.rule)
-        .filter(|r| r.style != crate::column_css::ColumnRuleStyle::None && r.width > 0.0)
+        .filter(|r| {
+            r.style != crate::column_css::ColumnRuleStyle::None && r.width > crate::units::Pt::ZERO
+        })
     else {
         return;
     };

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -853,10 +853,10 @@ fn convert_multicol_paragraph_slices(
                 inline_root::recalculate_paragraph_line_boxes(&mut lines);
 
                 let origin_pt = (
-                    group_x_pt + px_to_pt(col_slice.origin.x),
-                    group_y_pt + px_to_pt(col_slice.origin.y),
+                    group_x_pt + col_slice.origin.x.in_pt().to_f32(),
+                    group_y_pt + col_slice.origin.y.in_pt().to_f32(),
                 );
-                let size_pt = (col_w_pt, px_to_pt(col_slice.size.height));
+                let size_pt = (col_w_pt, col_slice.size.height.in_pt().to_f32());
 
                 slices.push(crate::drawables::ParagraphSlice {
                     origin_pt,

--- a/crates/fulgur/src/multicol_layout.rs
+++ b/crates/fulgur/src/multicol_layout.rs
@@ -44,10 +44,10 @@ pub struct ColumnLineSlice {
     /// Slice top-left in CSS pixels, relative to the column group
     /// segment (matches `ColumnGroupGeometry::col_heights`'s frame).
     /// Zero for placeholder entries — gate on `line_range.is_empty()`.
-    pub origin: taffy::Point<f32>,
+    pub origin: taffy::Point<crate::units::Px>,
     /// Slice size — `col_w × Σ line_height(line_range)`. CSS pixels.
     /// Zero for placeholder entries.
-    pub size: taffy::Size<f32>,
+    pub size: taffy::Size<crate::units::Px>,
 }
 
 /// Plan for one paragraph distributed across `ColumnGroupGeometry`'s
@@ -944,10 +944,13 @@ fn layout_self_inline_root_container(
             // `compute_multicol_layout` would normally shift this into the
             // border-box frame in the post-loop fixup; here we apply the
             // shift ourselves on the geometry below before returning.
-            origin: Point { x: col_x, y: 0.0 },
+            origin: Point {
+                x: col_x.px(),
+                y: 0.0_f32.px(),
+            },
             size: Size {
-                width: col_w,
-                height: *slice_h,
+                width: col_w.px(),
+                height: (*slice_h).px(),
             },
         });
     }
@@ -1243,8 +1246,14 @@ fn layout_column_group(
                     // `y_offset`). The container-level border-box shift
                     // applied in `compute_multicol_layout` updates these
                     // alongside the rest of the geometry.
-                    origin: Point { x: col_x, y: col_y },
-                    size,
+                    origin: Point {
+                        x: col_x.px(),
+                        y: col_y.px(),
+                    },
+                    size: taffy::Size {
+                        width: size.width.px(),
+                        height: size.height.px(),
+                    },
                 });
             }
         }
@@ -1289,8 +1298,8 @@ fn layout_column_group(
     // Taffy storage).
     for slices in placed_slices.values() {
         for slice in slices.iter().skip(1) {
-            let idx = resolve_col_idx(slice.origin.x);
-            let bottom = slice.origin.y + slice.size.height;
+            let idx = resolve_col_idx(slice.origin.x.to_f32());
+            let bottom = (slice.origin.y + slice.size.height).to_f32();
             if bottom > col_heights[idx] {
                 col_heights[idx] = bottom;
             }
@@ -1314,7 +1323,7 @@ fn layout_column_group(
         .map(|(source_id, mut slices)| {
             let mut by_col: Vec<Option<ColumnLineSlice>> = (0..n).map(|_| None).collect();
             for slice in slices.drain(..) {
-                let idx = resolve_col_idx(slice.origin.x);
+                let idx = resolve_col_idx(slice.origin.x.to_f32());
                 by_col[idx] = Some(slice);
             }
             let column_slices: Vec<ColumnLineSlice> =

--- a/crates/fulgur/src/multicol_layout.rs
+++ b/crates/fulgur/src/multicol_layout.rs
@@ -14,6 +14,7 @@
 //! wired into Taffy via `compute_leaf_layout`; multicol uses the same
 //! mechanism one layer up.
 
+use crate::units::F32Units;
 use blitz_dom::BaseDocument;
 use std::collections::BTreeMap;
 use taffy::{
@@ -84,22 +85,22 @@ pub struct ParagraphSplitEntry {
 pub struct ColumnGroupGeometry {
     /// Horizontal offset from the container's border-box left to column 0's
     /// left edge. Equals the container's (padding-left + border-left).
-    pub x_offset: f32,
+    pub x_offset: crate::units::Px,
     /// Vertical offset from the container's border-box top to this group's
     /// top. Includes the container's (padding-top + border-top); subsequent
     /// groups accumulate prior segment heights on top of that.
-    pub y_offset: f32,
+    pub y_offset: crate::units::Px,
     /// Width of a single column, in CSS pixels.
-    pub col_w: f32,
+    pub col_w: crate::units::Px,
     /// Horizontal gap between adjacent columns, in CSS pixels.
-    pub gap: f32,
+    pub gap: crate::units::Px,
     /// Number of columns this group balances across.
     pub n: u32,
     /// Per-column filled height. `col_heights[i]` is the bottom-most
     /// placement's `(location.y + size.height)` minus `y_offset` for column
     /// `i`, clamped to `>= 0.0`. An entry of `0.0` means column `i` received
     /// no placements. Always has length == `n`.
-    pub col_heights: Vec<f32>,
+    pub col_heights: Vec<crate::units::Px>,
     /// Inline-root paragraphs distributed across the columns of this
     /// group. Empty when no child paragraph needed splitting.
     pub paragraph_splits: Vec<ParagraphSplitEntry>,
@@ -672,7 +673,12 @@ pub fn compute_multicol_layout(
                     cursor_y,
                     child_inputs,
                 );
-                let seg_h = geometry.col_heights.iter().copied().fold(0.0_f32, f32::max);
+                let seg_h = geometry
+                    .col_heights
+                    .iter()
+                    .copied()
+                    .map(crate::units::Px::to_f32)
+                    .fold(0.0_f32, f32::max);
                 placements.extend(group_placements);
                 group_geometries.push(geometry);
                 cursor_y += seg_h;
@@ -704,8 +710,8 @@ pub fn compute_multicol_layout(
     // border-box origin) can use `group.x_offset + col_x_math` and
     // `group.y_offset` directly without reapplying the container's padding.
     for group in group_geometries.iter_mut() {
-        group.x_offset = inset_left;
-        group.y_offset += inset_top;
+        group.x_offset = inset_left.px();
+        group.y_offset += inset_top.px();
     }
 
     // Stash the per-container geometry for downstream consumers (Task 4's
@@ -854,12 +860,16 @@ fn layout_self_inline_root_container(
             *first = original_h;
         }
         let geometry = ColumnGroupGeometry {
-            x_offset: inset_left,
-            y_offset: inset_top,
-            col_w,
-            gap,
+            x_offset: inset_left.px(),
+            y_offset: inset_top.px(),
+            col_w: col_w.px(),
+            gap: gap.px(),
             n,
-            col_heights,
+            col_heights: col_heights
+                .iter()
+                .copied()
+                .map(crate::units::F32Units::px)
+                .collect(),
             paragraph_splits: Vec::new(),
         };
         tree.geometry.insert(
@@ -963,12 +973,16 @@ fn layout_self_inline_root_container(
     //    (mirrors the post-loop shift that the segment path applies in
     //    `compute_multicol_layout`).
     let geometry = ColumnGroupGeometry {
-        x_offset: inset_left,
-        y_offset: inset_top,
-        col_w,
-        gap,
+        x_offset: inset_left.px(),
+        y_offset: inset_top.px(),
+        col_w: col_w.px(),
+        gap: gap.px(),
         n,
-        col_heights,
+        col_heights: col_heights
+            .iter()
+            .copied()
+            .map(crate::units::F32Units::px)
+            .collect(),
         paragraph_splits,
     };
 
@@ -1318,12 +1332,16 @@ fn layout_column_group(
         // frame; `compute_multicol_layout` shifts them into the border-box
         // frame after every segment is placed (see the inset loop that runs
         // over `group_geometries` in that function).
-        x_offset: 0.0,
-        y_offset,
-        col_w,
-        gap,
+        x_offset: 0.0_f32.px(),
+        y_offset: y_offset.px(),
+        col_w: col_w.px(),
+        gap: gap.px(),
         n,
-        col_heights,
+        col_heights: col_heights
+            .iter()
+            .copied()
+            .map(crate::units::F32Units::px)
+            .collect(),
         paragraph_splits,
     };
 
@@ -2874,7 +2892,7 @@ mod tests {
             "col_heights length must equal n"
         );
         assert!(
-            group.col_heights[0] > 0.0 && group.col_heights[1] > 0.0,
+            group.col_heights[0].to_f32() > 0.0 && group.col_heights[1].to_f32() > 0.0,
             "balance should populate both columns, got col_heights={:?}",
             group.col_heights
         );
@@ -2883,12 +2901,17 @@ mod tests {
         // (group.y_offset + tallest) should match the container's border-box
         // content bottom (container_h minus inset_bottom). Since this fixture
         // has no padding/border, y_offset == 0 and tallest == container_h.
-        let tallest = group.col_heights.iter().copied().fold(0.0_f32, f32::max);
+        let tallest = group
+            .col_heights
+            .iter()
+            .copied()
+            .map(crate::units::Px::to_f32)
+            .fold(0.0_f32, f32::max);
         let container_h = doc.get_unrounded_layout(mc_node_id).size.height;
         assert!(
-            (group.y_offset + tallest - container_h).abs() < 1.0,
+            (group.y_offset.to_f32() + tallest - container_h).abs() < 1.0,
             "group bottom ({}) should match container height ({})",
-            group.y_offset + tallest,
+            group.y_offset.to_f32() + tallest,
             container_h
         );
     }
@@ -2982,12 +3005,13 @@ mod tests {
         assert_eq!(group.n, 2);
         assert_eq!(group.col_heights.len(), 2);
         assert!(
-            group.col_heights[0] > 0.0,
+            group.col_heights[0].to_f32() > 0.0,
             "first column must contain the paragraph, got {:?}",
             group.col_heights
         );
         assert_eq!(
-            group.col_heights[1], 0.0,
+            group.col_heights[1].to_f32(),
+            0.0,
             "column-fill: auto must leave the second column empty when content fits in the first, got {:?}",
             group.col_heights
         );
@@ -3021,12 +3045,12 @@ mod tests {
 
         // Both columns must be filled.
         assert!(
-            group.col_heights[0] > 0.0,
+            group.col_heights[0].to_f32() > 0.0,
             "col 0 must be filled, got {:?}",
             group.col_heights
         );
         assert!(
-            group.col_heights[1] > 0.0,
+            group.col_heights[1].to_f32() > 0.0,
             "col 1 must be filled (the bug we're fixing), got {:?}",
             group.col_heights
         );
@@ -3113,12 +3137,12 @@ mod tests {
         // Both columns must end up with content (the long paragraph
         // straddles them after the atomic sibling fills part of col 0).
         assert!(
-            group.col_heights[0] > 0.0,
+            group.col_heights[0].to_f32() > 0.0,
             "col 0 must be filled, got {:?}",
             group.col_heights,
         );
         assert!(
-            group.col_heights[1] > 0.0,
+            group.col_heights[1].to_f32() > 0.0,
             "col 1 must be filled, got {:?}",
             group.col_heights,
         );
@@ -3182,12 +3206,12 @@ mod tests {
             .expect("multicol container should have a geometry entry");
         let group = &mc_geom.groups[0];
         assert!(
-            group.col_heights[0] > 0.0,
+            group.col_heights[0].to_f32() > 0.0,
             "col 0 must be filled, got {:?}",
             group.col_heights
         );
         assert!(
-            group.col_heights[1] > 0.0,
+            group.col_heights[1].to_f32() > 0.0,
             "self-inline-root container must spread lines across both columns, got {:?}",
             group.col_heights
         );
@@ -3240,12 +3264,13 @@ mod tests {
         let group = &mc_geom.groups[0];
         assert_eq!(group.n, 2);
         assert!(
-            group.col_heights[0] > 0.0,
+            group.col_heights[0].to_f32() > 0.0,
             "col 0 must be filled, got {:?}",
             group.col_heights
         );
         assert_eq!(
-            group.col_heights[1], 0.0,
+            group.col_heights[1].to_f32(),
+            0.0,
             "column-fill: auto must leave col 1 empty when content fits in col 0, got {:?}",
             group.col_heights
         );

--- a/crates/fulgur/src/multicol_layout.rs
+++ b/crates/fulgur/src/multicol_layout.rs
@@ -3328,9 +3328,9 @@ mod tests {
             .expect("at least one multicol rule entry");
         assert_eq!(entry.rule.style, crate::column_css::ColumnRuleStyle::Solid);
         assert!(
-            (entry.rule.width - 2.0).abs() < 1e-3,
+            (entry.rule.width.to_f32() - 2.0).abs() < 1e-3,
             "width should be 2pt, got {}",
-            entry.rule.width
+            entry.rule.width.to_f32()
         );
         assert_eq!(entry.rule.color, [255, 0, 0, 255]);
         assert!(

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -2380,12 +2380,12 @@ fn build_multicol_stroke(
     use crate::column_css::ColumnRuleStyle;
     use crate::draw_primitives::{alpha_to_opacity, colored_stroke};
 
-    if rule.width <= 0.0 || rule.style == ColumnRuleStyle::None {
+    if rule.width <= crate::units::Pt::ZERO || rule.style == ColumnRuleStyle::None {
         return None;
     }
     let opacity = alpha_to_opacity(rule.color[3]);
-    let base = colored_stroke(&rule.color, rule.width, opacity);
-    let w = rule.width;
+    let base = colored_stroke(&rule.color, rule.width.to_f32(), opacity);
+    let w = rule.width.to_f32();
     let stroke = match rule.style {
         ColumnRuleStyle::None => return None,
         ColumnRuleStyle::Solid => base,
@@ -5217,8 +5217,9 @@ mod tests {
         width: f32,
         style: crate::column_css::ColumnRuleStyle,
     ) -> crate::column_css::ColumnRuleSpec {
+        use crate::units::F32Units;
         crate::column_css::ColumnRuleSpec {
-            width,
+            width: width.pt(),
             style,
             color: [0, 0, 0, 255],
         }

--- a/docs/plans/2026-06-27-engine-layout-api-design.md
+++ b/docs/plans/2026-06-27-engine-layout-api-design.md
@@ -252,6 +252,27 @@ later; `convert/mod.rs` documents the unresolved basis ambiguity), so they were
 **spun out to `fulgur-1ino`** rather than blanket-typed. The `type Pt = f32`
 alias removal remains P2 (`fulgur-2map.8`).
 
+### P1d outcome (fulgur-2map.6) — multicol/column geometry migrated
+
+Phase P1d typed the multicol geometry source structs to `units` newtypes,
+byte-neutral (examples_determinism + VRT goldens unchanged):
+
+- `multicol_layout::ColumnGroupGeometry` coords → `units::Px`
+  (`col_heights: Vec<f32>` → `Vec<Px>`); tagged at construction, readers untag.
+- `multicol_layout::ColumnLineSlice` `origin`/`size` →
+  `taffy::Point<Px>` / `taffy::Size<Px>` (taffy generics accept `Px`; no bound
+  friction, so it was migrated in-place rather than spun out).
+- `column_css::ColumnRuleSpec.width` → `units::Pt` (parser tags with `.pt()`;
+  `> Pt::ZERO` filter; `.to_f32()` at the krilla `colored_stroke` boundary).
+
+Fallout cleanup: `convert::record_multicol_rule` dropped the spike's now-redundant
+`.px()` tag (`g.x_offset.px().in_pt()` → `g.x_offset.in_pt()`), and
+`convert_multicol_paragraph_slices`'s px→pt locals became `.in_pt().to_f32()`.
+
+With P1a + P1d done, the only remaining single-unit deferral is the transform
+fold (`fulgur-1ino`, Affine2D + Point2). The `type Pt = f32` alias removal
+remains P2 (`fulgur-2map.8`).
+
 ## 8. 決定性 / 受け入れ条件
 
 - `layout_to_drawables` 抽出後・newtype 移行後とも `examples_determinism` golden と

--- a/docs/plans/2026-06-29-multicol-geometry-px-pt.md
+++ b/docs/plans/2026-06-29-multicol-geometry-px-pt.md
@@ -1,0 +1,252 @@
+# multicol/column geometry → units::Px/Pt (P1d) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (or executing-plans) to implement this plan task-by-task.
+
+**Goal:** Complete the multicol coordinate-newtype migration the spike
+(`fulgur-2map.2`) deferred — type `multicol_layout`'s px-source geometry
+(`ColumnGroupGeometry`, `ColumnLineSlice`) to `units::Px` and
+`column_css::ColumnRuleSpec.width` to `units::Pt`, byte-neutral (beads
+`fulgur-2map.6`, phase P1d).
+
+**Architecture:** The spike already split the pt carrier
+(`drawables::ColumnRuleGeometry`), so these source structs are now **pure
+single-unit**. Same pattern as P1a: tag at the source (`.px()` / `.pt()`),
+untag at use (`.to_f32()`) so existing f32 arithmetic and FFI calls (Parley
+`break_all_lines`, krilla `colored_stroke`) stay byte-identical. Two cleanups
+fall out: `convert::record_multicol_rule` drops the spike's now-redundant
+`.px()` tag (`g.x_offset.px().in_pt()` → `g.x_offset.in_pt()`), and the px→pt
+conversions in `convert_multicol_paragraph_slices` become `.in_pt()`.
+
+**Tech Stack:** Rust, `units::{Px, Pt, F32Units}` (`Pt::ZERO`/`max`/`min` exist
+from the spike; `Px::in_pt`/`to_f32` exist), `taffy::{Point, Size}<T>` generics,
+krilla, Parley, VRT byte comparison.
+
+## Scope
+
+**In scope (three single-unit migrations):**
+
+- `multicol_layout::ColumnGroupGeometry`: `x_offset`/`y_offset`/`col_w`/`gap` →
+  `units::Px`; `col_heights: Vec<f32>` → `Vec<units::Px>`. (`n: u32`,
+  `paragraph_splits` unchanged.)
+- `multicol_layout::ColumnLineSlice`: `origin: taffy::Point<f32>` →
+  `taffy::Point<units::Px>`, `size: taffy::Size<f32>` → `taffy::Size<units::Px>`.
+- `column_css::ColumnRuleSpec.width: f32` (pt) → `units::Pt`.
+
+**Out of scope:** the `type Pt = f32` alias (P2 / `fulgur-2map.8`);
+`ParagraphSplitEntry.line_range` (not a coordinate); the pt carrier
+`ColumnRuleGeometry` (done in the spike). No new `units` helpers needed
+(no Px arithmetic beyond direct `Px ± Px`; `Pt::ZERO` already exists).
+`pageable.rs` does not exist — `render.rs` is the v2 path.
+
+## The byte-neutral rule (read before every edit)
+
+`px_to_pt(v)` ≡ `v * 0.75` ≡ `v.px().in_pt()` ≡ `Px::in_pt` (one f32 multiply).
+`.px()`/`.pt()`/`.to_f32()` are pure labels on `#[repr(transparent)]` newtypes.
+NEVER reorder/reassociate arithmetic; preserve operand order. **Untag-at-use**
+is the default for readers that feed f32 math or an f32 FFI/helper. Proof =
+unchanged VRT goldens; never `FULGUR_VRT_UPDATE=1`.
+
+## Verification commands (end of every task)
+
+```bash
+export FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf"
+cargo build                                          # Finished
+cargo clippy -p fulgur --all-targets -- -D warnings  # clean
+cargo fmt --check                                    # clean
+cargo test -p fulgur --lib                           # all pass
+cargo test -p fulgur --test render_smoke             # all pass
+cargo test -p fulgur-cli --test examples_determinism # 11 passed
+cargo test -p fulgur-vrt                             # run_fulgur_vrt ... ok
+git status --short -- crates/fulgur-vrt/goldens/     # MUST be empty
+```
+
+**Baseline captured GREEN** before editing (examples_determinism 11/0, VRT ok).
+Base: `origin/main` `2ef34d18`.
+
+---
+
+### Task 1: `ColumnGroupGeometry` coordinate fields → `units::Px`
+
+**Files:** `crates/fulgur/src/multicol_layout.rs` (struct ~84; 2 construction
+sites ~856 & ~965; internal `col_heights` fold reader ~675; ~20 unit-test
+asserts), `crates/fulgur/src/convert/mod.rs` (`record_multicol_rule` ~676,
+`convert_multicol_paragraph_slices` ~743/788).
+
+**Step 1 — type the fields** (use fully-qualified `crate::units::Px` to avoid
+the `type Pt = f32` alias-shadowed module; mirror P1a):
+
+```rust
+    pub x_offset: crate::units::Px,
+    pub y_offset: crate::units::Px,
+    pub col_w: crate::units::Px,
+    pub gap: crate::units::Px,
+    // ...
+    pub col_heights: Vec<crate::units::Px>,
+```
+
+**Step 2 — build to get the worklist** (`cargo build` lists every break).
+
+**Step 3 — tag at construction** (the layout-math locals are Taffy-space f32;
+`.px()` is a pure label). At both `ColumnGroupGeometry { ... }` sites:
+
+```rust
+        x_offset: inset_left.px(),
+        y_offset: inset_top.px(),
+        col_w: col_w.px(),
+        gap: gap.px(),
+        n,
+        col_heights: col_heights.iter().copied().map(F32Units::px).collect(),
+        paragraph_splits: ...,
+```
+
+(`use crate::units::F32Units;` — confirm it's in scope in multicol_layout.rs;
+add if absent. The local `col_heights: Vec<f32>` keeps being built in f32; the
+`fold(0.0, f32::max)` that computes `max_col_h` from the LOCAL before
+construction stays f32 — only the struct field becomes `Vec<Px>`.)
+
+**Step 4 — untag readers:**
+
+- `convert::record_multicol_rule`: `g.x_offset.px().in_pt()` →
+  `g.x_offset.in_pt()` (drop the spike tag; byte-identical). `col_heights`
+  `.map(|h| h.px().in_pt())` → `.map(|h| h.in_pt())`.
+- `convert::convert_multicol_paragraph_slices`: `px_to_pt(group.x_offset)` →
+  `group.x_offset.in_pt()` (and `group.y_offset`); `break_all_lines(Some(group.col_w))`
+  → `break_all_lines(Some(group.col_w.to_f32()))` (Parley FFI is f32);
+  `px_to_pt(group.col_w)` (if any) → `group.col_w.in_pt()`.
+- multicol_layout internal: the `geometry.col_heights....fold(0.0_f32, f32::max)`
+  reader → `geometry.col_heights.iter().copied().map(crate::units::Px::to_f32).fold(0.0_f32, f32::max)`.
+- unit-test asserts reading `.col_heights[i]`/`.x_offset`/etc → append `.to_f32()`
+  (keep asserted numbers identical).
+
+**Step 5 — verify** (full block above) → goldens byte-identical.
+
+**Step 6 — commit:** `git add -A && git commit -m "refactor(multicol): type ColumnGroupGeometry coords with units::Px (byte-neutral, P1d)"`
+
+---
+
+### Task 2: `ColumnLineSlice` `origin`/`size` → `taffy::{Point,Size}<units::Px>`
+
+`taffy::Point<T>`/`Size<T>` are generic; `Px` satisfies their bounds (derives
+`Default`/`Clone`/`Copy`; has `Add`/`Sub`/`Mul`/`Div`). If `cargo build`
+reveals a taffy bound `Px` cannot satisfy, STOP and spin out a tracked issue
+(like `fulgur-1ino`) noting the taffy-generics reason — do not hack around it.
+
+**Files:** `crates/fulgur/src/multicol_layout.rs` (struct ~38; 3 construction
+sites ~931/1225 + `ColumnLineSlice::default()` ~926; distribution arithmetic
+~1278-1279, ~1303; tests), `crates/fulgur/src/convert/mod.rs`
+(`convert_multicol_paragraph_slices` ~861-864).
+
+**Step 1 — type the fields:**
+
+```rust
+    pub origin: taffy::Point<crate::units::Px>,
+    pub size: taffy::Size<crate::units::Px>,
+```
+
+**Step 2 — build worklist.**
+
+**Step 3 — tag at construction** (`.px()` the f32 taffy-space values):
+
+```rust
+        origin: taffy::Point { x: x.px(), y: y.px() },
+        size: taffy::Size { width: w.px(), height: h.px() },
+```
+
+(`ColumnLineSlice::default()` keeps deriving `Default` —
+`taffy::Point<Px>::default()` works since `Px: Default`.)
+
+**Step 4 — untag readers:**
+
+- multicol_layout distribution: `slice.origin.y + slice.size.height` stays
+  `Px + Px` (works, byte-identical) — but the consumer of that sum
+  (`bottom`) and `resolve_col_idx(slice.origin.x)` (closure `|x: f32|`) need
+  `.to_f32()` where they feed f32 code. Preserve operand order; prefer
+  `.to_f32()` at the f32 boundary. (`let bottom = (slice.origin.y + slice.size.height).to_f32();`
+  if `bottom` is compared as f32, OR keep `bottom: Px` and untag at its use.)
+- `convert::convert_multicol_paragraph_slices`: `px_to_pt(col_slice.origin.x)`
+  → `col_slice.origin.x.in_pt().to_f32()` (NOT bare `.in_pt()` — after Task 1
+  the sibling `group_x_pt` is `f32` and these are summed as `group_x_pt + <f32>`;
+  there is no `Add<Pt> for f32`, and the result feeds the out-of-scope
+  `(f32,f32)` `ParagraphSlice` tuples). Same for `col_slice.origin.y` and
+  `col_slice.size.height`. `.in_pt().to_f32()` ≡ `px_to_pt` (×0.75 as f32).
+- tests reading `.origin.x`/`.size.height` → `.to_f32()`.
+
+**Step 5 — verify** → goldens byte-identical (multicol inline-root-split
+goldens exercise paragraph slices).
+
+**Step 6 — commit:** `git add -A && git commit -m "refactor(multicol): type ColumnLineSlice origin/size with taffy Point/Size<Px> (byte-neutral, P1d)"`
+
+---
+
+### Task 3: `ColumnRuleSpec.width` → `units::Pt`
+
+**Files:** `crates/fulgur/src/column_css.rs` (struct ~71, `Default` ~81, parser
+assigns ~570 & ~709, ~14 test asserts), `crates/fulgur/src/convert/mod.rs`
+(`record_multicol_rule` filter ~663), `crates/fulgur/src/render.rs`
+(`build_multicol_stroke` ~2383-2388, 1 test), `crates/fulgur/src/multicol_layout.rs`
+(test ~3297), `crates/fulgur/src/blitz_adapter.rs` (test ~5129).
+
+**Step 1 — type the field + Default:**
+
+```rust
+    pub width: crate::units::Pt,
+// in impl Default:
+            width: 1.0_f32.pt(),   // needs `use crate::units::F32Units;`
+```
+
+**Step 2 — build worklist.**
+
+**Step 3 — producers / readers:**
+
+- parser assigns (`spec.width = w;` ×2, `w` is f32 pt from `length_to_pt`) →
+  `spec.width = w.pt();`. (Leave `length_to_pt`'s `-> Option<f32>` signature.)
+- `record_multicol_rule` filter: `r.width > 0.0` → `r.width > crate::units::Pt::ZERO`.
+- `render::build_multicol_stroke`: `rule.width <= 0.0` →
+  `rule.width <= crate::units::Pt::ZERO`; `colored_stroke(&rule.color, rule.width, opacity)`
+  → `colored_stroke(&rule.color, rule.width.to_f32(), opacity)` (helper takes f32);
+  `let w = rule.width;` → `let w = rule.width.to_f32();` (dash `w * 3.0` etc.
+  stay f32, unchanged).
+- test asserts `(rule.width - N).abs()` → `(rule.width.to_f32() - N).abs()`
+  (column_css ~14, render ~1, multicol_layout ~1, blitz_adapter ~1); keep
+  numbers identical.
+
+**Step 4 — verify** → multicol-rule-solid / multicol-2 / multicol-span-all
+goldens byte-identical.
+
+**Step 5 — commit:** `git add -A && git commit -m "refactor(column_css): type ColumnRuleSpec.width with units::Pt (byte-neutral, P1d)"`
+
+---
+
+### Task 4: Docs + final verification
+
+**Files:** `docs/plans/2026-06-27-engine-layout-api-design.md` (append a P1d
+outcome note under §7, noting ColumnGroupGeometry + ColumnLineSlice → Px and
+ColumnRuleSpec.width → Pt), and commit this plan
+(`docs/plans/2026-06-29-multicol-geometry-px-pt.md`).
+
+**Step 1** append note; `npx markdownlint-cli2` both files → 0 errors.
+**Step 2** run the full verification block → all green, goldens byte-identical.
+**Step 3** commit:
+`git add docs/plans/*.md && git commit -m "docs(2map): record P1d (multicol/column geometry) outcome"`
+
+> Coverage note: the migration updates many existing unit-test asserts and the
+> render_smoke multicol cases (from the spike + P1a) exercise the changed
+> producer/reader lines through `Engine::render_html`. If codecov/patch later
+> flags an uncovered changed line, add a focused render_smoke case (per
+> CLAUDE.md "Coverage scope"); confirm with `cargo llvm-cov nextest --workspace
+> --exclude fulgur-vrt`.
+
+---
+
+## Done criteria (maps to `fulgur-2map.6`)
+
+- [ ] `ColumnGroupGeometry` + `ColumnLineSlice` coords are `units::Px`;
+      `ColumnRuleSpec.width` is `units::Pt`.
+- [ ] `record_multicol_rule` drops the spike `.px()` tag (`g.field.in_pt()`).
+- [ ] Producers tag at source; readers untag at use; `to_f32()` only at FFI
+      (Parley/krilla) and f32-typed internal helpers.
+- [ ] `examples_determinism` + VRT goldens byte-identical (no `FULGUR_VRT_UPDATE`).
+- [ ] build / clippy `-D warnings` / fmt / `--lib` / `--test render_smoke` clean.
+- [ ] `type Pt = f32` alias untouched (P2). ColumnLineSlice included (or spun
+      out with a tracked issue if taffy bounds reject `Px`).


### PR DESCRIPTION
## 概要

`fulgur-2map` エピックの **Phase 1d**（beads `fulgur-2map.6`）。スパイク（`fulgur-2map.2`）が pt carrier を分離して以降、multicol の座標源は純単一単位になったため、それらを `units` newtype へ byte-neutral 移行する。

## 変更内容（3型の単一単位移行）

- **`multicol_layout::ColumnGroupGeometry`** 座標フィールド → `units::Px`（`col_heights: Vec<f32>` → `Vec<Px>`）。construction で `.px()` タグ、reader は使用箇所で untag。layout 算術は f32 のまま（Px 算術を導入しない）。
- **`multicol_layout::ColumnLineSlice`** `origin`/`size` → `taffy::Point<units::Px>` / `taffy::Size<units::Px>`。taffy generics は `Px`（Default/Copy/Add 等を満たす）を**問題なく受理**したため spin out せず in-place 移行。
- **`column_css::ColumnRuleSpec.width`** → `units::Pt`（parser は `.pt()` タグ、filter は `> Pt::ZERO`、krilla `colored_stroke` 境界で `.to_f32()`、dash 算術は f32 維持）。

## fallout クリーンアップ

- `convert::record_multicol_rule`: スパイクが付けた冗長な `.px()` タグを除去（`g.x_offset.px().in_pt()` → `g.x_offset.in_pt()`、源が Px 化したため。byte-identical）。
- `convert::convert_multicol_paragraph_slices`: px→pt local を `.in_pt().to_f32()` に（`px_to_pt` と byte 同一）。Parley `break_all_lines`/`align` は **raw px**（`.to_f32()`、×0.75 しない）— px/pt の区別が型で可視化された。

## byte-neutrality（受け入れの核心）

`px_to_pt(v)` ≡ `v * 0.75` ≡ `v.px().in_pt()` ≡ `Px::in_pt`。`.px()`/`.pt()`/`.to_f32()` は `#[repr(transparent)]` newtype 上の純ラベル。`Px + Px` / `Pt` 比較は内部 f32 に委譲。再結合なし。

- VRT `run_fulgur_vrt` ✅（goldens byte-identical、`FULGUR_VRT_UPDATE` 不使用。`multicol-rule-solid` / `multicol-2` / `multicol-span-all` / `multicol-inline-root-split-case-a/b` が対象経路を実駆動）
- `examples_determinism` ✅ 11 passed
- `cargo test -p fulgur --lib` ✅ 1495 / `--test render_smoke` ✅ 171
- `cargo build` / `clippy -p fulgur --all-targets -D warnings` / `fmt --check` ✅ clean

## スコープ（意図的な deferral）

- **`type Pt = f32` エイリアス撤去** → P2 / `fulgur-2map.8`
- **Affine2D + Point2**（transform px/pt fold）→ `fulgur-1ino`（spike から spin out）
- `drawables::ColumnRuleGeometry`（pt carrier）はスパイクで実装済み・本 PR では不変
- `ParagraphSlice` の `(f32,f32)` タプルは P1d 対象外（後続フェーズ）

外部 bindings（fulgur-wasm / pyfulgur / fulgur-ruby）はこれらのフィールドを参照しておらず破壊なし。

## Test Plan

- [x] `cargo build` / `clippy -p fulgur --all-targets -- -D warnings` / `fmt --check`
- [x] `cargo test -p fulgur --lib`（1495）/ `--test render_smoke`（171）
- [x] `cargo test -p fulgur-cli --test examples_determinism`（11）
- [x] `cargo test -p fulgur-vrt`（goldens byte 一致、再生成なし）

Closes beads `fulgur-2map.6`.