### PR TITLE
refactor(convert): type VerticalAlign + table/inline-baseline to Pt (fulgur-sipv.1, .3)

### DIFF
--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -1215,6 +1215,7 @@ fn extract_url_from_stylo_image(image: &style::values::computed::image::Image) -
 /// map it to fulgur's `VerticalAlign` enum.
 pub fn extract_vertical_align(node: &blitz_dom::Node) -> crate::paragraph::VerticalAlign {
     use crate::paragraph::VerticalAlign;
+    use crate::units::F32Units;
     let Some(styles) = node.primary_styles() else {
         return VerticalAlign::Baseline;
     };
@@ -1244,7 +1245,7 @@ pub fn extract_vertical_align(node: &blitz_dom::Node) -> crate::paragraph::Verti
                 // components the basis-0 resolve silently drops them —
                 // acceptable because calc() on vertical-align is rare.
                 let px = lp.resolve(style::values::computed::Length::new(0.0)).px();
-                VerticalAlign::Length(crate::convert::px_to_pt(px))
+                VerticalAlign::Length(px.px().in_pt())
             }
         }
     }
@@ -5141,7 +5142,10 @@ mod tests {
         let va = extract_vertical_align(doc.get_node(id).unwrap());
         match va {
             VerticalAlign::Length(v) => {
-                assert!((v - 6.0).abs() < 0.01, "expected 6pt (8px × 0.75), got {v}");
+                assert!(
+                    (v.to_f32() - 6.0).abs() < 0.01,
+                    "expected 6pt (8px × 0.75), got {v:?}"
+                );
             }
             other => panic!("expected VerticalAlign::Length(6.0), got {other:?}"),
         }

--- a/crates/fulgur/src/convert/inline_root.rs
+++ b/crates/fulgur/src/convert/inline_root.rs
@@ -329,7 +329,7 @@ pub(super) fn inline_box_baseline_offset_from_drawables(
     doc: &BaseDocument,
     out: &crate::drawables::Drawables,
     node_id: usize,
-) -> Option<f32> {
+) -> Option<crate::units::Pt> {
     if let Some(block) = out.block_styles.get(&node_id)
         && block.style.has_overflow_clip()
     {
@@ -351,7 +351,7 @@ fn pageable_last_baseline_from_drawables(
     out: &crate::drawables::Drawables,
     node_id: usize,
     depth: usize,
-) -> Option<f32> {
+) -> Option<crate::units::Pt> {
     if depth >= MAX_DOM_DEPTH {
         return None;
     }
@@ -361,10 +361,10 @@ fn pageable_last_baseline_from_drawables(
         let top_inset = out
             .block_styles
             .get(&node_id)
-            .map(|b| b.style.border_widths[0].to_f32() + b.style.padding[0].to_f32())
-            .unwrap_or(0.0);
+            .map(|b| b.style.border_widths[0] + b.style.padding[0])
+            .unwrap_or(crate::units::Pt::ZERO);
         if let Some(line) = para.lines.last() {
-            return Some(top_inset + line.baseline.to_f32());
+            return Some(top_inset + line.baseline);
         }
     }
     // 2) Otherwise walk DOM children in REVERSE, mirroring v1's
@@ -388,7 +388,7 @@ fn pageable_last_baseline_from_drawables(
             // recursively returns its inner baseline relative to its
             // own top edge; the container's own `top_inset` is folded
             // in by branch (1) above.
-            return Some(px_to_pt(child.final_layout.location.y) + inner);
+            return Some(child.final_layout.location.y.px().in_pt() + inner);
         }
     }
     None
@@ -573,7 +573,7 @@ pub(super) fn extract_paragraph(
                     // `block_styles[node_id]` for top-inset) directly.
                     let baseline_shift =
                         inline_box_baseline_offset_from_drawables(doc, out, node_id)
-                            .map(|bo| height - bo.pt())
+                            .map(|bo| height - bo)
                             .unwrap_or(crate::units::Pt::ZERO);
                     let computed_y =
                         positioned.y.px().in_pt() - accumulated_line_top + baseline_shift;
@@ -1269,7 +1269,7 @@ mod tests {
         let result = super::inline_box_baseline_offset_from_drawables(doc.deref(), &out, node_id);
         assert_eq!(
             result,
-            Some(12.0),
+            Some(12.0_f32.pt()),
             "no overflow clip + paragraph entry → Some(baseline)"
         );
     }
@@ -1284,7 +1284,11 @@ mod tests {
         out.block_styles.insert(node_id, make_block_entry_plain()); // overflow Visible
         out.paragraphs.insert(node_id, make_paragraph_entry(&[9.0]));
         let result = super::inline_box_baseline_offset_from_drawables(doc.deref(), &out, node_id);
-        assert_eq!(result, Some(9.0), "visible overflow must not short-circuit");
+        assert_eq!(
+            result,
+            Some(9.0_f32.pt()),
+            "visible overflow must not short-circuit"
+        );
     }
 
     // ── pageable_last_baseline_from_drawables ──────────────────────────────────
@@ -1317,7 +1321,7 @@ mod tests {
         let result = super::pageable_last_baseline_from_drawables(doc.deref(), &out, node_id, 0);
         assert_eq!(
             result,
-            Some(26.0),
+            Some(26.0_f32.pt()),
             "must return last line baseline (26.0), not first (12.0)"
         );
     }
@@ -1338,7 +1342,7 @@ mod tests {
         let result = super::pageable_last_baseline_from_drawables(doc.deref(), &out, node_id, 0);
         // top_inset = 4 + 2 = 6; baseline = 12 → Some(18).
         assert!(
-            result.is_some_and(|v| (v - 18.0).abs() < 0.001),
+            result.is_some_and(|v| (v.to_f32() - 18.0).abs() < 0.001),
             "expected Some(18.0), got {:?}",
             result
         );
@@ -1380,7 +1384,7 @@ mod tests {
             "reverse DOM walk must find child's paragraph entry"
         );
         assert!(
-            result.unwrap() >= 12.0,
+            result.unwrap().to_f32() >= 12.0,
             "baseline must be at least the child paragraph's baseline"
         );
     }

--- a/crates/fulgur/src/convert/table.rs
+++ b/crates/fulgur/src/convert/table.rs
@@ -108,8 +108,8 @@ fn collect_table_cells(
             continue;
         }
 
-        let cw = px_to_pt(child_node.final_layout.size.width);
-        let ch = px_to_pt(child_node.final_layout.size.height);
+        let cw = child_node.final_layout.size.width.px().in_pt();
+        let ch = child_node.final_layout.size.height.px().in_pt();
 
         let child_effective_is_empty = child_node
             .layout_children
@@ -117,13 +117,13 @@ fn collect_table_cells(
             .as_deref()
             .unwrap_or(&child_node.children)
             .is_empty();
-        if ch == 0.0 && cw == 0.0 && !child_effective_is_empty {
+        if ch == Pt::ZERO && cw == Pt::ZERO && !child_effective_is_empty {
             let child_is_header = is_header || is_table_section(child_node, "thead");
             collect_table_cells(doc, child_id, child_is_header, ctx, depth + 1, out);
             continue;
         }
 
-        if ch == 0.0 && cw == 0.0 {
+        if ch == Pt::ZERO && cw == Pt::ZERO {
             continue;
         }
 

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -115,7 +115,7 @@ pub enum VerticalAlign {
     Super,
     TextTop,
     TextBottom,
-    Length(f32),
+    Length(crate::units::Pt),
     Percent(f32),
 }
 
@@ -944,7 +944,7 @@ pub fn recalculate_line_box(line: &mut ShapedLine, metrics: &LineFontMetrics) {
             VerticalAlign::Super => baseline - metrics.superscript_offset.pt() - img.height,
             VerticalAlign::TextTop => baseline - metrics.ascent.pt(),
             VerticalAlign::TextBottom => baseline + metrics.descent.pt() - img.height,
-            VerticalAlign::Length(v) => baseline - v.pt() - img.height,
+            VerticalAlign::Length(v) => baseline - v - img.height,
             VerticalAlign::Percent(p) => baseline - (original_height * p) - img.height,
         };
 
@@ -1320,7 +1320,7 @@ mod tests {
         line.items.push(LineItem::Image(make_inline_image(
             10.0,
             6.0,
-            VerticalAlign::Length(3.0),
+            VerticalAlign::Length(3.0_f32.pt()),
         )));
         let m = default_metrics();
         recalculate_line_box(&mut line, &m);

--- a/docs/plans/2026-07-04-sipv-small-leaves.md
+++ b/docs/plans/2026-07-04-sipv-small-leaves.md
@@ -1,0 +1,75 @@
+# fulgur-sipv small leaves — VerticalAlign + table/inline-baseline → Pt
+
+**Goal:** Eliminate the remaining `px_to_pt`/`pt_to_px` in two clean, self-contained leaf
+subsystems by typing their data to `units::Pt`, byte-neutral. Part of epic `fulgur-sipv`.
+
+**Scope:** `fulgur-sipv.1` (VerticalAlign) + `fulgur-sipv.3` (table cw/ch + inline baseline).
+`fulgur-sipv.2` (BoxShadow) is **descoped** — consumer audit showed the shadow-draw path
+(`draw_single_box_shadow(x: f32,…)` in `background.rs`) is f32, so typing `BoxShadow` fields
+to `Pt` would add ~10 `.to_f32()` in the draw arithmetic (net +6 conversions, draw layer
+still f32). It is blocked on a draw-layer typing foundation; see the issue notes.
+
+**Consumer audit (why these two are clean):** both feed already-`Pt` sinks, so migrating the
+type lets the manual re-tags drop rather than forcing `.to_f32()`.
+
+---
+
+## Byte-neutral gate (same as P2b)
+
+Each edit is either dropping a `.pt()`/`.to_f32()` re-tag (sink already `Pt`) or swapping
+`px_to_pt(x)` → `x.px().in_pt()`. No arithmetic reassociation. After each task:
+
+```bash
+export FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf"
+cargo build -p fulgur && cargo clippy -p fulgur --all-targets -- -D warnings && cargo fmt --check
+cargo test -p fulgur --lib && cargo test -p fulgur-cli --test examples_determinism
+cargo test -p fulgur-vrt && git status --short -- crates/fulgur-vrt/goldens/   # MUST be empty
+```
+
+Baseline captured GREEN before edits (lib 1579, determinism 11, VRT clean). NEVER
+`FULGUR_VRT_UPDATE=1`.
+
+---
+
+## Task 1 — VerticalAlign::Length(f32) → Length(Pt) (`fulgur-sipv.1`)
+
+**Files:** `paragraph.rs` (enum def + consumer + test), `blitz_adapter.rs` (producer + test).
+
+| Site | Current | Fate |
+|------|---------|------|
+| `paragraph.rs:118` | `Length(f32)` | → `Length(Pt)` (enum variant) |
+| `blitz_adapter.rs:1247` | `VerticalAlign::Length(px_to_pt(px))` | → `VerticalAlign::Length(px.px().in_pt())` |
+| `paragraph.rs:947` | `Length(v) => baseline - v.pt() - img.height` | drop `.pt()` → `baseline - v - img.height` (`baseline`/`img.height` are `Pt` — verify) |
+| `blitz_adapter.rs:5143-5146` (test) | `Length(v) => …`, panic msg `Length(6.0)` | read `v` as `Pt`; assert via `.to_f32()` or `_f32.pt()` |
+| `paragraph.rs:1323` (test) | `Length(3.0)` | → `Length(3.0_f32.pt())` |
+
+Bring `Pt`/`F32Units` into scope where needed. `px_to_pt(px)` = `Pt(px*0.75)` = `px.px().in_pt()` (byte-identical). Commit: `refactor(paragraph): type VerticalAlign::Length to Pt (fulgur-sipv.1)`.
+
+## Task 2 — table cw/ch + inline baseline → Pt (`fulgur-sipv.3`)
+
+**2a table cw/ch** (`convert/table.rs`): `cw`/`ch` are used only in zero-compares.
+
+| Site | Current | Fate |
+|------|---------|------|
+| `table.rs:111-112` | `let cw = px_to_pt(child_node.final_layout.size.width);` | → `child_node.final_layout.size.width.px().in_pt()` (Pt) |
+| `table.rs:120,126` | `ch == 0.0 && cw == 0.0` | → `ch == Pt::ZERO && cw == Pt::ZERO` |
+
+**2b inline baseline** (`convert/inline_root.rs`): type both fns' return `Option<f32>` → `Option<Pt>`.
+
+| Site | Current | Fate |
+|------|---------|------|
+| `inline_root.rs:328,349` | `-> Option<f32>` (both fns) | → `-> Option<Pt>` |
+| `inline_root.rs:364-365` | `top_inset = border_widths[0].to_f32() + padding[0].to_f32()` | drop `.to_f32()` → `border_widths[0] + padding[0]` (Pt) |
+| `inline_root.rs:367` | `Some(top_inset + line.baseline.to_f32())` | drop `.to_f32()` → `Some(top_inset + line.baseline)` (Pt+Pt, order preserved) |
+| `inline_root.rs:391` | `Some(px_to_pt(child.final_layout.location.y) + inner)` | → `Some(child.final_layout.location.y.px().in_pt() + inner)` (Pt+Pt) |
+| `inline_root.rs:575` (consumer) | `.map(\|bo\| height - bo.pt())` | drop `.pt()` → `height - bo` (`height` is `Pt`, confirmed) |
+| tests `1269,1286,1317,1338,1375` | `Some(12.0)` / `Some(9.0)` etc. | → `Some(12.0_f32.pt())` etc.; `1253,1357` `is_none()` unchanged |
+
+Commit: `refactor(convert): type table cw/ch and inline baseline to Pt (fulgur-sipv.3)`.
+
+## Task 3 — verify + PR
+
+Full cadence green, goldens untouched. New PROD lines (paragraph baseline arm, inline
+baseline chain, table cell walk) are exercised by existing non-VRT tests (paragraph/inline/
+table integration + the baseline unit tests above); confirm via the coverage check if in
+doubt. Open one PR for both subtasks; close `fulgur-sipv.1` + `fulgur-sipv.3` on merge.


### PR DESCRIPTION
## 概要

内部 Px/Pt 移行エピック `fulgur-sipv` の最初のバッチ。**clean（純 win）な2つの leaf サブシステム**を `units::Pt` に型付けし、周辺の `px_to_pt` / `.pt()` / `.to_f32()` 再タグを除去します。**byte 中立**（生成 PDF は完全一致）。

- Closes `fulgur-sipv.1`（VerticalAlign）
- Closes `fulgur-sipv.3`（table cw/ch + inline baseline）

## 変更内容

### fulgur-sipv.1 — `VerticalAlign::Length(f32)` → `Length(Pt)`

- `paragraph::VerticalAlign::Length` の内側を `units::Pt` に
- producer（`blitz_adapter::extract_vertical_align`）: `px_to_pt(px)` → `px.px().in_pt()`
- consumer（paragraph の vertical-align 画像配置）: `baseline - v.pt() - img.height` → `baseline - v - img.height`（`baseline`/`img.height` は既に Pt）

### fulgur-sipv.3 — table cw/ch + inline baseline → Pt

- `convert/table.rs`: `cw`/`ch` が `px_to_pt` を落として `.px().in_pt()`、ゼロ比較を `Pt::ZERO` に
- `convert/inline_root.rs`: `inline_box_baseline_offset_from_drawables` / `pageable_last_baseline_from_drawables` の戻り値を `Option<Pt>` に。これで `top_inset`（`border_widths[0]+padding[0]`）、last-line return（`top_inset+line.baseline`）、再帰の child return（`location.y.px().in_pt()+inner`）、consumer :575（`height-bo`）が全て再タグを落とす

## `fulgur-sipv.2`（BoxShadow）を descope した理由

当初この batch に含める予定でしたが、**consumer 監査で除外**しました。`BoxShadow.offset_x/offset_y/blur/spread` を Pt 化しても、draw 経路（`background.rs` の `draw_single_box_shadow(x: f32, y: f32, w: f32, h: f32)` と `draw_blur_box_shadow`）が f32 算術（`x + shadow.offset_x - shadow.spread`、`w + 2.0 * shadow.spread`、`expand_radii(..., shadow.spread)`）なので、shadow.rs で `px_to_pt` を4件消す代わりに **draw 側に `.to_f32()` が10箇所以上散る（net +6、draw 層は f32 のまま）**。これは「境界を減らす場合のみ」の原則に反するため force しませんでした。

真の前提は「shadow-draw 経路（Canvas / rect-path の x/y/w/h）の Pt 化」で、これは Canvas/draw-primitive 層に波及する大きめの移行です。`fulgur-sipv.2` の notes にブロッカーを記録し、epic の系統的な論点（struct フィールド Pt 化系は draw 層が f32 のうちは軒並み churn になる → draw 層 typing foundation を先に置くか）として残しています。

## Byte 中立の証明

- 編集前に clean base で baseline GREEN 確認、各タスク後にも検証
- lib **1579** / `examples_determinism` **11** / VRT `run_fulgur_vrt` green、`crates/fulgur-vrt/goldens/` は**一度も変化せず**（`FULGUR_VRT_UPDATE=1` 不使用）
- 各変換は代数的恒等（`px.px().in_pt()` = `Pt(px*0.75)` = `px_to_pt(px)`、`.pt()`/`.to_f32()` 落としは同値）。演算順は保持（再結合なし）

## Test Plan

- [x] `cargo build` / `cargo clippy -p fulgur --all-targets -- -D warnings` / `cargo fmt --check` clean
- [x] `cargo test -p fulgur`（lib 1579 + integration）green
- [x] `FONTCONFIG_FILE=examples/.fontconfig/fonts.conf` で `examples_determinism` + VRT green、goldens byte-identical
- [x] 変更 PROD 経路（vertical-align 画像配置 / inline baseline chain / table cell walk）は既存の非VRT テスト（paragraph/inline/table integration + baseline unit tests）でカバー

epic `fulgur-sipv` の残り: .2（draw 層依存で保留）, .4-.8。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 文字の縦位置や表のレイアウト計算で、単位の扱いを統一し、ずれや判定の不整合が起きにくくなりました。
  * 文字の縦揃え、段落のベースライン、表セルのサイズ判定がより一貫した結果になるよう調整されました。

* **Documentation**
  * 今後の単位変換整理に向けた実施計画を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->