### PR TITLE
fix(release-plz): set publish=false on fulgur-vrt/fulgur-wpt to match Cargo.toml

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -84,10 +84,18 @@ git_only = true
 # release = false fully excludes these test/fixture crates (version 0.0.0) from
 # release-plz entirely — different from publish = false above, which still
 # version-tracks the binding crates via the core version_group.
+# publish = false is still required alongside release = false: `release-plz
+# release` validates that each package's configured publish flag matches its
+# Cargo.toml (which has publish = false here), and errors before the release =
+# false exclusion is applied otherwise. (release-pr/update skip this check, so
+# the mismatch only surfaced once release-plz.yml first ran `release-plz
+# release`.)
 [[package]]
 name = "fulgur-vrt"
 release = false
+publish = false
 
 [[package]]
 name = "fulgur-wpt"
 release = false
+publish = false


### PR DESCRIPTION
## 概要

`release-plz release` の config 検証エラーを修正する go-live ブロッカー hotfix。epic `fulgur-bg1n`。

PR #536 で `release-plz.yml` が導入され、初めて `release-plz release` が実行されたところ、以下で失敗した (run 28568287841 の release job を re-run して検出):

```text
ERROR Package `fulgur-vrt` has `publish = false` or `publish = []` in the Cargo.toml,
      but it has `publish = true` in the release-plz configuration.
```

## 原因

`release-plz.toml` の `[[package]] fulgur-vrt` / `fulgur-wpt` は `release = false` のみ設定し `publish` を未指定だった。そのため workspace デフォルトの `publish = true` が効き、両 crate の Cargo.toml (`publish = false`) と不整合。`release-plz release` はこの publish フラグ整合を検証してエラーにする (しかも `release = false` の除外適用より前に検証するため、release=false だけでは回避できない)。

`release-pr` / `release-plz update` はこの検証を行わないため、事前の dry-run では検出されず、`release-plz release` を実際に走らせて初めて表面化した。

## 修正

両エントリに `publish = false` を追加し Cargo.toml と一致させる。`release = false` による完全除外はそのまま維持。

## 検証

`release-plz release --dry-run` (実 token) が **exit 0**:

```text
INFO fulgur 0.20.0: Already published - Tag v0.20.0 already exists
INFO fulgur-cli 0.20.0: already published
```

- fulgur / fulgur-cli は publish 済みで正しく no-op
- fulgur-vrt / fulgur-wpt の config エラーは消失
- (fulgur-cli の CHANGELOG.md 未存在 WARN は release body が空になるだけで失敗ではない。per-crate changelog 整合は `fulgur-b0nb` スコープ)

## 補足 (go-live 状況)

同 re-run で **crates.io Trusted Publisher (OIDC) と `release` environment のゲート解除は検証済み** (Authenticate to crates.io ステップ成功)。本 PR マージで `release-plz release` の残る config ブロッカーが解消し、Release PR #537 (v0.21.0) をマージすれば初回リリースが通る見込み。

Refs: fulgur-25yf, epic fulgur-bg1n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 一部パッケージについて、リリース対象外・公開対象外の設定を明確化しました。
  * 設定不一致時にリリース処理でエラーになる点がわかるよう、注意書きを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->