### PR TITLE
fix(gcpm): bound target-text first-letter allocation to matched prefix

### DIFF
--- a/crates/fulgur/src/gcpm/target_ref.rs
+++ b/crates/fulgur/src/gcpm/target_ref.rs
@@ -171,20 +171,43 @@ fn compute_first_letter(text: &str) -> String {
         })
     }
 
+    // Iterate graphemes lazily and stop right after the first letter plus its
+    // trailing punctuation run, tracking only a byte offset. Materializing the
+    // whole trimmed string (e.g. `graphemes(true).collect::<Vec<&str>>()`) would
+    // allocate one fat pointer per grapheme for attacker-controlled target text,
+    // an OOM/DoS vector even when the returned prefix is a single grapheme
+    // (fulgur-lfgg).
     let trimmed = text.trim_start();
-    let gs: Vec<&str> = trimmed.graphemes(true).collect();
-    let mut i = 0;
-    while i < gs.len() && is_punct(gs[i]) {
-        i += 1;
+    let mut first_letter_end = None;
+    for (idx, g) in trimmed.grapheme_indices(true) {
+        match first_letter_end {
+            // Already past the first letter: absorb the trailing punctuation
+            // run, then stop at the first non-punctuation grapheme.
+            Some(_) => {
+                if is_punct(g) {
+                    first_letter_end = Some(idx + g.len());
+                    continue;
+                }
+                break;
+            }
+            // Still scanning the optional leading punctuation run.
+            None => {
+                if is_punct(g) {
+                    continue;
+                }
+                if is_letter(g) {
+                    first_letter_end = Some(idx + g.len());
+                    continue;
+                }
+                // A non-punctuation, non-letter grapheme before any letter
+                // (e.g. whitespace after leading punctuation) yields "".
+                return String::new();
+            }
+        }
     }
-    if i >= gs.len() || !is_letter(gs[i]) {
-        return String::new();
-    }
-    let mut j = i + 1;
-    while j < gs.len() && is_punct(gs[j]) {
-        j += 1;
-    }
-    gs[..j].concat()
+    first_letter_end
+        .map(|end| trimmed[..end].to_string())
+        .unwrap_or_default()
 }
 
 /// Return the **1-based** page number for a DOM node, derived from
@@ -379,6 +402,16 @@ mod tests {
     #[test]
     fn first_letter_trailing_punct_then_nonletter() {
         assert_eq!(compute_first_letter("「Hello」 world"), "「H");
+    }
+    #[test]
+    fn first_letter_large_tail_stops_early() {
+        // Regression for fulgur-lfgg: the first letter is at the start,
+        // followed by a huge non-punctuation tail. The result must be the
+        // single leading letter, and the implementation must not materialize
+        // the whole string (early-exit offset path).
+        let mut s = String::from("H");
+        s.push_str(&"x".repeat(1_000_000));
+        assert_eq!(compute_first_letter(&s), "H");
     }
 
     #[test]


### PR DESCRIPTION
## 背景

セキュリティスキャナの指摘 (`c5b059c1`, high / attack-path high) への対応。

`crates/fulgur/src/gcpm/target_ref.rs` の `compute_first_letter()` が、対象テキストを `trim_start` した後に **全書記素を `Vec<&str>` へ materialize** してから、先頭の first-letter プレフィックス (`gs[..j].concat()`) だけを返していました。

攻撃者が制御できる巨大なテキストノードを持つ id 付き要素に対して、CSS の `target-text(attr(href), first-letter)` を向けると:

- pass 1 で対象要素のテキスト全体が `AnchorEntry.text` に格納される
- pass 2 で `compute_first_letter()` が呼ばれ、**返り値が1書記素でも全長分の fat pointer (64bit で約 16 bytes/byte)** を確保する

untrusted HTML/CSS をサーバサイドでレンダリングする脅威モデルにおいて、これは OOM / DoS ベクタになります（検証では 5,000 万書記素で `memory allocation of 536870912 bytes failed`、n=100 万で `peak_live=16777217` と入力に線形増加を確認済み）。

## 修正

`graphemes(true).collect::<Vec<&str>>()` をやめ、`grapheme_indices(true)` で**遅延イテレート**するように変更しました。

- 先頭の任意 punctuation 連 → 最初の letter → 末尾の punctuation 連、まで走査したところで **早期に打ち切る**
- 保持するのはバイトオフセット (`first_letter_end`) のみで、返却は `trimmed[..end].to_string()`
- 確保量が返却プレフィックス長に限定され、末尾に巨大なテキストがあっても走査・確保しない

## 挙動の等価性

`is_punct` / `is_letter` の判定は不変で、同じ書記素列に対して選択されるバイト範囲だけが問題になります。`idx + g.len()` は次の書記素の開始バイトオフセット（＝旧コードの `j` 境界）と一致するため、`trimmed[..first_letter_end] == gs[..j].concat()` が成り立ちます。既存の behavioral テスト（先頭 punct 保持、末尾 punct 取り込み、書記素クラスタ、通貨記号拡張、空文字ケース等）はすべて変更なしでパスします。

`Content` / `Before` / `After` は元々テキストをそのまま clone する（出力＝入力サイズ）ため増幅は無く、対象外です。この1修正で CLI / Python / WASM いずれの経路もカバーします（すべて `resolve_target_text` を経由）。

## テスト

- `cargo test -p fulgur --lib` … 1553 passed
- `cargo test -p fulgur --test gcpm_integration` … 13 passed
- `cargo clippy -p fulgur --lib` … warning なし
- `cargo fmt --check` … OK
- 回帰テスト `first_letter_large_tail_stops_early` を追加（先頭に letter + 100万文字の tail → 出力 `"H"`、早期打ち切りのオフセット経路を exercise）

Fixes fulgur-lfgg
