### PR TITLE
P2a: Remove type Pt=f32 alias (incl. Rect)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ HTML string → Blitz (parse/style/layout) → Drawables / PaginationGeometryTab
 - **engine.rs** — `Engine` builder: configures and executes `render_html()`
 - **blitz_adapter.rs** — Thin adapter isolating Blitz API changes from the rest of the codebase
 - **convert.rs** — Transforms Blitz DOM nodes into `Drawables` and geometry records
-- **draw_primitives.rs** — Primitive geometry, canvas, style, and drawing-helper types (`Pt`, `Size`, `Rect`, `Canvas`, `BlockStyle`, background/gradient types, etc.)
+- **draw_primitives.rs** — Primitive geometry, canvas, style, and drawing-helper types (`Size`, `Rect`, `Canvas`, `BlockStyle`, background/gradient types, etc.)
 - **drawables.rs** — `Drawables` struct: flat per-node draw payloads (`BlockDraw`, `ParagraphDraw`, `ImageDraw`, etc.) used by the v2 render path
 - **paginate.rs** — Page splitting algorithm that walks the `PaginationGeometryTable`
 - **render.rs** — Draws paginated fragments onto Krilla surfaces via `render_v2`

--- a/crates/fulgur/src/convert/list_marker.rs
+++ b/crates/fulgur/src/convert/list_marker.rs
@@ -34,14 +34,14 @@ fn size_raster_marker(
     data: &Arc<Vec<u8>>,
     format: crate::image::ImageFormat,
     line_height: f32,
-) -> Option<(f32, f32)> {
+) -> Option<(crate::units::Pt, crate::units::Pt)> {
     let (iw, ih) = ImageRender::decode_dimensions(data, format)?;
-    let intrinsic_w = px_to_pt(iw as f32);
-    let intrinsic_h = px_to_pt(ih as f32);
+    let intrinsic_w = px_to_pt(iw as f32).pt();
+    let intrinsic_h = px_to_pt(ih as f32).pt();
     Some(crate::draw_primitives::clamp_marker_size(
         intrinsic_w,
         intrinsic_h,
-        line_height,
+        line_height.pt(),
     ))
 }
 
@@ -74,35 +74,38 @@ pub(super) fn resolve_list_marker(
             let entry = crate::drawables::ImageEntry {
                 image_data: Arc::clone(data),
                 format,
-                width: width.pt(),
-                height: height.pt(),
+                width,
+                height,
                 opacity: 1.0,
                 visible: true,
             };
             Some(ListItemMarker::Image {
                 marker: ImageMarker::Raster(entry),
-                width: width.pt(),
-                height: height.pt(),
+                width,
+                height,
             })
         }
         AssetKind::Svg => {
             let tree = usvg::Tree::from_data(data, &usvg::Options::default()).ok()?;
             let size = tree.size();
-            let intrinsic_w = px_to_pt(size.width());
-            let intrinsic_h = px_to_pt(size.height());
-            let (width, height) =
-                crate::draw_primitives::clamp_marker_size(intrinsic_w, intrinsic_h, line_height);
+            let intrinsic_w = px_to_pt(size.width()).pt();
+            let intrinsic_h = px_to_pt(size.height()).pt();
+            let (width, height) = crate::draw_primitives::clamp_marker_size(
+                intrinsic_w,
+                intrinsic_h,
+                line_height.pt(),
+            );
             let entry = crate::drawables::SvgEntry {
                 tree: Arc::new(tree),
-                width: width.pt(),
-                height: height.pt(),
+                width,
+                height,
                 opacity: 1.0,
                 visible: true,
             };
             Some(ListItemMarker::Image {
                 marker: ImageMarker::Svg(entry),
-                width: width.pt(),
-                height: height.pt(),
+                width,
+                height,
             })
         }
         AssetKind::Unknown => None,
@@ -137,8 +140,8 @@ pub(super) fn resolve_inside_image_marker(
             Some(InlineImage {
                 data: Arc::clone(data),
                 format,
-                width: width.pt(),
-                height: height.pt(),
+                width,
+                height,
                 x_offset: crate::units::Pt::ZERO,
                 vertical_align: VerticalAlign::Baseline,
                 opacity: 1.0,
@@ -426,6 +429,7 @@ mod tests {
         let result = size_raster_marker(&sample_png_arc(), ImageFormat::Png, 12.0);
         assert!(result.is_some());
         let (w, h) = result.unwrap();
+        let (w, h) = (w.to_f32(), h.to_f32());
         assert!((w - 0.75).abs() < 1e-4, "expected w≈0.75, got {w}");
         assert!((h - 0.75).abs() < 1e-4, "expected h≈0.75, got {h}");
     }
@@ -444,6 +448,7 @@ mod tests {
         let result = size_raster_marker(&sample_png_arc(), ImageFormat::Png, 0.5);
         assert!(result.is_some());
         let (w, h) = result.unwrap();
+        let (w, h) = (w.to_f32(), h.to_f32());
         assert!((h - 0.5).abs() < 1e-4, "expected h≈0.5, got {h}");
         assert!((w - 0.5).abs() < 1e-4, "expected w≈0.5, got {w}");
     }

--- a/crates/fulgur/src/draw_primitives.rs
+++ b/crates/fulgur/src/draw_primitives.rs
@@ -940,7 +940,7 @@ impl BlockStyle {
 #[derive(Debug, Clone, PartialEq)]
 pub struct BookmarkEntry {
     pub page_idx: usize,
-    pub y_pt: Pt,
+    pub y_pt: crate::units::Pt,
     pub level: u8,
     pub label: String,
 }
@@ -963,7 +963,7 @@ impl BookmarkCollector {
         self.current_page_idx = idx;
     }
 
-    pub fn record(&mut self, level: u8, label: String, y_pt: Pt) {
+    pub fn record(&mut self, level: u8, label: String, y_pt: crate::units::Pt) {
         self.entries.push(BookmarkEntry {
             page_idx: self.current_page_idx,
             y_pt,
@@ -2144,16 +2144,16 @@ mod dp_unit_tests {
     fn bookmark_collector_records_on_correct_page() {
         let mut bc = BookmarkCollector::new();
         bc.set_current_page(2);
-        bc.record(1, "Chapter One".to_string(), 100.0);
+        bc.record(1, "Chapter One".to_string(), 100.0.pt());
         bc.set_current_page(5);
-        bc.record(2, "Section 5.1".to_string(), 42.0);
+        bc.record(2, "Section 5.1".to_string(), 42.0.pt());
 
         let entries = bc.into_entries();
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].page_idx, 2);
         assert_eq!(entries[0].level, 1);
         assert_eq!(entries[0].label, "Chapter One");
-        assert!((entries[0].y_pt - 100.0).abs() < 1e-5);
+        assert!((entries[0].y_pt.to_f32() - 100.0).abs() < 1e-5);
         assert_eq!(entries[1].page_idx, 5);
         assert_eq!(entries[1].level, 2);
         assert_eq!(entries[1].label, "Section 5.1");

--- a/crates/fulgur/src/draw_primitives.rs
+++ b/crates/fulgur/src/draw_primitives.rs
@@ -78,9 +78,6 @@ impl DestinationRegistry {
     }
 }
 
-/// Point unit (1/72 inch)
-pub type Pt = f32;
-
 #[derive(Debug, Clone, Copy)]
 pub struct Size {
     pub width: crate::units::Pt,

--- a/crates/fulgur/src/draw_primitives.rs
+++ b/crates/fulgur/src/draw_primitives.rs
@@ -202,10 +202,10 @@ impl Affine2D {
     /// transformed individually, preserving the krilla quad-point order:
     /// bottom-left → bottom-right → top-right → top-left.
     pub fn transform_rect(&self, r: &Rect) -> Quad {
-        let x0 = r.x;
-        let y0 = r.y;
-        let x1 = r.x + r.width;
-        let y1 = r.y + r.height;
+        let x0 = r.x.to_f32();
+        let y0 = r.y.to_f32();
+        let x1 = (r.x + r.width).to_f32();
+        let y1 = (r.y + r.height).to_f32();
         let bl = self.transform_point(x0, y1);
         let br = self.transform_point(x1, y1);
         let tr = self.transform_point(x1, y0);
@@ -279,10 +279,10 @@ pub enum BreakInside {
 /// top-left corner.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Rect {
-    pub x: f32,
-    pub y: f32,
-    pub width: f32,
-    pub height: f32,
+    pub x: crate::units::Pt,
+    pub y: crate::units::Pt,
+    pub width: crate::units::Pt,
+    pub height: crate::units::Pt,
 }
 
 /// Four-point quadrilateral for transformed link areas.
@@ -403,7 +403,7 @@ impl LinkCollector {
         // Skip degenerate rects (non-positive width or height) to match the
         // filtering the old `rect_to_quad` helper performed via
         // `KRect::from_xywh`, which rejects them.
-        if rect.width <= 0.0 || rect.height <= 0.0 {
+        if rect.width <= crate::units::Pt::ZERO || rect.height <= crate::units::Pt::ZERO {
             return;
         }
         let quad = self.current_transform().transform_rect(&rect);
@@ -1638,10 +1638,10 @@ mod dp_unit_tests {
         collector.push_rect(
             &link,
             Rect {
-                x: 0.0,
-                y: 0.0,
-                width: 10.0,
-                height: 10.0,
+                x: 0.0.pt(),
+                y: 0.0.pt(),
+                width: 10.0.pt(),
+                height: 10.0.pt(),
             },
         );
 
@@ -1661,19 +1661,19 @@ mod dp_unit_tests {
         collector.push_rect(
             &link,
             Rect {
-                x: 0.0,
-                y: 0.0,
-                width: 0.0,
-                height: 10.0,
+                x: 0.0.pt(),
+                y: 0.0.pt(),
+                width: 0.0.pt(),
+                height: 10.0.pt(),
             },
         );
         collector.push_rect(
             &link,
             Rect {
-                x: 0.0,
-                y: 0.0,
-                width: 10.0,
-                height: 0.0,
+                x: 0.0.pt(),
+                y: 0.0.pt(),
+                width: 10.0.pt(),
+                height: 0.0.pt(),
             },
         );
         assert!(collector.occurrences().is_empty());
@@ -1688,10 +1688,10 @@ mod dp_unit_tests {
         collector.push_rect(
             &link,
             Rect {
-                x: 0.0,
-                y: 0.0,
-                width: 10.0,
-                height: 10.0,
+                x: 0.0.pt(),
+                y: 0.0.pt(),
+                width: 10.0.pt(),
+                height: 10.0.pt(),
             },
         );
         collector.pop_transform();
@@ -1958,10 +1958,10 @@ mod dp_unit_tests {
     #[test]
     fn affine2d_transform_rect_identity_is_noop() {
         let r = Rect {
-            x: 2.0,
-            y: 3.0,
-            width: 4.0,
-            height: 5.0,
+            x: 2.0.pt(),
+            y: 3.0.pt(),
+            width: 4.0.pt(),
+            height: 5.0.pt(),
         };
         let q = Affine2D::IDENTITY.transform_rect(&r);
         // bottom-left, bottom-right, top-right, top-left in Y-down coords
@@ -1978,10 +1978,10 @@ mod dp_unit_tests {
     #[test]
     fn affine2d_transform_rect_translation_shifts_all_corners() {
         let r = Rect {
-            x: 0.0,
-            y: 0.0,
-            width: 10.0,
-            height: 5.0,
+            x: 0.0.pt(),
+            y: 0.0.pt(),
+            width: 10.0.pt(),
+            height: 5.0.pt(),
         };
         let t = Affine2D::translation(2.0_f32.pt(), 3.0_f32.pt());
         let q = t.transform_rect(&r);
@@ -2192,20 +2192,20 @@ mod dp_unit_tests {
         collector.push_rect(
             &link,
             Rect {
-                x: 0.0,
-                y: 0.0,
-                width: 10.0,
-                height: 5.0,
+                x: 0.0.pt(),
+                y: 0.0.pt(),
+                width: 10.0.pt(),
+                height: 5.0.pt(),
             },
         );
         collector.set_current_page(2);
         collector.push_rect(
             &link,
             Rect {
-                x: 0.0,
-                y: 0.0,
-                width: 20.0,
-                height: 5.0,
+                x: 0.0.pt(),
+                y: 0.0.pt(),
+                width: 20.0.pt(),
+                height: 5.0.pt(),
             },
         );
 
@@ -2236,20 +2236,20 @@ mod dp_unit_tests {
         collector.push_rect(
             &link,
             Rect {
-                x: 0.0,
-                y: 0.0,
-                width: 10.0,
-                height: 5.0,
+                x: 0.0.pt(),
+                y: 0.0.pt(),
+                width: 10.0.pt(),
+                height: 5.0.pt(),
             },
         );
         collector.set_current_page(1);
         collector.push_rect(
             &link,
             Rect {
-                x: 5.0,
-                y: 0.0,
-                width: 10.0,
-                height: 5.0,
+                x: 5.0.pt(),
+                y: 0.0.pt(),
+                width: 10.0.pt(),
+                height: 5.0.pt(),
             },
         );
 
@@ -2355,10 +2355,10 @@ mod dp_unit_tests {
         collector.push_rect(
             &link,
             Rect {
-                x: 0.0,
-                y: 0.0,
-                width: 10.0,
-                height: 10.0,
+                x: 0.0.pt(),
+                y: 0.0.pt(),
+                width: 10.0.pt(),
+                height: 10.0.pt(),
             },
         );
 
@@ -2373,10 +2373,10 @@ mod dp_unit_tests {
         collector.push_rect(
             &link,
             Rect {
-                x: 20.0,
-                y: 0.0,
-                width: 10.0,
-                height: 10.0,
+                x: 20.0.pt(),
+                y: 0.0.pt(),
+                width: 10.0.pt(),
+                height: 10.0.pt(),
             },
         );
 

--- a/crates/fulgur/src/draw_primitives.rs
+++ b/crates/fulgur/src/draw_primitives.rs
@@ -1581,18 +1581,18 @@ pub(crate) fn draw_block_border(
 /// Returns `(width, height)` in pt. If the intrinsic height is zero, both
 /// return values are zero (avoids division by zero for malformed images).
 pub(crate) fn clamp_marker_size(
-    intrinsic_width: Pt,
-    intrinsic_height: Pt,
-    line_height: Pt,
-) -> (Pt, Pt) {
-    if intrinsic_height <= 0.0 {
-        return (0.0, 0.0);
+    intrinsic_width: crate::units::Pt,
+    intrinsic_height: crate::units::Pt,
+    line_height: crate::units::Pt,
+) -> (crate::units::Pt, crate::units::Pt) {
+    if intrinsic_height <= crate::units::Pt::ZERO {
+        return (crate::units::Pt::ZERO, crate::units::Pt::ZERO);
     }
     if intrinsic_height <= line_height {
         (intrinsic_width, intrinsic_height)
     } else {
-        let scale = line_height / intrinsic_height;
-        (intrinsic_width * scale, line_height)
+        let scale = line_height / intrinsic_height; // Pt / Pt = f32
+        (intrinsic_width * scale, line_height) // Pt * f32 = Pt
     }
 }
 
@@ -1866,31 +1866,31 @@ mod dp_unit_tests {
 
     #[test]
     fn clamp_marker_size_zero_height_returns_zero_zero() {
-        let (w, h) = clamp_marker_size(20.0, 0.0, 12.0);
-        assert_eq!(w, 0.0);
-        assert_eq!(h, 0.0);
+        let (w, h) = clamp_marker_size(20.0.pt(), 0.0.pt(), 12.0.pt());
+        assert_eq!(w, crate::units::Pt::ZERO);
+        assert_eq!(h, crate::units::Pt::ZERO);
     }
 
     #[test]
     fn clamp_marker_size_negative_height_returns_zero_zero() {
-        let (w, h) = clamp_marker_size(20.0, -5.0, 12.0);
-        assert_eq!(w, 0.0);
-        assert_eq!(h, 0.0);
+        let (w, h) = clamp_marker_size(20.0.pt(), (-5.0).pt(), 12.0.pt());
+        assert_eq!(w, crate::units::Pt::ZERO);
+        assert_eq!(h, crate::units::Pt::ZERO);
     }
 
     #[test]
     fn clamp_marker_size_within_line_height_passes_through() {
-        let (w, h) = clamp_marker_size(20.0, 10.0, 12.0);
-        assert_eq!(w, 20.0);
-        assert_eq!(h, 10.0);
+        let (w, h) = clamp_marker_size(20.0.pt(), 10.0.pt(), 12.0.pt());
+        assert_eq!(w.to_f32(), 20.0);
+        assert_eq!(h.to_f32(), 10.0);
     }
 
     #[test]
     fn clamp_marker_size_oversized_scales_down_preserving_aspect() {
         // intrinsic 40×20, line_height 10 → scale = 0.5 → (20, 10).
-        let (w, h) = clamp_marker_size(40.0, 20.0, 10.0);
-        assert!((w - 20.0).abs() < 1e-5);
-        assert!((h - 10.0).abs() < 1e-5);
+        let (w, h) = clamp_marker_size(40.0.pt(), 20.0.pt(), 10.0.pt());
+        assert!((w.to_f32() - 20.0).abs() < 1e-5);
+        assert!((h.to_f32() - 10.0).abs() < 1e-5);
     }
 
     // ── Affine2D math ───────────────────────────────────────

--- a/crates/fulgur/src/draw_primitives.rs
+++ b/crates/fulgur/src/draw_primitives.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use crate::image::ImageFormat;
+use crate::units::F32Units;
 
 /// Registry of block-level anchor destinations discovered during a pre-pass
 /// walk of the paginated page tree.
@@ -21,7 +22,7 @@ use crate::image::ImageFormat;
 #[derive(Debug, Default)]
 pub struct DestinationRegistry {
     current_page_idx: usize,
-    entries: BTreeMap<String, (usize, Pt, Pt)>,
+    entries: BTreeMap<String, (usize, crate::units::Pt, crate::units::Pt)>,
     /// Stack of transforms applied to coordinates before storing.
     transform_stack: Vec<Affine2D>,
 }
@@ -62,15 +63,17 @@ impl DestinationRegistry {
     }
 
     /// Record an anchor destination. First-write-wins: later duplicates are ignored.
-    pub fn record(&mut self, id: &str, x: Pt, y: Pt) {
-        let (tx, ty) = self.current_transform().transform_point(x, y);
+    pub fn record(&mut self, id: &str, x: crate::units::Pt, y: crate::units::Pt) {
+        let (tx, ty) = self
+            .current_transform()
+            .transform_point(x.to_f32(), y.to_f32());
         self.entries
             .entry(id.to_string())
-            .or_insert((self.current_page_idx, tx, ty));
+            .or_insert((self.current_page_idx, tx.pt(), ty.pt()));
     }
 
     /// Look up a recorded anchor. Returns `(page_idx, x, y)`.
-    pub fn get(&self, id: &str) -> Option<(usize, Pt, Pt)> {
+    pub fn get(&self, id: &str) -> Option<(usize, crate::units::Pt, crate::units::Pt)> {
         self.entries.get(id).copied()
     }
 }
@@ -1606,17 +1609,17 @@ mod dp_unit_tests {
         let mut reg = DestinationRegistry::new();
         reg.set_current_page(3);
         reg.push_transform(Affine2D::translation(10.0_f32.pt(), 20.0_f32.pt()));
-        reg.record("anchor", 5.0, 7.0);
+        reg.record("anchor", 5.0.pt(), 7.0.pt());
         let (page, x, y) = reg.get("anchor").expect("recorded");
         assert_eq!(page, 3);
-        assert!((x - 15.0).abs() < 1e-4);
-        assert!((y - 27.0).abs() < 1e-4);
+        assert!((x.to_f32() - 15.0).abs() < 1e-4);
+        assert!((y.to_f32() - 27.0).abs() < 1e-4);
         reg.pop_transform();
         // After pop, subsequent records use identity.
-        reg.record("anchor2", 1.0, 2.0);
+        reg.record("anchor2", 1.0.pt(), 2.0.pt());
         let (_, x2, y2) = reg.get("anchor2").expect("recorded");
-        assert!((x2 - 1.0).abs() < 1e-4);
-        assert!((y2 - 2.0).abs() < 1e-4);
+        assert!((x2.to_f32() - 1.0).abs() < 1e-4);
+        assert!((y2.to_f32() - 2.0).abs() < 1e-4);
     }
 
     // ── LinkCollector ──────────────────────────────────────
@@ -2263,13 +2266,13 @@ mod dp_unit_tests {
     fn destination_registry_first_write_wins_for_duplicate_ids() {
         let mut reg = DestinationRegistry::new();
         reg.set_current_page(0);
-        reg.record("anchor", 10.0, 20.0);
+        reg.record("anchor", 10.0.pt(), 20.0.pt());
         reg.set_current_page(1);
-        reg.record("anchor", 99.0, 99.0); // duplicate — should be ignored
+        reg.record("anchor", 99.0.pt(), 99.0.pt()); // duplicate — should be ignored
         let (page, x, y) = reg.get("anchor").expect("recorded");
         assert_eq!(page, 0, "first write should win");
-        assert!((x - 10.0).abs() < 1e-5);
-        assert!((y - 20.0).abs() < 1e-5);
+        assert!((x.to_f32() - 10.0).abs() < 1e-5);
+        assert!((y.to_f32() - 20.0).abs() < 1e-5);
     }
 
     // ── compute_overflow_clip_path: y-only clip branch ───────

--- a/crates/fulgur/src/link.rs
+++ b/crates/fulgur/src/link.rs
@@ -53,7 +53,8 @@ pub(crate) fn emit_link_annotations(
                 Some((page_idx, x_pt, y_pt)) => {
                     // x and y are in page-local (top-down) coordinates;
                     // krilla flips to PDF bottom-up during serialization.
-                    let dest = XyzDestination::new(page_idx, Point::from_xy(x_pt, y_pt));
+                    let dest =
+                        XyzDestination::new(page_idx, Point::from_xy(x_pt.to_f32(), y_pt.to_f32()));
                     Target::Destination(Destination::Xyz(dest))
                 }
                 None => {
@@ -95,6 +96,7 @@ mod tests {
 
     use crate::draw_primitives::{DestinationRegistry, LinkOccurrence, Quad};
     use crate::paragraph::LinkTarget;
+    use crate::units::F32Units;
 
     use super::emit_link_annotations;
 
@@ -239,7 +241,7 @@ mod tests {
             let mut registry = DestinationRegistry::new();
             // Use page 0 so the destination is valid within this single-page document.
             registry.set_current_page(0);
-            registry.record("section1", 0.0, 120.0);
+            registry.record("section1", 0.0.pt(), 120.0.pt());
             let occ = int_occ("section1", vec![make_quad(10.0, 40.0, 80.0, 12.0)]);
             emit_link_annotations(&mut page, &[occ], &registry, None);
         }
@@ -316,7 +318,7 @@ mod tests {
             let mut page = doc.start_page_with(page_settings());
             let mut registry = DestinationRegistry::new();
             registry.set_current_page(0);
-            registry.record("anchor", 0.0, 300.0);
+            registry.record("anchor", 0.0.pt(), 300.0.pt());
             let occs = vec![
                 ext_occ("https://a.example", vec![make_quad(0.0, 0.0, 60.0, 12.0)]), // emitted
                 int_occ("anchor", vec![make_quad(0.0, 20.0, 60.0, 12.0)]), // emitted (resolved)

--- a/crates/fulgur/src/outline.rs
+++ b/crates/fulgur/src/outline.rs
@@ -4,7 +4,7 @@ use krilla::destination::XyzDestination;
 use krilla::geom::Point;
 use krilla::outline::{Outline, OutlineNode};
 
-use crate::draw_primitives::{BookmarkEntry, Pt};
+use crate::draw_primitives::BookmarkEntry;
 
 /// Intermediate, testable tree node. Converted to `OutlineNode` by
 /// `to_krilla_node` before being attached to an `Outline`.
@@ -18,7 +18,7 @@ pub(crate) struct TreeNode {
     #[allow(dead_code)]
     pub level: u8,
     pub page_idx: usize,
-    pub y_pt: Pt,
+    pub y_pt: crate::units::Pt,
     pub children: Vec<TreeNode>,
 }
 
@@ -89,7 +89,7 @@ pub fn build_outline(entries: &[BookmarkEntry]) -> Outline {
 }
 
 fn to_krilla_node(node: TreeNode) -> OutlineNode {
-    let dest = XyzDestination::new(node.page_idx, Point::from_xy(0.0, node.y_pt));
+    let dest = XyzDestination::new(node.page_idx, Point::from_xy(0.0, node.y_pt.to_f32()));
     let mut o = OutlineNode::new(node.label, dest);
     for child in node.children {
         o.push_child(to_krilla_node(child));
@@ -100,8 +100,9 @@ fn to_krilla_node(node: TreeNode) -> OutlineNode {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::units::F32Units;
 
-    fn entry(page: usize, y: Pt, level: u8, label: &str) -> BookmarkEntry {
+    fn entry(page: usize, y: crate::units::Pt, level: u8, label: &str) -> BookmarkEntry {
         BookmarkEntry {
             page_idx: page,
             y_pt: y,
@@ -130,10 +131,10 @@ mod tests {
     #[test]
     fn simple_hierarchy() {
         let entries = vec![
-            entry(0, 10.0, 1, "Chapter 1"),
-            entry(0, 50.0, 2, "Section 1.1"),
-            entry(1, 10.0, 2, "Section 1.2"),
-            entry(2, 10.0, 1, "Chapter 2"),
+            entry(0, 10.0.pt(), 1, "Chapter 1"),
+            entry(0, 50.0.pt(), 2, "Section 1.1"),
+            entry(1, 10.0.pt(), 2, "Section 1.2"),
+            entry(2, 10.0.pt(), 1, "Chapter 2"),
         ];
         let tree = build_tree(&entries);
         let debug: Vec<_> = tree.iter().map(to_debug).collect();
@@ -171,7 +172,7 @@ mod tests {
 
     #[test]
     fn orphan_h3_becomes_top_level_when_stack_empty() {
-        let entries = vec![entry(0, 10.0, 3, "Stray")];
+        let entries = vec![entry(0, 10.0.pt(), 3, "Stray")];
         let tree = build_tree(&entries);
         assert_eq!(tree.len(), 1);
         assert_eq!(tree[0].label, "Stray");
@@ -181,7 +182,7 @@ mod tests {
 
     #[test]
     fn skipped_level_nests_under_nearest_shallower() {
-        let entries = vec![entry(0, 10.0, 1, "A"), entry(0, 50.0, 3, "A.x")];
+        let entries = vec![entry(0, 10.0.pt(), 1, "A"), entry(0, 50.0.pt(), 3, "A.x")];
         let tree = build_tree(&entries);
         assert_eq!(tree.len(), 1);
         assert_eq!(tree[0].children.len(), 1);

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use skrifa::MetadataProvider;
 
-use crate::draw_primitives::{Canvas, Pt};
+use crate::draw_primitives::Canvas;
 use crate::image::ImageFormat;
 use crate::units::F32Units;
 
@@ -560,8 +560,8 @@ pub struct InlineBoxRenderCtx<'a> {
     /// Page margin in PDF pt — needed by `draw_under_clip` /
     /// `draw_under_transform` / `draw_under_opacity` to compute
     /// descendant positions during the offset-transform dispatch.
-    pub margin_left_pt: Pt,
-    pub margin_top_pt: Pt,
+    pub margin_left_pt: f32,
+    pub margin_top_pt: f32,
 }
 
 /// Tracks the currently-open per-run tagged region while `draw_shaped_lines`

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -728,10 +728,10 @@ pub fn draw_shaped_lines(
                         let run_width: crate::units::Pt =
                             run.glyphs.iter().map(|g| g.x_advance * run.font_size).sum();
                         let rect = crate::draw_primitives::Rect {
-                            x: (x + run.x_offset).to_f32(),
-                            y: line_top_abs.to_f32(),
-                            width: run_width.max(crate::units::Pt::ZERO).to_f32(),
-                            height: line.height.to_f32(),
+                            x: x + run.x_offset,
+                            y: line_top_abs,
+                            width: run_width.max(crate::units::Pt::ZERO),
+                            height: line.height,
                         };
                         if let Some(collector) = canvas.link_collector.as_deref_mut() {
                             collector.push_rect(link_span, rect);
@@ -770,10 +770,10 @@ pub fn draw_shaped_lines(
                     // (x + x_offset, y + computed_y, width, height).
                     if let Some(link_span) = img.link.as_ref() {
                         let rect = crate::draw_primitives::Rect {
-                            x: (x + img.x_offset).to_f32(),
-                            y: (y + img.computed_y).to_f32(),
-                            width: img.width.max(crate::units::Pt::ZERO).to_f32(),
-                            height: img.height.max(crate::units::Pt::ZERO).to_f32(),
+                            x: x + img.x_offset,
+                            y: y + img.computed_y,
+                            width: img.width.max(crate::units::Pt::ZERO),
+                            height: img.height.max(crate::units::Pt::ZERO),
                         };
                         if let Some(collector) = canvas.link_collector.as_deref_mut() {
                             collector.push_rect(link_span, rect);
@@ -867,10 +867,10 @@ pub fn draw_shaped_lines(
                     // hit-areas remain intact even for opacity<1.0 boxes.
                     if let Some(link_span) = ib.link.as_ref() {
                         let rect = crate::draw_primitives::Rect {
-                            x: ox.to_f32(),
-                            y: oy.to_f32(),
-                            width: ib.width.max(crate::units::Pt::ZERO).to_f32(),
-                            height: ib.height.max(crate::units::Pt::ZERO).to_f32(),
+                            x: ox,
+                            y: oy,
+                            width: ib.width.max(crate::units::Pt::ZERO),
+                            height: ib.height.max(crate::units::Pt::ZERO),
                         };
                         if let Some(collector) = canvas.link_collector.as_deref_mut() {
                             collector.push_rect(link_span, rect);

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -119,7 +119,7 @@ pub fn render_v2(
             };
             let x_pt = resolved_margin.left + first_frag.x.in_pt().to_f32();
             let y_pt = resolved_margin.top + body_y_off + first_frag.y.in_pt().to_f32();
-            dest_registry.record(id.as_str(), x_pt, y_pt);
+            dest_registry.record(id.as_str(), x_pt.pt(), y_pt.pt());
         }
     }
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -476,7 +476,7 @@ fn draw_v2_page(
             && let Some(c) = canvas.bookmark_collector.as_deref_mut()
         {
             let y_pt = margin_top_pt + first_frag.y.in_pt().to_f32();
-            c.record(anchor.level, anchor.label.clone(), y_pt);
+            c.record(anchor.level, anchor.label.clone(), y_pt.pt());
         }
 
         if transformed_descendants.contains(&node_id) {

--- a/crates/fulgur/src/svg.rs
+++ b/crates/fulgur/src/svg.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use usvg::Tree;
 
-use crate::draw_primitives::{Canvas, Pt};
+use crate::draw_primitives::Canvas;
 
 /// An inline `<svg>` element rendered as vector graphics.
 #[derive(Clone)]
@@ -45,10 +45,10 @@ impl SvgRender {
     pub fn draw(
         &self,
         canvas: &mut Canvas<'_, '_>,
-        x: Pt,
-        y: Pt,
-        _avail_width: Pt,
-        _avail_height: Pt,
+        x: crate::units::Pt,
+        y: crate::units::Pt,
+        _avail_width: crate::units::Pt,
+        _avail_height: crate::units::Pt,
     ) {
         use crate::draw_primitives::draw_with_opacity;
         use krilla_svg::{SurfaceExt, SvgSettings};
@@ -60,7 +60,7 @@ impl SvgRender {
             let Some(size) = krilla::geom::Size::from_wh(self.width, self.height) else {
                 return;
             };
-            let transform = krilla::geom::Transform::from_translate(x, y);
+            let transform = krilla::geom::Transform::from_translate(x.to_f32(), y.to_f32());
             canvas.surface.push_transform(&transform);
             // draw_svg returns Option<()>; None means the tree was malformed.
             // We silently skip rather than panic, matching ImageRender's behavior
@@ -75,6 +75,7 @@ impl SvgRender {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::units::F32Units;
 
     // Minimal valid SVG: 100x50 red rectangle
     const MINIMAL_SVG: &str = r#"<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50"><rect width="100" height="50" fill="red"/></svg>"#;
@@ -102,7 +103,7 @@ mod tests {
                     tag_collector: None,
                     link_run_node_id: None,
                 };
-                svg.draw(&mut canvas, 10.0, 20.0, 400.0, 400.0);
+                svg.draw(&mut canvas, 10.0.pt(), 20.0.pt(), 400.0.pt(), 400.0.pt());
             }
         }
         let _ = doc.finish();

--- a/crates/fulgur/src/units.rs
+++ b/crates/fulgur/src/units.rs
@@ -6,9 +6,9 @@
 //! easy. These newtypes put the unit in the type so the compiler rejects
 //! `Px + Pt`. Both are `#[repr(transparent)]` over `f32`, so they are
 //! zero-cost at runtime; the migration that flips coordinate fields to these
-//! types lands in later phases (tracked in the fulgur-2map epic). Note
-//! `draw_primitives::Pt` is currently a `type Pt = f32` alias that this
-//! migration upgrades to [`Pt`]; until that lands these newtypes are not
+//! types lands in later phases (tracked in the fulgur-2map epic). The legacy
+//! `draw_primitives::Pt = f32` alias this migration upgrades to [`Pt`] has
+//! been removed (P2a, fulgur-2map.8); these newtypes are still not
 //! re-exported at the crate root.
 //!
 //! - Construct with [`F32Units::px`] / [`F32Units::pt`] (e.g. `frag.x.px()`).

--- a/docs/plans/2026-06-27-engine-layout-api-design.md
+++ b/docs/plans/2026-06-27-engine-layout-api-design.md
@@ -294,6 +294,25 @@ Phase P1c typed `pagination_layout::Fragment`'s coordinate fields to
 Unblocks P1e (`fulgur-2map.7`, `Drawables` aggregate coordinate fields). The
 `type Pt = f32` alias removal remains P2 (`fulgur-2map.8`).
 
+### P2a outcome (fulgur-2map.8) - `type Pt = f32` alias removed
+
+Phase P2a deleted the legacy `draw_primitives::Pt = f32` alias, byte-neutral
+(examples_determinism + VRT goldens unchanged):
+
+- `draw_primitives::Rect` (link-activation rect), `DestinationRegistry` (anchor
+  resolution), `BookmarkEntry.y_pt`/`BookmarkCollector` (PDF outline), and
+  `clamp_marker_size` (list-style-image marker sizing) retyped to `units::Pt`.
+- `InlineBoxRenderCtx`'s margin fields renamed `Pt` -> plain `f32` (no typed neighbor
+  exists there - see the epic's P2b sibling issue for the "genuine f32-f32 boundary, no
+  transitional gap" reasoning applied consistently).
+- `svg::SvgRender::draw` (confirmed dead code, not reachable from the v2 render path)
+  retyped for completeness so the alias's last consumer was gone before deletion.
+- The "27 hardcoded 0.75 constants" clause from the original P2 scope was already
+  resolved as a side effect of P1a-P1e; no action was needed for it.
+
+Split from the original P2 scope: `px_to_pt`/`pt_to_px` internal call-site consolidation
+continues as sibling issue P2b (`fulgur-2map.12`), sequenced after this phase.
+
 ## 8. 決定性 / 受け入れ条件
 
 - `layout_to_drawables` 抽出後・newtype 移行後とも `examples_determinism` golden と

--- a/docs/plans/2026-06-27-engine-layout-api-design.md
+++ b/docs/plans/2026-06-27-engine-layout-api-design.md
@@ -294,7 +294,7 @@ Phase P1c typed `pagination_layout::Fragment`'s coordinate fields to
 Unblocks P1e (`fulgur-2map.7`, `Drawables` aggregate coordinate fields). The
 `type Pt = f32` alias removal remains P2 (`fulgur-2map.8`).
 
-### P2a outcome (fulgur-2map.8) - `type Pt = f32` alias removed
+### P2a outcome (fulgur-2map.8) — `type Pt = f32` alias removed
 
 Phase P2a deleted the legacy `draw_primitives::Pt = f32` alias, byte-neutral
 (examples_determinism + VRT goldens unchanged):
@@ -302,8 +302,8 @@ Phase P2a deleted the legacy `draw_primitives::Pt = f32` alias, byte-neutral
 - `draw_primitives::Rect` (link-activation rect), `DestinationRegistry` (anchor
   resolution), `BookmarkEntry.y_pt`/`BookmarkCollector` (PDF outline), and
   `clamp_marker_size` (list-style-image marker sizing) retyped to `units::Pt`.
-- `InlineBoxRenderCtx`'s margin fields renamed `Pt` -> plain `f32` (no typed neighbor
-  exists there - see the epic's P2b sibling issue for the "genuine f32-f32 boundary, no
+- `InlineBoxRenderCtx`'s margin fields renamed `Pt` → plain `f32` (no typed neighbor
+  exists there — see the epic's P2b sibling issue for the "genuine f32-f32 boundary, no
   transitional gap" reasoning applied consistently).
 - `svg::SvgRender::draw` (confirmed dead code, not reachable from the v2 render path)
   retyped for completeness so the alias's last consumer was gone before deletion.

--- a/docs/plans/2026-07-01-p2a-pt-alias-removal.md
+++ b/docs/plans/2026-07-01-p2a-pt-alias-removal.md
@@ -1,0 +1,756 @@
+# P2a: Remove `type Pt = f32` alias Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Delete the legacy `pub type Pt = f32;` alias in `draw_primitives.rs` so the
+crate has exactly one `Pt` type (`units::Pt`), by retyping its last few consumers
+(`Rect`, `DestinationRegistry`, `BookmarkCollector`/`BookmarkEntry`, `clamp_marker_size`,
+`InlineBoxRenderCtx`, `SvgRender::draw`) to either `units::Pt` or plain `f32` as
+appropriate, with zero change to rendered PDF bytes.
+
+**Architecture:** This is a byte-neutral mechanical refactor, not new behavior, so there
+is no "write a failing test first" step — the existing test suite + VRT goldens ARE the
+spec. Each task retypes one struct/function, then the compiler (`cargo build -p fulgur`)
+enumerates every call site that needs a matching fixup. Two fixup rules, applied per call
+site (see `.claude/rules/coordinate-system.md` and `project_units_migration_patch_coverage`
+memory):
+
+- Caller already holds a `units::Pt`/`units::Px` value feeding the old bare-`f32`/`Pt`-alias
+  parameter → **drop** the existing `.to_f32()` (or add nothing — it now flows through
+  untagged).
+- Caller holds a raw `f32` (from an out-of-scope source like `Margin`/`Config`, or a test
+  literal) → **add** `.pt()` (from `crate::units::F32Units`) at the call site.
+- The one exception is `InlineBoxRenderCtx` (Task 5): it has no typed neighbor at all (both
+  sides are permanently-f32 margin plumbing), so the fix is a straight rename `Pt` → `f32`,
+  not a retype.
+
+After every task: `cargo build -p fulgur` must succeed with the fixups applied, then run
+the file-local unit tests, then the full `cargo test -p fulgur --lib` + VRT + examples_determinism
+at the end of the whole plan (Task 8) to prove byte-neutrality end-to-end.
+
+**Tech Stack:** Rust, `units::Pt`/`units::Px` newtypes (`crates/fulgur/src/units.rs`,
+already fully implemented — Add/Sub/Mul\<f32\>/Div\<f32\>/Div\<Self\>/Neg/PartialOrd/Sum/
+ZERO/max/min/abs, no new operators needed), Krilla (`krilla::geom::Point`/`Transform`) as
+the FFI boundary.
+
+**Baseline (already verified in the worktree before this plan was written):**
+`examples_determinism` 11/11 passed, VRT `run_fulgur_vrt` ok, `git status --short --
+crates/fulgur-vrt/goldens/` empty, `cargo build -p fulgur` clean.
+
+---
+
+### Task 1: Retype `draw_primitives::Rect` to `units::Pt`
+
+**Files:**
+
+- Modify: `crates/fulgur/src/draw_primitives.rs` (struct def ~L281, `transform_rect`
+  ~L204, `push_rect` ~L402, 12 test construction sites: L1640, L1663, L1672, L1690,
+  L1960, L1980, L2194, L2204, L2238, L2248, L2357, L2375)
+- Modify: `crates/fulgur/src/paragraph.rs` (3 production construction sites: text-run
+  link rect ~L727, image link rect ~L769, inline-box link rect ~L866)
+
+**Step 1: Retype the struct**
+
+```rust
+// draw_primitives.rs — was: pub x: f32, pub y: f32, pub width: f32, pub height: f32
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Rect {
+    pub x: crate::units::Pt,
+    pub y: crate::units::Pt,
+    pub width: crate::units::Pt,
+    pub height: crate::units::Pt,
+}
+```
+
+**Step 2: Fix `transform_rect`** — untag right before the f32-only `transform_point` call
+(a/b/c/d stay dimensionless f32; this is the correct FFI-ish boundary landing point now
+that Rect itself is typed):
+
+```rust
+pub fn transform_rect(&self, r: &Rect) -> Quad {
+    let x0 = r.x.to_f32();
+    let y0 = r.y.to_f32();
+    let x1 = (r.x + r.width).to_f32();
+    let y1 = (r.y + r.height).to_f32();
+    let bl = self.transform_point(x0, y1);
+    let br = self.transform_point(x1, y1);
+    let tr = self.transform_point(x1, y0);
+    let tl = self.transform_point(x0, y0);
+    Quad {
+        points: [[bl.0, bl.1], [br.0, br.1], [tr.0, tr.1], [tl.0, tl.1]],
+    }
+}
+```
+
+**Step 3: Fix `push_rect`'s degenerate-rect guard** — use the operator, not a to_f32 compare:
+
+```rust
+pub fn push_rect(&mut self, link: &std::sync::Arc<crate::paragraph::LinkSpan>, rect: Rect) {
+    if rect.width <= crate::units::Pt::ZERO || rect.height <= crate::units::Pt::ZERO {
+        return;
+    }
+    // ... unchanged below
+```
+
+**Step 4: Fix the 3 production construction sites in `paragraph.rs`** — each currently
+`.to_f32()`s an already-Pt value into the old f32 `Rect`; drop the `.to_f32()` calls. Example
+(text-run link rect, ~L727-734):
+
+```rust
+// BEFORE
+let rect = crate::draw_primitives::Rect {
+    x: (x + run.x_offset).to_f32(),
+    y: line_top_abs.to_f32(),
+    width: run_width.max(crate::units::Pt::ZERO).to_f32(),
+    height: line.height.to_f32(),
+};
+// AFTER
+let rect = crate::draw_primitives::Rect {
+    x: x + run.x_offset,
+    y: line_top_abs,
+    width: run_width.max(crate::units::Pt::ZERO),
+    height: line.height,
+};
+```
+
+Apply the same drop-`.to_f32()` pattern to the image link rect (~L769, fields
+`(x + img.x_offset)`, `(y + img.computed_y)`, `img.width.max(Pt::ZERO)`,
+`img.height.max(Pt::ZERO)`) and the inline-box link rect (~L866, fields `ox`, `oy`,
+`ib.width.max(Pt::ZERO)`, `ib.height.max(Pt::ZERO)`).
+
+**Step 5: Fix the 12 test construction sites in `draw_primitives.rs`** — every one is a
+literal-field-value `Rect { x: 0.0, y: 0.0, width: N.0, height: N.0 }`; append `.pt()`
+(from `crate::units::F32Units`, already imported in this test module as
+`use crate::units::F32Units;`) to every literal field value. Example (L1640):
+
+```rust
+// BEFORE
+Rect { x: 0.0, y: 0.0, width: 10.0, height: 10.0 }
+// AFTER
+Rect { x: 0.0.pt(), y: 0.0.pt(), width: 10.0.pt(), height: 10.0.pt() }
+```
+
+Repeat identically at every other listed line (all are the same shape: 4 float literal
+fields on a `Rect { ... }` struct literal).
+
+**Step 6: Build and fix any remaining errors**
+
+Run: `cargo build -p fulgur`
+Expected: succeeds once all sites above are fixed. If the compiler flags a site not listed
+above, apply the same rule (typed neighbor → drop conversion; raw literal/f32 → `.pt()`).
+
+**Step 7: Run targeted tests**
+
+Run: `cargo test -p fulgur --lib draw_primitives:: paragraph::`
+Expected: all pass, same test count as baseline.
+
+**Step 8: Commit**
+
+```bash
+git add crates/fulgur/src/draw_primitives.rs crates/fulgur/src/paragraph.rs
+git commit -m "refactor(draw_primitives): type Rect with units::Pt (byte-neutral, P2a)"
+```
+
+---
+
+### Task 2: Retype `DestinationRegistry` to `units::Pt`
+
+**Files:**
+
+- Modify: `crates/fulgur/src/draw_primitives.rs` (struct ~L22, `record`/`get` ~L65-75,
+  test call sites ~L1608-1619, ~L2266-2268)
+- Modify: `crates/fulgur/src/render.rs` (call site ~L120-122)
+
+**Step 1: Retype the struct and methods**
+
+```rust
+pub struct DestinationRegistry {
+    current_page_idx: usize,
+    entries: BTreeMap<String, (usize, crate::units::Pt, crate::units::Pt)>,
+    transform_stack: Vec<Affine2D>,
+}
+
+impl DestinationRegistry {
+    // ...
+    pub fn record(&mut self, id: &str, x: crate::units::Pt, y: crate::units::Pt) {
+        let (tx, ty) = self.current_transform().transform_point(x.to_f32(), y.to_f32());
+        self.entries
+            .entry(id.to_string())
+            .or_insert((self.current_page_idx, tx.pt(), ty.pt()));
+    }
+
+    pub fn get(&self, id: &str) -> Option<(usize, crate::units::Pt, crate::units::Pt)> {
+        self.entries.get(id).copied()
+    }
+}
+```
+
+Note `transform_point` still takes/returns bare `f32` (a/b/c/d are dimensionless) — untag
+with `.to_f32()` going in, re-tag with `.pt()` coming out. This is the same
+tag-at-boundary pattern as Task 1's `transform_rect`.
+
+**Step 2: Fix the `render.rs` call site** (~L120-122) — `x_pt`/`y_pt` are computed from a
+mix of out-of-scope f32 `Margin` and already-Pt fragment values `.to_f32()`'d down to raw
+f32; tag once at the call boundary:
+
+```rust
+// BEFORE
+let x_pt = resolved_margin.left + first_frag.x.in_pt().to_f32();
+let y_pt = resolved_margin.top + body_y_off + first_frag.y.in_pt().to_f32();
+dest_registry.record(id.as_str(), x_pt, y_pt);
+// AFTER
+let x_pt = resolved_margin.left + first_frag.x.in_pt().to_f32();
+let y_pt = resolved_margin.top + body_y_off + first_frag.y.in_pt().to_f32();
+dest_registry.record(id.as_str(), x_pt.pt(), y_pt.pt());
+```
+
+(`x_pt`/`y_pt` themselves stay `f32` locals — only the call arguments are tagged. Do not
+retype the locals; `resolved_margin.left`/`.top` are permanently-f32 `Margin` fields.)
+
+**Step 3: Fix the 2 test blocks in `draw_primitives.rs`**
+
+`destination_registry_push_pop_transform_affects_record` (~L1604-1620): tag the `record`
+call literals with `.pt()`, untag the `get` result with `.to_f32()` at the assertion:
+
+```rust
+reg.record("anchor", 5.0.pt(), 7.0.pt());
+let (page, x, y) = reg.get("anchor").expect("recorded");
+assert_eq!(page, 3);
+assert!((x.to_f32() - 15.0).abs() < 1e-4);
+assert!((y.to_f32() - 27.0).abs() < 1e-4);
+reg.pop_transform();
+reg.record("anchor2", 1.0.pt(), 2.0.pt());
+let (_, x2, y2) = reg.get("anchor2").expect("recorded");
+assert!((x2.to_f32() - 1.0).abs() < 1e-4);
+assert!((y2.to_f32() - 2.0).abs() < 1e-4);
+```
+
+`destination_registry_first_write_wins` (~L2266-2268, exact test name may differ slightly
+— confirm via `grep -n "first-write-wins" -A5 crates/fulgur/src/draw_primitives.rs`): same
+`.pt()` tagging on the two `record(...)` calls.
+
+**Step 4: Build, test, commit**
+
+Run: `cargo build -p fulgur` then `cargo test -p fulgur --lib draw_primitives:: render::`
+Expected: clean build, all tests pass.
+
+```bash
+git add crates/fulgur/src/draw_primitives.rs crates/fulgur/src/render.rs
+git commit -m "refactor(draw_primitives): type DestinationRegistry with units::Pt (byte-neutral, P2a)"
+```
+
+---
+
+### Task 3: Retype `BookmarkCollector`/`BookmarkEntry.y_pt` to `units::Pt`
+
+**Files:**
+
+- Modify: `crates/fulgur/src/draw_primitives.rs` (`BookmarkEntry` ~L938,
+  `BookmarkCollector::record` ~L963, test ~L2140-2157)
+- Modify: `crates/fulgur/src/render.rs` (call site ~L478-479)
+- Modify: `crates/fulgur/src/outline.rs` (`TreeNode.y_pt` ~L21, `to_krilla_node` ~L91-92,
+  test helper `entry()` ~L104-111 and its 4 call sites ~L133-136, L174, L184)
+
+**Step 1: Retype `BookmarkEntry`/`BookmarkCollector`**
+
+```rust
+pub struct BookmarkEntry {
+    pub page_idx: usize,
+    pub y_pt: crate::units::Pt,
+    pub level: u8,
+    pub label: String,
+}
+
+impl BookmarkCollector {
+    // ...
+    pub fn record(&mut self, level: u8, label: String, y_pt: crate::units::Pt) {
+        self.entries.push(BookmarkEntry { page_idx: self.current_page_idx, y_pt, level, label });
+    }
+}
+```
+
+**Step 2: Fix the `render.rs` call site** (~L478-479), same tag-at-boundary pattern as Task 2:
+
+```rust
+let y_pt = margin_top_pt + first_frag.y.in_pt().to_f32();
+c.record(anchor.level, anchor.label.clone(), y_pt.pt());
+```
+
+**Step 3: Fix `outline.rs`**
+
+```rust
+// TreeNode struct
+pub(crate) struct TreeNode {
+    pub label: String,
+    #[allow(dead_code)]
+    pub level: u8,
+    pub page_idx: usize,
+    pub y_pt: crate::units::Pt,
+    pub children: Vec<TreeNode>,
+}
+```
+
+`build_tree`'s `y_pt: e.y_pt` line needs no change (both sides now `units::Pt`).
+`to_krilla_node` is the genuine krilla FFI boundary — untag there:
+
+```rust
+fn to_krilla_node(node: TreeNode) -> OutlineNode {
+    let dest = XyzDestination::new(node.page_idx, Point::from_xy(0.0, node.y_pt.to_f32()));
+    // ... unchanged below
+```
+
+Test helper and its imports — `outline.rs` currently does
+`use crate::draw_primitives::{BookmarkEntry, Pt};`; drop `Pt` (no longer used after this
+edit) and tag the helper's `y` parameter:
+
+```rust
+use crate::draw_primitives::BookmarkEntry;
+// ...
+fn entry(page: usize, y: crate::units::Pt, level: u8, label: &str) -> BookmarkEntry {
+    BookmarkEntry { page_idx: page, y_pt: y, level, label: label.to_string() }
+}
+```
+
+Update its 4 call sites (`entry(0, 10.0, 1, "Chapter 1")` etc. at ~L133-136, `entry(0,
+10.0, 3, "Stray")` at ~L174, `entry(0, 10.0, 1, "A")` / `entry(0, 50.0, 3, "A.x")` at
+~L184) to append `.pt()` to the numeric literal, e.g. `entry(0, 10.0.pt(), 1, "Chapter
+1")`. Add `use crate::units::F32Units;` to the test module if not already present (check
+first — `draw_primitives.rs`'s test module already imports it; `outline.rs`'s test module
+may not).
+
+**Step 4: Fix the `draw_primitives.rs` test** (~L2140-2157) — tag the `record(...)`
+literals, untag `y_pt` at the assertion:
+
+```rust
+bc.record(1, "Chapter One".to_string(), 100.0.pt());
+bc.set_current_page(5);
+bc.record(2, "Section 5.1".to_string(), 42.0.pt());
+
+let entries = bc.into_entries();
+// ...
+assert!((entries[0].y_pt.to_f32() - 100.0).abs() < 1e-5);
+```
+
+**Step 5: Build, test, commit**
+
+Run: `cargo build -p fulgur` then `cargo test -p fulgur --lib draw_primitives:: outline:: render::`
+Expected: clean build, all tests pass.
+
+```bash
+git add crates/fulgur/src/draw_primitives.rs crates/fulgur/src/render.rs crates/fulgur/src/outline.rs
+git commit -m "refactor(draw_primitives): type BookmarkEntry.y_pt with units::Pt (byte-neutral, P2a)"
+```
+
+---
+
+### Task 4: Retype `clamp_marker_size` to `units::Pt`
+
+**Files:**
+
+- Modify: `crates/fulgur/src/draw_primitives.rs` (`clamp_marker_size` ~L1580-1591, 4 tests
+  ~L1865-1889)
+- Modify: `crates/fulgur/src/convert/list_marker.rs` (`size_raster_marker` ~L31-42,
+  `resolve_list_marker` Svg branch ~L88-99)
+
+**Step 1: Retype `clamp_marker_size`** — internal ops become the existing `units::Pt`
+operators (Div\<Self\>→f32 for the scale ratio, Mul\<f32\>→Pt for scaling, PartialOrd for
+the comparisons):
+
+```rust
+pub(crate) fn clamp_marker_size(
+    intrinsic_width: crate::units::Pt,
+    intrinsic_height: crate::units::Pt,
+    line_height: crate::units::Pt,
+) -> (crate::units::Pt, crate::units::Pt) {
+    if intrinsic_height <= crate::units::Pt::ZERO {
+        return (crate::units::Pt::ZERO, crate::units::Pt::ZERO);
+    }
+    if intrinsic_height <= line_height {
+        (intrinsic_width, intrinsic_height)
+    } else {
+        let scale = line_height / intrinsic_height; // Pt / Pt = f32
+        (intrinsic_width * scale, line_height) // Pt * f32 = Pt
+    }
+}
+```
+
+**Step 2: Fix `list_marker.rs`'s `size_raster_marker`** — retype its return so the two
+call sites in `resolve_list_marker` don't need to re-tag `width`/`height` before storing
+into the already-`units::Pt` `ImageEntry`/`ListItemMarker` fields:
+
+```rust
+fn size_raster_marker(
+    data: &Arc<Vec<u8>>,
+    format: crate::image::ImageFormat,
+    line_height: f32,
+) -> Option<(crate::units::Pt, crate::units::Pt)> {
+    let (iw, ih) = ImageRender::decode_dimensions(data, format)?;
+    let intrinsic_w = px_to_pt(iw as f32).pt();
+    let intrinsic_h = px_to_pt(ih as f32).pt();
+    Some(crate::draw_primitives::clamp_marker_size(
+        intrinsic_w,
+        intrinsic_h,
+        line_height.pt(),
+    ))
+}
+```
+
+(`line_height: f32` parameter itself is untouched — still fed from further up the call
+chain as raw f32; only tagged right at the `clamp_marker_size` call.)
+
+**Step 3: Fix `resolve_list_marker`'s two branches** — drop the now-redundant `.pt()` at
+every `width`/`height` use (both `AssetKind::Raster` and `AssetKind::Svg` arms have 4 uses
+each: `ImageEntry`/`SvgEntry` width+height, `ListItemMarker::Image` width+height):
+
+```rust
+// Raster arm — BEFORE: width.pt() / height.pt() (x4)
+let (width, height) = size_raster_marker(data, format, line_height)?;
+let entry = crate::drawables::ImageEntry {
+    image_data: Arc::clone(data),
+    format,
+    width,
+    height,
+    opacity: 1.0,
+    visible: true,
+};
+Some(ListItemMarker::Image { marker: ImageMarker::Raster(entry), width, height })
+```
+
+```rust
+// Svg arm — tag intrinsic_w/intrinsic_h/line_height at the clamp_marker_size call,
+// then drop .pt() at the 4 width/height uses below it
+let intrinsic_w = px_to_pt(size.width()).pt();
+let intrinsic_h = px_to_pt(size.height()).pt();
+let (width, height) =
+    crate::draw_primitives::clamp_marker_size(intrinsic_w, intrinsic_h, line_height.pt());
+let entry = crate::drawables::SvgEntry {
+    tree: Arc::new(tree),
+    width,
+    height,
+    opacity: 1.0,
+    visible: true,
+};
+Some(ListItemMarker::Image { marker: ImageMarker::Svg(entry), width, height })
+```
+
+**Step 4: Fix the 4 tests in `draw_primitives.rs`** (~L1865-1889) — tag the 3 literal
+args, untag the 2 returned values at each assertion:
+
+```rust
+#[test]
+fn clamp_marker_size_zero_height_returns_zero_zero() {
+    let (w, h) = clamp_marker_size(20.0.pt(), 0.0.pt(), 12.0.pt());
+    assert_eq!(w, crate::units::Pt::ZERO);
+    assert_eq!(h, crate::units::Pt::ZERO);
+}
+
+#[test]
+fn clamp_marker_size_negative_height_returns_zero_zero() {
+    let (w, h) = clamp_marker_size(20.0.pt(), (-5.0).pt(), 12.0.pt());
+    assert_eq!(w, crate::units::Pt::ZERO);
+    assert_eq!(h, crate::units::Pt::ZERO);
+}
+
+#[test]
+fn clamp_marker_size_within_line_height_passes_through() {
+    let (w, h) = clamp_marker_size(20.0.pt(), 10.0.pt(), 12.0.pt());
+    assert_eq!(w.to_f32(), 20.0);
+    assert_eq!(h.to_f32(), 10.0);
+}
+
+#[test]
+fn clamp_marker_size_oversized_scales_down_preserving_aspect() {
+    let (w, h) = clamp_marker_size(40.0.pt(), 20.0.pt(), 10.0.pt());
+    assert!((w.to_f32() - 20.0).abs() < 1e-5);
+    assert!((h.to_f32() - 10.0).abs() < 1e-5);
+}
+```
+
+**Step 5: Build, test, commit**
+
+Run: `cargo build -p fulgur` then `cargo test -p fulgur --lib draw_primitives:: list_marker::`
+Expected: clean build, all tests pass.
+
+```bash
+git add crates/fulgur/src/draw_primitives.rs crates/fulgur/src/convert/list_marker.rs
+git commit -m "refactor(draw_primitives): type clamp_marker_size with units::Pt (byte-neutral, P2a)"
+```
+
+---
+
+### Task 5: `InlineBoxRenderCtx` margin fields — rename `Pt` alias to plain `f32`
+
+**Files:**
+
+- Modify: `crates/fulgur/src/paragraph.rs` (`InlineBoxRenderCtx` ~L556-565)
+
+**Context:** `margin_left_pt`/`margin_top_pt` are threaded as bare `f32` through ~10
+`render.rs` function signatures (`draw_v2_page`, `dispatch_fragment`,
+`dispatch_inline_box_content`, etc. — 142 occurrences of the identifier across the file).
+`InlineBoxRenderCtx` is the only place holding these values under the `Pt` alias name.
+There is no typed neighbor to bridge (same as `engine.rs`/`background.rs` in the P2b
+design) — retyping to `units::Pt` here would only add pointless `.to_f32()` noise at its
+1-2 read sites, or, if chased "properly" through its callees, balloon into an unrelated
+~10-function render.rs ripple. The correct fix is a straight rename to match the type
+these values actually have everywhere else.
+
+**Step 1: Retype the two fields**
+
+```rust
+pub struct InlineBoxRenderCtx<'a> {
+    pub drawables: &'a crate::drawables::Drawables,
+    pub geometry: &'a crate::pagination_layout::PaginationGeometryTable,
+    pub page_index: u32,
+    pub margin_left_pt: f32,
+    pub margin_top_pt: f32,
+}
+```
+
+No other change needed — every reader/writer of `ctx.margin_left_pt`/`.margin_top_pt`
+(the `geo_x_pt`/`geo_y_pt` computation and the `dispatch_inline_box_content` call, both in
+`paragraph.rs`) already treats it as plain `f32`.
+
+**Step 2: Build**
+
+Run: `cargo build -p fulgur`
+Expected: succeeds with no other changes required (this task is a pure signature
+type-name swap since `Pt` already means `f32` today).
+
+**Step 3: Commit**
+
+```bash
+git add crates/fulgur/src/paragraph.rs
+git commit -m "refactor(paragraph): rename InlineBoxRenderCtx margin fields Pt alias to f32 (byte-neutral, P2a)"
+```
+
+---
+
+### Task 6: `SvgRender::draw` — retype the last incidental `Pt`-alias usage
+
+**Files:**
+
+- Modify: `crates/fulgur/src/svg.rs` (`draw` signature ~L44-50, internal `Transform::from_translate`
+  ~L60, test call site ~L105)
+
+**Context:** `SvgRender` is confirmed dead code (not called from the actual v2 SVG draw
+path in `render.rs`; only referenced there in a doc comment). It's still `pub mod svg`
+with the crate's last `Pt`-alias usage, so it must be retyped (not left as-is) before the
+alias declaration can be deleted in Task 7. Do not delete the struct itself — that's a
+separate, out-of-scope cleanup.
+
+**Step 1: Retype the signature and untag at the krilla FFI call**
+
+```rust
+pub fn draw(
+    &self,
+    canvas: &mut Canvas<'_, '_>,
+    x: crate::units::Pt,
+    y: crate::units::Pt,
+    _avail_width: crate::units::Pt,
+    _avail_height: crate::units::Pt,
+) {
+    use crate::draw_primitives::draw_with_opacity;
+    use krilla_svg::{SurfaceExt, SvgSettings};
+
+    if !self.visible {
+        return;
+    }
+    draw_with_opacity(canvas, self.opacity, |canvas| {
+        let Some(size) = krilla::geom::Size::from_wh(self.width, self.height) else {
+            return;
+        };
+        let transform = krilla::geom::Transform::from_translate(x.to_f32(), y.to_f32());
+        canvas.surface.push_transform(&transform);
+        let _ = canvas.surface.draw_svg(&self.tree, size, SvgSettings::default());
+        canvas.surface.pop();
+    });
+}
+```
+
+Drop the now-unused `use crate::draw_primitives::{Canvas, Pt};` import line down to
+`use crate::draw_primitives::Canvas;`.
+
+**Step 2: Fix the one test call site** (~L105, inside `draw_onto_surface`):
+
+```rust
+svg.draw(&mut canvas, 10.0.pt(), 20.0.pt(), 400.0.pt(), 400.0.pt());
+```
+
+Add `use crate::units::F32Units;` to the test module if not already present (check with
+`grep -n "^    use" crates/fulgur/src/svg.rs`).
+
+**Step 3: Build, test, commit**
+
+Run: `cargo build -p fulgur` then `cargo test -p fulgur --lib svg::`
+Expected: clean build, all tests pass.
+
+```bash
+git add crates/fulgur/src/svg.rs
+git commit -m "refactor(svg): type dead SvgRender::draw with units::Pt (byte-neutral, P2a)"
+```
+
+---
+
+### Task 7: Delete the `type Pt = f32` alias
+
+**Files:**
+
+- Modify: `crates/fulgur/src/draw_primitives.rs` (delete `pub type Pt = f32;` ~L79 and its
+  doc comment)
+
+**Step 1: Confirm no remaining bare references**
+
+Run: `grep -rn '\bPt\b' crates/fulgur/src --include='*.rs' | grep -v 'units::Pt\|crate::units\|// '`
+Expected: empty (or only non-code doc-comment prose mentioning "Pt" generically, which is
+fine — e.g. `paragraph.rs`'s `approx_pt` doc comment already confirmed harmless).
+
+**Step 2: Delete the alias**
+
+```rust
+// draw_primitives.rs — delete these two lines entirely:
+// /// Point unit (1/72 inch)
+// pub type Pt = f32;
+```
+
+**Step 3: Build**
+
+Run: `cargo build -p fulgur`
+Expected: succeeds. If it fails, a consumer was missed in Tasks 1-6 — find it via the
+compile error, apply the same tag/untag rule, and fix before proceeding (do not
+reintroduce the alias).
+
+**Step 4: Check public-reachability (informational only)**
+
+Run: `cargo doc -p fulgur --no-deps 2>&1 | grep -i "draw_primitives::Pt"` (should find
+nothing — confirms the public item is gone). This is a legitimate breaking change under
+`draw_primitives` being `pub mod`; `cargo-semver-checks` will flag it downstream in CI as
+advisory (project is ZeroVer, not a blocker) — no action needed here beyond noting it in
+the close reason later.
+
+**Step 5: Commit**
+
+```bash
+git add crates/fulgur/src/draw_primitives.rs
+git commit -m "refactor(draw_primitives): delete legacy type Pt=f32 alias (P2a)"
+```
+
+---
+
+### Task 8: Full verification suite (byte-neutral proof)
+
+**Files:** none (verification only)
+
+**Step 1: Full build + lint**
+
+Run: `cargo build` (whole workspace), `cargo clippy -p fulgur --all-targets -- -D
+warnings`, `cargo fmt --check`
+Expected: all clean.
+
+**Step 2: Full lib test suite**
+
+Run: `cargo test -p fulgur --lib`
+Expected: all pass, count >= baseline (1497 per the last P1e note — should be roughly the
+same, this task adds no new tests, only retypes existing ones).
+
+**Step 3: examples_determinism + VRT, byte-identical against baseline**
+
+Run:
+
+```bash
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur-cli --test examples_determinism
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur-vrt
+git status --short -- crates/fulgur-vrt/goldens/
+```
+
+Expected: `examples_determinism` 11/11 passed, `run_fulgur_vrt` ok, golden git status
+empty (byte-identical — the whole point of this refactor). **Never** set
+`FULGUR_VRT_UPDATE=1`. If goldens differ, STOP and find the wrong tag/untag site — do not
+regenerate goldens to make it pass.
+
+**Step 4: codecov/patch coverage spot-check**
+
+The `.to_f32()`/`.pt()` sites touched in Tasks 1-6 are exactly the pattern that dropped
+patch coverage in P1c/P1e (memory `project_units_migration_patch_coverage`). Check whether
+any changed line in `transform_rect`, `push_rect`, `clamp_marker_size`, or the
+`paragraph.rs` link-rect construction sites is exercised only by VRT (which the coverage
+job excludes) and not by an existing `render_smoke.rs` case or in-crate unit test. If so,
+add a minimal behavioral case to `crates/fulgur/tests/render_smoke.rs` (pattern:
+`Engine::builder().build().render_html(html)` + `assert!(!pdf.is_empty())`) covering a
+link inside styled text (exercises the Rect path) and a `list-style-image` marker
+(exercises `clamp_marker_size`) if no such case already exists.
+
+Run: `grep -n "link\|list-style-image" crates/fulgur/tests/render_smoke.rs` first to check
+what's already covered before adding anything.
+
+**Step 5: Commit (only if Step 4 added a test)**
+
+```bash
+git add crates/fulgur/tests/render_smoke.rs
+git commit -m "test(render_smoke): cover P2a-touched draw paths for patch coverage"
+```
+
+---
+
+### Task 9: Documentation — record the P2a outcome
+
+**Files:**
+
+- Modify: `docs/plans/2026-06-27-engine-layout-api-design.md` (append outcome section,
+  matching the P1a/P1c/P1d/P1e precedent already in the file)
+- Modify: `.claude/rules/coordinate-system.md` (only if it still describes `Pt` as an f32
+  alias anywhere — check first, likely no change needed since it already refers to
+  `units::Pt` throughout after the `fulgur-1ino` merge)
+
+**Step 1: Check whether coordinate-system.md needs an update**
+
+Run: `grep -n "Pt\b" .claude/rules/coordinate-system.md`
+Expected: no remaining references to the removed alias (it already documents `units::Pt`
+post-`fulgur-1ino`). If clean, skip to Step 2.
+
+**Step 2: Append a P2a outcome section** to
+`docs/plans/2026-06-27-engine-layout-api-design.md`, after the existing "P1c outcome"
+section, following the same style as the others:
+
+```markdown
+### P2a outcome (fulgur-2map.8) - `type Pt = f32` alias removed
+
+Phase P2a deleted the legacy `draw_primitives::Pt = f32` alias, byte-neutral
+(examples_determinism + VRT goldens unchanged):
+
+- `draw_primitives::Rect` (link-activation rect), `DestinationRegistry` (anchor
+  resolution), `BookmarkEntry.y_pt`/`BookmarkCollector` (PDF outline), and
+  `clamp_marker_size` (list-style-image marker sizing) retyped to `units::Pt`.
+- `InlineBoxRenderCtx`'s margin fields renamed `Pt` -> plain `f32` (no typed neighbor
+  exists there - see the epic's P2b sibling issue for the "genuine f32-f32 boundary, no
+  transitional gap" reasoning applied consistently).
+- `svg::SvgRender::draw` (confirmed dead code, not reachable from the v2 render path)
+  retyped for completeness so the alias's last consumer was gone before deletion.
+- The "27 hardcoded 0.75 constants" clause from the original P2 scope was already
+  resolved as a side effect of P1a-P1e; no action was needed for it.
+
+Split from the original P2 scope: `px_to_pt`/`pt_to_px` internal call-site consolidation
+continues as sibling issue P2b (`fulgur-2map.12`), sequenced after this phase.
+```
+
+**Step 3: Commit**
+
+```bash
+git add docs/plans/2026-06-27-engine-layout-api-design.md
+git commit -m "docs(plan): record P2a (Pt alias removal) outcome"
+```
+
+---
+
+## Notes for the executor
+
+- Every task after Task 5 depends on the struct/function retyped by earlier tasks
+  compiling cleanly — run them in order (1 → 2 → 3 → 4 → 5 → 6 → 7 → 8 → 9).
+- Tasks 1-6 are independent of each other in principle (different structs/functions) but
+  are sequenced to keep the alias's remaining-consumer count monotonically shrinking, so
+  Task 7's "confirm no remaining bare references" grep is a clean go/no-go check.
+- If a `cargo build` step in any task surfaces a call site not mentioned in this plan
+  (possible — the investigation was thorough but not automated), apply the same two
+  fixup rules from the Architecture section rather than guessing; when genuinely
+  ambiguous, stop and ask rather than picking `.pt()` vs `.to_f32()` by pattern-matching
+  syntax alone (this is the exact mistake the P2b design flags as a silent-bytes-change
+  risk).


### PR DESCRIPTION
## 概要

`crates/fulgur/src/draw_primitives.rs` に残っていた移行期の `pub type Pt = f32;` エイリアス（P1a〜P1eのunits::Px/Pt newtype移行で唯一取り残されていた境界）を削除しました。byte-neutralなリファクタリングで、PDF出力バイトへの影響はありません。

beads issue: `fulgur-2map.8`（epic `fulgur-2map` の子issue）

## 変更内容（9タスク、9コミット）

1. `draw_primitives::Rect`（リンク領域矩形）を `units::Pt` 化
2. `DestinationRegistry`（アンカー解決）を `units::Pt` 化
3. `BookmarkEntry.y_pt`/`BookmarkCollector`（PDF目次）を `units::Pt` 化
4. `clamp_marker_size`（list-style-imageマーカーサイズ計算）を `units::Pt` 化
5. `InlineBoxRenderCtx` のmargin fieldsは、型付けされた隣接値が存在しないため素の `f32` にリネームのみ（`units::Pt`化はせず、render.rs全体142箇所への不要な波及を回避）
6. `svg::SvgRender::draw`（デッドコード、v2描画パスから未使用と確認済み）の型付け——エイリアス最後の利用者だったため
7. `type Pt = f32` エイリアス自体を削除
8. フル検証（build/clippy/fmt/lib tests/render_smoke/examples_determinism/VRT byte-identical + `cargo llvm-cov` によるcodecov/patch coverage実測、未カバー行ゼロ確認）
9. ドキュメント更新（epic design docにP2aのoutcome追記、`units.rs`/`CLAUDE.md`の古い`Pt`言及を修正）

なお、issue記載の「27箇所のハードコード0.75定数置換」は、P1a〜P1eで既に解消済みであることを確認し、追加作業不要と判断しました。

## 検証

- `cargo build --workspace` / `cargo clippy -p fulgur --all-targets -- -D warnings` / `cargo fmt --check`: すべてクリーン
- `cargo test -p fulgur --lib`: 1544 passed
- `examples_determinism`: 11/11 passed
- VRT (`cargo test -p fulgur-vrt`): `run_fulgur_vrt` ok、golden diff ゼロ（`FULGUR_VRT_UPDATE` 未使用）
- `cargo llvm-cov nextest --workspace --exclude fulgur-vrt` で変更行の実測カバレッジを確認、未カバーのPROD行ゼロ

各コミットは独立したsubagentによるspec compliance review + code quality reviewの2段階レビューを経ており、最後に全体を通した holistic review も実施済みです。

## 補足（クローズ理由に記録予定）

- `draw_primitives` は `pub mod` のため、このエイリアス削除は公開APIの破壊的変更です。`cargo-semver-checks` が検知しうる想定ですが、プロジェクトのZeroVer方針によりブロッカーではなくadvisory扱いです。
- `svg::SvgRender::draw` は今回型を揃えましたが、デッドコード自体の削除は本PRのスコープ外としています（将来のクリーンアップ候補）。
- `px_to_pt`/`pt_to_px` の内部呼び出し整理は sibling issue `fulgur-2map.12`（P2b）に分割済みで、本PRマージ後に着手します。

## Test plan

- [x] `cargo build` / `clippy` / `fmt` クリーン
- [x] `cargo test -p fulgur --lib` 全通過
- [x] `examples_determinism` 11/11
- [x] VRT golden byte-identical
- [x] codecov/patch coverage 実測（未カバー行ゼロ）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * リンク、ブックマーク、画像、SVG の配置やサイズ計算がより一貫した単位で処理されるようになり、表示位置のずれや判定の不整合が起きにくくなりました。
* **Documentation**
  * 仕様整理に合わせて、関連ドキュメントの説明と実施計画を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->