### PR TITLE
ci(release): SHA-pin all actions in release.yml (supply-chain hardening)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,18 +81,21 @@ jobs:
             rustflags: "-C linker=lld-link"
             install-mold: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           ref: "v${{ needs.setup.outputs.version }}"
           # Read-only checkout (build binaries / publish npm from artifacts);
           # no push happens here, so don't leave the token in .git/config.
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
+          # SHA pin drops the `@stable` ref, so name the channel explicitly —
+          # the action infers the toolchain from the ref name otherwise.
+          toolchain: stable
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           shared-key: ${{ matrix.target }}-release
 
@@ -138,12 +141,12 @@ jobs:
           New-Item -ItemType Directory -Force npm-bin
           Copy-Item "target/${{ matrix.target }}/release/fulgur.exe" "npm-bin/fulgur.exe"
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: npm-${{ matrix.target }}
           path: npm-bin/
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: fulgur-${{ matrix.target }}
           path: fulgur-v${{ needs.setup.outputs.version }}-${{ matrix.target }}.*
@@ -163,7 +166,7 @@ jobs:
     # would imply a gate that isn't there. Publishing this Release fires
     # `release:published`, which triggers release-python.yml / release-ruby.yml.
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: artifacts
           pattern: 'fulgur-*'
@@ -175,7 +178,7 @@ jobs:
       # 手順は docs/RELEASE_SETUP.md を参照。
       - name: Generate App token for release publish
         id: app-token
-        uses: actions/create-github-app-token@v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -227,20 +230,20 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           ref: "v${{ needs.setup.outputs.version }}"
           # Read-only checkout (build binaries / publish npm from artifacts);
           # no push happens here, so don't leave the token in .git/config.
           persist-credentials: false
 
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Download all npm artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: npm-*
           path: npm-artifacts


### PR DESCRIPTION
## 概要

epic fulgur-bg1n の一環。`release.yml` の全 action を mutable tag から検証済みの full-length commit SHA に pin する supply-chain hardening。PR #540 で `release-plz.yml` に適用済みの対策を `release.yml` にも展開する。

## 背景

`release.yml` は書き込み権限を持つリリース workflow（App token で GitHub Release を publish → `release-python` / `release-ruby` / npm を連鎖発火）。mutable tag のままだと、upstream の tag が動いた／侵害された場合にリリーストークンの下で任意コードが走りうる。Codex Cloud security finding (high) が `release-plz.yml` で出たのと同種の指摘が `release.yml` でも出る可能性が高い。

## 変更内容

10箇所の action を SHA pin（`checkout`×2, `download-artifact`×2, `upload-artifact`×2, `rust-toolchain`, `rust-cache`, `create-github-app-token`, `setup-node`）:

| action | pin SHA | 版 | 出所 |
|--------|---------|-----|------|
| `actions/checkout` | `df4cb1c0…` | v6.0.3 | release-plz.yml と一致 |
| `dtolnay/rust-toolchain` | `29eef336…` | stable | release-plz.yml |
| `Swatinem/rust-cache` | `c1937114…` | v2.9.1 | release-plz.yml |
| `actions/create-github-app-token` | `bcd2ba49…` | v3.2.0 | release-plz.yml と一致 |
| `actions/upload-artifact` | `043fb46d…` | v7.0.1 | upstream 独立検証 |
| `actions/download-artifact` | `3e5f45b2…` | v8.0.1 | upstream 独立検証 |
| `actions/setup-node` | `48b55a01…` | v6.4.0 | upstream 独立検証 |

## 設計判断

- **一貫性優先**: `checkout` / `rust-cache` / `rust-toolchain` / `create-github-app-token` は release-plz.yml で検証済みの SHA を再利用。同じリリース workflow 群で版を揃えることで、dependabot の github-actions group bump が両者を一緒に前進させる。
- **rust-cache**: `@v2` major tag は pin 後に移動済み（`42dc69e`、具体版タグ無し）だが、release-plz.yml と揃えて検証済みの v2.9.1 を採用。
- **rust-toolchain@stable は tag ではなく branch**: SHA pin すると action が channel 推論に使う ref 名が失われるため、`with: toolchain: stable` を明示追加（release-plz.yml と同じ対処）。これが無いとリリースビルドが壊れる。

## 検証

- mutable ref 残存ゼロを grep 確認（`uses:.*@(v[0-9]|stable|…)` が 0 件）
- 全 pin 行に `# vX.Y.Z`（rust-toolchain は `# stable`）コメント
- YAML 妥当性を確認
- 実際の Release PR / タグ push での CI・ビルド動作は次回リリースで自然確認

Closes fulgur-a6gc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actions の参照を固定バージョンではなく SHA 指定に更新し、ワークフローの安定性と再現性を向上させました。
  * ビルド、リリース、npm 公開の各処理で使用するアクションを安全な固定参照に統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->