### PR TITLE
refactor(transform): type Affine2D + Point2 with units::Pt (byte-neutral, fulgur-1ino)

### DIFF
--- a/.claude/rules/coordinate-system.md
+++ b/.claude/rules/coordinate-system.md
@@ -48,24 +48,43 @@ Helper definitions: `convert.rs:37-63`
 
 ## Exception: `compute_transform` arguments
 
-`blitz_adapter::compute_transform(styles, border_box_width, border_box_height)` takes
-`border_box_width` / `border_box_height` in **CSS px** — do not convert.
-Stylo's `length-percentage` resolution operates in CSS px space.
-The returned `Affine2D.e`/`.f` (translate components) are also in CSS px;
-the call site in `convert.rs` folds them into pt-space later.
+`blitz_adapter::compute_transform(styles, border_box_width, border_box_height)` is the one
+place that runs Stylo length resolution in **pt space, not px**. The parameters are still
+bare `f32`, but the `convert/mod.rs` call site feeds them **pt-valued** dims —
+`size_in_pt(node.final_layout.size)` (see the "PR 8i note" near `convert/mod.rs:605`).
+There is **no later px → pt fold**: the matrix and origin are produced and consumed as pt.
+
+Why feeding pt works: Stylo's `LengthPercentage::resolve` is unit-agnostic — a `Length` is
+just a number. Resolving against the pt-valued basis makes `%` translates and
+`transform-origin` come out correct against a pt basis. Absolute lengths ignore the basis
+and pass through as their numeric value, which the render path then treats as pt.
+
+The returned `Affine2D.e`/`.f` (translate components) and the `Point2` origin are now typed
+`units::Pt` (pt space) and are consumed directly by `render::draw_under_transform`.
+**Do not add `.in_pt()` to them** — they are already pt.
+
+Known consequence (out of scope for the typing migration): an absolute-length
+`translate(Npx)` ends up as `N` **pt**, a latent 4/3 over-shift, because the px value is
+reinterpreted as pt with no conversion. That is a behavior bug tracked separately — the
+`Pt` typing reflects today's reality, it does not change or fix it.
 
 ## Stylo length-percentage resolution
 
-`LengthPercentage::resolve(basis: Length)` — `basis` must be in **CSS px**.
-Passing a pt value produces a 3/4× error.
+For **layout-space** resolves (positioned insets, pseudo offsets, border-radius,
+viewport-relative lengths), `LengthPercentage::resolve(basis: Length)` — `basis` must be in
+**CSS px**. Passing a pt value produces a 3/4× error.
 
 ```rust
 // WRONG: pt basis
-origin.horizontal.resolve(Length::new(border_box_width_pt))
+inset.resolve(Length::new(cb_width_pt)).px()
 
 // CORRECT: px basis (layout values are CSS px)
-origin.horizontal.resolve(Length::new(border_box_width_px))
+inset.resolve(Length::new(cb_width_px)).px()
 ```
+
+The `transform` path is the deliberate exception to this rule: it resolves against a **pt**
+basis and uses the result directly as pt — see *Exception: `compute_transform` arguments*
+above.
 
 ## Krilla / Pageable coordinate system
 

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -2901,8 +2901,8 @@ pub(crate) fn compute_transform(
         || !m.b.is_finite()
         || !m.c.is_finite()
         || !m.d.is_finite()
-        || !m.e.is_finite()
-        || !m.f.is_finite()
+        || !m.e.to_f32().is_finite()
+        || !m.f.to_f32().is_finite()
     {
         log::warn!("transform produced non-finite matrix; falling back to identity");
         return None;
@@ -2931,6 +2931,7 @@ fn op_to_matrix(
     w: f32,
     h: f32,
 ) -> Affine2D {
+    use crate::units::F32Units;
     use style::values::computed::Length;
     use style::values::generics::transform::GenericTransformOperation::*;
 
@@ -2940,15 +2941,19 @@ fn op_to_matrix(
             b: m.b,
             c: m.c,
             d: m.d,
-            e: m.e,
-            f: m.f,
+            e: m.e.pt(),
+            f: m.f.pt(),
         },
         Translate(x, y) => Affine2D::translation(
-            x.resolve(Length::new(w)).px(),
-            y.resolve(Length::new(h)).px(),
+            x.resolve(Length::new(w)).px().pt(),
+            y.resolve(Length::new(h)).px().pt(),
         ),
-        TranslateX(x) => Affine2D::translation(x.resolve(Length::new(w)).px(), 0.0),
-        TranslateY(y) => Affine2D::translation(0.0, y.resolve(Length::new(h)).px()),
+        TranslateX(x) => {
+            Affine2D::translation(x.resolve(Length::new(w)).px().pt(), crate::units::Pt::ZERO)
+        }
+        TranslateY(y) => {
+            Affine2D::translation(crate::units::Pt::ZERO, y.resolve(Length::new(h)).px().pt())
+        }
         Scale(sx, sy) => Affine2D::scale(*sx, *sy),
         ScaleX(sx) => Affine2D::scale(*sx, 1.0),
         ScaleY(sy) => Affine2D::scale(1.0, *sy),
@@ -5310,8 +5315,10 @@ mod transform_tests {
             <div style="transform: translate(10px, 20px)">hi</div>
         </body></html>"#;
         let (m, _) = compute_for_div(html, 100.0, 100.0).expect("should have transform");
-        assert!(approx(m.e, 10.0));
-        assert!(approx(m.f, 20.0));
+        let me = m.e.to_f32();
+        let mf = m.f.to_f32();
+        assert!(approx(me, 10.0));
+        assert!(approx(mf, 20.0));
         assert!(approx(m.a, 1.0));
         assert!(approx(m.d, 1.0));
     }
@@ -5322,8 +5329,10 @@ mod transform_tests {
             <div style="transform: translate(50%, 25%)">hi</div>
         </body></html>"#;
         let (m, _) = compute_for_div(html, 200.0, 80.0).expect("should have transform");
-        assert!(approx(m.e, 100.0), "expected 100 (50% of 200), got {}", m.e);
-        assert!(approx(m.f, 20.0), "expected 20 (25% of 80), got {}", m.f);
+        let me = m.e.to_f32();
+        let mf = m.f.to_f32();
+        assert!(approx(me, 100.0), "expected 100 (50% of 200), got {me}");
+        assert!(approx(mf, 20.0), "expected 20 (25% of 80), got {mf}");
     }
 
     #[test]
@@ -5336,8 +5345,10 @@ mod transform_tests {
         assert!(approx(m.b, 2.0));
         assert!(approx(m.c, 3.0));
         assert!(approx(m.d, 4.0));
-        assert!(approx(m.e, 5.0));
-        assert!(approx(m.f, 6.0));
+        let me = m.e.to_f32();
+        let mf = m.f.to_f32();
+        assert!(approx(me, 5.0));
+        assert!(approx(mf, 6.0));
     }
 
     #[test]
@@ -5384,8 +5395,8 @@ mod transform_tests {
         </body></html>"#;
         let (m, _) = compute_for_div(html, 100.0, 100.0).expect("rotateZ should produce a wrapper");
         // 90° rotation: (1, 0) → (0, 1).
-        let x = m.a * 1.0 + m.c * 0.0 + m.e;
-        let y = m.b * 1.0 + m.d * 0.0 + m.f;
+        let x = m.a * 1.0 + m.c * 0.0 + m.e.to_f32();
+        let y = m.b * 1.0 + m.d * 0.0 + m.f.to_f32();
         assert!(approx(x, 0.0), "x expected 0.0, got {x}");
         assert!(approx(y, 1.0), "y expected 1.0, got {y}");
     }

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -5324,6 +5324,30 @@ mod transform_tests {
     }
 
     #[test]
+    fn translate_x_only_sets_e_leaves_f_zero() {
+        let html = r#"<!DOCTYPE html><html><body>
+            <div style="transform: translateX(10px)">hi</div>
+        </body></html>"#;
+        let (m, _) = compute_for_div(html, 100.0, 100.0).expect("should have transform");
+        let me = m.e.to_f32();
+        let mf = m.f.to_f32();
+        assert!(approx(me, 10.0), "translateX e should be 10, got {me}");
+        assert!(approx(mf, 0.0), "translateX f should be 0, got {mf}");
+    }
+
+    #[test]
+    fn translate_y_only_sets_f_leaves_e_zero() {
+        let html = r#"<!DOCTYPE html><html><body>
+            <div style="transform: translateY(20px)">hi</div>
+        </body></html>"#;
+        let (m, _) = compute_for_div(html, 100.0, 100.0).expect("should have transform");
+        let me = m.e.to_f32();
+        let mf = m.f.to_f32();
+        assert!(approx(me, 0.0), "translateY e should be 0, got {me}");
+        assert!(approx(mf, 20.0), "translateY f should be 20, got {mf}");
+    }
+
+    #[test]
     fn translate_percent_resolves_against_border_box() {
         let html = r#"<!DOCTYPE html><html><body>
             <div style="transform: translate(50%, 25%)">hi</div>

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -2881,6 +2881,7 @@ pub(crate) fn compute_transform(
     border_box_width: f32,
     border_box_height: f32,
 ) -> Option<(Affine2D, Point2)> {
+    use crate::units::F32Units;
     use style::values::computed::Length;
 
     // Fast path: most DOM nodes have no transform. Reading the
@@ -2914,8 +2915,13 @@ pub(crate) fn compute_transform(
     let origin_x = origin
         .horizontal
         .resolve(Length::new(border_box_width))
-        .px();
-    let origin_y = origin.vertical.resolve(Length::new(border_box_height)).px();
+        .px()
+        .pt();
+    let origin_y = origin
+        .vertical
+        .resolve(Length::new(border_box_height))
+        .px()
+        .pt();
 
     Some((m, Point2::new(origin_x, origin_y)))
 }
@@ -5340,15 +5346,15 @@ mod transform_tests {
             <div style="transform: rotate(45deg)">hi</div>
         </body></html>"#;
         let (_, origin) = compute_for_div(html, 100.0, 60.0).expect("should have transform");
+        let ox = origin.x.to_f32();
+        let oy = origin.y.to_f32();
         assert!(
-            approx(origin.x, 50.0),
-            "default origin x should be 50% of 100, got {}",
-            origin.x
+            approx(ox, 50.0),
+            "default origin x should be 50% of 100, got {ox}"
         );
         assert!(
-            approx(origin.y, 30.0),
-            "default origin y should be 50% of 60, got {}",
-            origin.y
+            approx(oy, 30.0),
+            "default origin y should be 50% of 60, got {oy}"
         );
     }
 

--- a/crates/fulgur/src/draw_primitives.rs
+++ b/crates/fulgur/src/draw_primitives.rs
@@ -222,18 +222,20 @@ impl std::ops::Mul for Affine2D {
     }
 }
 
-/// A 2D point in user-space coordinates (Pt).
+/// A 2D point in user-space coordinates (PDF pt).
 ///
-/// Used for both absolute draw positions and box-local offsets such as
-/// `transform-origin`; the interpretation depends on the call site.
+/// Used only for `transform-origin` (`drawables::TransformEntry.origin`).
+/// The value is the box-local origin already in pt space — `compute_transform`
+/// is fed pt-valued box dims, so no px→pt fold happens. **Do not add
+/// `.in_pt()`**: that would scale an already-pt value by 0.75.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Point2 {
-    pub x: Pt,
-    pub y: Pt,
+    pub x: crate::units::Pt,
+    pub y: crate::units::Pt,
 }
 
 impl Point2 {
-    pub const fn new(x: Pt, y: Pt) -> Self {
+    pub const fn new(x: crate::units::Pt, y: crate::units::Pt) -> Self {
         Self { x, y }
     }
 }

--- a/crates/fulgur/src/draw_primitives.rs
+++ b/crates/fulgur/src/draw_primitives.rs
@@ -101,8 +101,12 @@ pub struct Affine2D {
     pub b: f32,
     pub c: f32,
     pub d: f32,
-    pub e: f32,
-    pub f: f32,
+    /// Translate-x. **A value in pt space** — not the result of a px→pt fold,
+    /// but the output of the pt-basis hack treated as pt. **Do not add
+    /// `.in_pt()`**: that would scale an already-pt value by 0.75.
+    pub e: crate::units::Pt,
+    /// Translate-y. Same pt-space semantics as [`e`](Self::e).
+    pub f: crate::units::Pt,
 }
 
 impl Affine2D {
@@ -111,8 +115,8 @@ impl Affine2D {
         b: 0.0,
         c: 0.0,
         d: 1.0,
-        e: 0.0,
-        f: 0.0,
+        e: crate::units::Pt::ZERO,
+        f: crate::units::Pt::ZERO,
     };
 
     /// ε tolerance for identity detection (absorbs trig float noise).
@@ -123,11 +127,11 @@ impl Affine2D {
             && self.b.abs() < Self::IDENTITY_EPS
             && self.c.abs() < Self::IDENTITY_EPS
             && (self.d - 1.0).abs() < Self::IDENTITY_EPS
-            && self.e.abs() < Self::IDENTITY_EPS
-            && self.f.abs() < Self::IDENTITY_EPS
+            && self.e.to_f32().abs() < Self::IDENTITY_EPS
+            && self.f.to_f32().abs() < Self::IDENTITY_EPS
     }
 
-    pub fn translation(tx: f32, ty: f32) -> Self {
+    pub fn translation(tx: crate::units::Pt, ty: crate::units::Pt) -> Self {
         Self {
             a: 1.0,
             b: 0.0,
@@ -144,8 +148,8 @@ impl Affine2D {
             b: 0.0,
             c: 0.0,
             d: sy,
-            e: 0.0,
-            f: 0.0,
+            e: crate::units::Pt::ZERO,
+            f: crate::units::Pt::ZERO,
         }
     }
 
@@ -156,8 +160,8 @@ impl Affine2D {
             b: s,
             c: -s,
             d: c,
-            e: 0.0,
-            f: 0.0,
+            e: crate::units::Pt::ZERO,
+            f: crate::units::Pt::ZERO,
         }
     }
 
@@ -168,20 +172,27 @@ impl Affine2D {
             b: ay_rad.tan(),
             c: ax_rad.tan(),
             d: 1.0,
-            e: 0.0,
-            f: 0.0,
+            e: crate::units::Pt::ZERO,
+            f: crate::units::Pt::ZERO,
         }
     }
 
     pub fn to_krilla(&self) -> krilla::geom::Transform {
-        krilla::geom::Transform::from_row(self.a, self.b, self.c, self.d, self.e, self.f)
+        krilla::geom::Transform::from_row(
+            self.a,
+            self.b,
+            self.c,
+            self.d,
+            self.e.to_f32(),
+            self.f.to_f32(),
+        )
     }
 
     /// Apply this affine transform to a 2D point.
     pub fn transform_point(&self, x: f32, y: f32) -> (f32, f32) {
         (
-            self.a * x + self.c * y + self.e,
-            self.b * x + self.d * y + self.f,
+            self.a * x + self.c * y + self.e.to_f32(),
+            self.b * x + self.d * y + self.f.to_f32(),
         )
     }
 
@@ -216,6 +227,8 @@ impl std::ops::Mul for Affine2D {
             b: self.b * rhs.a + self.d * rhs.b,
             c: self.a * rhs.c + self.c * rhs.d,
             d: self.b * rhs.c + self.d * rhs.d,
+            // e/f rows: f32*Pt→Pt and Pt+Pt→Pt via units ops; the expression is
+            // left verbatim (no reassociation) to keep the transform byte-neutral.
             e: self.a * rhs.e + self.c * rhs.f + self.e,
             f: self.b * rhs.e + self.d * rhs.f + self.f,
         }
@@ -1592,7 +1605,7 @@ mod dp_unit_tests {
     fn destination_registry_push_pop_transform_affects_record() {
         let mut reg = DestinationRegistry::new();
         reg.set_current_page(3);
-        reg.push_transform(Affine2D::translation(10.0, 20.0));
+        reg.push_transform(Affine2D::translation(10.0_f32.pt(), 20.0_f32.pt()));
         reg.record("anchor", 5.0, 7.0);
         let (page, x, y) = reg.get("anchor").expect("recorded");
         assert_eq!(page, 3);
@@ -1886,7 +1899,7 @@ mod dp_unit_tests {
 
     #[test]
     fn affine2d_translation_is_not_identity() {
-        assert!(!Affine2D::translation(1.0, 0.0).is_identity());
+        assert!(!Affine2D::translation(1.0_f32.pt(), 0.0_f32.pt()).is_identity());
     }
 
     #[test]
@@ -1921,17 +1934,19 @@ mod dp_unit_tests {
 
     #[test]
     fn affine2d_mul_two_translations_add() {
-        let t1 = Affine2D::translation(3.0, 4.0);
-        let t2 = Affine2D::translation(1.0, -2.0);
+        let t1 = Affine2D::translation(3.0_f32.pt(), 4.0_f32.pt());
+        let t2 = Affine2D::translation(1.0_f32.pt(), (-2.0_f32).pt());
         let composed = t1 * t2;
-        assert!((composed.e - 4.0).abs() < 1e-5);
-        assert!((composed.f - 2.0).abs() < 1e-5);
+        let composed_e = composed.e.to_f32();
+        let composed_f = composed.f.to_f32();
+        assert!((composed_e - 4.0).abs() < 1e-5);
+        assert!((composed_f - 2.0).abs() < 1e-5);
     }
 
     #[test]
     fn affine2d_mul_scale_then_translate() {
         let s = Affine2D::scale(2.0, 3.0);
-        let t = Affine2D::translation(10.0, 5.0);
+        let t = Affine2D::translation(10.0_f32.pt(), 5.0_f32.pt());
         // (s * t) * p = s * (t * p): translate first, then scale
         let composed = s * t;
         let (x, y) = composed.transform_point(1.0, 1.0);
@@ -1968,7 +1983,7 @@ mod dp_unit_tests {
             width: 10.0,
             height: 5.0,
         };
-        let t = Affine2D::translation(2.0, 3.0);
+        let t = Affine2D::translation(2.0_f32.pt(), 3.0_f32.pt());
         let q = t.transform_rect(&r);
         for pt in &q.points {
             assert!(pt[0] >= 2.0 - 1e-5 && pt[0] <= 12.0 + 1e-5, "x={}", pt[0]);

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -836,7 +836,7 @@ pub fn draw_shaped_lines(
                         let off_y = oy.to_f32() - geo_y_pt;
                         let transform = krilla::geom::Transform::from_translate(off_x, off_y);
                         let link_affine =
-                            crate::draw_primitives::Affine2D::translation(off_x, off_y);
+                            crate::draw_primitives::Affine2D::translation(off_x.pt(), off_y.pt());
                         crate::draw_primitives::draw_with_opacity(canvas, ib.opacity, |canvas| {
                             if let Some(lc) = canvas.link_collector.as_deref_mut() {
                                 lc.push_transform(link_affine);

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -1322,8 +1322,8 @@ fn draw_under_transform(
 ) {
     // `effective_matrix` mirrors `TransformWrapperPageable::effective_matrix`:
     //   T(x + ox, y + oy) · M · T(-(x + ox), -(y + oy))
-    let ox = x_pt + tx.origin.x;
-    let oy = y_pt + tx.origin.y;
+    let ox = x_pt + tx.origin.x.to_f32();
+    let oy = y_pt + tx.origin.y.to_f32();
     use crate::draw_primitives::Affine2D;
     let full = Affine2D::translation(ox, oy) * tx.matrix * Affine2D::translation(-ox, -oy);
 
@@ -4618,7 +4618,10 @@ mod tests {
             10,
             crate::drawables::TransformEntry {
                 matrix: crate::draw_primitives::Affine2D::translation(0.0, 0.0),
-                origin: crate::draw_primitives::Point2 { x: 0.0, y: 0.0 },
+                origin: crate::draw_primitives::Point2::new(
+                    crate::units::Pt::ZERO,
+                    crate::units::Pt::ZERO,
+                ),
                 descendants: vec![11, 12],
             },
         );

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -1325,7 +1325,9 @@ fn draw_under_transform(
     let ox = x_pt + tx.origin.x.to_f32();
     let oy = y_pt + tx.origin.y.to_f32();
     use crate::draw_primitives::Affine2D;
-    let full = Affine2D::translation(ox, oy) * tx.matrix * Affine2D::translation(-ox, -oy);
+    let full = Affine2D::translation(ox.pt(), oy.pt())
+        * tx.matrix
+        * Affine2D::translation((-ox).pt(), (-oy).pt());
 
     if let Some(lc) = canvas.link_collector.as_deref_mut() {
         lc.push_transform(full);
@@ -4617,7 +4619,7 @@ mod tests {
         d.transforms.insert(
             10,
             crate::drawables::TransformEntry {
-                matrix: crate::draw_primitives::Affine2D::translation(0.0, 0.0),
+                matrix: crate::draw_primitives::Affine2D::translation(0.0_f32.pt(), 0.0_f32.pt()),
                 origin: crate::draw_primitives::Point2::new(
                     crate::units::Pt::ZERO,
                     crate::units::Pt::ZERO,

--- a/crates/fulgur/tests/transform_integration.rs
+++ b/crates/fulgur/tests/transform_integration.rs
@@ -10,6 +10,7 @@ use fulgur::config::{Margin, PageSize};
 use fulgur::draw_primitives::Affine2D;
 use fulgur::drawables::{Drawables, TransformEntry};
 use fulgur::engine::Engine;
+use fulgur::units::F32Units;
 
 fn build_drawables(html: &str) -> Drawables {
     let engine = Engine::builder().build();
@@ -34,7 +35,9 @@ fn entry_from(html: &str) -> TransformEntry {
 fn effective_matrix(entry: &TransformEntry, draw_x: f32, draw_y: f32) -> Affine2D {
     let ox = draw_x + entry.origin.x.to_f32();
     let oy = draw_y + entry.origin.y.to_f32();
-    Affine2D::translation(ox, oy) * entry.matrix * Affine2D::translation(-ox, -oy)
+    Affine2D::translation(ox.pt(), oy.pt())
+        * entry.matrix
+        * Affine2D::translation((-ox).pt(), (-oy).pt())
 }
 
 fn approx(actual: f32, expected: f32, tol: f32, label: &str) {
@@ -67,8 +70,8 @@ fn translate_px() {
     approx(m.b, 0.0, 1e-5, "translate.b");
     approx(m.c, 0.0, 1e-5, "translate.c");
     approx(m.d, 1.0, 1e-5, "translate.d");
-    approx(m.e, 10.0, 1e-5, "translate.e");
-    approx(m.f, 20.0, 1e-5, "translate.f");
+    approx(m.e.to_f32(), 10.0, 1e-5, "translate.e");
+    approx(m.f.to_f32(), 20.0, 1e-5, "translate.f");
 }
 
 #[test]
@@ -78,8 +81,8 @@ fn rotate_90_at_top_left_origin() {
     let m = effective_matrix(&entry, 0.0, 0.0);
     // Apply m to the point (1, 0): a*1 + c*0 + e = a, b*1 + d*0 + f = b.
     // After a +90 deg rotation (1, 0) should land at (0, 1).
-    let x1 = m.a * 1.0 + m.c * 0.0 + m.e;
-    let y1 = m.b * 1.0 + m.d * 0.0 + m.f;
+    let x1 = m.a * 1.0 + m.c * 0.0 + m.e.to_f32();
+    let y1 = m.b * 1.0 + m.d * 0.0 + m.f.to_f32();
     approx(x1, 0.0, 1e-5, "rotate90.x");
     approx(y1, 1.0, 1e-5, "rotate90.y");
 }
@@ -94,8 +97,8 @@ fn rotate_90_at_default_center_origin_fixes_center() {
     // the fixed point of the rotation.
     let cx = 100.0 * 0.75 / 2.0;
     let cy = 100.0 * 0.75 / 2.0;
-    let x = m.a * cx + m.c * cy + m.e;
-    let y = m.b * cx + m.d * cy + m.f;
+    let x = m.a * cx + m.c * cy + m.e.to_f32();
+    let y = m.b * cx + m.d * cy + m.f.to_f32();
     approx(x, cx, 1e-4, "rotate90-center.x");
     approx(y, cy, 1e-4, "rotate90-center.y");
 }
@@ -109,8 +112,8 @@ fn scale_has_correct_diagonal() {
     approx(m.d, 3.0, 1e-5, "scale.d");
     approx(m.b, 0.0, 1e-5, "scale.b");
     approx(m.c, 0.0, 1e-5, "scale.c");
-    approx(m.e, 0.0, 1e-5, "scale.e");
-    approx(m.f, 0.0, 1e-5, "scale.f");
+    approx(m.e.to_f32(), 0.0, 1e-5, "scale.e");
+    approx(m.f.to_f32(), 0.0, 1e-5, "scale.f");
 }
 
 #[test]
@@ -126,8 +129,8 @@ fn matrix_preserved_with_origin_zero() {
             b: 2.0,
             c: 3.0,
             d: 4.0,
-            e: 5.0,
-            f: 6.0,
+            e: 5.0_f32.pt(),
+            f: 6.0_f32.pt(),
         }
     );
 }
@@ -151,8 +154,8 @@ fn composition_right_to_left() {
     let m = effective_matrix(&entry, 0.0, 0.0);
     // CSS transforms apply right-to-left: rotate first, then translate.
     // point (1, 0) -> rotate90 -> (0, 1) -> translate(10, 0) -> (10, 1).
-    let x = m.a * 1.0 + m.c * 0.0 + m.e;
-    let y = m.b * 1.0 + m.d * 0.0 + m.f;
+    let x = m.a * 1.0 + m.c * 0.0 + m.e.to_f32();
+    let y = m.b * 1.0 + m.d * 0.0 + m.f.to_f32();
     approx(x, 10.0, 1e-4, "compose.x");
     approx(y, 1.0, 1e-4, "compose.y");
 }

--- a/crates/fulgur/tests/transform_integration.rs
+++ b/crates/fulgur/tests/transform_integration.rs
@@ -32,8 +32,8 @@ fn entry_from(html: &str) -> TransformEntry {
 /// composition: translate the origin into the draw frame, conjugate the
 /// raw matrix by it, so rotation / scale happen around the chosen origin.
 fn effective_matrix(entry: &TransformEntry, draw_x: f32, draw_y: f32) -> Affine2D {
-    let ox = draw_x + entry.origin.x;
-    let oy = draw_y + entry.origin.y;
+    let ox = draw_x + entry.origin.x.to_f32();
+    let oy = draw_y + entry.origin.y.to_f32();
     Affine2D::translation(ox, oy) * entry.matrix * Affine2D::translation(-ox, -oy)
 }
 

--- a/docs/plans/2026-07-01-transform-affine-point2-units.md
+++ b/docs/plans/2026-07-01-transform-affine-point2-units.md
@@ -1,0 +1,326 @@
+# Transform Affine2D + Point2 を typed units に移行 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** `Affine2D.{e,f}`（transform matrix の translate 成分）と `Point2.{x,y}`（transform-origin）を bare `f32` / legacy `type Pt = f32` alias から `units::Pt` newtype に移行し、現挙動を 1 byte も変えない（byte-neutral）。
+
+**Architecture:** transform pipeline は実体として全部 pt 空間で self-consistent に動作している（`compute_transform` は pt dims を渡され、render は ×0.75 せず pt として直接消費）。「fold は存在しない」と認め、translate 成分と origin を `Pt` で型付けする。`a,b,c,d` は無次元のため f32 据え置き。ripple は `transform_point`/`to_krilla`/FFI 境界で `.to_f32()` untag、producer 境界で `.pt()` tag に封じ込める。
+
+**Tech Stack:** Rust, `crate::units::{Pt, F32Units}`（`#[repr(transparent)]` newtype, 演算子 impl, `Pt::ZERO`/`Pt::abs`）, krilla, Stylo computed values。
+
+---
+
+## 不変条件（全 Task で厳守）
+
+1. **byte-neutral**: `.in_pt()` / ×0.75 を一切入れない。`compute_transform` の dims 入力（`size_in_pt` = pt）を変えない。Stylo の `.resolve(..).px()`（f32 抽出）に `.pt()` を足すだけ（tag であって変換ではない）。
+2. **Mul / 式構造を 1:1 保持**: `Affine2D::Mul` の式を再結合しない（f32 丸めが変わる）。`f32 * Pt → Pt`（commutative impl）、`Pt + Pt → Pt` に自然に乗る。
+3. **「goldens pass ≠ behavior 不変」**: 絶対長 translate(例 `translate(20px)`)は golden 未カバーの可能性が高い。`.in_pt()` を 1 箇所でも誤って入れると goldens 緑のまま behavior が変わる。**証明は VRT golden の byte-identical**（`FULGUR_VRT_UPDATE` なし）。
+4. 潜在 4/3 バグ（絶対長 translate の過大シフト）は**この issue では是正しない**。Task 4 で別 issue 起票。
+
+---
+
+## Task 1: `Point2` を `units::Pt` に移行
+
+`Point2` は transform-origin 専用。legacy `type Pt = f32` alias から `units::Pt` に切替。`Affine2D` はこの Task では f32 のまま（独立にコンパイル可能）。
+
+**Files:**
+- Modify: `crates/fulgur/src/draw_primitives.rs:229-239`（`Point2` struct + `Point2::new`）
+- Modify: `crates/fulgur/src/blitz_adapter.rs:2913-2920`（`compute_transform` の origin 構築）
+- Modify: `crates/fulgur/src/render.rs:1325-1326`（`draw_under_transform` の `tx.origin` 読み出し）
+- Modify: `crates/fulgur/src/render.rs:4621`（test default `Point2 { x:0.0, y:0.0 }`）
+
+**Step 1: `Point2` を units::Pt に**
+
+`draw_primitives.rs` の `Point2`（現在 `pub x: Pt` = legacy alias）を:
+
+```rust
+/// A 2D point in user-space coordinates (PDF pt).
+///
+/// Used only for `transform-origin` (`drawables::TransformEntry.origin`).
+/// The value is the box-local origin already in pt space — `compute_transform`
+/// is fed pt-valued box dims, so no px→pt fold happens. **Do not add
+/// `.in_pt()`**: that would scale an already-pt value by 0.75.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Point2 {
+    pub x: crate::units::Pt,
+    pub y: crate::units::Pt,
+}
+
+impl Point2 {
+    pub const fn new(x: crate::units::Pt, y: crate::units::Pt) -> Self {
+        Self { x, y }
+    }
+}
+```
+
+**Step 2: `compute_transform` の origin を tag**
+
+`blitz_adapter.rs:2913-2920` — `.px()`（Stylo の f32 抽出）に `.pt()` を足す。`use crate::units::F32Units;` を関数スコープか module 先頭に追加:
+
+```rust
+    let origin = styles.clone_transform_origin();
+    let origin_x = origin.horizontal.resolve(Length::new(border_box_width)).px().pt();
+    let origin_y = origin.vertical.resolve(Length::new(border_box_height)).px().pt();
+
+    Some((m, Point2::new(origin_x, origin_y)))
+```
+
+（`use crate::units::F32Units;` を `compute_transform` 冒頭に追加。`.px()` は Stylo `Length` の inherent method、`.pt()` は f32 の trait method で衝突しない。）
+
+**Step 3: `draw_under_transform` の origin 読み出しを untag**
+
+`render.rs:1325-1326`:
+
+```rust
+    let ox = x_pt + tx.origin.x.to_f32();
+    let oy = y_pt + tx.origin.y.to_f32();
+```
+
+**Step 4: test default を修正**
+
+`render.rs:4621`（private field のため struct literal 不可）:
+
+```rust
+                origin: crate::draw_primitives::Point2::new(
+                    crate::units::Pt::ZERO,
+                    crate::units::Pt::ZERO,
+                ),
+```
+
+**Step 5: ビルド**
+
+Run: `cargo build -p fulgur`
+Expected: コンパイル成功（他の Point2 利用箇所が無いことは grep 済み）
+
+**Step 6: transform テスト**
+
+Run: `cargo test -p fulgur --test transform_integration`
+Expected: 全 PASS（origin の値は不変なので byte-neutral）
+
+**Step 7: コミット**
+
+```bash
+git add crates/fulgur/src/draw_primitives.rs crates/fulgur/src/blitz_adapter.rs crates/fulgur/src/render.rs
+git commit -m "refactor(transform): type Point2 (transform-origin) with units::Pt (byte-neutral)"
+```
+
+---
+
+## Task 2: `Affine2D.{e,f}` を `units::Pt` に移行
+
+`a,b,c,d` は無次元 f32 据え置き、`e,f`（translate）を `units::Pt` に。
+
+**Files:**
+- Modify: `crates/fulgur/src/draw_primitives.rs:98-223`（`Affine2D` struct + impl + Mul）
+- Modify: `crates/fulgur/src/blitz_adapter.rs:2923-2968`（`op_to_matrix`: translation/Matrix arm）
+- Modify: `crates/fulgur/src/render.rs:1328`（`draw_under_transform` の translation 構築）
+- Modify: `crates/fulgur/src/paragraph.rs:839`（image link の translation）
+- Modify: `crates/fulgur/src/draw_primitives.rs:1920-1926`（既存 Affine2D 単体テスト）
+- Verify-only: `crates/fulgur/src/link.rs`（LinkCollector の Affine2D 合成は Mul 経由で自動対応、変更不要のはず）
+
+**Step 1: `Affine2D` struct + impl を型付け**
+
+`draw_primitives.rs`:
+
+```rust
+pub struct Affine2D {
+    pub a: f32,
+    pub b: f32,
+    pub c: f32,
+    pub d: f32,
+    /// Translate-x. **pt 空間の値**（px→pt fold の結果ではなく、pt-basis hack の
+    /// 出力を pt として扱っているだけ）。**`.in_pt()` を足すな** — byte が変わる。
+    pub e: crate::units::Pt,
+    pub f: crate::units::Pt,
+}
+
+impl Affine2D {
+    pub const IDENTITY: Self = Self {
+        a: 1.0, b: 0.0, c: 0.0, d: 1.0,
+        e: crate::units::Pt::ZERO,
+        f: crate::units::Pt::ZERO,
+    };
+
+    const IDENTITY_EPS: f32 = 1e-5;
+
+    pub fn is_identity(&self) -> bool {
+        (self.a - 1.0).abs() < Self::IDENTITY_EPS
+            && self.b.abs() < Self::IDENTITY_EPS
+            && self.c.abs() < Self::IDENTITY_EPS
+            && (self.d - 1.0).abs() < Self::IDENTITY_EPS
+            && self.e.to_f32().abs() < Self::IDENTITY_EPS
+            && self.f.to_f32().abs() < Self::IDENTITY_EPS
+    }
+
+    pub fn translation(tx: crate::units::Pt, ty: crate::units::Pt) -> Self {
+        Self { a: 1.0, b: 0.0, c: 0.0, d: 1.0, e: tx, f: ty }
+    }
+
+    pub fn scale(sx: f32, sy: f32) -> Self {
+        Self { a: sx, b: 0.0, c: 0.0, d: sy, e: crate::units::Pt::ZERO, f: crate::units::Pt::ZERO }
+    }
+
+    pub fn rotation(theta_rad: f32) -> Self {
+        let (s, c) = theta_rad.sin_cos();
+        Self { a: c, b: s, c: -s, d: c, e: crate::units::Pt::ZERO, f: crate::units::Pt::ZERO }
+    }
+
+    pub fn skew(ax_rad: f32, ay_rad: f32) -> Self {
+        Self { a: 1.0, b: ay_rad.tan(), c: ax_rad.tan(), d: 1.0, e: crate::units::Pt::ZERO, f: crate::units::Pt::ZERO }
+    }
+
+    pub fn to_krilla(&self) -> krilla::geom::Transform {
+        krilla::geom::Transform::from_row(self.a, self.b, self.c, self.d, self.e.to_f32(), self.f.to_f32())
+    }
+
+    pub fn transform_point(&self, x: f32, y: f32) -> (f32, f32) {
+        (
+            self.a * x + self.c * y + self.e.to_f32(),
+            self.b * x + self.d * y + self.f.to_f32(),
+        )
+    }
+    // transform_rect は transform_point を呼ぶだけ → 変更不要
+}
+```
+
+**Step 2: `Mul` impl — 式構造 1:1 保持**
+
+`draw_primitives.rs:213-222`。`a,c` は f32, `rhs.e,rhs.f,self.e,self.f` は Pt。`f32 * Pt → Pt`、`Pt + Pt → Pt` に自然に乗る。**式を一切いじらない**:
+
+```rust
+            e: self.a * rhs.e + self.c * rhs.f + self.e,
+            f: self.b * rhs.e + self.d * rhs.f + self.f,
+```
+
+（a,b,c,d の行はそのまま f32 演算。)
+
+**Step 3: `op_to_matrix` を tag**
+
+`blitz_adapter.rs:2940-2945`。`use crate::units::F32Units;`（Task 1 で追加済みなら不要）。`.px()`（Stylo f32 抽出）に `.pt()`:
+
+```rust
+        Translate(x, y) => Affine2D::translation(
+            x.resolve(Length::new(w)).px().pt(),
+            y.resolve(Length::new(h)).px().pt(),
+        ),
+        TranslateX(x) => Affine2D::translation(x.resolve(Length::new(w)).px().pt(), 0.0_f32.pt()),
+        TranslateY(y) => Affine2D::translation(0.0_f32.pt(), y.resolve(Length::new(h)).px().pt()),
+```
+
+`Matrix(m)` arm（`m.e`,`m.f` は f32）:
+
+```rust
+        Matrix(m) => Affine2D { a: m.a, b: m.b, c: m.c, d: m.d, e: m.e.pt(), f: m.f.pt() },
+```
+
+**Step 4: `draw_under_transform` の translation を tag**
+
+`render.rs:1328`（`ox`,`oy` は f32 local のまま、引数を tag）:
+
+```rust
+    let full = Affine2D::translation(ox.pt(), oy.pt()) * tx.matrix * Affine2D::translation((-ox).pt(), (-oy).pt());
+```
+
+**Step 5: paragraph.rs の image translation を tag**
+
+`paragraph.rs:839`:
+
+```rust
+                        let link_affine =
+                            crate::draw_primitives::Affine2D::translation(off_x.pt(), off_y.pt());
+```
+
+**Step 6: 既存 Affine2D 単体テストを typed API に更新**
+
+`draw_primitives.rs:1925-1926`（`composed.e - 4.0` → untag）:
+
+```rust
+        assert!((composed.e.to_f32() - 4.0).abs() < 1e-5);
+        assert!((composed.f.to_f32() - 2.0).abs() < 1e-5);
+```
+
+その他の Affine2D テスト（`translation(..)` 呼び出し、`.e`/`.f` 比較）も同様に `0.0_f32.pt()` で構築、`.to_f32()` で untag。`cargo build --tests` のエラーに沿って機械的に修正。
+
+**Step 7: ビルド（lib + tests）**
+
+Run: `cargo build -p fulgur --tests`
+Expected: コンパイル成功。`link.rs` が変更不要でコンパイルできることを確認（LinkCollector の Affine2D 合成は Mul で自動対応）。エラーが出たら untag(`.to_f32()`)/tag(`.pt()`)を該当箇所に追加。
+
+**Step 8: lib + integration テスト**
+
+Run: `cargo test -p fulgur`
+Expected: 全 PASS（Affine2D の math は repr(transparent) + inline で f32 と同一機械語、値不変）
+
+**Step 9: コミット**
+
+```bash
+git add crates/fulgur/src/draw_primitives.rs crates/fulgur/src/blitz_adapter.rs crates/fulgur/src/render.rs crates/fulgur/src/paragraph.rs
+git commit -m "refactor(transform): type Affine2D translate components (e,f) with units::Pt (byte-neutral)"
+```
+
+---
+
+## Task 3: docs 訂正 + footgun note + byte-neutral 証明
+
+**Files:**
+- Modify: `.claude/rules/coordinate-system.md`（`compute_transform` exception 節 — stale）
+
+**Step 1: coordinate-system.md の stale 記述を訂正**
+
+`compute_transform` の節は「px-in / px-out、convert で後段 fold」と書いてあるが、実体は「pt dims を渡し、render は ×0.75 せず pt 消費」。実態に合わせて訂正し、translate `e,f` と origin が pt-basis hack の出力（fold は存在しない）であること、`.in_pt()` を足すと 4/3 になることを明記。絶対長 translate の 4/3 潜在バグを別 issue として参照。
+
+**Step 2: fmt + clippy**
+
+Run: `cargo fmt -p fulgur` then `cargo fmt --check`
+Run: `cargo clippy -p fulgur --all-targets`
+Expected: フォーマット整合、clippy 警告なし
+
+**Step 3: codecov patch coverage 確認**
+
+`transform_integration.rs`（通常の integration test、codecov 対象）が `compute_transform` / `draw_under_transform` の typed 経路を踏むことを確認。新たに公開された typed surface（`Affine2D::translation(Pt,Pt)` 等）が lib 側で未カバーなら、`draw_primitives.rs` の `#[cfg(test)]` に unit test を追加。`.to_f32()` を assert 引数に直書きすると patch coverage の region アーティファクトになる（`project_units_migration_patch_coverage.md`）ので、値を変数に束縛してから assert する。
+
+**Step 4: byte-neutral 証明（load-bearing）**
+
+Run: `FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur-vrt`
+Expected: 全 PASS（**`FULGUR_VRT_UPDATE` は付けない**）。golden 差分が出たら byte-neutral 違反 = どこかで `.in_pt()` を誤って入れた or Mul を再結合した。
+
+Run: `cargo test -p fulgur-cli --test examples_determinism`（存在すれば）
+Expected: PASS（run-twice 自己比較。nondeterminism 検出用）
+
+**Step 5: コミット**
+
+```bash
+git add .claude/rules/coordinate-system.md crates/fulgur/src/draw_primitives.rs
+git commit -m "docs(coordinate-system): correct compute_transform px/pt note; transform fold is pt-basis hack not a fold"
+```
+
+---
+
+## Task 4: 4/3 絶対長 translate 是正の follow-up issue 起票
+
+byte-neutral スコープ外の behavior 修正を別 issue に切り出す。
+
+**Step 1: issue 起票**
+
+```bash
+bd create --title="Fix 4/3 over-translation for absolute-length CSS transform translate" \
+  --type=bug --priority=2 \
+  --description="compute_transform is fed pt-valued box dims and Stylo's .px() extraction is consumed as pt without x0.75. % translate and 50% origin round-trip correctly, but absolute-length translate (e.g. translate(20px)) shifts 20pt = 26.67px instead of the correct 20px = 15pt — a 4/3 over-shift. Fixing requires feeding px dims and folding px->pt, which changes PDF bytes (golden/VRT updates). Spun out of fulgur-1ino (byte-neutral typing migration)."
+```
+
+（`--description` は eval 経由なので backtick を含めない / 必要ならファイル経由。）
+
+**Step 2: 確認**
+
+Run: `bd show <new-id>`
+Expected: issue 作成確認
+
+---
+
+## 完了条件（受け入れ基準）
+
+- VRT golden が `FULGUR_VRT_UPDATE` なしで byte-identical
+- `cargo test -p fulgur` 全 PASS、`cargo clippy` / `cargo fmt --check` clean
+- `draw_primitives::Pt`(legacy alias) の `Point2` 利用が消えた（`Affine2D` も alias 非依存）
+- `coordinate-system.md` の compute_transform 記述が実態と一致
+- 4/3 是正の follow-up issue が起票済み


### PR DESCRIPTION
## 概要

`fulgur-1ino`。CSS `transform` パイプラインの座標を bare `f32` / レガシー `type Pt = f32` エイリアスから `units::Pt` newtype に移行する **byte-neutral**（PDF 出力バイト不変）な型付け作業です。`fulgur-2map` エピック（`Engine::layout()` 公開に向けた Px/Pt newtype 基盤）の一部で、P1a からスピンアウトされました。

- `Point2`（transform-origin）の `x`/`y` → `units::Pt`
- `Affine2D` の translate 成分 `e`/`f` → `units::Pt`（`a,b,c,d` は無次元のため `f32` 据え置き）

## 核心の発見: 「fold」は実体として存在しない

issue と `coordinate-system.md` は「`compute_transform` は CSS px 入力・px 出力、`convert` で後段 pt に fold」と記述していましたが、**実際のコードではこの契約は成立していませんでした**。`record_transform` は `size_in_pt`(pt) を渡し、`render::draw_under_transform` は ×0.75 せず pt として直接消費する self-consistent な hack です。

つまり本作業の実装的な意味は「fold は無い、全部 pt だと認め `Pt` で型付けする」であり、`.in_pt()`（reinterpret hatch）は不要でした。producer 境界（Stylo の `.px()` 抽出直後）で `.pt()` tag、consumer 境界（`to_krilla` / `transform_point` / render の origin 読み出し）で `.to_f32()` untag に ripple を封じ込めています。

## byte-neutral の担保

型付けのみで、`.in_pt()` / ×0.75 は一切導入していません（diff 内の `in_pt`/`0.75` の出現は doc の footgun 警告のみ）。`Affine2D::Mul` の `e`/`f` 式は再結合せず逐語保存（`f32*Pt→Pt`、`Pt+Pt→Pt` に自然に乗る）。

- ✅ **VRT golden byte-identical**（`FULGUR_VRT_UPDATE` なし、31 reftests）= load-bearing な byte-neutral 証明
- ✅ `cargo test -p fulgur` 全 PASS（lib 1542 + integration）。`transform_integration::translate_px` が実 `compute_transform` 経路で `m.e == 10.0` を assert し、VRT が踏めない絶対長 translate 経路を guard（`.in_pt()` が紛れれば 7.5 になり失敗する）
- ✅ `examples_determinism` PASS、clippy / fmt / markdownlint clean

## 変更内容

| commit | 内容 |
|--------|------|
| `Point2` | transform-origin を `units::Pt` に |
| `Affine2D` | matrix translate `e,f` を `units::Pt` に、`a,b,c,d` は f32 |
| docs | `coordinate-system.md` の compute_transform 記述を実態（pt-basis hack、fold なし）に訂正。隣接の「Stylo length-percentage resolution」節の矛盾する例も修正 |
| plan | 実装 plan を `docs/plans/` に追加 |

## スコープ外 / 派生 issue

絶対長 translate（例 `translate(20px)`）は現状 20pt シフト＝本来 15pt に対し **4/3 過大**という pre-existing な潜在バグがあります（`%` translate と `50%` origin は正しい）。是正には px 入力＋px→pt fold が必要で PDF 出力バイトが変わる **behavior 変更**のため、本 PR のスコープ外とし別 issue **`fulgur-9vw5`** に切り出しました（`discovered-from` リンク済み）。本 PR の `units::Pt` 型付けは現状の pt reality を反映するもので、この挙動を変えも直しもしません。

## Test Plan

- [x] VRT golden byte-identical（`FONTCONFIG_FILE=… cargo test -p fulgur-vrt`、UPDATE なし）
- [x] `cargo test -p fulgur` 全 PASS
- [x] `cargo clippy` / `cargo fmt --check` clean
- [x] `examples_determinism` PASS
