### PR TITLE
test(convert): add coverage for utility functions in convert/mod.rs

### DIFF
--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -1565,10 +1565,10 @@ mod utility_fn_tests {
             ..taffy::Layout::new()
         };
         let (x, y, w, h) = layout_in_pt(&layout);
-        assert!((x - 3.0).abs() < 1e-4, "x={x}");
-        assert!((y - 6.0).abs() < 1e-4, "y={y}");
-        assert!((w - 75.0).abs() < 1e-4, "w={w}");
-        assert!((h - 150.0).abs() < 1e-4, "h={h}");
+        assert_eq!(x, 3.0);
+        assert_eq!(y, 6.0);
+        assert_eq!(w, 75.0);
+        assert_eq!(h, 150.0);
     }
 
     #[test]
@@ -1591,8 +1591,8 @@ mod utility_fn_tests {
             height: 120.0,
         };
         let (w, h) = size_in_pt(size);
-        assert!((w - 60.0).abs() < 1e-4, "w={w}");
-        assert!((h - 90.0).abs() < 1e-4, "h={h}");
+        assert_eq!(w, 60.0);
+        assert_eq!(h, 90.0);
     }
 
     #[test]
@@ -1622,10 +1622,10 @@ mod utility_fn_tests {
     #[test]
     fn px_to_pt_known_values() {
         // 1 px = 0.75 pt
-        assert!((px_to_pt(1.0) - 0.75).abs() < 1e-6);
+        assert_eq!(px_to_pt(1.0), 0.75);
         // 4 px = 3 pt
-        assert!((px_to_pt(4.0) - 3.0).abs() < 1e-6);
+        assert_eq!(px_to_pt(4.0), 3.0);
         // 96 px (1 in) = 72 pt
-        assert!((px_to_pt(96.0) - 72.0).abs() < 1e-4);
+        assert_eq!(px_to_pt(96.0), 72.0);
     }
 }

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -1495,3 +1495,137 @@ mod semantics_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod utility_fn_tests {
+    //! Unit tests for pure utility functions in this module.
+    //! These exercise branches that the integration tests (semantics_tests,
+    //! bookmark_outline_tests) do not reach because they rely on unusual CSS
+    //! keyword variants or specific URL schemes.
+
+    use super::*;
+
+    // --- css_text_align_to_parley_alignment ---
+
+    #[test]
+    fn text_align_all_variants() {
+        use ::style::values::specified::TextAlignKeyword;
+        let cases: &[(TextAlignKeyword, parley::Alignment)] = &[
+            (TextAlignKeyword::Start, parley::Alignment::Start),
+            (TextAlignKeyword::Left, parley::Alignment::Left),
+            (TextAlignKeyword::Right, parley::Alignment::Right),
+            (TextAlignKeyword::Center, parley::Alignment::Center),
+            (TextAlignKeyword::Justify, parley::Alignment::Justify),
+            (TextAlignKeyword::End, parley::Alignment::End),
+            // Moz* aliases map to their logical equivalents.
+            // These keywords can't be produced from normal author CSS in Stylo
+            // (they originate from internal browser UA/quirks paths), so the
+            // only way to test them is through direct enum construction.
+            (TextAlignKeyword::MozCenter, parley::Alignment::Center),
+            (TextAlignKeyword::MozLeft, parley::Alignment::Left),
+            (TextAlignKeyword::MozRight, parley::Alignment::Right),
+        ];
+        for &(keyword, expected) in cases {
+            assert_eq!(
+                css_text_align_to_parley_alignment(keyword),
+                expected,
+                "keyword {keyword:?} should map to {expected:?}"
+            );
+        }
+    }
+
+    // --- extract_asset_name ---
+
+    #[test]
+    fn extract_asset_name_strips_file_scheme() {
+        assert_eq!(extract_asset_name("file:///foo/bar.png"), "foo/bar.png");
+        assert_eq!(extract_asset_name("file:///"), "");
+    }
+
+    #[test]
+    fn extract_asset_name_passthrough_non_file_url() {
+        assert_eq!(extract_asset_name("logo.png"), "logo.png");
+        assert_eq!(
+            extract_asset_name("http://example.com/img.png"),
+            "http://example.com/img.png"
+        );
+    }
+
+    // --- layout_in_pt ---
+
+    #[test]
+    fn layout_in_pt_converts_px_to_pt() {
+        // 1 CSS px = 0.75 PDF pt, so 4 px → 3 pt, 100 px → 75 pt.
+        let layout = taffy::Layout {
+            location: taffy::geometry::Point { x: 4.0, y: 8.0 },
+            size: taffy::geometry::Size {
+                width: 100.0,
+                height: 200.0,
+            },
+            ..taffy::Layout::new()
+        };
+        let (x, y, w, h) = layout_in_pt(&layout);
+        assert!((x - 3.0).abs() < 1e-4, "x={x}");
+        assert!((y - 6.0).abs() < 1e-4, "y={y}");
+        assert!((w - 75.0).abs() < 1e-4, "w={w}");
+        assert!((h - 150.0).abs() < 1e-4, "h={h}");
+    }
+
+    #[test]
+    fn layout_in_pt_zero_layout_stays_zero() {
+        let layout = taffy::Layout::new();
+        let (x, y, w, h) = layout_in_pt(&layout);
+        assert_eq!(x, 0.0);
+        assert_eq!(y, 0.0);
+        assert_eq!(w, 0.0);
+        assert_eq!(h, 0.0);
+    }
+
+    // --- size_in_pt ---
+
+    #[test]
+    fn size_in_pt_converts_px_to_pt() {
+        // 80 px → 60 pt, 120 px → 90 pt
+        let size = taffy::geometry::Size {
+            width: 80.0,
+            height: 120.0,
+        };
+        let (w, h) = size_in_pt(size);
+        assert!((w - 60.0).abs() < 1e-4, "w={w}");
+        assert!((h - 90.0).abs() < 1e-4, "h={h}");
+    }
+
+    #[test]
+    fn size_in_pt_zero_size_stays_zero() {
+        let size = taffy::geometry::Size {
+            width: 0.0,
+            height: 0.0,
+        };
+        let (w, h) = size_in_pt(size);
+        assert_eq!(w, 0.0);
+        assert_eq!(h, 0.0);
+    }
+
+    // --- px_to_pt / pt_to_px roundtrip ---
+
+    #[test]
+    fn px_pt_roundtrip() {
+        for &v in &[0.0f32, 1.0, 12.0, 96.0, 595.0] {
+            let roundtripped = pt_to_px(px_to_pt(v));
+            assert!(
+                (roundtripped - v).abs() < 1e-3,
+                "roundtrip failed for {v}: got {roundtripped}"
+            );
+        }
+    }
+
+    #[test]
+    fn px_to_pt_known_values() {
+        // 1 px = 0.75 pt
+        assert!((px_to_pt(1.0) - 0.75).abs() < 1e-6);
+        // 4 px = 3 pt
+        assert!((px_to_pt(4.0) - 3.0).abs() < 1e-6);
+        // 96 px (1 in) = 72 pt
+        assert!((px_to_pt(96.0) - 72.0).abs() < 1e-4);
+    }
+}


### PR DESCRIPTION
## 対象モジュール

`crates/fulgur/src/convert/mod.rs`

## カバレッジ変化

| 指標 | 変更前 | 変更後 |
|------|--------|--------|
| Line Coverage | 88.68 % (96 missed / 848) | 91.17 % (82 missed / 929) |
| Region Coverage | 90.04 % | 91.47 % |
| Function Coverage | 93.06 % | 95.06 % |

line coverage +2.49 pp、missed lines 96 → 82 (14 lines 削減)。

## 追加したテスト一覧

新規モジュール `utility_fn_tests` に 9 テストを追加。

| テスト名 | 対象関数 | カバーした分岐 |
|----------|----------|----------------|
| `text_align_all_variants` | `css_text_align_to_parley_alignment` | 全9バリアント（`End`・`MozCenter`・`MozLeft`・`MozRight` は通常の author CSS からは生成されないため、enum 値を直接構築して初めてテスト可能） |
| `extract_asset_name_strips_file_scheme` | `extract_asset_name` | `file:///` プレフィックスを除去するパス |
| `extract_asset_name_passthrough_non_file_url` | `extract_asset_name` | プレフィックスなし URL のパススルー |
| `layout_in_pt_converts_px_to_pt` | `layout_in_pt` | CSS px → PDF pt 変換（4 px = 3 pt） |
| `layout_in_pt_zero_layout_stays_zero` | `layout_in_pt` | ゼロ値がゼロのまま通過 |
| `size_in_pt_converts_px_to_pt` | `size_in_pt` | CSS px → PDF pt 変換 |
| `size_in_pt_zero_size_stays_zero` | `size_in_pt` | ゼロ値がゼロのまま通過 |
| `px_pt_roundtrip` | `px_to_pt` / `pt_to_px` | 往復変換の精度保証 |
| `px_to_pt_known_values` | `px_to_pt` | 1 px=0.75 pt、96 px=72 pt などの既知変換値 |

## 意図的にカバーしなかった箇所

- `find_body_id_in_dom`・`extract_body_offset_pt`・`extract_root_dir_rtl`・`node_has_transform`・`convert_node_inner` など DOM ウォーク系関数: `blitz_adapter::parse_and_layout` 経由で Blitz DOM を必要とするため、本ルーティン（テスト専用）の範囲で追加しても、既存の統合テスト（`semantics_tests`）が既にカバーしているか、カバーに意味あるアサーションを書きにくい純 IO 分岐のみ残る。
- `record_semantics_pass`・`walk_semantics` のうち未カバーの条件分岐: `semantics_tests` で大部分をカバー済み。残りは Blitz が特定の内部 node 型を返すケースで、テスト用 HTML からは再現困難。


---
_Generated by [Claude Code](https://claude.ai/code/session_01C7XvCsniNHHM4nCwp2kWCB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * 変換まわりの各種ユーティリティに対する単体テストを追加しました。
  * CSSの文字揃え変換（Moz*別名含む）やアセット名の抽出、px/pt変換、往復整合、ゼロ値の扱いなど主要ケースを網羅的に確認できるようになりました。
  * 公開APIや実行時の挙動は変更されていません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->