### PR TITLE
refactor(pagination): migrate Fragment coords to units::Px (P1c, byte-neutral)

### DIFF
--- a/crates/fulgur/src/convert/positioned.rs
+++ b/crates/fulgur/src/convert/positioned.rs
@@ -264,8 +264,8 @@ fn maybe_apply_abs_pseudo_inset_correction(
     else {
         return;
     };
-    let parent_x_px = parent_frag.x;
-    let parent_y_px = parent_frag.y;
+    let parent_x_px = parent_frag.x.to_f32();
+    let parent_y_px = parent_frag.y.to_f32();
 
     let pseudo_w_px = pt_to_px(pseudo_w_pt);
     let pseudo_h_px = pt_to_px(pseudo_h_pt);
@@ -306,10 +306,10 @@ fn maybe_apply_abs_pseudo_inset_correction(
     entry.fragments.clear();
     entry.fragments.push(crate::pagination_layout::Fragment {
         page_index: parent_frag.page_index,
-        x: new_x_px,
-        y: new_y_px,
-        width: pseudo_w_px,
-        height: pseudo_h_px,
+        x: new_x_px.px(),
+        y: new_y_px.px(),
+        width: pseudo_w_px.px(),
+        height: pseudo_h_px.px(),
     });
 }
 
@@ -1414,7 +1414,7 @@ mod tests {
     ) -> (f32, f32) {
         let geom = geometry.get(&node_id).expect("node missing from geometry");
         let frag = geom.fragments.first().expect("node has no fragments");
-        (frag.x, frag.y)
+        (frag.x.to_f32(), frag.y.to_f32())
     }
 
     // maybe_apply_abs_pseudo_inset_correction: `right` + `bottom` set, `left`

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -1213,6 +1213,7 @@ impl EngineBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::units::F32Units;
 
     #[test]
     fn collect_pseudo_text_resolves_string_and_attr() {
@@ -1444,10 +1445,10 @@ mod tests {
     fn frag_on_page(page_index: u32) -> crate::pagination_layout::Fragment {
         crate::pagination_layout::Fragment {
             page_index,
-            x: 0.0,
-            y: 0.0,
-            width: 0.0,
-            height: 0.0,
+            x: 0.0_f32.px(),
+            y: 0.0_f32.px(),
+            width: 0.0_f32.px(),
+            height: 0.0_f32.px(),
         }
     }
 

--- a/crates/fulgur/src/gcpm/target_ref.rs
+++ b/crates/fulgur/src/gcpm/target_ref.rs
@@ -201,6 +201,7 @@ pub fn page_for_node(geometry: &PaginationGeometryTable, node_id: usize) -> Opti
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::units::F32Units;
 
     fn make_map() -> AnchorMap {
         let mut m = AnchorMap::new();
@@ -399,17 +400,17 @@ mod tests {
                 fragments: vec![
                     Fragment {
                         page_index: 2,
-                        x: 0.0,
-                        y: 0.0,
-                        width: 0.0,
-                        height: 0.0,
+                        x: 0.0_f32.px(),
+                        y: 0.0_f32.px(),
+                        width: 0.0_f32.px(),
+                        height: 0.0_f32.px(),
                     },
                     Fragment {
                         page_index: 3,
-                        x: 0.0,
-                        y: 0.0,
-                        width: 0.0,
-                        height: 0.0,
+                        x: 0.0_f32.px(),
+                        y: 0.0_f32.px(),
+                        width: 0.0_f32.px(),
+                        height: 0.0_f32.px(),
                     },
                 ],
                 is_repeat: false,

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -4841,9 +4841,9 @@ h2 { string-set: chapter-title content(text); }
         );
 
         let has_later_text_fragment = geom.values().any(|g| {
-            g.fragments
-                .iter()
-                .any(|f| f.page_index == 1 && f.height.to_f32() > 0.0 && f.height.to_f32() < 100.0)
+            g.fragments.iter().any(|f| {
+                f.page_index == 1 && f.height > crate::units::Px::ZERO && f.height < 100.0_f32.px()
+            })
         });
 
         assert!(

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -61,6 +61,7 @@
 //! repeat `position: fixed` elements on every page (`is_repeat=true`
 //! on the resulting `PaginationGeometry`).
 
+use crate::units::F32Units;
 use blitz_dom::BaseDocument;
 use std::collections::{BTreeMap, BTreeSet};
 use taffy::{
@@ -70,17 +71,18 @@ use taffy::{
 
 /// One placement slot recorded per (source node × page).
 ///
-/// `x`, `y`, `width`, `height` are in CSS pixels — Taffy's native unit —
-/// and `y` is measured from the page's content-box top. The convert /
-/// draw layer is responsible for `px_to_pt` conversion before reaching
+/// `x`, `y`, `width`, `height` are type-enforced CSS pixels
+/// ([`crate::units::Px`]) — Taffy's native unit — and `y` is measured from
+/// the page's content-box top. The convert / draw layer is responsible for
+/// `px_to_pt` conversion ([`crate::units::Px::in_pt`]) before reaching
 /// Krilla.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Fragment {
     pub page_index: u32,
-    pub x: f32,
-    pub y: f32,
-    pub width: f32,
-    pub height: f32,
+    pub x: crate::units::Px,
+    pub y: crate::units::Px,
+    pub width: crate::units::Px,
+    pub height: crate::units::Px,
 }
 
 /// Per-source-node geometry: every page on which the node has a placement.
@@ -447,10 +449,10 @@ impl<'a> PaginationLayoutTree<'a> {
             .fragments
             .push(Fragment {
                 page_index: 0,
-                x: body_x,
-                y: 0.0,
-                width: body_w,
-                height: body_layout.size.height,
+                x: body_x.px(),
+                y: 0.0_f32.px(),
+                width: body_w.px(),
+                height: body_layout.size.height.px(),
             });
 
         // Prefer body's `layout_children` — same rationale as
@@ -559,10 +561,10 @@ impl<'a> PaginationLayoutTree<'a> {
                         .fragments
                         .push(Fragment {
                             page_index,
-                            x: body_x + layout.location.x,
-                            y: cursor_y,
-                            width: 0.0,
-                            height: 0.0,
+                            x: (body_x + layout.location.x).px(),
+                            y: cursor_y.px(),
+                            width: 0.0_f32.px(),
+                            height: 0.0_f32.px(),
                         });
                     emitted += 1;
                 }
@@ -648,10 +650,10 @@ impl<'a> PaginationLayoutTree<'a> {
                         .fragments
                         .push(Fragment {
                             page_index,
-                            x: body_x + layout.location.x,
-                            y: cursor_y,
-                            width: child_w,
-                            height: 0.0,
+                            x: (body_x + layout.location.x).px(),
+                            y: cursor_y.px(),
+                            width: child_w.px(),
+                            height: 0.0_f32.px(),
                         });
                     emitted += 1;
                 }
@@ -959,10 +961,10 @@ impl<'a> PaginationLayoutTree<'a> {
                     .fragments
                     .push(Fragment {
                         page_index,
-                        x: frag_x,
-                        y: cursor_y,
-                        width: child_w,
-                        height: first_slice_h,
+                        x: frag_x.px(),
+                        y: cursor_y.px(),
+                        width: child_w.px(),
+                        height: first_slice_h.px(),
                     });
                 record_subtree_descendants(
                     &mut self.geometry,
@@ -992,10 +994,10 @@ impl<'a> PaginationLayoutTree<'a> {
                         .fragments
                         .push(Fragment {
                             page_index,
-                            x: frag_x,
-                            y: 0.0,
-                            width: child_w,
-                            height: last_slice_h,
+                            x: frag_x.px(),
+                            y: 0.0_f32.px(),
+                            width: child_w.px(),
+                            height: last_slice_h.px(),
                         });
                     remaining -= last_slice_h;
                 }
@@ -1029,10 +1031,10 @@ impl<'a> PaginationLayoutTree<'a> {
 
             let frag = Fragment {
                 page_index,
-                x: frag_x,
-                y: cursor_y,
-                width: child_w,
-                height: child_h,
+                x: frag_x.px(),
+                y: cursor_y.px(),
+                width: child_w.px(),
+                height: child_h.px(),
             };
             self.geometry
                 .entry(child_id)
@@ -1183,10 +1185,10 @@ fn record_subtree_descendants(
             .fragments
             .push(Fragment {
                 page_index,
-                x: child_x,
-                y: child_y,
-                width: w,
-                height: h,
+                x: child_x.px(),
+                y: child_y.px(),
+                width: w.px(),
+                height: h.px(),
             });
         record_subtree_descendants(
             geometry,
@@ -1547,10 +1549,10 @@ fn fragment_block_subtree(
             .fragments
             .push(Fragment {
                 page_index: page_in,
-                x: parent_x_in_body,
-                y: cursor_in,
-                width: parent_w,
-                height: h,
+                x: parent_x_in_body.px(),
+                y: cursor_in.px(),
+                width: parent_w.px(),
+                height: h.px(),
             });
         return (page_in, cursor_in + h);
     }
@@ -1794,10 +1796,10 @@ fn fragment_block_subtree(
                     .fragments
                     .push(Fragment {
                         page_index,
-                        x: parent_x_in_body,
-                        y: page_start_y,
-                        width: parent_w,
-                        height: cursor_y - page_start_y,
+                        x: parent_x_in_body.px(),
+                        y: page_start_y.px(),
+                        width: parent_w.px(),
+                        height: (cursor_y - page_start_y).px(),
                     });
                 page_index += 1;
                 cursor_y = 0.0;
@@ -1814,10 +1816,10 @@ fn fragment_block_subtree(
                     .fragments
                     .push(Fragment {
                         page_index,
-                        x: parent_x_in_body + layout.location.x,
-                        y: cursor_y,
-                        width: child_w,
-                        height: 0.0,
+                        x: (parent_x_in_body + layout.location.x).px(),
+                        y: cursor_y.px(),
+                        width: child_w.px(),
+                        height: 0.0_f32.px(),
                     });
             }
             // Honour `break-after: page` for zero-height elements
@@ -1830,10 +1832,10 @@ fn fragment_block_subtree(
                     .fragments
                     .push(Fragment {
                         page_index,
-                        x: parent_x_in_body,
-                        y: page_start_y,
-                        width: parent_w,
-                        height: cursor_y - page_start_y,
+                        x: parent_x_in_body.px(),
+                        y: page_start_y.px(),
+                        width: parent_w.px(),
+                        height: (cursor_y - page_start_y).px(),
                     });
                 page_index += 1;
                 cursor_y = 0.0;
@@ -1875,10 +1877,10 @@ fn fragment_block_subtree(
                 .fragments
                 .push(Fragment {
                     page_index,
-                    x: parent_x_in_body,
-                    y: page_start_y,
-                    width: parent_w,
-                    height: cursor_y - page_start_y,
+                    x: parent_x_in_body.px(),
+                    y: page_start_y.px(),
+                    width: parent_w.px(),
+                    height: (cursor_y - page_start_y).px(),
                 });
             page_index += 1;
             cursor_y = 0.0;
@@ -2009,10 +2011,10 @@ fn fragment_block_subtree(
                                 .fragments
                                 .push(Fragment {
                                     page_index: pre_recursion_page,
-                                    x: parent_x_in_body,
-                                    y: page_start_y,
-                                    width: parent_w,
-                                    height: prev_height,
+                                    x: parent_x_in_body.px(),
+                                    y: page_start_y.px(),
+                                    width: parent_w.px(),
+                                    height: prev_height.px(),
                                 });
                         }
                     }
@@ -2028,10 +2030,10 @@ fn fragment_block_subtree(
                                 .fragments
                                 .push(Fragment {
                                     page_index: p,
-                                    x: parent_x_in_body,
-                                    y: 0.0,
-                                    width: parent_w,
-                                    height: page_height_px,
+                                    x: parent_x_in_body.px(),
+                                    y: 0.0_f32.px(),
+                                    width: parent_w.px(),
+                                    height: page_height_px.px(),
                                 });
                         }
                     }
@@ -2057,10 +2059,10 @@ fn fragment_block_subtree(
                     .fragments
                     .push(Fragment {
                         page_index,
-                        x: parent_x_in_body,
-                        y: page_start_y,
-                        width: parent_w,
-                        height: cursor_y - page_start_y,
+                        x: parent_x_in_body.px(),
+                        y: page_start_y.px(),
+                        width: parent_w.px(),
+                        height: (cursor_y - page_start_y).px(),
                     });
                 page_index += 1;
                 cursor_y = 0.0;
@@ -2100,10 +2102,10 @@ fn fragment_block_subtree(
                     .fragments
                     .push(Fragment {
                         page_index,
-                        x: parent_x_in_body,
-                        y: page_start_y,
-                        width: parent_w,
-                        height: cursor_y - page_start_y,
+                        x: parent_x_in_body.px(),
+                        y: page_start_y.px(),
+                        width: parent_w.px(),
+                        height: (cursor_y - page_start_y).px(),
                     });
             }
             page_index += 1;
@@ -2127,10 +2129,10 @@ fn fragment_block_subtree(
             .fragments
             .push(Fragment {
                 page_index,
-                x: child_x_in_body,
-                y: child_page_y,
-                width: child_w,
-                height: child_h,
+                x: child_x_in_body.px(),
+                y: child_page_y.px(),
+                width: child_w.px(),
+                height: child_h.px(),
             });
         record_subtree_descendants(
             geometry,
@@ -2157,10 +2159,10 @@ fn fragment_block_subtree(
                 .fragments
                 .push(Fragment {
                     page_index,
-                    x: parent_x_in_body,
-                    y: page_start_y,
-                    width: parent_w,
-                    height: cursor_y - page_start_y,
+                    x: parent_x_in_body.px(),
+                    y: page_start_y.px(),
+                    width: parent_w.px(),
+                    height: (cursor_y - page_start_y).px(),
                 });
             page_index += 1;
             cursor_y = 0.0;
@@ -2204,10 +2206,10 @@ fn fragment_block_subtree(
         .fragments
         .push(Fragment {
             page_index,
-            x: parent_x_in_body,
-            y: page_start_y,
-            width: parent_w,
-            height: cursor_y - page_start_y,
+            x: parent_x_in_body.px(),
+            y: page_start_y.px(),
+            width: parent_w.px(),
+            height: (cursor_y - page_start_y).px(),
         });
 
     (page_index, cursor_y)
@@ -2335,10 +2337,10 @@ fn fragment_inline_root(
             let frag_h = prev_line_bottom - frag_top_local;
             let frag = Fragment {
                 page_index,
-                x: paragraph_x,
-                y: paragraph_top_in_body,
-                width,
-                height: frag_h,
+                x: paragraph_x.px(),
+                y: paragraph_top_in_body.px(),
+                width: width.px(),
+                height: frag_h.px(),
             };
             geometry.entry(child_id).or_default().fragments.push(frag);
             emitted += 1;
@@ -2355,10 +2357,10 @@ fn fragment_inline_root(
     let frag_h = last_bottom_local - frag_top_local;
     let frag = Fragment {
         page_index,
-        x: paragraph_x,
-        y: paragraph_top_in_body,
-        width,
-        height: frag_h,
+        x: paragraph_x.px(),
+        y: paragraph_top_in_body.px(),
+        width: width.px(),
+        height: frag_h.px(),
     };
     geometry.entry(child_id).or_default().fragments.push(frag);
     emitted += 1;
@@ -2662,10 +2664,10 @@ pub fn append_position_fixed_fragments(
         for page_index in 0..pages {
             entry.fragments.push(Fragment {
                 page_index,
-                x,
-                y,
-                width: w,
-                height: h,
+                x: x.px(),
+                y: y.px(),
+                width: w.px(),
+                height: h.px(),
             });
         }
 
@@ -2738,10 +2740,10 @@ fn record_fixed_subtree_descendants(
         for page_index in 0..pages.max(1) {
             entry.fragments.push(Fragment {
                 page_index,
-                x: stored_x,
-                y: stored_y,
-                width: w,
-                height: h,
+                x: stored_x.px(),
+                y: stored_y.px(),
+                width: w.px(),
+                height: h.px(),
             });
         }
 
@@ -3185,10 +3187,10 @@ fn record_subtree_fragments_at_offset(
                     };
                     entry.fragments.push(Fragment {
                         page_index,
-                        x: stored_x,
-                        y: stored_y,
-                        width: w,
-                        height: stored_h,
+                        x: stored_x.px(),
+                        y: stored_y.px(),
+                        width: w.px(),
+                        height: stored_h.px(),
                     });
                 }
                 descendant_total_pages = descendant_total_pages.max(last_page.saturating_add(1));
@@ -3794,7 +3796,11 @@ mod tests {
         );
         let h2_pages: Vec<u32> = table
             .values()
-            .filter(|g| g.fragments.iter().any(|f| (f.height - 30.0).abs() < 0.5))
+            .filter(|g| {
+                g.fragments
+                    .iter()
+                    .any(|f| (f.height.to_f32() - 30.0).abs() < 0.5)
+            })
             .map(|g| g.fragments[0].page_index)
             .collect();
         assert_eq!(h2_pages.len(), 2, "expected 2 h2 entries, got {h2_pages:?}");
@@ -4101,7 +4107,8 @@ h2 { string-set: chapter-title content(text); }
         assert_eq!(fragments.len(), 1, "single zero-height fragment");
         assert_eq!(fragments[0].page_index, 0);
         assert_eq!(
-            fragments[0].height, 0.0,
+            fragments[0].height.to_f32(),
+            0.0,
             "running fragment must not advance the cursor"
         );
 
@@ -4129,24 +4136,24 @@ h2 { string-set: chapter-title content(text); }
         let mut geom = PaginationGeometryTable::new();
         geom.entry(10).or_default().fragments.push(Fragment {
             page_index: 0,
-            x: 0.0,
-            y: 0.0,
-            width: 100.0,
-            height: 50.0,
+            x: 0.0_f32.px(),
+            y: 0.0_f32.px(),
+            width: 100.0_f32.px(),
+            height: 50.0_f32.px(),
         });
         geom.entry(20).or_default().fragments.push(Fragment {
             page_index: 0,
-            x: 0.0,
-            y: 50.0,
-            width: 100.0,
-            height: 50.0,
+            x: 0.0_f32.px(),
+            y: 50.0_f32.px(),
+            width: 100.0_f32.px(),
+            height: 50.0_f32.px(),
         });
         geom.entry(30).or_default().fragments.push(Fragment {
             page_index: 1,
-            x: 0.0,
-            y: 0.0,
-            width: 100.0,
-            height: 50.0,
+            x: 0.0_f32.px(),
+            y: 0.0_f32.px(),
+            width: 100.0_f32.px(),
+            height: 50.0_f32.px(),
         });
 
         let mut markers: BTreeMap<usize, Vec<(String, String)>> = BTreeMap::new();
@@ -4187,17 +4194,17 @@ h2 { string-set: chapter-title content(text); }
         let mut geom = PaginationGeometryTable::new();
         geom.entry(42).or_default().fragments.push(Fragment {
             page_index: 0,
-            x: 0.0,
-            y: 0.0,
-            width: 100.0,
-            height: 800.0,
+            x: 0.0_f32.px(),
+            y: 0.0_f32.px(),
+            width: 100.0_f32.px(),
+            height: 800.0_f32.px(),
         });
         geom.entry(42).or_default().fragments.push(Fragment {
             page_index: 1,
-            x: 0.0,
-            y: 0.0,
-            width: 100.0,
-            height: 200.0,
+            x: 0.0_f32.px(),
+            y: 0.0_f32.px(),
+            width: 100.0_f32.px(),
+            height: 200.0_f32.px(),
         });
 
         let mut markers: BTreeMap<usize, Vec<(String, String)>> = BTreeMap::new();
@@ -4268,9 +4275,9 @@ h2 { string-set: chapter-title content(text); }
         let fixed_entries: Vec<_> = geom
             .iter()
             .filter(|(_, g)| {
-                g.fragments
-                    .iter()
-                    .any(|f| (f.width - 100.0).abs() < 0.5 && (f.height - 50.0).abs() < 0.5)
+                g.fragments.iter().any(|f| {
+                    (f.width.to_f32() - 100.0).abs() < 0.5 && (f.height.to_f32() - 50.0).abs() < 0.5
+                })
             })
             .collect();
         assert_eq!(
@@ -4334,7 +4341,11 @@ h2 { string-set: chapter-title content(text); }
         // Locate the fixed div fragment by its 30px height.
         let entries: Vec<_> = geom
             .iter()
-            .filter(|(_, g)| g.fragments.iter().any(|f| (f.height - 30.0).abs() < 0.5))
+            .filter(|(_, g)| {
+                g.fragments
+                    .iter()
+                    .any(|f| (f.height.to_f32() - 30.0).abs() < 0.5)
+            })
             .collect();
         assert_eq!(entries.len(), 1, "exactly one fixed entry");
         let (_, g) = entries[0];
@@ -4343,9 +4354,9 @@ h2 { string-set: chapter-title content(text); }
         // viewport_h_px=800, height=30 → bottom edge sits at 800 → top at 770.
         // body has zero height (no in-flow content), so body_offset_xy=(0,0).
         assert!(
-            (frag.y - 770.0).abs() < 1.0,
+            (frag.y.to_f32() - 770.0).abs() < 1.0,
             "bottom:0 fixed should resolve to y=770 (viewport_h - height); got {}",
-            frag.y
+            frag.y.to_f32()
         );
     }
 
@@ -4370,16 +4381,20 @@ h2 { string-set: chapter-title content(text); }
 
         let entries: Vec<_> = geom
             .iter()
-            .filter(|(_, g)| g.fragments.iter().any(|f| (f.width - 36.0).abs() < 0.5))
+            .filter(|(_, g)| {
+                g.fragments
+                    .iter()
+                    .any(|f| (f.width.to_f32() - 36.0).abs() < 0.5)
+            })
             .collect();
         assert_eq!(entries.len(), 1, "expected one fixed entry");
         let frag = entries[0].1.fragments.first().unwrap();
         assert_eq!(frag.page_index, 0, "expected fixed fragment only on page 0");
         // With Taffy-like rounding: round(cb_h - b) - round(h) => round(800.6)-36 = 765.
         assert!(
-            (frag.y - 765.0).abs() < 0.25,
+            (frag.y.to_f32() - 765.0).abs() < 0.25,
             "fractional fixed bottom anchor should resolve to y≈765; got {}",
-            frag.y
+            frag.y.to_f32()
         );
     }
 
@@ -4404,12 +4419,12 @@ h2 { string-set: chapter-title content(text); }
         let frag = geom
             .values()
             .flat_map(|g| &g.fragments)
-            .find(|f| f.page_index == 1 && (f.height - 19.0).abs() < 0.5)
+            .find(|f| f.page_index == 1 && (f.height.to_f32() - 19.0).abs() < 0.5)
             .expect("absolute bottom:-viewport fragment should land on page 1");
         assert!(
-            (frag.y - 952.0).abs() < 0.01,
+            (frag.y.to_f32() - 952.0).abs() < 0.01,
             "absolute ref fragment should keep the same page-local bottom anchor as fixed; got {}",
-            frag.y
+            frag.y.to_f32()
         );
     }
 
@@ -4445,16 +4460,20 @@ h2 { string-set: chapter-title content(text); }
 
         let entries: Vec<_> = geom
             .iter()
-            .filter(|(_, g)| g.fragments.iter().any(|f| (f.height - 30.0).abs() < 0.5))
+            .filter(|(_, g)| {
+                g.fragments
+                    .iter()
+                    .any(|f| (f.height.to_f32() - 30.0).abs() < 0.5)
+            })
             .collect();
         assert_eq!(entries.len(), 1, "exactly one fixed entry");
         let frag = entries[0].1.fragments.first().unwrap();
         // top:0 → resolved_y=0 → stored_y = 0 - body_y_px = -body_y_px.
         assert!(
-            (frag.y - (-body_y_px)).abs() < 0.5,
+            (frag.y.to_f32() - (-body_y_px)).abs() < 0.5,
             "top:0 fixed frag.y must be -body_offset (={}); got {}",
             -body_y_px,
-            frag.y
+            frag.y.to_f32()
         );
     }
 
@@ -4494,9 +4513,9 @@ h2 { string-set: chapter-title content(text); }
         let entries: Vec<_> = geom
             .iter()
             .filter(|(_, g)| {
-                g.fragments
-                    .iter()
-                    .any(|f| (f.width - 36.0).abs() < 0.5 && (f.height - 36.0).abs() < 0.5)
+                g.fragments.iter().any(|f| {
+                    (f.width.to_f32() - 36.0).abs() < 0.5 && (f.height.to_f32() - 36.0).abs() < 0.5
+                })
             })
             .collect();
         assert_eq!(
@@ -4523,21 +4542,22 @@ h2 { string-set: chapter-title content(text); }
         let f0 = &entries[0].1.fragments[0];
         let f1 = &entries[1].1.fragments[0];
         assert!(
-            (f0.x - f1.x).abs() < 0.5 && (f0.y - f1.y).abs() < 0.5,
+            (f0.x.to_f32() - f1.x.to_f32()).abs() < 0.5
+                && (f0.y.to_f32() - f1.y.to_f32()).abs() < 0.5,
             "root and child must share (x, y); got root=({},{}) child=({},{})",
-            f0.x,
-            f0.y,
-            f1.x,
-            f1.y,
+            f0.x.to_f32(),
+            f0.y.to_f32(),
+            f1.x.to_f32(),
+            f1.y.to_f32(),
         );
 
         // Pin the y coordinate: bottom:0 with height=36 in an 800px
         // viewport places the box top at y=764. body is empty so
         // body_offset_xy=(0,0).
         assert!(
-            (f0.y - 764.0).abs() < 1.0,
+            (f0.y.to_f32() - 764.0).abs() < 1.0,
             "bottom:0 fixed (h=36) must resolve to y=764 (viewport_h - h); got {}",
-            f0.y,
+            f0.y.to_f32(),
         );
     }
 
@@ -4569,7 +4589,7 @@ h2 { string-set: chapter-title content(text); }
         let mut found = None;
         for g in geom.values() {
             for f in &g.fragments {
-                if (f.height - 30.0).abs() < 0.5 {
+                if (f.height.to_f32() - 30.0).abs() < 0.5 {
                     found = Some(f.clone());
                 }
             }
@@ -4580,9 +4600,9 @@ h2 { string-set: chapter-title content(text); }
         // body_offset compensation is a no-op and viewport-CB
         // resolution gives y = 800 - 30 = 770.
         assert!(
-            (frag.y - 770.0).abs() < 1.0,
+            (frag.y.to_f32() - 770.0).abs() < 1.0,
             "abs body-direct bottom:0 should land at y=770; got {}",
-            frag.y
+            frag.y.to_f32()
         );
     }
 
@@ -4613,7 +4633,11 @@ h2 { string-set: chapter-title content(text); }
 
         let mut tall_entries: Vec<Vec<u32>> = geom
             .values()
-            .filter(|g| g.fragments.iter().any(|f| (f.height - 1800.0).abs() < 0.5))
+            .filter(|g| {
+                g.fragments
+                    .iter()
+                    .any(|f| (f.height.to_f32() - 1800.0).abs() < 0.5)
+            })
             .map(|g| {
                 let mut pages: Vec<u32> = g.fragments.iter().map(|f| f.page_index).collect();
                 pages.sort_unstable();
@@ -4703,7 +4727,11 @@ h2 { string-set: chapter-title content(text); }
         // Isolate the 10px-wide abs node's fragments.
         let abs_pages: Vec<u32> = geom
             .values()
-            .filter(|g| g.fragments.iter().any(|f| (f.width - 10.0).abs() < 0.5))
+            .filter(|g| {
+                g.fragments
+                    .iter()
+                    .any(|f| (f.width.to_f32() - 10.0).abs() < 0.5)
+            })
             .flat_map(|g| g.fragments.iter().map(|f| f.page_index))
             .collect();
         assert_eq!(
@@ -4738,7 +4766,7 @@ h2 { string-set: chapter-title content(text); }
         let has_later_text_fragment = geom.values().any(|g| {
             g.fragments
                 .iter()
-                .any(|f| f.page_index == 1 && f.height > 0.0 && f.height < 100.0)
+                .any(|f| f.page_index == 1 && f.height.to_f32() > 0.0 && f.height.to_f32() < 100.0)
         });
 
         assert!(
@@ -4762,9 +4790,10 @@ h2 { string-set: chapter-title content(text); }
             .values()
             .find(|g| {
                 g.is_repeat
-                    && g.fragments
-                        .iter()
-                        .any(|f| (f.width - 10.0).abs() < 0.5 && (f.height - 20.0).abs() < 0.5)
+                    && g.fragments.iter().any(|f| {
+                        (f.width.to_f32() - 10.0).abs() < 0.5
+                            && (f.height.to_f32() - 20.0).abs() < 0.5
+                    })
             })
             .map(|g| {
                 let mut pages: Vec<u32> = g.fragments.iter().map(|f| f.page_index).collect();
@@ -4806,12 +4835,18 @@ h2 { string-set: chapter-title content(text); }
         let mut tiny_overflow_pages = None;
         let mut exact_boundary_pages = None;
         for g in geom.values() {
-            if g.fragments.iter().any(|f| (f.height - 800.1).abs() < 0.05) {
+            if g.fragments
+                .iter()
+                .any(|f| (f.height.to_f32() - 800.1).abs() < 0.05)
+            {
                 let mut pages: Vec<u32> = g.fragments.iter().map(|f| f.page_index).collect();
                 pages.sort_unstable();
                 tiny_overflow_pages = Some(pages);
             }
-            if g.fragments.iter().any(|f| (f.height - 800.0).abs() < 0.05) {
+            if g.fragments
+                .iter()
+                .any(|f| (f.height.to_f32() - 800.0).abs() < 0.05)
+            {
                 let mut pages: Vec<u32> = g.fragments.iter().map(|f| f.page_index).collect();
                 pages.sort_unstable();
                 exact_boundary_pages = Some(pages);
@@ -4953,9 +4988,11 @@ h2 { string-set: chapter-title content(text); }
             .values()
             .flat_map(|g| g.fragments.iter())
             .filter(|f| {
-                f.page_index == 0 && (f.height - 100.0).abs() < 0.5 && (f.width - 100.0).abs() < 0.5
+                f.page_index == 0
+                    && (f.height.to_f32() - 100.0).abs() < 0.5
+                    && (f.width.to_f32() - 100.0).abs() < 0.5
             })
-            .map(|f| f.y)
+            .map(|f| f.y.to_f32())
             .collect();
         assert_eq!(
             card_y.len(),
@@ -4994,16 +5031,16 @@ h2 { string-set: chapter-title content(text); }
         let mut candidates: Vec<_> = geom
             .values()
             .flat_map(|g| g.fragments.iter())
-            .filter(|f| f.page_index == 1 && (f.height - 30.0).abs() < 0.5)
+            .filter(|f| f.page_index == 1 && (f.height.to_f32() - 30.0).abs() < 0.5)
             .collect();
         candidates.sort_by(|a, b| a.y.partial_cmp(&b.y).unwrap());
         let h2 = candidates
             .first()
             .expect("expected the trailing h2 to land on page 1");
         assert!(
-            h2.y >= 100.0,
+            h2.y.to_f32() >= 100.0,
             "block sibling after split grid must continue after the grid tail; got y={} (pre-fix: y=0 overlaps the tail)",
-            h2.y
+            h2.y.to_f32()
         );
     }
 
@@ -5044,11 +5081,11 @@ h2 { string-set: chapter-title content(text); }
         for (id, g) in geom.iter() {
             for f in &g.fragments {
                 assert!(
-                    f.y.is_finite() && f.height.is_finite(),
+                    f.y.to_f32().is_finite() && f.height.to_f32().is_finite(),
                     "node {id}: non-finite fragment y={} height={} leaked through \
                      fragment_block_subtree",
-                    f.y,
-                    f.height,
+                    f.y.to_f32(),
+                    f.height.to_f32(),
                 );
             }
         }
@@ -5081,16 +5118,16 @@ h2 { string-set: chapter-title content(text); }
         let mut candidates: Vec<_> = geom
             .values()
             .flat_map(|g| g.fragments.iter())
-            .filter(|f| f.page_index == 1 && (f.height - 30.0).abs() < 0.5)
+            .filter(|f| f.page_index == 1 && (f.height.to_f32() - 30.0).abs() < 0.5)
             .collect();
         candidates.sort_by(|a, b| a.y.partial_cmp(&b.y).unwrap());
         let h2 = candidates
             .first()
             .expect("expected the trailing h2 to land on page 1");
         assert!(
-            h2.y >= 100.0,
+            h2.y.to_f32() >= 100.0,
             "block sibling after split flex must continue after the flex tail; got y={} (pre-fix: y=0 overlaps the tail)",
-            h2.y
+            h2.y.to_f32()
         );
     }
 
@@ -5116,8 +5153,10 @@ h2 { string-set: chapter-title content(text); }
         let mut cells: Vec<_> = geom
             .values()
             .flat_map(|g| g.fragments.iter())
-            .filter(|f| (f.height - 100.0).abs() < 0.5 && (f.width - 100.0).abs() < 0.5)
-            .map(|f| (f.page_index, f.x, f.y))
+            .filter(|f| {
+                (f.height.to_f32() - 100.0).abs() < 0.5 && (f.width.to_f32() - 100.0).abs() < 0.5
+            })
+            .map(|f| (f.page_index, f.x.to_f32(), f.y.to_f32()))
             .collect();
         cells.sort_by(|a, b| a.partial_cmp(b).unwrap());
         let page_one_cells: Vec<_> = cells.iter().filter(|(p, _, _)| *p == 1).collect();
@@ -5154,8 +5193,10 @@ h2 { string-set: chapter-title content(text); }
         let mut cells: Vec<_> = geom
             .values()
             .flat_map(|g| g.fragments.iter())
-            .filter(|f| (f.height - 100.0).abs() < 0.5 && (f.width - 100.0).abs() < 0.5)
-            .map(|f| (f.page_index, f.x, f.y))
+            .filter(|f| {
+                (f.height.to_f32() - 100.0).abs() < 0.5 && (f.width.to_f32() - 100.0).abs() < 0.5
+            })
+            .map(|f| (f.page_index, f.x.to_f32(), f.y.to_f32()))
             .collect();
         cells.sort_by(|a, b| a.partial_cmp(b).unwrap());
         let page_one_cells: Vec<_> = cells.iter().filter(|(p, _, _)| *p == 1).collect();
@@ -5192,8 +5233,8 @@ h2 { string-set: chapter-title content(text); }
         let mut page_one_cells: Vec<_> = geom
             .values()
             .flat_map(|g| g.fragments.iter())
-            .filter(|f| f.page_index == 1 && (f.width - 100.0).abs() < 0.5)
-            .map(|f| (f.height, f.x, f.y))
+            .filter(|f| f.page_index == 1 && (f.width.to_f32() - 100.0).abs() < 0.5)
+            .map(|f| (f.height.to_f32(), f.x.to_f32(), f.y.to_f32()))
             .collect();
         page_one_cells.sort_by(|a, b| a.partial_cmp(b).unwrap());
         let unshifted = page_one_cells
@@ -5228,8 +5269,8 @@ h2 { string-set: chapter-title content(text); }
         let mut page_one_cells: Vec<_> = geom
             .values()
             .flat_map(|g| g.fragments.iter())
-            .filter(|f| f.page_index == 1 && (f.width - 100.0).abs() < 0.5)
-            .map(|f| (f.height, f.x, f.y))
+            .filter(|f| f.page_index == 1 && (f.width.to_f32() - 100.0).abs() < 0.5)
+            .map(|f| (f.height.to_f32(), f.x.to_f32(), f.y.to_f32()))
             .collect();
         page_one_cells.sort_by(|a, b| a.partial_cmp(b).unwrap());
         let unshifted = page_one_cells
@@ -5276,8 +5317,10 @@ h2 { string-set: chapter-title content(text); }
         let mut inner: Vec<(u32, f32, f32)> = geom
             .values()
             .flat_map(|g| g.fragments.iter())
-            .filter(|f| (f.width - 100.0).abs() < 0.5 && (f.height - 50.0).abs() < 0.5)
-            .map(|f| (f.page_index, f.x, f.y))
+            .filter(|f| {
+                (f.width.to_f32() - 100.0).abs() < 0.5 && (f.height.to_f32() - 50.0).abs() < 0.5
+            })
+            .map(|f| (f.page_index, f.x.to_f32(), f.y.to_f32()))
             .collect();
         inner.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
@@ -5343,8 +5386,10 @@ h2 { string-set: chapter-title content(text); }
         let mut inner: Vec<(u32, f32, f32)> = geom
             .values()
             .flat_map(|g| g.fragments.iter())
-            .filter(|f| (f.width - 100.0).abs() < 0.5 && (f.height - 50.0).abs() < 0.5)
-            .map(|f| (f.page_index, f.x, f.y))
+            .filter(|f| {
+                (f.width.to_f32() - 100.0).abs() < 0.5 && (f.height.to_f32() - 50.0).abs() < 0.5
+            })
+            .map(|f| (f.page_index, f.x.to_f32(), f.y.to_f32()))
             .collect();
         inner.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
@@ -5466,7 +5511,7 @@ h2 { string-set: chapter-title content(text); }
         let b_on_page1: Vec<&Fragment> = geom
             .values()
             .flat_map(|g| g.fragments.iter())
-            .filter(|f| f.page_index == 1 && (f.height - 100.0).abs() < 0.5)
+            .filter(|f| f.page_index == 1 && (f.height.to_f32() - 100.0).abs() < 0.5)
             .collect();
         assert!(
             !b_on_page1.is_empty(),
@@ -5474,11 +5519,11 @@ h2 { string-set: chapter-title content(text); }
         );
         for f in &b_on_page1 {
             assert!(
-                f.y.abs() < 0.5,
+                f.y.to_f32().abs() < 0.5,
                 "B should land at y=0 on the new page (forced break discards \
                  the inter-child gap), but got y={} (gap leaked through \
                  break-before — see Devin Review on PR #285). frag={f:?}",
-                f.y,
+                f.y.to_f32(),
             );
         }
     }
@@ -5498,7 +5543,7 @@ h2 { string-set: chapter-title content(text); }
         let second_on_page1: Vec<&Fragment> = geom
             .values()
             .flat_map(|g| g.fragments.iter())
-            .filter(|f| f.page_index == 1 && (f.height - 90.0).abs() < 0.5)
+            .filter(|f| f.page_index == 1 && (f.height.to_f32() - 90.0).abs() < 0.5)
             .collect();
         assert_eq!(
             second_on_page1.len(),
@@ -5506,7 +5551,7 @@ h2 { string-set: chapter-title content(text); }
             "expected only the second child on page 1, geom={geom:?}"
         );
         assert!(
-            (second_on_page1[0].y - 10.0).abs() < 0.5,
+            (second_on_page1[0].y.to_f32() - 10.0).abs() < 0.5,
             "body-level break-before should keep the element's own top margin on the new page; geom={geom:?}"
         );
     }
@@ -5522,10 +5567,10 @@ h2 { string-set: chapter-title content(text); }
         let mut geom = PaginationGeometryTable::new();
         geom.entry(1).or_default().fragments.push(Fragment {
             page_index: 2,
-            x: 0.0,
-            y: 0.0,
-            width: 1.0,
-            height: 1.0,
+            x: 0.0_f32.px(),
+            y: 0.0_f32.px(),
+            width: 1.0_f32.px(),
+            height: 1.0_f32.px(),
         });
         assert_eq!(super::implied_page_count(&geom), 3);
     }
@@ -5576,9 +5621,9 @@ h2 { string-set: chapter-title content(text); }
         assert_eq!(frags[0].page_index, 0);
         assert_eq!(frags[1].page_index, 1);
         // First fragment: lines 0-1 (height = 150).
-        assert!((frags[0].height - 150.0).abs() < 0.01);
+        assert!((frags[0].height.to_f32() - 150.0).abs() < 0.01);
         // Second fragment: lines 2-3 (height = 150 in para-local).
-        assert!((frags[1].height - 150.0).abs() < 0.01);
+        assert!((frags[1].height.to_f32() - 150.0).abs() < 0.01);
         // cursor_y on page 1 = paragraph_top_in_body (0.0) + 150 = 150.
         assert!((new_cursor - 150.0).abs() < 0.01);
     }
@@ -5601,7 +5646,7 @@ h2 { string-set: chapter-title content(text); }
         let frags = &geom.get(&1).unwrap().fragments;
         assert_eq!(frags.len(), 1);
         assert_eq!(frags[0].page_index, 0);
-        assert!((frags[0].height - 225.0).abs() < 0.01);
+        assert!((frags[0].height.to_f32() - 225.0).abs() < 0.01);
     }
 
     #[test]
@@ -5621,7 +5666,7 @@ h2 { string-set: chapter-title content(text); }
         // The oversized child is the entry whose height ≈ 1000.
         let oversize = table
             .values()
-            .find(|g| (g.fragments[0].height - 1000.0).abs() < 1.0)
+            .find(|g| (g.fragments[0].height.to_f32() - 1000.0).abs() < 1.0)
             .expect("oversized child fragment");
         assert_eq!(oversize.fragments.len(), 1);
         assert_eq!(oversize.fragments[0].page_index, 0);
@@ -5826,7 +5871,7 @@ h2 { string-set: chapter-title content(text); }
         let max_page = geom
             .values()
             .flat_map(|g| g.fragments.iter())
-            .filter(|f| (f.height - 1800.0).abs() < 0.5)
+            .filter(|f| (f.height.to_f32() - 1800.0).abs() < 0.5)
             .map(|f| f.page_index)
             .max();
         assert!(
@@ -5892,8 +5937,10 @@ h2 { string-set: chapter-title content(text); }
         let mut frags: Vec<(u32, f32, f32)> = geom
             .values()
             .flat_map(|g| g.fragments.iter())
-            .filter(|f| (f.height - 60.0).abs() < 0.5 && (f.width - 100.0).abs() < 0.5)
-            .map(|f| (f.page_index, f.x, f.y))
+            .filter(|f| {
+                (f.height.to_f32() - 60.0).abs() < 0.5 && (f.width.to_f32() - 100.0).abs() < 0.5
+            })
+            .map(|f| (f.page_index, f.x.to_f32(), f.y.to_f32()))
             .collect();
         frags.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
@@ -5928,8 +5975,10 @@ h2 { string-set: chapter-title content(text); }
         let mut frags: Vec<(u32, f32, f32)> = geom
             .values()
             .flat_map(|g| g.fragments.iter())
-            .filter(|f| (f.height - 60.0).abs() < 0.5 && (f.width - 100.0).abs() < 0.5)
-            .map(|f| (f.page_index, f.x, f.y))
+            .filter(|f| {
+                (f.height.to_f32() - 60.0).abs() < 0.5 && (f.width.to_f32() - 100.0).abs() < 0.5
+            })
+            .map(|f| (f.page_index, f.x.to_f32(), f.y.to_f32()))
             .collect();
         frags.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
@@ -5982,8 +6031,10 @@ h2 { string-set: chapter-title content(text); }
         let mut inner: Vec<(u32, f32, f32)> = geom
             .values()
             .flat_map(|g| g.fragments.iter())
-            .filter(|f| (f.height - 40.0).abs() < 0.5 && (f.width - 100.0).abs() < 0.5)
-            .map(|f| (f.page_index, f.x, f.y))
+            .filter(|f| {
+                (f.height.to_f32() - 40.0).abs() < 0.5 && (f.width.to_f32() - 100.0).abs() < 0.5
+            })
+            .map(|f| (f.page_index, f.x.to_f32(), f.y.to_f32()))
             .collect();
         inner.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
@@ -6033,8 +6084,10 @@ h2 { string-set: chapter-title content(text); }
         let mut inner: Vec<(u32, f32, f32)> = geom
             .values()
             .flat_map(|g| g.fragments.iter())
-            .filter(|f| (f.height - 40.0).abs() < 0.5 && (f.width - 100.0).abs() < 0.5)
-            .map(|f| (f.page_index, f.x, f.y))
+            .filter(|f| {
+                (f.height.to_f32() - 40.0).abs() < 0.5 && (f.width.to_f32() - 100.0).abs() < 0.5
+            })
+            .map(|f| (f.page_index, f.x.to_f32(), f.y.to_f32()))
             .collect();
         inner.sort_by(|a, b| a.partial_cmp(b).unwrap());
 

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -3810,6 +3810,84 @@ mod tests {
         assert_eq!(h2_pages, vec![0, 1]);
     }
 
+    /// fulgur-2map.5: directly exercise `fragment_block_subtree`'s
+    /// `depth >= MAX_DOM_DEPTH` guard (pagination_layout.rs ~1539-1557).
+    ///
+    /// The guard is the FIRST statement of the function, so calling it
+    /// with `depth = crate::MAX_DOM_DEPTH` trips the bail immediately —
+    /// no deep HTML and no big-stack thread required (the prior
+    /// render_smoke coverage needed a 600-deep `<div>` chain plus a
+    /// 256 MB stack just to recurse far enough to reach this arm). This
+    /// also tracks the constant itself: if `MAX_DOM_DEPTH` ever changes,
+    /// the test still enters the guard at exactly the limit.
+    #[test]
+    fn fragment_block_subtree_at_depth_limit_bails_with_whole_fragment() {
+        let doc = parse(
+            r#"<html><body style="margin:0"><div id="d" style="height:50px"></div></body></html>"#,
+            600.0,
+        );
+        let parent_id = find_by_id(&doc, "d").expect("div#d should exist");
+        // The bail copies this node's laid-out height into the fragment.
+        let node_h = doc
+            .get_node(parent_id)
+            .expect("div node")
+            .final_layout
+            .size
+            .height;
+        assert!(
+            (node_h - 50.0).abs() < 1.0,
+            "div should lay out ~50px tall, got {node_h}"
+        );
+
+        let mut geom = PaginationGeometryTable::new();
+        let (page_out, cursor_out) = fragment_block_subtree(
+            &mut geom,
+            &doc, // &BaseDocument via deref coercion
+            None, // column_styles
+            None, // used_page_names
+            parent_id,
+            600.0,                // parent_w
+            0.0,                  // parent_x_in_body
+            0,                    // page_in
+            0.0,                  // cursor_in
+            800.0,                // page_height_px
+            crate::MAX_DOM_DEPTH, // depth → trips the guard immediately
+        );
+
+        // The bail pushes exactly ONE whole fragment for parent_id at its
+        // entry coordinates, then returns (page_in, cursor_in + height).
+        let entry = geom
+            .get(&parent_id)
+            .expect("bail must emit a geometry entry for parent_id");
+        // Hot-path-bind `.len()` so the assert message doesn't introduce a
+        // failure-only region that codecov marks uncovered (see the P1c
+        // assert-arg artifact note in CLAUDE.md / units migration memory).
+        let n_frags = entry.fragments.len();
+        assert_eq!(
+            n_frags, 1,
+            "bail emits a single whole fragment, got {n_frags}"
+        );
+        let frag = &entry.fragments[0];
+        assert_eq!(frag.page_index, 0, "fragment stays on the entry page");
+        let fx = frag.x.to_f32();
+        assert_eq!(fx, 0.0, "fragment x == parent_x_in_body, got {fx}");
+        let fy = frag.y.to_f32();
+        assert_eq!(fy, 0.0, "fragment y == cursor_in, got {fy}");
+        let fw = frag.width.to_f32();
+        assert_eq!(fw, 600.0, "fragment width == parent_w, got {fw}");
+        let fh = frag.height.to_f32();
+        assert!(
+            (fh - node_h).abs() < 1.0,
+            "fragment height == node layout height: {fh} vs {node_h}"
+        );
+
+        assert_eq!(page_out, 0, "bail returns the entry page unchanged");
+        assert!(
+            (cursor_out - node_h).abs() < 1.0,
+            "cursor advances by the node height: {cursor_out} vs {node_h}"
+        );
+    }
+
     #[test]
     fn three_short_blocks_fit_one_page() {
         // Each block is 200px tall; page is 800px → all three fit on
@@ -4353,10 +4431,10 @@ h2 { string-set: chapter-title content(text); }
         let frag = &g.fragments[0];
         // viewport_h_px=800, height=30 → bottom edge sits at 800 → top at 770.
         // body has zero height (no in-flow content), so body_offset_xy=(0,0).
+        let frag_y = frag.y.to_f32();
         assert!(
-            (frag.y.to_f32() - 770.0).abs() < 1.0,
-            "bottom:0 fixed should resolve to y=770 (viewport_h - height); got {}",
-            frag.y.to_f32()
+            (frag_y - 770.0).abs() < 1.0,
+            "bottom:0 fixed should resolve to y=770 (viewport_h - height); got {frag_y}",
         );
     }
 
@@ -4391,10 +4469,10 @@ h2 { string-set: chapter-title content(text); }
         let frag = entries[0].1.fragments.first().unwrap();
         assert_eq!(frag.page_index, 0, "expected fixed fragment only on page 0");
         // With Taffy-like rounding: round(cb_h - b) - round(h) => round(800.6)-36 = 765.
+        let frag_y = frag.y.to_f32();
         assert!(
-            (frag.y.to_f32() - 765.0).abs() < 0.25,
-            "fractional fixed bottom anchor should resolve to y≈765; got {}",
-            frag.y.to_f32()
+            (frag_y - 765.0).abs() < 0.25,
+            "fractional fixed bottom anchor should resolve to y≈765; got {frag_y}",
         );
     }
 
@@ -4421,10 +4499,10 @@ h2 { string-set: chapter-title content(text); }
             .flat_map(|g| &g.fragments)
             .find(|f| f.page_index == 1 && (f.height.to_f32() - 19.0).abs() < 0.5)
             .expect("absolute bottom:-viewport fragment should land on page 1");
+        let frag_y = frag.y.to_f32();
         assert!(
-            (frag.y.to_f32() - 952.0).abs() < 0.01,
-            "absolute ref fragment should keep the same page-local bottom anchor as fixed; got {}",
-            frag.y.to_f32()
+            (frag_y - 952.0).abs() < 0.01,
+            "absolute ref fragment should keep the same page-local bottom anchor as fixed; got {frag_y}",
         );
     }
 
@@ -4469,11 +4547,12 @@ h2 { string-set: chapter-title content(text); }
         assert_eq!(entries.len(), 1, "exactly one fixed entry");
         let frag = entries[0].1.fragments.first().unwrap();
         // top:0 → resolved_y=0 → stored_y = 0 - body_y_px = -body_y_px.
+        let frag_y = frag.y.to_f32();
         assert!(
-            (frag.y.to_f32() - (-body_y_px)).abs() < 0.5,
+            (frag_y - (-body_y_px)).abs() < 0.5,
             "top:0 fixed frag.y must be -body_offset (={}); got {}",
             -body_y_px,
-            frag.y.to_f32()
+            frag_y
         );
     }
 
@@ -4541,23 +4620,21 @@ h2 { string-set: chapter-title content(text); }
         // wrong.
         let f0 = &entries[0].1.fragments[0];
         let f1 = &entries[1].1.fragments[0];
+        let f0x = f0.x.to_f32();
+        let f0y = f0.y.to_f32();
+        let f1x = f1.x.to_f32();
+        let f1y = f1.y.to_f32();
         assert!(
-            (f0.x.to_f32() - f1.x.to_f32()).abs() < 0.5
-                && (f0.y.to_f32() - f1.y.to_f32()).abs() < 0.5,
-            "root and child must share (x, y); got root=({},{}) child=({},{})",
-            f0.x.to_f32(),
-            f0.y.to_f32(),
-            f1.x.to_f32(),
-            f1.y.to_f32(),
+            (f0x - f1x).abs() < 0.5 && (f0y - f1y).abs() < 0.5,
+            "root and child must share (x, y); got root=({f0x},{f0y}) child=({f1x},{f1y})",
         );
 
         // Pin the y coordinate: bottom:0 with height=36 in an 800px
         // viewport places the box top at y=764. body is empty so
         // body_offset_xy=(0,0).
         assert!(
-            (f0.y.to_f32() - 764.0).abs() < 1.0,
-            "bottom:0 fixed (h=36) must resolve to y=764 (viewport_h - h); got {}",
-            f0.y.to_f32(),
+            (f0y - 764.0).abs() < 1.0,
+            "bottom:0 fixed (h=36) must resolve to y=764 (viewport_h - h); got {f0y}",
         );
     }
 
@@ -4599,10 +4676,10 @@ h2 { string-set: chapter-title content(text); }
         // Same math as the fixed case: body has zero height, so
         // body_offset compensation is a no-op and viewport-CB
         // resolution gives y = 800 - 30 = 770.
+        let frag_y = frag.y.to_f32();
         assert!(
-            (frag.y.to_f32() - 770.0).abs() < 1.0,
-            "abs body-direct bottom:0 should land at y=770; got {}",
-            frag.y.to_f32()
+            (frag_y - 770.0).abs() < 1.0,
+            "abs body-direct bottom:0 should land at y=770; got {frag_y}",
         );
     }
 
@@ -5037,10 +5114,10 @@ h2 { string-set: chapter-title content(text); }
         let h2 = candidates
             .first()
             .expect("expected the trailing h2 to land on page 1");
+        let h2_y = h2.y.to_f32();
         assert!(
-            h2.y.to_f32() >= 100.0,
-            "block sibling after split grid must continue after the grid tail; got y={} (pre-fix: y=0 overlaps the tail)",
-            h2.y.to_f32()
+            h2_y >= 100.0,
+            "block sibling after split grid must continue after the grid tail; got y={h2_y} (pre-fix: y=0 overlaps the tail)",
         );
     }
 
@@ -5080,12 +5157,12 @@ h2 { string-set: chapter-title content(text); }
         // keeping every emitted coordinate finite.
         for (id, g) in geom.iter() {
             for f in &g.fragments {
+                let fy = f.y.to_f32();
+                let fh = f.height.to_f32();
                 assert!(
-                    f.y.to_f32().is_finite() && f.height.to_f32().is_finite(),
-                    "node {id}: non-finite fragment y={} height={} leaked through \
+                    fy.is_finite() && fh.is_finite(),
+                    "node {id}: non-finite fragment y={fy} height={fh} leaked through \
                      fragment_block_subtree",
-                    f.y.to_f32(),
-                    f.height.to_f32(),
                 );
             }
         }
@@ -5124,10 +5201,10 @@ h2 { string-set: chapter-title content(text); }
         let h2 = candidates
             .first()
             .expect("expected the trailing h2 to land on page 1");
+        let h2_y = h2.y.to_f32();
         assert!(
-            h2.y.to_f32() >= 100.0,
-            "block sibling after split flex must continue after the flex tail; got y={} (pre-fix: y=0 overlaps the tail)",
-            h2.y.to_f32()
+            h2_y >= 100.0,
+            "block sibling after split flex must continue after the flex tail; got y={h2_y} (pre-fix: y=0 overlaps the tail)",
         );
     }
 
@@ -5518,12 +5595,12 @@ h2 { string-set: chapter-title content(text); }
             "expected B fragment on page 1, geom={geom:?}"
         );
         for f in &b_on_page1 {
+            let fy = f.y.to_f32();
             assert!(
-                f.y.to_f32().abs() < 0.5,
+                fy.abs() < 0.5,
                 "B should land at y=0 on the new page (forced break discards \
-                 the inter-child gap), but got y={} (gap leaked through \
+                 the inter-child gap), but got y={fy} (gap leaked through \
                  break-before — see Devin Review on PR #285). frag={f:?}",
-                f.y.to_f32(),
             );
         }
     }

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -828,10 +828,10 @@ pub fn draw_shaped_lines(
                         // position `(ox, oy)`.
                         let geo_x_pt = ctx.margin_left_pt
                             + ctx.drawables.body_offset_pt.0
-                            + crate::convert::px_to_pt(content_frag.x);
+                            + content_frag.x.in_pt().to_f32();
                         let geo_y_pt = ctx.margin_top_pt
                             + ctx.drawables.body_offset_pt.1
-                            + crate::convert::px_to_pt(content_frag.y);
+                            + content_frag.y.in_pt().to_f32();
                         let off_x = ox.to_f32() - geo_x_pt;
                         let off_y = oy.to_f32() - geo_y_pt;
                         let transform = krilla::geom::Transform::from_translate(off_x, off_y);

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -1194,7 +1194,6 @@ fn paint_multicol_paragraph_slices(
     margin_top_pt: f32,
     page_index: u32,
 ) {
-    use crate::convert::px_to_pt;
     use crate::draw_primitives::draw_with_opacity;
     let Some(slices_entry) = drawables.paragraph_slices.get(&source_node_id) else {
         return;
@@ -1227,12 +1226,12 @@ fn paint_multicol_paragraph_slices(
     // a slice's effective top in the current fragment frame is
     // `slice.origin_pt.1 - consumed`. `cutoff` is the visible strip's
     // height on this page.
-    let consumed: f32 = px_to_pt(
-        container_geom.fragments[..target_pos]
-            .iter()
-            .map(|f| f.height.to_f32())
-            .sum::<f32>(),
-    );
+    let consumed: f32 = container_geom.fragments[..target_pos]
+        .iter()
+        .map(|f| f.height)
+        .sum::<crate::units::Px>()
+        .in_pt()
+        .to_f32();
     let cutoff = target_frag.height.in_pt().to_f32();
 
     let container_x_pt = margin_left_pt + target_frag.x.in_pt().to_f32();

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -117,8 +117,8 @@ pub fn render_v2(
             } else {
                 0.0
             };
-            let x_pt = resolved_margin.left + crate::convert::px_to_pt(first_frag.x);
-            let y_pt = resolved_margin.top + body_y_off + crate::convert::px_to_pt(first_frag.y);
+            let x_pt = resolved_margin.left + first_frag.x.in_pt().to_f32();
+            let y_pt = resolved_margin.top + body_y_off + first_frag.y.in_pt().to_f32();
             dest_registry.record(id.as_str(), x_pt, y_pt);
         }
     }
@@ -446,8 +446,6 @@ fn draw_v2_page(
     opacity_wrapped_descendants: &std::collections::BTreeSet<usize>,
     page_node_ids: &[usize],
 ) {
-    use crate::convert::px_to_pt;
-
     // Skip sets and per-page dispatch list are built once in
     // `render_v2`. Walking only `page_node_ids` (instead of the full
     // `geometry` map per page) is what fixes the O(P²) regression
@@ -477,7 +475,7 @@ fn draw_v2_page(
             && let Some(anchor) = drawables.bookmark_anchors.get(&node_id)
             && let Some(c) = canvas.bookmark_collector.as_deref_mut()
         {
-            let y_pt = margin_top_pt + px_to_pt(first_frag.y);
+            let y_pt = margin_top_pt + first_frag.y.in_pt().to_f32();
             c.record(anchor.level, anchor.label.clone(), y_pt);
         }
 
@@ -529,8 +527,8 @@ fn draw_v2_page(
             if frag.page_index != page_index {
                 continue;
             }
-            let x_pt = margin_left_pt + px_to_pt(frag.x);
-            let y_pt = margin_top_pt + px_to_pt(frag.y);
+            let x_pt = margin_left_pt + frag.x.in_pt().to_f32();
+            let y_pt = margin_top_pt + frag.y.in_pt().to_f32();
 
             if let Some(tx) = drawables.transforms.get(&node_id) {
                 draw_under_transform(
@@ -749,8 +747,6 @@ pub(crate) fn dispatch_inline_box_content(
     page_index: u32,
     inline_box_subtree_descendants: &std::collections::BTreeMap<usize, Vec<usize>>,
 ) {
-    use crate::convert::px_to_pt;
-
     if let Some(tx) = drawables.transforms.get(&content_id) {
         draw_under_transform(
             canvas,
@@ -835,8 +831,10 @@ pub(crate) fn dispatch_inline_box_content(
             else {
                 continue;
             };
-            let desc_x_pt = margin_left_pt + drawables.body_offset_pt.0 + px_to_pt(desc_frag.x);
-            let desc_y_pt = margin_top_pt + drawables.body_offset_pt.1 + px_to_pt(desc_frag.y);
+            let desc_x_pt =
+                margin_left_pt + drawables.body_offset_pt.0 + desc_frag.x.in_pt().to_f32();
+            let desc_y_pt =
+                margin_top_pt + drawables.body_offset_pt.1 + desc_frag.y.in_pt().to_f32();
             dispatch_fragment(
                 canvas,
                 desc_id,
@@ -1232,13 +1230,13 @@ fn paint_multicol_paragraph_slices(
     let consumed: f32 = px_to_pt(
         container_geom.fragments[..target_pos]
             .iter()
-            .map(|f| f.height)
+            .map(|f| f.height.to_f32())
             .sum::<f32>(),
     );
-    let cutoff = px_to_pt(target_frag.height);
+    let cutoff = target_frag.height.in_pt().to_f32();
 
-    let container_x_pt = margin_left_pt + px_to_pt(target_frag.x);
-    let container_y_pt = margin_top_pt + px_to_pt(target_frag.y);
+    let container_x_pt = margin_left_pt + target_frag.x.in_pt().to_f32();
+    let container_y_pt = margin_top_pt + target_frag.y.in_pt().to_f32();
 
     // Single-fragment containers (the common case) keep the original
     // behaviour: paint every slice at `container_origin + origin_pt`,
@@ -1323,8 +1321,6 @@ fn draw_under_transform(
     margin_top_pt: f32,
     page_index: u32,
 ) {
-    use crate::convert::px_to_pt;
-
     // `effective_matrix` mirrors `TransformWrapperPageable::effective_matrix`:
     //   T(x + ox, y + oy) · M · T(-(x + ox), -(y + oy))
     let ox = x_pt + tx.origin.x;
@@ -1432,8 +1428,8 @@ fn draw_under_transform(
             if desc_frag.page_index != page_index {
                 continue;
             }
-            let desc_x = margin_left_pt + px_to_pt(desc_frag.x);
-            let desc_y = margin_top_pt + px_to_pt(desc_frag.y);
+            let desc_x = margin_left_pt + desc_frag.x.in_pt().to_f32();
+            let desc_y = margin_top_pt + desc_frag.y.in_pt().to_f32();
             if let Some(desc_tx) = drawables.transforms.get(&desc_id) {
                 draw_under_transform(
                     canvas,
@@ -1630,13 +1626,12 @@ fn draw_under_clip(
     margin_top_pt: f32,
     page_index: u32,
 ) {
-    use crate::convert::px_to_pt;
     use crate::draw_primitives::draw_with_opacity;
 
     let total_width = block
         .layout_size
         .map(|s| s.width.to_f32())
-        .unwrap_or_else(|| px_to_pt(frag.width));
+        .unwrap_or_else(|| frag.width.in_pt().to_f32());
     // Mirror `draw_block_inner_paint` / `draw_under_opacity`'s
     // `is_split` height fix. When this `overflow: hidden | clip`
     // block spans multiple pages (one fragment per page slice), use
@@ -1651,13 +1646,13 @@ fn draw_under_clip(
     let total_height = block
         .layout_size
         .map(|s| {
-            if is_split && frag.height > 0.0 {
-                px_to_pt(frag.height)
+            if is_split && frag.height > crate::units::Px::ZERO {
+                frag.height.in_pt().to_f32()
             } else {
                 s.height.to_f32()
             }
         })
-        .unwrap_or_else(|| px_to_pt(frag.height));
+        .unwrap_or_else(|| frag.height.in_pt().to_f32());
 
     let para_for_block = drawables.paragraphs.get(&node_id);
     let img_for_block = drawables.images.get(&node_id);
@@ -1847,8 +1842,8 @@ fn draw_under_clip(
                 if desc_frag.page_index != page_index {
                     continue;
                 }
-                let desc_x = margin_left_pt + px_to_pt(desc_frag.x);
-                let desc_y = margin_top_pt + px_to_pt(desc_frag.y);
+                let desc_x = margin_left_pt + desc_frag.x.in_pt().to_f32();
+                let desc_y = margin_top_pt + desc_frag.y.in_pt().to_f32();
                 if let Some(desc_tx) = drawables.transforms.get(&desc_id) {
                     draw_under_transform(
                         canvas,
@@ -1997,7 +1992,6 @@ fn draw_under_opacity(
     margin_top_pt: f32,
     page_index: u32,
 ) {
-    use crate::convert::px_to_pt;
     use crate::draw_primitives::draw_with_opacity;
 
     draw_with_opacity(canvas, block.opacity, |canvas| {
@@ -2053,7 +2047,7 @@ fn draw_under_opacity(
             let total_width = block
                 .layout_size
                 .map(|s| s.width.to_f32())
-                .unwrap_or_else(|| px_to_pt(frag.width));
+                .unwrap_or_else(|| frag.width.in_pt().to_f32());
             // Mirror `draw_block_inner_paint`'s `is_split` height fix.
             // When this opacity-scoped block spans multiple pages
             // (one fragment per page slice), use `frag.height` so each
@@ -2067,13 +2061,13 @@ fn draw_under_opacity(
             let total_height = block
                 .layout_size
                 .map(|s| {
-                    if is_split && frag.height > 0.0 {
-                        px_to_pt(frag.height)
+                    if is_split && frag.height > crate::units::Px::ZERO {
+                        frag.height.in_pt().to_f32()
                     } else {
                         s.height.to_f32()
                     }
                 })
-                .unwrap_or_else(|| px_to_pt(frag.height));
+                .unwrap_or_else(|| frag.height.in_pt().to_f32());
             if block.visible {
                 crate::background::draw_box_shadows(
                     canvas,
@@ -2187,8 +2181,8 @@ fn draw_under_opacity(
                 if desc_frag.page_index != page_index {
                     continue;
                 }
-                let desc_x = margin_left_pt + px_to_pt(desc_frag.x);
-                let desc_y = margin_top_pt + px_to_pt(desc_frag.y);
+                let desc_x = margin_left_pt + desc_frag.x.in_pt().to_f32();
+                let desc_y = margin_top_pt + desc_frag.y.in_pt().to_f32();
                 if let Some(desc_tx) = drawables.transforms.get(&desc_id) {
                     draw_under_transform(
                         canvas,
@@ -2315,13 +2309,12 @@ fn paint_multicol_rule_for_page(
     let consumed = container_geom.fragments[..target_pos]
         .iter()
         .map(|f| f.height)
-        .sum::<f32>()
-        .px()
+        .sum::<crate::units::Px>()
         .in_pt();
-    let cutoff = target_frag.height.px().in_pt();
+    let cutoff = target_frag.height.in_pt();
 
-    let x_base = margin_left_pt.pt() + target_frag.x.px().in_pt();
-    let y_base = margin_top_pt.pt() + target_frag.y.px().in_pt();
+    let x_base = margin_left_pt.pt() + target_frag.x.in_pt();
+    let y_base = margin_top_pt.pt() + target_frag.y.in_pt();
 
     for group in &entry.groups {
         if group.n < 2 || group.col_heights.len() != group.n as usize {
@@ -2598,7 +2591,7 @@ fn draw_block_inner_paint(
     let total_width = entry
         .layout_size
         .map(|s| s.width.to_f32())
-        .unwrap_or_else(|| crate::convert::px_to_pt(frag.width));
+        .unwrap_or_else(|| frag.width.in_pt().to_f32());
     // For split blocks (one fragment per page), `frag.height` reports
     // the per-page slice height. `entry.layout_size.height` always
     // carries Taffy's full block height, so painting bg / border with
@@ -2620,13 +2613,13 @@ fn draw_block_inner_paint(
     let total_height = entry
         .layout_size
         .map(|s| {
-            if is_split && frag.height > 0.0 {
-                crate::convert::px_to_pt(frag.height)
+            if is_split && frag.height > crate::units::Px::ZERO {
+                frag.height.in_pt().to_f32()
             } else {
                 s.height.to_f32()
             }
         })
-        .unwrap_or_else(|| crate::convert::px_to_pt(frag.height));
+        .unwrap_or_else(|| frag.height.in_pt().to_f32());
 
     if entry.visible {
         crate::background::draw_box_shadows(canvas, &entry.style, x, y, total_width, total_height);
@@ -2683,7 +2676,7 @@ fn table_box_size(
         .layout_size
         .map(|s| s.height.to_f32())
         .unwrap_or_else(|| {
-            let from_frag = crate::convert::px_to_pt(frag.height);
+            let from_frag = frag.height.in_pt().to_f32();
             if from_frag > 0.0 {
                 from_frag
             } else {
@@ -2735,7 +2728,6 @@ fn draw_under_clip_table(
     margin_top_pt: f32,
     page_index: u32,
 ) {
-    use crate::convert::px_to_pt;
     use crate::draw_primitives::draw_with_opacity;
 
     let _ = geom;
@@ -2815,8 +2807,8 @@ fn draw_under_clip_table(
                 if desc_frag.page_index != page_index {
                     continue;
                 }
-                let desc_x = margin_left_pt + px_to_pt(desc_frag.x);
-                let desc_y = margin_top_pt + px_to_pt(desc_frag.y);
+                let desc_x = margin_left_pt + desc_frag.x.in_pt().to_f32();
+                let desc_y = margin_top_pt + desc_frag.y.in_pt().to_f32();
                 if let Some(desc_tx) = drawables.transforms.get(&desc_id) {
                     draw_under_transform(
                         canvas,
@@ -3236,12 +3228,11 @@ fn paragraph_lines_for_page(
         return Some(all_lines.to_vec());
     }
 
-    let target_h = fragments[target_pos].height.px().in_pt();
+    let target_h = fragments[target_pos].height.in_pt();
     let consumed: crate::units::Pt = fragments[..target_pos]
         .iter()
         .map(|f| f.height)
-        .sum::<f32>()
-        .px()
+        .sum::<crate::units::Px>()
         .in_pt();
 
     let eps = 0.01_f32.pt();
@@ -4477,10 +4468,10 @@ mod tests {
     fn make_fragment(page_index: u32, height: f32) -> crate::pagination_layout::Fragment {
         crate::pagination_layout::Fragment {
             page_index,
-            x: 0.0,
-            y: 0.0,
-            width: 100.0,
-            height,
+            x: 0.0_f32.px(),
+            y: 0.0_f32.px(),
+            width: 100.0_f32.px(),
+            height: height.px(),
         }
     }
 
@@ -4755,10 +4746,10 @@ mod tests {
     fn make_frag_with_height(height: f32) -> crate::pagination_layout::Fragment {
         crate::pagination_layout::Fragment {
             page_index: 0,
-            x: 0.0,
-            y: 0.0,
-            width: 0.0,
-            height,
+            x: 0.0_f32.px(),
+            y: 0.0_f32.px(),
+            width: 0.0_f32.px(),
+            height: height.px(),
         }
     }
 

--- a/crates/fulgur/src/units.rs
+++ b/crates/fulgur/src/units.rs
@@ -135,6 +135,12 @@ impl_unit_arith!(Px);
 impl_unit_arith!(Pt);
 
 impl Px {
+    /// The zero length. Use instead of `0.0_f32.px()` for sign comparisons
+    /// (`x > Px::ZERO`); the private field means `Px(0.0)` is not
+    /// constructible outside this module. (`Px` has no `max`/`min` yet —
+    /// add them, mirroring `Pt`, when a clamp idiom first needs them.)
+    pub const ZERO: Px = Px(0.0);
+
     /// Raw `f32` value. Use only at FFI boundaries.
     #[inline]
     pub const fn to_f32(self) -> f32 {
@@ -249,6 +255,14 @@ mod tests {
                 .fold(Pt(0.0), Pt::max),
             Pt(2.0)
         );
+    }
+
+    #[test]
+    fn px_zero_is_zero() {
+        assert_eq!(Px::ZERO, Px(0.0));
+        assert!(Px(1.0) > Px::ZERO);
+        // boundary: zero is not strictly greater than zero (the `> Px::ZERO` idiom)
+        assert!(Px(0.0) <= Px::ZERO);
     }
 
     #[test]

--- a/crates/fulgur/tests/pseudo_absolute_content_url.rs
+++ b/crates/fulgur/tests/pseudo_absolute_content_url.rs
@@ -52,7 +52,7 @@ fn placement(geometry: &PaginationGeometryTable, node_id: usize) -> (f32, f32) {
         .fragments
         .first()
         .unwrap_or_else(|| panic!("expected at least one fragment for node {node_id}"));
-    (frag.x, frag.y)
+    (frag.x.to_f32(), frag.y.to_f32())
 }
 
 #[test]

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -4856,3 +4856,114 @@ fn render_batch_failure_does_not_abort_siblings() {
     );
     assert!(results[2].is_err(), "item 2 (no title) should fail");
 }
+
+// --- P1c (fulgur-2map.5) Fragment->units::Px coverage closure ---
+//
+// These five tests drive `fragment_block_subtree` break-after / depth
+// bail-out paths and `draw_under_opacity`'s split-height path through
+// the full `Engine::render` pipeline. Those Fragment construction
+// sites were previously exercised only by VRT goldens (excluded from
+// the codecov measurement), so the `.px()` / `frag.height.in_pt()`
+// lines showed as uncovered patch lines. See CLAUDE.md "Coverage
+// scope".
+
+/// fulgur-2map.5: an opacity-scoped block with block-level
+/// descendants (non-empty `opacity_descendants`) that itself SPLITS
+/// across a page boundary must reach `draw_under_opacity`'s
+/// `is_split && frag.height > Px::ZERO` arm (render.rs ~2065). The
+/// pre-existing split-opacity smoke test wraps an atomic `<svg>`
+/// (shared-node content) which keeps the block a single fragment, so
+/// `is_split` stays false there. Two tall block children guarantee a
+/// real multi-fragment split.
+#[test]
+fn render_v2_smoke_opacity_block_split_uses_per_slice_height_block_children() {
+    let html = r#"<!doctype html><html><body>
+        <div style="opacity:0.5;background:#f0f4ff;border:2px solid #89c">
+          <div style="height:600px;background:#eef">first block child</div>
+          <div style="height:600px;background:#fce">second block child</div>
+        </div>
+    </body></html>"#;
+    let pdf = Engine::builder().build().render(html).expect("v2 render");
+    assert!(pdf.starts_with(b"%PDF"));
+    let pdf_str = String::from_utf8_lossy(&pdf);
+    let page_count = pdf_str.matches("/Type /Page\n").count();
+    assert!(
+        page_count >= 2,
+        "expected multi-page split, got {page_count}"
+    );
+}
+
+/// fulgur-2map.5: a nested block parent whose child carries
+/// `break-after: page` (a simple leaf child - no recursion) emits a
+/// parent Fragment via `fragment_block_subtree`'s post-fragment
+/// break-after arm (pagination_layout.rs ~2162). The parent is routed
+/// through `fragment_block_subtree` because it has a forced break
+/// below.
+#[test]
+fn render_v2_smoke_break_after_child_no_recursion_emits_parent_fragment() {
+    let html = r#"<!doctype html><html><body>
+        <div style="background:#eef">
+          <div style="height:80px">before the forced break</div>
+          <div style="break-after:page;height:80px">forces a page break after</div>
+          <div style="height:80px">after the forced break</div>
+        </div>
+    </body></html>"#;
+    let pdf = Engine::builder().build().render(html).expect("v2 render");
+    assert!(pdf.starts_with(b"%PDF"));
+    let pdf_str = String::from_utf8_lossy(&pdf);
+    let page_count = pdf_str.matches("/Type /Page\n").count();
+    assert!(
+        page_count >= 2,
+        "break-after:page must paginate, got {page_count}"
+    );
+}
+
+/// fulgur-2map.5: a zero-height child (explicit `height:0`, no
+/// content) carrying `break-after: page` inside a nested block parent
+/// hits `fragment_block_subtree`'s zero-height break-after arm
+/// (pagination_layout.rs ~1835). The explicit `height:0` keeps the
+/// child out of the positive-height path (~2162).
+#[test]
+fn render_v2_smoke_break_after_zero_height_child_emits_parent_fragment() {
+    let html = r#"<!doctype html><html><body>
+        <div style="background:#eef">
+          <div style="height:80px">before</div>
+          <div style="break-after:page;height:0"></div>
+          <div style="height:80px">after</div>
+        </div>
+    </body></html>"#;
+    let pdf = Engine::builder().build().render(html).expect("v2 render");
+    assert!(pdf.starts_with(b"%PDF"));
+    let pdf_str = String::from_utf8_lossy(&pdf);
+    let page_count = pdf_str.matches("/Type /Page\n").count();
+    assert!(
+        page_count >= 2,
+        "zero-height break-after must paginate, got {page_count}"
+    );
+}
+
+/// fulgur-2map.5: a child that itself recurses (two tall grandchildren
+/// -> `would_split` true) AND carries `break-after: page` hits
+/// `fragment_block_subtree`'s post-recursion break-after arm
+/// (pagination_layout.rs ~2062).
+#[test]
+fn render_v2_smoke_break_after_recursing_child_emits_parent_fragment() {
+    let html = r#"<!doctype html><html><body>
+        <div style="background:#eef">
+          <div style="height:80px">before</div>
+          <div style="break-after:page;background:#dfe">
+            <div style="height:600px">tall grandchild one</div>
+            <div style="height:600px">tall grandchild two</div>
+          </div>
+          <div style="height:80px">after</div>
+        </div>
+    </body></html>"#;
+    let pdf = Engine::builder().build().render(html).expect("v2 render");
+    assert!(pdf.starts_with(b"%PDF"));
+    let pdf_str = String::from_utf8_lossy(&pdf);
+    let page_count = pdf_str.matches("/Type /Page\n").count();
+    assert!(
+        page_count >= 2,
+        "recursing break-after must paginate, got {page_count}"
+    );
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -18,8 +18,9 @@ use tempfile::tempdir;
 /// root) directly from raw PDF bytes. Robust to whatever delimiter
 /// krilla emits after `/Type /Page` — unlike a fixed `"/Type /Page\n"`
 /// string match, which silently miscounts if the trailing byte ever
-/// changes.
-fn count_pages(pdf: &[u8]) -> usize {
+/// changes. Mirrors the `page_count` helper used by the other
+/// pagination integration tests.
+fn page_count(pdf: &[u8]) -> usize {
     let prefix = b"/Type /Page";
     let mut count = 0;
     let mut i = 0;
@@ -36,6 +37,15 @@ fn count_pages(pdf: &[u8]) -> usize {
         }
     }
     count
+}
+
+/// Render `html` through the v2 pipeline and assert it produced a valid
+/// PDF that paginated (`>= 2` pages). `what` labels the failure case.
+fn assert_paginates(html: &str, what: &str) {
+    let pdf = Engine::builder().build().render(html).expect("v2 render");
+    assert!(pdf.starts_with(b"%PDF"));
+    let pages = page_count(&pdf);
+    assert!(pages >= 2, "{what}, got {pages}");
 }
 
 fn check_pdf_snapshot(name: &str, pdf: &[u8]) {
@@ -4883,13 +4893,14 @@ fn render_batch_failure_does_not_abort_siblings() {
 
 // --- P1c (fulgur-2map.5) Fragment->units::Px coverage closure ---
 //
-// These five tests drive `fragment_block_subtree` break-after / depth
-// bail-out paths and `draw_under_opacity`'s split-height path through
-// the full `Engine::render` pipeline. Those Fragment construction
-// sites were previously exercised only by VRT goldens (excluded from
-// the codecov measurement), so the `.px()` / `frag.height.in_pt()`
-// lines showed as uncovered patch lines. See CLAUDE.md "Coverage
-// scope".
+// These four tests drive `fragment_block_subtree`'s break-after arms
+// and `draw_under_opacity`'s split-height path through the full
+// `Engine::render` pipeline. Those Fragment construction sites were
+// previously exercised only by VRT goldens (excluded from the codecov
+// measurement), so the `.px()` / `frag.height.in_pt()` lines showed as
+// uncovered patch lines. See CLAUDE.md "Coverage scope". (The
+// `depth >= MAX_DOM_DEPTH` bail-out is covered by an in-crate unit test
+// in `pagination_layout.rs`, which can call the guard directly.)
 
 /// fulgur-2map.5: an opacity-scoped block with block-level
 /// descendants (non-empty `opacity_descendants`) that itself SPLITS
@@ -4907,13 +4918,7 @@ fn render_v2_smoke_opacity_block_split_uses_per_slice_height_block_children() {
           <div style="height:600px;background:#fce">second block child</div>
         </div>
     </body></html>"#;
-    let pdf = Engine::builder().build().render(html).expect("v2 render");
-    assert!(pdf.starts_with(b"%PDF"));
-    let page_count = count_pages(&pdf);
-    assert!(
-        page_count >= 2,
-        "expected multi-page split, got {page_count}"
-    );
+    assert_paginates(html, "expected multi-page split");
 }
 
 /// fulgur-2map.5: a nested block parent whose child carries
@@ -4931,13 +4936,7 @@ fn render_v2_smoke_break_after_child_no_recursion_emits_parent_fragment() {
           <div style="height:80px">after the forced break</div>
         </div>
     </body></html>"#;
-    let pdf = Engine::builder().build().render(html).expect("v2 render");
-    assert!(pdf.starts_with(b"%PDF"));
-    let page_count = count_pages(&pdf);
-    assert!(
-        page_count >= 2,
-        "break-after:page must paginate, got {page_count}"
-    );
+    assert_paginates(html, "break-after:page must paginate");
 }
 
 /// fulgur-2map.5: a zero-height child (explicit `height:0`, no
@@ -4954,13 +4953,7 @@ fn render_v2_smoke_break_after_zero_height_child_emits_parent_fragment() {
           <div style="height:80px">after</div>
         </div>
     </body></html>"#;
-    let pdf = Engine::builder().build().render(html).expect("v2 render");
-    assert!(pdf.starts_with(b"%PDF"));
-    let page_count = count_pages(&pdf);
-    assert!(
-        page_count >= 2,
-        "zero-height break-after must paginate, got {page_count}"
-    );
+    assert_paginates(html, "zero-height break-after must paginate");
 }
 
 /// fulgur-2map.5: a child that itself recurses (two tall grandchildren
@@ -4979,11 +4972,5 @@ fn render_v2_smoke_break_after_recursing_child_emits_parent_fragment() {
           <div style="height:80px">after</div>
         </div>
     </body></html>"#;
-    let pdf = Engine::builder().build().render(html).expect("v2 render");
-    assert!(pdf.starts_with(b"%PDF"));
-    let page_count = count_pages(&pdf);
-    assert!(
-        page_count >= 2,
-        "recursing break-after must paginate, got {page_count}"
-    );
+    assert_paginates(html, "recursing break-after must paginate");
 }

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -14,6 +14,30 @@ use std::path::PathBuf;
 use fulgur::{AssetBundle, Engine};
 use tempfile::tempdir;
 
+/// Count `/Type /Page` objects (excluding the `/Type /Pages` page-tree
+/// root) directly from raw PDF bytes. Robust to whatever delimiter
+/// krilla emits after `/Type /Page` — unlike a fixed `"/Type /Page\n"`
+/// string match, which silently miscounts if the trailing byte ever
+/// changes.
+fn count_pages(pdf: &[u8]) -> usize {
+    let prefix = b"/Type /Page";
+    let mut count = 0;
+    let mut i = 0;
+    while i + prefix.len() < pdf.len() {
+        if &pdf[i..i + prefix.len()] == prefix {
+            // `/Type /Pages` (the tree root) has an alphanumeric next
+            // byte (`s`); a real page object is followed by a delimiter.
+            if !pdf[i + prefix.len()].is_ascii_alphanumeric() {
+                count += 1;
+            }
+            i += prefix.len();
+        } else {
+            i += 1;
+        }
+    }
+    count
+}
+
 fn check_pdf_snapshot(name: &str, pdf: &[u8]) {
     let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/snapshots");
     std::fs::create_dir_all(&dir).unwrap();
@@ -4885,8 +4909,7 @@ fn render_v2_smoke_opacity_block_split_uses_per_slice_height_block_children() {
     </body></html>"#;
     let pdf = Engine::builder().build().render(html).expect("v2 render");
     assert!(pdf.starts_with(b"%PDF"));
-    let pdf_str = String::from_utf8_lossy(&pdf);
-    let page_count = pdf_str.matches("/Type /Page\n").count();
+    let page_count = count_pages(&pdf);
     assert!(
         page_count >= 2,
         "expected multi-page split, got {page_count}"
@@ -4910,8 +4933,7 @@ fn render_v2_smoke_break_after_child_no_recursion_emits_parent_fragment() {
     </body></html>"#;
     let pdf = Engine::builder().build().render(html).expect("v2 render");
     assert!(pdf.starts_with(b"%PDF"));
-    let pdf_str = String::from_utf8_lossy(&pdf);
-    let page_count = pdf_str.matches("/Type /Page\n").count();
+    let page_count = count_pages(&pdf);
     assert!(
         page_count >= 2,
         "break-after:page must paginate, got {page_count}"
@@ -4934,8 +4956,7 @@ fn render_v2_smoke_break_after_zero_height_child_emits_parent_fragment() {
     </body></html>"#;
     let pdf = Engine::builder().build().render(html).expect("v2 render");
     assert!(pdf.starts_with(b"%PDF"));
-    let pdf_str = String::from_utf8_lossy(&pdf);
-    let page_count = pdf_str.matches("/Type /Page\n").count();
+    let page_count = count_pages(&pdf);
     assert!(
         page_count >= 2,
         "zero-height break-after must paginate, got {page_count}"
@@ -4960,8 +4981,7 @@ fn render_v2_smoke_break_after_recursing_child_emits_parent_fragment() {
     </body></html>"#;
     let pdf = Engine::builder().build().render(html).expect("v2 render");
     assert!(pdf.starts_with(b"%PDF"));
-    let pdf_str = String::from_utf8_lossy(&pdf);
-    let page_count = pdf_str.matches("/Type /Page\n").count();
+    let page_count = count_pages(&pdf);
     assert!(
         page_count >= 2,
         "recursing break-after must paginate, got {page_count}"

--- a/docs/plans/2026-06-27-engine-layout-api-design.md
+++ b/docs/plans/2026-06-27-engine-layout-api-design.md
@@ -273,6 +273,27 @@ With P1a + P1d done, the only remaining single-unit deferral is the transform
 fold (`fulgur-1ino`, Affine2D + Point2). The `type Pt = f32` alias removal
 remains P2 (`fulgur-2map.8`).
 
+### P1c outcome (fulgur-2map.5) — pagination Fragment coords migrated
+
+Phase P1c typed `pagination_layout::Fragment`'s coordinate fields to
+`units::Px`, byte-neutral (examples_determinism + VRT goldens unchanged):
+
+- `Fragment { x, y, width, height }` → `units::Px` (`page_index` stays `u32`).
+  Construction sites tag at the source with `.px()`; readers untag with
+  `.to_f32()` (px-space f32 math + the `frag.height > Px::ZERO` comparisons) or
+  `.in_pt()` / `.in_pt().to_f32()` at the render.rs px→pt boundary, across 7
+  files.
+- Internal pagination math (`cursor_y` / `page_height_px` / `child_h` / `gap`,
+  incl. the `(this_top - prev_bottom).max(0.0)` gap clamp) stays `f32`; `.px()`
+  is applied only at the `Fragment { ... }` construction boundary (mirrors P1d:
+  local stays f32, struct field becomes the newtype), keeping the hot-path
+  arithmetic byte-identical.
+- `Px::ZERO` added (mirrors `Pt::ZERO`); no `Px::max` / `Px::min` needed (no
+  `Px` clamp exists — the gap clamp stays f32).
+
+Unblocks P1e (`fulgur-2map.7`, `Drawables` aggregate coordinate fields). The
+`type Pt = f32` alias removal remains P2 (`fulgur-2map.8`).
+
 ## 8. 決定性 / 受け入れ条件
 
 - `layout_to_drawables` 抽出後・newtype 移行後とも `examples_determinism` golden と

--- a/docs/plans/2026-06-29-pagination-fragment-px.md
+++ b/docs/plans/2026-06-29-pagination-fragment-px.md
@@ -1,0 +1,290 @@
+# pagination_layout Fragment → units::Px (P1c) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (or executing-plans) to implement this plan task-by-task.
+
+**Goal:** Type `pagination_layout::Fragment`'s coordinate fields
+(`x`/`y`/`width`/`height`) with `units::Px`, plus all fragmenter producers
+and render/convert consumers, byte-neutral (beads `fulgur-2map.5`, phase P1c).
+
+**Architecture:** Faithful copy of the P1d pattern
+(`docs/plans/2026-06-29-multicol-geometry-px-pt.md`): tag at the source
+(`.px()` on Taffy-space f32 locals at every `Fragment { ... }` construction),
+untag at use (`.to_f32()` for f32 px-space readers and f32 FFI;
+`.in_pt()` / `.in_pt().to_f32()` at the px→pt conversion boundary) so existing
+f32 arithmetic stays byte-identical. **Lower per-site risk than P1d**: Fragment
+fields are bare `f32` (not `taffy::Point`/`Size`), so there is no taffy-generics
+bound problem. Higher *volume*: one struct, ~34 construction sites and ~40
+reader sites across 7 files.
+
+**Tech Stack:** Rust, `units::{Px, Pt, F32Units}` (`Px::in_pt`/`to_f32`,
+`F32Units::px` exist; `Px::ZERO` added in Task 1), krilla/Parley FFI, VRT
+byte comparison.
+
+## Scope
+
+**In scope:**
+
+- `pagination_layout::Fragment`: `x`/`y`/`width`/`height: f32` → `units::Px`
+  (`page_index: u32` unchanged).
+- All `Fragment { ... }` construction sites (prod + tests): tag with `.px()`.
+- All readers: render.rs (px→pt boundary), convert/positioned.rs (px-space),
+  gcpm/target_ref.rs, pagination_layout.rs internal, engine.rs/render.rs test
+  helpers, column_css.rs/blitz_adapter.rs test asserts.
+
+**Out of scope (record for reviewers + later phases):**
+
+- Internal pagination math stays `f32`: `cursor_y`, `page_height_px`,
+  `child_h`, `gap`, and the gap clamp `(this_top - prev_bottom).max(0.0)`.
+  These are Taffy-space f32 locals; tag with `.px()` ONLY at the `Fragment`
+  construction boundary (mirrors P1d Task 1: local stays f32, struct field
+  becomes the newtype). This keeps the hot-path arithmetic byte-identical and
+  confines the type change to the struct boundary.
+- `PaginationGeometry.is_repeat` / `paragraph_splits` / any non-coordinate
+  field; `Drawables` aggregate fields (that is P1e / `fulgur-2map.7`, which
+  this blocks); `type Pt = f32` alias (P2 / `fulgur-2map.8`).
+
+## The byte-neutral rules (read before EVERY edit)
+
+1. `px_to_pt(v)` ≡ `v * 0.75` ≡ `v.px().in_pt()` ≡ `Px::in_pt` (one f32
+   multiply). `.px()` / `.to_f32()` / `.in_pt()` are pure labels /
+   single-op conversions on `#[repr(transparent)]` newtypes.
+2. **Reassociation rule (the one real risk at the px→pt boundary).** f32:
+   `(a+b)*0.75 != a*0.75 + b*0.75`. Preserve the CURRENT order:
+   - `px_to_pt(a + b)` form  → `(a + b).px().in_pt()` (add in px, convert once).
+   - `px_to_pt(a) + px_to_pt(b)` form → keep two separate conversions.
+   - A pre-audit grep found **zero** combined-field conversions in
+     render/convert/gcpm readers today (every reader converts a single
+     Fragment field), but `cargo build`'s worklist is the definitive source.
+     Re-check any new multi-field reader against this rule before splitting.
+3. Internal pagination_layout f32 sums (e.g. `frag.y + frag.height` in px
+   space) stay f32 via `.to_f32()`, preserving operand order — these were f32
+   already, so they are byte-identical.
+4. **Untag-at-use is the default** for readers that feed f32 math, an f32
+   FFI/helper, or an f32-typed sibling in a `+`. NEVER reorder/reassociate.
+   Proof = unchanged VRT goldens; **never** `FULGUR_VRT_UPDATE=1`.
+
+## Reader two-systems in render.rs (both exist today)
+
+- **Unmigrated** (31 sites): `margin_left_pt + px_to_pt(frag.x)` where the
+  sibling is f32 pt → `margin_left_pt + frag.x.in_pt().to_f32()`. (`.in_pt()`
+  returns `Pt`; there is no `Add<Pt> for f32`, so `.to_f32()` is required.
+  `.in_pt().to_f32()` ≡ `px_to_pt`, ×0.75, byte-identical.)
+- **Spike-migrated** (render.rs ~2321/2323/2324):
+  `margin_left_pt.pt() + target_frag.x.px().in_pt()` → drop the spike `.px()`
+  tag → `margin_left_pt.pt() + target_frag.x.in_pt()`.
+
+## Verification commands (end of every task)
+
+```bash
+export FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf"
+cargo build                                          # Finished
+cargo clippy -p fulgur --all-targets -- -D warnings  # clean
+cargo fmt --check                                    # clean
+cargo test -p fulgur --lib                           # 1497 pass (Task 1: +1)
+cargo test -p fulgur --test render_smoke             # 171 pass
+cargo test -p fulgur-cli --test examples_determinism # 11 passed
+cargo test -p fulgur-vrt                             # run_fulgur_vrt ... ok
+git status --short -- crates/fulgur-vrt/goldens/     # MUST be empty
+```
+
+**Baseline captured GREEN** before any edit on the SAME base commit
+(`origin/main` `d6903b08`, includes units + P1a + P1b paragraph + P1d
+multicol): `--lib` 1497, render_smoke 171, examples_determinism 11/0, VRT ok,
+goldens clean. This attributes any later red to the change, not font drift.
+
+---
+
+### Task 1: Add `Px::ZERO` helper (+ unit test)
+
+`frag.height > 0.0` appears 3× in render.rs (~1654, ~2070, ~2623). Mirror the
+P1d convention (`r.width > Pt::ZERO`) with a typed zero so the migrated
+comparison reads `frag.height > Px::ZERO`. `units` is `pub mod` (lib.rs:63)
+and `Px` is a `pub` type, so a `pub const` is exempt from dead_code even before
+Task 2 uses it. Add ONLY `ZERO` (genuinely used 3×); do NOT pre-add
+`Px::max`/`min` — no current Px clamp exists (the gap clamp stays f32). If
+Task 2's build surfaces a real need for `Px::max`/`min`, add them then.
+
+**Files:** `crates/fulgur/src/units.rs` (the `impl Px { ... }` block ~137-149;
+the `#[cfg(test)] mod tests` block).
+
+**Step 1 — add the const** to `impl Px`, mirroring `Pt::ZERO`:
+
+```rust
+impl Px {
+    /// The zero length. Use instead of `0.0_f32.px()` for clamp / sign
+    /// idioms (`x > Px::ZERO`); the private field means `Px(0.0)` is not
+    /// constructible outside this module.
+    pub const ZERO: Px = Px(0.0);
+
+    // ... existing to_f32 / in_pt ...
+}
+```
+
+**Step 2 — add a unit test** in `mod tests`:
+
+```rust
+    #[test]
+    fn px_zero_is_zero() {
+        assert_eq!(Px::ZERO, Px(0.0));
+        assert!(Px(1.0) > Px::ZERO);
+        assert!(!(Px(0.0) > Px::ZERO));
+    }
+```
+
+**Step 3 — verify:** `cargo build`; `cargo test -p fulgur --lib`
+(now 1498 pass); `cargo clippy -p fulgur --all-targets -- -D warnings`;
+`cargo fmt --check`. (No golden run needed — units-only change.)
+
+**Step 4 — commit:**
+
+```bash
+git add crates/fulgur/src/units.rs
+git commit -m "feat(units): add Px::ZERO mirroring Pt::ZERO (P1c prep)"
+```
+
+---
+
+### Task 2: Migrate `Fragment` coordinate fields → `units::Px`
+
+This is the atomic core: typing the struct field breaks compilation across all
+7 files at once, so the build is red until every construction site AND every
+reader is fixed. Work file-by-file off the `cargo build` worklist; do NOT run
+goldens until the build is green.
+
+**Files:**
+
+- `crates/fulgur/src/pagination_layout.rs` — struct (~78); ~24 prod + test
+  `Fragment { ... }` construction sites; internal `first_frag` readers
+  (~2428/2486/2539) and test asserts (~3797 `(f.height - 30.0)`, ~4346
+  `(frag.y - 770.0)`, ~4309/4341 etc.).
+- `crates/fulgur/src/render.rs` — 31 `px_to_pt(frag.*)` readers; 3 spike
+  `.px().in_pt()` readers (~2321/2323/2324); 3 `frag.height > 0.0`
+  comparisons (~1654/2070/2623); 2 test helpers `make_fragment` (~4477),
+  `make_frag_with_height` (~4755).
+- `crates/fulgur/src/convert/positioned.rs` — readers `parent_frag.x`/`.y`
+  (~267/268, px-space), tuple `(frag.x, frag.y)` (~1417); construction (~307).
+- `crates/fulgur/src/gcpm/target_ref.rs` — construction sites (~400/407).
+- `crates/fulgur/src/engine.rs` — test helper `frag_on_page` (~1444).
+- `crates/fulgur/src/column_css.rs`, `crates/fulgur/src/blitz_adapter.rs` —
+  test construction / asserts (build will surface).
+
+**Step 1 — type the fields** (use fully-qualified `crate::units::Px` to avoid
+the `type Pt = f32` alias-shadowed module; mirror P1a/P1d):
+
+```rust
+#[derive(Clone, Debug, PartialEq)]
+pub struct Fragment {
+    pub page_index: u32,
+    pub x: crate::units::Px,
+    pub y: crate::units::Px,
+    pub width: crate::units::Px,
+    pub height: crate::units::Px,
+}
+```
+
+Update the struct doc comment: the fields are still "CSS pixels — Taffy's
+native unit", now type-enforced.
+
+**Step 2 — build to get the worklist:** `cargo build` lists every break.
+Confirm `use crate::units::F32Units;` is in scope in each file that gains a
+`.px()` (add the import if a break says `.px` is unknown).
+
+**Step 3 — tag at construction** (the layout-math locals — `cursor_y`,
+`child_h`, computed `x`/`w`/`h`, literals like `0.0` — are Taffy-space f32;
+`.px()` is a pure label). At EVERY `Fragment { ... }`:
+
+```rust
+        Fragment {
+            page_index,
+            x: x.px(),
+            y: cursor_y.px(),
+            width: width.px(),
+            height: child_h.px(),
+        }
+```
+
+For literal constructions in tests, e.g. `x: 0.0` → `x: 0.0_f32.px()` (or
+`x: 0.0.px()` if the receiver type infers; prefer the explicit suffix).
+Test helpers (`frag_on_page`, `make_fragment`, `make_frag_with_height`) take
+f32 params — `.px()` them at the `Fragment { ... }` they build.
+
+**Step 4 — untag readers** (per the two-systems + reassociation + untag-at-use
+rules above):
+
+- **render.rs px→pt readers:** `px_to_pt(frag.x)` → `frag.x.in_pt().to_f32()`
+  (same for `.y`/`.width`/`.height` and the `desc_frag`/`first_frag`/
+  `target_frag` variants). Where the call uses `crate::convert::px_to_pt(...)`,
+  the replacement is `frag.height.in_pt().to_f32()` likewise.
+- **render.rs spike readers (~2321/2323/2324):** drop `.px()` →
+  `target_frag.height.in_pt()`, `target_frag.x.in_pt()`, `target_frag.y.in_pt()`.
+- **render.rs comparisons (~1654/2070/2623):** `frag.height > 0.0` →
+  `frag.height > crate::units::Px::ZERO`.
+- **convert/positioned.rs:** `let parent_x_px = parent_frag.x;` →
+  `parent_frag.x.to_f32()` (the `_px` var stays f32 px-space; no conversion).
+  Same for `parent_y_px`. Tuple `(frag.x, frag.y)` → `(frag.x.to_f32(), frag.y.to_f32())`
+  IF the tuple is `(f32, f32)` (confirm from the worklist; if it propagates
+  into a px→pt expression, follow the reassociation rule there instead).
+- **pagination_layout.rs internal readers** (`first_frag.y`/`.height`, split
+  accumulation): untag with `.to_f32()` preserving operand order; these are
+  px-space f32 math, byte-identical. `.fragments.push/clear/iter/len/first`
+  are Vec ops — unaffected.
+- **test asserts** reading `.x`/`.y`/`.width`/`.height` (pagination_layout
+  ~3797/4346/etc., column_css, blitz_adapter): append `.to_f32()`; keep the
+  asserted numbers identical.
+
+**Step 5 — verify** (full block above) → build/clippy/fmt clean; `--lib`,
+render_smoke, examples_determinism, VRT all pass; `git status --short --
+crates/fulgur-vrt/goldens/` **empty** (byte-identical goldens, no
+`FULGUR_VRT_UPDATE`).
+
+**Step 6 — commit:**
+
+```bash
+git add -A
+git commit -m "refactor(pagination): type Fragment coords with units::Px (byte-neutral, P1c)"
+```
+
+---
+
+### Task 3: Docs + final verification
+
+**Files:** `docs/plans/2026-06-27-engine-layout-api-design.md` (append a P1c
+outcome note under the phase-status section — find where P1a/P1b/P1d outcomes
+are recorded and add P1c: `Fragment` coords → `Px`, internal pagination math
+stays f32, byte-neutral), and commit this plan
+(`docs/plans/2026-06-29-pagination-fragment-px.md`).
+
+**Step 1** append the P1c outcome note; `npx markdownlint-cli2 'docs/plans/2026-06-29-pagination-fragment-px.md' 'docs/plans/2026-06-27-engine-layout-api-design.md'` → 0 errors.
+
+**Step 2** run the full verification block → all green, goldens byte-identical.
+
+**Step 3** commit:
+
+```bash
+git add docs/plans/2026-06-29-pagination-fragment-px.md docs/plans/2026-06-27-engine-layout-api-design.md
+git commit -m "docs(2map): record P1c (pagination Fragment) outcome + plan"
+```
+
+> Coverage note: render_smoke + existing pagination/render unit tests exercise
+> the changed producer/reader lines through `Engine::render_html`. If
+> codecov/patch later flags an uncovered changed line, add a focused
+> render_smoke case (per CLAUDE.md "Coverage scope"); confirm with
+> `cargo llvm-cov nextest --workspace --exclude fulgur-vrt`.
+
+---
+
+## Done criteria (maps to `fulgur-2map.5`)
+
+- [ ] `Fragment.x/.y/.width/.height` are `units::Px`; `page_index` unchanged.
+- [ ] Internal pagination math (`cursor_y`/`page_height_px`/`child_h`/gap)
+      stays f32; `.px()` only at the `Fragment` construction boundary.
+- [ ] Producers tag at source; readers untag at use; `.in_pt()` /
+      `.in_pt().to_f32()` only at the px→pt boundary; reassociation order
+      preserved.
+- [ ] `examples_determinism` + VRT goldens byte-identical (no
+      `FULGUR_VRT_UPDATE`); `git status` on goldens empty.
+- [ ] build / clippy `-D warnings` / fmt / `--lib` / render_smoke clean.
+- [ ] `Px::ZERO` added (used 3×); `Px::max`/`min` NOT pre-added unless build
+      required them. `type Pt = f32` alias untouched (P2).
+- [ ] Unblocks `fulgur-2map.7` (P1e Drawables aggregate).


### PR DESCRIPTION
## 概要

座標 newtype 移行 epic (`fulgur-2map`) のフェーズ **P1c**。`pagination_layout::Fragment` の座標フィールド `x`/`y`/`width`/`height` を bare `f32` から `units::Px` に型付けします（`page_index: u32` は不変）。先行フェーズ P1b(paragraph) / P1d(multicol) と同一の per-phase パターンの忠実なコピーです。

## 変更内容

- **`Fragment` フィールド → `units::Px`**: 7 ファイルに渡り、構築サイト ~36 箇所を `.px()` でタグ付け、reader ~40 箇所を untag。
  - render.rs の px→pt 境界: `px_to_pt(frag.x)` → `frag.x.in_pt().to_f32()`（spike 移行済みの箇所は `.px()` タグを drop して `.in_pt()`）
  - px 空間維持の reader / テスト assert: `.to_f32()`
  - 比較: `frag.height > 0.0` → `frag.height > Px::ZERO`（新規 `Px::ZERO` を `Pt::ZERO` 対称で追加）
- **内部ページネーション演算は f32 据え置き**: `cursor_y` / `page_height_px` / `child_h` / `gap`（gap クランプ `.max(0.0)` 含む）は Taffy 空間の f32 のまま。`.px()` は `Fragment { ... }` 構築境界でのみ適用し、ホットパス演算を byte-identical に保ちます。

## byte-neutral 証明

PDF 出力はビット単位で不変です。`examples_determinism`(11) と VRT goldens を **`FULGUR_VRT_UPDATE` を一切使わず**に実行し、`git status -- crates/fulgur-vrt/goldens/` が空（=golden バイト不変）であることを確認済み。唯一の順序リスクだった 2 つの `sum::<Px>().in_pt()` チェーンも、`Sum for Px` が内側 f32 を同一順で畳み込むため byte-identical です。

## codecov patch coverage

CI の coverage job は VRT を除外する (`--workspace --exclude fulgur-vrt`) ため、従来 VRT golden のみでカバーされていた `fragment_block_subtree` の分割分岐 / `draw_under_opacity` の split arm が patch で未カバー化します。これを behavioral test で解消しました（golden 再生成ではなく）:

- `break-after: page` / opacity split 経路を覆う render_smoke を追加
- `depth >= MAX_DOM_DEPTH` の bail-out は in-crate unit test で `fragment_block_subtree(depth = crate::MAX_DOM_DEPTH)` を直接呼んで実証（定数追従・256MB スタック不要）
- assert メッセージ引数内の `.to_f32()` region アーティファクトは hot-path 束縛で解消

→ **patch coverage 100%（365/365、未カバー 0）** を `cargo llvm-cov nextest --workspace --exclude fulgur-vrt` の lcov と diff の cross-ref で独立確認済み。

## テスト

- `cargo build` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo fmt --check` clean
- `fulgur --lib` 1499 / `render_smoke` 175 / `examples_determinism` 11 / VRT `run_fulgur_vrt` ok

## 関連

- beads: `fulgur-2map.5`（P1c）。`fulgur-2map.7`（P1e: Drawables 集約フィールド）を unblock します。
- plan: `docs/plans/2026-06-29-pagination-fragment-px.md`、outcome は `docs/plans/2026-06-27-engine-layout-api-design.md` §7 に記録。
- フォローアップ: `fulgur-dsnh`（`MAX_DOM_DEPTH` が `render_html` 経路で上流の stack overflow を防げていない潜在バグ。本 PR の depth-bail カバレッジ作業で発見、スコープ外として起票）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * pagination の `Fragment`（座標・サイズ）を px 単位で扱うよう整理し、単位付きの一貫した計算に対応しました。
  * `Px::ZERO` を追加しました。
* **Bug Fixes**
  * px↔pt 換算の境界での座標・分割判定が安定するよう調整しました。
* **Tests**
  * v2 レンダリングのエンドツーエンド smoke テストを追加し、ページ数の検出を堅牢化しました。
* **Documentation**
  * 移行手順と検証方針に関する計画書を更新・追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->