### PR TITLE
ci: free more disk on the coverage cell to fix recurring 'No space left on device'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,11 +87,17 @@ jobs:
         if: runner.os == 'Linux'
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
-          tool-cache: false
+          # `tool-cache` + `large-packages` removal is slow (~1-2 min each), so pay
+          # it only on the coverage cell — it runs `cargo llvm-cov nextest` twice
+          # (instrumented build + profraw) and was flaking on "No space left on
+          # device". Other Linux cells keep them off (no time cost). The coverage
+          # job uses none of the hostedtoolcache (Rust via rustup, cargo-llvm-cov /
+          # nextest via taiki-e into ~/.cargo/bin), so removing tool-cache is safe.
+          tool-cache: ${{ matrix.coverage }}
           android: true
           dotnet: true
           haskell: true
-          large-packages: false
+          large-packages: ${{ matrix.coverage }}
           docker-images: true
           swap-storage: false
       - uses: actions/checkout@v6


### PR DESCRIPTION
## 背景

coverage ジョブ（`test (ubuntu-latest … fulgur-cov)`）が **`No space left on device`** で flaky に落ちています（PR #547 / #549 で再発、いずれもジョブ内容とは無関係のインフラ枯渇）。

原因: このセルは `cargo llvm-cov nextest` を **2回**（default ＋ `fulgur/parallel`）走らせ、計測ビルド＋profraw で `target/` が肥大。既存の `Free disk space` step は動いていますが、最大の削減レバーである `large-packages`（と `tool-cache`）が `false` で、空きが閾値ギリギリでした。

## 変更

`Free disk space (Linux)` step の `tool-cache` / `large-packages` を **coverage セルのみ** `${{ matrix.coverage }}` で有効化（約 +18GB）:

```yaml
          tool-cache: ${{ matrix.coverage }}
          large-packages: ${{ matrix.coverage }}
```

- coverage セル（`matrix.coverage == true`）だけ重い削減を行い、確実に閾値超え。
- 他の Linux ジョブ（wpt / 通常 test、`coverage: false`）は現状維持 → `large-packages` 除去の ~1-2 分は払わず **CI 時間に影響なし**。
- `tool-cache` 除去は coverage ジョブが hostedtoolcache を使わない（Rust=rustup、cargo-llvm-cov/nextest=taiki-e install で `~/.cargo/bin`）ため安全。step は checkout 前なので tool 導入前に消えるのも問題なし。
- `swap-storage` は OOM 回避のため `false` 据え置き（これでも足りなければ次の一手）。
- ci.yml の他4箇所の `Free disk space` step（`matrix.coverage` を持たないジョブ）は無変更。

Refs: fulgur-* (disk exhaustion)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI の Linux テスト実行で、カバレッジ対象の実行セルのみ追加のキャッシュ設定を有効にするよう調整しました。
  * キャッシュ削除の遅延や容量不足による不安定さを避けるための運用方針を反映しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->