### PR TITLE
release-plz: add base workspace config (fulgur-7b3l)

### DIFF
--- a/docs/plans/2026-07-01-release-plz-base-setup.md
+++ b/docs/plans/2026-07-01-release-plz-base-setup.md
@@ -1,0 +1,191 @@
+# release-plz Base Setup Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `release-plz.toml` configuring the 7-crate fulgur workspace (publish control, version-group lockstep, exclusions) and validate it locally with `release-plz update`, without performing a real version bump or touching CI.
+
+**Architecture:** `release-plz.toml` lives at the workspace root next to `Cargo.toml`. `[workspace]` sets shared defaults; five `[[package]]` blocks override per-crate `publish`/`version_group`, and two set `release = false` to fully exclude test/fixture crates. Validation runs `release-plz update` (the only local, no-network preview command — it has no `--dry-run` flag and writes files directly) inside this worktree, then the resulting Cargo.toml/Cargo.lock/CHANGELOG.md edits are inspected and reverted so only `release-plz.toml` itself is committed.
+
+**Tech Stack:** release-plz CLI (Rust, installed via `cargo install`), TOML config.
+
+**Scope boundary:** This plan does NOT wire release-plz into CI (fulgur-f7o2), does NOT decide the changelog source (fulgur-b0nb), and does NOT reconcile release-plz's bump detection with the ZeroVer minor-fixed policy (fulgur-q7mc). The dry-run is expected to propose a non-ZeroVer-compliant bump — that's a documented finding for q7mc, not something to fix here.
+
+---
+
+### Task 1: Write `release-plz.toml`
+
+**Files:**
+
+- Create: `release-plz.toml` (workspace root, alongside `Cargo.toml`)
+
+**Background — verified facts (do not re-derive, just use):**
+
+Root `Cargo.toml` workspace members (`Cargo.toml:3`):
+`crates/fulgur`, `crates/fulgur-cli`, `crates/fulgur-ruby`, `crates/fulgur-vrt`, `crates/fulgur-wasm`, `crates/fulgur-wpt`, `crates/pyfulgur`
+
+Per-crate `publish` field as it stands today in each `Cargo.toml`:
+
+| Crate | `publish` today | Role |
+|---|---|---|
+| `fulgur` | unset (defaults to publishable) | crates.io, version-synced |
+| `fulgur-cli` | unset (defaults to publishable) | crates.io, version-synced |
+| `fulgur-wasm` | `false` | not on crates.io, version-synced |
+| `pyfulgur` | `false` | not on crates.io, version-synced |
+| `fulgur-ruby` | `false` | not on crates.io, version-synced |
+| `fulgur-vrt` | `false`, version `0.0.0` | excluded entirely |
+| `fulgur-wpt` | `false`, version `0.0.0` | excluded entirely |
+
+release-plz errors if `release-plz.toml` sets `publish = true` for a package whose own `Cargo.toml` has `publish = false` — so the three binding crates must have `publish = false` in `release-plz.toml` too, not be left at a conflicting default.
+
+**Step 1: Write the file**
+
+```toml
+[workspace]
+release = true
+
+[[package]]
+name = "fulgur"
+version_group = "core"
+publish = true
+
+[[package]]
+name = "fulgur-cli"
+version_group = "core"
+publish = true
+
+[[package]]
+name = "fulgur-wasm"
+version_group = "core"
+publish = false
+
+[[package]]
+name = "pyfulgur"
+version_group = "core"
+publish = false
+
+[[package]]
+name = "fulgur-ruby"
+version_group = "core"
+publish = false
+
+[[package]]
+name = "fulgur-vrt"
+release = false
+
+[[package]]
+name = "fulgur-wpt"
+release = false
+```
+
+**Step 2: Sanity-check the TOML parses**
+
+Run: `python3 -c "import tomllib; tomllib.load(open('release-plz.toml','rb')); print('ok')"`
+Expected: `ok`
+
+(`tomllib` is stdlib on Python ≥3.11; if unavailable, `cargo install --quiet toml-test-or-similar` is overkill — just eyeball it or let Step 1 of Task 2 below be the real validator, since `release-plz update` will fail loudly on malformed TOML.)
+
+Note: this check only validates TOML *syntax* — it does not validate that the keys/structure match release-plz's own config schema. release-plz's `Config` struct uses `#[serde(deny_unknown_fields)]` and accepts only `workspace`, `changelog`, and `package` as top-level keys, so a syntactically-valid file can still be rejected by release-plz itself (e.g. an unrecognized top-level key like `$schema` would fail to load even though `tomllib` parses it fine). That schema-level check only happens when Task 2 actually runs `release-plz update`.
+
+**Step 3: Commit is deferred**
+
+Do not commit yet — Task 2's validation run needs `release-plz.toml` present but uncommitted is fine. We commit once validation confirms the config is correct (end of Task 2).
+
+---
+
+### Task 2: Install release-plz and validate via local dry-run
+
+**Files:**
+
+- Modify (temporarily, then reverted): `crates/*/Cargo.toml`, `Cargo.lock`, `CHANGELOG.md` (whichever `release-plz update` touches)
+- Read: output of `release-plz update`
+
+**Step 1: Install the CLI**
+
+Run: `cargo install release-plz --locked`
+Expected: builds and installs; `release-plz --version` then prints a `0.3.x` version string. This compiles from source and may take a few minutes — run with a generous timeout or in the background.
+
+**Step 2: Confirm the working tree is otherwise clean before running update**
+
+Run: `git status --short`
+Expected: only `release-plz.toml` shows as untracked (`??`). If anything else is dirty, stop and figure out why before proceeding — `release-plz update` needs a clean baseline to produce a readable diff.
+
+**Step 3: Run the local preview**
+
+Run: `release-plz update`
+Expected: it exits 0 and reports version bumps for `fulgur`, `fulgur-cli`, `fulgur-wasm`, `pyfulgur`, `fulgur-ruby` (same target version across all five, since they share `version_group = "core"`), and does **not** touch `fulgur-vrt` / `fulgur-wpt`.
+
+**Step 4: Inspect what changed**
+
+Run: `git status --short && git diff --stat`
+Expected: `Cargo.lock`, the five lockstep crates' `Cargo.toml` (version bump), and likely a `CHANGELOG.md` per publishable crate (release-plz's own changelog generator, independent of the current PR-based one — this divergence is expected and is b0nb's decision point, not something to reconcile here).
+
+Look specifically for:
+
+- Did `fulgur-vrt`/`fulgur-wpt` get left alone? (must be yes — confirms `release = false` worked)
+- Did the five lockstep crates land on the *same* version number? (must be yes — confirms `version_group` worked)
+- What bump size did it choose (patch/minor/major)? Record this verbatim — it's very likely **not** the ZeroVer "always minor" the project wants, since release-plz infers bump size from conventional-commit parsing / semver-check, and this repo doesn't reliably use conventional commit prefixes. That mismatch is the exact gap fulgur-q7mc exists to close.
+
+**Step 5: Revert the file mutations, keep only the config**
+
+Run: `git checkout -- Cargo.lock crates/fulgur/Cargo.toml crates/fulgur-cli/Cargo.toml crates/fulgur-wasm/Cargo.toml crates/pyfulgur/Cargo.toml crates/fulgur-ruby/Cargo.toml`
+
+Then check for any `CHANGELOG.md` files `release-plz update` created or modified (`git status --short`) and revert those too the same way (`git checkout -- <path>` for tracked files it modified, `rm` for any new ones it created from scratch). Re-run `git status --short` afterward.
+
+Expected: only `release-plz.toml` remains as an untracked addition; everything else matches `main`.
+
+**Step 6: Commit**
+
+```bash
+git add release-plz.toml
+git commit -m "chore(release): add release-plz.toml for workspace base config"
+```
+
+**Step 7: Record dry-run findings in the beads issue**
+
+Append the Step 4 observations (bump size chosen, confirmation that vrt/wpt were excluded, confirmation that the 5 crates landed on the same version, any surprises e.g. semver_check output) to `fulgur-7b3l`'s notes:
+
+```bash
+bd update fulgur-7b3l --append-notes "release-plz update dry-run 結果: <observed bump size>, vrt/wpt 除外 <確認結果>, 5 crate lockstep <確認結果>, semver_check 出力 <あれば>"
+```
+
+Use single-quoted content or a file if the findings text contains backticks or `${...}` (these go through eval — see project memory `feedback_bd_description_quoting`).
+
+---
+
+### Verification
+
+- `release-plz.toml` exists at the workspace root and is the only change in the final commit (`git show --stat HEAD`).
+- `cargo build --workspace` still succeeds (config addition must not affect the Rust build).
+- `fulgur-7b3l` notes contain the recorded dry-run findings.
+
+---
+
+### Addendum (post-execution correction)
+
+Task 1's Step 1 snippet, as originally written, does **not** achieve the 5-crate
+lockstep Task 2 Step 3/4 expects. The actual dry-run (`release-plz update`)
+showed only `fulgur`/`fulgur-cli` proposed for a bump — `fulgur-wasm`/
+`pyfulgur`/`fulgur-ruby` silently dropped out of `version_group = "core"`,
+because release-plz filters packages by their own `Cargo.toml` `publish` field
+*before* applying `version_group`, and these three have `publish = false`.
+
+The fix, applied as a follow-up commit rather than amending Task 1's snippet
+in place: add `git_only = true` to the three non-publishing crates'
+`[[package]]` blocks. This tells release-plz to resolve their "current
+version" from git tags instead of the crates.io registry, which keeps them
+inside the publishable set so `version_group` can lock them to the rest.
+Verified empirically: all 5 crates landed on the same proposed version after
+the fix.
+
+Caveat carried forward (not resolved by this task): the binding crates have
+no `<crate>-vX.Y.Z`-style git tags in this repo's history (only generic
+`vX.Y.Z` workspace tags), so `git_only`'s tag-based baseline treated them as
+"initial release" before `version_group` force-aligned them. This was only
+exercised through `release-plz update` (the local calculation phase) — the
+real `release-plz release` (tagging/publish) phase is unverified against this
+tag scheme. That's a question for whichever issue ends up owning fulgur's
+release tagging strategy (likely fulgur-f7o2), not something resolved here.
+
+If you're copying the Task 1 TOML snippet for a similar setup elsewhere,
+include the `git_only = true` lines from the start rather than reproducing
+this two-step discovery.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -15,16 +15,19 @@ publish = true
 name = "fulgur-wasm"
 version_group = "core"
 publish = false
+git_only = true
 
 [[package]]
 name = "pyfulgur"
 version_group = "core"
 publish = false
+git_only = true
 
 [[package]]
 name = "fulgur-ruby"
 version_group = "core"
 publish = false
+git_only = true
 
 [[package]]
 name = "fulgur-vrt"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,35 @@
+[workspace]
+release = true
+
+[[package]]
+name = "fulgur"
+version_group = "core"
+publish = true
+
+[[package]]
+name = "fulgur-cli"
+version_group = "core"
+publish = true
+
+[[package]]
+name = "fulgur-wasm"
+version_group = "core"
+publish = false
+
+[[package]]
+name = "pyfulgur"
+version_group = "core"
+publish = false
+
+[[package]]
+name = "fulgur-ruby"
+version_group = "core"
+publish = false
+
+[[package]]
+name = "fulgur-vrt"
+release = false
+
+[[package]]
+name = "fulgur-wpt"
+release = false

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,10 +1,26 @@
 [workspace]
 release = true
+# semver_check defaults to true for libraries, but fulgur-wasm/pyfulgur/fulgur-ruby
+# are bindings that aren't published to crates.io and have no registry baseline to
+# diff against — leave it off workspace-wide and opt in only where it's meaningful.
+semver_check = false
+# Default tag/release naming is per-package ("{{ package }}-v{{ version }}") once a
+# workspace has more than one publishable crate (fulgur + fulgur-cli here), which
+# would produce multiple tags/releases instead of the single v$VERSION tag the
+# current pipeline and this epic's design rely on. Disable by default, then opt a
+# single package back in below as the canonical release tag/name.
+git_tag_enable = false
+git_release_enable = false
 
 [[package]]
 name = "fulgur"
 version_group = "core"
 publish = true
+semver_check = true
+git_tag_enable = true
+git_tag_name = "v{{ version }}"
+git_release_enable = true
+git_release_name = "v{{ version }}"
 
 [[package]]
 name = "fulgur-cli"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -11,6 +11,9 @@ name = "fulgur-cli"
 version_group = "core"
 publish = true
 
+# git_only: without this, release-plz checks crates.io for these publish=false
+# crates, finds nothing, and they silently drop out of the "core" version_group
+# lockstep (only fulgur/fulgur-cli would get bumped). See fulgur-7b3l notes.
 [[package]]
 name = "fulgur-wasm"
 version_group = "core"
@@ -29,6 +32,9 @@ version_group = "core"
 publish = false
 git_only = true
 
+# release = false fully excludes these test/fixture crates (version 0.0.0) from
+# release-plz entirely — different from publish = false above, which still
+# version-tracks the binding crates via the core version_group.
 [[package]]
 name = "fulgur-vrt"
 release = false


### PR DESCRIPTION
## Summary

- `release-plz.toml` を workspace root に追加。7 crate の publish/version_group/release 設定を各 crate の実際の Cargo.toml `publish` フィールドに合わせて構成。
  - `fulgur` / `fulgur-cli`: `version_group = "core"`, `publish = true`（crates.io 対象）
  - `fulgur-wasm` / `pyfulgur` / `fulgur-ruby`: `version_group = "core"`, `publish = false`, `git_only = true`（crates.io には出さないが version lockstep を維持）
  - `fulgur-vrt` / `fulgur-wpt`: `release = false`（release-plz の管理対象から完全除外）
- ローカル worktree 内で `release-plz update` を実際に実行して dry-run 検証（バージョンバンプ・CHANGELOG.md は revert 済み、コミットには含まれていない）。
- 検証中に発見: `git_only` を追加しないと publish=false の3 crate が `version_group` の対象から脱落し、`fulgur`/`fulgur-cli` の2 crateのみ bump 提案される (release-plz が各 crate 自身の Cargo.toml `publish` フィールドでフィルタしてから version_group を適用するため)。`git_only = true` を追加して解消し、5 crate 全ての lockstep を確認済み。
- 上記の発見と留保事項 (release-plz release フェーズでのタグ挙動は未検証、vrt/wpt の release=false 効果は publish=false フィルタと切り分けられていない、bump サイズは patch で ZeroVer minor 固定ポリシーと不一致) は `fulgur-7b3l` の notes に記録済み。

## Scope

release-plz.toml の追加とローカル検証のみ。CI 配線 (fulgur-f7o2)・changelog 方式決定 (fulgur-b0nb)・ZeroVer bump 整合 (fulgur-q7mc) は別 issue のスコープで、本 PR には含めていません。

## Test plan

- [x] `python3 -c "import tomllib; tomllib.load(open('release-plz.toml','rb'))"` — TOML 構文有効
- [x] worktree 内で `release-plz update --allow-dirty` を実行し、5 crate lockstep (0.20.0 → 0.20.1) と vrt/wpt 除外を確認、変更は revert してコミットに含めていない
- [x] `cargo build --workspace` — 成功
- [x] `cargo fmt --check` — 成功
- [x] `cargo test -p fulgur --lib` — 1542 件全件パス
- [x] `npx markdownlint-cli2 'docs/plans/2026-07-01-release-plz-base-setup.md'` — 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * リポジトリ全体のリリース管理を行うための設定が追加されました。
  * 複数パッケージのバージョン更新ルールや、リリース対象外にするパッケージの扱いが整理されました。

* **Documentation**
  * リリース設定の導入手順と運用フローをまとめた計画書が追加されました。
  * 実行結果の確認方法や、設定調整時の注意点も記載されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->