### PR TITLE
fix(pagination): revert MAX_PAGES to 10k and collapse pathological childless tall blocks

### DIFF
--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -25,13 +25,16 @@ pub(crate) const MAX_DOM_DEPTH: usize = 512;
 /// time). This constant therefore caps single-element amplification, not the
 /// absolute page count — code must not assume `page_count <= MAX_PAGES`.
 ///
-/// Set high enough that legitimate large documents (batch report generation
-/// is a primary use case) do not hit it — at this value the truncation only
-/// fires for attacker-amplified input, and rendering the bound is still
-/// bounded (~100k pages ≈ a few seconds). Content past the per-element cap is
+/// Kept deliberately conservative for untrusted server-side rendering (a
+/// shared multi-tenant renderer is the primary deployment): a tiny
+/// pathological input must not amplify into one render iteration and PDF
+/// page per fragment. The most common amplifier — a childless block with a
+/// huge height, which prints only blank pages — is additionally collapsed to
+/// a single page in `pagination_layout` (fulgur-ezst), so this ceiling only
+/// bounds the residual content-bearing case. Content past the cap is
 /// truncated (clamp-and-warn). Sibling of the `MAX_DOM_DEPTH` / background
 /// `MAX_TILES` defensive bounds.
-pub(crate) const MAX_PAGES: u32 = 100_000;
+pub(crate) const MAX_PAGES: u32 = 10_000;
 
 pub mod asset;
 pub mod background;

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -4105,6 +4105,47 @@ mod tests {
         );
     }
 
+    /// fulgur-ezst: pins the no-reflow / no-free-page-reduction mechanism of
+    /// the childless collapse. The collapse skips only the per-page fragment
+    /// pushes — it deliberately leaves the slice loop's `page_index` counter
+    /// advancing all the way to `MAX_PAGES` — so a following in-flow sibling
+    /// lands on the SAME deep page it would occupy without the collapse (the
+    /// document is not silently shortened, and siblings do not reflow up to
+    /// page 0). If someone "optimizes" the loop to break early once the
+    /// collapse is decided, the `<p>` would jump to page ~0/1 and this test
+    /// fails. Asserts: the tall div contributes exactly one fragment
+    /// (collapse fired) while the `<p>` sibling's fragment stays at
+    /// `page_index >= MAX_PAGES`.
+    #[test]
+    fn childless_collapse_does_not_reflow_following_sibling() {
+        use std::ops::DerefMut;
+        let html = r#"<html><body><div id="tall" style="height: 99999999px"></div><p id="after">after</p></body></html>"#;
+        let mut doc = parse(html, 600.0);
+        let table = run_pass(&mut doc, 800.0);
+        let tall_id = find_by_id(doc.deref_mut(), "tall").expect("div#tall");
+        let after_id = find_by_id(doc.deref_mut(), "after").expect("p#after");
+        let tall_frags = table
+            .get(&tall_id)
+            .expect("div#tall must appear in geometry")
+            .fragments
+            .len();
+        assert_eq!(
+            tall_frags, 1,
+            "collapsed childless div must contribute exactly one fragment, got {tall_frags}",
+        );
+        let after_page = table
+            .get(&after_id)
+            .expect("p#after must appear in geometry")
+            .fragments[0]
+            .page_index;
+        assert!(
+            after_page >= crate::MAX_PAGES,
+            "following sibling must stay on its deep page (>= MAX_PAGES {}); got {after_page} \
+             — an early loop break would reflow it near page 0",
+            crate::MAX_PAGES,
+        );
+    }
+
     /// fulgur-2m6w: a non-finite Taffy height (`+inf` / `NaN`) is treated
     /// as zero so it can never reach the slicing loop (where `+inf` would
     /// make `remaining -= last_slice_h` loop forever) nor poison the

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -1092,6 +1092,44 @@ impl<'a> PaginationLayoutTree<'a> {
     }
 }
 
+/// fulgur-ezst: true if `parent_id`'s subtree renders any box (a descendant
+/// with non-zero size). Mirrors `record_subtree_descendants`' walk — the
+/// `layout_children` preference and the zero-size-container recursion (so a
+/// `<tbody>`/`<tr>`/anonymous wrapper still counts its cells as content) —
+/// but short-circuits on the first rendered descendant. Used to classify a
+/// pathologically tall block as "childless" (collapsible). Conservative: a
+/// subtree deeper than `MAX_DOM_DEPTH` reads as no content, matching
+/// `record_subtree_descendants` (which also stops recording there, so such
+/// content renders blank regardless). Keep this walk in sync with
+/// `record_subtree_descendants`.
+fn subtree_has_rendered_content(doc: &BaseDocument, parent_id: usize, depth: usize) -> bool {
+    if depth >= crate::MAX_DOM_DEPTH {
+        return false;
+    }
+    let Some(parent) = doc.get_node(parent_id) else {
+        return false;
+    };
+    let layout_children_borrow = parent.layout_children.borrow();
+    let walk_children: &[usize] = layout_children_borrow
+        .as_deref()
+        .filter(|v| !v.is_empty())
+        .unwrap_or(&parent.children);
+    for &child_id in walk_children {
+        let Some(child) = doc.get_node(child_id) else {
+            continue;
+        };
+        let layout = child.final_layout;
+        if layout.size.height <= 0.0 && layout.size.width <= 0.0 {
+            if subtree_has_rendered_content(doc, child_id, depth + 1) {
+                return true;
+            }
+            continue;
+        }
+        return true;
+    }
+    false
+}
+
 /// fulgur-s67g Phase 2.5: recursively record fragments for every
 /// visible descendant of a body-direct child, attaching them to the
 /// same `page_index` as the ancestor.

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -993,7 +993,8 @@ impl<'a> PaginationLayoutTree<'a> {
                 // truncate-and-warn path below unchanged.
                 let collapse_childless = self.page_height_px > 0.0
                     && (remaining / self.page_height_px).ceil() > crate::MAX_PAGES as f32
-                    && !subtree_has_rendered_content(self.doc, child_id, 0);
+                    && !subtree_has_rendered_content(self.doc, child_id, 0)
+                    && !is_replaced_content(self.doc, child_id);
                 // fulgur-2m6w: cap the per-page-strip slicing at
                 // `MAX_PAGES`. `child_h` is attacker-controlled CSS
                 // (`height` / `vh`), so without this bound a few bytes of
@@ -1120,6 +1121,19 @@ impl<'a> PaginationLayoutTree<'a> {
     }
 }
 
+/// fulgur-ezst (Codex P2 on PR #553): true if `node_id` is a replaced
+/// element that paints its own box content — `<img>` / `<svg>`, matching
+/// `convert::replaced`'s dispatch. Such a node has no rendered *descendants*
+/// yet is visible content in its own right, so a pathologically tall one
+/// must NOT be collapsed like a blank spacer (the collapse would clip the
+/// image to a single page). A background / border is decoration, not
+/// replaced content, and stays collapsible by design (see `MAX_PAGES`).
+fn is_replaced_content(doc: &BaseDocument, node_id: usize) -> bool {
+    doc.get_node(node_id)
+        .and_then(|n| n.element_data())
+        .is_some_and(|el| matches!(el.name.local.as_ref(), "img" | "svg"))
+}
+
 /// fulgur-ezst: true if `parent_id`'s subtree renders any VISIBLE box (a
 /// descendant with positive area — both width and height > 0). Used to
 /// classify a pathologically tall block as "childless" (collapsible): the
@@ -1157,9 +1171,20 @@ fn subtree_has_rendered_content(doc: &BaseDocument, parent_id: usize, depth: usi
             continue;
         };
         let layout = child.final_layout;
-        if layout.size.height <= 0.0 || layout.size.width <= 0.0 {
-            // Zero-area box paints nothing itself, but may host visible
-            // descendants overflowing it (overflow: visible) — recurse.
+        // `visibility: hidden` / `collapse` occupies layout space but paints
+        // nothing (conversion skips its paint), so it does not count as
+        // content — a `<div style="visibility:hidden">` must not defeat the
+        // collapse (Codex P2 on PR #553).
+        let invisible = {
+            use style::properties::longhands::visibility::computed_value::T as Visibility;
+            child
+                .primary_styles()
+                .is_some_and(|s| s.clone_visibility() != Visibility::Visible)
+        };
+        if invisible || layout.size.height <= 0.0 || layout.size.width <= 0.0 {
+            // An invisible or zero-area box paints nothing itself, but may
+            // host visible descendants — overflowing it (overflow: visible)
+            // or flipping `visibility` back to `visible` — so recurse.
             if subtree_has_rendered_content(doc, child_id, depth + 1) {
                 return true;
             }
@@ -4177,6 +4202,57 @@ mod tests {
             x,
             crate::MAX_DOM_DEPTH
         ));
+    }
+
+    /// fulgur-ezst (Codex P2 on PR #553): a replaced element (`<img>`/`<svg>`)
+    /// has no descendants but paints its own box, so a pathologically tall
+    /// one must NOT collapse (that would clip the image to one page) — it
+    /// takes the cap path like any content-bearing block.
+    #[test]
+    fn replaced_tall_block_is_not_collapsed() {
+        let html = r#"<html><body><img style="display:block;width:10px;height:99999999px" src="x.png"></body></html>"#;
+        let mut doc = parse(html, 600.0);
+        let table = run_pass(&mut doc, 800.0);
+        let pages = implied_page_count(&table);
+        assert!(
+            pages > 1_000,
+            "a replaced element paints its own content and must not collapse; got {pages}",
+        );
+        assert!(
+            pages <= crate::MAX_PAGES + 1,
+            "still clamped to ~MAX_PAGES ({}); got {pages}",
+            crate::MAX_PAGES,
+        );
+    }
+
+    /// fulgur-ezst (Codex P2 on PR #553): a `visibility:hidden` descendant
+    /// occupies layout space but paints nothing, so it must not defeat the
+    /// collapse — a tall block whose only child is invisible still collapses.
+    #[test]
+    fn invisible_only_child_collapses() {
+        let html = r#"<html><body><div style="height:99999999px"><div style="visibility:hidden;height:1px"></div></div></body></html>"#;
+        let mut doc = parse(html, 600.0);
+        let table = run_pass(&mut doc, 800.0);
+        assert_eq!(
+            implied_page_count(&table),
+            1,
+            "a visibility:hidden-only descendant must not defeat the collapse",
+        );
+    }
+
+    /// fulgur-ezst: the visibility skip must still recurse — a
+    /// `visibility:visible` descendant under a `visibility:hidden` wrapper is
+    /// real content, so the tall block is not childless and stays capped.
+    #[test]
+    fn visible_child_under_hidden_wrapper_blocks_collapse() {
+        let html = r#"<html><body><div style="height:99999999px"><div style="visibility:hidden"><p style="visibility:visible">x</p></div></div></body></html>"#;
+        let mut doc = parse(html, 600.0);
+        let table = run_pass(&mut doc, 800.0);
+        let pages = implied_page_count(&table);
+        assert!(
+            pages > 1_000,
+            "visible content under a hidden wrapper must block the collapse; got {pages}",
+        );
     }
 
     /// fulgur-ezst: pins the no-reflow / no-free-page-reduction mechanism of

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -1120,16 +1120,26 @@ impl<'a> PaginationLayoutTree<'a> {
     }
 }
 
-/// fulgur-ezst: true if `parent_id`'s subtree renders any box (a descendant
-/// with non-zero size). Mirrors `record_subtree_descendants`' walk — the
-/// `layout_children` preference and the zero-size-container recursion (so a
-/// `<tbody>`/`<tr>`/anonymous wrapper still counts its cells as content) —
-/// but short-circuits on the first rendered descendant. Used to classify a
-/// pathologically tall block as "childless" (collapsible). Conservative: a
-/// subtree deeper than `MAX_DOM_DEPTH` reads as no content, matching
-/// `record_subtree_descendants` (which also stops recording there, so such
-/// content renders blank regardless). Keep this walk in sync with
-/// `record_subtree_descendants`.
+/// fulgur-ezst: true if `parent_id`'s subtree renders any VISIBLE box (a
+/// descendant with positive area — both width and height > 0). Used to
+/// classify a pathologically tall block as "childless" (collapsible): the
+/// collapse is safe only when nothing visible would be lost.
+///
+/// Walks children like `record_subtree_descendants` (the `layout_children`
+/// preference, short-circuiting on the first hit), but the emptiness test
+/// differs deliberately: a descendant with zero AREA (EITHER dimension
+/// <= 0) paints nothing, so it does not count as content — instead we
+/// recurse into it, because with `overflow: visible` a zero-height /
+/// zero-width box can still host visible descendants that overflow it.
+/// (This is why the test is `||`, not `&&`: an empty block child lays out
+/// width>0 / height==0, and `&&` would wrongly count it as content and
+/// disable the collapse — a trivial DoS bypass,
+/// `<div style="height:99999999px"><div></div></div>`; Codex P2 on PR #553.)
+/// `record_subtree_descendants` still *records* such zero-area boxes (their
+/// node ids may carry counters / ids), which is a separate question from
+/// "does this paint anything". Conservative on depth: a subtree deeper than
+/// `MAX_DOM_DEPTH` reads as no content, matching `record_subtree_descendants`
+/// (which also stops recording there, so such content renders blank anyway).
 fn subtree_has_rendered_content(doc: &BaseDocument, parent_id: usize, depth: usize) -> bool {
     if depth >= crate::MAX_DOM_DEPTH {
         return false;
@@ -1147,7 +1157,9 @@ fn subtree_has_rendered_content(doc: &BaseDocument, parent_id: usize, depth: usi
             continue;
         };
         let layout = child.final_layout;
-        if layout.size.height <= 0.0 && layout.size.width <= 0.0 {
+        if layout.size.height <= 0.0 || layout.size.width <= 0.0 {
+            // Zero-area box paints nothing itself, but may host visible
+            // descendants overflowing it (overflow: visible) — recurse.
             if subtree_has_rendered_content(doc, child_id, depth + 1) {
                 return true;
             }
@@ -4103,6 +4115,68 @@ mod tests {
             5,
             "a sub-cap childless band must render fully, not collapse",
         );
+    }
+
+    /// fulgur-ezst (Codex P2 on PR #553): an empty *block* child lays out
+    /// with positive width but zero height, so a `height <= 0 && width <= 0`
+    /// emptiness test would wrongly count it as content and disable the
+    /// collapse — a trivial DoS bypass. `subtree_has_rendered_content` treats
+    /// any zero-AREA descendant as blank (recursing for overflow), so a tall
+    /// block whose only child is an empty block still collapses to one page.
+    #[test]
+    fn childless_tall_block_with_empty_block_child_collapses() {
+        let html = r#"<html><body><div style="height: 99999999px"><div></div></div></body></html>"#;
+        let mut doc = parse(html, 600.0);
+        let table = run_pass(&mut doc, 800.0);
+        assert_eq!(
+            implied_page_count(&table),
+            1,
+            "an empty (zero-area) block child must not defeat the collapse",
+        );
+    }
+
+    /// fulgur-ezst: the emptiness recursion must still find VISIBLE content
+    /// nested under a zero-area wrapper — a zero-height (overflow:visible)
+    /// wrapper holding a real `<p>` is content, so the tall block is NOT
+    /// childless and stays on the cap path. Guards the `||` fix against
+    /// over-collapsing (dropping visibly-overflowing descendants).
+    #[test]
+    fn tall_block_with_content_under_zero_height_wrapper_is_not_collapsed() {
+        let html = r#"<html><body><div style="height: 99999999px"><div style="height: 0"><p>x</p></div></div></body></html>"#;
+        let mut doc = parse(html, 600.0);
+        let table = run_pass(&mut doc, 800.0);
+        let pages = implied_page_count(&table);
+        assert!(
+            pages > 1_000,
+            "visible content under a zero-height wrapper must block the collapse; got {pages}",
+        );
+        assert!(
+            pages <= crate::MAX_PAGES + 1,
+            "still clamped to ~MAX_PAGES ({}); got {pages}",
+            crate::MAX_PAGES,
+        );
+    }
+
+    /// fulgur-ezst: the defensive guards of `subtree_has_rendered_content`
+    /// read as "no content" (false) without panicking — a nonexistent node
+    /// id (the `get_node` None guard) and a call already at the recursion
+    /// ceiling (the `MAX_DOM_DEPTH` guard).
+    #[test]
+    fn subtree_has_rendered_content_guards() {
+        use std::ops::DerefMut;
+        let html = r#"<html><body><div id="x">hi</div></body></html>"#;
+        let mut doc = parse(html, 600.0);
+        let x = find_by_id(doc.deref_mut(), "x").expect("div#x");
+        assert!(!subtree_has_rendered_content(
+            doc.deref_mut(),
+            usize::MAX,
+            0
+        ));
+        assert!(!subtree_has_rendered_content(
+            doc.deref_mut(),
+            x,
+            crate::MAX_DOM_DEPTH
+        ));
     }
 
     /// fulgur-ezst: pins the no-reflow / no-free-page-reduction mechanism of

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -977,6 +977,23 @@ impl<'a> PaginationLayoutTree<'a> {
                 );
                 let mut remaining = child_h - first_slice_h;
                 let mut last_slice_h = first_slice_h;
+                // fulgur-ezst: a CHILDLESS block whose slicing would exceed
+                // the cap is a pathological amplifier — `<div
+                // style="height:99999999px">` is a web-only spacer/overflow
+                // idiom that prints nothing but blank pages. Emit only its
+                // first slice: skip the per-page fragment pushes while
+                // leaving the loop's page_index / cursor_y / remaining math
+                // untouched, so following in-flow siblings keep their exact
+                // positions (no reflow) and a trailing block collapses for
+                // free (`implied_page_count` reads the max fragment index).
+                // Background / border presence does NOT gate this — nobody
+                // authors a >MAX_PAGES-tall filled band on purpose. A
+                // content-bearing block, or a childless band that fits
+                // within the cap, is not collapsed and takes the
+                // truncate-and-warn path below unchanged.
+                let collapse_childless = self.page_height_px > 0.0
+                    && (remaining / self.page_height_px).ceil() > crate::MAX_PAGES as f32
+                    && !subtree_has_rendered_content(self.doc, child_id, 0);
                 // fulgur-2m6w: cap the per-page-strip slicing at
                 // `MAX_PAGES`. `child_h` is attacker-controlled CSS
                 // (`height` / `vh`), so without this bound a few bytes of
@@ -988,26 +1005,37 @@ impl<'a> PaginationLayoutTree<'a> {
                 while remaining > 0.0 && page_index < crate::MAX_PAGES {
                     page_index += 1;
                     last_slice_h = remaining.min(self.page_height_px);
-                    self.geometry
-                        .entry(child_id)
-                        .or_default()
-                        .fragments
-                        .push(Fragment {
-                            page_index,
-                            x: frag_x.px(),
-                            y: 0.0_f32.px(),
-                            width: child_w.px(),
-                            height: last_slice_h.px(),
-                        });
+                    if !collapse_childless {
+                        self.geometry
+                            .entry(child_id)
+                            .or_default()
+                            .fragments
+                            .push(Fragment {
+                                page_index,
+                                x: frag_x.px(),
+                                y: 0.0_f32.px(),
+                                width: child_w.px(),
+                                height: last_slice_h.px(),
+                            });
+                    }
                     remaining -= last_slice_h;
                 }
                 if remaining > 0.0 {
-                    log::warn!(
-                        "pagination: block height {child_h}px exceeds the \
-                         {}-page limit; truncating remaining content to bound \
-                         rendering (fulgur-2m6w)",
-                        crate::MAX_PAGES,
-                    );
+                    if collapse_childless {
+                        log::warn!(
+                            "pagination: collapsed a childless block of \
+                             height {child_h}px (slicing would exceed the \
+                             {}-page limit) to a single page (fulgur-ezst)",
+                            crate::MAX_PAGES,
+                        );
+                    } else {
+                        log::warn!(
+                            "pagination: block height {child_h}px exceeds the \
+                             {}-page limit; truncating remaining content to \
+                             bound rendering (fulgur-2m6w)",
+                            crate::MAX_PAGES,
+                        );
+                    }
                 }
                 cursor_y = if child_h - first_slice_h > 0.0 {
                     last_slice_h
@@ -3996,41 +4024,84 @@ mod tests {
         walk(doc, doc.root_element().id, id)
     }
 
-    /// fulgur-2m6w: a tiny input with a pathologically tall CSS height
-    /// must not generate an unbounded number of page strips. Without the
-    /// page cap a `height: 99999999px` div on an 800px strip slices into
-    /// ~125 000 fragments/pages, which downstream (`render.rs`) turns into
-    /// a `vec![Vec::new(); page_count]` allocation plus a per-page render
-    /// loop — a CPU/memory-exhaustion DoS from a few bytes of untrusted
-    /// HTML. The slicing loop is clamped to `MAX_PAGES`.
+    /// fulgur-ezst: a tiny input with a pathologically tall CSS height on a
+    /// CHILDLESS block prints only blank pages, so instead of slicing it to
+    /// the `MAX_PAGES` cap (~10k blank pages) the fragmenter collapses it to
+    /// a single page. `height: 99999999px` would otherwise slice into
+    /// ~125 000 fragments — the small-input DoS.
     #[test]
-    fn pathological_tall_block_is_page_capped() {
+    fn pathological_childless_tall_block_collapses() {
         let html = r#"<html><body><div style="height: 99999999px"></div></body></html>"#;
+        let mut doc = parse(html, 600.0);
+        let table = run_pass(&mut doc, 800.0);
+        assert_eq!(
+            implied_page_count(&table),
+            1,
+            "childless pathological height must collapse to a single page",
+        );
+    }
+
+    /// fulgur-ezst: Stylo/Taffy clamps an absurd `<length>` to `f32::MAX`
+    /// (≈3.4e38), the worst-case finite input. A childless block that tall
+    /// also collapses to one page (the ceiling-bounded slice loop still runs
+    /// its counter math but pushes no fragment).
+    #[test]
+    fn f32_max_childless_height_collapses() {
+        let html = r#"<html><body><div style="height: 1e39px"></div></body></html>"#;
+        let mut doc = parse(html, 600.0);
+        let table = run_pass(&mut doc, 800.0);
+        assert_eq!(
+            implied_page_count(&table),
+            1,
+            "childless f32::MAX height must collapse to a single page",
+        );
+    }
+
+    /// fulgur-ezst: background presence does not gate the collapse — a
+    /// childless filled band this tall is still a pathological amplifier.
+    #[test]
+    fn childless_tall_block_with_background_collapses() {
+        let html =
+            r#"<html><body><div style="height: 99999999px; background: red"></div></body></html>"#;
+        let mut doc = parse(html, 600.0);
+        let table = run_pass(&mut doc, 800.0);
+        assert_eq!(implied_page_count(&table), 1);
+    }
+
+    /// fulgur-ezst: a tall block WITH rendered content is not childless, so
+    /// it is NOT collapsed — it still clamps to ~MAX_PAGES (truncate-and-
+    /// warn). Also guards routing: a huge parent with a small child must
+    /// reach the slice loop, not the recursion branch (the recursion gate
+    /// measures descendant overflow, not the parent's intrinsic height).
+    #[test]
+    fn content_bearing_tall_block_is_page_capped() {
+        let html = r#"<html><body><div style="height: 99999999px"><p>x</p></div></body></html>"#;
         let mut doc = parse(html, 600.0);
         let table = run_pass(&mut doc, 800.0);
         let pages = implied_page_count(&table);
         assert!(
+            pages > 1_000,
+            "content-bearing block must take the cap path, not collapse; got {pages}",
+        );
+        assert!(
             pages <= crate::MAX_PAGES + 1,
-            "page count must be clamped to ~MAX_PAGES ({}), got {pages}",
+            "content-bearing block must stay clamped to ~MAX_PAGES ({}); got {pages}",
             crate::MAX_PAGES,
         );
     }
 
-    /// fulgur-2m6w: Stylo/Taffy clamps an absurd `<length>` to `f32::MAX`
-    /// (≈3.4e38) rather than `+inf`, so `height: 1e39px` is the true
-    /// worst-case *finite* input — without the cap it would slice into
-    /// ~4e35 strips (an effective hang, and `page_index` (u32) would wrap
-    /// /panic long before). The cap bounds it to `MAX_PAGES` all the same.
+    /// fulgur-ezst: a childless band that fits WITHIN the cap renders its
+    /// full page count — the collapse must not over-fire on ordinary
+    /// multi-page spacers. `height: 4000px` on an 800px strip = 5 pages.
     #[test]
-    fn f32_max_height_block_is_page_capped() {
-        let html = r#"<html><body><div style="height: 1e39px"></div></body></html>"#;
+    fn childless_subcap_band_renders_full() {
+        let html = r#"<html><body><div style="height: 4000px"></div></body></html>"#;
         let mut doc = parse(html, 600.0);
         let table = run_pass(&mut doc, 800.0);
-        let pages = implied_page_count(&table);
-        assert!(
-            pages <= crate::MAX_PAGES + 1,
-            "f32::MAX height must be clamped to ~MAX_PAGES ({}), got {pages}",
-            crate::MAX_PAGES,
+        assert_eq!(
+            implied_page_count(&table),
+            5,
+            "a sub-cap childless band must render fully, not collapse",
         );
     }
 

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -4677,7 +4677,7 @@ fn table_caption_preserves_full_width_table() {
 /// a moderate height (~tens of pages) keeps the render fast — the page CAP
 /// itself (the `99999999px` / `f32::MAX` amplification bound) is covered by
 /// the fast pagination unit tests in `pagination_layout.rs`, which need no
-/// render. Rendering the full 100k-page ceiling here would just be a slow
+/// render. Rendering the full 10k-page ceiling here would just be a slow
 /// CI tax for no extra coverage.
 #[test]
 fn pathological_tall_block_render_is_bounded() {
@@ -4687,6 +4687,25 @@ fn pathological_tall_block_render_is_bounded() {
         .render(html)
         .expect("render must terminate and succeed");
     assert!(!pdf.is_empty(), "expected a non-empty bounded PDF");
+}
+
+/// fulgur-ezst: a childless block tall enough to exceed the page cap must
+/// collapse end-to-end — a real `render` yields a tiny, single-page
+/// PDF rather than a ~10k-page one. Byte size cleanly separates the two: a
+/// collapsed render is a few KB; the uncollapsed cap render would be MBs.
+#[test]
+fn childless_cap_exceeding_block_collapses_end_to_end() {
+    let html = r#"<!doctype html><html><body><div style="height:99999999px"></div></body></html>"#;
+    let pdf = Engine::builder()
+        .build()
+        .render(html)
+        .expect("render must terminate and succeed");
+    assert!(!pdf.is_empty(), "expected a non-empty PDF");
+    assert!(
+        pdf.len() < 500_000,
+        "collapsed render must be small (single page); got {} bytes",
+        pdf.len(),
+    );
 }
 
 /// fulgur-2qpt: deprecated aliases `render_html` and `render_html_to_file`

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -4692,7 +4692,9 @@ fn pathological_tall_block_render_is_bounded() {
 /// fulgur-ezst: a childless block tall enough to exceed the page cap must
 /// collapse end-to-end — a real `render` yields a tiny, single-page
 /// PDF rather than a ~10k-page one. Byte size cleanly separates the two: a
-/// collapsed render is a few KB; the uncollapsed cap render would be MBs.
+/// collapsed render is a few KB (measured ~1.5 KB); the uncollapsed cap
+/// render would be MBs. The `< 500_000` threshold sits far below the
+/// uncollapsed size yet well above the collapsed one.
 #[test]
 fn childless_cap_exceeding_block_collapses_end_to_end() {
     let html = r#"<!doctype html><html><body><div style="height:99999999px"></div></body></html>"#;

--- a/docs/plans/2026-07-03-childless-tall-block-collapse.md
+++ b/docs/plans/2026-07-03-childless-tall-block-collapse.md
@@ -1,0 +1,434 @@
+# MAX_PAGES revert + childless tall-block collapse — Implementation Plan
+
+**Goal:** Restore the 10k pagination DoS bound (regressed to 100k by commit
+d3204be) and collapse pathologically tall *childless* blocks to a single
+page so a 79-byte input stops amplifying into a huge render job.
+
+**Architecture:** Two levers in `crates/fulgur`. (1) `MAX_PAGES` back to
+`10_000` (absolute page-index ceiling; keeps the additive-not-multiplicative
+property). (2) In the body-direct tall-block slice loop, when a block has no
+rendered descendant content and its slicing would exceed the cap, gate the
+per-page fragment `push` while leaving the loop's `page_index`/`cursor_y`/
+`remaining` math untouched — so following siblings never reflow and a
+trailing block collapses for free via `implied_page_count` (max fragment
+index). Background presence does not gate the collapse.
+
+**Tech Stack:** Rust, Blitz/Taffy layout, `PaginationGeometryTable`,
+`cargo test`/`clippy`/`fmt`.
+
+**Issue:** fulgur-ezst (design in its `design` field). Related: fulgur-2m6w.
+
+**Scope boundary:** The `position:absolute; top:<huge>` page-extension path
+(`pagination_layout.rs` ~3145) stays cap-bounded (clamped to `MAX_PAGES`),
+NOT collapsed — a deliberate boundary. After the revert it yields up to 10k
+bounded pages, not 1. Only the body-direct in-flow slice loop gets the
+childless collapse.
+
+---
+
+## Task 1: Revert MAX_PAGES 100k → 10k
+
+**Files:**
+
+- Modify: `crates/fulgur/src/lib.rs:5-34` (doc comment + constant)
+
+**Step 1: Replace the constant and its doc comment**
+
+Replace the doc comment block (lines 5-33) and constant (line 34) with:
+
+```rust
+/// Per-element page-amplification bound (NOT a strict total-page ceiling —
+/// see the note below). Bounds the per-page-strip slicing of an oversized
+/// block in `pagination_layout` (and the absolute-positioning page-extension
+/// path) so a tiny input with a pathologically tall CSS height / offset
+/// (e.g. `height: 99999999px`, `position:absolute; top:99999999px`) cannot
+/// force unbounded fragment / page generation — which downstream inflates a
+/// `vec![Vec::new(); page_count]` allocation and a per-page render loop into
+/// a CPU/memory-exhaustion DoS.
+///
+/// The cap is keyed off the running `page_index`, not a per-element budget.
+/// That is deliberate: it makes many oversized siblings **additive** rather
+/// than **multiplicative** — each extra oversized block contributes only its
+/// own first fragment once the slice loop is capped, so the document total
+/// settles at `MAX_PAGES + N` for `N` body children instead of
+/// `N * MAX_PAGES`. A per-element budget would re-open that multi-element
+/// amplification, so the cap must stay keyed off the absolute page index
+/// (Codex review on PR #501).
+///
+/// Consequence: the total page count can slightly **exceed** `MAX_PAGES`
+/// (it is `MAX_PAGES + N`, still input-proportional and rendered in bounded
+/// time). This constant therefore caps single-element amplification, not the
+/// absolute page count — code must not assume `page_count <= MAX_PAGES`.
+///
+/// Kept deliberately conservative for untrusted server-side rendering (a
+/// shared multi-tenant renderer is the primary deployment): a tiny
+/// pathological input must not amplify into one render iteration and PDF
+/// page per fragment. The most common amplifier — a childless block with a
+/// huge height, which prints only blank pages — is additionally collapsed to
+/// a single page in `pagination_layout` (fulgur-ezst), so this ceiling only
+/// bounds the residual content-bearing case. Content past the cap is
+/// truncated (clamp-and-warn). Sibling of the `MAX_DOM_DEPTH` / background
+/// `MAX_TILES` defensive bounds.
+pub(crate) const MAX_PAGES: u32 = 10_000;
+```
+
+**Step 2: Build and run the pagination tests**
+
+Run: `cargo test -p fulgur --lib pagination_layout 2>&1 | tail -20`
+Expected: PASS. The existing `pathological_tall_block_is_page_capped` /
+`f32_max_height_block_is_page_capped` assert `pages <= MAX_PAGES + 1`, which
+still holds at 10k (they read the constant symbolically). Task 3 retargets
+them to the collapse behavior.
+
+**Step 3: Commit**
+
+```bash
+git add crates/fulgur/src/lib.rs
+git commit -m "fix(pagination): revert MAX_PAGES ceiling 100k -> 10k (DoS regression)"
+```
+
+---
+
+## Task 2: Add the `subtree_has_rendered_content` predicate
+
+**Files:**
+
+- Modify: `crates/fulgur/src/pagination_layout.rs` (add fn next to
+  `record_subtree_descendants`, ~line 1116)
+
+**Step 1: Add the predicate**
+
+Insert immediately before `fn record_subtree_descendants` (line 1116):
+
+```rust
+/// fulgur-ezst: true if `parent_id`'s subtree renders any box (a descendant
+/// with non-zero size). Mirrors `record_subtree_descendants`' walk — the
+/// `layout_children` preference and the zero-size-container recursion (so a
+/// `<tbody>`/`<tr>`/anonymous wrapper still counts its cells as content) —
+/// but short-circuits on the first rendered descendant. Used to classify a
+/// pathologically tall block as "childless" (collapsible). Conservative: a
+/// subtree deeper than `MAX_DOM_DEPTH` reads as no content, matching
+/// `record_subtree_descendants` (which also stops recording there, so such
+/// content renders blank regardless). Keep this walk in sync with
+/// `record_subtree_descendants`.
+fn subtree_has_rendered_content(doc: &BaseDocument, parent_id: usize, depth: usize) -> bool {
+    if depth >= crate::MAX_DOM_DEPTH {
+        return false;
+    }
+    let Some(parent) = doc.get_node(parent_id) else {
+        return false;
+    };
+    let layout_children_borrow = parent.layout_children.borrow();
+    let walk_children: &[usize] = layout_children_borrow
+        .as_deref()
+        .filter(|v| !v.is_empty())
+        .unwrap_or(&parent.children);
+    for &child_id in walk_children {
+        let Some(child) = doc.get_node(child_id) else {
+            continue;
+        };
+        let layout = child.final_layout;
+        if layout.size.height <= 0.0 && layout.size.width <= 0.0 {
+            if subtree_has_rendered_content(doc, child_id, depth + 1) {
+                return true;
+            }
+            continue;
+        }
+        return true;
+    }
+    false
+}
+```
+
+**Step 2: Build**
+
+Run: `cargo build -p fulgur 2>&1 | tail -5`
+Expected: compiles (a `dead_code` warning is fine until Task 3 wires it in;
+if clippy denies warnings locally, proceed — Task 3 uses it immediately).
+
+**Step 3: Commit**
+
+```bash
+git add crates/fulgur/src/pagination_layout.rs
+git commit -m "feat(pagination): add subtree_has_rendered_content childless predicate"
+```
+
+---
+
+## Task 3: Collapse pathological childless blocks in the slice loop (TDD)
+
+**Files:**
+
+- Test + Modify: `crates/fulgur/src/pagination_layout.rs` (slice loop
+  ~978-1011; tests ~3961-3997)
+
+**Step 1: Retarget the two existing cap tests to the collapse behavior
+(write the failing tests)**
+
+Replace `pathological_tall_block_is_page_capped` (lines ~3961-3979) and
+`f32_max_height_block_is_page_capped` (lines ~3981-3997) with:
+
+```rust
+    /// fulgur-ezst: a tiny input with a pathologically tall CSS height on a
+    /// CHILDLESS block prints only blank pages, so instead of slicing it to
+    /// the `MAX_PAGES` cap (~10k blank pages) the fragmenter collapses it to
+    /// a single page. `height: 99999999px` would otherwise slice into
+    /// ~125 000 fragments — the small-input DoS.
+    #[test]
+    fn pathological_childless_tall_block_collapses() {
+        let html = r#"<html><body><div style="height: 99999999px"></div></body></html>"#;
+        let mut doc = parse(html, 600.0);
+        let table = run_pass(&mut doc, 800.0);
+        assert_eq!(
+            implied_page_count(&table),
+            1,
+            "childless pathological height must collapse to a single page",
+        );
+    }
+
+    /// fulgur-ezst: Stylo/Taffy clamps an absurd `<length>` to `f32::MAX`
+    /// (≈3.4e38), the worst-case finite input. A childless block that tall
+    /// also collapses to one page (the ceiling-bounded slice loop still runs
+    /// its counter math but pushes no fragment).
+    #[test]
+    fn f32_max_childless_height_collapses() {
+        let html = r#"<html><body><div style="height: 1e39px"></div></body></html>"#;
+        let mut doc = parse(html, 600.0);
+        let table = run_pass(&mut doc, 800.0);
+        assert_eq!(
+            implied_page_count(&table),
+            1,
+            "childless f32::MAX height must collapse to a single page",
+        );
+    }
+```
+
+**Step 2: Run to verify they FAIL**
+
+Run: `cargo test -p fulgur --lib pathological_childless_tall_block_collapses f32_max_childless_height_collapses 2>&1 | tail -20`
+Expected: FAIL — `implied_page_count` is `10_001`, not `1` (collapse not
+implemented yet).
+
+**Step 3: Implement the collapse in the slice loop**
+
+In `pagination_layout.rs`, locate the block starting at `let mut remaining =
+child_h - first_slice_h;` (line ~978). Insert the collapse decision after
+`let mut last_slice_h = first_slice_h;` and gate the `push`:
+
+```rust
+                let mut remaining = child_h - first_slice_h;
+                let mut last_slice_h = first_slice_h;
+                // fulgur-ezst: a CHILDLESS block whose slicing would exceed
+                // the cap is a pathological amplifier — `<div
+                // style="height:99999999px">` is a web-only spacer/overflow
+                // idiom that prints nothing but blank pages. Emit only its
+                // first slice: skip the per-page fragment pushes while
+                // leaving the loop's page_index / cursor_y / remaining math
+                // untouched, so following in-flow siblings keep their exact
+                // positions (no reflow) and a trailing block collapses for
+                // free (`implied_page_count` reads the max fragment index).
+                // Background / border presence does NOT gate this — nobody
+                // authors a >MAX_PAGES-tall filled band on purpose. A
+                // content-bearing block, or a childless band that fits
+                // within the cap, is not collapsed and takes the
+                // truncate-and-warn path below unchanged.
+                let collapse_childless = self.page_height_px > 0.0
+                    && (remaining / self.page_height_px).ceil() > crate::MAX_PAGES as f32
+                    && !subtree_has_rendered_content(self.doc, child_id, 0);
+                // fulgur-2m6w: cap the per-page-strip slicing at
+                // `MAX_PAGES`. `child_h` is attacker-controlled CSS
+                // (`height` / `vh`), so without this bound a few bytes of
+                // HTML (`<div style="height:99999999px">`) generate ~10^5
+                // fragments — and a non-finite height would never reduce
+                // `remaining`, looping forever. The `page_index` ceiling is
+                // load-bearing on its own (it stops the loop even when
+                // `remaining` is `+inf`); content past the cap is truncated.
+                while remaining > 0.0 && page_index < crate::MAX_PAGES {
+                    page_index += 1;
+                    last_slice_h = remaining.min(self.page_height_px);
+                    if !collapse_childless {
+                        self.geometry
+                            .entry(child_id)
+                            .or_default()
+                            .fragments
+                            .push(Fragment {
+                                page_index,
+                                x: frag_x.px(),
+                                y: 0.0_f32.px(),
+                                width: child_w.px(),
+                                height: last_slice_h.px(),
+                            });
+                    }
+                    remaining -= last_slice_h;
+                }
+                if remaining > 0.0 {
+                    if collapse_childless {
+                        log::warn!(
+                            "pagination: collapsed a childless block of \
+                             height {child_h}px (slicing would exceed the \
+                             {}-page limit) to a single page (fulgur-ezst)",
+                            crate::MAX_PAGES,
+                        );
+                    } else {
+                        log::warn!(
+                            "pagination: block height {child_h}px exceeds the \
+                             {}-page limit; truncating remaining content to \
+                             bound rendering (fulgur-2m6w)",
+                            crate::MAX_PAGES,
+                        );
+                    }
+                }
+```
+
+**Step 4: Run to verify the two tests PASS**
+
+Run: `cargo test -p fulgur --lib pathological_childless_tall_block_collapses f32_max_childless_height_collapses 2>&1 | tail -20`
+Expected: PASS.
+
+**Step 5: Add the remaining unit tests (background, content-bearing cap,
+sub-cap band)**
+
+Append after `f32_max_childless_height_collapses`:
+
+```rust
+    /// fulgur-ezst: background presence does not gate the collapse — a
+    /// childless filled band this tall is still a pathological amplifier.
+    #[test]
+    fn childless_tall_block_with_background_collapses() {
+        let html =
+            r#"<html><body><div style="height: 99999999px; background: red"></div></body></html>"#;
+        let mut doc = parse(html, 600.0);
+        let table = run_pass(&mut doc, 800.0);
+        assert_eq!(implied_page_count(&table), 1);
+    }
+
+    /// fulgur-ezst: a tall block WITH rendered content is not childless, so
+    /// it is NOT collapsed — it still clamps to ~MAX_PAGES (truncate-and-
+    /// warn). Also guards routing: a huge parent with a small child must
+    /// reach the slice loop, not the recursion branch (the recursion gate
+    /// measures descendant overflow, not the parent's intrinsic height).
+    #[test]
+    fn content_bearing_tall_block_is_page_capped() {
+        let html = r#"<html><body><div style="height: 99999999px"><p>x</p></div></body></html>"#;
+        let mut doc = parse(html, 600.0);
+        let table = run_pass(&mut doc, 800.0);
+        let pages = implied_page_count(&table);
+        assert!(
+            pages > 1_000,
+            "content-bearing block must take the cap path, not collapse; got {pages}",
+        );
+        assert!(
+            pages <= crate::MAX_PAGES + 1,
+            "content-bearing block must stay clamped to ~MAX_PAGES ({}); got {pages}",
+            crate::MAX_PAGES,
+        );
+    }
+
+    /// fulgur-ezst: a childless band that fits WITHIN the cap renders its
+    /// full page count — the collapse must not over-fire on ordinary
+    /// multi-page spacers. `height: 4000px` on an 800px strip = 5 pages.
+    #[test]
+    fn childless_subcap_band_renders_full() {
+        let html = r#"<html><body><div style="height: 4000px"></div></body></html>"#;
+        let mut doc = parse(html, 600.0);
+        let table = run_pass(&mut doc, 800.0);
+        assert_eq!(
+            implied_page_count(&table),
+            5,
+            "a sub-cap childless band must render fully, not collapse",
+        );
+    }
+```
+
+**Step 6: Run the full pagination test module**
+
+Run: `cargo test -p fulgur --lib pagination_layout 2>&1 | tail -25`
+Expected: PASS (new tests + unchanged `non_finite_height_treated_as_zero`,
+abs-path cap tests which read `MAX_PAGES` symbolically).
+
+**Step 7: Commit**
+
+```bash
+git add crates/fulgur/src/pagination_layout.rs
+git commit -m "feat(pagination): collapse pathological childless tall blocks (fulgur-ezst)"
+```
+
+---
+
+## Task 4: End-to-end smoke coverage
+
+**Files:**
+
+- Modify: `crates/fulgur/tests/render_smoke.rs` (~4683; add a new test)
+
+**Step 1: Add the collapse smoke test**
+
+Keep the existing `pathological_tall_block_render_is_bounded` (50000px, ~63
+pages — a sub-cap childless band that is NOT collapsed and exercises the
+multi-slice draw path). Add after it:
+
+```rust
+/// fulgur-ezst: a childless block tall enough to exceed the page cap must
+/// collapse end-to-end — a real `render_html` yields a tiny, single-page
+/// PDF rather than a ~10k-page one. Byte size cleanly separates the two: a
+/// collapsed render is a few KB; the uncollapsed cap render would be MBs.
+#[test]
+fn childless_cap_exceeding_block_collapses_end_to_end() {
+    let html = r#"<!doctype html><html><body><div style="height:99999999px"></div></body></html>"#;
+    let pdf = Engine::builder()
+        .build()
+        .render_html(html)
+        .expect("render must terminate and succeed");
+    assert!(!pdf.is_empty(), "expected a non-empty PDF");
+    assert!(
+        pdf.len() < 500_000,
+        "collapsed render must be small (single page); got {} bytes",
+        pdf.len(),
+    );
+}
+```
+
+**Step 2: Run the smoke tests**
+
+Run: `cargo test -p fulgur --test render_smoke childless_cap_exceeding_block_collapses_end_to_end pathological_tall_block_render_is_bounded 2>&1 | tail -15`
+Expected: PASS (both).
+
+**Step 3: Commit**
+
+```bash
+git add crates/fulgur/tests/render_smoke.rs
+git commit -m "test(pagination): end-to-end childless collapse smoke test (fulgur-ezst)"
+```
+
+---
+
+## Task 5: Full verification
+
+**Step 1: Full fulgur test suite**
+
+Run: `cargo test -p fulgur 2>&1 | tail -25`
+Expected: all green (lib + integration). Watch for any test that hardcoded
+100k-page expectations (grep found none, but confirm).
+
+**Step 2: Lint**
+
+Run: `cargo clippy -p fulgur --all-targets 2>&1 | tail -15`
+Expected: no warnings (the predicate is now used).
+
+Run: `cargo fmt --check 2>&1 | tail -5`
+Expected: clean.
+
+Run: `npx markdownlint-cli2 'docs/plans/2026-07-03-childless-tall-block-collapse.md' 2>&1 | tail -5`
+Expected: 0 errors.
+
+**Step 3: Manual DoS sanity check (optional, mirrors the finding's PoC)**
+
+```bash
+printf '%s' '<div style="height:99999999px"></div>' > /tmp/poc.html
+cargo run -q -p fulgur-cli --release -- render /tmp/poc.html -o /tmp/poc.pdf
+ls -l /tmp/poc.pdf   # expect a few KB, not ~31 MB
+```
+
+Expected: fast, tiny PDF (single page).
+
+**Step 4: No commit** (verification only).


### PR DESCRIPTION
## 概要

セキュリティトリアージが commit `d3204be`（`MAX_PAGES` を 10k→100k に引き上げ）を DoS 回帰として指摘した件への対応です。79 バイトの入力 `<div style="height:99999999px"></div>` が約 10 万ページに増幅し、共有レンダラで約 12 秒 / 200MB RSS / 31MB PDF を消費します。この脅威モデル（マルチテナントで untrusted な HTML/CSS を共有レンダリング）はまさに本プロジェクトの主要ユースケースなので、防御を元の水準に戻したうえで、根本原因である「病的に高い空ブロック」を畳みます。

2 つのレバーで対応します。

1. **`MAX_PAGES` を 100k → 10k に revert**（セキュリティ本体）。全ケース（空・背景のみ・中身あり）を 10k で bounded に戻す。10k ページは単一ドキュメントとして既に巨大で、引き上げは念のためのものだったため機能的コストはほぼゼロ。`page_index` を基準にした加算的（`MAX_PAGES + N`）な性質は維持。
2. **病的に高い _childless_ ブロックの畳み込み**（fulgur-ezst）。body 直下のスライスループで、描画される子孫を持たず、かつスライスがキャップを超えるブロックについて、ページごとのフラグメント `push` だけを抑止する。ループの `page_index` / `cursor_y` / `remaining` のカウンタ演算は不変に保つため、**後続の in-flow 兄弟は一切 reflow せず**、末尾の childless ブロックは `implied_page_count`（フラグメント最大インデックス由来）経由で自然に 1 ページへ畳まれる。背景・ボーダーの有無で分岐しない（>MAX_PAGES 相当の塗り帯を意図的に書く人はいない）。中身のあるブロックや、キャップ未満の childless バンドは畳まれず従来どおり。

## 挙動

| 入力 | 変更前 | 変更後 |
|---|---|---|
| `height:99999999px`（子なし・背景なし） | 10 万ページ（100k 時） | 1 ページ |
| `height:99999999px; background:red`（子なし） | 10 万ページ | 1 ページ |
| `height:5000px; background:gradient`（子なし・~7p, キャップ未満） | ~7 ページ | ~7 ページ（不変） |
| `height:99999999px` に中身あり | 10 万ページ | ~10k で truncate-and-warn |

## スコープ外（意図的な境界）

`position:absolute; top:<巨大>` のページ拡張経路は cap-bounded のまま（10k にクランプ、畳み込みはしない）。畳み込みは body 直下の in-flow スライスループに限定。

## テスト

- `subtree_has_rendered_content`（childless 判定、`record_subtree_descendants` の walk をミラー・短絡）
- 単体（`pagination_layout.rs`）: childless collapse（背景あり含む）/ 中身ありは cap 維持 / キャップ未満バンドは全ページ描画 / **後続兄弟の no-reflow を pin**（collapse 後も `<p>` は page ≈ `MAX_PAGES` に留まる）
- end-to-end smoke（`render_smoke.rs`）: `height:99999999px` を実レンダリングして単一ページの小さな PDF（実測 ~1.5KB）になることを確認
- `cargo test -p fulgur` 全 green / `clippy --all-targets` 0 warnings / `fmt --check` clean / markdownlint clean

## 関連

- fulgur-ezst（本 PR の設計・受け入れ基準）
- fulgur-2m6w（元の per-page-strip スライスキャップ、PR #501）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 極端に高い要素がある場合のページ分割を調整し、不要なページ増加を抑えました。
  * 内容のない高いブロックは、適切に1ページ相当へまとめられるようになりました。
  * 背景のみの要素や可視コンテンツを含む要素では、従来どおりのページ分割が維持されます。

* **Tests**
  * 上限超過時の出力サイズや、折りたたみ動作の検証を追加・強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->