### PR TITLE
ci(release-plz): App-authored Release PR + supply-chain hardening

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -31,7 +31,7 @@ jobs:
           path-to-signatures: '.github/cla-signatures.json'
           path-to-document: 'https://github.com/fulgur-rs/fulgur/blob/main/CLA.md'
           branch: 'cla-signatures'
-          allowlist: 'dependabot[bot],github-actions[bot],renovate[bot],Copilot,devin-ai-integration[bot]'
+          allowlist: 'dependabot[bot],github-actions[bot],renovate[bot],Copilot,devin-ai-integration[bot],fulgur-release-bot[bot]'
           custom-notsigned-prcomment: >
             Thank you for your pull request! Before we can merge this contribution,
             please sign our Contributor License Agreement (CLA). The CLA is a

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -37,11 +37,14 @@ jobs:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           # Scope to what release-pr needs: create/update the Release PR
-          # (pull-requests) and create + push the PR branch via the API
-          # (contents). The version-bump commit never touches
-          # .github/workflows/*, so no `workflows` permission is needed here.
+          # (pull-requests) and create/advance the PR branch via the API
+          # (contents). Include workflows too: the release branch can be
+          # advanced across a commit that touched .github/workflows/* (e.g. this
+          # very change once it lands on main), and GitHub rejects App ref
+          # updates spanning workflow-file changes without it. The App grants it.
           permission-contents: write
           permission-pull-requests: write
+          permission-workflows: write
 
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -116,16 +119,20 @@ jobs:
             exit 1
           }
 
-          (cd crates/fulgur-ruby && bundle install)
+          # Don't expose the App token to Bundler: `bundle install` runs
+          # arbitrary gem build/install hooks, so drop GH_TOKEN from its env.
+          (cd crates/fulgur-ruby && env -u GH_TOKEN bundle install)
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           git commit -m "chore: sync auxiliary version files to $VERSION" || echo "no changes to sync"
-          # Checkout did not persist credentials; set the App token on the
-          # remote only now, right before the push. This keeps the token out of
-          # git config for earlier steps and makes the push App-authored (so it
-          # triggers CI on the Release PR).
+          # Put the App token on the remote only for the push, and scrub it
+          # immediately after — via a trap so it's removed even if the push
+          # fails — so it isn't left in .git/config for later actions' post-job
+          # hooks (checkout did not persist credentials for the same reason).
+          # The token makes the push App-authored, which triggers CI on the PR.
+          trap 'git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git" || true' EXIT
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push
 

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -32,7 +32,7 @@ jobs:
       # to have Pull requests + Contents: Read and write.
       - name: Generate App token for the Release PR
         id: app-token
-        uses: actions/create-github-app-token@v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -45,19 +45,21 @@ jobs:
           permission-pull-requests: write
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           fetch-depth: 0
-          # Persist the App token so the aux-file-sync step's git push is also
-          # App-authored (and thus triggers CI on the Release PR).
-          persist-credentials: true
-          token: ${{ steps.app-token.outputs.token }}
+          # Don't persist a token in git config where later actions could read
+          # it. release-plz pushes the PR branch via the GitHub API (auth'd by
+          # the App token in its env, below); the aux-file-sync step sets the
+          # App token on its remote URL immediately before its own git push,
+          # which also keeps that push App-authored so it triggers CI.
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           shared-key: ubuntu-latest-fulgur
           save-if: false
@@ -70,7 +72,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
-      - uses: ruby/setup-ruby@v1.312.0
+      - uses: ruby/setup-ruby@12fd324f1d0b43274fdc8130f6980590a667c455  # v1.312.0
         if: fromJSON(steps.release-plz.outputs.pr).number
         with:
           ruby-version: '3.3'
@@ -121,6 +123,11 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           git commit -m "chore: sync auxiliary version files to $VERSION" || echo "no changes to sync"
+          # Checkout did not persist credentials; set the App token on the
+          # remote only now, right before the push. This keeps the token out of
+          # git config for earlier steps and makes the push App-authored (so it
+          # triggers CI on the Release PR).
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push
 
   release:
@@ -143,15 +150,16 @@ jobs:
       id-token: write  # required by rust-lang/crates-io-auth-action (OIDC)
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           shared-key: ubuntu-latest-fulgur
           save-if: false
@@ -164,16 +172,16 @@ jobs:
       # This works because release-plz creates the `vX.Y.Z` tag via the GitHub
       # API (github_client.create_tag) using the token passed below as
       # GITHUB_TOKEN — the App token — so the tag-push event is App-authored and
-      # fires release.yml. The checkout above keeps the DEFAULT GITHUB_TOKEN in
-      # its git credentials, which is fine: this job never `git push`es.
+      # fires release.yml. Checkout does not persist credentials, which is fine:
+      # this job never `git push`es (release-plz uses the API).
       # CAUTION: release-plz only takes the API path when tags are unsigned. If
       # you ever enable tag signing (git config tag.gpgSign true) or add a
       # `git push` step here, release-plz falls back to the git CLI, which would
-      # use the default token and SILENTLY break the release.yml cascade — you
-      # must then also persist the App token into this checkout's credentials.
+      # then need the App token configured on the remote immediately before the
+      # push (else it uses the default token and SILENTLY breaks the cascade).
       - name: Generate App token for tag/release push
         id: app-token
-        uses: actions/create-github-app-token@v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -187,7 +195,7 @@ jobs:
 
       - name: Authenticate to crates.io
         id: crates-auth
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18  # v1.0.5
 
       - name: Run release-plz release
         uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7  # v0.5.130

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -25,15 +25,26 @@ jobs:
       group: release-plz-pr-${{ github.ref }}
       cancel-in-progress: false
     steps:
+      # Create the Release PR (and push the aux-file-sync commit) as the release
+      # App, NOT the default GITHUB_TOKEN. A PR/commit authored via GITHUB_TOKEN
+      # does not fire other workflows, so ci.yml would never run on the Release
+      # PR and every release would need CI kicked off by hand. Requires the App
+      # to have Pull requests + Contents: Read and write.
+      - name: Generate App token for the Release PR
+        id: app-token
+        uses: actions/create-github-app-token@v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          # release-plz itself pushes to the PR branch via the GitHub API using
-          # the GITHUB_TOKEN env var below, but the aux-file-sync step further
-          # down uses the git CLI directly and needs persisted credentials to
-          # push (see release-plz docs/github/persist-credentials.md).
+          # Persist the App token so the aux-file-sync step's git push is also
+          # App-authored (and thus triggers CI on the Release PR).
           persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
@@ -50,7 +61,7 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - uses: ruby/setup-ruby@v1.312.0
         if: fromJSON(steps.release-plz.outputs.pr).number
@@ -61,7 +72,7 @@ jobs:
       - name: Sync auxiliary version files onto the release PR branch
         if: fromJSON(steps.release-plz.outputs.pr).number
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -e
           PR_NUMBER=${{ fromJSON(steps.release-plz.outputs.pr).number }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -36,11 +36,10 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-          # Least privilege: release-pr creates/updates the PR + pushes the
-          # branch; release creates the tag/GH Release (POST /git/refs,
-          # /releases) and reads associated PRs for contributors. Both are
-          # fully covered by contents+pull-requests write. Tag creation is via
-          # the API, not git push, so no `workflows` permission is needed.
+          # Scope to what release-pr needs: create/update the Release PR
+          # (pull-requests) and create + push the PR branch via the API
+          # (contents). The version-bump commit never touches
+          # .github/workflows/*, so no `workflows` permission is needed here.
           permission-contents: write
           permission-pull-requests: write
 
@@ -185,13 +184,16 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-          # Least privilege: release-pr creates/updates the PR + pushes the
-          # branch; release creates the tag/GH Release (POST /git/refs,
-          # /releases) and reads associated PRs for contributors. Both are
-          # fully covered by contents+pull-requests write. Tag creation is via
-          # the API, not git push, so no `workflows` permission is needed.
+          # Scope to what `release-plz release` needs: create the tag + GH
+          # Release (contents) and read associated PRs for contributors
+          # (pull-requests). Keep `workflows: write` too — a release tag can
+          # point at a commit that touched .github/workflows/*, and the
+          # documented release-bot setup requires it for that case
+          # (docs/RELEASE_SETUP.md); the App already grants it, so requesting it
+          # here removes the risk of the tag/release API rejecting the SHA.
           permission-contents: write
           permission-pull-requests: write
+          permission-workflows: write
 
       - name: Authenticate to crates.io
         id: crates-auth

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -36,6 +36,13 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          # Least privilege: release-pr creates/updates the PR + pushes the
+          # branch; release creates the tag/GH Release (POST /git/refs,
+          # /releases) and reads associated PRs for contributors. Both are
+          # fully covered by contents+pull-requests write. Tag creation is via
+          # the API, not git push, so no `workflows` permission is needed.
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -170,6 +177,13 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          # Least privilege: release-pr creates/updates the PR + pushes the
+          # branch; release creates the tag/GH Release (POST /git/refs,
+          # /releases) and reads associated PRs for contributors. Both are
+          # fully covered by contents+pull-requests write. Tag creation is via
+          # the API, not git push, so no `workflows` permission is needed.
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Authenticate to crates.io
         id: crates-auth

--- a/docs/RELEASE_SETUP.md
+++ b/docs/RELEASE_SETUP.md
@@ -238,6 +238,9 @@ workflows permission` で拒否されるためで、App 側に `Workflows: Read 
    - Repository permissions:
      - **Contents: Read and write** (release 作成・編集に必要)
      - **Workflows: Read and write** (tag push 時に workflow ファイル変更を伴う commit を通すために必要)
+     - **Pull requests: Read and write** (`release-plz.yml` の release-pr job が
+       この App token で Release PR を作成/更新するために必要。App 作成の PR/commit
+       にすることで `ci.yml` (pull_request) が Release PR で自動発火する)
    - Where can this GitHub App be installed?: "Only on this account"
 2. 作成後の App 設定画面で:
    - **App ID** を控える (数値)


### PR DESCRIPTION
## 概要

`release-plz.yml` の (1) Release PR CI 自動化 と (2) サプライチェーン堅牢化。epic `fulgur-bg1n`。

## (1) Release PR に CI を自動発火させる（`fulgur-inp6`）

`release-pr` job が `GITHUB_TOKEN`（`github-actions[bot]`）で PR を作成/push していたため、`GITHUB_TOKEN` 起因の PR/commit は他 workflow を発火させない制約で `ci.yml`（`pull_request`）が自動起動せず、初回 Release PR #537 は CI を手動起動する必要があった（毎回再発）。

- `release-pr` job を release App token（`RELEASE_APP_ID`/`RELEASE_APP_PRIVATE_KEY`）で動かす（release-plz の `GITHUB_TOKEN` env + aux-sync の push）。App 作成の PR/push は CI を発火させる。
- App に Pull requests: Read and write を付与済み（2026-07-02）。

## (2) サプライチェーン堅牢化（Codex Cloud security finding: high）

write-scoped なリリース workflow が mutable action tag + persisted checkout 認証情報を併用していた点への対応:

- **`persist-credentials: false`**（両 checkout）。token を git config に残さず、後続 action が読めないようにする。release-plz は PR ブランチ push / タグ作成を **GitHub API** で行う（release_plz_core 0.36.15 で確認: GitHub 経路は `github_create_release_branch` / `github_force_push` / `create_tag` = API、git push ではない）ので persisted 認証情報は不要。aux-file-sync の git CLI push だけ、push 直前に `git remote set-url` で App token を明示（→ push も App 名義で CI 発火を維持）。
- **全 action を検証済み commit SHA で pin**（checkout v6.0.3 / rust-cache v2.9.1 / ruby/setup-ruby v1.312.0 / crates-io-auth-action v1.0.5 / create-github-app-token v3.2.0）。token を直接受け取る release-plz/action は元から SHA pin 済み。
- ⚠️ SHA は各 upstream から独立に解決。finding 提案の rust-cache SHA (`e18b497`) は v2.9.1 タグではなくリリース直後の changelog commit だったため、正しいタグ commit (`c193711`) を使用。

## (3) App token 最小権限化（coderabbit）

両 `create-github-app-token` step に `permission-contents: write` + `permission-pull-requests: write` を明示。release_plz_core のソースで release/release-pr パスの API 呼び出しを確認し必要十分（タグ作成は API 経由なので `workflows` 権限不要）。

## 検証

- actionlint クリーン（mutable tag ゼロ）
- token 経路・CI 発火の実挙動はマージ後の Release PR で確定
- **release.yml も同等のサプライチェーン堅牢化が必要**（同じ write-scoped リリース workflow）→ follow-up `fulgur-inp6` 系で対応

Refs: fulgur-inp6, epic fulgur-bg1n
