### PR TITLE
refactor(convert): type list font-metrics to Pt (fulgur-sipv.5)

### DIFF
--- a/crates/fulgur/src/convert/inline_root.rs
+++ b/crates/fulgur/src/convert/inline_root.rs
@@ -86,7 +86,7 @@ pub(super) fn try_convert(
 
         // Inside list-style-image marker injection.
         if !paragraph.lines.is_empty() {
-            let first_line_height = paragraph.lines[0].height.to_f32();
+            let first_line_height = paragraph.lines[0].height;
             if let Some(inline_img) =
                 list_marker::resolve_inside_image_marker(node, first_line_height, ctx.assets)
             {

--- a/crates/fulgur/src/convert/list_item.rs
+++ b/crates/fulgur/src/convert/list_item.rs
@@ -33,14 +33,14 @@ pub(super) fn try_convert(
         let marker = list_marker::resolve_list_marker(node, marker_line_height, ctx.assets)
             .unwrap_or(crate::drawables::ListItemMarker::Text {
                 lines: marker_lines,
-                width: marker_width.pt(),
+                width: marker_width,
             });
 
         out.list_items.insert(
             node_id,
             crate::drawables::ListItemEntry {
                 marker,
-                marker_line_height: marker_line_height.pt(),
+                marker_line_height,
                 opacity,
                 visible,
             },
@@ -79,11 +79,11 @@ pub(super) fn try_convert(
 
         let line_height = {
             use ::style::values::computed::font::LineHeight;
-            let font_size_pt = px_to_pt(styles.clone_font_size().used_size().px());
+            let font_size_pt = styles.clone_font_size().used_size().px().px().in_pt();
             match styles.clone_line_height() {
                 LineHeight::Normal => font_size_pt * DEFAULT_LINE_HEIGHT_RATIO,
                 LineHeight::Number(num) => font_size_pt * num.0,
-                LineHeight::Length(value) => px_to_pt(value.0.px()),
+                LineHeight::Length(value) => value.0.px().px().in_pt(),
             }
         };
 
@@ -92,7 +92,7 @@ pub(super) fn try_convert(
                 node_id,
                 crate::drawables::ListItemEntry {
                     marker,
-                    marker_line_height: line_height.pt(),
+                    marker_line_height: line_height,
                     opacity,
                     visible,
                 },
@@ -131,18 +131,21 @@ pub(super) fn try_convert(
         let content_box = compute_content_box(node, &style);
 
         let (font_size_pt, line_height) = if let Some(styles) = node.primary_styles() {
-            let fs = px_to_pt(styles.clone_font_size().used_size().px());
+            let fs = styles.clone_font_size().used_size().px().px().in_pt();
             let lh = {
                 use ::style::values::computed::font::LineHeight;
                 match styles.clone_line_height() {
                     LineHeight::Normal => fs * DEFAULT_LINE_HEIGHT_RATIO,
                     LineHeight::Number(num) => fs * num.0,
-                    LineHeight::Length(value) => px_to_pt(value.0.px()),
+                    LineHeight::Length(value) => value.0.px().px().in_pt(),
                 }
             };
             (fs, lh)
         } else {
-            (px_to_pt(12.0), px_to_pt(12.0) * DEFAULT_LINE_HEIGHT_RATIO)
+            (
+                12.0_f32.px().in_pt(),
+                12.0_f32.px().in_pt() * DEFAULT_LINE_HEIGHT_RATIO,
+            )
         };
 
         let color = get_text_color(doc, node_id);
@@ -174,8 +177,8 @@ pub(super) fn try_convert(
             // Empty <li>: standalone paragraph with just the marker.
             if let Some(item) = empty_li_marker_item {
                 let lines = vec![ShapedLine {
-                    height: line_height.pt(),
-                    baseline: (line_height / DEFAULT_LINE_HEIGHT_RATIO).pt(),
+                    height: line_height,
+                    baseline: line_height / DEFAULT_LINE_HEIGHT_RATIO,
                     items: vec![item],
                 }];
                 out.paragraphs.insert(
@@ -240,8 +243,8 @@ pub(super) fn try_convert(
             if let Some(item) = marker_item {
                 if !inject_marker_into_first_paragraph(out, &pre_paragraph_ids, item.clone()) {
                     let lines = vec![ShapedLine {
-                        height: line_height.pt(),
-                        baseline: (line_height / DEFAULT_LINE_HEIGHT_RATIO).pt(),
+                        height: line_height,
+                        baseline: line_height / DEFAULT_LINE_HEIGHT_RATIO,
                         items: vec![item],
                     }];
                     out.paragraphs.insert(

--- a/crates/fulgur/src/convert/list_item.rs
+++ b/crates/fulgur/src/convert/list_item.rs
@@ -142,10 +142,8 @@ pub(super) fn try_convert(
             };
             (fs, lh)
         } else {
-            (
-                12.0_f32.px().in_pt(),
-                12.0_f32.px().in_pt() * DEFAULT_LINE_HEIGHT_RATIO,
-            )
+            let fs = 12.0_f32.px().in_pt();
+            (fs, fs * DEFAULT_LINE_HEIGHT_RATIO)
         };
 
         let color = get_text_color(doc, node_id);

--- a/crates/fulgur/src/convert/list_marker.rs
+++ b/crates/fulgur/src/convert/list_marker.rs
@@ -33,7 +33,7 @@ fn resolve_list_style_image_asset<'a>(
 fn size_raster_marker(
     data: &Arc<Vec<u8>>,
     format: crate::image::ImageFormat,
-    line_height: f32,
+    line_height: crate::units::Pt,
 ) -> Option<(crate::units::Pt, crate::units::Pt)> {
     let (iw, ih) = ImageRender::decode_dimensions(data, format)?;
     let intrinsic_w = (iw as f32).px().in_pt();
@@ -41,7 +41,7 @@ fn size_raster_marker(
     Some(crate::draw_primitives::clamp_marker_size(
         intrinsic_w,
         intrinsic_h,
-        line_height.pt(),
+        line_height,
     ))
 }
 
@@ -55,7 +55,7 @@ fn size_raster_marker(
 /// `extract_marker_lines` — matching CSS spec fallback semantics.
 pub(super) fn resolve_list_marker(
     node: &Node,
-    line_height: f32,
+    line_height: crate::units::Pt,
     assets: Option<&AssetBundle>,
 ) -> Option<ListItemMarker> {
     use crate::image::AssetKind;
@@ -64,7 +64,7 @@ pub(super) fn resolve_list_marker(
     // extract_marker_lines returns 0.0) would clamp image size to 0x0.
     // Return None so the caller falls back to the text marker instead of
     // creating an invisible image marker that suppresses the fallback.
-    if line_height <= 0.0 {
+    if line_height <= crate::units::Pt::ZERO {
         return None;
     }
     let (data, kind) = resolve_list_style_image_asset(node, assets)?;
@@ -90,11 +90,8 @@ pub(super) fn resolve_list_marker(
             let size = tree.size();
             let intrinsic_w = size.width().px().in_pt();
             let intrinsic_h = size.height().px().in_pt();
-            let (width, height) = crate::draw_primitives::clamp_marker_size(
-                intrinsic_w,
-                intrinsic_h,
-                line_height.pt(),
-            );
+            let (width, height) =
+                crate::draw_primitives::clamp_marker_size(intrinsic_w, intrinsic_h, line_height);
             let entry = crate::drawables::SvgEntry {
                 tree: Arc::new(tree),
                 width,
@@ -119,7 +116,7 @@ pub(super) fn resolve_list_marker(
 /// cannot be resolved, or the image is SVG.
 pub(super) fn resolve_inside_image_marker(
     node: &Node,
-    first_line_height: f32,
+    first_line_height: crate::units::Pt,
     assets: Option<&AssetBundle>,
 ) -> Option<InlineImage> {
     use crate::image::AssetKind;
@@ -129,7 +126,7 @@ pub(super) fn resolve_inside_image_marker(
     if !crate::blitz_adapter::is_list_position_inside(&list_data.position) {
         return None;
     }
-    if first_line_height <= 0.0 {
+    if first_line_height <= crate::units::Pt::ZERO {
         return None;
     }
 
@@ -160,38 +157,36 @@ pub(super) fn extract_marker_lines(
     doc: &BaseDocument,
     node: &Node,
     ctx: &mut ConvertContext<'_>,
-) -> (Vec<ShapedLine>, f32, f32) {
+) -> (Vec<ShapedLine>, crate::units::Pt, crate::units::Pt) {
     let elem_data = match node.element_data() {
         Some(d) => d,
-        None => return (Vec::new(), 0.0, 0.0),
+        None => return (Vec::new(), crate::units::Pt::ZERO, crate::units::Pt::ZERO),
     };
     let list_item_data = match &elem_data.list_item_data {
         Some(d) => d,
-        None => return (Vec::new(), 0.0, 0.0),
+        None => return (Vec::new(), crate::units::Pt::ZERO, crate::units::Pt::ZERO),
     };
     let Some(parley_layout) =
         crate::blitz_adapter::list_position_outside_layout(&list_item_data.position)
     else {
-        return (Vec::new(), 0.0, 0.0);
+        return (Vec::new(), crate::units::Pt::ZERO, crate::units::Pt::ZERO);
     };
 
     let marker_text = marker_to_string(&list_item_data.marker);
 
     let mut shaped_lines = Vec::new();
-    let mut max_width: f32 = 0.0;
-    let mut line_height_pt: f32 = 0.0;
+    let mut max_width = crate::units::Pt::ZERO;
+    let mut line_height_pt = crate::units::Pt::ZERO;
 
     for line in parley_layout.lines() {
         let metrics = line.metrics();
-        if line_height_pt == 0.0 {
-            // Stays f32: this feeds the f32 marker-row height returned from
-            // this fn, a distinct sink from the `Pt`-typed `ShapedLine.height`
-            // below (`.px().in_pt()`). The dual conversion idiom is intentional,
-            // not an inconsistency.
-            line_height_pt = px_to_pt(metrics.line_height);
+        if line_height_pt == crate::units::Pt::ZERO {
+            // Marker-row height returned from this fn (a distinct value from the
+            // per-line `ShapedLine.height` below, though both are now `Pt`).
+            line_height_pt = metrics.line_height.px().in_pt();
         }
         let mut items = Vec::new();
-        let mut line_width: f32 = 0.0;
+        let mut line_width = crate::units::Pt::ZERO;
         let mut prev_run_key = usize::MAX;
         let mut run_glyph_offset = 0usize;
 
@@ -236,7 +231,7 @@ pub(super) fn extract_marker_lines(
                         )
                     });
                     run_glyph_offset += 1;
-                    line_width += px_to_pt(g.advance);
+                    line_width += g.advance.px().in_pt();
                     glyphs.push(ShapedGlyph {
                         id: g.id,
                         x_advance: g.advance / font_size_parley,
@@ -347,7 +342,7 @@ pub(super) fn shape_marker_with_skrifa(
     marker: &Marker,
     font_data: &Arc<Vec<u8>>,
     font_index: u32,
-    font_size: f32,
+    font_size: crate::units::Pt,
     color: [u8; 4],
 ) -> Option<ShapedGlyphRun> {
     let text = marker_skrifa_text(marker);
@@ -355,7 +350,8 @@ pub(super) fn shape_marker_with_skrifa(
     let font_ref = skrifa::FontRef::from_index(font_data, font_index).ok()?;
     let charmap = font_ref.charmap();
     let glyph_metrics = font_ref.glyph_metrics(
-        skrifa::instance::Size::new(font_size),
+        // skrifa external boundary: font size is a raw f32 in font-metric space.
+        skrifa::instance::Size::new(font_size.to_f32()),
         skrifa::instance::LocationRef::default(),
     );
 
@@ -367,7 +363,7 @@ pub(super) fn shape_marker_with_skrifa(
         let advance = glyph_metrics.advance_width(gid).unwrap_or(0.0);
         glyphs.push(ShapedGlyph {
             id: gid.to_u32(),
-            x_advance: advance / font_size,
+            x_advance: advance / font_size.to_f32(),
             x_offset: 0.0,
             y_offset: 0.0,
             text_range: byte_offset..byte_offset + ch_len,
@@ -378,7 +374,7 @@ pub(super) fn shape_marker_with_skrifa(
     Some(ShapedGlyphRun {
         font_data: Arc::clone(font_data),
         font_index,
-        font_size: font_size.pt(),
+        font_size,
         color,
         decoration: TextDecoration::default(),
         glyphs,
@@ -426,7 +422,7 @@ mod tests {
     #[test]
     fn size_raster_marker_valid_png_within_line_height_passes_through() {
         // 1×1 px PNG → intrinsic 0.75×0.75 pt; line_height=12 → no downscale.
-        let result = size_raster_marker(&sample_png_arc(), ImageFormat::Png, 12.0);
+        let result = size_raster_marker(&sample_png_arc(), ImageFormat::Png, 12.0_f32.pt());
         assert!(result.is_some());
         let (w, h) = result.unwrap();
         let (w, h) = (w.to_f32(), h.to_f32());
@@ -437,7 +433,7 @@ mod tests {
     #[test]
     fn size_raster_marker_invalid_bytes_returns_none() {
         let bad = Arc::new(vec![0u8; 8]);
-        let result = size_raster_marker(&bad, ImageFormat::Png, 12.0);
+        let result = size_raster_marker(&bad, ImageFormat::Png, 12.0_f32.pt());
         assert!(result.is_none());
     }
 
@@ -445,7 +441,7 @@ mod tests {
     fn size_raster_marker_small_line_height_scales_down() {
         // Intrinsic 0.75×0.75 pt, line_height=0.5 → scale=0.5/0.75≈0.667
         // → result height clamped to line_height, width scaled proportionally.
-        let result = size_raster_marker(&sample_png_arc(), ImageFormat::Png, 0.5);
+        let result = size_raster_marker(&sample_png_arc(), ImageFormat::Png, 0.5_f32.pt());
         assert!(result.is_some());
         let (w, h) = result.unwrap();
         let (w, h) = (w.to_f32(), h.to_f32());
@@ -553,8 +549,13 @@ mod tests {
     #[test]
     fn shape_marker_with_skrifa_invalid_font_returns_none() {
         let bad_font = Arc::new(vec![0u8; 16]);
-        let result =
-            shape_marker_with_skrifa(&Marker::Char('•'), &bad_font, 0, 12.0, [0, 0, 0, 255]);
+        let result = shape_marker_with_skrifa(
+            &Marker::Char('•'),
+            &bad_font,
+            0,
+            12.0_f32.pt(),
+            [0, 0, 0, 255],
+        );
         assert!(result.is_none());
     }
 
@@ -562,8 +563,13 @@ mod tests {
     fn shape_marker_with_skrifa_char_produces_two_glyphs() {
         // Marker::Char('•') → skrifa text "• " (2 chars = 2 glyphs).
         let font_data = load_noto_sans_ttf();
-        let result =
-            shape_marker_with_skrifa(&Marker::Char('•'), &font_data, 0, 12.0, [255, 0, 0, 255]);
+        let result = shape_marker_with_skrifa(
+            &Marker::Char('•'),
+            &font_data,
+            0,
+            12.0_f32.pt(),
+            [255, 0, 0, 255],
+        );
         assert!(result.is_some());
         let run = result.unwrap();
         assert_eq!(run.glyphs.len(), 2, "bullet + trailing space = 2 glyphs");
@@ -582,7 +588,7 @@ mod tests {
             &Marker::String("1. ".to_string()),
             &font_data,
             0,
-            10.0,
+            10.0_f32.pt(),
             [0, 0, 0, 255],
         );
         assert!(result.is_some());
@@ -600,7 +606,7 @@ mod tests {
             &Marker::String("A".to_string()),
             &font_data,
             0,
-            12.0,
+            12.0_f32.pt(),
             [0, 0, 0, 255],
         );
         let run = result.unwrap();
@@ -621,7 +627,7 @@ mod tests {
             &Marker::String("AB".to_string()),
             &font_data,
             0,
-            12.0,
+            12.0_f32.pt(),
             [0, 0, 0, 255],
         );
         let run = result.unwrap();

--- a/crates/fulgur/src/convert/list_marker.rs
+++ b/crates/fulgur/src/convert/list_marker.rs
@@ -422,7 +422,7 @@ mod tests {
     #[test]
     fn size_raster_marker_valid_png_within_line_height_passes_through() {
         // 1×1 px PNG → intrinsic 0.75×0.75 pt; line_height=12 → no downscale.
-        let result = size_raster_marker(&sample_png_arc(), ImageFormat::Png, 12.0_f32.pt());
+        let result = size_raster_marker(&sample_png_arc(), ImageFormat::Png, 12.0.pt());
         assert!(result.is_some());
         let (w, h) = result.unwrap();
         let (w, h) = (w.to_f32(), h.to_f32());
@@ -433,7 +433,7 @@ mod tests {
     #[test]
     fn size_raster_marker_invalid_bytes_returns_none() {
         let bad = Arc::new(vec![0u8; 8]);
-        let result = size_raster_marker(&bad, ImageFormat::Png, 12.0_f32.pt());
+        let result = size_raster_marker(&bad, ImageFormat::Png, 12.0.pt());
         assert!(result.is_none());
     }
 
@@ -441,7 +441,7 @@ mod tests {
     fn size_raster_marker_small_line_height_scales_down() {
         // Intrinsic 0.75×0.75 pt, line_height=0.5 → scale=0.5/0.75≈0.667
         // → result height clamped to line_height, width scaled proportionally.
-        let result = size_raster_marker(&sample_png_arc(), ImageFormat::Png, 0.5_f32.pt());
+        let result = size_raster_marker(&sample_png_arc(), ImageFormat::Png, 0.5.pt());
         assert!(result.is_some());
         let (w, h) = result.unwrap();
         let (w, h) = (w.to_f32(), h.to_f32());
@@ -505,7 +505,7 @@ mod tests {
         let glyph_run = ShapedGlyphRun {
             font_data: Arc::clone(&font_data),
             font_index: 0,
-            font_size: 12.0_f32.pt(),
+            font_size: 12.0.pt(),
             color: [0, 0, 0, 255],
             decoration: TextDecoration::default(),
             glyphs: vec![ShapedGlyph {
@@ -520,8 +520,8 @@ mod tests {
             link: None,
         };
         let line = ShapedLine {
-            height: 12.0_f32.pt(),
-            baseline: 9.0_f32.pt(),
+            height: 12.0.pt(),
+            baseline: 9.0.pt(),
             items: vec![LineItem::Text(glyph_run)],
         };
         let mut drawables = Drawables::new();
@@ -549,13 +549,8 @@ mod tests {
     #[test]
     fn shape_marker_with_skrifa_invalid_font_returns_none() {
         let bad_font = Arc::new(vec![0u8; 16]);
-        let result = shape_marker_with_skrifa(
-            &Marker::Char('•'),
-            &bad_font,
-            0,
-            12.0_f32.pt(),
-            [0, 0, 0, 255],
-        );
+        let result =
+            shape_marker_with_skrifa(&Marker::Char('•'), &bad_font, 0, 12.0.pt(), [0, 0, 0, 255]);
         assert!(result.is_none());
     }
 
@@ -567,7 +562,7 @@ mod tests {
             &Marker::Char('•'),
             &font_data,
             0,
-            12.0_f32.pt(),
+            12.0.pt(),
             [255, 0, 0, 255],
         );
         assert!(result.is_some());
@@ -588,7 +583,7 @@ mod tests {
             &Marker::String("1. ".to_string()),
             &font_data,
             0,
-            10.0_f32.pt(),
+            10.0.pt(),
             [0, 0, 0, 255],
         );
         assert!(result.is_some());
@@ -606,7 +601,7 @@ mod tests {
             &Marker::String("A".to_string()),
             &font_data,
             0,
-            12.0_f32.pt(),
+            12.0.pt(),
             [0, 0, 0, 255],
         );
         let run = result.unwrap();
@@ -627,7 +622,7 @@ mod tests {
             &Marker::String("AB".to_string()),
             &font_data,
             0,
-            12.0_f32.pt(),
+            12.0.pt(),
             [0, 0, 0, 255],
         );
         let run = result.unwrap();

--- a/crates/fulgur/src/convert/list_marker.rs
+++ b/crates/fulgur/src/convert/list_marker.rs
@@ -182,7 +182,7 @@ pub(super) fn extract_marker_lines(
         let metrics = line.metrics();
         if line_height_pt == crate::units::Pt::ZERO {
             // Marker-row height returned from this fn (a distinct value from the
-            // per-line `ShapedLine.height` below, though both are now `Pt`).
+            // per-line `ShapedLine.height` below, though both are `Pt`).
             line_height_pt = metrics.line_height.px().in_pt();
         }
         let mut items = Vec::new();

--- a/docs/plans/2026-07-04-sipv5-font-metrics.md
+++ b/docs/plans/2026-07-04-sipv5-font-metrics.md
@@ -1,0 +1,42 @@
+# fulgur-sipv.5 — list font-metrics → Pt
+
+**Goal:** Drop the 7 `px_to_pt` in the list-marker font-metric flow by typing five coupled
+signatures to `units::Pt`, byte-neutral. Consumer audit verdict: CLEAN — all fulgur sinks are
+`Pt`; the only `.to_f32()` additions are at the **skrifa external boundary** (permanent, correct,
+not churn).
+
+## Byte-neutral gate
+
+Baseline GREEN before edits (lib 1597, determinism 11, VRT clean). After each logical step:
+build + clippy -D warnings + fmt + lib + determinism + VRT + `git status goldens` empty. Never
+`FULGUR_VRT_UPDATE=1`. No arithmetic reassociation.
+
+## The five coupled signatures (all in `convert/list_marker.rs`)
+
+1. `size_raster_marker(…, line_height: Pt)` — drop `.pt()` on `clamp_marker_size(_,_, line_height)`.
+2. `resolve_list_marker(node, line_height: Pt, …)` — `line_height <= Pt::ZERO`; SVG-branch
+   `clamp_marker_size(_,_, line_height)` drop `.pt()`.
+3. `resolve_inside_image_marker(node, first_line_height: Pt, …)` — same shape.
+4. `extract_marker_lines(…) -> (Vec<ShapedLine>, Pt, Pt)` — `line_height_pt`/`line_width`/`max_width`
+   become `Pt`: `metrics.line_height.px().in_pt()`, `g.advance.px().in_pt()`, `== Pt::ZERO`,
+   `max_width.max(line_width)` (Pt::max), early `return (vec![], Pt::ZERO, Pt::ZERO)`.
+5. `shape_marker_with_skrifa(…, font_size: Pt, …)` — the **skrifa boundary**:
+   `Size::new(font_size.to_f32())`, `x_advance: advance / font_size.to_f32()` (acceptable f32 seam);
+   `font_size: font_size.pt()` → `font_size` (drop tag).
+
+## Call sites (compiler-driven — change sigs, then fix what breaks)
+
+- `list_item.rs:82,86,134,140,145` — `px_to_pt(…stylo.px())` → `…stylo.px().px().in_pt()`; the
+  `12.0` fallback literals → `12.0_f32.pt()`; `font_size_pt`/`line_height`/`fs` locals become `Pt`
+  (Pt·f32 arithmetic stays Pt). Their `.pt()` sinks into `ShapedLine.height`/marker fields drop.
+- `list_item.rs:29` (`extract_marker_lines`) → `marker_width.pt()`/`marker_line_height.pt()` at
+  `:36`/`:43` drop; `resolve_list_marker(marker_line_height)` passes `Pt`.
+- `inline_root.rs:91` (`resolve_inside_image_marker`) — `first_line_height` is
+  `paragraph.lines[0].height.to_f32()`; drop the `.to_f32()` → pass `Pt` directly.
+- Tests in `list_marker.rs` (`shape_marker_with_skrifa`/`size_raster_marker`) pass `12.0` →
+  `12.0_f32.pt()`; assertions on the returned `Pt` tuple use `.to_f32()`.
+
+## Verify + PR
+
+Full cadence, goldens untouched. New PROD lines covered by existing list_style_image / inside-marker
+integration + the list_marker unit tests. One PR; close `fulgur-sipv.5` on merge.


### PR DESCRIPTION
## 概要

内部 Px/Pt 移行エピック `fulgur-sipv` の2バッチ目。list-marker の font-metric flow を `units::Pt` に型付けし、`px_to_pt` を除去します。**byte 中立**。

- Closes `fulgur-sipv.5`

## 事前 consumer 監査

`.2`（BoxShadow）で学んだ「sink 型だけでなく consumer まで辿る」を最初から適用。判定は **CLEAN**: fulgur 側 sink（`ShapedLine`/`ShapedGlyphRun`/`ImageEntry`/marker フィールド）は全て Pt。

## 変更内容

5つの結合したシグネチャを Pt 化:

- `size_raster_marker(line_height: Pt)`
- `resolve_list_marker(line_height: Pt)` / `resolve_inside_image_marker(first_line_height: Pt)`
- `extract_marker_lines(...) -> (Vec<ShapedLine>, Pt, Pt)`
- `shape_marker_with_skrifa(font_size: Pt)`

これで `list_item.rs`/`list_marker.rs` の 7 `px_to_pt` と、consumer 側の `.pt()`/`.to_f32()` 再タグ（`ListItemEntry`、`ShapedLine` 構築、`inline_root` の `first_line_height`）が落ちます。

**唯一の `.to_f32()` 追加は skrifa 外部 API 境界**（`Size::new(font_size.to_f32())`、`x_advance = advance / font_size.to_f32()`）— resvg/krilla と同種の永続的で正しい f32 seam、draw 層 WALL ではない。

## Byte 中立

- baseline GREEN → 編集 → lib **1597** / `examples_determinism` **11** / VRT green、`goldens/` 変化なし（`FULGUR_VRT_UPDATE=1` 不使用）
- 代数的恒等（`X.px().in_pt()` = `Pt(X*0.75)` = `px_to_pt(X)`）、演算順保持

## Test Plan

- [x] build / clippy -D warnings / fmt clean
- [x] `cargo test -p fulgur` 全 pass、`px_to_pt` は両ファイルから0件
- [x] determinism + VRT green、goldens byte-identical
