### PR TITLE
fix(cli): make --size authoritative over CSS @page orientation

### DIFF
--- a/crates/fulgur-cli/src/main.rs
+++ b/crates/fulgur-cli/src/main.rs
@@ -162,12 +162,14 @@ enum Commands {
         /// Page size: keyword (A4, Letter, A3) or custom WxH with units
         /// (units mm/cm/in/pt/px; 'x' or space separator),
         /// e.g. 210x297mm or 2352.6ptx3481.39pt.
-        /// Takes priority over CSS @page { size }. Omit --size to let
+        /// Takes priority over CSS @page { size }, including orientation:
+        /// with --size, CSS @page landscape/portrait is ignored and the page
+        /// stays portrait unless --landscape is also given. Omit --size to let
         /// CSS @page { size } take effect (falls back to A4 if neither set).
         #[arg(short, long)]
         size: Option<String>,
 
-        /// Landscape orientation
+        /// Landscape orientation (also forces landscape over CSS @page)
         #[arg(short, long)]
         landscape: bool,
 

--- a/crates/fulgur-cli/src/main.rs
+++ b/crates/fulgur-cli/src/main.rs
@@ -164,8 +164,9 @@ enum Commands {
         /// e.g. 210x297mm or 2352.6ptx3481.39pt.
         /// Takes priority over CSS @page { size }, including orientation:
         /// with --size, CSS @page landscape/portrait is ignored and the page
-        /// stays portrait unless --landscape is also given. Omit --size to let
-        /// CSS @page { size } take effect (falls back to A4 if neither set).
+        /// keeps the orientation implied by the size itself (its own W×H, or a
+        /// keyword's portrait default) unless --landscape swaps it. Omit --size
+        /// to let CSS @page { size } take effect (falls back to A4 if neither set).
         #[arg(short, long)]
         size: Option<String>,
 

--- a/crates/fulgur/src/gcpm/page_settings.rs
+++ b/crates/fulgur/src/gcpm/page_settings.rs
@@ -47,6 +47,11 @@ fn selector_matches(selector: &str, page_num: usize, first_page_is_left: bool) -
 /// ```text
 /// CLI override (config.overrides) > CSS @page selector match > CSS @page default > Config defaults
 /// ```
+///
+/// When `config.overrides.page_size` is set (i.e. `--size` / `builder.page_size`),
+/// the CLI fully owns page geometry **including orientation**: CSS `@page`
+/// orientation is intentionally ignored, and landscape is taken solely from
+/// `config.landscape` (request it with `--landscape` / `builder.landscape(true)`).
 pub fn resolve_page_settings(
     rules: &[PageSettingsRule],
     page_num: usize,
@@ -85,13 +90,11 @@ pub fn resolve_page_settings(
 
     // --- Resolve page size and landscape ---
     let (size, landscape) = if config.overrides.page_size {
-        // CLI override for size — also respect CLI landscape override separately.
-        let ls = if config.overrides.landscape {
-            config.landscape
-        } else {
-            resolve_landscape_from_css(css_size, config.landscape)
-        };
-        (config.page_size, ls)
+        // CLI `--size` owns geometry, including orientation: CSS `@page`
+        // orientation is ignored so `--size` is authoritative on both axes.
+        // Landscape comes solely from `config.landscape` (default portrait;
+        // set via `--landscape` / `builder.landscape(true)`).
+        (config.page_size, config.landscape)
     } else {
         match css_size {
             Some(PageSizeDecl::Keyword(name)) => {
@@ -146,15 +149,6 @@ pub fn resolve_page_settings(
     };
 
     (size, margin, landscape)
-}
-
-/// Extract landscape flag from a CSS size declaration.
-fn resolve_landscape_from_css(css_size: Option<&PageSizeDecl>, fallback: bool) -> bool {
-    match css_size {
-        Some(PageSizeDecl::KeywordWithOrientation(_, is_landscape)) => *is_landscape,
-        Some(PageSizeDecl::Custom(_, _)) => false,
-        _ => fallback,
-    }
 }
 
 #[cfg(test)]
@@ -249,6 +243,39 @@ mod tests {
         }];
         let (_, _, landscape) = resolve_page_settings(&rules, 1, 10, &config, false);
         assert!(landscape);
+    }
+
+    #[test]
+    fn test_cli_override_ignores_css_landscape() {
+        // `--size` (overrides.page_size) is authoritative on the orientation
+        // axis too: a CSS `@page { size: <keyword> landscape }` must not rotate
+        // the CLI-specified size. Without `--landscape`, config.landscape is
+        // false, so the result stays portrait. (fulgur-u4k5)
+        let config = Config::builder().page_size(PageSize::A4).build();
+        let rules = vec![PageSettingsRule {
+            page_selector: None,
+            size: Some(PageSizeDecl::KeywordWithOrientation("A4".into(), true)),
+            margin: PartialMargin::default(),
+        }];
+        let (_, _, landscape) = resolve_page_settings(&rules, 1, 10, &config, false);
+        assert!(!landscape, "CLI --size must ignore CSS @page landscape");
+    }
+
+    #[test]
+    fn test_cli_override_with_landscape_flag_is_landscape() {
+        // `--size A4 --landscape` still yields landscape: orientation comes
+        // solely from config.landscape in the override path. (fulgur-u4k5)
+        let config = Config::builder()
+            .page_size(PageSize::A4)
+            .landscape(true)
+            .build();
+        let rules = vec![PageSettingsRule {
+            page_selector: None,
+            size: Some(PageSizeDecl::KeywordWithOrientation("A4".into(), false)),
+            margin: PartialMargin::default(),
+        }];
+        let (_, _, landscape) = resolve_page_settings(&rules, 1, 10, &config, false);
+        assert!(landscape, "--landscape must force landscape under --size");
     }
 
     #[test]

--- a/docs/plans/2026-07-03-cli-size-overrides-css-orientation-design.md
+++ b/docs/plans/2026-07-03-cli-size-overrides-css-orientation-design.md
@@ -1,0 +1,120 @@
+# CLI `--size` overrides CSS `@page` orientation (fulgur-u4k5)
+
+## Problem
+
+Passing `--size` sets `config.overrides.page_size = true`, which makes the CLI
+dimensions win over CSS `@page { size }`. However, orientation leaks through:
+an orientation-only CSS rule such as `@page { size: landscape }` is still
+applied via `resolve_page_settings` / `resolve_landscape_from_css`, even when
+`--size` is given.
+
+Concretely, `fulgur render --size 200ptx400pt` against landscape CSS produces a
+`400x200` (rotated) MediaBox. The `--size` help text promises priority over CSS
+`@page { size }`, but that promise does not hold on the orientation axis, and
+there is no CLI flag to cancel a CSS orientation.
+
+## Key constraint: keyword/custom distinction is already gone at the config layer
+
+`main.rs` maps both `--size A4` and `--size 200ptx400pt` through
+`parse_page_size` into the same bare `PageSize { width, height }`. By the time
+`resolve_page_settings` runs, `config.page_size` carries no record of whether it
+originated from a keyword or explicit dimensions. The library/builder layer has
+no concept of "keyword" either (`PageSize::A4` is just a dimension constant).
+
+This rules out a purely local fix that treats keyword and custom sizes
+differently (the issue's option (c)): that would require threading a new
+size-kind intent from the CLI into `config`. Any orientation policy that the
+config layer can express must treat keyword and custom sizes identically.
+
+## Decision
+
+Adopt **full CLI priority** (the issue's option (b)): when `--size` is given,
+the CLI owns page geometry including orientation. CSS `@page` orientation is
+ignored in the override path; orientation is requested explicitly with
+`--landscape` (or `builder.landscape(true)`).
+
+The intentional magic of `--size A4 + CSS landscape = landscape A4` is dropped.
+Its only cost is one extra flag: `--size A4 --landscape` reproduces the result
+explicitly. This trade-off was confirmed with the maintainer.
+
+### Rejected alternatives
+
+- **(c) keyword-only magic** — preserves `--size A4 + CSS landscape` but not
+  `--size 200ptx400pt + CSS landscape`. Impossible as a local `page_settings.rs`
+  change (see the constraint above); requires new CLI→config plumbing for a
+  behavior the maintainer judged not worth keeping.
+- **(a) `--portrait` flag as the primary fix** — does not by itself make
+  `--size` authoritative; it only adds a manual override. Split out as separate
+  scope (see below).
+
+## Implementation
+
+Single change in `crates/fulgur/src/gcpm/page_settings.rs`, override branch
+(currently lines 87-94):
+
+```rust
+let (size, landscape) = if config.overrides.page_size {
+    // --size given: the CLI fully owns page geometry, including
+    // orientation. CSS @page orientation is intentionally ignored;
+    // request landscape with --landscape / builder.landscape(true).
+    (config.page_size, config.landscape)
+} else {
+    // ... unchanged non-override path (CSS is respected) ...
+};
+```
+
+The old branch chose `config.landscape` when `overrides.landscape` was set and
+otherwise fell back to `resolve_landscape_from_css(css_size, config.landscape)`.
+Both arms collapse to `config.landscape`, so:
+
+- `resolve_landscape_from_css` (lines 152-158) becomes dead and is **deleted**.
+- All call sites (`render.rs:104`, `render.rs:188`, `engine.rs:174`) route
+  through the same `resolve_page_settings`, so fixing the function fixes every
+  render path.
+
+### Behavior matrix (after the change)
+
+| Input | Result |
+|-------|--------|
+| `--size 200ptx400pt` + CSS landscape | portrait `400` tall (bug fixed) |
+| `--size A4` | portrait A4 |
+| `--size A4 --landscape` | landscape A4 |
+| `--size A4` + CSS landscape | portrait A4 (CSS ignored) |
+| no `--size` + CSS landscape | landscape (non-override path, unchanged) |
+
+The fix lives in the library `resolve_page_settings`, so it also affects
+library callers, not just the CLI: `Engine::builder().page_size(...)` sets
+`overrides.page_size`, so a caller that sets a page size without
+`.landscape(true)` now renders portrait even under CSS `@page { size:
+landscape }` (previously landscape). This is consistent with option (b)
+(override fully owns geometry) and is acceptable under the 0.x lockstep minor
+bump.
+
+### Ancillary changes
+
+1. **Help text** (`main.rs`, the `size` arg doc): state that `--size` takes
+   priority over CSS `@page` orientation as well, and that `--landscape`
+   requests landscape. Removes the current over-promise.
+2. **Doc comment** (`page_settings.rs` priority model, lines 44-49): note that
+   the override path ignores CSS orientation.
+3. **New unit test** `test_cli_override_ignores_css_landscape`: override +
+   CSS `KeywordWithOrientation("A4", true)` → `landscape == false`.
+
+## Testing
+
+- Unit test in `page_settings.rs` (pure function; covered by the lib test suite
+  per the codecov scope note in `CLAUDE.md`).
+- Existing tests are unaffected: no current test asserts
+  `override + CSS landscape → landscape`. `test_page_size_landscape_from_css`
+  uses the non-override path; `test_cli_override_beats_css` does not check
+  orientation.
+
+## Out of scope (separate issues)
+
+- **`--portrait` flag** — a general CLI way to force portrait in the *no-`--size`*
+  case (size from CSS, orientation forced from CLI). Requires reworking the CLI
+  orientation wiring into a tri-state (`auto`/`portrait`/`landscape`). Filed
+  separately.
+- **Invalid `--size` footgun** — a bad `--size` value warns and falls back to A4
+  while still suppressing CSS `@page`. The issue already notes this as a
+  separate axis (`--size` authority); consider a non-zero exit separately.


### PR DESCRIPTION
## 概要

`fulgur-u4k5` の修正。CLI `--size` を渡しても、orientation-only な CSS `@page`（例 `@page { size: landscape }`）が override パスで適用され続け、`fulgur render --size 200ptx400pt` が landscape CSS に対して MediaBox `400x200`（回転）を出力していた。`--size` のヘルプは CSS `@page { size }` への優先を謳うが、orientation 軸ではその約束が成り立っていなかった。

## 方針: option (b) CLI 完全優先

`--size`（`config.overrides.page_size`）指定時は、size も orientation も CLI が完全に所有する。CSS `@page` orientation は無視し、向きは `config.landscape` のみから決まる（landscape は `--landscape` / `builder.landscape(true)` で明示要求）。

暗黙の `--size A4 + CSS landscape = landscape A4` マジックは破棄。`--size A4 --landscape` と明示すれば同じ結果が得られる。

### 却下した案

- **(c) keyword 限定でマジック温存** — `parse_page_size` の時点で keyword/custom の区別が消えるため `page_settings.rs` のローカル修正では実装不可（CLI→config plumbing が必要）で、温存する価値が無いと判断。
- **(a) `--portrait` を主対策に** — `--size` の権威性そのものは直せない。no-size ケース用の追加機能として `fulgur-6n08` に分離（本 PR に依存）。

## 変更点

- `crates/fulgur/src/gcpm/page_settings.rs`: override 分岐を `(config.page_size, config.landscape)` に単純化。dead になった `resolve_landscape_from_css` helper を削除。priority model の doc comment に orientation を無視する旨を追記。
- `crates/fulgur-cli/src/main.rs`: `--size` / `--landscape` の help を「orientation も CLI 優先」に整合し over-promise を解消。
- `crates/fulgur/src/gcpm/page_settings.rs` tests: `test_cli_override_ignores_css_landscape` と `test_cli_override_with_landscape_flag_is_landscape` を追加。
- `docs/plans/2026-07-03-cli-size-overrides-css-orientation-design.md`: 設計文書。

## 挙動マトリクス

| 入力 | 変更後 |
|------|--------|
| `--size 200ptx400pt` + CSS landscape | portrait `200x400`（✓ バグ修正） |
| `--size A4` | portrait A4 |
| `--size A4 --landscape` | landscape A4 |
| `--size A4` + CSS landscape | portrait A4（CSS 無視） |
| `--size` 無し + CSS landscape | landscape（非 override パス、不変） |

修正は library の `resolve_page_settings` に入るため、`Engine::builder().page_size(...)` 経由の library caller にも同様に波及する（0.x lockstep minor bump の範囲で許容）。

## 検証

- `cargo test -p fulgur --lib` 1570 件 / `cargo test -p fulgur-cli -p fulgur` 統合テスト全通過（`page_size_cli`, `examples_determinism`, help スナップショット破損なし）。
- `cargo clippy` / `cargo fmt --check` クリーン。
- **実 PDF の MediaBox を 3 ケース実測**:
  - `--size 200ptx400pt` + CSS landscape → `0 0 200 400`（回転しない）
  - `--size 200ptx400pt --landscape` → `0 0 400 200`
  - `--size` 無し + CSS landscape → `0 0 841.89 595.28`（landscape A4、不変）
- VRT goldens は別ジョブのためローカル `--lib` ではカバーされない。`--size` override と CSS orientation を併用する golden があれば byte 差分で落ちる可能性があるので、CI の VRT ジョブ結果を要確認。

Closes fulgur-u4k5
