### PR TITLE
test(render): add coverage for dispatch_inline_box_content and related paths

### DIFF
--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -6169,4 +6169,105 @@ mod tests {
         );
         assert!(pdf.starts_with(b"%PDF"));
     }
+
+    // --- dispatch_inline_box_content: transform on inline-block ---
+
+    #[test]
+    fn render_smoke_inline_block_with_transform_dispatches_under_transform() {
+        // An inline-block element with `transform` inside a paragraph creates a
+        // `LineItem::InlineBox` in the shaped line. `dispatch_inline_box_content`
+        // must route it through `draw_under_transform` (the first branch,
+        // `drawables.transforms.get(&content_id).is_some()`).
+        let pdf = render_html(
+            r#"<!doctype html><html><body>
+            <p>Before
+              <span style="display:inline-block;transform:rotate(15deg);
+                           background:#cef;width:40px;height:20px;
+                           line-height:20px;text-align:center">R</span>
+            after</p>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // --- dispatch_inline_box_content: overflow:hidden clip on inline-block ---
+
+    #[test]
+    fn render_smoke_inline_block_with_overflow_hidden_dispatches_under_clip() {
+        // An inline-block with `overflow:hidden` containing a wider child exercises
+        // `dispatch_inline_box_content`'s clip branch (`block.style.has_overflow_clip()`).
+        let pdf = render_html(
+            r#"<!doctype html><html><body>
+            <p>Text
+              <span style="display:inline-block;overflow:hidden;
+                           width:40px;height:20px;background:#fce">
+                <span style="display:inline-block;width:120px;height:20px;
+                             background:#e9f">wide child</span>
+              </span>
+            more text</p>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // --- dispatch_inline_box_content: opacity scope on inline-block ---
+
+    #[test]
+    fn render_smoke_inline_block_with_opacity_and_svg_child_dispatches_under_opacity() {
+        // An inline-block with fractional `opacity` and an SVG child triggers
+        // `opacity_descendants` population during convert, then
+        // `dispatch_inline_box_content` routes through `draw_under_opacity`
+        // (the third branch, `!block.opacity_descendants.is_empty()`).
+        let pdf = render_html(
+            r##"<!doctype html><html><body>
+            <p>Text
+              <span style="display:inline-block;opacity:0.5;width:24px;height:24px">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24">
+                  <circle cx="12" cy="12" r="10" fill="#3af"/>
+                </svg>
+              </span>
+            more</p>
+            </body></html>"##,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // --- dest_registry: body_y_off = 0.0 branch on page 2+ ---
+
+    #[test]
+    fn render_smoke_id_anchor_on_second_page_sets_destination() {
+        // A node with `id` whose first fragment is on page 2+ exercises the
+        // `body_y_off = 0.0` branch in `render_v2`'s dest-registry loop
+        // (`page_idx != 0` → else 0.0).
+        let pdf = render_html(
+            r#"<!doctype html><html><body>
+            <div style="height:1200pt">spacer to push to page 2</div>
+            <p id="page2-target">This paragraph is on page 2.</p>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // --- draw_v2_page: multicol rule skipped for transformed descendant ---
+
+    #[test]
+    fn render_smoke_multicol_rule_inside_transform_skips_outer_paint() {
+        // A multicol container nested inside a `transform` element ends up in
+        // `transformed_descendants`. The column-rule loop in `draw_v2_page` must
+        // skip it (the `transformed_descendants.contains(&container_id)` guard at
+        // the top of the loop) and instead paint the rule from inside
+        // `draw_under_transform`.
+        let pdf = render_html(
+            r#"<!doctype html><html><body>
+            <div style="transform:rotate(1deg)">
+              <div style="column-count:2;column-rule:2px solid #369;
+                          column-gap:20px;width:400px;font-size:12px">
+                <p>Column A text here for rule test.</p>
+                <p>Column B text here for rule test.</p>
+              </div>
+            </div>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
 }


### PR DESCRIPTION
## Summary

`render.rs` のカバレッジが最も低いファイル（88.46%）として特定されました。
未カバーの主な領域は `dispatch_inline_box_content` 関数（行 750–804）と関連するレンダリングパスで、
いずれも blitz バックエンドを通じた smoke テストが必要でした。

カバレッジ変化（`cargo llvm-cov --package fulgur --lib`）:

| 指標 | 変更前 | 変更後 |
|------|-------|-------|
| `render.rs` 行カバレッジ | 88.46% (491行未カバー) | **89.89%** (436行未カバー) |
| `render.rs` 領域カバレッジ | 89.11% | **90.31%** |
| TOTAL 行カバレッジ | 94.54% | **94.71%** |

改善: render.rs で 55 行、TOTAL で 59 行のカバレッジ増加。

## Changes

- `crates/fulgur/src/render.rs` のテストモジュールに smoke テスト 5 件を追加:
  - `render_smoke_inline_block_with_transform_dispatches_under_transform` — `dispatch_inline_box_content` の transform ブランチ（行 750–765）をカバー。段落内の `display:inline-block` + `transform` 要素で発火。
  - `render_smoke_inline_block_with_overflow_hidden_dispatches_under_clip` — `dispatch_inline_box_content` の clip ブランチ（行 767–784）をカバー。`overflow:hidden` のインラインブロックで発火。
  - `render_smoke_inline_block_with_opacity_and_svg_child_dispatches_under_opacity` — `dispatch_inline_box_content` の opacity ブランチ（行 786–803）をカバー。`opacity:0.5` + SVG 子要素のインラインブロックで発火。
  - `render_smoke_id_anchor_on_second_page_sets_destination` — `render_v2` の dest-registry ループ内 `body_y_off = 0.0` ブランチ（行 118）をカバー。2 ページ目に `id` 属性付き要素を配置。
  - `render_smoke_multicol_rule_inside_transform_skips_outer_paint` — `draw_v2_page` の multicol rule ループで `transformed_descendants.contains(&container_id)` が true のとき skip するブランチ（行 703）をカバー。

## 意図的に対象外とした未カバーブランチ

- `dispatch_inline_box_content` のデフォルト fallback パス（行 809 以降）: 上記 3 ブランチの else として到達するが、その場合は `dispatch_fragment` に委譲するだけで追加ロジックなし。既存の smoke テストで間接的にカバー済み。
- `pageable_last_baseline_from_drawables`（`convert/inline_root.rs`）: `doc: &BaseDocument` パラメータが必要で純粋関数テスト不可。
- `try_convert` 各種（`convert/list_item.rs`、`convert/inline_root.rs`）: blitz 依存で直接ユニットテスト不可。

## Test plan

- [x] `cargo test -p fulgur --lib` — 1558 テスト全件 OK（追加 5 件含む）
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — 差分なし

## Related issues

<!-- なし -->


---
_Generated by [Claude Code](https://claude.ai/code/session_011XHz5gEW7eSNzXacAF1N5w)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 描画処理の検証を追加し、変換・クリップ・透明度を含む要素の表示が期待どおりになることを確認しました。
  * 複数ページや複雑なレイアウト条件でも、アンカー登録や描画の安定性をチェックするテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->