### PR TITLE
refactor(paragraph): migrate paragraph coordinate types to units::Pt (P1b, byte-neutral)

### DIFF
--- a/crates/fulgur/src/convert/inline_root.rs
+++ b/crates/fulgur/src/convert/inline_root.rs
@@ -573,13 +573,13 @@ pub(super) fn extract_paragraph(
                         .insert(node_id, descendants);
 
                     let link = ctx.link_cache.lookup(doc, node_id);
-                    let height_pt = positioned.height.px().in_pt();
+                    let height = positioned.height.px().in_pt();
                     // Read baseline from `out` (Drawables). The Drawables-aware
                     // lookup queries `out.paragraphs[node_id]` (and
                     // `block_styles[node_id]` for top-inset) directly.
                     let baseline_shift =
                         inline_box_baseline_offset_from_drawables(doc, out, node_id)
-                            .map(|bo| height_pt - bo.pt())
+                            .map(|bo| height - bo.pt())
                             .unwrap_or(crate::units::Pt::ZERO);
                     let computed_y =
                         positioned.y.px().in_pt() - accumulated_line_top + baseline_shift;
@@ -591,7 +591,7 @@ pub(super) fn extract_paragraph(
                     items.push(LineItem::InlineBox(InlineBoxItem {
                         node_id: content,
                         width: positioned.width.px().in_pt(),
-                        height: height_pt,
+                        height,
                         x_offset: positioned.x.px().in_pt(),
                         computed_y,
                         link,
@@ -602,13 +602,13 @@ pub(super) fn extract_paragraph(
             }
         }
 
-        let line_height_pt = metrics.line_height.px().in_pt();
+        let line_height = metrics.line_height.px().in_pt();
         shaped_lines.push(ShapedLine {
-            height: line_height_pt,
+            height: line_height,
             baseline: metrics.baseline.px().in_pt(),
             items,
         });
-        accumulated_line_top += line_height_pt;
+        accumulated_line_top += line_height;
     }
 
     if shaped_lines.is_empty() {

--- a/crates/fulgur/src/convert/inline_root.rs
+++ b/crates/fulgur/src/convert/inline_root.rs
@@ -808,15 +808,12 @@ mod tests {
             l
         }];
         recalculate_paragraph_line_boxes(&mut lines);
-        assert!(
-            approx_pt(lines[0].height, 16.0),
-            "height={}",
-            lines[0].height.to_f32()
-        );
+        let h = lines[0].height;
+        assert!(approx_pt(h, 16.0), "height={h:?}");
         assert!(
             approx_pt(lines[0].baseline, 12.0),
-            "baseline={}",
-            lines[0].baseline.to_f32()
+            "baseline={:?}",
+            lines[0].baseline
         );
     }
 
@@ -842,23 +839,23 @@ mod tests {
         recalculate_paragraph_line_boxes(&mut lines);
         assert!(
             approx_pt(lines[0].height, 16.0),
-            "line0 height={}",
-            lines[0].height.to_f32()
+            "line0 height={:?}",
+            lines[0].height
         );
         assert!(
             approx_pt(lines[0].baseline, 12.0),
-            "line0 baseline={}",
-            lines[0].baseline.to_f32()
+            "line0 baseline={:?}",
+            lines[0].baseline
         );
         assert!(
             approx_pt(lines[1].height, 14.0),
-            "line1 height={}",
-            lines[1].height.to_f32()
+            "line1 height={:?}",
+            lines[1].height
         );
         assert!(
             approx_pt(lines[1].baseline, 26.0),
-            "line1 baseline={}",
-            lines[1].baseline.to_f32()
+            "line1 baseline={:?}",
+            lines[1].baseline
         );
     }
 
@@ -877,21 +874,18 @@ mod tests {
             l
         }];
         recalculate_paragraph_line_boxes(&mut lines);
-        assert!(
-            approx_pt(lines[0].height, 16.0),
-            "height={}",
-            lines[0].height.to_f32()
-        );
+        let h = lines[0].height;
+        assert!(approx_pt(h, 16.0), "height={h:?}");
         assert!(
             approx_pt(lines[0].baseline, 12.0),
-            "baseline={}",
-            lines[0].baseline.to_f32()
+            "baseline={:?}",
+            lines[0].baseline
         );
         if let LineItem::Image(img) = &lines[0].items[0] {
             assert!(
                 approx_pt(img.computed_y, 4.0),
-                "computed_y={}",
-                img.computed_y.to_f32()
+                "computed_y={:?}",
+                img.computed_y
             );
         } else {
             panic!("expected Image at index 0");
@@ -929,8 +923,8 @@ mod tests {
         // Line 0 must be unchanged.
         assert!(
             approx_pt(lines[0].height, 10.0),
-            "line0 height={}",
-            lines[0].height.to_f32()
+            "line0 height={:?}",
+            lines[0].height
         );
 
         // For line 1: normalize baseline → 18-10=8; img_top=8-2=6; no expansion;
@@ -938,8 +932,8 @@ mod tests {
         if let LineItem::Image(img) = &lines[1].items[0] {
             assert!(
                 approx_pt(img.computed_y, 16.0),
-                "computed_y={}",
-                img.computed_y.to_f32()
+                "computed_y={:?}",
+                img.computed_y
             );
         } else {
             panic!("expected Image in line 1 at index 0");

--- a/crates/fulgur/src/convert/inline_root.rs
+++ b/crates/fulgur/src/convert/inline_root.rs
@@ -1,6 +1,7 @@
 use super::*;
 use super::{list_marker, positioned, pseudo};
 use crate::paragraph::{InlineBoxItem, ParagraphRender};
+use crate::units::F32Units;
 
 /// Dispatcher entry for inline-root nodes (those with `node.flags.is_inline_root()`).
 ///
@@ -80,12 +81,12 @@ pub(super) fn try_convert(
         if before_inline.is_some() || after_inline.is_some() {
             pseudo::inject_inline_pseudo_images(&mut paragraph.lines, before_inline, after_inline);
             recalculate_paragraph_line_boxes(&mut paragraph.lines);
-            paragraph.cached_height = paragraph.lines.iter().map(|l| l.height).sum();
+            paragraph.cached_height = paragraph.lines.iter().map(|l| l.height.to_f32()).sum();
         }
 
         // Inside list-style-image marker injection.
         if !paragraph.lines.is_empty() {
-            let first_line_height = paragraph.lines[0].height;
+            let first_line_height = paragraph.lines[0].height.to_f32();
             if let Some(inline_img) =
                 list_marker::resolve_inside_image_marker(node, first_line_height, ctx.assets)
             {
@@ -101,7 +102,7 @@ pub(super) fn try_convert(
                     .items
                     .insert(0, LineItem::Image(inline_img));
                 recalculate_paragraph_line_boxes(&mut paragraph.lines);
-                paragraph.cached_height = paragraph.lines.iter().map(|l| l.height).sum();
+                paragraph.cached_height = paragraph.lines.iter().map(|l| l.height.to_f32()).sum();
             }
         }
 
@@ -159,8 +160,8 @@ pub(super) fn try_convert(
     } else if before_inline.is_some() || after_inline.is_some() {
         // Synthesize a minimal paragraph for pseudo-only elements.
         let mut line = ShapedLine {
-            height: 0.0,
-            baseline: 0.0,
+            height: crate::units::Pt::ZERO,
+            baseline: crate::units::Pt::ZERO,
             items: vec![],
         };
         pseudo::inject_inline_pseudo_images(
@@ -242,7 +243,7 @@ pub(super) fn metrics_from_line(line: &ShapedLine) -> LineFontMetrics {
         };
         if let Ok(font_ref) = skrifa::FontRef::from_index(&run.font_data, run.font_index) {
             let metrics = font_ref.metrics(
-                skrifa::instance::Size::new(run.font_size),
+                skrifa::instance::Size::new(run.font_size.to_f32()),
                 skrifa::instance::LocationRef::default(),
             );
             return LineFontMetrics {
@@ -259,8 +260,8 @@ pub(super) fn metrics_from_line(line: &ShapedLine) -> LineFontMetrics {
 
 /// Recalculate line boxes for all lines in a paragraph.
 pub(super) fn recalculate_paragraph_line_boxes(lines: &mut [ShapedLine]) {
-    let mut original_y_acc: f32 = 0.0;
-    let mut new_y_acc: f32 = 0.0;
+    let mut original_y_acc = crate::units::Pt::ZERO;
+    let mut new_y_acc = crate::units::Pt::ZERO;
     for line in lines.iter_mut() {
         let original_height = line.height;
         let font_metrics = metrics_from_line(line);
@@ -369,7 +370,7 @@ fn pageable_last_baseline_from_drawables(
             .map(|b| b.style.border_widths[0].to_f32() + b.style.padding[0].to_f32())
             .unwrap_or(0.0);
         if let Some(line) = para.lines.last() {
-            return Some(top_inset + line.baseline);
+            return Some(top_inset + line.baseline.to_f32());
         }
     }
     // 2) Otherwise walk DOM children in REVERSE, mirroring v1's
@@ -459,7 +460,7 @@ pub(super) fn extract_paragraph(
     let text = &text_layout.text;
 
     let mut shaped_lines = Vec::new();
-    let mut accumulated_line_top: f32 = 0.0;
+    let mut accumulated_line_top = crate::units::Pt::ZERO;
 
     for line in parley_layout.lines() {
         let metrics = line.metrics();
@@ -477,7 +478,7 @@ pub(super) fn extract_paragraph(
                     let font_index = font_ref.index;
                     let font_arc = ctx.get_or_insert_font(font_ref);
                     let font_size_parley = run.font_size();
-                    let font_size = px_to_pt(font_size_parley);
+                    let font_size = font_size_parley.px().in_pt();
 
                     let brush = &glyph_run.style().brush;
                     let color = get_text_color(doc, brush.id);
@@ -526,7 +527,7 @@ pub(super) fn extract_paragraph(
 
                     if !glyphs.is_empty() {
                         let run_text = text.clone();
-                        let run_x_offset = px_to_pt(glyph_run.offset());
+                        let run_x_offset = glyph_run.offset().px().in_pt();
                         items.push(LineItem::Text(ShapedGlyphRun {
                             font_data: font_arc,
                             font_index,
@@ -572,15 +573,16 @@ pub(super) fn extract_paragraph(
                         .insert(node_id, descendants);
 
                     let link = ctx.link_cache.lookup(doc, node_id);
-                    let height_pt = px_to_pt(positioned.height);
+                    let height_pt = positioned.height.px().in_pt();
                     // Read baseline from `out` (Drawables). The Drawables-aware
                     // lookup queries `out.paragraphs[node_id]` (and
                     // `block_styles[node_id]` for top-inset) directly.
                     let baseline_shift =
                         inline_box_baseline_offset_from_drawables(doc, out, node_id)
-                            .map(|bo| height_pt - bo)
-                            .unwrap_or(0.0);
-                    let computed_y = px_to_pt(positioned.y) - accumulated_line_top + baseline_shift;
+                            .map(|bo| height_pt - bo.pt())
+                            .unwrap_or(crate::units::Pt::ZERO);
+                    let computed_y =
+                        positioned.y.px().in_pt() - accumulated_line_top + baseline_shift;
                     let visible = doc
                         .get_node(node_id)
                         .map(super::style::extract_opacity_visible)
@@ -588,9 +590,9 @@ pub(super) fn extract_paragraph(
                         .unwrap_or(true);
                     items.push(LineItem::InlineBox(InlineBoxItem {
                         node_id: content,
-                        width: px_to_pt(positioned.width),
+                        width: positioned.width.px().in_pt(),
                         height: height_pt,
-                        x_offset: px_to_pt(positioned.x),
+                        x_offset: positioned.x.px().in_pt(),
                         computed_y,
                         link,
                         opacity: 1.0,
@@ -600,10 +602,10 @@ pub(super) fn extract_paragraph(
             }
         }
 
-        let line_height_pt = px_to_pt(metrics.line_height);
+        let line_height_pt = metrics.line_height.px().in_pt();
         shaped_lines.push(ShapedLine {
             height: line_height_pt,
-            baseline: px_to_pt(metrics.baseline),
+            baseline: metrics.baseline.px().in_pt(),
             items,
         });
         accumulated_line_top += line_height_pt;
@@ -636,14 +638,19 @@ mod tests {
         (a - b).abs() < 0.01
     }
 
+    /// Compare a migrated `Pt` coordinate against a raw `f32` expectation.
+    fn approx_pt(a: crate::units::Pt, b: f32) -> bool {
+        (a.to_f32() - b).abs() < 0.01
+    }
+
     /// A line with no items (text-only placeholder) and a paragraph-relative
     /// baseline. `baseline` here is the offset from the paragraph top, matching
     /// the convention used by `extract_paragraph` (which stores
     /// `px_to_pt(parley_metrics.baseline)` — a paragraph-relative value).
     fn text_line(height: f32, baseline: f32) -> ShapedLine {
         ShapedLine {
-            height,
-            baseline,
+            height: height.pt(),
+            baseline: baseline.pt(),
             items: Vec::new(),
         }
     }
@@ -652,12 +659,12 @@ mod tests {
         LineItem::Text(ShapedGlyphRun {
             font_data: Arc::new(font_data),
             font_index: 0,
-            font_size: 12.0,
+            font_size: 12.0_f32.pt(),
             color: [0, 0, 0, 255],
             decoration: TextDecoration::default(),
             glyphs: Vec::new(),
             text: String::new(),
-            x_offset: 0.0,
+            x_offset: crate::units::Pt::ZERO,
             link: None,
         })
     }
@@ -666,13 +673,13 @@ mod tests {
         LineItem::Image(InlineImage {
             data: Arc::new(vec![]),
             format: ImageFormat::Png,
-            width,
-            height,
-            x_offset: 0.0,
+            width: width.pt(),
+            height: height.pt(),
+            x_offset: crate::units::Pt::ZERO,
             vertical_align: va,
             opacity: 1.0,
             visible: true,
-            computed_y: 0.0,
+            computed_y: crate::units::Pt::ZERO,
             link: None,
         })
     }
@@ -680,10 +687,10 @@ mod tests {
     fn make_inline_box() -> LineItem {
         LineItem::InlineBox(InlineBoxItem {
             node_id: None,
-            width: 10.0,
-            height: 10.0,
-            x_offset: 0.0,
-            computed_y: 0.0,
+            width: 10.0_f32.pt(),
+            height: 10.0_f32.pt(),
+            x_offset: crate::units::Pt::ZERO,
+            computed_y: crate::units::Pt::ZERO,
             link: None,
             opacity: 1.0,
             visible: true,
@@ -697,7 +704,7 @@ mod tests {
         items
             .iter()
             .filter_map(|item| match item {
-                LineItem::Image(img) => Some(img.computed_y),
+                LineItem::Image(img) => Some(img.computed_y.to_f32()),
                 _ => None,
             })
             .collect()
@@ -801,11 +808,15 @@ mod tests {
             l
         }];
         recalculate_paragraph_line_boxes(&mut lines);
-        assert!(approx(lines[0].height, 16.0), "height={}", lines[0].height);
         assert!(
-            approx(lines[0].baseline, 12.0),
+            approx_pt(lines[0].height, 16.0),
+            "height={}",
+            lines[0].height.to_f32()
+        );
+        assert!(
+            approx_pt(lines[0].baseline, 12.0),
             "baseline={}",
-            lines[0].baseline
+            lines[0].baseline.to_f32()
         );
     }
 
@@ -830,24 +841,24 @@ mod tests {
         ];
         recalculate_paragraph_line_boxes(&mut lines);
         assert!(
-            approx(lines[0].height, 16.0),
+            approx_pt(lines[0].height, 16.0),
             "line0 height={}",
-            lines[0].height
+            lines[0].height.to_f32()
         );
         assert!(
-            approx(lines[0].baseline, 12.0),
+            approx_pt(lines[0].baseline, 12.0),
             "line0 baseline={}",
-            lines[0].baseline
+            lines[0].baseline.to_f32()
         );
         assert!(
-            approx(lines[1].height, 14.0),
+            approx_pt(lines[1].height, 14.0),
             "line1 height={}",
-            lines[1].height
+            lines[1].height.to_f32()
         );
         assert!(
-            approx(lines[1].baseline, 26.0),
+            approx_pt(lines[1].baseline, 26.0),
             "line1 baseline={}",
-            lines[1].baseline
+            lines[1].baseline.to_f32()
         );
     }
 
@@ -866,14 +877,22 @@ mod tests {
             l
         }];
         recalculate_paragraph_line_boxes(&mut lines);
-        assert!(approx(lines[0].height, 16.0), "height={}", lines[0].height);
         assert!(
-            approx(lines[0].baseline, 12.0),
+            approx_pt(lines[0].height, 16.0),
+            "height={}",
+            lines[0].height.to_f32()
+        );
+        assert!(
+            approx_pt(lines[0].baseline, 12.0),
             "baseline={}",
-            lines[0].baseline
+            lines[0].baseline.to_f32()
         );
         if let LineItem::Image(img) = &lines[0].items[0] {
-            assert!(approx(img.computed_y, 4.0), "computed_y={}", img.computed_y);
+            assert!(
+                approx_pt(img.computed_y, 4.0),
+                "computed_y={}",
+                img.computed_y.to_f32()
+            );
         } else {
             panic!("expected Image at index 0");
         }
@@ -909,18 +928,18 @@ mod tests {
 
         // Line 0 must be unchanged.
         assert!(
-            approx(lines[0].height, 10.0),
+            approx_pt(lines[0].height, 10.0),
             "line0 height={}",
-            lines[0].height
+            lines[0].height.to_f32()
         );
 
         // For line 1: normalize baseline → 18-10=8; img_top=8-2=6; no expansion;
         // img.computed_y = 6 → += new_y_acc(10) → 16.
         if let LineItem::Image(img) = &lines[1].items[0] {
             assert!(
-                approx(img.computed_y, 16.0),
+                approx_pt(img.computed_y, 16.0),
                 "computed_y={}",
-                img.computed_y
+                img.computed_y.to_f32()
             );
         } else {
             panic!("expected Image in line 1 at index 0");
@@ -1017,13 +1036,13 @@ mod tests {
 
         // Line 0 must expand.
         let (h0, b0) = (lines[0].height, lines[0].baseline);
-        assert!(approx(h0, 24.0));
-        assert!(approx(b0, 20.0));
+        assert!(approx_pt(h0, 24.0));
+        assert!(approx_pt(b0, 20.0));
 
         // Line 1 height unchanged; baseline adjusted by new_y_acc=24 not 16.
         let (h1, b1) = (lines[1].height, lines[1].baseline);
-        assert!(approx(h1, 12.0));
-        assert!(approx(b1, 32.0));
+        assert!(approx_pt(h1, 12.0));
+        assert!(approx_pt(b1, 32.0));
         // Text-only line has no images; this call covers the `_ => None` arm of image_ys.
         assert!(image_ys(&lines[1].items).is_empty());
     }
@@ -1056,7 +1075,7 @@ mod tests {
 
         // Line 0: verify expansion occurred so the test is meaningful.
         let h0 = lines[0].height;
-        assert!(approx(h0, 24.0));
+        assert!(approx_pt(h0, 24.0));
 
         // Line 1 image: computed_y = line-local img_top(4) + new_y_acc(24) = 28.
         // image_ys covers the LineItem::Image arm; the _ => None arm is covered in
@@ -1097,8 +1116,8 @@ mod tests {
             lines: baselines
                 .iter()
                 .map(|&b| ShapedLine {
-                    height: 16.0,
-                    baseline: b,
+                    height: 16.0_f32.pt(),
+                    baseline: b.pt(),
                     items: vec![],
                 })
                 .collect(),

--- a/crates/fulgur/src/convert/list_item.rs
+++ b/crates/fulgur/src/convert/list_item.rs
@@ -592,8 +592,8 @@ mod tests {
         };
         assert!(
             (existing.x_offset.to_f32() - 15.0).abs() < 0.001,
-            "got {}",
-            existing.x_offset.to_f32()
+            "got {:?}",
+            existing.x_offset
         );
     }
 
@@ -626,8 +626,8 @@ mod tests {
         };
         assert!(
             (ib.x_offset.to_f32() - 11.0).abs() < 0.001,
-            "got {}",
-            ib.x_offset.to_f32()
+            "got {:?}",
+            ib.x_offset
         );
     }
 
@@ -670,8 +670,8 @@ mod tests {
         };
         assert!(
             (ib.x_offset.to_f32() - 12.0).abs() < 0.001,
-            "got {}",
-            ib.x_offset.to_f32()
+            "got {:?}",
+            ib.x_offset
         );
     }
 
@@ -802,8 +802,8 @@ mod tests {
         };
         assert!(
             (shifted.x_offset.to_f32() - 15.0).abs() < 0.001,
-            "got {}",
-            shifted.x_offset.to_f32()
+            "got {:?}",
+            shifted.x_offset
         );
     }
 
@@ -828,8 +828,8 @@ mod tests {
         };
         assert!(
             (shifted.x_offset.to_f32() - 11.0).abs() < 0.001,
-            "got {}",
-            shifted.x_offset.to_f32()
+            "got {:?}",
+            shifted.x_offset
         );
     }
 
@@ -858,24 +858,24 @@ mod tests {
         };
         assert!(
             (t.x_offset.to_f32() - 11.0).abs() < 0.001,
-            "text: got {}",
-            t.x_offset.to_f32()
+            "text: got {:?}",
+            t.x_offset
         );
         let LineItem::Image(im) = &items[2] else {
             panic!("expected Image at 2");
         };
         assert!(
             (im.x_offset.to_f32() - 12.0).abs() < 0.001,
-            "image: got {}",
-            im.x_offset.to_f32()
+            "image: got {:?}",
+            im.x_offset
         );
         let LineItem::InlineBox(ib) = &items[3] else {
             panic!("expected InlineBox at 3");
         };
         assert!(
             (ib.x_offset.to_f32() - 13.0).abs() < 0.001,
-            "ib: got {}",
-            ib.x_offset.to_f32()
+            "ib: got {:?}",
+            ib.x_offset
         );
         // Second line must be unchanged.
         let LineItem::InlineBox(l1_ib) = &out.paragraphs[&5].lines[1].items[0] else {
@@ -883,8 +883,8 @@ mod tests {
         };
         assert!(
             (l1_ib.x_offset.to_f32() - 0.0).abs() < 0.001,
-            "line 1 shifted unexpectedly: {}",
-            l1_ib.x_offset.to_f32()
+            "line 1 shifted unexpectedly: {:?}",
+            l1_ib.x_offset
         );
     }
 
@@ -918,8 +918,8 @@ mod tests {
         };
         assert!(
             (ib.x_offset.to_f32() - 7.0).abs() < 0.001,
-            "expected no shift, got {}",
-            ib.x_offset.to_f32()
+            "expected no shift, got {:?}",
+            ib.x_offset
         );
         // Marker is still inserted at index 0.
         assert_eq!(out.paragraphs[&5].lines[0].items.len(), 2);

--- a/crates/fulgur/src/convert/list_item.rs
+++ b/crates/fulgur/src/convert/list_item.rs
@@ -1,5 +1,6 @@
 use super::*;
 use super::{inline_root, list_marker, positioned, pseudo};
+use crate::units::F32Units;
 
 /// Dispatcher entry for list-item nodes.
 ///
@@ -179,8 +180,8 @@ pub(super) fn try_convert(
             // Empty <li>: standalone paragraph with just the marker.
             if let Some(item) = empty_li_marker_item {
                 let lines = vec![ShapedLine {
-                    height: line_height,
-                    baseline: line_height / DEFAULT_LINE_HEIGHT_RATIO,
+                    height: line_height.pt(),
+                    baseline: (line_height / DEFAULT_LINE_HEIGHT_RATIO).pt(),
                     items: vec![item],
                 }];
                 out.paragraphs.insert(
@@ -248,8 +249,8 @@ pub(super) fn try_convert(
             if let Some(item) = marker_item {
                 if !inject_marker_into_first_paragraph(out, &pre_paragraph_ids, item.clone()) {
                     let lines = vec![ShapedLine {
-                        height: line_height,
-                        baseline: line_height / DEFAULT_LINE_HEIGHT_RATIO,
+                        height: line_height.pt(),
+                        baseline: (line_height / DEFAULT_LINE_HEIGHT_RATIO).pt(),
                         items: vec![item],
                     }];
                     out.paragraphs.insert(
@@ -313,7 +314,7 @@ fn inject_marker_into_first_paragraph(
             .glyphs
             .iter()
             .map(|g| g.x_advance * run.font_size)
-            .sum::<f32>(),
+            .sum::<crate::units::Pt>(),
         LineItem::Image(img) => img.width,
         LineItem::InlineBox(ib) => ib.width,
     };
@@ -386,7 +387,7 @@ fn build_list_item_body(
                     after_inline,
                 );
                 inline_root::recalculate_paragraph_line_boxes(&mut paragraph.lines);
-                paragraph.cached_height = paragraph.lines.iter().map(|l| l.height).sum();
+                paragraph.cached_height = paragraph.lines.iter().map(|l| l.height.to_f32()).sum();
             }
             out.paragraphs.insert(
                 node.id,
@@ -403,8 +404,8 @@ fn build_list_item_body(
             pseudo::register_pseudo_content(doc, node, ctx, depth, content_box, out);
         } else if before_inline.is_some() || after_inline.is_some() {
             let mut line = ShapedLine {
-                height: 0.0,
-                baseline: 0.0,
+                height: crate::units::Pt::ZERO,
+                baseline: crate::units::Pt::ZERO,
                 items: vec![],
             };
             pseudo::inject_inline_pseudo_images(
@@ -474,13 +475,14 @@ mod tests {
         InlineBoxItem, InlineImage, LineItem, ShapedGlyph, ShapedGlyphRun, ShapedLine,
         TextDecoration, VerticalAlign,
     };
+    use crate::units::F32Units;
     use std::collections::BTreeSet;
     use std::sync::Arc;
 
     fn make_line(items: Vec<LineItem>) -> ShapedLine {
         ShapedLine {
-            height: 12.0,
-            baseline: 9.0,
+            height: 12.0_f32.pt(),
+            baseline: 9.0_f32.pt(),
             items,
         }
     }
@@ -497,10 +499,10 @@ mod tests {
     fn inline_box(width: f32, x_offset: f32) -> LineItem {
         LineItem::InlineBox(InlineBoxItem {
             node_id: None,
-            width,
-            height: 10.0,
-            x_offset,
-            computed_y: 0.0,
+            width: width.pt(),
+            height: 10.0_f32.pt(),
+            x_offset: x_offset.pt(),
+            computed_y: crate::units::Pt::ZERO,
             link: None,
             opacity: 1.0,
             visible: true,
@@ -573,7 +575,7 @@ mod tests {
         let LineItem::InlineBox(marker_ib) = &first_line.items[0] else {
             panic!("expected InlineBox at index 0");
         };
-        assert_eq!(marker_ib.width, 10.0);
+        assert_eq!(marker_ib.width.to_f32(), 10.0);
     }
 
     #[test]
@@ -589,9 +591,9 @@ mod tests {
             panic!("expected InlineBox at index 1");
         };
         assert!(
-            (existing.x_offset - 15.0).abs() < 0.001,
+            (existing.x_offset.to_f32() - 15.0).abs() < 0.001,
             "got {}",
-            existing.x_offset
+            existing.x_offset.to_f32()
         );
     }
 
@@ -604,13 +606,13 @@ mod tests {
         let image_marker = LineItem::Image(InlineImage {
             data: Arc::new(vec![]),
             format: crate::image::ImageFormat::Png,
-            width: 8.0,
-            height: 8.0,
-            x_offset: 0.0,
+            width: 8.0_f32.pt(),
+            height: 8.0_f32.pt(),
+            x_offset: crate::units::Pt::ZERO,
             vertical_align: VerticalAlign::Baseline,
             opacity: 1.0,
             visible: true,
-            computed_y: 0.0,
+            computed_y: crate::units::Pt::ZERO,
             link: None,
         });
         assert!(inject_marker_into_first_paragraph(
@@ -622,7 +624,11 @@ mod tests {
         let LineItem::InlineBox(ib) = &out.paragraphs[&5].lines[0].items[1] else {
             panic!("expected InlineBox at index 1");
         };
-        assert!((ib.x_offset - 11.0).abs() < 0.001, "got {}", ib.x_offset);
+        assert!(
+            (ib.x_offset.to_f32() - 11.0).abs() < 0.001,
+            "got {}",
+            ib.x_offset.to_f32()
+        );
     }
 
     #[test]
@@ -635,7 +641,7 @@ mod tests {
         let text_marker = LineItem::Text(ShapedGlyphRun {
             font_data: Arc::new(vec![]),
             font_index: 0,
-            font_size: 12.0,
+            font_size: 12.0_f32.pt(),
             color: [0, 0, 0, 255],
             decoration: TextDecoration::default(),
             glyphs: vec![
@@ -655,14 +661,18 @@ mod tests {
                 },
             ],
             text: "• ".to_string(),
-            x_offset: 0.0,
+            x_offset: crate::units::Pt::ZERO,
             link: None,
         });
         inject_marker_into_first_paragraph(&mut out, &pre, text_marker);
         let LineItem::InlineBox(ib) = &out.paragraphs[&5].lines[0].items[1] else {
             panic!("expected InlineBox at index 1");
         };
-        assert!((ib.x_offset - 12.0).abs() < 0.001, "got {}", ib.x_offset);
+        assert!(
+            (ib.x_offset.to_f32() - 12.0).abs() < 0.001,
+            "got {}",
+            ib.x_offset.to_f32()
+        );
     }
 
     #[test]
@@ -748,12 +758,12 @@ mod tests {
         LineItem::Text(ShapedGlyphRun {
             font_data: Arc::new(vec![]),
             font_index: 0,
-            font_size: 12.0,
+            font_size: 12.0_f32.pt(),
             color: [0, 0, 0, 255],
             decoration: TextDecoration::default(),
             glyphs: vec![],
             text: String::new(),
-            x_offset,
+            x_offset: x_offset.pt(),
             link: None,
         })
     }
@@ -762,13 +772,13 @@ mod tests {
         LineItem::Image(InlineImage {
             data: Arc::new(vec![]),
             format: crate::image::ImageFormat::Png,
-            width,
-            height: 10.0,
-            x_offset,
+            width: width.pt(),
+            height: 10.0_f32.pt(),
+            x_offset: x_offset.pt(),
             vertical_align: VerticalAlign::Baseline,
             opacity: 1.0,
             visible: true,
-            computed_y: 0.0,
+            computed_y: crate::units::Pt::ZERO,
             link: None,
         })
     }
@@ -791,9 +801,9 @@ mod tests {
             panic!("expected Text at index 1");
         };
         assert!(
-            (shifted.x_offset - 15.0).abs() < 0.001,
+            (shifted.x_offset.to_f32() - 15.0).abs() < 0.001,
             "got {}",
-            shifted.x_offset
+            shifted.x_offset.to_f32()
         );
     }
 
@@ -817,9 +827,9 @@ mod tests {
             panic!("expected Image at index 1");
         };
         assert!(
-            (shifted.x_offset - 11.0).abs() < 0.001,
+            (shifted.x_offset.to_f32() - 11.0).abs() < 0.001,
             "got {}",
-            shifted.x_offset
+            shifted.x_offset.to_f32()
         );
     }
 
@@ -847,34 +857,34 @@ mod tests {
             panic!("expected Text at 1");
         };
         assert!(
-            (t.x_offset - 11.0).abs() < 0.001,
+            (t.x_offset.to_f32() - 11.0).abs() < 0.001,
             "text: got {}",
-            t.x_offset
+            t.x_offset.to_f32()
         );
         let LineItem::Image(im) = &items[2] else {
             panic!("expected Image at 2");
         };
         assert!(
-            (im.x_offset - 12.0).abs() < 0.001,
+            (im.x_offset.to_f32() - 12.0).abs() < 0.001,
             "image: got {}",
-            im.x_offset
+            im.x_offset.to_f32()
         );
         let LineItem::InlineBox(ib) = &items[3] else {
             panic!("expected InlineBox at 3");
         };
         assert!(
-            (ib.x_offset - 13.0).abs() < 0.001,
+            (ib.x_offset.to_f32() - 13.0).abs() < 0.001,
             "ib: got {}",
-            ib.x_offset
+            ib.x_offset.to_f32()
         );
         // Second line must be unchanged.
         let LineItem::InlineBox(l1_ib) = &out.paragraphs[&5].lines[1].items[0] else {
             panic!("expected InlineBox in line 1");
         };
         assert!(
-            (l1_ib.x_offset - 0.0).abs() < 0.001,
+            (l1_ib.x_offset.to_f32() - 0.0).abs() < 0.001,
             "line 1 shifted unexpectedly: {}",
-            l1_ib.x_offset
+            l1_ib.x_offset.to_f32()
         );
     }
 
@@ -889,12 +899,12 @@ mod tests {
         let zero_glyph_marker = LineItem::Text(ShapedGlyphRun {
             font_data: Arc::new(vec![]),
             font_index: 0,
-            font_size: 12.0,
+            font_size: 12.0_f32.pt(),
             color: [0, 0, 0, 255],
             decoration: TextDecoration::default(),
             glyphs: vec![],
             text: String::new(),
-            x_offset: 0.0,
+            x_offset: crate::units::Pt::ZERO,
             link: None,
         });
         assert!(inject_marker_into_first_paragraph(
@@ -907,9 +917,9 @@ mod tests {
             panic!("expected InlineBox at index 1");
         };
         assert!(
-            (ib.x_offset - 7.0).abs() < 0.001,
+            (ib.x_offset.to_f32() - 7.0).abs() < 0.001,
             "expected no shift, got {}",
-            ib.x_offset
+            ib.x_offset.to_f32()
         );
         // Marker is still inserted at index 0.
         assert_eq!(out.paragraphs[&5].lines[0].items.len(), 2);

--- a/crates/fulgur/src/convert/list_marker.rs
+++ b/crates/fulgur/src/convert/list_marker.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::blitz_adapter::{Marker, marker_skrifa_text, marker_to_string};
+use crate::units::F32Units;
 
 /// Resolve a node's computed `list-style-image` to bundled asset bytes and
 /// detected asset kind. Returns `None` when there is no `list-style-image`,
@@ -136,13 +137,13 @@ pub(super) fn resolve_inside_image_marker(
             Some(InlineImage {
                 data: Arc::clone(data),
                 format,
-                width,
-                height,
-                x_offset: 0.0,
+                width: width.pt(),
+                height: height.pt(),
+                x_offset: crate::units::Pt::ZERO,
                 vertical_align: VerticalAlign::Baseline,
                 opacity: 1.0,
                 visible: true,
-                computed_y: 0.0,
+                computed_y: crate::units::Pt::ZERO,
                 link: None,
             })
         }
@@ -198,7 +199,7 @@ pub(super) fn extract_marker_lines(
                 // conversion. Glyph ratios stay unitless by dividing by
                 // the original parley value.
                 let font_size_parley = run.font_size();
-                let font_size = px_to_pt(font_size_parley);
+                let font_size = font_size_parley.px().in_pt();
 
                 let brush = &glyph_run.style().brush;
                 let color = get_text_color(doc, brush.id);
@@ -247,7 +248,7 @@ pub(super) fn extract_marker_lines(
                         decoration: Default::default(),
                         glyphs,
                         text: marker_text.clone(),
-                        x_offset: px_to_pt(glyph_run.offset()),
+                        x_offset: glyph_run.offset().px().in_pt(),
                         link: None,
                     }));
                 }
@@ -256,8 +257,8 @@ pub(super) fn extract_marker_lines(
 
         max_width = max_width.max(line_width);
         shaped_lines.push(ShapedLine {
-            height: px_to_pt(metrics.line_height),
-            baseline: px_to_pt(metrics.baseline),
+            height: metrics.line_height.px().in_pt(),
+            baseline: metrics.baseline.px().in_pt(),
             items,
         });
     }
@@ -370,12 +371,12 @@ pub(super) fn shape_marker_with_skrifa(
     Some(ShapedGlyphRun {
         font_data: Arc::clone(font_data),
         font_index,
-        font_size,
+        font_size: font_size.pt(),
         color,
         decoration: TextDecoration::default(),
         glyphs,
         text,
-        x_offset: 0.0,
+        x_offset: crate::units::Pt::ZERO,
         link: None,
     })
 }
@@ -499,7 +500,7 @@ mod tests {
         let glyph_run = ShapedGlyphRun {
             font_data: Arc::clone(&font_data),
             font_index: 0,
-            font_size: 12.0,
+            font_size: 12.0_f32.pt(),
             color: [0, 0, 0, 255],
             decoration: TextDecoration::default(),
             glyphs: vec![ShapedGlyph {
@@ -510,12 +511,12 @@ mod tests {
                 text_range: 0..1,
             }],
             text: "A".to_string(),
-            x_offset: 0.0,
+            x_offset: crate::units::Pt::ZERO,
             link: None,
         };
         let line = ShapedLine {
-            height: 12.0,
-            baseline: 9.0,
+            height: 12.0_f32.pt(),
+            baseline: 9.0_f32.pt(),
             items: vec![LineItem::Text(glyph_run)],
         };
         let mut drawables = Drawables::new();
@@ -558,10 +559,10 @@ mod tests {
         let run = result.unwrap();
         assert_eq!(run.glyphs.len(), 2, "bullet + trailing space = 2 glyphs");
         assert_eq!(run.text, "• ");
-        assert_eq!(run.font_size, 12.0);
+        assert_eq!(run.font_size.to_f32(), 12.0);
         assert_eq!(run.color, [255, 0, 0, 255]);
         assert_eq!(run.font_index, 0);
-        assert_eq!(run.x_offset, 0.0);
+        assert_eq!(run.x_offset.to_f32(), 0.0);
     }
 
     #[test]

--- a/crates/fulgur/src/convert/list_marker.rs
+++ b/crates/fulgur/src/convert/list_marker.rs
@@ -181,6 +181,10 @@ pub(super) fn extract_marker_lines(
     for line in parley_layout.lines() {
         let metrics = line.metrics();
         if line_height_pt == 0.0 {
+            // Stays f32: this feeds the f32 marker-row height returned from
+            // this fn, a distinct sink from the `Pt`-typed `ShapedLine.height`
+            // below (`.px().in_pt()`). The dual conversion idiom is intentional,
+            // not an inconsistency.
             line_height_pt = px_to_pt(metrics.line_height);
         }
         let mut items = Vec::new();

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -839,7 +839,7 @@ fn convert_multicol_paragraph_slices(
                 //    aligned with `ParagraphEntry::lines`'s contract
                 //    (every consumer of `Vec<ShapedLine>` expects
                 //    `recalculate_paragraph_line_boxes` to have run).
-                let consumed: f32 = all_lines[..col_slice.line_range.start]
+                let consumed: crate::units::Pt = all_lines[..col_slice.line_range.start]
                     .iter()
                     .map(|l| l.height)
                     .sum();
@@ -913,7 +913,7 @@ fn shape_paragraph_glyph_runs(
                 let font_index = font_ref.index;
                 let font_arc = ctx.get_or_insert_font(font_ref);
                 let font_size_parley = run.font_size();
-                let font_size = px_to_pt(font_size_parley);
+                let font_size = font_size_parley.px().in_pt();
 
                 let brush = &glyph_run.style().brush;
                 let color = get_text_color(doc, brush.id);
@@ -956,7 +956,7 @@ fn shape_paragraph_glyph_runs(
 
                 if !glyphs.is_empty() {
                     let run_text = text.to_string();
-                    let run_x_offset = px_to_pt(glyph_run.offset());
+                    let run_x_offset = glyph_run.offset().px().in_pt();
                     items.push(LineItem::Text(ShapedGlyphRun {
                         font_data: font_arc,
                         font_index,
@@ -974,10 +974,10 @@ fn shape_paragraph_glyph_runs(
             // `convert_multicol_paragraph_slices`'s scope note.
         }
 
-        let line_height_pt = px_to_pt(metrics.line_height);
+        let line_height_pt = metrics.line_height.px().in_pt();
         shaped_lines.push(ShapedLine {
             height: line_height_pt,
-            baseline: px_to_pt(metrics.baseline),
+            baseline: metrics.baseline.px().in_pt(),
             items,
         });
     }

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -974,9 +974,9 @@ fn shape_paragraph_glyph_runs(
             // `convert_multicol_paragraph_slices`'s scope note.
         }
 
-        let line_height_pt = metrics.line_height.px().in_pt();
+        let line_height = metrics.line_height.px().in_pt();
         shaped_lines.push(ShapedLine {
-            height: line_height_pt,
+            height: line_height,
             baseline: metrics.baseline.px().in_pt(),
             items,
         });

--- a/crates/fulgur/src/convert/pseudo.rs
+++ b/crates/fulgur/src/convert/pseudo.rs
@@ -350,11 +350,7 @@ mod tests {
         assert_eq!(lines[0].items.len(), 1);
         match &lines[0].items[0] {
             LineItem::Image(img) => {
-                assert!(
-                    approx(img.x_offset, 0.0),
-                    "x_offset={}",
-                    img.x_offset.to_f32()
-                );
+                assert!(approx(img.x_offset, 0.0), "x_offset={:?}", img.x_offset);
                 assert!(approx(img.width, 20.0));
             }
             _ => panic!("expected Image at index 0"),
@@ -374,11 +370,7 @@ mod tests {
         }
         match &lines[0].items[1] {
             LineItem::Image(img) => {
-                assert!(
-                    approx(img.x_offset, 20.0),
-                    "shifted x={}",
-                    img.x_offset.to_f32()
-                );
+                assert!(approx(img.x_offset, 20.0), "shifted x={:?}", img.x_offset);
             }
             _ => panic!("expected shifted Image at index 1"),
         }
@@ -457,8 +449,8 @@ mod tests {
             LineItem::Image(img) => {
                 assert!(
                     approx(img.x_offset, 7.0),
-                    "second-line x_offset={}",
-                    img.x_offset.to_f32()
+                    "second-line x_offset={:?}",
+                    img.x_offset
                 );
             }
             _ => panic!("expected untouched Image in second line"),
@@ -477,8 +469,8 @@ mod tests {
             LineItem::Image(img) => {
                 assert!(
                     approx(img.x_offset, 15.0),
-                    "after x_offset={}",
-                    img.x_offset.to_f32()
+                    "after x_offset={:?}",
+                    img.x_offset
                 );
             }
             _ => panic!("expected appended after Image"),
@@ -525,8 +517,8 @@ mod tests {
             LineItem::Image(img) => {
                 assert!(
                     approx(img.x_offset, 34.0),
-                    "after x_offset={}",
-                    img.x_offset.to_f32()
+                    "after x_offset={:?}",
+                    img.x_offset
                 );
             }
             _ => panic!("expected appended after Image"),
@@ -556,8 +548,8 @@ mod tests {
             LineItem::Image(img) => {
                 assert!(
                     approx(img.x_offset, 10.0),
-                    "after x_offset={}",
-                    img.x_offset.to_f32()
+                    "after x_offset={:?}",
+                    img.x_offset
                 );
             }
             _ => panic!("expected appended after Image"),
@@ -571,11 +563,7 @@ mod tests {
         assert_eq!(lines[0].items.len(), 1);
         match &lines[0].items[0] {
             LineItem::Image(img) => {
-                assert!(
-                    approx(img.x_offset, 0.0),
-                    "x_offset={}",
-                    img.x_offset.to_f32()
-                );
+                assert!(approx(img.x_offset, 0.0), "x_offset={:?}", img.x_offset);
             }
             _ => panic!("expected after Image in empty line"),
         }
@@ -640,8 +628,8 @@ mod tests {
             LineItem::Image(img) => {
                 assert!(
                     approx(img.x_offset, 13.0),
-                    "after x_offset={}",
-                    img.x_offset.to_f32()
+                    "after x_offset={:?}",
+                    img.x_offset
                 );
             }
             _ => panic!("expected after Image appended"),
@@ -690,21 +678,13 @@ mod tests {
         }
         match &lines[0].items[1] {
             LineItem::Image(img) => {
-                assert!(
-                    approx(img.x_offset, 8.0),
-                    "shifted x={}",
-                    img.x_offset.to_f32()
-                );
+                assert!(approx(img.x_offset, 8.0), "shifted x={:?}", img.x_offset);
             }
             _ => panic!("expected shifted Image at 1"),
         }
         match lines[0].items.last().unwrap() {
             LineItem::Image(img) => {
-                assert!(
-                    approx(img.x_offset, 18.0),
-                    "after x={}",
-                    img.x_offset.to_f32()
-                );
+                assert!(approx(img.x_offset, 18.0), "after x={:?}", img.x_offset);
             }
             _ => panic!("expected after Image at end"),
         }

--- a/crates/fulgur/src/convert/pseudo.rs
+++ b/crates/fulgur/src/convert/pseudo.rs
@@ -2,6 +2,7 @@ use super::inline_root;
 use super::positioned::{is_absolutely_positioned, walk_absolute_children};
 use super::replaced::{make_image_entry, resolve_image_dimensions};
 use super::*;
+use crate::units::F32Units;
 
 /// Build an `ImageEntry` for a `::before`/`::after` pseudo-element node
 /// whose computed `content` resolves to a single `url(...)` image.
@@ -179,13 +180,13 @@ pub(super) fn build_inline_pseudo_image(
     Some(InlineImage {
         data,
         format,
-        width: w,
-        height: h,
-        x_offset: 0.0,
+        width: w.pt(),
+        height: h.pt(),
+        x_offset: crate::units::Pt::ZERO,
         vertical_align,
         opacity,
         visible,
-        computed_y: 0.0,
+        computed_y: crate::units::Pt::ZERO,
         link: None,
     })
 }
@@ -219,7 +220,7 @@ pub(super) fn inject_inline_pseudo_images(
                     LineItem::InlineBox(ib) => ib.x_offset += shift,
                 }
             }
-            img.x_offset = 0.0;
+            img.x_offset = crate::units::Pt::ZERO;
             first_line.items.insert(0, LineItem::Image(img));
         }
     }
@@ -235,12 +236,12 @@ pub(super) fn inject_inline_pseudo_images(
                                 .glyphs
                                 .iter()
                                 .map(|g| g.x_advance * run.font_size)
-                                .sum::<f32>()
+                                .sum::<crate::units::Pt>()
                     }
                     LineItem::Image(i) => i.x_offset + i.width,
                     LineItem::InlineBox(ib) => ib.x_offset + ib.width,
                 })
-                .fold(0.0_f32, f32::max);
+                .fold(crate::units::Pt::ZERO, crate::units::Pt::max);
             img.x_offset = last_end;
             last_line.items.push(LineItem::Image(img));
         }
@@ -268,52 +269,53 @@ mod tests {
         InlineBoxItem, InlineImage, LineItem, ShapedGlyph, ShapedGlyphRun, ShapedLine,
         TextDecoration, VerticalAlign,
     };
+    use crate::units::F32Units;
     use std::sync::Arc;
 
     fn make_image(width: f32) -> InlineImage {
         InlineImage {
             data: Arc::new(vec![]),
             format: ImageFormat::Png,
-            width,
-            height: 10.0,
-            x_offset: 0.0,
+            width: width.pt(),
+            height: 10.0_f32.pt(),
+            x_offset: crate::units::Pt::ZERO,
             vertical_align: VerticalAlign::Baseline,
             opacity: 1.0,
             visible: true,
-            computed_y: 0.0,
+            computed_y: crate::units::Pt::ZERO,
             link: None,
         }
     }
 
     fn empty_line() -> ShapedLine {
         ShapedLine {
-            height: 16.0,
-            baseline: 12.0,
+            height: 16.0_f32.pt(),
+            baseline: 12.0_f32.pt(),
             items: vec![],
         }
     }
 
     fn image_line(x_offset: f32, width: f32) -> ShapedLine {
         ShapedLine {
-            height: 16.0,
-            baseline: 12.0,
+            height: 16.0_f32.pt(),
+            baseline: 12.0_f32.pt(),
             items: vec![LineItem::Image(InlineImage {
                 data: Arc::new(vec![]),
                 format: ImageFormat::Png,
-                width,
-                height: 10.0,
-                x_offset,
+                width: width.pt(),
+                height: 10.0_f32.pt(),
+                x_offset: x_offset.pt(),
                 vertical_align: VerticalAlign::Baseline,
                 opacity: 1.0,
                 visible: true,
-                computed_y: 0.0,
+                computed_y: crate::units::Pt::ZERO,
                 link: None,
             })],
         }
     }
 
-    fn approx(a: f32, b: f32) -> bool {
-        (a - b).abs() < 0.001
+    fn approx(a: crate::units::Pt, b: f32) -> bool {
+        (a.to_f32() - b).abs() < 0.001
     }
 
     // ── empty-lines guards ───────────────────────────────────────────────────
@@ -348,7 +350,11 @@ mod tests {
         assert_eq!(lines[0].items.len(), 1);
         match &lines[0].items[0] {
             LineItem::Image(img) => {
-                assert!(approx(img.x_offset, 0.0), "x_offset={}", img.x_offset);
+                assert!(
+                    approx(img.x_offset, 0.0),
+                    "x_offset={}",
+                    img.x_offset.to_f32()
+                );
                 assert!(approx(img.width, 20.0));
             }
             _ => panic!("expected Image at index 0"),
@@ -368,7 +374,11 @@ mod tests {
         }
         match &lines[0].items[1] {
             LineItem::Image(img) => {
-                assert!(approx(img.x_offset, 20.0), "shifted x={}", img.x_offset);
+                assert!(
+                    approx(img.x_offset, 20.0),
+                    "shifted x={}",
+                    img.x_offset.to_f32()
+                );
             }
             _ => panic!("expected shifted Image at index 1"),
         }
@@ -381,7 +391,7 @@ mod tests {
         let run = ShapedGlyphRun {
             font_data: Arc::new(vec![]),
             font_index: 0,
-            font_size: 10.0,
+            font_size: 10.0_f32.pt(),
             color: [0, 0, 0, 255],
             decoration: TextDecoration::default(),
             glyphs: vec![ShapedGlyph {
@@ -392,19 +402,19 @@ mod tests {
                 text_range: 0..1,
             }],
             text: "a".to_string(),
-            x_offset: 3.0,
+            x_offset: 3.0_f32.pt(),
             link: None,
         };
         let mut lines = vec![ShapedLine {
-            height: 16.0,
-            baseline: 12.0,
+            height: 16.0_f32.pt(),
+            baseline: 12.0_f32.pt(),
             items: vec![LineItem::Text(run)],
         }];
         super::inject_inline_pseudo_images(&mut lines, Some(make_image(20.0)), None);
         assert_eq!(lines[0].items.len(), 2);
         match &lines[0].items[1] {
             LineItem::Text(r) => {
-                assert!(approx(r.x_offset, 23.0), "x_offset={}", r.x_offset);
+                assert!(approx(r.x_offset, 23.0), "x_offset={}", r.x_offset.to_f32());
             }
             _ => panic!("expected Text at index 1"),
         }
@@ -414,24 +424,24 @@ mod tests {
     fn before_shifts_inline_box_items() {
         let ib = InlineBoxItem {
             node_id: None,
-            width: 30.0,
-            height: 10.0,
-            x_offset: 5.0,
-            computed_y: 0.0,
+            width: 30.0_f32.pt(),
+            height: 10.0_f32.pt(),
+            x_offset: 5.0_f32.pt(),
+            computed_y: crate::units::Pt::ZERO,
             link: None,
             opacity: 1.0,
             visible: true,
         };
         let mut lines = vec![ShapedLine {
-            height: 16.0,
-            baseline: 12.0,
+            height: 16.0_f32.pt(),
+            baseline: 12.0_f32.pt(),
             items: vec![LineItem::InlineBox(ib)],
         }];
         super::inject_inline_pseudo_images(&mut lines, Some(make_image(10.0)), None);
         assert_eq!(lines[0].items.len(), 2);
         match &lines[0].items[1] {
             LineItem::InlineBox(b) => {
-                assert!(approx(b.x_offset, 15.0), "x_offset={}", b.x_offset);
+                assert!(approx(b.x_offset, 15.0), "x_offset={}", b.x_offset.to_f32());
             }
             _ => panic!("expected InlineBox at index 1"),
         }
@@ -448,7 +458,7 @@ mod tests {
                 assert!(
                     approx(img.x_offset, 7.0),
                     "second-line x_offset={}",
-                    img.x_offset
+                    img.x_offset.to_f32()
                 );
             }
             _ => panic!("expected untouched Image in second line"),
@@ -468,7 +478,7 @@ mod tests {
                 assert!(
                     approx(img.x_offset, 15.0),
                     "after x_offset={}",
-                    img.x_offset
+                    img.x_offset.to_f32()
                 );
             }
             _ => panic!("expected appended after Image"),
@@ -482,7 +492,7 @@ mod tests {
         let run = ShapedGlyphRun {
             font_data: Arc::new(vec![]),
             font_index: 0,
-            font_size: 4.0,
+            font_size: 4.0_f32.pt(),
             color: [0, 0, 0, 255],
             decoration: TextDecoration::default(),
             glyphs: vec![
@@ -502,12 +512,12 @@ mod tests {
                 },
             ],
             text: "ab".to_string(),
-            x_offset: 2.0,
+            x_offset: 2.0_f32.pt(),
             link: None,
         };
         let mut lines = vec![ShapedLine {
-            height: 16.0,
-            baseline: 12.0,
+            height: 16.0_f32.pt(),
+            baseline: 12.0_f32.pt(),
             items: vec![LineItem::Text(run)],
         }];
         super::inject_inline_pseudo_images(&mut lines, None, Some(make_image(20.0)));
@@ -516,7 +526,7 @@ mod tests {
                 assert!(
                     approx(img.x_offset, 34.0),
                     "after x_offset={}",
-                    img.x_offset
+                    img.x_offset.to_f32()
                 );
             }
             _ => panic!("expected appended after Image"),
@@ -528,17 +538,17 @@ mod tests {
         // x_offset=3, width=7 → end=10
         let ib = InlineBoxItem {
             node_id: None,
-            width: 7.0,
-            height: 5.0,
-            x_offset: 3.0,
-            computed_y: 0.0,
+            width: 7.0_f32.pt(),
+            height: 5.0_f32.pt(),
+            x_offset: 3.0_f32.pt(),
+            computed_y: crate::units::Pt::ZERO,
             link: None,
             opacity: 1.0,
             visible: true,
         };
         let mut lines = vec![ShapedLine {
-            height: 16.0,
-            baseline: 12.0,
+            height: 16.0_f32.pt(),
+            baseline: 12.0_f32.pt(),
             items: vec![LineItem::InlineBox(ib)],
         }];
         super::inject_inline_pseudo_images(&mut lines, None, Some(make_image(5.0)));
@@ -547,7 +557,7 @@ mod tests {
                 assert!(
                     approx(img.x_offset, 10.0),
                     "after x_offset={}",
-                    img.x_offset
+                    img.x_offset.to_f32()
                 );
             }
             _ => panic!("expected appended after Image"),
@@ -561,7 +571,11 @@ mod tests {
         assert_eq!(lines[0].items.len(), 1);
         match &lines[0].items[0] {
             LineItem::Image(img) => {
-                assert!(approx(img.x_offset, 0.0), "x_offset={}", img.x_offset);
+                assert!(
+                    approx(img.x_offset, 0.0),
+                    "x_offset={}",
+                    img.x_offset.to_f32()
+                );
             }
             _ => panic!("expected after Image in empty line"),
         }
@@ -582,27 +596,27 @@ mod tests {
         // item3: Image x=1 w=8 → end=9
         // fold(f32::max) must yield 13
         let mut lines = vec![ShapedLine {
-            height: 16.0,
-            baseline: 12.0,
+            height: 16.0_f32.pt(),
+            baseline: 12.0_f32.pt(),
             items: vec![
                 LineItem::Image(InlineImage {
                     data: Arc::new(vec![]),
                     format: ImageFormat::Png,
-                    width: 5.0,
-                    height: 10.0,
-                    x_offset: 0.0,
+                    width: 5.0_f32.pt(),
+                    height: 10.0_f32.pt(),
+                    x_offset: crate::units::Pt::ZERO,
                     vertical_align: VerticalAlign::Baseline,
                     opacity: 1.0,
                     visible: true,
-                    computed_y: 0.0,
+                    computed_y: crate::units::Pt::ZERO,
                     link: None,
                 }),
                 LineItem::InlineBox(InlineBoxItem {
                     node_id: None,
-                    width: 10.0,
-                    height: 5.0,
-                    x_offset: 3.0,
-                    computed_y: 0.0,
+                    width: 10.0_f32.pt(),
+                    height: 5.0_f32.pt(),
+                    x_offset: 3.0_f32.pt(),
+                    computed_y: crate::units::Pt::ZERO,
                     link: None,
                     opacity: 1.0,
                     visible: true,
@@ -610,13 +624,13 @@ mod tests {
                 LineItem::Image(InlineImage {
                     data: Arc::new(vec![]),
                     format: ImageFormat::Png,
-                    width: 8.0,
-                    height: 10.0,
-                    x_offset: 1.0,
+                    width: 8.0_f32.pt(),
+                    height: 10.0_f32.pt(),
+                    x_offset: 1.0_f32.pt(),
                     vertical_align: VerticalAlign::Baseline,
                     opacity: 1.0,
                     visible: true,
-                    computed_y: 0.0,
+                    computed_y: crate::units::Pt::ZERO,
                     link: None,
                 }),
             ],
@@ -627,7 +641,7 @@ mod tests {
                 assert!(
                     approx(img.x_offset, 13.0),
                     "after x_offset={}",
-                    img.x_offset
+                    img.x_offset.to_f32()
                 );
             }
             _ => panic!("expected after Image appended"),
@@ -676,13 +690,21 @@ mod tests {
         }
         match &lines[0].items[1] {
             LineItem::Image(img) => {
-                assert!(approx(img.x_offset, 8.0), "shifted x={}", img.x_offset);
+                assert!(
+                    approx(img.x_offset, 8.0),
+                    "shifted x={}",
+                    img.x_offset.to_f32()
+                );
             }
             _ => panic!("expected shifted Image at 1"),
         }
         match lines[0].items.last().unwrap() {
             LineItem::Image(img) => {
-                assert!(approx(img.x_offset, 18.0), "after x={}", img.x_offset);
+                assert!(
+                    approx(img.x_offset, 18.0),
+                    "after x={}",
+                    img.x_offset.to_f32()
+                );
             }
             _ => panic!("expected after Image at end"),
         }

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -6,6 +6,7 @@ use skrifa::MetadataProvider;
 
 use crate::draw_primitives::{Canvas, Pt};
 use crate::image::ImageFormat;
+use crate::units::F32Units;
 
 /// Which decoration lines to draw (bitflags).
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -93,12 +94,12 @@ pub struct LinkSpan {
 pub struct ShapedGlyphRun {
     pub font_data: Arc<Vec<u8>>,
     pub font_index: u32,
-    pub font_size: f32,
+    pub font_size: crate::units::Pt,
     pub color: [u8; 4], // RGBA
     pub decoration: TextDecoration,
     pub glyphs: Vec<ShapedGlyph>,
     pub text: String,
-    pub x_offset: f32,
+    pub x_offset: crate::units::Pt,
     pub link: Option<Arc<LinkSpan>>,
 }
 
@@ -123,9 +124,9 @@ pub enum VerticalAlign {
 pub struct InlineImage {
     pub data: Arc<Vec<u8>>,
     pub format: ImageFormat,
-    pub width: f32,
-    pub height: f32,
-    pub x_offset: f32,
+    pub width: crate::units::Pt,
+    pub height: crate::units::Pt,
+    pub x_offset: crate::units::Pt,
     pub vertical_align: VerticalAlign,
     pub opacity: f32,
     pub visible: bool,
@@ -136,7 +137,7 @@ pub struct InlineImage {
     /// consumed height so the next fragment starts at its own paragraph
     /// origin. Contrast with `InlineBoxItem::computed_y`, which stays
     /// line-relative for its entire lifetime.
-    pub computed_y: f32,
+    pub computed_y: crate::units::Pt,
     pub link: Option<Arc<LinkSpan>>,
 }
 
@@ -145,9 +146,9 @@ pub struct InlineImage {
 #[derive(Clone, Debug)]
 pub struct InlineBoxItem {
     pub node_id: Option<usize>,
-    pub width: f32,
-    pub height: f32,
-    pub x_offset: f32,
+    pub width: crate::units::Pt,
+    pub height: crate::units::Pt,
+    pub x_offset: crate::units::Pt,
     /// Y offset from the line top in pt. `extract_paragraph` converts
     /// Parley's paragraph-relative `y` to line-relative by subtracting the
     /// accumulated line_top. Unlike `InlineImage::computed_y`, this value
@@ -155,7 +156,7 @@ pub struct InlineBoxItem {
     /// `recalculate_line_box` does not promote it, and `split_paragraph`
     /// does not rebase it (each fragment's own `line_top` accumulator
     /// handles vertical positioning naturally).
-    pub computed_y: f32,
+    pub computed_y: crate::units::Pt,
     pub link: Option<Arc<LinkSpan>>,
     pub opacity: f32,
     pub visible: bool,
@@ -174,9 +175,9 @@ pub enum LineItem {
 /// A shaped line of text.
 #[derive(Clone)]
 pub struct ShapedLine {
-    pub height: f32,
+    pub height: crate::units::Pt,
     /// Absolute offset from the paragraph's top edge to this line's baseline (from Parley).
-    pub baseline: f32,
+    pub baseline: crate::units::Pt,
     pub items: Vec<LineItem>,
 }
 
@@ -199,7 +200,7 @@ pub struct ParagraphRender {
 
 impl ParagraphRender {
     pub fn new(lines: Vec<ShapedLine>) -> Self {
-        let cached_height: f32 = lines.iter().map(|l| l.height).sum();
+        let cached_height: f32 = lines.iter().map(|l| l.height.to_f32()).sum();
         Self {
             lines,
             cached_height,
@@ -437,17 +438,22 @@ fn draw_decoration_line(
 
 /// A contiguous span of runs sharing the same decoration attributes.
 struct DecorationSpan {
-    x: f32,
-    width: f32,
+    x: crate::units::Pt,
+    width: crate::units::Pt,
     decoration: TextDecoration,
     /// Use metrics from the first run in the span
     font_data: Arc<Vec<u8>>,
     font_index: u32,
-    font_size: f32,
+    font_size: crate::units::Pt,
 }
 
 /// Collect contiguous runs with the same decoration into spans, then draw each span once.
-fn draw_line_decorations(canvas: &mut Canvas<'_, '_>, items: &[LineItem], x: Pt, baseline_y: Pt) {
+fn draw_line_decorations(
+    canvas: &mut Canvas<'_, '_>,
+    items: &[LineItem],
+    x: crate::units::Pt,
+    baseline_y: crate::units::Pt,
+) {
     let mut spans: Vec<DecorationSpan> = Vec::new();
 
     for item in items {
@@ -461,13 +467,14 @@ fn draw_line_decorations(canvas: &mut Canvas<'_, '_>, items: &[LineItem], x: Pt,
         }
 
         let run_x = x + run.x_offset;
-        let run_width: f32 = run.glyphs.iter().map(|g| g.x_advance * run.font_size).sum();
+        let run_width: crate::units::Pt =
+            run.glyphs.iter().map(|g| g.x_advance * run.font_size).sum();
 
         // Try to extend the previous span if decoration matches
         if let Some(last) = spans.last_mut() {
             let last_end = last.x + last.width;
             let gap = (run_x - last_end).abs();
-            if last.decoration.same_appearance(&run.decoration) && gap < 0.5 {
+            if last.decoration.same_appearance(&run.decoration) && gap < 0.5_f32.pt() {
                 last.width = (run_x + run_width) - last.x;
                 continue;
             }
@@ -484,27 +491,28 @@ fn draw_line_decorations(canvas: &mut Canvas<'_, '_>, items: &[LineItem], x: Pt,
     }
 
     for span in &spans {
-        let metrics = get_decoration_metrics(&span.font_data, span.font_index, span.font_size);
+        let metrics =
+            get_decoration_metrics(&span.font_data, span.font_index, span.font_size.to_f32());
 
         if span.decoration.line.contains(TextDecorationLine::UNDERLINE) {
-            let line_y = baseline_y + metrics.underline_offset;
+            let line_y = baseline_y + metrics.underline_offset.pt();
             draw_decoration_line(
                 canvas,
-                span.x,
-                line_y,
-                span.width,
+                span.x.to_f32(),
+                line_y.to_f32(),
+                span.width.to_f32(),
                 metrics.underline_thickness,
                 span.decoration.color,
                 span.decoration.style,
             );
         }
         if span.decoration.line.contains(TextDecorationLine::OVERLINE) {
-            let line_y = baseline_y - metrics.overline_pos;
+            let line_y = baseline_y - metrics.overline_pos.pt();
             draw_decoration_line(
                 canvas,
-                span.x,
-                line_y,
-                span.width,
+                span.x.to_f32(),
+                line_y.to_f32(),
+                span.width.to_f32(),
                 metrics.underline_thickness,
                 span.decoration.color,
                 span.decoration.style,
@@ -515,12 +523,12 @@ fn draw_line_decorations(canvas: &mut Canvas<'_, '_>, items: &[LineItem], x: Pt,
             .line
             .contains(TextDecorationLine::LINE_THROUGH)
         {
-            let line_y = baseline_y - metrics.strikethrough_offset;
+            let line_y = baseline_y - metrics.strikethrough_offset.pt();
             draw_decoration_line(
                 canvas,
-                span.x,
-                line_y,
-                span.width,
+                span.x.to_f32(),
+                line_y.to_f32(),
+                span.width.to_f32(),
                 metrics.strikethrough_thickness,
                 span.decoration.color,
                 span.decoration.style,
@@ -629,8 +637,8 @@ fn link_span_ptr(link: Option<&Arc<LinkSpan>>) -> Option<usize> {
 pub fn draw_shaped_lines(
     canvas: &mut Canvas<'_, '_>,
     lines: &[ShapedLine],
-    x: Pt,
-    y: Pt,
+    x: crate::units::Pt,
+    y: crate::units::Pt,
     inline_box_ctx: Option<InlineBoxRenderCtx<'_>>,
 ) {
     // Track the top edge of each line within the paragraph (paragraph y=0 at
@@ -639,7 +647,7 @@ pub fn draw_shaped_lines(
     // top via cumulative height is both simpler and more robust than trying
     // to derive it from `line.baseline` (which is an absolute baseline offset
     // and does not carry per-line ascent).
-    let mut line_top: f32 = 0.0;
+    let mut line_top = crate::units::Pt::ZERO;
     // Per-run tagging mode is active when canvas.link_run_node_id is set and
     // tagging is enabled. In this mode each glyph-run or inline-image cluster
     // bounded by `Arc<LinkSpan>` identity gets its own start_tagged/end_tagged
@@ -698,13 +706,16 @@ pub fn draw_shaped_lines(
                     };
                     canvas.surface.set_fill(Some(fill));
 
-                    let start = krilla::geom::Point::from_xy(x + run.x_offset, baseline_y);
+                    let start = krilla::geom::Point::from_xy(
+                        (x + run.x_offset).to_f32(),
+                        baseline_y.to_f32(),
+                    );
                     canvas.surface.draw_glyphs(
                         start,
                         &krilla_glyphs,
                         font,
                         &run.text,
-                        run.font_size,
+                        run.font_size.to_f32(),
                         false,
                     );
 
@@ -714,13 +725,13 @@ pub fn draw_shaped_lines(
                     // (same glyph advance accumulator); height uses the full
                     // line box so the hit area is stable across lines.
                     if let Some(link_span) = run.link.as_ref() {
-                        let run_width: f32 =
+                        let run_width: crate::units::Pt =
                             run.glyphs.iter().map(|g| g.x_advance * run.font_size).sum();
                         let rect = crate::draw_primitives::Rect {
-                            x: x + run.x_offset,
-                            y: line_top_abs,
-                            width: run_width.max(0.0),
-                            height: line.height,
+                            x: (x + run.x_offset).to_f32(),
+                            y: line_top_abs.to_f32(),
+                            width: run_width.max(crate::units::Pt::ZERO).to_f32(),
+                            height: line.height.to_f32(),
                         };
                         if let Some(collector) = canvas.link_collector.as_deref_mut() {
                             collector.push_rect(link_span, rect);
@@ -739,12 +750,16 @@ pub fn draw_shaped_lines(
                         let Ok(image) = img.format.to_krilla_image(data) else {
                             return;
                         };
-                        let Some(size) = krilla::geom::Size::from_wh(img.width, img.height) else {
+                        let Some(size) =
+                            krilla::geom::Size::from_wh(img.width.to_f32(), img.height.to_f32())
+                        else {
                             return;
                         };
                         let img_y = y + img.computed_y;
-                        let transform =
-                            krilla::geom::Transform::from_translate(x + img.x_offset, img_y);
+                        let transform = krilla::geom::Transform::from_translate(
+                            (x + img.x_offset).to_f32(),
+                            img_y.to_f32(),
+                        );
                         canvas.surface.push_transform(&transform);
                         canvas.surface.draw_image(image, size);
                         canvas.surface.pop();
@@ -755,10 +770,10 @@ pub fn draw_shaped_lines(
                     // (x + x_offset, y + computed_y, width, height).
                     if let Some(link_span) = img.link.as_ref() {
                         let rect = crate::draw_primitives::Rect {
-                            x: x + img.x_offset,
-                            y: y + img.computed_y,
-                            width: img.width.max(0.0),
-                            height: img.height.max(0.0),
+                            x: (x + img.x_offset).to_f32(),
+                            y: (y + img.computed_y).to_f32(),
+                            width: img.width.max(crate::units::Pt::ZERO).to_f32(),
+                            height: img.height.max(crate::units::Pt::ZERO).to_f32(),
                         };
                         if let Some(collector) = canvas.link_collector.as_deref_mut() {
                             collector.push_rect(link_span, rect);
@@ -817,8 +832,8 @@ pub fn draw_shaped_lines(
                         let geo_y_pt = ctx.margin_top_pt
                             + ctx.drawables.body_offset_pt.1
                             + crate::convert::px_to_pt(content_frag.y);
-                        let off_x = ox - geo_x_pt;
-                        let off_y = oy - geo_y_pt;
+                        let off_x = ox.to_f32() - geo_x_pt;
+                        let off_y = oy.to_f32() - geo_y_pt;
                         let transform = krilla::geom::Transform::from_translate(off_x, off_y);
                         let link_affine =
                             crate::draw_primitives::Affine2D::translation(off_x, off_y);
@@ -852,10 +867,10 @@ pub fn draw_shaped_lines(
                     // hit-areas remain intact even for opacity<1.0 boxes.
                     if let Some(link_span) = ib.link.as_ref() {
                         let rect = crate::draw_primitives::Rect {
-                            x: ox,
-                            y: oy,
-                            width: ib.width.max(0.0),
-                            height: ib.height.max(0.0),
+                            x: ox.to_f32(),
+                            y: oy.to_f32(),
+                            width: ib.width.max(crate::units::Pt::ZERO).to_f32(),
+                            height: ib.height.max(crate::units::Pt::ZERO).to_f32(),
                         };
                         if let Some(collector) = canvas.link_collector.as_deref_mut() {
                             collector.push_rect(link_span, rect);
@@ -904,12 +919,12 @@ pub fn recalculate_line_box(line: &mut ShapedLine, metrics: &LineFontMetrics) {
     let original_height = line.height;
     let baseline = line.baseline;
 
-    let mut line_top: f32 = 0.0;
-    let mut line_bottom: f32 = original_height;
+    let mut line_top = crate::units::Pt::ZERO;
+    let mut line_bottom = original_height;
 
     // Phase 1: compute img_top for flow-aligned images and expand line box.
     // Store (index, img_top) for later computed_y assignment.
-    let mut positions: Vec<(usize, f32)> = Vec::new();
+    let mut positions: Vec<(usize, crate::units::Pt)> = Vec::new();
 
     for (idx, item) in line.items.iter().enumerate() {
         let img = match item {
@@ -924,12 +939,12 @@ pub fn recalculate_line_box(line: &mut ShapedLine, metrics: &LineFontMetrics) {
                 continue;
             }
             VerticalAlign::Baseline => baseline - img.height,
-            VerticalAlign::Middle => baseline - metrics.x_height / 2.0 - img.height / 2.0,
-            VerticalAlign::Sub => baseline + metrics.subscript_offset - img.height,
-            VerticalAlign::Super => baseline - metrics.superscript_offset - img.height,
-            VerticalAlign::TextTop => baseline - metrics.ascent,
-            VerticalAlign::TextBottom => baseline + metrics.descent - img.height,
-            VerticalAlign::Length(v) => baseline - v - img.height,
+            VerticalAlign::Middle => baseline - (metrics.x_height / 2.0).pt() - img.height / 2.0,
+            VerticalAlign::Sub => baseline + metrics.subscript_offset.pt() - img.height,
+            VerticalAlign::Super => baseline - metrics.superscript_offset.pt() - img.height,
+            VerticalAlign::TextTop => baseline - metrics.ascent.pt(),
+            VerticalAlign::TextBottom => baseline + metrics.descent.pt() - img.height,
+            VerticalAlign::Length(v) => baseline - v.pt() - img.height,
             VerticalAlign::Percent(p) => baseline - (original_height * p) - img.height,
         };
 
@@ -993,13 +1008,13 @@ mod tests {
         InlineImage {
             data: Arc::new(TEST_PNG.to_vec()),
             format: ImageFormat::Png,
-            width,
-            height,
-            x_offset: 0.0,
+            width: width.pt(),
+            height: height.pt(),
+            x_offset: crate::units::Pt::ZERO,
             vertical_align: va,
             opacity: 1.0,
             visible: true,
-            computed_y: 0.0,
+            computed_y: crate::units::Pt::ZERO,
             link: None,
         }
     }
@@ -1017,14 +1032,19 @@ mod tests {
     /// A text-only line: height=16, baseline=12.
     fn text_line(height: f32, baseline: f32) -> ShapedLine {
         ShapedLine {
-            height,
-            baseline,
+            height: height.pt(),
+            baseline: baseline.pt(),
             items: Vec::new(),
         }
     }
 
     fn approx(a: f32, b: f32) -> bool {
         (a - b).abs() < 0.01
+    }
+
+    /// Compare a migrated `Pt` coordinate against a raw `f32` expectation.
+    fn approx_pt(a: crate::units::Pt, b: f32) -> bool {
+        (a.to_f32() - b).abs() < 0.01
     }
 
     // ---------- Baseline ----------
@@ -1041,10 +1061,22 @@ mod tests {
         )));
         let m = default_metrics();
         recalculate_line_box(&mut line, &m);
-        assert!(approx(line.height, 16.0), "height={}", line.height);
-        assert!(approx(line.baseline, 12.0), "baseline={}", line.baseline);
+        assert!(
+            approx_pt(line.height, 16.0),
+            "height={}",
+            line.height.to_f32()
+        );
+        assert!(
+            approx_pt(line.baseline, 12.0),
+            "baseline={}",
+            line.baseline.to_f32()
+        );
         if let LineItem::Image(img) = &line.items[0] {
-            assert!(approx(img.computed_y, 4.0), "computed_y={}", img.computed_y);
+            assert!(
+                approx_pt(img.computed_y, 4.0),
+                "computed_y={}",
+                img.computed_y.to_f32()
+            );
         }
     }
 
@@ -1060,10 +1092,22 @@ mod tests {
         )));
         let m = default_metrics();
         recalculate_line_box(&mut line, &m);
-        assert!(approx(line.height, 24.0), "height={}", line.height);
-        assert!(approx(line.baseline, 20.0), "baseline={}", line.baseline);
+        assert!(
+            approx_pt(line.height, 24.0),
+            "height={}",
+            line.height.to_f32()
+        );
+        assert!(
+            approx_pt(line.baseline, 20.0),
+            "baseline={}",
+            line.baseline.to_f32()
+        );
         if let LineItem::Image(img) = &line.items[0] {
-            assert!(approx(img.computed_y, 0.0), "computed_y={}", img.computed_y);
+            assert!(
+                approx_pt(img.computed_y, 0.0),
+                "computed_y={}",
+                img.computed_y.to_f32()
+            );
         }
     }
 
@@ -1080,9 +1124,17 @@ mod tests {
         )));
         let m = default_metrics();
         recalculate_line_box(&mut line, &m);
-        assert!(approx(line.height, 16.0), "height={}", line.height);
+        assert!(
+            approx_pt(line.height, 16.0),
+            "height={}",
+            line.height.to_f32()
+        );
         if let LineItem::Image(img) = &line.items[0] {
-            assert!(approx(img.computed_y, 3.0), "computed_y={}", img.computed_y);
+            assert!(
+                approx_pt(img.computed_y, 3.0),
+                "computed_y={}",
+                img.computed_y.to_f32()
+            );
         }
     }
 
@@ -1101,9 +1153,9 @@ mod tests {
         recalculate_line_box(&mut line, &m);
         if let LineItem::Image(img) = &line.items[0] {
             assert!(
-                approx(img.computed_y, 10.0),
+                approx_pt(img.computed_y, 10.0),
                 "computed_y={}",
-                img.computed_y
+                img.computed_y.to_f32()
             );
         }
     }
@@ -1122,7 +1174,11 @@ mod tests {
         let m = default_metrics();
         recalculate_line_box(&mut line, &m);
         if let LineItem::Image(img) = &line.items[0] {
-            assert!(approx(img.computed_y, 0.0), "computed_y={}", img.computed_y);
+            assert!(
+                approx_pt(img.computed_y, 0.0),
+                "computed_y={}",
+                img.computed_y.to_f32()
+            );
         }
     }
 
@@ -1140,7 +1196,11 @@ mod tests {
         let m = default_metrics();
         recalculate_line_box(&mut line, &m);
         if let LineItem::Image(img) = &line.items[0] {
-            assert!(approx(img.computed_y, 0.0), "computed_y={}", img.computed_y);
+            assert!(
+                approx_pt(img.computed_y, 0.0),
+                "computed_y={}",
+                img.computed_y.to_f32()
+            );
         }
     }
 
@@ -1158,7 +1218,11 @@ mod tests {
         let m = default_metrics();
         recalculate_line_box(&mut line, &m);
         if let LineItem::Image(img) = &line.items[0] {
-            assert!(approx(img.computed_y, 8.0), "computed_y={}", img.computed_y);
+            assert!(
+                approx_pt(img.computed_y, 8.0),
+                "computed_y={}",
+                img.computed_y.to_f32()
+            );
         }
     }
 
@@ -1176,7 +1240,11 @@ mod tests {
         let m = default_metrics();
         recalculate_line_box(&mut line, &m);
         if let LineItem::Image(img) = &line.items[0] {
-            assert!(approx(img.computed_y, 0.0), "computed_y={}", img.computed_y);
+            assert!(
+                approx_pt(img.computed_y, 0.0),
+                "computed_y={}",
+                img.computed_y.to_f32()
+            );
         }
     }
 
@@ -1195,9 +1263,9 @@ mod tests {
         recalculate_line_box(&mut line, &m);
         if let LineItem::Image(img) = &line.items[0] {
             assert!(
-                approx(img.computed_y, line.height - 8.0),
+                approx_pt(img.computed_y, line.height.to_f32() - 8.0),
                 "computed_y={}",
-                img.computed_y,
+                img.computed_y.to_f32(),
             );
         }
     }
@@ -1216,7 +1284,11 @@ mod tests {
         let m = default_metrics();
         recalculate_line_box(&mut line, &m);
         if let LineItem::Image(img) = &line.items[0] {
-            assert!(approx(img.computed_y, 3.0), "computed_y={}", img.computed_y);
+            assert!(
+                approx_pt(img.computed_y, 3.0),
+                "computed_y={}",
+                img.computed_y.to_f32()
+            );
         }
     }
 
@@ -1234,7 +1306,11 @@ mod tests {
         let m = default_metrics();
         recalculate_line_box(&mut line, &m);
         if let LineItem::Image(img) = &line.items[0] {
-            assert!(approx(img.computed_y, 2.0), "computed_y={}", img.computed_y);
+            assert!(
+                approx_pt(img.computed_y, 2.0),
+                "computed_y={}",
+                img.computed_y.to_f32()
+            );
         }
     }
 
@@ -1251,9 +1327,17 @@ mod tests {
         )));
         let m = default_metrics();
         recalculate_line_box(&mut line, &m);
-        assert!(approx(line.height, 20.0), "height={}", line.height);
+        assert!(
+            approx_pt(line.height, 20.0),
+            "height={}",
+            line.height.to_f32()
+        );
         if let LineItem::Image(img) = &line.items[0] {
-            assert!(approx(img.computed_y, 0.0), "computed_y={}", img.computed_y);
+            assert!(
+                approx_pt(img.computed_y, 0.0),
+                "computed_y={}",
+                img.computed_y.to_f32()
+            );
         }
     }
 
@@ -1276,31 +1360,31 @@ mod tests {
         )));
 
         // Simulate the caller's coordinate conversion:
-        let y_acc = 16.0; // first line height
+        let y_acc = 16.0_f32.pt(); // first line height
         line2.baseline -= y_acc; // now line-local: 12.0
         let m = default_metrics();
         recalculate_line_box(&mut line2, &m);
         // Image fits within [0, 16): no expansion
         assert!(
-            approx(line2.height, 16.0),
+            approx_pt(line2.height, 16.0),
             "height should stay 16, got {}",
-            line2.height
+            line2.height.to_f32()
         );
         // Convert computed_y to paragraph-absolute
         if let LineItem::Image(img) = &mut line2.items[0] {
             img.computed_y += y_acc;
             // paragraph-absolute computed_y = line-local (4.0) + y_acc (16.0) = 20.0
             assert!(
-                approx(img.computed_y, 20.0),
+                approx_pt(img.computed_y, 20.0),
                 "paragraph-absolute computed_y should be 20, got {}",
-                img.computed_y
+                img.computed_y.to_f32()
             );
         }
         line2.baseline += y_acc; // restore to paragraph-absolute: 28.0
         assert!(
-            approx(line2.baseline, 28.0),
+            approx_pt(line2.baseline, 28.0),
             "baseline should be 28, got {}",
-            line2.baseline
+            line2.baseline.to_f32()
         );
     }
 
@@ -1334,17 +1418,17 @@ mod tests {
     fn line_item_inline_box_variant_can_be_constructed() {
         let item = LineItem::InlineBox(InlineBoxItem {
             node_id: Some(42),
-            width: 50.0,
-            height: 20.0,
-            x_offset: 10.0,
-            computed_y: 0.0,
+            width: 50.0_f32.pt(),
+            height: 20.0_f32.pt(),
+            x_offset: 10.0_f32.pt(),
+            computed_y: crate::units::Pt::ZERO,
             link: None,
             opacity: 1.0,
             visible: true,
         });
         match item {
             LineItem::InlineBox(ib) => {
-                assert_eq!(ib.width, 50.0);
+                assert_eq!(ib.width.to_f32(), 50.0);
                 assert_eq!(ib.node_id, Some(42));
             }
             _ => panic!("expected InlineBox variant"),
@@ -1360,12 +1444,12 @@ mod tests {
         let glyph_run = ShapedGlyphRun {
             font_data: Arc::new(Vec::new()),
             font_index: 0,
-            font_size: 10.0,
+            font_size: 10.0_f32.pt(),
             color: [0, 0, 0, 255],
             decoration: TextDecoration::default(),
             glyphs: Vec::new(),
             text: String::from("hi"),
-            x_offset: 0.0,
+            x_offset: crate::units::Pt::ZERO,
             link: None,
         };
         let text = LineItem::Text(glyph_run);
@@ -1378,17 +1462,17 @@ mod tests {
         // InlineBox variant — node_id: Some(1).
         let ib = LineItem::InlineBox(InlineBoxItem {
             node_id: Some(1),
-            width: 10.0,
-            height: 5.0,
-            x_offset: 1.0,
-            computed_y: 2.0,
+            width: 10.0_f32.pt(),
+            height: 5.0_f32.pt(),
+            x_offset: 1.0_f32.pt(),
+            computed_y: 2.0_f32.pt(),
             link: None,
             opacity: 1.0,
             visible: true,
         });
         let s = format!("{:?}", ib);
         assert!(s.contains("InlineBox"), "{}", s);
-        assert!(s.contains("width: 10.0"), "{}", s);
+        assert!(s.contains("width: Pt(10.0)"), "{}", s);
     }
 
     // ---------- recalculate_line_box: Text item `continue` arms ----------
@@ -1401,12 +1485,12 @@ mod tests {
         let run = ShapedGlyphRun {
             font_data: Arc::new(Vec::new()),
             font_index: 0,
-            font_size: 12.0,
+            font_size: 12.0_f32.pt(),
             color: [0, 0, 0, 255],
             decoration: TextDecoration::default(),
             glyphs: Vec::new(),
             text: String::new(),
-            x_offset: 0.0,
+            x_offset: crate::units::Pt::ZERO,
             link: None,
         };
         let mut line = text_line(16.0, 12.0);
@@ -1414,8 +1498,16 @@ mod tests {
         let m = default_metrics();
         recalculate_line_box(&mut line, &m);
         // Text items are skipped: height and baseline must be unchanged.
-        assert!(approx(line.height, 16.0), "height={}", line.height);
-        assert!(approx(line.baseline, 12.0), "baseline={}", line.baseline);
+        assert!(
+            approx_pt(line.height, 16.0),
+            "height={}",
+            line.height.to_f32()
+        );
+        assert!(
+            approx_pt(line.baseline, 12.0),
+            "baseline={}",
+            line.baseline.to_f32()
+        );
     }
 
     // ---------- recalculate_line_box: Phase-1 line_bottom expansion ----------
@@ -1447,13 +1539,21 @@ mod tests {
         recalculate_line_box(&mut line, &metrics);
         // line_top stays 0 (img_top=15 > 0), shift=0
         // height = 20 - 0 = 20
-        assert!(approx(line.height, 20.0), "height={}", line.height);
-        assert!(approx(line.baseline, 12.0), "baseline={}", line.baseline);
+        assert!(
+            approx_pt(line.height, 20.0),
+            "height={}",
+            line.height.to_f32()
+        );
+        assert!(
+            approx_pt(line.baseline, 12.0),
+            "baseline={}",
+            line.baseline.to_f32()
+        );
         if let LineItem::Image(img) = &line.items[0] {
             assert!(
-                approx(img.computed_y, 15.0),
+                approx_pt(img.computed_y, 15.0),
                 "computed_y={}",
-                img.computed_y
+                img.computed_y.to_f32()
             );
         }
     }
@@ -1475,12 +1575,24 @@ mod tests {
         )));
         let m = default_metrics();
         recalculate_line_box(&mut line, &m);
-        assert!(approx(line.height, 20.0), "height={}", line.height);
+        assert!(
+            approx_pt(line.height, 20.0),
+            "height={}",
+            line.height.to_f32()
+        );
         // baseline = 12 + shift(4) = 16
-        assert!(approx(line.baseline, 16.0), "baseline={}", line.baseline);
+        assert!(
+            approx_pt(line.baseline, 16.0),
+            "baseline={}",
+            line.baseline.to_f32()
+        );
         if let LineItem::Image(img) = &line.items[0] {
             // computed_y = img_top + shift = -4 + 4 = 0
-            assert!(approx(img.computed_y, 0.0), "computed_y={}", img.computed_y);
+            assert!(
+                approx_pt(img.computed_y, 0.0),
+                "computed_y={}",
+                img.computed_y.to_f32()
+            );
         }
     }
 
@@ -1546,16 +1658,16 @@ mod tests {
     #[test]
     fn recalculate_line_box_skips_inline_box_items() {
         let mut line = ShapedLine {
-            height: 16.0,
-            baseline: 12.0,
+            height: 16.0_f32.pt(),
+            baseline: 12.0_f32.pt(),
             items: vec![
                 LineItem::Image(make_inline_image(10.0, 6.0, VerticalAlign::Top)),
                 LineItem::InlineBox(InlineBoxItem {
                     node_id: None,
-                    width: 30.0,
-                    height: 20.0,
-                    x_offset: 0.0,
-                    computed_y: 3.0,
+                    width: 30.0_f32.pt(),
+                    height: 20.0_f32.pt(),
+                    x_offset: crate::units::Pt::ZERO,
+                    computed_y: 3.0_f32.pt(),
                     link: None,
                     opacity: 1.0,
                     visible: true,
@@ -1567,8 +1679,12 @@ mod tests {
         assert_eq!(line.items.len(), 2);
         match &line.items[1] {
             LineItem::InlineBox(ib) => {
-                assert_eq!(ib.width, 30.0);
-                assert!(approx(ib.computed_y, 3.0), "computed_y={}", ib.computed_y);
+                assert_eq!(ib.width.to_f32(), 30.0);
+                assert!(
+                    approx_pt(ib.computed_y, 3.0),
+                    "computed_y={}",
+                    ib.computed_y.to_f32()
+                );
             }
             _ => panic!("expected InlineBox at index 1"),
         }
@@ -1594,12 +1710,12 @@ mod link_span_tests {
         let run = ShapedGlyphRun {
             font_data: Arc::new(Vec::new()),
             font_index: 0,
-            font_size: 12.0,
+            font_size: 12.0_f32.pt(),
             color: [0, 0, 0, 255],
             decoration: TextDecoration::default(),
             glyphs: Vec::new(),
             text: String::new(),
-            x_offset: 0.0,
+            x_offset: crate::units::Pt::ZERO,
             link: None,
         };
         assert!(run.link.is_none());

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -939,7 +939,7 @@ pub fn recalculate_line_box(line: &mut ShapedLine, metrics: &LineFontMetrics) {
                 continue;
             }
             VerticalAlign::Baseline => baseline - img.height,
-            VerticalAlign::Middle => baseline - (metrics.x_height / 2.0).pt() - img.height / 2.0,
+            VerticalAlign::Middle => baseline - metrics.x_height.pt() / 2.0 - img.height / 2.0,
             VerticalAlign::Sub => baseline + metrics.subscript_offset.pt() - img.height,
             VerticalAlign::Super => baseline - metrics.superscript_offset.pt() - img.height,
             VerticalAlign::TextTop => baseline - metrics.ascent.pt(),

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -1088,15 +1088,11 @@ mod tests {
         let occ = lc.take_page(0);
         assert_eq!(occ.len(), 1, "exactly one link occurrence expected");
         assert_eq!(occ[0].quads.len(), 1, "one rect for the linked image");
+        // Identity transform stack ⇒ the quad vertices are exactly the rect
+        // corners in `transform_rect`'s bl, br, tr, tl order. rect =
+        // (x + x_offset, y + computed_y, width, height) = (7, 10, 20, 10).
         let pts = occ[0].quads[0].points;
-        let min_x = pts.iter().map(|p| p[0]).fold(f32::INFINITY, f32::min);
-        let max_x = pts.iter().map(|p| p[0]).fold(f32::NEG_INFINITY, f32::max);
-        let min_y = pts.iter().map(|p| p[1]).fold(f32::INFINITY, f32::min);
-        let max_y = pts.iter().map(|p| p[1]).fold(f32::NEG_INFINITY, f32::max);
-        assert!((min_x - 7.0).abs() < 1e-4, "min_x={min_x:?}");
-        assert!((max_x - 27.0).abs() < 1e-4, "max_x={max_x:?}");
-        assert!((min_y - 10.0).abs() < 1e-4, "min_y={min_y:?}");
-        assert!((max_y - 20.0).abs() < 1e-4, "max_y={max_y:?}");
+        assert_eq!(pts, [[7.0, 20.0], [27.0, 20.0], [27.0, 10.0], [7.0, 10.0]]);
     }
 
     /// Compare a migrated `Pt` coordinate against a raw `f32` expectation.

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -1042,6 +1042,63 @@ mod tests {
         (a - b).abs() < 0.01
     }
 
+    // ---------- inline-image link rect ----------
+
+    /// Covers the inline-image link-rect arm of `draw_shaped_lines` (the
+    /// `if let Some(link_span) = img.link` block): a visible `InlineImage`
+    /// carrying an `<a>` link must push a `LinkCollector` rect whose
+    /// coordinates equal the image's drawn box
+    /// `(x + x_offset, y + computed_y, width, height)`. This path is not
+    /// reachable through `render_html` today — linked inline `<img>`
+    /// materialisation into a `LineItem::Image` with `link` set is still
+    /// pending (see `tests/link_integration.rs`) — so we drive
+    /// `draw_shaped_lines` directly with a `LinkCollector`-backed canvas.
+    #[test]
+    fn draw_shaped_lines_image_link_rect_matches_drawn_coords() {
+        let link = Arc::new(LinkSpan {
+            target: LinkTarget::External(Arc::new("https://example.com".into())),
+            alt_text: None,
+        });
+        let mut img = make_inline_image(20.0, 10.0, VerticalAlign::Baseline);
+        img.x_offset = 2.0_f32.pt();
+        img.computed_y = 3.0_f32.pt();
+        img.link = Some(Arc::clone(&link));
+
+        let mut line = text_line(16.0, 12.0);
+        line.items.push(LineItem::Image(img));
+
+        let mut lc = crate::draw_primitives::LinkCollector::new();
+        {
+            let mut doc = krilla::Document::new();
+            let settings =
+                krilla::page::PageSettings::from_wh(200.0, 200.0).expect("valid page size");
+            let mut page = doc.start_page_with(settings);
+            let mut surface = page.surface();
+            let mut canvas = Canvas {
+                surface: &mut surface,
+                bookmark_collector: None,
+                link_collector: Some(&mut lc),
+                tag_collector: None,
+                link_run_node_id: None,
+            };
+            // Draw origin (5, 7) pt; rect must land at (5+2, 7+3, 20, 10).
+            draw_shaped_lines(&mut canvas, &[line], 5.0_f32.pt(), 7.0_f32.pt(), None);
+        }
+
+        let occ = lc.take_page(0);
+        assert_eq!(occ.len(), 1, "exactly one link occurrence expected");
+        assert_eq!(occ[0].quads.len(), 1, "one rect for the linked image");
+        let pts = occ[0].quads[0].points;
+        let min_x = pts.iter().map(|p| p[0]).fold(f32::INFINITY, f32::min);
+        let max_x = pts.iter().map(|p| p[0]).fold(f32::NEG_INFINITY, f32::max);
+        let min_y = pts.iter().map(|p| p[1]).fold(f32::INFINITY, f32::min);
+        let max_y = pts.iter().map(|p| p[1]).fold(f32::NEG_INFINITY, f32::max);
+        assert!((min_x - 7.0).abs() < 1e-4, "min_x={min_x:?}");
+        assert!((max_x - 27.0).abs() < 1e-4, "max_x={max_x:?}");
+        assert!((min_y - 10.0).abs() < 1e-4, "min_y={min_y:?}");
+        assert!((max_y - 20.0).abs() < 1e-4, "max_y={max_y:?}");
+    }
+
     /// Compare a migrated `Pt` coordinate against a raw `f32` expectation.
     fn approx_pt(a: crate::units::Pt, b: f32) -> bool {
         (a.to_f32() - b).abs() < 0.01
@@ -1061,21 +1118,17 @@ mod tests {
         )));
         let m = default_metrics();
         recalculate_line_box(&mut line, &m);
-        assert!(
-            approx_pt(line.height, 16.0),
-            "height={}",
-            line.height.to_f32()
-        );
+        assert!(approx_pt(line.height, 16.0), "height={:?}", line.height);
         assert!(
             approx_pt(line.baseline, 12.0),
-            "baseline={}",
-            line.baseline.to_f32()
+            "baseline={:?}",
+            line.baseline
         );
         if let LineItem::Image(img) = &line.items[0] {
             assert!(
                 approx_pt(img.computed_y, 4.0),
-                "computed_y={}",
-                img.computed_y.to_f32()
+                "computed_y={:?}",
+                img.computed_y
             );
         }
     }
@@ -1092,21 +1145,17 @@ mod tests {
         )));
         let m = default_metrics();
         recalculate_line_box(&mut line, &m);
-        assert!(
-            approx_pt(line.height, 24.0),
-            "height={}",
-            line.height.to_f32()
-        );
+        assert!(approx_pt(line.height, 24.0), "height={:?}", line.height);
         assert!(
             approx_pt(line.baseline, 20.0),
-            "baseline={}",
-            line.baseline.to_f32()
+            "baseline={:?}",
+            line.baseline
         );
         if let LineItem::Image(img) = &line.items[0] {
             assert!(
                 approx_pt(img.computed_y, 0.0),
-                "computed_y={}",
-                img.computed_y.to_f32()
+                "computed_y={:?}",
+                img.computed_y
             );
         }
     }
@@ -1124,16 +1173,12 @@ mod tests {
         )));
         let m = default_metrics();
         recalculate_line_box(&mut line, &m);
-        assert!(
-            approx_pt(line.height, 16.0),
-            "height={}",
-            line.height.to_f32()
-        );
+        assert!(approx_pt(line.height, 16.0), "height={:?}", line.height);
         if let LineItem::Image(img) = &line.items[0] {
             assert!(
                 approx_pt(img.computed_y, 3.0),
-                "computed_y={}",
-                img.computed_y.to_f32()
+                "computed_y={:?}",
+                img.computed_y
             );
         }
     }
@@ -1154,8 +1199,8 @@ mod tests {
         if let LineItem::Image(img) = &line.items[0] {
             assert!(
                 approx_pt(img.computed_y, 10.0),
-                "computed_y={}",
-                img.computed_y.to_f32()
+                "computed_y={:?}",
+                img.computed_y
             );
         }
     }
@@ -1176,8 +1221,8 @@ mod tests {
         if let LineItem::Image(img) = &line.items[0] {
             assert!(
                 approx_pt(img.computed_y, 0.0),
-                "computed_y={}",
-                img.computed_y.to_f32()
+                "computed_y={:?}",
+                img.computed_y
             );
         }
     }
@@ -1198,8 +1243,8 @@ mod tests {
         if let LineItem::Image(img) = &line.items[0] {
             assert!(
                 approx_pt(img.computed_y, 0.0),
-                "computed_y={}",
-                img.computed_y.to_f32()
+                "computed_y={:?}",
+                img.computed_y
             );
         }
     }
@@ -1220,8 +1265,8 @@ mod tests {
         if let LineItem::Image(img) = &line.items[0] {
             assert!(
                 approx_pt(img.computed_y, 8.0),
-                "computed_y={}",
-                img.computed_y.to_f32()
+                "computed_y={:?}",
+                img.computed_y
             );
         }
     }
@@ -1242,8 +1287,8 @@ mod tests {
         if let LineItem::Image(img) = &line.items[0] {
             assert!(
                 approx_pt(img.computed_y, 0.0),
-                "computed_y={}",
-                img.computed_y.to_f32()
+                "computed_y={:?}",
+                img.computed_y
             );
         }
     }
@@ -1264,8 +1309,8 @@ mod tests {
         if let LineItem::Image(img) = &line.items[0] {
             assert!(
                 approx_pt(img.computed_y, line.height.to_f32() - 8.0),
-                "computed_y={}",
-                img.computed_y.to_f32(),
+                "computed_y={:?}",
+                img.computed_y,
             );
         }
     }
@@ -1286,8 +1331,8 @@ mod tests {
         if let LineItem::Image(img) = &line.items[0] {
             assert!(
                 approx_pt(img.computed_y, 3.0),
-                "computed_y={}",
-                img.computed_y.to_f32()
+                "computed_y={:?}",
+                img.computed_y
             );
         }
     }
@@ -1308,8 +1353,8 @@ mod tests {
         if let LineItem::Image(img) = &line.items[0] {
             assert!(
                 approx_pt(img.computed_y, 2.0),
-                "computed_y={}",
-                img.computed_y.to_f32()
+                "computed_y={:?}",
+                img.computed_y
             );
         }
     }
@@ -1327,16 +1372,12 @@ mod tests {
         )));
         let m = default_metrics();
         recalculate_line_box(&mut line, &m);
-        assert!(
-            approx_pt(line.height, 20.0),
-            "height={}",
-            line.height.to_f32()
-        );
+        assert!(approx_pt(line.height, 20.0), "height={:?}", line.height);
         if let LineItem::Image(img) = &line.items[0] {
             assert!(
                 approx_pt(img.computed_y, 0.0),
-                "computed_y={}",
-                img.computed_y.to_f32()
+                "computed_y={:?}",
+                img.computed_y
             );
         }
     }
@@ -1367,8 +1408,8 @@ mod tests {
         // Image fits within [0, 16): no expansion
         assert!(
             approx_pt(line2.height, 16.0),
-            "height should stay 16, got {}",
-            line2.height.to_f32()
+            "height should stay 16, got {:?}",
+            line2.height
         );
         // Convert computed_y to paragraph-absolute
         if let LineItem::Image(img) = &mut line2.items[0] {
@@ -1376,15 +1417,15 @@ mod tests {
             // paragraph-absolute computed_y = line-local (4.0) + y_acc (16.0) = 20.0
             assert!(
                 approx_pt(img.computed_y, 20.0),
-                "paragraph-absolute computed_y should be 20, got {}",
-                img.computed_y.to_f32()
+                "paragraph-absolute computed_y should be 20, got {:?}",
+                img.computed_y
             );
         }
         line2.baseline += y_acc; // restore to paragraph-absolute: 28.0
         assert!(
             approx_pt(line2.baseline, 28.0),
-            "baseline should be 28, got {}",
-            line2.baseline.to_f32()
+            "baseline should be 28, got {:?}",
+            line2.baseline
         );
     }
 
@@ -1498,15 +1539,11 @@ mod tests {
         let m = default_metrics();
         recalculate_line_box(&mut line, &m);
         // Text items are skipped: height and baseline must be unchanged.
-        assert!(
-            approx_pt(line.height, 16.0),
-            "height={}",
-            line.height.to_f32()
-        );
+        assert!(approx_pt(line.height, 16.0), "height={:?}", line.height);
         assert!(
             approx_pt(line.baseline, 12.0),
-            "baseline={}",
-            line.baseline.to_f32()
+            "baseline={:?}",
+            line.baseline
         );
     }
 
@@ -1539,21 +1576,17 @@ mod tests {
         recalculate_line_box(&mut line, &metrics);
         // line_top stays 0 (img_top=15 > 0), shift=0
         // height = 20 - 0 = 20
-        assert!(
-            approx_pt(line.height, 20.0),
-            "height={}",
-            line.height.to_f32()
-        );
+        assert!(approx_pt(line.height, 20.0), "height={:?}", line.height);
         assert!(
             approx_pt(line.baseline, 12.0),
-            "baseline={}",
-            line.baseline.to_f32()
+            "baseline={:?}",
+            line.baseline
         );
         if let LineItem::Image(img) = &line.items[0] {
             assert!(
                 approx_pt(img.computed_y, 15.0),
-                "computed_y={}",
-                img.computed_y.to_f32()
+                "computed_y={:?}",
+                img.computed_y
             );
         }
     }
@@ -1575,23 +1608,19 @@ mod tests {
         )));
         let m = default_metrics();
         recalculate_line_box(&mut line, &m);
-        assert!(
-            approx_pt(line.height, 20.0),
-            "height={}",
-            line.height.to_f32()
-        );
+        assert!(approx_pt(line.height, 20.0), "height={:?}", line.height);
         // baseline = 12 + shift(4) = 16
         assert!(
             approx_pt(line.baseline, 16.0),
-            "baseline={}",
-            line.baseline.to_f32()
+            "baseline={:?}",
+            line.baseline
         );
         if let LineItem::Image(img) = &line.items[0] {
             // computed_y = img_top + shift = -4 + 4 = 0
             assert!(
                 approx_pt(img.computed_y, 0.0),
-                "computed_y={}",
-                img.computed_y.to_f32()
+                "computed_y={:?}",
+                img.computed_y
             );
         }
     }
@@ -1682,8 +1711,8 @@ mod tests {
                 assert_eq!(ib.width.to_f32(), 30.0);
                 assert!(
                     approx_pt(ib.computed_y, 3.0),
-                    "computed_y={}",
-                    ib.computed_y.to_f32()
+                    "computed_y={:?}",
+                    ib.computed_y
                 );
             }
             _ => panic!("expected InlineBox at index 1"),

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -7,6 +7,7 @@ use crate::gcpm::counter::resolve_content_to_html_with_anchor;
 use crate::gcpm::margin_box::{Edge, MarginBoxPosition, MarginBoxRect, compute_edge_layout};
 use crate::gcpm::running::RunningElementStore;
 use crate::gcpm::target_ref::AnchorMap;
+use crate::units::F32Units;
 use krilla::SerializeSettings;
 use krilla::configure::{Configuration, Validator};
 use krilla::tagging::{Identifier, Node, TagGroup, TagTree};
@@ -1285,7 +1286,7 @@ fn paint_multicol_paragraph_slices(
             }
             let abs_x = container_x_pt + slice.origin_pt.0;
             let abs_y = container_y_pt + slice_top;
-            crate::paragraph::draw_shaped_lines(canvas, &slice.lines, abs_x, abs_y, None);
+            crate::paragraph::draw_shaped_lines(canvas, &slice.lines, abs_x.pt(), abs_y.pt(), None);
         }
     });
     if use_run_tagging {
@@ -3080,7 +3081,7 @@ fn draw_list_item_marker(
 
     match &entry.marker {
         ListItemMarker::Text { lines, width } if !lines.is_empty() => {
-            crate::paragraph::draw_shaped_lines(canvas, lines, x - *width, y, None);
+            crate::paragraph::draw_shaped_lines(canvas, lines, (x - *width).pt(), y.pt(), None);
         }
         ListItemMarker::Image {
             marker,
@@ -3210,7 +3211,7 @@ fn draw_paragraph_inner_paint(
         margin_left_pt,
         margin_top_pt,
     });
-    crate::paragraph::draw_shaped_lines(canvas, &slice, x, y, inline_box_ctx);
+    crate::paragraph::draw_shaped_lines(canvas, &slice, x.pt(), y.pt(), inline_box_ctx);
 }
 
 /// Phase 4 PR 3 follow-up (PR #302 Devin): mirror
@@ -3235,20 +3236,20 @@ fn paragraph_lines_for_page(
         return Some(all_lines.to_vec());
     }
 
-    let target_h = crate::convert::px_to_pt(fragments[target_pos].height);
-    let consumed: f32 = crate::convert::px_to_pt(
-        fragments[..target_pos]
-            .iter()
-            .map(|f| f.height)
-            .sum::<f32>(),
-    );
+    let target_h = fragments[target_pos].height.px().in_pt();
+    let consumed: crate::units::Pt = fragments[..target_pos]
+        .iter()
+        .map(|f| f.height)
+        .sum::<f32>()
+        .px()
+        .in_pt();
 
     let eps = 0.01_f32;
-    let mut line_top: f32 = 0.0;
+    let mut line_top = crate::units::Pt::ZERO;
     let mut start_idx = 0usize;
     while start_idx < all_lines.len() {
         let next_top = line_top + all_lines[start_idx].height;
-        if next_top > consumed + eps {
+        if next_top > consumed + eps.pt() {
             break;
         }
         line_top = next_top;
@@ -3256,10 +3257,10 @@ fn paragraph_lines_for_page(
     }
 
     let mut end_idx = start_idx;
-    let mut accum = 0.0_f32;
+    let mut accum = crate::units::Pt::ZERO;
     while end_idx < all_lines.len() {
         let line_h = all_lines[end_idx].height;
-        if accum + line_h > target_h + eps {
+        if accum + line_h > target_h + eps.pt() {
             break;
         }
         accum += line_h;
@@ -4274,20 +4275,20 @@ mod tests {
         crate::paragraph::ShapedGlyphRun {
             font_data: std::sync::Arc::new(vec![]),
             font_index: 0,
-            font_size: 12.0,
+            font_size: 12.0_f32.pt(),
             color: [0, 0, 0, 255],
             decoration: crate::paragraph::TextDecoration::default(),
             glyphs: vec![],
             text: text.to_string(),
-            x_offset: 0.0,
+            x_offset: crate::units::Pt::ZERO,
             link,
         }
     }
 
     fn make_shaped_line(items: Vec<crate::paragraph::LineItem>) -> crate::paragraph::ShapedLine {
         crate::paragraph::ShapedLine {
-            height: 16.0,
-            baseline: 12.0,
+            height: 16.0_f32.pt(),
+            baseline: 12.0_f32.pt(),
             items,
         }
     }
@@ -4333,10 +4334,10 @@ mod tests {
     fn para_has_link_runs_inline_box_returns_false() {
         let item = crate::paragraph::InlineBoxItem {
             node_id: None,
-            width: 10.0,
-            height: 10.0,
-            x_offset: 0.0,
-            computed_y: 0.0,
+            width: 10.0_f32.pt(),
+            height: 10.0_f32.pt(),
+            x_offset: crate::units::Pt::ZERO,
+            computed_y: crate::units::Pt::ZERO,
             link: None,
             opacity: 1.0,
             visible: true,
@@ -4357,13 +4358,13 @@ mod tests {
         let img = crate::paragraph::InlineImage {
             data: std::sync::Arc::new(vec![]),
             format: crate::image::ImageFormat::Png,
-            width: 20.0,
-            height: 20.0,
-            x_offset: 0.0,
+            width: 20.0_f32.pt(),
+            height: 20.0_f32.pt(),
+            x_offset: crate::units::Pt::ZERO,
             vertical_align: crate::paragraph::VerticalAlign::Baseline,
             opacity: 1.0,
             visible: true,
-            computed_y: 0.0,
+            computed_y: crate::units::Pt::ZERO,
             link: Some(span),
         };
         let line = make_shaped_line(vec![crate::paragraph::LineItem::Image(img)]);
@@ -4376,13 +4377,13 @@ mod tests {
         let img = crate::paragraph::InlineImage {
             data: std::sync::Arc::new(vec![]),
             format: crate::image::ImageFormat::Png,
-            width: 10.0,
-            height: 10.0,
-            x_offset: 0.0,
+            width: 10.0_f32.pt(),
+            height: 10.0_f32.pt(),
+            x_offset: crate::units::Pt::ZERO,
             vertical_align: crate::paragraph::VerticalAlign::Baseline,
             opacity: 1.0,
             visible: true,
-            computed_y: 0.0,
+            computed_y: crate::units::Pt::ZERO,
             link: None,
         };
         let line = make_shaped_line(vec![crate::paragraph::LineItem::Image(img)]);
@@ -4443,21 +4444,21 @@ mod tests {
         let img = crate::paragraph::InlineImage {
             data: std::sync::Arc::new(vec![]),
             format: crate::image::ImageFormat::Png,
-            width: 10.0,
-            height: 10.0,
-            x_offset: 0.0,
+            width: 10.0_f32.pt(),
+            height: 10.0_f32.pt(),
+            x_offset: crate::units::Pt::ZERO,
             vertical_align: crate::paragraph::VerticalAlign::Baseline,
             opacity: 1.0,
             visible: true,
-            computed_y: 0.0,
+            computed_y: crate::units::Pt::ZERO,
             link: None,
         };
         let inline_box = crate::paragraph::InlineBoxItem {
             node_id: None,
-            width: 10.0,
-            height: 10.0,
-            x_offset: 0.0,
-            computed_y: 0.0,
+            width: 10.0_f32.pt(),
+            height: 10.0_f32.pt(),
+            x_offset: crate::units::Pt::ZERO,
+            computed_y: crate::units::Pt::ZERO,
             link: None,
             opacity: 1.0,
             visible: true,
@@ -4485,8 +4486,8 @@ mod tests {
 
     fn make_line(height_pt: f32, baseline_pt: f32) -> crate::paragraph::ShapedLine {
         crate::paragraph::ShapedLine {
-            height: height_pt,
-            baseline: baseline_pt,
+            height: height_pt.pt(),
+            baseline: baseline_pt.pt(),
             items: vec![],
         }
     }
@@ -4515,7 +4516,7 @@ mod tests {
         let sliced = result.unwrap();
         assert_eq!(sliced.len(), 3);
         assert!(
-            (sliced[0].baseline - 12.0).abs() < 0.01,
+            (sliced[0].baseline.to_f32() - 12.0).abs() < 0.01,
             "baseline unchanged on non-split"
         );
     }
@@ -4535,7 +4536,7 @@ mod tests {
         let sliced = result.unwrap();
         assert_eq!(sliced.len(), 1, "page 0 should contain exactly one line");
         assert!(
-            (sliced[0].baseline - 9.0).abs() < 0.01,
+            (sliced[0].baseline.to_f32() - 9.0).abs() < 0.01,
             "page 0 baseline unchanged (consumed=0)"
         );
     }
@@ -4554,7 +4555,7 @@ mod tests {
         let sliced = result.unwrap();
         assert_eq!(sliced.len(), 1, "page 1 should contain exactly one line");
         assert!(
-            (sliced[0].baseline - 9.0).abs() < 0.01,
+            (sliced[0].baseline.to_f32() - 9.0).abs() < 0.01,
             "baseline rebased: 21pt - 12pt consumed = 9pt"
         );
     }
@@ -5089,19 +5090,19 @@ mod tests {
         let img = crate::paragraph::InlineImage {
             data: Arc::new(vec![]),
             format: crate::image::ImageFormat::Png,
-            width: 10.0,
-            height: 8.0,
-            x_offset: 0.0,
+            width: 10.0_f32.pt(),
+            height: 8.0_f32.pt(),
+            x_offset: crate::units::Pt::ZERO,
             vertical_align: crate::paragraph::VerticalAlign::Baseline,
             opacity: 1.0,
             visible: true,
-            computed_y: 15.0,
+            computed_y: 15.0_f32.pt(),
             link: None,
         };
         let line0 = make_line(12.0, 9.0); // page 0: no items
         let line1 = crate::paragraph::ShapedLine {
-            height: 12.0,
-            baseline: 21.0,
+            height: 12.0_f32.pt(),
+            baseline: 21.0_f32.pt(),
             items: vec![crate::paragraph::LineItem::Image(img)],
         };
         let fragments = vec![
@@ -5114,9 +5115,9 @@ mod tests {
         assert_eq!(sliced.len(), 1, "one line on page 1");
         if let crate::paragraph::LineItem::Image(img) = &sliced[0].items[0] {
             assert!(
-                (img.computed_y - 3.0).abs() < 0.01,
+                (img.computed_y.to_f32() - 3.0).abs() < 0.01,
                 "expected computed_y=3.0 after rebasing, got {}",
-                img.computed_y,
+                img.computed_y.to_f32(),
             );
         } else {
             panic!("expected Image item in sliced line");
@@ -5161,17 +5162,17 @@ mod tests {
         d.semantics.insert(node_id, make_h1_semantic_entry(None));
         let ib = crate::paragraph::InlineBoxItem {
             node_id: None,
-            width: 50.0,
-            height: 20.0,
-            x_offset: 0.0,
-            computed_y: 0.0,
+            width: 50.0_f32.pt(),
+            height: 20.0_f32.pt(),
+            x_offset: crate::units::Pt::ZERO,
+            computed_y: crate::units::Pt::ZERO,
             link: None,
             opacity: 1.0,
             visible: true,
         };
         let line = crate::paragraph::ShapedLine {
-            height: 16.0,
-            baseline: 12.0,
+            height: 16.0_f32.pt(),
+            baseline: 12.0_f32.pt(),
             items: vec![crate::paragraph::LineItem::InlineBox(ib)],
         };
         d.paragraphs.insert(node_id, make_para(vec![line]));

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -5116,8 +5116,8 @@ mod tests {
         if let crate::paragraph::LineItem::Image(img) = &sliced[0].items[0] {
             assert!(
                 (img.computed_y.to_f32() - 3.0).abs() < 0.01,
-                "expected computed_y=3.0 after rebasing, got {}",
-                img.computed_y.to_f32(),
+                "expected computed_y=3.0 after rebasing, got {:?}",
+                img.computed_y,
             );
         } else {
             panic!("expected Image item in sliced line");

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -3244,12 +3244,12 @@ fn paragraph_lines_for_page(
         .px()
         .in_pt();
 
-    let eps = 0.01_f32;
+    let eps = 0.01_f32.pt();
     let mut line_top = crate::units::Pt::ZERO;
     let mut start_idx = 0usize;
     while start_idx < all_lines.len() {
         let next_top = line_top + all_lines[start_idx].height;
-        if next_top > consumed + eps.pt() {
+        if next_top > consumed + eps {
             break;
         }
         line_top = next_top;
@@ -3260,7 +3260,7 @@ fn paragraph_lines_for_page(
     let mut accum = crate::units::Pt::ZERO;
     while end_idx < all_lines.len() {
         let line_h = all_lines[end_idx].height;
-        if accum + line_h > target_h + eps.pt() {
+        if accum + line_h > target_h + eps {
             break;
         }
         accum += line_h;

--- a/crates/fulgur/src/units.rs
+++ b/crates/fulgur/src/units.rs
@@ -146,6 +146,13 @@ impl Px {
     pub fn in_pt(self) -> Pt {
         Pt(self.0 * PX_TO_PT)
     }
+
+    /// Absolute value. Mirrors `f32::abs` so a migrated `(a - b).abs()`
+    /// stays byte-identical.
+    #[inline]
+    pub fn abs(self) -> Px {
+        Px(self.0.abs())
+    }
 }
 
 impl Pt {
@@ -177,6 +184,13 @@ impl Pt {
     #[inline]
     pub fn min(self, other: Pt) -> Pt {
         Pt(self.0.min(other.0))
+    }
+
+    /// Absolute value. Mirrors `f32::abs` so a migrated `(a - b).abs()`
+    /// stays byte-identical.
+    #[inline]
+    pub fn abs(self) -> Pt {
+        Pt(self.0.abs())
     }
 }
 
@@ -242,6 +256,16 @@ mod tests {
                 .fold(Pt(0.0), Pt::max),
             Pt(2.0)
         );
+    }
+
+    #[test]
+    fn abs_mirrors_f32() {
+        assert_eq!((-3.5_f32).pt().abs(), 3.5_f32.pt());
+        assert_eq!(2.0_f32.pt().abs(), 2.0_f32.pt());
+        assert_eq!((-1.0_f32).px().abs(), 1.0_f32.px());
+        // Byte-identical to the raw f32 op it replaces.
+        let v = -7.25_f32;
+        assert_eq!(v.pt().abs().to_f32(), v.abs());
     }
 
     #[test]

--- a/crates/fulgur/src/units.rs
+++ b/crates/fulgur/src/units.rs
@@ -146,13 +146,6 @@ impl Px {
     pub fn in_pt(self) -> Pt {
         Pt(self.0 * PX_TO_PT)
     }
-
-    /// Absolute value. Mirrors `f32::abs` so a migrated `(a - b).abs()`
-    /// stays byte-identical.
-    #[inline]
-    pub fn abs(self) -> Px {
-        Px(self.0.abs())
-    }
 }
 
 impl Pt {
@@ -262,7 +255,6 @@ mod tests {
     fn abs_mirrors_f32() {
         assert_eq!((-3.5_f32).pt().abs(), 3.5_f32.pt());
         assert_eq!(2.0_f32.pt().abs(), 2.0_f32.pt());
-        assert_eq!((-1.0_f32).px().abs(), 1.0_f32.px());
         // Byte-identical to the raw f32 op it replaces.
         let v = -7.25_f32;
         assert_eq!(v.pt().abs().to_f32(), v.abs());

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -2065,10 +2065,10 @@ fn multicol_inline_root_split_emits_paragraph_slices_case_b() {
         // wasn't rebased and is still parley-absolute).
         let first = &slice.lines[0];
         assert!(
-            first.baseline > 0.0 && first.baseline <= first.height,
+            first.baseline.to_f32() > 0.0 && first.baseline <= first.height,
             "slice line[0].baseline must be slice-local: got baseline={}, height={}",
-            first.baseline,
-            first.height,
+            first.baseline.to_f32(),
+            first.height.to_f32(),
         );
     }
     // The two slices must land in different x columns.
@@ -2112,10 +2112,10 @@ fn multicol_inline_root_split_emits_paragraph_slices_case_a() {
         assert!(slice.size_pt.1 > 0.0, "slice height (pt) must be > 0");
         let first = &slice.lines[0];
         assert!(
-            first.baseline > 0.0 && first.baseline <= first.height,
+            first.baseline.to_f32() > 0.0 && first.baseline <= first.height,
             "slice line[0].baseline must be slice-local: got baseline={}, height={}",
-            first.baseline,
-            first.height,
+            first.baseline.to_f32(),
+            first.height.to_f32(),
         );
     }
     assert_ne!(
@@ -2318,7 +2318,7 @@ fn multicol_inline_root_split_honours_text_align_center() {
         line.items
             .iter()
             .find_map(|item| match item {
-                LineItem::Text(t) => Some(t.x_offset),
+                LineItem::Text(t) => Some(t.x_offset.to_f32()),
                 _ => None,
             })
             .expect("first line of slice must have a text item")

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -2065,7 +2065,7 @@ fn multicol_inline_root_split_emits_paragraph_slices_case_b() {
         // wasn't rebased and is still parley-absolute).
         let first = &slice.lines[0];
         assert!(
-            first.baseline.to_f32() > 0.0 && first.baseline <= first.height,
+            first.baseline > fulgur::units::Pt::ZERO && first.baseline <= first.height,
             "slice line[0].baseline must be slice-local: got baseline={}, height={}",
             first.baseline.to_f32(),
             first.height.to_f32(),
@@ -2112,7 +2112,7 @@ fn multicol_inline_root_split_emits_paragraph_slices_case_a() {
         assert!(slice.size_pt.1 > 0.0, "slice height (pt) must be > 0");
         let first = &slice.lines[0];
         assert!(
-            first.baseline.to_f32() > 0.0 && first.baseline <= first.height,
+            first.baseline > fulgur::units::Pt::ZERO && first.baseline <= first.height,
             "slice line[0].baseline must be slice-local: got baseline={}, height={}",
             first.baseline.to_f32(),
             first.height.to_f32(),

--- a/docs/plans/2026-06-29-fulgur-2map4-paragraph-px-pt-plan.md
+++ b/docs/plans/2026-06-29-fulgur-2map4-paragraph-px-pt-plan.md
@@ -1,0 +1,167 @@
+# P1b: Migrate paragraph types to Px/Pt — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (or subagent-driven-development) to implement this plan task-by-task.
+
+**Goal:** Migrate the coordinate fields of `ShapedLine`, `ShapedGlyphRun`, `ShapedGlyph`, `InlineImage`, `InlineBoxItem` from raw `f32` (and the legacy `draw_primitives::Pt = f32` alias) to `crate::units::Pt`, byte-neutrally.
+
+**Architecture:** Follow the spike pattern (fulgur-2map.2 / PR #509): type each field as its native stored unit, call `to_f32()` only at FFI (Krilla, skrifa, the f32 `Rect`/decoration draw helpers), never reassociate float ops. `font_size` becomes `units::Pt` so `EM(f32) * font_size(Pt) = Pt` falls out naturally. Font-metric helpers (`get_decoration_metrics`/`DecorationMetrics`, `LineFontMetrics`) stay `f32` (Strategy C) — skrifa is an f32 FFI boundary. The full per-site method-gap inventory lives in the beads issue `fulgur-2map.4` design field; this plan is the SEQUENCE + verification gates.
+
+**Tech Stack:** Rust, `crate::units` newtypes, Krilla, skrifa, Parley. Determinism guarded by `examples_determinism` + `fulgur-vrt` byte-wise PDF goldens.
+
+**Base branch:** `origin/main` (this worktree). **Baseline already taken GREEN before any edit:** fulgur --lib 1495, examples_determinism 11, VRT `run_fulgur_vrt` ok.
+
+**Byte-neutral law (applies to EVERY task):**
+- Preserve f32 operation order; never reassociate. `a + b - c` stays `a + b - c`.
+- `units::Pt` ops are byte-transparent: `f32 * Pt = Pt(self * rhs.0)`, `Pt::sum = Pt(map(.0).sum())`, `Pt::max/min` mirror `f32::max/min`, `Pt::abs` mirrors `f32::abs`.
+- NEVER run `FULGUR_VRT_UPDATE=1`. Goldens must stay untouched.
+- `FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf"` for examples_determinism + VRT.
+
+---
+
+### Task 1: Add `Pt::abs()` (and `Px::abs()`) to `units.rs`
+
+**Files:**
+- Modify: `crates/fulgur/src/units.rs` (impl Pt around :151-181; impl Px around :137-149)
+- Test: `crates/fulgur/src/units.rs` `#[cfg(test)] mod tests`
+
+**Step 1 — Write the failing test** (append to units.rs tests mod):
+
+```rust
+#[test]
+fn abs_mirrors_f32() {
+    assert_eq!((-3.5_f32).pt().abs(), 3.5_f32.pt());
+    assert_eq!(2.0_f32.pt().abs(), 2.0_f32.pt());
+    assert_eq!((-1.0_f32).px().abs(), 1.0_f32.px());
+    // Byte-identical to the raw f32 op it replaces.
+    let v = -7.25_f32;
+    assert_eq!(v.pt().abs().to_f32(), v.abs());
+}
+```
+
+**Step 2 — Run, expect FAIL** (`abs` not found):
+
+Run: `cargo test -p fulgur --lib units::tests::abs_mirrors_f32`
+Expected: compile error `no method named 'abs'`.
+
+**Step 3 — Implement.** In `impl Pt` (mirror the existing `max`/`min` doc-comment style):
+
+```rust
+    /// Absolute value. Mirrors `f32::abs` so a migrated `(a - b).abs()`
+    /// stays byte-identical.
+    #[inline]
+    pub fn abs(self) -> Pt {
+        Pt(self.0.abs())
+    }
+```
+
+In `impl Px` add the symmetric:
+
+```rust
+    /// Absolute value. Mirrors `f32::abs`.
+    #[inline]
+    pub fn abs(self) -> Px {
+        Px(self.0.abs())
+    }
+```
+
+**Step 4 — Run, expect PASS:** `cargo test -p fulgur --lib units::tests::abs_mirrors_f32`
+
+**Step 5 — Commit:**
+
+```bash
+git add crates/fulgur/src/units.rs
+git commit -m "feat(units): add Pt/Px abs() for P1b paragraph migration"
+```
+
+---
+
+### Task 2: Migrate the 5 paragraph struct fields + all consumers (compiler-driven, atomic)
+
+This is the load-bearing task. Field-type changes cascade through the type checker, so the struct defs and ALL consumers land in ONE compiling commit. Work the compiler error list top-to-bottom; the design field enumerates every site so nothing should surprise you. Do NOT insert any `* PX_TO_PT` / `* 0.75` to "fix" the EM×font_size width sites — that is a REFUTED hazard (see design); the product is already pt.
+
+**Files (all in `crates/fulgur/src/`):**
+- Modify `paragraph.rs`: struct defs (`ShapedGlyphRun.font_size`/`.x_offset`; `ShapedLine.height`/`.baseline`; `InlineImage` width/height/x_offset/computed_y; `InlineBoxItem` width/height/x_offset/computed_y) → `crate::units::Pt`; `ShapedGlyph` UNCHANGED. Then `draw_shaped_lines` (sig `x,y: crate::units::Pt`, `line_top` accumulator → `Pt::ZERO`, 3 LineItem arms), `draw_line_decorations` (`DecorationSpan{x,width}` → Pt, `font_size` → Pt, `run_width` Pt, `gap=(run_x-last_end).abs()`, `gap < 0.5_f32.pt()`, `.max(Pt::ZERO)`, `get_decoration_metrics(.., span.font_size.to_f32())`, `line_y = baseline_y + metrics.X.pt()`, `draw_decoration_line(span.x.to_f32(), line_y.to_f32(), span.width.to_f32(), ..)`), `recalculate_line_box` (`LineFontMetrics` stays f32 → `.pt()` tags; `VerticalAlign::Length(v)`/`Percent(p)` v/p f32 → tag to match current pt arithmetic; Pt comparisons), test fixtures at ~:1363,:1404,:1597 (`font_size: 10.0` → `10.0_f32.pt()`; coord fields likewise), and the `draw_shaped_lines` test arms ~:2059-2130.
+- Modify `convert/inline_root.rs`: construction at :518-540 (`ShapedGlyphRun{font_size: px_to_pt(..)` already pt — wrap producer so the field is Pt; `x_offset: px_to_pt(glyph_run.offset())`), :589-598 (`InlineBoxItem`), :603-608 (`ShapedLine`). `px_to_pt(x)` returns f32 today — produce `Pt` via `x.px().in_pt()` OR `px_to_pt(x).pt()` (pick one consistently; both byte-identical, prefer `.px().in_pt()` to match spike idiom). EM-fractions (`g.advance / font_size_parley`) UNCHANGED.
+- Modify `convert/list_marker.rs`: `InlineImage` construction ~:136-147 (width/height/x_offset/computed_y → Pt; `x_offset: 0.0` → `Pt::ZERO`, `computed_y: 0.0` → `Pt::ZERO`).
+- Modify `render.rs`: `paragraph_lines_for_page` split path ~:3238-3284 (`consumed`/`target_h` → Pt via `sum().px().in_pt()` pattern since Fragment is still px-f32 (P1c, open); `line_top`/`next_top` → Pt; `next_top > consumed + eps` → tag eps; `line.baseline -= consumed`, `img.computed_y -= consumed`); list-item marker `draw_shaped_lines` caller ~:3070 (pass `units::Pt` x/y).
+- Modify any `pageable.rs` `draw_shaped_lines` caller (ListItemPageable::draw) to pass `units::Pt`.
+- Link rects: `draw_primitives::Rect` is f32 (P1a did NOT migrate it) → `.to_f32()` on each Pt coord at rect construction (paragraph.rs link-rect arms for text/image/inline-box).
+- Krilla FFI: `Point::from_xy(x + run.x_offset, baseline_y)` and `from_translate(...)` and `draw_glyphs(.., run.font_size, ..)` → `.to_f32()` on the Pt args; `Size::from_wh(img.width, img.height)` → `.to_f32()`.
+
+**Step 1 — Change the 5 struct field types** in paragraph.rs. Expect a long compiler error list.
+
+**Step 2 — Drive the compiler.** Fix each error using the design's method-gap inventory. Reach for, in order of preference: same-unit op (Pt±Pt) → `Pt::ZERO`/`Pt::max`/`Pt::abs` → `.pt()` tag on an f32 that is semantically pt → `.to_f32()` ONLY at a genuine FFI/f32-struct boundary (Krilla, skrifa, `Rect`, `draw_decoration_line`). If you find yourself changing a numeric literal or op order, STOP — that breaks byte-neutrality.
+
+**Step 3 — Build clean:**
+
+Run: `cargo build -p fulgur`
+Expected: `Finished` (0 errors).
+
+**Step 4 — Lint clean:**
+
+Run: `cargo clippy -p fulgur -- -D warnings` then `cargo fmt --check`
+Expected: no warnings; fmt clean. (Watch for clippy wanting `.to_f32()` simplifications — keep explicit if it preserves clarity.)
+
+**Step 5 — Unit tests green (incl. UNCHANGED metrics tests):**
+
+Run: `cargo test -p fulgur --lib`
+Expected: 1495+ passed, 0 failed. The `get_decoration_metrics_*` / `*_grow_with_font_size` tests must pass UNCHANGED — that is the proof Strategy C kept the metrics subsystem out of scope. (If you had to edit them, you drifted into Strategy A — reconsider.)
+
+**Step 6 — Byte-neutral determinism gate:**
+
+```bash
+export FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf"
+cargo test -p fulgur-cli --test examples_determinism
+cargo test -p fulgur-vrt
+```
+
+Expected: examples_determinism 11 passed; VRT `run_fulgur_vrt` ok against UNCHANGED goldens. NEVER set `FULGUR_VRT_UPDATE=1`. If VRT goes red, a byte changed — bisect the boundary (most likely an EM×font_size width site, a `.px().in_pt()` vs `.pt()` mismatch, or a reassociated sum) and fix the typing, NOT the golden.
+
+**Step 7 — Commit:**
+
+```bash
+git add -A
+git commit -m "refactor(paragraph): migrate ShapedLine/ShapedGlyphRun/InlineImage/InlineBoxItem coords to units::Pt (byte-neutral, P1b)"
+```
+
+---
+
+### Task 3: Final holistic byte-neutral verification
+
+**Step 1 — Full workspace build + lint:**
+
+```bash
+cargo build
+cargo clippy -p fulgur -- -D warnings
+cargo fmt --check
+```
+
+**Step 2 — Full determinism re-run from a clean state** (guards against incremental-compilation masking):
+
+```bash
+export FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf"
+cargo test -p fulgur --lib
+cargo test -p fulgur-cli --test examples_determinism
+cargo test -p fulgur-vrt
+```
+
+Expected: all green, goldens byte-identical.
+
+**Step 3 — Confirm scope hygiene:**
+
+```bash
+git diff origin/main --stat
+```
+
+Expected touched files: `units.rs`, `paragraph.rs`, `convert/inline_root.rs`, `convert/list_marker.rs`, `render.rs`, possibly `pageable.rs`, plus this plan. NOT touched: `draw_primitives.rs` `Rect`/`Pt` alias, Fragment, Drawables aggregate, DecorationMetrics/LineFontMetrics field types, any `goldens/`.
+
+**Step 4 — Done.** Hand back for code review (requesting-code-review) → finishing-a-development-branch.
+
+---
+
+## Notes / pitfalls
+
+- `Pt` derives `PartialOrd`, so `Pt < Pt` works; `Pt < f32` does NOT — use `0.5_f32.pt()` / `Pt::ZERO` or compare via `.to_f32()`.
+- `px_to_pt(x)` (convert.rs helper) returns `f32`. To produce a `Pt` field, prefer `x.px().in_pt()` (spike idiom) over `px_to_pt(x).pt()`; both are byte-identical (`x * 0.75`), pick one and stay consistent.
+- The decoration internal helpers (`draw_decoration_line`/`draw_straight_line`/wavy, ~:303-435) take raw f32 and STAY f32 — they are below the to_f32 boundary. Do not migrate their internal `half < 0.01` / `(cx+half).min(...)`.
+- Coverage: this is pure type migration (no new logic), so existing tests + the new `Pt::abs` unit test suffice; no new draw-path smoke test required.


### PR DESCRIPTION
## 概要

Epic `fulgur-2map`（`Engine::layout()` を Px/Pt newtype 座標基盤上で公開）の **P1b**。`paragraph.rs` の5構造体（`ShapedLine` / `ShapedGlyphRun` / `ShapedGlyph` / `InlineImage` / `InlineBoxItem`）の座標フィールドを生 `f32`・legacy `draw_primitives::Pt(=f32)` alias から `crate::units::Pt` へ移行する **byte-neutral** フェーズです。spike（`fulgur-2map.2` / #509）で確立したフェーズ共通パターン（型の出自を native unit とし、変換は `in_pt`/`in_px`、`to_f32` は FFI のみ、演算順序は不変）を踏襲します。

## 型の決定と検証済みの急所

- **`ShapedGlyphRun.font_size` は PDF pt**（`convert/inline_root.rs` で `px_to_pt(font_size_parley)` 済）。よって `Pt` 化。これにより `EM分数(f32) * font_size(Pt) = Pt` が自然に成立し、本 issue が警告した「EM分数 × font_size の単位扱い」を型で解消します。
- **`ShapedGlyph.x_advance` / `x_offset` / `y_offset` は無次元 EM分数**（`g.advance / font_size_parley`）で、Krilla へ素通しされ font_size でスケールされます。→ **`ShapedGlyph` は型変更なし（f32 据え置き）**。
- 帰結として、decoration span 幅・link rect 幅の `g.x_advance * run.font_size` は **すでに pt**。事前調査で「F2/F3 は unit mismatch、`* PX_TO_PT` を挿入すべき」とされた指摘は、font_size を px と誤認したことによる **誤検知（refuted）** です。`* PX_TO_PT` / `* 0.75` の挿入はバイトを変えるため**入れていません**（レビューで蒸し返さないようご注意ください）。Krilla 側からも二重確認: `draw_glyphs` は font_size を pt サーフェス単位で要求し、誤れば文字が 4/3 倍になりますが goldens は green です。

## スコープ（Strategy C）

font メトリクス helper（`get_decoration_metrics` / `DecorationMetrics` / `recalculate_line_box` の `LineFontMetrics`）は **f32 のまま据え置き**（skrifa は f32 FFI 境界）。`font_size.to_f32()` で渡し、f32 メトリクスが `Pt` 座標と合流する箇所は `.pt()` でタグ付けします。これにより当該 subsystem と約10個の unit test は**無改変**で green を維持します（＝ Strategy A への逸脱がないことの証左）。

`units.rs` に `Pt::abs()` / `Px::abs()` を追加（spike が `ZERO`/`max`/`min` を追加した流儀に一致、`f32::abs` を mirror）。

## byte-neutral 証跡

clean `origin/main` で編集前 baseline を GREEN 確認した上で、移行後も **goldens 据え置きのまま byte-identical**（`FULGUR_VRT_UPDATE` は不使用）:

- `cargo test -p fulgur --lib` — **1496 passed**（baseline 1495 + 新規 `abs` test 1）
- `cargo test -p fulgur-cli --test examples_determinism` — **11 passed**
- `cargo test -p fulgur-vrt` — `run_fulgur_vrt ok`（PDF byte 比較、goldens 無改変）
- `cargo clippy -p fulgur --all-targets -- -D warnings` / `cargo fmt --check` — clean
- `cargo build`（全 workspace）— green。これは型検査により `draw_shaped_lines` 等の**全 consumer が漏れなく移行された証明**でもあります（未移行 caller があればコンパイル不能）。

## スコープ外（後続フェーズ）

`draw_primitives::Pt` alias の撤去・`Rect` 移行・Fragment（P1c / `fulgur-2map.5`）・Drawables 集約（P1e / `fulgur-2map.7`）・`DecorationMetrics`/`LineFontMetrics` のフィールド移行・`layout()` 公開。

## 関連

- issue: `fulgur-2map.4`（マージ時に close、`fulgur-2map.7` (P1e) を unblock）
- base: `origin/main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 段落・リスト・インライン画像/疑似画像の 高さ・ベースライン・横位置 を 一貫した単位で計算し、位置ずれを改善しました。
  * リンク当たり矩形や 文字装飾 の 描画位置 を安定化しました。
* **Tests**
  * 単位換算を反映した 期待値比較 を更新し、レンダリング結果の決定性確認を強化しました。
* **Documentation**
  * 単位移行と検証手順の 計画資料 を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->