### PR TITLE
test: gate failure path (release-plz-*, throwaway do not merge)

### DIFF
--- a/.github/workflows/release-pr-approval-gate.yml
+++ b/.github/workflows/release-pr-approval-gate.yml
@@ -81,3 +81,5 @@ jobs:
           else
             set_status failure "A maintainer must approve this Release PR (on the current commit) before it can merge"
           fi
+
+# gate failure-path test (release-plz-* branch)


### PR DESCRIPTION
Throwaway: verify the gate emits FAILURE for a release-plz-* PR with no approval. Will be closed.