### PR TITLE
ci(release): drop skip-bindings label gate (bindings ship in lockstep)

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -213,46 +213,13 @@ jobs:
           print(f\"OK: {len(pdf)} bytes\")
           "'
 
-  # release-prepare.yml が release PR に `release:skip-bindings` ラベルを付けて
-  # いれば bindings publish を丸ごと skip する。release event は PR コンテキストを
-  # 持たないため、tag → commit → associated PR の順に逆引きしてラベルを参照する。
-  check-skip-label:
-    name: Check skip-bindings label
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      skip: ${{ steps.check.outputs.skip }}
-    steps:
-      - name: Check label
-        id: check
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.event.release.tag_name }}
-          EVENT: ${{ github.event_name }}
-        run: |
-          if [ "$EVENT" != "release" ]; then
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          SHA=$(gh api "repos/$GITHUB_REPOSITORY/commits/$TAG" --jq .sha)
-          LABELS=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SHA/pulls" \
-            --jq '.[].labels[].name' 2>/dev/null || true)
-          if printf '%s\n' "$LABELS" | grep -qx 'release:skip-bindings'; then
-            echo "release:skip-bindings label set on associated PR; skipping PyPI publish"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
   publish:
     name: Publish to PyPI
-    needs: [build-wheels, build-sdist, smoke-test, smoke-test-sdist, smoke-test-musl, check-skip-label]
+    needs: [build-wheels, build-sdist, smoke-test, smoke-test-sdist, smoke-test-musl]
     # 本番 PyPI publish は release イベント (release.yml がタグから発火) のみ。
     # workflow_dispatch からは任意の ref を publish できないようにする (security)。
     # 手動検証は publish-testpypi (dry_run=true) を使う。
-    if: github.event_name == 'release' && needs.check-skip-label.outputs.skip != 'true'
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -234,39 +234,6 @@ jobs:
             "
           '
 
-  # release-prepare.yml が release PR に `release:skip-bindings` ラベルを付けて
-  # いれば bindings publish を丸ごと skip する。release event は PR コンテキストを
-  # 持たないため、tag → commit → associated PR の順に逆引きしてラベルを参照する。
-  check-skip-label:
-    name: Check skip-bindings label
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      skip: ${{ steps.check.outputs.skip }}
-    steps:
-      - name: Check label
-        id: check
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.event.release.tag_name }}
-          EVENT: ${{ github.event_name }}
-        run: |
-          if [ "$EVENT" != "release" ]; then
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          SHA=$(gh api "repos/$GITHUB_REPOSITORY/commits/$TAG" --jq .sha)
-          LABELS=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SHA/pulls" \
-            --jq '.[].labels[].name' 2>/dev/null || true)
-          if printf '%s\n' "$LABELS" | grep -qx 'release:skip-bindings'; then
-            echo "release:skip-bindings label set on associated PR; skipping RubyGems publish"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
   # NOTE: RubyGems publish は release イベント (release.yml がタグから発火) のみ。
   # workflow_dispatch からは任意の ref を push できないようにする (security)。
   # RubyGems には TestPyPI 相当が無いため、workflow_dispatch は build + smoke
@@ -274,8 +241,8 @@ jobs:
   # See docs/RELEASE_SETUP.md.
   publish:
     name: Publish to RubyGems
-    needs: [build-source-gem, smoke-test-source-gem, build-precompiled, smoke-test, smoke-test-musl, check-skip-label]
-    if: github.event_name == 'release' && needs.check-skip-label.outputs.skip != 'true'
+    needs: [build-source-gem, smoke-test-source-gem, build-precompiled, smoke-test, smoke-test-musl]
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     environment: rubygems
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,13 +208,9 @@ jobs:
     # published — a failed gh release upload/edit must not leave npm shipped
     # while the release is missing its binaries.
     needs: [setup, build-binaries, release]
-    # KNOWN TEMPORARY REGRESSION (fulgur-n5tw → to be fixed in fulgur-f7o2):
-    # this workflow now triggers on tag push, so `github.event.pull_request`
-    # no longer exists and the previous `release:skip-bindings` label gate
-    # (`!contains(github.event.pull_request.labels.*.name, ...)`) cannot be
-    # evaluated. npm publish is therefore unconditional for now. release-python
-    # / release-ruby already reverse-look-up the merged PR's labels via the GH
-    # API on `release:published`; f7o2 will give npm the same treatment.
+    # npm publishes unconditionally, in lockstep with the crates.io release —
+    # bindings are never partially skipped, so there is no per-release label gate
+    # to evaluate here. See fulgur-f7o2 for the removal of the old label support.
     runs-on: ubuntu-latest
     # `environment: release` here is NOT an approval gate (the `release`
     # environment has no required reviewers — approval is the Release PR gate,

--- a/docs/RELEASE_SETUP.md
+++ b/docs/RELEASE_SETUP.md
@@ -29,29 +29,6 @@ Key points:
 - **No API stability guarantees until `1.0`.** Each minor on the `0.x` line is
   free to introduce breaking changes.
 
-## Skip bindings (core-only release)
-
-To ship a core-only release (crates.io + GitHub Release + CLI binary) and
-suppress PyPI / RubyGems publish, add the `release:skip-bindings` label to the
-release-plz **Release PR** before merging it.
-
-What happens:
-
-- `release-python.yml` and `release-ruby.yml` run a `check-skip-label` job that
-  resolves tag → commit → associated PR labels and skips the `publish` job when
-  the `release:skip-bindings` label is present → PyPI / RubyGems are not updated.
-- crates.io publish, GitHub Release publish, and CLI binary uploads are
-  unconditional — the CLI binary is treated as a core release artifact.
-- **npm is currently NOT skipped by this label.** The tag-triggered `release.yml`
-  can no longer read the Release PR's labels (`github.event.pull_request` is
-  absent on a tag push), so `publish-npm` runs unconditionally for now (tracked
-  in fulgur-f7o2, which will give npm the same reverse-lookup as PyPI / RubyGems).
-
-If you later need to publish bindings against an already-tagged core release,
-trigger `release-python.yml` / `release-ruby.yml` via `workflow_dispatch`. That
-escape hatch is intentionally left in place but not yet documented as a first-
-class flow.
-
 ## PR-based changelog (`release-notes:*` labels)
 
 CHANGELOG and GitHub Release notes are generated **from merged PRs**, not from
@@ -246,10 +223,6 @@ Release flow:
 4. `release-python.yml` / `release-ruby.yml` publish to PyPI / RubyGems on
    `release:published`.
 
-With `skip_bindings=true` (label `release:skip-bindings` on the merged PR):
-step 4's publish job is skipped via `check-skip-label`
-(`needs.check-skip-label.outputs.skip != 'true'` gate).
-
 The OIDC claim scope (repo + workflow + environment) is independent of reviewer
 settings — `if: github.event_name == 'release'` separately blocks publishing from
 arbitrary refs.
@@ -371,22 +344,11 @@ Actions タブで `release-python.yml` / `release-ruby.yml` が自動的に `rel
 5. The tag fires `release.yml`: build binaries → publish the GitHub Release →
    publish npm. Publishing the GitHub Release fires `release:published`. No further
    approval — ② already authorized the release.
-6. `release-python.yml` / `release-ruby.yml` run on `release:published`;
-   `check-skip-label` sees no skip label → PyPI / RubyGems publish.
+6. `release-python.yml` / `release-ruby.yml` run on `release:published` and
+   publish to PyPI / RubyGems.
 
 Two approvals per release: ① the Release PR, then ② the `crates-io` deployment
 (see [Approval model](#approval-model)).
-
-### Core-only release (skip bindings)
-
-Add the `release:skip-bindings` label to the release-plz Release PR before
-merging it (there is no `workflow_dispatch` input for this anymore).
-
-- crates.io / GitHub Release / CLI binary still ship.
-- `release-python.yml` / `release-ruby.yml` still run build + smoke tests but
-  `check-skip-label` skips their `publish` job → PyPI / RubyGems are not updated.
-- npm is currently **not** skipped by the label (see *Skip bindings* above;
-  tracked in fulgur-f7o2).
 
 ### Previewing release notes
 


### PR DESCRIPTION
## 概要

epic fulgur-bg1n の一環。f7o2 の当初スコープ「bindings publish の chain 接続 + skip_bindings ラベル**維持**」を、方針転換により「**skip-bindings 撤廃 + chain 動作確認**」に変更して実装。

## 方針転換の背景

bindings（PyPI / RubyGems / npm）は常に crates.io と同時 publish する **version lockstep** に確定。部分的に bindings だけスキップする運用は想定しないため、`release:skip-bindings` ラベルによるスキップ機構をコード・docs ごと撤廃する。

なお **chain 接続（`release:published` → bindings publish、App token による GH Release publish）は inp6 / n5tw で既に完了**しており、chain の追加実装は不要だった（f7o2 に残っていたのは skip-bindings の整理のみ）。

## 変更内容

- **release-python.yml / release-ruby.yml**: `check-skip-label` job（tag→commit→PR ラベル逆引き）を削除し、各 `publish` job の `needs` / `if` から除去（`if: github.event_name == 'release'` のみに）
- **release.yml**: `publish-npm` の「KNOWN TEMPORARY REGRESSION」コメントを解消。npm unconditional が **確定した正しい状態** であることを反映
- **docs/RELEASE_SETUP.md**: 「Skip bindings」セクション、Security controls 内の skip_bindings 段落、「Core-only release」手順を削除。Normal-release 手順の `check-skip-label` 言及を修正
- `workflow_dispatch` トリガー自体（dry-run 検証用）は維持。skip-bindings の escape-hatch 説明文のみ削除

## ⚠️ マージ後に手動対応が必要

コードから参照が消えたため、GitHub repository の label **`release:skip-bindings`** が孤児になります。手動削除してください（Settings → Labels、または `gh label delete "release:skip-bindings" --repo fulgur-rs/fulgur`）。

## 検証

- skip-bindings / check-skip-label / core-only 参照が workflow / docs で **ゼロ**（CHANGELOG 履歴・plan 文書は対象外）
- 全 workflow の YAML 妥当性
- publish job の `needs` / `if` に宙吊り参照なし
- markdownlint 0 errors・見出し構造整合

## 補足

docs/plans への pivot 記録（PR-based changelog 方針との整合含む）は依存先の **fulgur-b0nb** に委譲。本 PR マージで b0nb のブロックが外れる。

Refs fulgur-f7o2