### PR TITLE
fix: remove invalid no_increment_regex from release-plz.toml

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -10,13 +10,28 @@ semver_check = false
 # is_minor_bump()/is_major_bump()); major stays pinned at 0 since
 # breaking_always_increment_major is left at its false default.
 custom_minor_increment_regex = ".*"
-# Commits of these types alone shouldn't trigger a release at all (chore(deps)
-# bumps, docs typos, CI tweaks, etc). Narrowing custom_minor_increment_regex
-# instead would be wrong here: anything it doesn't match still falls through
-# to release-plz's default Patch case, silently reintroducing the patch bumps
-# this policy exists to eliminate. no_increment_regex is the only way to skip
-# a release outright rather than just changing which part gets bumped.
-no_increment_regex = "^(chore|docs|style|test|build|ci)"
+# `no_increment_regex` (used here previously, added in PR #533) does not exist
+# in release-plz's actual release-plz.toml schema (verified against
+# `release-plz generate-schema` on release-plz 0.3.159, the latest published
+# version as of this writing -- it's only a next_version crate Rust API,
+# never wired through release_plz_core's TOML config). Any release-plz
+# invocation against that key fails immediately with
+# `unknown field `no_increment_regex``, so main's release-plz.toml has been
+# unusable since PR #533 merged.
+#
+# There's no config-only fix that also skips releases outright for
+# chore/docs/style/test/build/ci-only commits: the schema-real equivalent,
+# `release_commits`, gates whether get_next_version() even runs for a
+# package -- and packages with no `release_commits`-matching commit of their
+# own fall through to a separate "dependency changed" code path that bumps a
+# bare patch and bypasses version_group's lockstep-max propagation entirely
+# (verified empirically: with release_commits set, fulgur-cli alone ended up
+# at 0.20.1 while fulgur/fulgur-ruby/fulgur-wasm/pyfulgur went to 0.21.0).
+# Preserving the 5-crate "core" version_group lockstep matters more than
+# skipping releases for trivial-only commits, so that requirement is dropped
+# instead: every push that changes anything still bumps minor across the
+# whole group, even chore/docs/ci-only ones. That's a reversion to the
+# original ZeroVer "every release bumps minor" philosophy, not a regression.
 # Default tag/release naming is per-package ("{{ package }}-v{{ version }}") once a
 # workspace has more than one publishable crate (fulgur + fulgur-cli here), which
 # would produce multiple tags/releases instead of the single v$VERSION tag the


### PR DESCRIPTION
## Summary
- PR #533でマージした`no_increment_regex`はrelease-plzの実際のTOMLスキーマに存在しないフィールドで、`release-plz generate-schema`（0.3.159、最新版）で実機確認したところ`unknown field`エラーで即座に失敗する。つまりmainの`release-plz.toml`はPR #533マージ以降、release-plzを実行すると全面的に壊れている状態だった
- 代替として`release_commits`（実スキーマに存在、release対象判定を全コミットメッセージに対して行う）を試したが、これは`version_group`のlockstepを壊すことを実機検証で確認した。自身に直接コミットのないcrate（例: `fulgur-cli`）が「依存更新のみ」の別経路に落ち、`version_group`のlockstep-max伝播をスキップしてpatchのみbumpしてしまう（`fulgur-cli`だけ`0.20.1`、他4crateは`0.21.0`という不整合を確認）
- 5crateのlockstepを維持する方を優先し、`custom_minor_increment_regex = ".*"`のみを残す方針に変更。これにより「非本質的コミットのみでもリリースをスキップしない」という挙動に戻るが、これは元々のZeroVer「毎回minor固定」方針への回帰であり、退行ではない
- `release-plz update --allow-dirty`のdry-runで5crate全て`0.20.0 -> 0.21.0`に正しくlockstepすることを確認済み

## Test plan
- [x] `python3 -c "import tomllib; tomllib.load(open('release-plz.toml','rb'))"` でTOML構文確認
- [x] `release-plz update --allow-dirty`のdry-runで、config parseエラーが解消し、5crate（fulgur/fulgur-cli/fulgur-ruby/fulgur-wasm/pyfulgur）全てが`0.21.0`にlockstepすることを確認（結果は破棄、コミットしていない）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * リリース時のバージョン更新ルールを整理し、変更内容に応じた更新がより一貫して行われるようにしました。
  * 一部の変更種別でリリースが抑制されるのではなく、関連する更新がまとまって反映されやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->