### PR TITLE
ci: maintainer-approval gate for release-plz Release PRs

### DIFF
--- a/.github/workflows/release-pr-approval-gate.yml
+++ b/.github/workflows/release-pr-approval-gate.yml
@@ -1,0 +1,83 @@
+name: Release PR approval gate
+
+# Require a maintainer approval on release-plz Release PRs before they can be
+# merged — merging a Release PR is what triggers the actual crates.io / npm /
+# PyPI / RubyGems release. This is enforced by reporting a `release-pr-approval`
+# commit status that the `main` branch ruleset marks as a required status check.
+# Ordinary (non-release) PRs get an immediate `success`, so this gate never
+# blocks normal contributions and does not require approvals on your own PRs.
+#
+# SECURITY: this uses `pull_request_target` (a writable token, available even
+# for fork PRs) so it can set the status on every PR — but it NEVER checks out
+# or executes PR-authored code. It only reads reviews and writes a commit status
+# through the API, so there is no untrusted-code-with-secrets exposure.
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+concurrency:
+  group: release-pr-approval-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  gate:
+    name: Require maintainer approval (release PRs)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate approval and report status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -euo pipefail
+          CONTEXT="release-pr-approval"
+
+          set_status() {
+            gh api -X POST "repos/$REPO/statuses/$HEAD_SHA" \
+              -f state="$1" -f context="$CONTEXT" -f description="$2" >/dev/null
+          }
+
+          # Only release-plz Release PRs (head branch `release-plz-*`) are gated.
+          case "$HEAD_REF" in
+            release-plz-*) : ;;
+            *)
+              set_status success "Not a release PR — not gated"
+              exit 0
+              ;;
+          esac
+
+          # An approval counts only if it is: the reviewer's latest review, made
+          # on the CURRENT head commit (a new push re-closes the gate), by an
+          # OWNER / MEMBER / COLLABORATOR who is not the PR author (the release
+          # bot). This mirrors "dismiss stale reviews" + "require last push
+          # approval" without needing branch-wide required reviews.
+          approvals=$(gh api "repos/$REPO/pulls/$PR/reviews?per_page=100" \
+            | jq --arg sha "$HEAD_SHA" --arg author "$AUTHOR" '
+                [ .[]
+                  | select(.commit_id == $sha)
+                  | select(.user.login != $author)
+                ]
+                | group_by(.user.login)
+                | map(sort_by(.submitted_at) | last)
+                | map(select(
+                    .state == "APPROVED"
+                    and (.author_association | IN("OWNER", "MEMBER", "COLLABORATOR"))
+                  ))
+                | length')
+
+          if [ "${approvals:-0}" -ge 1 ]; then
+            set_status success "Approved by a maintainer on the current commit"
+          else
+            set_status failure "A maintainer must approve this Release PR (on the current commit) before it can merge"
+          fi


### PR DESCRIPTION
## 概要

release-plz の **Release PR（`chore: release vX.Y.Z`）だけ**に maintainer の approve を必須にする。Release PR のマージ = 本番リリース（crates.io / npm / PyPI / RubyGems）発火なので、その直前に人間の承認ゲートを設ける。**通常の PR には一切影響しない**（自分の feature PR に承認を強制しない）。epic `fulgur-bg1n` 系。

## なぜカスタムか

native の branch ruleset の required-reviews は **main 宛の全 PR** に効くため、自分の feature PR にも承認必須になる（自己承認不可で単独メンテだと詰む）。そのため「Release PR だけ」を対象にするカスタムゲートを採用。

## 仕組み

`pull_request_target` + `pull_request_review` で走る workflow が `release-pr-approval` という**コミットステータス**を出す:

- head ブランチが `release-plz-*` **でない** PR → 即 `success`（ゲート対象外）
- `release-plz-*` の Release PR → **現 head SHA に対する**、author（release bot）以外の **OWNER/MEMBER/COLLABORATOR** の `APPROVED` レビューがあれば `success`、無ければ `failure`
  - 現 SHA 限定なので、新しい push が入ると承認がリセットされる（dismiss-stale / require-last-push-approval 相当）

この `release-pr-approval` を main ルールセットの **required status check** にすると、Release PR は承認まで merge 不可になる。

- 外部 action 不使用・PR コードを checkout しない（`pull_request_target` として安全）
- actionlint クリーン、jq ロジックは検証済み

## ⚠️ ロールアウト順序（重要）

required check は「workflow が main に載って status を出せるようになってから」追加すること（逆だと全 PR が存在しない check 待ちでブロックされる）:

1. 本 PR をマージ（workflow が main に載る）
2. 通常 PR で `release-pr-approval` が `success` を出すのを確認
3. main ルールセットに `release-pr-approval` を required status check として追加（`gh api` で実施可能）
4. 既存 open PR には status が未付与のことがあるので、必要なら再 trigger

Refs: fulgur-v7ef
