### PR TITLE
fix(column_css): make module pub, keep parser internals pub(crate) (P3a)

### DIFF
--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -633,7 +633,9 @@ fn walk_for_inline_styles(
 /// bytes (O(nodes + css_bytes)), the second applies the cascade (also
 /// O(nodes + css_bytes)). Keeping them separate mirrors the CSS cascade —
 /// stylesheets are parsed once, then matched against every node.
-pub fn extract_column_style_table(doc: &HtmlDocument) -> crate::column_css::ColumnStyleTable {
+pub(crate) fn extract_column_style_table(
+    doc: &HtmlDocument,
+) -> crate::column_css::ColumnStyleTable {
     // 1. Concatenate every top-level <style> block's text content.
     let mut css = String::new();
     let root_id = doc.root_element().id;

--- a/crates/fulgur/src/column_css.rs
+++ b/crates/fulgur/src/column_css.rs
@@ -169,12 +169,12 @@ impl ColumnStyleProps {
 /// over `HashMap` so iteration order is deterministic — even though this
 /// table is only consulted during draw setup (never serialised directly),
 /// determinism is a project-wide invariant (see `CLAUDE.md`).
-pub type ColumnStyleTable = BTreeMap<usize, ColumnStyleProps>;
+pub(crate) type ColumnStyleTable = BTreeMap<usize, ColumnStyleProps>;
 
 /// A single parsed stylesheet rule: one or more selectors and the properties
 /// that apply when any of them matches.
 #[derive(Clone, Debug)]
-pub struct StyleRule {
+pub(crate) struct StyleRule {
     pub selectors: Vec<ComplexSelector>,
     pub props: ColumnStyleProps,
 }
@@ -183,7 +183,7 @@ pub struct StyleRule {
 /// selector. `Universal` matches every element; the other variants match
 /// against the corresponding attribute / tag.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum SimpleSelector {
+pub(crate) enum SimpleSelector {
     /// Lowercased tag name (e.g. `div`).
     Type(String),
     /// Class name without the leading `.`.
@@ -198,7 +198,7 @@ pub enum SimpleSelector {
 /// the same element (logical AND). `div.foo#bar` is a compound of three
 /// parts.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct CompoundSelector {
+pub(crate) struct CompoundSelector {
     pub parts: Vec<SimpleSelector>,
 }
 
@@ -206,7 +206,7 @@ pub struct CompoundSelector {
 /// the rule target. `prev_sibling` (if `Some`) is a compound selector that
 /// must match the element immediately preceding `subject` in the DOM.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct ComplexSelector {
+pub(crate) struct ComplexSelector {
     pub subject: CompoundSelector,
     /// Adjacent-sibling context (`E + F` → F is subject, E is prev_sibling).
     pub prev_sibling: Option<CompoundSelector>,
@@ -527,7 +527,7 @@ fn parse_page_value<'i>(input: &mut Parser<'i, '_>) -> Result<PageName, ParseErr
 /// Parse a CSS declaration block (no surrounding braces) into
 /// [`ColumnStyleProps`]. Invalid declarations drop silently; valid ones fill
 /// their field. Last-declaration-wins within a block.
-pub fn parse_declaration_block(css: &str) -> ColumnStyleProps {
+pub(crate) fn parse_declaration_block(css: &str) -> ColumnStyleProps {
     let mut props = ColumnStyleProps::default();
     let mut input = ParserInput::new(css);
     let mut parser = Parser::new(&mut input);
@@ -727,7 +727,7 @@ fn parse_column_rule_shorthand(input: &mut Parser<'_, '_>) -> Option<ColumnRuleS
 /// descendant/child/general-sibling combinators) — per Phase A scope
 /// discipline the whole rule is dropped silently so authors do not get a
 /// half-applied result. The adjacent-sibling combinator (`+`) is supported.
-pub fn parse_selector_list(input: &str) -> Vec<ComplexSelector> {
+pub(crate) fn parse_selector_list(input: &str) -> Vec<ComplexSelector> {
     let mut parser_input = ParserInput::new(input);
     let mut parser = Parser::new(&mut parser_input);
 
@@ -847,7 +847,7 @@ fn matches_compound(sel: &CompoundSelector, node: &blitz_dom::Node) -> bool {
     })
 }
 
-pub fn matches_complex(
+pub(crate) fn matches_complex(
     sel: &ComplexSelector,
     node: &blitz_dom::Node,
     doc: &blitz_html::HtmlDocument,
@@ -891,7 +891,7 @@ pub fn matches_complex(
 /// `parse_block`). Qualified rules whose prelude contains an unsupported
 /// selector are dropped. Empty property blocks are kept out of the result
 /// to save memory.
-pub fn parse_stylesheet(source: &str) -> Vec<StyleRule> {
+pub(crate) fn parse_stylesheet(source: &str) -> Vec<StyleRule> {
     let mut rules = Vec::new();
     let mut input = ParserInput::new(source);
     let mut parser = Parser::new(&mut input);
@@ -975,7 +975,7 @@ impl<'i, 'a> QualifiedRuleParser<'i> for SheetParser<'a> {
 /// order) and then inline `style` attributes (last — they beat the
 /// stylesheet) into each node's entry. Nodes with no matching rule and no
 /// inline declaration are skipped entirely.
-pub fn build_column_style_table(
+pub(crate) fn build_column_style_table(
     doc: &blitz_html::HtmlDocument,
     stylesheet_rules: &[StyleRule],
 ) -> ColumnStyleTable {

--- a/crates/fulgur/src/column_css.rs
+++ b/crates/fulgur/src/column_css.rs
@@ -118,7 +118,7 @@ pub struct ColumnStyleProps {
     /// author did not set the property — consumers should treat that as the
     /// initial value (`BreakInside::Auto`). Stored as `Option` for the same
     /// reason as the other fields: a later rule overwrites only the
-    /// properties it declares (see [`merge`](Self::merge)).
+    /// properties it declares (see `merge`).
     pub break_inside: Option<BreakInside>,
     /// `break-after` / `page-break-after` resolved by the sniffer.
     pub break_after: Option<BreakAfter>,

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -134,7 +134,7 @@ pub struct ConvertContext<'a> {
     /// [`crate::blitz_adapter::extract_column_style_table`]. `record_multicol_rule`
     /// reads `rule` properties from here when registering multicol containers
     /// in `drawables.multicol_rules`.
-    pub column_styles: crate::column_css::ColumnStyleTable,
+    pub(crate) column_styles: crate::column_css::ColumnStyleTable,
     /// Per-multicol-container geometry recorded by the Taffy multicol hook
     /// (see [`crate::multicol_layout::run_pass`]). `record_multicol_rule`
     /// reads this to register `column-rule` paint specs without re-running

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -116,11 +116,12 @@ pub struct ImageEntry {
 ///
 /// `tree` is `Arc<usvg::Tree>` — an external-crate type. Consumers that
 /// construct, inspect, or pattern-match on `usvg::Tree` directly (rather
-/// than treating it as opaque) must depend on the exact `usvg` version
-/// series this crate resolves (see the `usvg` entry in this crate's
-/// `Cargo.toml`); a mismatched `usvg` version will not type-unify even if
-/// semver-compatible, since `usvg::Tree` is not part of `usvg`'s own
-/// stability guarantees across our pinned range.
+/// than treating it as opaque) must depend on the same `usvg` version
+/// range this crate resolves (see the `usvg` entry in this crate's
+/// `Cargo.toml`). Rust type identity is per-resolved-crate-instance: a
+/// `usvg::Tree` from a differently-resolved `usvg` dependency is a
+/// distinct type and will not interoperate with fulgur's, even across a
+/// nominally-minor 0.x bump.
 #[derive(Debug, Clone)]
 pub struct SvgEntry {
     pub tree: std::sync::Arc<usvg::Tree>,

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -113,6 +113,14 @@ pub struct ImageEntry {
 }
 
 /// SVG draw payload for v2. Mirrors the fields `SvgRender` holds.
+///
+/// `tree` is `Arc<usvg::Tree>` — an external-crate type. Consumers that
+/// construct, inspect, or pattern-match on `usvg::Tree` directly (rather
+/// than treating it as opaque) must depend on the exact `usvg` version
+/// series this crate resolves (see the `usvg` entry in this crate's
+/// `Cargo.toml`); a mismatched `usvg` version will not type-unify even if
+/// semver-compatible, since `usvg::Tree` is not part of `usvg`'s own
+/// stability guarantees across our pinned range.
 #[derive(Debug, Clone)]
 pub struct SvgEntry {
     pub tree: std::sync::Arc<usvg::Tree>,

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -36,7 +36,7 @@ pub(crate) const MAX_PAGES: u32 = 100_000;
 pub mod asset;
 pub mod background;
 pub mod blitz_adapter;
-pub(crate) mod column_css;
+pub mod column_css;
 pub mod config;
 pub mod convert;
 pub mod draw_primitives;

--- a/crates/fulgur/tests/public_reachability.rs
+++ b/crates/fulgur/tests/public_reachability.rs
@@ -1,0 +1,19 @@
+//! Regression guard for fulgur-2map.9 (P3a): confirms that `Drawables`-reachable
+//! `column_css` types stay nameable via `fulgur::column_css::*` from outside the
+//! crate. If `column_css` (or one of these types) is ever made private/pub(crate)
+//! again, this file fails to compile — that's the point.
+
+use fulgur::column_css::{ColumnFill, ColumnRuleSpec, ColumnRuleStyle, ColumnStyleProps, PageName};
+
+#[test]
+fn column_css_public_types_are_externally_nameable() {
+    let spec = ColumnRuleSpec::default();
+    assert_eq!(spec.style, ColumnRuleStyle::default());
+
+    let props = ColumnStyleProps {
+        fill: Some(ColumnFill::default()),
+        page: Some(PageName::Auto),
+        ..ColumnStyleProps::default()
+    };
+    assert_eq!(props.fill, Some(ColumnFill::Balance));
+}

--- a/docs/plans/2026-07-01-p3a-public-reachability-gaps.md
+++ b/docs/plans/2026-07-01-p3a-public-reachability-gaps.md
@@ -1,0 +1,257 @@
+# P3a: Public-Reachability Gaps Implementation Plan
+
+**Goal:** Make `column_css`'s public-facing types (`ColumnRuleSpec` and friends, already
+reachable as *values* through `Drawables.multicol_rules`) nameable from outside the crate,
+without leaking the CSS parser's internal implementation types, and document the `usvg`
+version-pin requirement for `SvgEntry.tree` consumers. This unblocks `fulgur-2map.10`
+(public `Engine::layout()`).
+
+**Architecture:** `column_css` becomes a `pub mod` (was `pub(crate) mod`). The 10
+CSS-parser-internal items inside it (`ColumnStyleTable`, `StyleRule`, `SimpleSelector`,
+`CompoundSelector`, `ComplexSelector`, and 5 parse/match functions) are downgraded from
+`pub` to `pub(crate)` in the same change, so only the 5 already-Drawables-reachable data
+types (`ColumnRuleSpec`, `ColumnStyleProps`, `ColumnRuleStyle`, `ColumnFill`, `PageName`)
+become genuinely externally nameable. Verified empirically in a throwaway trial build: this
+does not regress `blitz_adapter::extract_column_style_table` (still builds warning-free) and
+removes exactly the 10 pre-existing `unreachable_pub` warnings on `column_css` items (verified
+via `RUSTFLAGS="-W unreachable_pub"`), leaving only 4 pre-existing, unrelated `net.rs`
+warnings untouched.
+
+**Tech Stack:** Rust, cargo, existing fulgur integration test conventions
+(`crates/fulgur/tests/*.rs`).
+
+---
+
+## Task 1: Public-reachability regression test + visibility fix (TDD)
+
+**Files:**
+
+- Create: `crates/fulgur/tests/public_reachability.rs`
+- Modify: `crates/fulgur/src/lib.rs:39`
+- Modify: `crates/fulgur/src/column_css.rs` (10 items: lines 172, 177, 186, 201, 209, 530,
+  730, 850, 894, 978 — line numbers as of this plan's writing; re-grep before editing since
+  earlier edits in this task may shift later ones)
+
+**Step 1: Write the failing test**
+
+Create `crates/fulgur/tests/public_reachability.rs`:
+
+```rust
+//! Regression guard for fulgur-2map.9 (P3a): confirms that `Drawables`-reachable
+//! `column_css` types stay nameable via `fulgur::column_css::*` from outside the
+//! crate. If `column_css` (or one of these types) is ever made private/pub(crate)
+//! again, this file fails to compile — that's the point.
+
+use fulgur::column_css::{ColumnFill, ColumnRuleSpec, ColumnRuleStyle, ColumnStyleProps, PageName};
+
+#[test]
+fn column_css_public_types_are_externally_nameable() {
+    let spec = ColumnRuleSpec::default();
+    assert_eq!(spec.style, ColumnRuleStyle::default());
+
+    let props = ColumnStyleProps {
+        fill: Some(ColumnFill::default()),
+        page: Some(PageName::Auto),
+        ..ColumnStyleProps::default()
+    };
+    assert_eq!(props.fill, Some(ColumnFill::Balance));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p fulgur --test public_reachability 2>&1 | head -20`
+
+Expected: compile error `E0603` — `` module `column_css` is private `` (because
+`crates/fulgur/src/lib.rs:39` still says `pub(crate) mod column_css;`).
+
+**Step 3: Implement the minimal visibility change**
+
+In `crates/fulgur/src/lib.rs:39`, change:
+
+```rust
+pub(crate) mod column_css;
+```
+
+to:
+
+```rust
+pub mod column_css;
+```
+
+In `crates/fulgur/src/column_css.rs`, downgrade exactly these 10 declarations from `pub` to
+`pub(crate)` (do not touch any other `pub` item in the file — the 5 data types
+`ColumnRuleStyle`, `ColumnRuleSpec`, `ColumnFill`, `PageName`, `ColumnStyleProps` stay `pub`):
+
+```rust
+pub(crate) type ColumnStyleTable = BTreeMap<usize, ColumnStyleProps>;
+pub(crate) struct StyleRule {
+pub(crate) enum SimpleSelector {
+pub(crate) struct CompoundSelector {
+pub(crate) struct ComplexSelector {
+pub(crate) fn parse_declaration_block(css: &str) -> ColumnStyleProps {
+pub(crate) fn parse_selector_list(input: &str) -> Vec<ComplexSelector> {
+pub(crate) fn matches_complex(
+pub(crate) fn parse_stylesheet(source: &str) -> Vec<StyleRule> {
+pub(crate) fn build_column_style_table(
+```
+
+(Only the declaration line's leading `pub` token changes to `pub(crate)`; struct/enum bodies,
+fields, and function bodies are untouched.)
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p fulgur --test public_reachability 2>&1 | tail -10`
+
+Expected: `test column_css_public_types_are_externally_nameable ... ok`
+
+**Step 5: Run the full lib test suite to check for fallout**
+
+Run: `cargo test -p fulgur --lib 2>&1 | tail -10`
+
+Expected: `1544 passed; 0 failed` (same count as the worktree baseline recorded before this
+plan — if the count differs, stop and investigate before continuing).
+
+**Step 6: Confirm no `unreachable_pub` regressions and no new warnings**
+
+Run:
+
+```bash
+touch crates/fulgur/src/lib.rs
+RUSTFLAGS="-W unreachable_pub" cargo build -p fulgur --message-format=short 2>&1 | grep -c warning
+```
+
+Expected: `5` (4 individual pre-existing `net.rs` warnings + 1 summary line — matches the
+verified pre-fix-minus-column_css baseline; if it's still 15, the downgrade didn't take
+effect somewhere).
+
+**Step 7: Commit**
+
+```bash
+git add crates/fulgur/src/lib.rs crates/fulgur/src/column_css.rs crates/fulgur/tests/public_reachability.rs
+git commit -m "fix(column_css): make module pub, keep parser internals pub(crate)
+
+Drawables.multicol_rules already leaks ColumnRuleSpec (and 4 sibling
+types) as values; column_css being pub(crate) made them unnameable by
+external consumers. Make the module pub while downgrading the 10
+CSS-parser-internal items to pub(crate) so only the already-reachable
+data types become nameable.
+
+fulgur-2map.9"
+```
+
+---
+
+## Task 2: Document the usvg version-pin requirement on `SvgEntry.tree`
+
+**Files:**
+
+- Modify: `crates/fulgur/src/drawables.rs:115-117` (doc comment directly above the `SvgEntry`
+  struct and/or above the `tree` field — re-check exact line numbers after Task 1's edits
+  land, since this file itself is untouched by Task 1 but line numbers in this plan were
+  captured before Task 1 ran)
+
+**Step 1: Add the doc comment**
+
+Current code (`crates/fulgur/src/drawables.rs`, immediately before `pub struct SvgEntry`):
+
+```rust
+/// SVG draw payload for v2. Mirrors the fields `SvgRender` holds.
+#[derive(Debug, Clone)]
+pub struct SvgEntry {
+    pub tree: std::sync::Arc<usvg::Tree>,
+```
+
+Change to:
+
+```rust
+/// SVG draw payload for v2. Mirrors the fields `SvgRender` holds.
+///
+/// `tree` is `Arc<usvg::Tree>` — an external-crate type. Consumers that
+/// construct, inspect, or pattern-match on `usvg::Tree` directly (rather
+/// than treating it as opaque) must depend on the exact `usvg` version
+/// series this crate resolves (see the `usvg` entry in this crate's
+/// `Cargo.toml`); a mismatched `usvg` version will not type-unify even if
+/// semver-compatible, since `usvg::Tree` is not part of `usvg`'s own
+/// stability guarantees across our pinned range.
+#[derive(Debug, Clone)]
+pub struct SvgEntry {
+    pub tree: std::sync::Arc<usvg::Tree>,
+```
+
+**Step 2: Verify the doc builds cleanly**
+
+Run: `cargo doc -p fulgur --no-deps 2>&1 | tail -20`
+
+Expected: no new warnings (no broken intra-doc links; the comment above uses plain text, not
+`[...]` links, so this should be a no-op check).
+
+**Step 3: Commit**
+
+```bash
+git add crates/fulgur/src/drawables.rs
+git commit -m "docs(drawables): document usvg version-pin requirement on SvgEntry.tree
+
+fulgur-2map.9"
+```
+
+---
+
+## Task 3: Full verification pass
+
+No code changes in this task — confirms the epic's byte-neutrality requirement and runs the
+full acceptance-criteria checklist from the beads issue.
+
+**Step 1: Build and lint**
+
+```bash
+cargo build -p fulgur 2>&1 | tail -10
+cargo clippy -p fulgur --lib 2>&1 | tail -20
+cargo fmt --check 2>&1 | tail -20
+```
+
+Expected: clean build, no new clippy warnings beyond pre-existing baseline, `fmt --check`
+passes (no diff).
+
+**Step 2: Full fulgur test suite**
+
+```bash
+cargo test -p fulgur 2>&1 | tail -20
+```
+
+Expected: all tests pass, including the new `public_reachability` integration test.
+
+**Step 3: VRT golden byte-identity check**
+
+```bash
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur-vrt 2>&1 | tail -30
+```
+
+Expected: all VRT reftests pass (no PDF byte diffs against `goldens/fulgur/**/*.pdf`) — this
+is a pure visibility + doc-comment change, so no draw-path behavior changes and no golden
+updates should be needed. If any VRT test fails, stop and investigate before proceeding (do
+NOT run with `FULGUR_VRT_UPDATE=1` to paper over an unexpected diff).
+
+**Step 4: CLI examples determinism check**
+
+```bash
+cargo test -p fulgur-cli --test examples_determinism 2>&1 | tail -30
+```
+
+Expected: passes, no byte diffs.
+
+**Step 5: Report**
+
+If all four checks pass, this plan's implementation is complete and matches every acceptance
+criterion recorded on `fulgur-2map.9`. No commit needed for this task (verification-only,
+unless `cargo fmt` step 1 found and needs fixing — if so, `git add -u && git commit -m "style: cargo fmt"`
+before proceeding).
+
+---
+
+## Post-plan
+
+Update the beads issue: `bd update fulgur-2map.9 --status=in_review` (or hand off per
+`superpowers:finishing-a-development-branch`), and confirm the follow-up refactor issue
+`fulgur-fx6v` (splitting `column_css.rs` into `types.rs` + `parser.rs`) remains filed and
+non-blocking.


### PR DESCRIPTION
## 概要

`fulgur-2map.9`（Epic `fulgur-2map`: `Engine::layout()` 公開に向けたPx/Pt newtype座標基盤整備、P3a）の実装です。次フェーズ `fulgur-2map.10`（公開 `Engine::layout()` + `LayoutOutput`）の前提となる public-reachability gap を解消します。

- `column_css` を `pub mod` 化しつつ、CSSパーサー内部専用の10項目 (`ColumnStyleTable`/`StyleRule`/セレクタ型/parse系関数) は `pub(crate)` に格下げ。`Drawables.multicol_rules` 経由で既に値として漏れていた5型 (`ColumnRuleSpec`/`ColumnStyleProps`/`ColumnRuleStyle`/`ColumnFill`/`PageName`) だけが外部から名前で参照可能になる
- 回帰防止用に `crates/fulgur/tests/public_reachability.rs` を追加（外部パスでの型参照がコンパイルできることを保証するテスト）
- `SvgEntry.tree: Arc<usvg::Tree>` に usvg バージョン依存関係のdocコメントを追加（Cargo.toml参照方式、バージョン番号のハードコードなし）

設計の詳細は `docs/plans/2026-07-01-p3a-public-reachability-gaps.md` およびbeads issue `fulgur-2map.9` のdesignフィールドを参照してください。

## フォローアップ（本PRでは対応せず、別issueとして起票済み・非ブロッキング）

- `fulgur-fx6v`: `column_css.rs` (1887行) を `types.rs` + `parser.rs` に物理分割するリファクタリング
- `fulgur-n8ie`: `fulgur-2map.10` 時に `pub use usvg;` でtype-identity保証を検討

## Test plan

- [x] `cargo build -p fulgur`
- [x] `cargo clippy -p fulgur --lib`（新規warning無し、`unreachable_pub`確認込み）
- [x] `cargo fmt --check`
- [x] `cargo test -p fulgur`（lib 1544件 + 全integration test + doctest、0 failed）
- [x] `FONTCONFIG_FILE=... cargo test -p fulgur-vrt`（golden byte-diff無し）
- [x] `cargo test -p fulgur-cli --test examples_determinism`（byte-diff無し）
- [x] subagent-driven-development: 全3タスクをspec compliance + code quality review、branch全体の最終レビューも実施（すべて "Ready to merge: Yes"）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 一部のカラム関連機能が外部から利用しやすくなりました。
  * 公開範囲の回帰を防ぐための検証が追加されました。

* **Documentation**
  * SVG関連の注意事項と、利用時の互換性に関する説明が明確になりました。

* **Bug Fixes**
  * 公開APIの範囲を整理し、意図しない外部公開や参照のぶれを抑えました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->