### PR TITLE
ci(release-gate): show pending (not failure) for un-approved Release PRs

### DIFF
--- a/.github/workflows/release-pr-approval-gate.yml
+++ b/.github/workflows/release-pr-approval-gate.yml
@@ -79,5 +79,9 @@ jobs:
           if [ "${approvals:-0}" -ge 1 ]; then
             set_status success "Approved by a maintainer on the current commit"
           else
-            set_status failure "A maintainer must approve this Release PR (on the current commit) before it can merge"
+            # `pending` (not `failure`): a Release PR awaiting approval is not a
+            # broken build. A required check must be `success` to merge, so
+            # `pending` still blocks the merge — but it shows a neutral "waiting"
+            # indicator instead of a red ✗ that looks like a CI failure.
+            set_status pending "Waiting for a maintainer approval on the current commit"
           fi


### PR DESCRIPTION
Release PR が承認待ちのとき `release-pr-approval` を `failure`(赤✗) で出していたため、本物の CI 失敗と見分けが付かなかった。承認待ちを `pending`(黄色●=待機) に変更する。

required status check は `success` でないと merge できないので、`pending` でも merge ブロックは同じ。見た目だけが変わり、「承認待ち」だと一目で分かるようになる。

- approved → `success`(緑)
- release PR 未承認 → `pending`(黄, 待機)
- 非 release PR → `success`(緑, 対象外)

Refs: fulgur-v7ef

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * リリース承認待ちの状態表示を調整し、保留中のときは `pending` と「Waiting…」が表示されるようになりました。
  * 承認がまだ不足している場合でも、失敗ではなく待機状態として扱われるため、状況がより分かりやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->