### PR TITLE
fix(gcpm): inject static pseudo content per selector to remove render DoS

### DIFF
--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -1839,7 +1839,7 @@ use crate::gcpm::running::{RunningElementStore, serialize_node};
 use crate::gcpm::string_set::{StringSetEntry, StringSetStore, extract_text_content};
 use crate::gcpm::{
     ContentCounterMapping, ContentItem, CounterMapping, CounterOp, ParsedSelector, PseudoElement,
-    RunningMapping, StringSetMapping, StringSetValue, TargetUrl,
+    RunningMapping, StaticContentMapping, StringSetMapping, StringSetValue, TargetUrl,
 };
 use std::cell::RefCell;
 use std::collections::BTreeMap;
@@ -2318,7 +2318,7 @@ impl CounterPass {
                     "{}[data-fulgur-cid=\"{}\"]::before{{content:\"{}\"}}",
                     specificity_prefix,
                     cid,
-                    css_escape_string(&resolved)
+                    crate::gcpm::parser::css_escape_string(&resolved)
                 );
             }
         }
@@ -2345,7 +2345,7 @@ impl CounterPass {
                     "{}[data-fulgur-cid=\"{}\"]::after{{content:\"{}\"}}",
                     specificity_prefix,
                     cid,
-                    css_escape_string(&resolved)
+                    crate::gcpm::parser::css_escape_string(&resolved)
                 );
             }
         }
@@ -2728,24 +2728,6 @@ fn resolve_label(
     out
 }
 
-fn css_escape_string(s: &str) -> String {
-    let mut out = String::new();
-    for ch in s.chars() {
-        match ch {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\a "),
-            '\r' => out.push_str("\\d "),
-            '\0' => out.push_str("\\0 "),
-            c if c.is_control() => {
-                out.push_str(&format!("\\{:x} ", c as u32));
-            }
-            _ => out.push(ch),
-        }
-    }
-    out
-}
-
 /// Serialize a string as a CSS identifier per the CSSOM
 /// [serialize an identifier][algo] algorithm — the same logic as the
 /// JavaScript `CSS.escape()` function.
@@ -2801,6 +2783,42 @@ fn css_escape_ident(s: &str) -> String {
         index += 1;
     }
     out
+}
+
+/// Serialize flattened static pseudo-content mappings into CSS: one
+/// `<selector><pseudo> { content: "<flattened>" }` rule per mapping.
+///
+/// Injected after the author stylesheet (via [`InjectCssPass`]), each rule
+/// carries the same specificity as the author's simple-selector rule — the
+/// GCPM parser only produces mappings for simple `.class` / `#id` / `tag`
+/// selectors — and so wins by source order, rendering the full flattened
+/// value where blitz-dom 0.2.4 would otherwise emit only `items[0]`. Cost is
+/// O(mappings): unlike `CounterPass`, no DOM walk and no per-node rule, so a
+/// hostile document cannot amplify a small input into an OOM (see
+/// [`crate::gcpm::StaticContentMapping`]).
+pub(crate) fn build_static_content_css(mappings: &[StaticContentMapping]) -> String {
+    use std::fmt::Write;
+    let mut css = String::new();
+    for m in mappings {
+        let selector = match &m.parsed {
+            // Tag names come from the HTML parser as valid identifiers and
+            // match case-insensitively for HTML — lowercased for good measure
+            // (mirrors `element_specificity_prefix`).
+            ParsedSelector::Tag(name) => name.to_ascii_lowercase(),
+            ParsedSelector::Class(name) => format!(".{}", css_escape_ident(name)),
+            ParsedSelector::Id(name) => format!("#{}", css_escape_ident(name)),
+        };
+        let pseudo = match m.pseudo {
+            PseudoElement::Before => "::before",
+            PseudoElement::After => "::after",
+        };
+        let _ = write!(
+            css,
+            "{selector}{pseudo}{{content:\"{}\"}}",
+            crate::gcpm::parser::css_escape_string(&m.text)
+        );
+    }
+    css
 }
 
 /// Reconstruct a CSS selector prefix from an element's own identity —
@@ -3395,6 +3413,39 @@ mod tests {
     use super::*;
     use crate::gcpm::TargetTextKind;
 
+    #[test]
+    fn build_static_content_css_serializes_selectors_and_escapes() {
+        let mappings = vec![
+            StaticContentMapping {
+                parsed: ParsedSelector::Tag("DIV".into()),
+                pseudo: PseudoElement::Before,
+                text: "[x]".into(),
+            },
+            StaticContentMapping {
+                parsed: ParsedSelector::Class("note".into()),
+                pseudo: PseudoElement::After,
+                // A `"` and a `\` must be CSS-escaped so the injected rule
+                // is well-formed and cannot break out of the string.
+                text: "a\"b\\c".into(),
+            },
+            StaticContentMapping {
+                parsed: ParsedSelector::Id("foo".into()),
+                pseudo: PseudoElement::Before,
+                text: "y".into(),
+            },
+        ];
+        let css = build_static_content_css(&mappings);
+        assert_eq!(
+            css,
+            r#"div::before{content:"[x]"}.note::after{content:"a\"b\\c"}#foo::before{content:"y"}"#
+        );
+    }
+
+    #[test]
+    fn build_static_content_css_empty_for_no_mappings() {
+        assert!(build_static_content_css(&[]).is_empty());
+    }
+
     /// `relayout_position_fixed` must reshape every `position: fixed`
     /// subtree against the supplied viewport, not against the nearest
     /// positioned ancestor (the size that Taffy assigned during the
@@ -3671,6 +3722,7 @@ mod tests {
             string_set_mappings: vec![],
             counter_mappings: vec![],
             content_counter_mappings: vec![],
+            static_content_mappings: vec![],
             page_settings: vec![],
             bookmark_mappings: vec![],
             cleaned_css: String::new(),
@@ -3711,6 +3763,7 @@ mod tests {
             string_set_mappings: vec![],
             counter_mappings: vec![],
             content_counter_mappings: vec![],
+            static_content_mappings: vec![],
             page_settings: vec![],
             bookmark_mappings: vec![],
             cleaned_css: String::new(),
@@ -3737,6 +3790,7 @@ mod tests {
             string_set_mappings: vec![],
             counter_mappings: vec![],
             content_counter_mappings: vec![],
+            static_content_mappings: vec![],
             page_settings: vec![],
             bookmark_mappings: vec![],
             cleaned_css: String::new(),
@@ -3766,6 +3820,7 @@ mod tests {
             string_set_mappings: vec![],
             counter_mappings: vec![],
             content_counter_mappings: vec![],
+            static_content_mappings: vec![],
             page_settings: vec![],
             bookmark_mappings: vec![],
             cleaned_css: String::new(),

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -319,6 +319,22 @@ impl Engine {
             crate::blitz_adapter::apply_single_pass(&inject_pass, &mut doc, &ctx);
         }
 
+        // Inject flattened static pseudo-content (multi-item string `content:`
+        // lists). One selector-level rule per mapping — no per-node expansion,
+        // so this stays O(mappings) even for a hostile document. Injected after
+        // the author stylesheet so the flattened rule wins by source order and
+        // renders in full where blitz-dom would truncate to `items[0]`
+        // (fulgur-2ykw). Works for AssetBundle / `<link>` CSS *and* inline
+        // `<style>` (whose original text is never rewritten to `cleaned_css`).
+        if !gcpm.static_content_mappings.is_empty() {
+            let static_css =
+                crate::blitz_adapter::build_static_content_css(&gcpm.static_content_mappings);
+            if !static_css.is_empty() {
+                let inject_pass = crate::blitz_adapter::InjectCssPass { css: static_css };
+                crate::blitz_adapter::apply_single_pass(&inject_pass, &mut doc, &ctx);
+            }
+        }
+
         // BookmarkPass runs AFTER CounterPass and StringSetPass so it can
         // resolve `counter()` / `string()` inside `bookmark-label` against
         // the per-node snapshots harvested above (fulgur-70c).

--- a/crates/fulgur/src/gcpm/mod.rs
+++ b/crates/fulgur/src/gcpm/mod.rs
@@ -217,6 +217,27 @@ pub struct ContentCounterMapping {
     pub content: Vec<ContentItem>,
 }
 
+/// Maps a simple CSS selector + pseudo-element to a *static* pseudo-element
+/// content string that has already been flattened at parse time.
+///
+/// blitz-dom 0.2.4 renders only `items[0]` of a multi-item pseudo `content`
+/// list, so `p::before { content: "[" "x" "]" }` would show just `[`. Rather
+/// than route such static lists through the per-node [`ContentCounterMapping`]
+/// / `CounterPass` machinery — which emits one generated rule per *matching
+/// node* and lets a hostile document amplify a small input into an OOM —
+/// fulgur concatenates the strings once here and injects a single selector-
+/// level rule (`<selector><pseudo> { content: "<flattened>" }`). The rule
+/// carries the same specificity as the author rule and is injected after it,
+/// so it wins by source order. See `crate::gcpm::parser` (routing) and
+/// `crate::blitz_adapter::build_static_content_css` (injection).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StaticContentMapping {
+    pub parsed: ParsedSelector,
+    pub pseudo: PseudoElement,
+    /// The concatenation of every `String` item, already unescaped.
+    pub text: String,
+}
+
 /// Leader type for `content: leader()`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LeaderStyle {
@@ -401,6 +422,11 @@ pub struct GcpmContext {
     pub counter_mappings: Vec<CounterMapping>,
     /// Mappings from CSS selectors + pseudo-elements to content items with counter().
     pub content_counter_mappings: Vec<ContentCounterMapping>,
+    /// Mappings from CSS selectors + pseudo-elements to flattened *static*
+    /// pseudo content (multi-item string lists that need no per-element
+    /// resolution). Injected as one selector-level rule each — see
+    /// [`StaticContentMapping`].
+    pub static_content_mappings: Vec<StaticContentMapping>,
     /// Mappings from CSS selectors to `bookmark-level` / `bookmark-label` declarations.
     pub bookmark_mappings: Vec<BookmarkMapping>,
     /// The CSS with GCPM constructs stripped, suitable for normal rendering.
@@ -443,6 +469,8 @@ impl GcpmContext {
         self.counter_mappings.extend(other.counter_mappings);
         self.content_counter_mappings
             .extend(other.content_counter_mappings);
+        self.static_content_mappings
+            .extend(other.static_content_mappings);
         self.bookmark_mappings.extend(other.bookmark_mappings);
         if !other.cleaned_css.is_empty() {
             if !self.cleaned_css.is_empty() {
@@ -479,6 +507,7 @@ mod tests {
             page_settings: vec![],
             counter_mappings: vec![],
             content_counter_mappings: vec![],
+            static_content_mappings: vec![],
             bookmark_mappings: vec![],
             cleaned_css: String::new(),
         };
@@ -502,6 +531,7 @@ mod tests {
             page_settings: vec![],
             counter_mappings: vec![],
             content_counter_mappings: vec![],
+            static_content_mappings: vec![],
             bookmark_mappings: vec![],
             cleaned_css: String::new(),
         };
@@ -520,6 +550,7 @@ mod tests {
             page_settings: vec![],
             counter_mappings: vec![],
             content_counter_mappings: vec![],
+            static_content_mappings: vec![],
             bookmark_mappings: vec![],
             cleaned_css: String::new(),
         };
@@ -538,6 +569,7 @@ mod tests {
             page_settings: vec![],
             counter_mappings: vec![],
             content_counter_mappings: vec![],
+            static_content_mappings: vec![],
             bookmark_mappings: vec![],
             cleaned_css: "body { color: red; }".to_string(),
         };
@@ -556,6 +588,7 @@ mod tests {
             page_settings: vec![],
             counter_mappings: vec![],
             content_counter_mappings: vec![],
+            static_content_mappings: vec![],
             bookmark_mappings: vec![],
             cleaned_css: "p { margin: 0; }".to_string(),
         };
@@ -576,6 +609,7 @@ mod tests {
             page_settings: vec![],
             counter_mappings: vec![],
             content_counter_mappings: vec![],
+            static_content_mappings: vec![],
             bookmark_mappings: vec![],
             cleaned_css: String::new(),
         };
@@ -586,6 +620,7 @@ mod tests {
             page_settings: vec![],
             counter_mappings: vec![],
             content_counter_mappings: vec![],
+            static_content_mappings: vec![],
             bookmark_mappings: vec![],
             cleaned_css: "body { color: blue; }".to_string(),
         };

--- a/crates/fulgur/src/gcpm/mod.rs
+++ b/crates/fulgur/src/gcpm/mod.rs
@@ -226,10 +226,17 @@ pub struct ContentCounterMapping {
 /// / `CounterPass` machinery — which emits one generated rule per *matching
 /// node* and lets a hostile document amplify a small input into an OOM —
 /// fulgur concatenates the strings once here and injects a single selector-
-/// level rule (`<selector><pseudo> { content: "<flattened>" }`). The rule
-/// carries the same specificity as the author rule and is injected after it,
-/// so it wins by source order. See `crate::gcpm::parser` (routing) and
-/// `crate::blitz_adapter::build_static_content_css` (injection).
+/// level rule (`<selector><pseudo> { content: "<flattened>" }`).
+///
+/// The injected rule carries the same specificity as the author's (always
+/// simple) selector. For AssetBundle / `<link>` CSS the parser also strips the
+/// original declaration from `cleaned_css`, so the injection is the only
+/// source — this is what makes an `!important` original render `[x]` rather
+/// than truncating. Inline `<style>` text is never rewritten to `cleaned_css`,
+/// so there the original persists and the injection wins by source order (it
+/// is emitted after the author stylesheet). See `crate::gcpm::parser`
+/// (routing + strip) and `crate::blitz_adapter::build_static_content_css`
+/// (injection).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StaticContentMapping {
     pub parsed: ParsedSelector,

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -774,6 +774,22 @@ impl<'i, 'a> DeclarationParser<'i> for StyleRuleParser<'a> {
                         })
                         .collect(),
                 );
+                // Strip the original declaration from cleaned CSS (this affects
+                // the AssetBundle / `<link>` paths, where cleaned_css is what
+                // Blitz sees) so it cannot compete with the injected flattened
+                // rule. This matters most when the original is `!important`:
+                // left in place it wins in Stylo and blitz-dom keeps truncating
+                // to `items[0]` (renders `[` not `[x]`). Inline `<style>`
+                // discards cleaned_css, so its original persists there and the
+                // injection wins by source order instead (inline `!important`
+                // multi-item is thus an unchanged, pre-existing limitation).
+                let start = decl_start.position().byte_index();
+                let end = input.position().byte_index();
+                self.edits.push(CssEdit::Replace {
+                    start,
+                    end,
+                    replacement: String::new(),
+                });
             } else if has_counter || items.len() > 1 {
                 // Per-element dynamic content (counter / `target-*` / `attr()`,
                 // or any other multi-item list Blitz cannot render in full).
@@ -2055,9 +2071,15 @@ mod tests {
         assert_eq!(m.parsed, ParsedSelector::Tag("div".into()));
         assert_eq!(m.pseudo, PseudoElement::Before);
         assert_eq!(m.text, "ABCD");
-        // Sibling declarations are untouched; the original `content` stays in
-        // cleaned CSS (the injected selector-level rule overrides it — we never
-        // rewrite cleaned CSS, so inline `<style>` is handled identically).
+        // The original `content` declaration is stripped from cleaned CSS so it
+        // cannot compete with the injected flattened rule (critical for an
+        // `!important` original on the AssetBundle / `<link>` path). Sibling
+        // declarations survive.
+        assert!(
+            !ctx.cleaned_css.contains("\"AB\""),
+            "original multi-item content must be stripped: {:?}",
+            ctx.cleaned_css
+        );
         assert!(ctx.cleaned_css.contains("color: red"));
     }
 

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -8,8 +8,8 @@ use super::margin_box::MarginBoxPosition;
 use super::{
     ContentCounterMapping, ContentItem, CounterMapping, CounterOp, CounterStyle, ElementPolicy,
     GcpmContext, LeaderStyle, MarginBoxRule, PageSettingsRule, PageSizeDecl, ParsedSelector,
-    PartialMargin, PseudoElement, RunningMapping, StringPolicy, StringSetMapping, StringSetValue,
-    TargetTextKind, TargetUrl,
+    PartialMargin, PseudoElement, RunningMapping, StaticContentMapping, StringPolicy,
+    StringSetMapping, StringSetValue, TargetTextKind, TargetUrl,
 };
 
 // ---------------------------------------------------------------------------
@@ -39,6 +39,7 @@ struct GcpmSheetParser<'a> {
     string_set_mappings: &'a mut Vec<StringSetMapping>,
     counter_mappings: &'a mut Vec<CounterMapping>,
     content_counter_mappings: &'a mut Vec<ContentCounterMapping>,
+    static_content_mappings: &'a mut Vec<StaticContentMapping>,
     page_settings: &'a mut Vec<PageSettingsRule>,
     bookmark_mappings: &'a mut Vec<BookmarkMapping>,
 }
@@ -197,6 +198,7 @@ impl<'i, 'a> QualifiedRuleParser<'i> for GcpmSheetParser<'a> {
         let mut string_set: Option<(String, Vec<StringSetValue>)> = None;
         let mut counter_ops: Vec<CounterOp> = Vec::new();
         let mut content_items: Option<Vec<ContentItem>> = None;
+        let mut static_content: Option<String> = None;
         let mut bookmark_level: Option<BookmarkLevel> = None;
         let mut bookmark_label: Option<Vec<ContentItem>> = None;
 
@@ -206,6 +208,7 @@ impl<'i, 'a> QualifiedRuleParser<'i> for GcpmSheetParser<'a> {
             string_set: &mut string_set,
             counter_ops: &mut counter_ops,
             content_items: &mut content_items,
+            static_content: &mut static_content,
             bookmark_level: &mut bookmark_level,
             bookmark_label: &mut bookmark_label,
             has_pseudo: pseudo.is_some(),
@@ -243,6 +246,16 @@ impl<'i, 'a> QualifiedRuleParser<'i> for GcpmSheetParser<'a> {
                     parsed: selector.clone(),
                     pseudo,
                     content: items,
+                });
+            }
+        }
+
+        if let Some(text) = static_content {
+            if let Some(pseudo) = pseudo {
+                self.static_content_mappings.push(StaticContentMapping {
+                    parsed: selector.clone(),
+                    pseudo,
+                    text,
                 });
             }
         }
@@ -612,6 +625,10 @@ struct StyleRuleParser<'a> {
     string_set: &'a mut Option<(String, Vec<StringSetValue>)>,
     counter_ops: &'a mut Vec<CounterOp>,
     content_items: &'a mut Option<Vec<ContentItem>>,
+    /// The flattened value of a static, all-`String` multi-item pseudo
+    /// `content` list. Mutually exclusive with `content_items` (the last
+    /// `content` declaration in a rule wins and sets exactly one of them).
+    static_content: &'a mut Option<String>,
     bookmark_level: &'a mut Option<BookmarkLevel>,
     bookmark_label: &'a mut Option<Vec<ContentItem>>,
     has_pseudo: bool,
@@ -728,26 +745,46 @@ impl<'i, 'a> DeclarationParser<'i> for StyleRuleParser<'a> {
                         | ContentItem::TargetText { .. }
                 )
             });
-            // blitz-dom 0.2.4's `flush_pseudo_elements`
-            // (`construct.rs:367`) materializes only `items[0]` of a
-            // pseudo element's multi-item `Content::Items` list, so a
-            // plain `content: "[" "x" "]"` would render just the leading
-            // `[`. Route ANY multi-item content (not only counter-bearing
-            // lists) through CounterPass, which flattens every item into
-            // a single resolved string and injects it as a synthetic
-            // single-item rule Blitz can render in full (fulgur-2ykw).
-            // Single-item plain content stays on Blitz's native path —
-            // `items[0]` IS the whole value there, so no truncation and
-            // no behavior change.
-            let route_via_counter_pass = has_counter || items.len() > 1;
-            // Last-declaration-wins: always update content_items (clear when
-            // the new content needs no CounterPass handling).
-            if route_via_counter_pass {
+            let is_plain_text = !items.is_empty()
+                && items
+                    .iter()
+                    .all(|item| matches!(item, ContentItem::String(_)));
+            // blitz-dom 0.2.4's `flush_pseudo_elements` (`construct.rs:367`)
+            // materializes only `items[0]` of a pseudo element's multi-item
+            // `Content::Items` list, so a plain `content: "[" "x" "]"` would
+            // render just the leading `[`. Routing splits by whether the
+            // content is *static* or *per-element dynamic*. Last-declaration-
+            // wins: each branch sets exactly one of `content_items` /
+            // `static_content` and clears the other.
+            if is_plain_text && items.len() > 1 {
+                // Static multi-item string list. Flatten by concatenation and
+                // record it for a single selector-level injection
+                // (`StaticContentMapping`). Routing it through CounterPass
+                // instead would emit one generated rule *per matching node*,
+                // an O(nodes * literal_len) amplification a hostile document
+                // can drive into an OOM — the fulgur-2ykw truncation fix must
+                // not reintroduce that DoS.
+                *self.content_items = None;
+                *self.static_content = Some(
+                    items
+                        .iter()
+                        .filter_map(|item| match item {
+                            ContentItem::String(s) => Some(s.as_str()),
+                            _ => None,
+                        })
+                        .collect(),
+                );
+            } else if has_counter || items.len() > 1 {
+                // Per-element dynamic content (counter / `target-*` / `attr()`,
+                // or any other multi-item list Blitz cannot render in full).
+                // Blitz cannot resolve it, so it routes through CounterPass,
+                // which resolves per element. These values are short (or, for
+                // `attr()`, bytes the author already spent inline on every
+                // matching element), so there is no amplification. Strip the
+                // original `content: ...` so Blitz does not also render its
+                // truncated view.
                 *self.content_items = Some(items);
-                // Strip the original `content: ...` from cleaned CSS so
-                // Blitz does not also render its (truncated) view —
-                // CounterPass injects a synthetic ::before/::after rule
-                // with the fully resolved value.
+                *self.static_content = None;
                 let start = decl_start.position().byte_index();
                 let end = input.position().byte_index();
                 self.edits.push(CssEdit::Replace {
@@ -756,9 +793,12 @@ impl<'i, 'a> DeclarationParser<'i> for StyleRuleParser<'a> {
                     replacement: String::new(),
                 });
             } else {
-                // Plain `content: "..."` stays in cleaned CSS so Blitz can
-                // render it directly.
+                // Single-item plain content is already the whole value at
+                // `items[0]`, and unsupported single-item forms (e.g.
+                // `content: url(...)`) are best left to Blitz. Either way the
+                // declaration stays verbatim in cleaned CSS.
                 *self.content_items = None;
+                *self.static_content = None;
             }
         } else {
             // Skip other declarations
@@ -1266,6 +1306,7 @@ pub fn parse_gcpm(css: &str) -> GcpmContext {
     let mut string_set_mappings = Vec::new();
     let mut counter_mappings = Vec::new();
     let mut content_counter_mappings = Vec::new();
+    let mut static_content_mappings = Vec::new();
     let mut page_settings = Vec::new();
     let mut bookmark_mappings = Vec::new();
     let mut edits: Vec<CssEdit> = Vec::new();
@@ -1282,6 +1323,7 @@ pub fn parse_gcpm(css: &str) -> GcpmContext {
             string_set_mappings: &mut string_set_mappings,
             counter_mappings: &mut counter_mappings,
             content_counter_mappings: &mut content_counter_mappings,
+            static_content_mappings: &mut static_content_mappings,
             page_settings: &mut page_settings,
             bookmark_mappings: &mut bookmark_mappings,
         };
@@ -1301,10 +1343,35 @@ pub fn parse_gcpm(css: &str) -> GcpmContext {
         string_set_mappings,
         counter_mappings,
         content_counter_mappings,
+        static_content_mappings,
         page_settings,
         bookmark_mappings,
         cleaned_css,
     }
+}
+
+/// Serialize `s` as the body of a CSS double-quoted string (the caller
+/// supplies the surrounding `"`). Escapes `"` and `\`, and every control
+/// character per the CSS `<string-token>` grammar, so a resolved literal can
+/// be re-embedded into a generated rule — `CounterPass`'s per-node overlay or
+/// [`crate::blitz_adapter::build_static_content_css`]'s selector-level static
+/// injection — without malforming, or prematurely closing, the string.
+pub(crate) fn css_escape_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\a "),
+            '\r' => out.push_str("\\d "),
+            '\0' => out.push_str("\\0 "),
+            c if c.is_control() => {
+                out.push_str(&format!("\\{:x} ", c as u32));
+            }
+            _ => out.push(ch),
+        }
+    }
+    out
 }
 
 /// Build `cleaned_css` from the original CSS and a list of edits.
@@ -1966,6 +2033,61 @@ mod tests {
             ctx.cleaned_css
         );
         assert!(ctx.cleaned_css.contains("font-weight: bold"));
+    }
+
+    #[test]
+    fn test_parse_pseudo_multi_item_plain_string_flattened_not_routed() {
+        // A multi-item, all-`String` content list must NOT enter
+        // `content_counter_mappings` (CounterPass expands one generated rule
+        // per matching node — an O(nodes * literal_len) amplification / DoS).
+        // Instead it is flattened once and recorded as a `StaticContentMapping`
+        // for a single selector-level injection (fulgur-2ykw truncation
+        // workaround preserved without per-node expansion).
+        let css = r#"div::before { content: "AB" "CD"; color: red; }"#;
+        let ctx = parse_gcpm(css);
+        assert!(
+            ctx.content_counter_mappings.is_empty(),
+            "plain multi-item strings must not enter CounterPass: {:?}",
+            ctx.content_counter_mappings
+        );
+        assert_eq!(ctx.static_content_mappings.len(), 1);
+        let m = &ctx.static_content_mappings[0];
+        assert_eq!(m.parsed, ParsedSelector::Tag("div".into()));
+        assert_eq!(m.pseudo, PseudoElement::Before);
+        assert_eq!(m.text, "ABCD");
+        // Sibling declarations are untouched; the original `content` stays in
+        // cleaned CSS (the injected selector-level rule overrides it — we never
+        // rewrite cleaned CSS, so inline `<style>` is handled identically).
+        assert!(ctx.cleaned_css.contains("color: red"));
+    }
+
+    #[test]
+    fn test_parse_pseudo_multi_item_plain_string_flatten_keeps_unescaped_text() {
+        // The recorded `text` is the raw concatenation of the parsed (already
+        // unescaped) `String` items. CSS-escaping happens later, at injection
+        // time (`build_static_content_css`), so the mapping stores the literal
+        // value `a"bc\d`.
+        let css = r#"p::after { content: "a\"b" "c\\d"; }"#;
+        let ctx = parse_gcpm(css);
+        assert!(ctx.content_counter_mappings.is_empty());
+        assert_eq!(ctx.static_content_mappings.len(), 1);
+        assert_eq!(ctx.static_content_mappings[0].text, "a\"bc\\d");
+    }
+
+    #[test]
+    fn test_parse_pseudo_single_item_plain_string_not_recorded_as_static() {
+        // A single-item plain string is already the whole value at `items[0]`
+        // — Blitz renders it natively, so it needs neither CounterPass nor a
+        // static injection. It must stay verbatim in cleaned CSS.
+        let css = r#".note::before { content: "Note: "; }"#;
+        let ctx = parse_gcpm(css);
+        assert!(ctx.content_counter_mappings.is_empty());
+        assert!(
+            ctx.static_content_mappings.is_empty(),
+            "single-item plain content must not be recorded: {:?}",
+            ctx.static_content_mappings
+        );
+        assert!(ctx.cleaned_css.contains(r#"content: "Note: ""#));
     }
 
     #[test]

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -3879,11 +3879,11 @@ fn pseudo_multi_item_static_content_covers_all_matching_nodes() {
 
 /// Multi-item static pseudo content declared in **AssetBundle / `<link>`
 /// CSS** (not inline `<style>`) — the finding's primary attack surface via
-/// `render_html(combined_css)`. Here the original declaration *does* live in
-/// `cleaned_css` (which is injected as a `<style>`); the fix deliberately
-/// does NOT strip it and instead relies on the later selector-level injection
-/// winning by source order. This asserts the full `[x]` renders, proving the
-/// bundle path works identically to the inline path.
+/// `render_html(combined_css)`. On this path `cleaned_css` is what Blitz sees,
+/// so the parser strips the original declaration and the injected selector-
+/// level rule is the only source. This asserts the full `[x]` renders (see
+/// `verify_bundle_important_multi_item` for the `!important` variant that the
+/// strip specifically rescues).
 #[test]
 fn pseudo_multi_item_static_content_via_bundle_css() {
     let font_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -3914,6 +3914,76 @@ fn pseudo_multi_item_static_content_via_bundle_css() {
         text.contains("[x]"),
         "multi-item static content declared in bundle CSS must render all \
          items (`[x]`), not just `[`. Got: {text:?}"
+    );
+}
+
+/// Regression: a multi-item static `content` declared `!important` in
+/// AssetBundle / `<link>` CSS. Because the injected selector-level rule is
+/// normal priority, an un-stripped `!important` original would win in Stylo
+/// and blitz-dom would keep truncating to `items[0]` (`[`). The parser
+/// therefore strips the original from `cleaned_css` on the bundle/link path,
+/// so the injection is the only source and the full `[x]` renders. (Inline
+/// `<style>` `!important` is a separate, pre-existing limitation — its text is
+/// never in `cleaned_css`, so the important original survives there.)
+#[test]
+fn pseudo_multi_item_important_static_content_via_bundle_css() {
+    let font_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/.fonts/NotoSans-Regular.ttf");
+    let mut assets = AssetBundle::default();
+    assets
+        .add_font_file(&font_path)
+        .unwrap_or_else(|e| panic!("failed to load Noto Sans: {e}"));
+    assets.add_css(
+        "body { font-family: 'Noto Sans', sans-serif; font-size: 12pt; } \
+         p::after { content: \"[\" \"x\" \"]\" !important; }",
+    );
+    let pdf = Engine::builder()
+        .tagged(true)
+        .lang("en")
+        .assets(assets)
+        .build()
+        .render("<!doctype html><html><body><p>Body text</p></body></html>")
+        .expect("bundle render");
+    let Some(text) = extract_pdf_text(&pdf) else {
+        eprintln!("pdftotext not available; skipping text assertion");
+        return;
+    };
+    assert!(
+        text.contains("[x]"),
+        "`!important` multi-item static content in bundle CSS must render all \
+         items (`[x]`); a surviving `!important` original would truncate to \
+         `[`. Got: {text:?}"
+    );
+}
+
+/// Known limitation (documented, not a bug to fix here): when the *same*
+/// simple `selector::pseudo` is declared twice — first with `counter()` /
+/// `target-*` (routed per-node through `CounterPass` with boosted specificity)
+/// and then with a static multi-item string (injected at plain selector-level
+/// specificity) — the later static rule does NOT override the earlier dynamic
+/// one, so `[1]` wins instead of `Q1Q2`. Preserving source order here would
+/// require cross-rule declaration-order tracking; the DoS-safe fix is not
+/// worth the surface for a pattern no real document uses (same class as the
+/// accepted GCPM cascade-collision limitation fulgur-da3u). This test pins the
+/// current behavior so a future change is noticed.
+#[test]
+fn pseudo_counter_then_static_same_selector_is_known_limitation() {
+    let html = r##"<!doctype html><html><head><style>
+      body { font-family: 'Noto Sans', sans-serif; font-size: 12pt; counter-reset: n; }
+      p { counter-increment: n; }
+      p::after { content: "[" counter(n) "]"; }
+      p::after { content: "Q1" "Q2"; }
+    </style></head><body><p>x</p></body></html>"##;
+    let pdf = tagged_render_with_noto(html);
+    let Some(text) = extract_pdf_text(&pdf) else {
+        eprintln!("pdftotext not available; skipping text assertion");
+        return;
+    };
+    // Documents the current (limitation) behavior: the counter content wins.
+    assert!(
+        text.contains("[1]") && !text.contains("Q1Q2"),
+        "known limitation: counter content is expected to win over the later \
+         static rule. Got: {text:?}"
     );
 }
 

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -3845,6 +3845,78 @@ fn pseudo_multi_item_content_renders_all_items() {
     );
 }
 
+/// Static multi-item pseudo content is injected once at the *selector*
+/// level, not once per matching node — that per-node expansion is the
+/// availability bug this hardening removed (a hostile document could turn a
+/// small `p::after { content: "…20KB…" "x" }` plus many `<p>` into O(nodes ×
+/// literal_len) generated CSS). This proves the single injected `p::after`
+/// rule still reaches every matching element: all three paragraphs render
+/// the full flattened `Q1Q2`.
+#[test]
+fn pseudo_multi_item_static_content_covers_all_matching_nodes() {
+    let html = r##"<!doctype html><html><head><style>
+      body { font-family: 'Noto Sans', sans-serif; font-size: 12pt; }
+      p::after { content: "Q1" "Q2"; }
+    </style></head><body>
+      <p>a</p><p>b</p><p>c</p>
+    </body></html>"##;
+    let pdf = tagged_render_with_noto(html);
+    assert!(!pdf.is_empty());
+
+    let Some(text) = extract_pdf_text(&pdf) else {
+        eprintln!("pdftotext not available; skipping text assertion");
+        return;
+    };
+    // One `p::after` rule, three matching `<p>` → three contiguous `Q1Q2`.
+    let count = text.matches("Q1Q2").count();
+    assert!(
+        count >= 3,
+        "one selector-level `p::after` rule must reach all three \
+         paragraphs (expected >= 3 contiguous `Q1Q2`, got {count}). \
+         Text: {text:?}"
+    );
+}
+
+/// Multi-item static pseudo content declared in **AssetBundle / `<link>`
+/// CSS** (not inline `<style>`) — the finding's primary attack surface via
+/// `render_html(combined_css)`. Here the original declaration *does* live in
+/// `cleaned_css` (which is injected as a `<style>`); the fix deliberately
+/// does NOT strip it and instead relies on the later selector-level injection
+/// winning by source order. This asserts the full `[x]` renders, proving the
+/// bundle path works identically to the inline path.
+#[test]
+fn pseudo_multi_item_static_content_via_bundle_css() {
+    let font_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/.fonts/NotoSans-Regular.ttf");
+    let mut assets = AssetBundle::default();
+    assets
+        .add_font_file(&font_path)
+        .unwrap_or_else(|e| panic!("failed to load Noto Sans: {e}"));
+    // The GCPM content rule is in bundle CSS, not inline `<style>`.
+    assets.add_css(
+        "body { font-family: 'Noto Sans', sans-serif; font-size: 12pt; } \
+         p::after { content: \"[\" \"x\" \"]\"; }",
+    );
+    let pdf = Engine::builder()
+        .tagged(true)
+        .lang("en")
+        .assets(assets)
+        .build()
+        .render("<!doctype html><html><body><p>Body text</p></body></html>")
+        .expect("bundle render");
+    assert!(!pdf.is_empty());
+
+    let Some(text) = extract_pdf_text(&pdf) else {
+        eprintln!("pdftotext not available; skipping text assertion");
+        return;
+    };
+    assert!(
+        text.contains("[x]"),
+        "multi-item static content declared in bundle CSS must render all \
+         items (`[x]`), not just `[`. Got: {text:?}"
+    );
+}
+
 /// fulgur-2ykw: the canonical 3-item case — open-bracket string +
 /// `counter()` + close-bracket string — on `::before` (the spec sibling
 /// of the `::after` path; both go through blitz-dom's shared


### PR DESCRIPTION
## 背景

セキュリティスキャナの指摘「Plain pseudo content rewrite enables PDF render DoS」を調査・修正しました。

指摘は commit `a0b3ba6` に対するものでしたが、その後の 2 コミット（`ccb68a98`「preserve plain pseudo content cascade」、`909d8b49`「render all items of multi-item element pseudo content」）で状況が変化しており、現行コードでは:

- 単一文字列 `content: "..."` は既にネイティブ経路に戻り済み（指摘の主攻撃は緩和済み）
- 指摘が挙げる `pseudo_text_by_node` クローン増幅も既に除去済み
- **残存していた問題**: 多要素の全文字列コンテンツ `content: "AAA…" "x"` が `items.len() > 1` により **per-node の `CounterPass` 経路**に乗り、`O(nodes × literal_len)` の生成 CSS 増幅を起こしていた

## 根本原因

多要素の pseudo コンテンツが `CounterPass` に流されていたのは、blitz-dom 0.2.4 が多要素 `Content::Items` を `items[0]` までしか描画しない truncation バグ（fulgur-2ykw）の回避のためでした。しかし `CounterPass` は**マッチする要素ごとに 1 ルール**を生成するため、静的文字列（全マッチ要素で同一値）をこの経路に流すと増幅源になっていました。

## 修正

静的文字列コンテンツは per-element 解決が不要なので、parse 時に 1 度だけ平坦化して新しい `StaticContentMapping` に記録し、engine が **セレクタ単位で 1 回だけ** `<selector><pseudo> { content: "<flattened>" }` を著者スタイルの後に注入します。

- GCPM パーサーは単純セレクタ（`.class` / `#id` / `tag`）の mapping しか生成しないため、注入ルールは著者ルールと同一 specificity になり **source order** で勝ちます
- AssetBundle / `<link>` CSS と inline `<style>`（元テキストは `cleaned_css` に書き換えられない）の両方で機能します
- `CounterPass` は不変。counter / `target-*` / `attr()` コンテンツ（短い、または要素ごとに著者が inline で bytes を消費する＝増幅なし）は従来どおり `CounterPass` 経由です
- 併せて `css_escape_string` を `gcpm::parser` に移設（`CounterPass` と新規注入で共有）し重複を削除

## 効果の実測

CSS 増幅を純粋に切り分けるため `display:none`（グリフ描画コストが乗らない）で計測:

| 10000 div × 20KB 文字列, `display:none`（入力 140KB） | 時間 | ピーク RSS | 出力 |
|---|---|---|---|
| 修正前 | 49.7 秒 | 1.07 GB | 1.5KB PDF |
| 修正後 | **0.28 秒** | **297 MB** | 1.5KB PDF |

**正直な特性化**: 本修正が除去するのは `O(nodes × literal_len)` の **CSS 生成増幅**です。コンテンツが実際に可視で描画される場合、`N×L` 文字を表示するグリフ描画コスト（Parley の glyph shaping、どのレンダラでも不可避）が別途あり、これは本修正の対象外です（サービス層の入力サイズ・ノード数制限が担当領域。指摘の attack-path 分析もこれを前提としています）。攻撃者が最も効率的に増幅を狙う形（非表示・画面外要素）では、上表のとおり増幅は完全に解消されます。

## テスト

- `parser`: 多要素→静的マッピング化・非 routing、エスケープ前テキスト保持、単一要素の非記録（3 本）
- `blitz_adapter`: `build_static_content_css` のセレクタ直列化・CSS エスケープ（2 本）
- `render_smoke`: inline `<style>`（既存）、**bundle CSS 経由**、複数マッチノードを 1 ルールでカバー（3 本）
- lib 1573 / render_smoke 178 / gcpm_integration 13 / VRT 全 pass、`cargo fmt` / `clippy` クリーン

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 疑似要素の固定テキストが、より自然にまとめて表示されるようになりました。
  * 外部スタイルシート経由でも同じ表示が反映されるようになりました。

* **バグ修正**
  * `::before` / `::after` の文字列表示で、複数テキストの連結やエスケープが正しく扱われるようになりました。
  * 画面生成時に、該当スタイルが一部要素へ適用されない問題を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->