### PR TITLE
release-plz: force minor-only bumps via custom_minor_increment_regex

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,6 +4,12 @@ release = true
 # are bindings that aren't published to crates.io and have no registry baseline to
 # diff against — leave it off workspace-wide and opt in only where it's meaningful.
 semver_check = false
+# ZeroVer policy: never auto-bump patch, only minor. Matching everything here
+# means every triggering commit (conventional or not) resolves to Minor instead
+# of falling through to release-plz's default Patch case (see next_version's
+# is_minor_bump()/is_major_bump()); major stays pinned at 0 since
+# breaking_always_increment_major is left at its false default.
+custom_minor_increment_regex = ".*"
 # Default tag/release naming is per-package ("{{ package }}-v{{ version }}") once a
 # workspace has more than one publishable crate (fulgur + fulgur-cli here), which
 # would produce multiple tags/releases instead of the single v$VERSION tag the

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -10,6 +10,13 @@ semver_check = false
 # is_minor_bump()/is_major_bump()); major stays pinned at 0 since
 # breaking_always_increment_major is left at its false default.
 custom_minor_increment_regex = ".*"
+# Commits of these types alone shouldn't trigger a release at all (chore(deps)
+# bumps, docs typos, CI tweaks, etc). Narrowing custom_minor_increment_regex
+# instead would be wrong here: anything it doesn't match still falls through
+# to release-plz's default Patch case, silently reintroducing the patch bumps
+# this policy exists to eliminate. no_increment_regex is the only way to skip
+# a release outright rather than just changing which part gets bumped.
+no_increment_regex = "^(chore|docs|style|test|build|ci)"
 # Default tag/release naming is per-package ("{{ package }}-v{{ version }}") once a
 # workspace has more than one publishable crate (fulgur + fulgur-cli here), which
 # would produce multiple tags/releases instead of the single v$VERSION tag the


### PR DESCRIPTION
## Summary
- ZeroVerポリシー（毎回minor固定、patchは手動hotfix専用）を release-plz の自動化に乗せるため、`release-plz.toml` の `[workspace]` に `custom_minor_increment_regex = ".*"` を追加
- release-plz には「ZeroVer専用サポート」という名前の機能はなく、近い `features_always_increment_minor` は `feat:` コミットのみが対象で `fix:` のみのPRではpatch bumpが残ってしまうため不十分（`next_version` クレートのソースで検証済み）
- `custom_minor_increment_regex` にマッチした commit は `next_version::version_increment.rs` の `is_minor_bump()` により無条件でMinor判定になり、release-plz既定のPatchへのフォールスルーが起きなくなる。`is_major_bump()` は `current.major != 0 || breaking_always_increment_major` が条件のため、major は 0 固定である限り上がらない
- 関連して beads epic fulgur-bg1n 配下を整理: 前提が崩れた fulgur-q7mc（golden差分でminor強制接続する設計）はclose、fulgur-0nkc（VRT golden差分検出）はbump判定接続を外し独立したCIマーカー用途として存続

## Test plan
- [ ] `release-plz update --dry-run` 等で、fix:のみのコミットでもminor bumpになることを確認
- [ ] 既存のcore version_group（fulgur/fulgur-cli/fulgur-wasm/pyfulgur/fulgur-ruby）の同期bumpが崩れないことを確認