### PR TITLE
test: verify approval gate (throwaway, do not merge)

### DIFF
--- a/.github/workflows/release-pr-approval-gate.yml
+++ b/.github/workflows/release-pr-approval-gate.yml
@@ -81,3 +81,5 @@ jobs:
           else
             set_status failure "A maintainer must approve this Release PR (on the current commit) before it can merge"
           fi
+
+# (verify: release-pr-approval gate emits a status on non-release PRs)


### PR DESCRIPTION
Throwaway PR to verify the release-pr-approval gate emits a status. Will be closed.