### PR TITLE
feat(engine): expose public Engine::layout() + LayoutOutput (fulgur-2map.10)

### DIFF
--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -45,7 +45,28 @@ struct RenderPassOutput {
 /// Unit contract: `drawables` coordinates are PDF pt; `geometry` fragments are
 /// CSS px (`units::Px`). See the crate `units` module and
 /// `.claude/rules/coordinate-system.md`.
+///
+/// # Limitations
+///
+/// This carries only **body** layout. CSS Paged Media constructs that
+/// [`render`](Engine::render) paints from the render-side GCPM state —
+/// `@page` margin boxes, `position: running()` headers/footers, and the page
+/// numbers rendered inside them — are **not** included in `drawables` /
+/// `geometry`; an image / OCR consumer composing from `LayoutOutput` alone
+/// will omit them (fulgur-2map design doc §1/§9).
+///
+/// Likewise, when author CSS overrides the page box (`@page { size / margin }`,
+/// including `:left` / `:right` / `:first`), the pipeline paginates against the
+/// **resolved** content box, but the resolved page size / margin is not yet
+/// surfaced here — a consumer must not assume [`Engine::config`] alone
+/// describes the canvas. Surfacing margin boxes and resolved page geometry is a
+/// tracked follow-up ([fulgur-2map.10] notes).
+///
+/// This struct is `#[non_exhaustive]`: it is only ever returned by
+/// [`Engine::layout`] (consumers read fields, never construct it), so those
+/// follow-up fields can be added without a breaking change.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct LayoutOutput {
     pub drawables: crate::drawables::Drawables,
     pub geometry: crate::pagination_layout::PaginationGeometryTable,
@@ -717,10 +738,14 @@ impl Engine {
     /// Lay out `html` and return the renderer-agnostic per-node draw payloads
     /// (`drawables`) plus the pagination geometry, without serializing a PDF.
     ///
-    /// Page shape (canvas size, margins, orientation) comes from the builder
-    /// configuration, exactly as [`render`](Engine::render) uses it. Documents
-    /// with `target-counter()` / `target-counters()` / `target-text()` run the
-    /// same internal 2-pass resolution as `render`, so the returned `drawables`
+    /// Page shape (canvas size, margins, orientation) starts from the builder
+    /// configuration and is then resolved against author CSS exactly as
+    /// [`render`](Engine::render) resolves it — so `@page { size / margin }`
+    /// overrides (including `:left` / `:right` / `:first`) drive pagination
+    /// here too. The resolved page box itself is not surfaced on
+    /// [`LayoutOutput`] yet; see its `# Limitations`. Documents with
+    /// `target-counter()` / `target-counters()` / `target-text()` run the same
+    /// internal 2-pass resolution as `render`, so the returned `drawables`
     /// carry resolved cross-reference values, not fixed-width placeholders.
     ///
     /// This is the shared layout path behind `render`; a downstream image
@@ -732,7 +757,16 @@ impl Engine {
         // AnchorMap so those resolve. Project the final artifacts once.
         let pass1 = self.layout_to_drawables(html, None)?;
         let artifacts = if pass1.needs_pass_two {
-            self.layout_to_drawables(html, Some(&pass1.collected_anchor_map))?
+            // Retain only the AnchorMap across passes (as `render`'s loop
+            // effectively does — its per-pass drawables/geometry are dropped
+            // inside `render_pass`). Destructure `pass1` so its drawables,
+            // geometry, and GCPM stores are freed before pass 2 allocates,
+            // keeping peak memory single-pass-sized for large raster/OCR inputs.
+            let LayoutArtifacts {
+                collected_anchor_map,
+                ..
+            } = pass1;
+            self.layout_to_drawables(html, Some(&collected_anchor_map))?
         } else {
             pass1
         };

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -36,6 +36,37 @@ struct RenderPassOutput {
     needs_pass_two: bool,
 }
 
+/// Renderer-agnostic layout result produced by [`Engine::layout`].
+///
+/// Carries the parse → style → layout → `Drawables` output that both PDF
+/// rendering and out-of-core consumers (image rasterization, OCR label
+/// generation) build on, without pulling PDF serialization into core.
+///
+/// Unit contract: `drawables` coordinates are PDF pt; `geometry` fragments are
+/// CSS px (`units::Px`). See the crate `units` module and
+/// `.claude/rules/coordinate-system.md`.
+pub struct LayoutOutput {
+    pub drawables: crate::drawables::Drawables,
+    pub geometry: crate::pagination_layout::PaginationGeometryTable,
+}
+
+/// Full per-pass output of [`Engine::layout_to_drawables`] — a superset of the
+/// public [`LayoutOutput`] holding every side-channel `render::render_v2`
+/// needs. `fonts` / `system_fonts` are intentionally absent: both are re-derived
+/// from `&self` at the render call site, byte-identically to the old inline path.
+struct LayoutArtifacts {
+    drawables: crate::drawables::Drawables,
+    pagination_geometry: crate::pagination_layout::PaginationGeometryTable,
+    gcpm: crate::gcpm::GcpmContext,
+    running_store: crate::gcpm::running::RunningElementStore,
+    string_set_for_render: HashMap<usize, Vec<(String, String)>>,
+    counter_ops_for_render: BTreeMap<usize, Vec<crate::gcpm::CounterOp>>,
+    html_title: Option<String>,
+    implicit_href_map: BTreeMap<usize, String>,
+    collected_anchor_map: AnchorMap,
+    needs_pass_two: bool,
+}
+
 impl Engine {
     pub fn builder() -> EngineBuilder {
         EngineBuilder {
@@ -103,7 +134,11 @@ impl Engine {
     /// empty strings.
     ///
     /// See [`RenderPassOutput`] for the returned fields.
-    fn render_pass(&self, html: &str, anchor_map: Option<&AnchorMap>) -> Result<RenderPassOutput> {
+    fn layout_to_drawables(
+        &self,
+        html: &str,
+        anchor_map: Option<&AnchorMap>,
+    ) -> Result<LayoutArtifacts> {
         let html = crate::blitz_adapter::rewrite_marker_content_url_in_html(html);
 
         let combined_css = self
@@ -597,9 +632,53 @@ impl Engine {
 
         let drawables = crate::convert::dom_to_drawables(&doc, &mut convert_ctx);
         let html_title = crate::blitz_adapter::extract_html_title(&doc);
+        // Reclaim the post-convert geometry without partially moving
+        // `convert_ctx`, then drop it so its `&running_store` borrow ends and
+        // `running_store` can be moved into the artifacts.
+        let pagination_geometry = std::mem::take(&mut convert_ctx.pagination_geometry);
+        drop(convert_ctx);
+        Ok(LayoutArtifacts {
+            drawables,
+            pagination_geometry,
+            gcpm,
+            running_store,
+            string_set_for_render,
+            counter_ops_for_render,
+            html_title,
+            implicit_href_map,
+            collected_anchor_map,
+            needs_pass_two: needs_anchor_map_for_pass_two,
+        })
+    }
+
+    /// Single render pass: lay out via [`layout_to_drawables`], then serialize
+    /// the pages via the unchanged [`render::render_v2`]. `render`'s 2-pass
+    /// loop is untouched. See [`RenderPassOutput`] for the returned fields.
+    fn render_pass(&self, html: &str, anchor_map: Option<&AnchorMap>) -> Result<RenderPassOutput> {
+        let LayoutArtifacts {
+            drawables,
+            pagination_geometry,
+            gcpm,
+            running_store,
+            string_set_for_render,
+            counter_ops_for_render,
+            html_title,
+            implicit_href_map,
+            collected_anchor_map,
+            needs_pass_two,
+        } = self.layout_to_drawables(html, anchor_map)?;
+
+        // Re-derive fonts / system_fonts from `&self` — byte-identical to the
+        // value `layout_to_drawables` used for parsing.
+        let fonts = self
+            .assets
+            .as_ref()
+            .map(|a| a.fonts.as_slice())
+            .unwrap_or(&[]);
+
         let pdf = crate::render::render_v2(
             &self.config,
-            &convert_ctx.pagination_geometry,
+            &pagination_geometry,
             &drawables,
             &gcpm,
             &running_store,
@@ -615,7 +694,7 @@ impl Engine {
         Ok(RenderPassOutput {
             pdf,
             anchor_map: collected_anchor_map,
-            needs_pass_two: needs_anchor_map_for_pass_two,
+            needs_pass_two,
         })
     }
 
@@ -624,6 +703,35 @@ impl Engine {
         let pdf = self.render(html)?;
         std::fs::write(path, pdf)?;
         Ok(())
+    }
+
+    /// Lay out `html` and return the renderer-agnostic per-node draw payloads
+    /// (`drawables`) plus the pagination geometry, without serializing a PDF.
+    ///
+    /// Page shape (canvas size, margins, orientation) comes from the builder
+    /// configuration, exactly as [`render`](Engine::render) uses it. Documents
+    /// with `target-counter()` / `target-counters()` / `target-text()` run the
+    /// same internal 2-pass resolution as `render`, so the returned `drawables`
+    /// carry resolved cross-reference values, not fixed-width placeholders.
+    ///
+    /// This is the shared layout path behind `render`; a downstream image
+    /// rasterizer or OCR-label generator can consume [`LayoutOutput`] without
+    /// pulling PDF serialization into core.
+    pub fn layout(&self, html: &str) -> Result<LayoutOutput> {
+        // Pass 1, mirroring `render`'s 2-pass loop.
+        let pass1 = self.layout_to_drawables(html, None)?;
+        if !pass1.needs_pass_two {
+            return Ok(LayoutOutput {
+                drawables: pass1.drawables,
+                geometry: pass1.pagination_geometry,
+            });
+        }
+        // Pass 2: re-lay-out with the pass-1 AnchorMap so `target-*` resolve.
+        let pass2 = self.layout_to_drawables(html, Some(&pass1.collected_anchor_map))?;
+        Ok(LayoutOutput {
+            drawables: pass2.drawables,
+            geometry: pass2.pagination_geometry,
+        })
     }
 
     /// Render a template with data to PDF bytes.

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -45,6 +45,7 @@ struct RenderPassOutput {
 /// Unit contract: `drawables` coordinates are PDF pt; `geometry` fragments are
 /// CSS px (`units::Px`). See the crate `units` module and
 /// `.claude/rules/coordinate-system.md`.
+#[derive(Debug, Clone)]
 pub struct LayoutOutput {
     pub drawables: crate::drawables::Drawables,
     pub geometry: crate::pagination_layout::PaginationGeometryTable,
@@ -90,6 +91,16 @@ impl Engine {
 
     pub fn assets(&self) -> Option<&AssetBundle> {
         self.assets.as_ref()
+    }
+
+    /// Font byte-blobs registered on the [`AssetBundle`], or an empty slice
+    /// when no assets are set. Shared by every layout / render entry point so
+    /// they all parse against the identical font set.
+    fn fonts(&self) -> &[std::sync::Arc<Vec<u8>>] {
+        self.assets
+            .as_ref()
+            .map(|a| a.fonts.as_slice())
+            .unwrap_or(&[])
     }
 
     /// Render HTML string to PDF bytes.
@@ -157,11 +168,7 @@ impl Engine {
         let mut gcpm = crate::gcpm::parser::parse_gcpm(&combined_css);
         let css_to_inject = gcpm.cleaned_css.clone();
 
-        let fonts = self
-            .assets
-            .as_ref()
-            .map(|a| a.fonts.as_slice())
-            .unwrap_or(&[]);
+        let fonts = self.fonts();
 
         // Parse the HTML and resolve every <link rel="stylesheet"> /
         // @import file inside `base_path` in one shot. The returned
@@ -676,11 +683,7 @@ impl Engine {
 
         // Re-derive fonts / system_fonts from `&self` — byte-identical to the
         // value `layout_to_drawables` used for parsing.
-        let fonts = self
-            .assets
-            .as_ref()
-            .map(|a| a.fonts.as_slice())
-            .unwrap_or(&[]);
+        let fonts = self.fonts();
 
         let pdf = crate::render::render_v2(
             &self.config,
@@ -808,11 +811,7 @@ impl Engine {
     /// constructs that do not touch GCPM.
     #[doc(hidden)]
     pub fn build_drawables_for_testing_no_gcpm(&self, html: &str) -> crate::drawables::Drawables {
-        let fonts = self
-            .assets
-            .as_ref()
-            .map(|a| a.fonts.as_slice())
-            .unwrap_or(&[]);
+        let fonts = self.fonts();
 
         let (mut doc, _link_gcpm) = crate::blitz_adapter::parse_html_with_local_resources(
             html,
@@ -877,11 +876,7 @@ impl Engine {
         crate::drawables::Drawables,
         crate::pagination_layout::PaginationGeometryTable,
     ) {
-        let fonts = self
-            .assets
-            .as_ref()
-            .map(|a| a.fonts.as_slice())
-            .unwrap_or(&[]);
+        let fonts = self.fonts();
 
         let (mut doc, _link_gcpm) = crate::blitz_adapter::parse_html_with_local_resources(
             html,
@@ -968,9 +963,10 @@ impl Engine {
         // those corrections from tests that drive
         // `pseudo_absolute_content_url::
         // absolute_pseudo_with_right_bottom_offsets_by_image_size`.
-        // The production `render` path already passes
-        // `&convert_ctx.pagination_geometry` to `render_v2` after
-        // convert, so this matches the production read order.
+        // The production path already reads `convert_ctx.pagination_geometry`
+        // after convert — `layout_to_drawables` `mem::take`s it into a
+        // `pagination_geometry` local (the same value) that `render_pass` then
+        // hands to `render_v2` — so this matches the production read order.
         (drawables, convert_ctx.pagination_geometry)
     }
 }
@@ -1837,7 +1833,7 @@ mod tests {
     #[test]
     fn render_page_with_css_landscape_size_produces_pdf() {
         // `@page { size: A4 landscape; }` triggers the `resolved_landscape =
-        // true` branch in render_pass (line 182).
+        // true` branch in `layout_to_drawables`.
         let html = "<!doctype html><html><head><style>\
             @page { size: A4 landscape; }\
             </style></head><body><p>landscape</p></body></html>";

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -125,15 +125,21 @@ impl Engine {
         Ok(pdf2)
     }
 
-    /// Single render pass. When `anchor_map` is `Some`, the supplied map
-    /// is wired into [`CounterPass`] so `target-counter()` /
-    /// `target-counters()` / `target-text()` inside `::before` / `::after`
-    /// resolve against pass-1 anchor data, and is passed through to
-    /// `render::render_v2` so margin-box `target-*` resolvers can do the
-    /// same. When `None`, those resolvers fall back to placeholders /
-    /// empty strings.
+    /// Run the full parse → style → layout → convert pipeline for a single
+    /// pass and return the resolved [`LayoutArtifacts`] (drawables, pagination
+    /// geometry, and the side-channel data `render::render_v2` needs) —
+    /// **without** serializing a PDF.
     ///
-    /// See [`RenderPassOutput`] for the returned fields.
+    /// When `anchor_map` is `Some`, the supplied pass-1 map is wired into
+    /// [`CounterPass`] so `target-counter()` / `target-counters()` /
+    /// `target-text()` inside `::before` / `::after` resolve against pass-1
+    /// anchor data, and is carried in the returned artifacts so margin-box
+    /// `target-*` resolvers in `render::render_v2` can do the same. When
+    /// `None`, those resolvers fall back to placeholders / empty strings.
+    ///
+    /// This is the single shared layout path: both `render_pass` (which
+    /// serializes the result to PDF) and the public [`layout`](Engine::layout)
+    /// build on it. See [`LayoutArtifacts`] for the returned fields.
     fn layout_to_drawables(
         &self,
         html: &str,

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -727,19 +727,18 @@ impl Engine {
     /// rasterizer or OCR-label generator can consume [`LayoutOutput`] without
     /// pulling PDF serialization into core.
     pub fn layout(&self, html: &str) -> Result<LayoutOutput> {
-        // Pass 1, mirroring `render`'s 2-pass loop.
+        // Mirror `render`'s 2-pass loop: pass 1 always runs; when it reports
+        // `target-*` cross-references, pass 2 re-lays-out with the pass-1
+        // AnchorMap so those resolve. Project the final artifacts once.
         let pass1 = self.layout_to_drawables(html, None)?;
-        if !pass1.needs_pass_two {
-            return Ok(LayoutOutput {
-                drawables: pass1.drawables,
-                geometry: pass1.pagination_geometry,
-            });
-        }
-        // Pass 2: re-lay-out with the pass-1 AnchorMap so `target-*` resolve.
-        let pass2 = self.layout_to_drawables(html, Some(&pass1.collected_anchor_map))?;
+        let artifacts = if pass1.needs_pass_two {
+            self.layout_to_drawables(html, Some(&pass1.collected_anchor_map))?
+        } else {
+            pass1
+        };
         Ok(LayoutOutput {
-            drawables: pass2.drawables,
-            geometry: pass2.pagination_geometry,
+            drawables: artifacts.drawables,
+            geometry: artifacts.pagination_geometry,
         })
     }
 

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -67,7 +67,7 @@ pub mod units;
 
 pub use asset::AssetBundle;
 pub use config::{Config, ConfigBuilder, Margin, PageSize};
-pub use engine::{Engine, EngineBuilder};
+pub use engine::{Engine, EngineBuilder, LayoutOutput};
 pub use error::{Error, Result};
 pub use outline::build_outline;
 

--- a/crates/fulgur/tests/public_reachability.rs
+++ b/crates/fulgur/tests/public_reachability.rs
@@ -17,3 +17,22 @@ fn column_css_public_types_are_externally_nameable() {
     };
     assert_eq!(props.fill, Some(ColumnFill::Balance));
 }
+
+/// Regression guard for fulgur-2map.10 (P3b): `LayoutOutput`'s field types
+/// (`Drawables`, `PaginationGeometryTable`) must stay nameable via external
+/// `fulgur::…` paths. `LayoutOutput.geometry` exposes `PaginationGeometryTable`
+/// (→ `PaginationGeometry` → `Fragment` → `units::Px`) publicly for the first
+/// time; if any of that chain is ever privatized, this fails to compile.
+#[test]
+fn layout_output_field_types_are_externally_nameable() {
+    use fulgur::pagination_layout::PaginationGeometryTable;
+    use fulgur::{Engine, LayoutOutput};
+
+    let out: LayoutOutput = Engine::builder()
+        .build()
+        .layout("<p>x</p>")
+        .expect("layout");
+    let _geometry: &PaginationGeometryTable = &out.geometry;
+    let _drawables: &fulgur::drawables::Drawables = &out.drawables;
+    assert!(!out.geometry.is_empty());
+}

--- a/crates/fulgur/tests/public_reachability.rs
+++ b/crates/fulgur/tests/public_reachability.rs
@@ -35,4 +35,10 @@ fn layout_output_field_types_are_externally_nameable() {
     let _geometry: &PaginationGeometryTable = &out.geometry;
     let _drawables: &fulgur::drawables::Drawables = &out.drawables;
     assert!(!out.geometry.is_empty());
+
+    // Exercise the public `Debug` + `Clone` derives: consumers rely on them,
+    // and invoking them here attributes the `#[derive(Debug, Clone)]` region
+    // on `LayoutOutput` for codecov/patch (it is otherwise never called).
+    let cloned = out.clone();
+    assert!(!format!("{cloned:?}").is_empty());
 }

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -5186,4 +5186,29 @@ fn layout_two_pass_target_counter_returns_drawables_and_geometry() {
         !out.drawables.paragraphs.is_empty(),
         "the paragraphs should produce draw payloads after 2-pass layout"
     );
+
+    // Pass-2-SPECIFIC guard: `target-counter(attr(href), page)` in the
+    // `a::after` resolves against the pass-1 `AnchorMap`. The `#a` heading
+    // lands on page 2 (`page-break-before: always`), so the resolved pseudo
+    // content is " (p.2)". On a regression to single-pass this stays a
+    // fixed-width placeholder (never the literal resolved page number), so
+    // this assert fails — which the non-empty checks above cannot detect.
+    // Reads the pre-raster run text (`ShapedGlyphRun::text`), so it is
+    // font-independent (no glyph inspection).
+    let resolved_text: String = out
+        .drawables
+        .paragraphs
+        .values()
+        .flat_map(|entry| &entry.lines)
+        .flat_map(|line| &line.items)
+        .filter_map(|item| match item {
+            fulgur::paragraph::LineItem::Text(run) => Some(run.text.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        resolved_text.contains("(p.2)"),
+        "pass-2 target-counter should resolve to the real page number \"(p.2)\"; \
+         got run text: {resolved_text:?}"
+    );
 }

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -5143,3 +5143,47 @@ fn render_v2_smoke_break_after_recursing_child_emits_parent_fragment() {
     </body></html>"#;
     assert_paginates(html, "recursing break-after must paginate");
 }
+
+/// Smoke: public `Engine::layout()` single-pass path. A plain document
+/// (no `target-*`) takes the `!needs_pass_two` early return. Asserts the
+/// renderer-agnostic layout output carries drawables + geometry, so an
+/// out-of-core consumer (image / OCR) has something to compose.
+#[test]
+fn layout_single_pass_returns_drawables_and_geometry() {
+    let out = Engine::builder()
+        .build()
+        .layout("<html><body><p>hello layout</p></body></html>")
+        .expect("layout single-pass");
+    assert!(!out.geometry.is_empty(), "geometry should record fragments");
+    assert!(
+        !out.drawables.paragraphs.is_empty(),
+        "the <p> should produce a paragraph draw payload"
+    );
+}
+
+/// Smoke: public `Engine::layout()` 2-pass path. A `target-counter()` in
+/// `::after` forces `needs_pass_two`, so `layout()` falls through the early
+/// return and re-lays out with the pass-1 `AnchorMap`. Covers the else-arm
+/// of the branch for codecov/patch (the single-pass test covers the `return`).
+#[test]
+fn layout_two_pass_target_counter_returns_drawables_and_geometry() {
+    let html = r##"<!doctype html>
+<html><head><style>
+  a::after { content: " (p." target-counter(attr(href), page) ")"; }
+  h2 { page-break-before: always; }
+</style></head>
+<body>
+  <a href="#a">Chapter A</a>
+  <h2 id="a">Chapter A</h2>
+  <p>aaa</p>
+</body></html>"##;
+    let out = Engine::builder()
+        .build()
+        .layout(html)
+        .expect("layout 2-pass");
+    assert!(!out.geometry.is_empty(), "geometry should record fragments");
+    assert!(
+        !out.drawables.paragraphs.is_empty(),
+        "the paragraphs should produce draw payloads after 2-pass layout"
+    );
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -39,6 +39,23 @@ fn page_count(pdf: &[u8]) -> usize {
     count
 }
 
+/// Concatenate every `ShapedGlyphRun` string across a paragraph's shaped
+/// lines — enough to identify a paragraph by its text content in the flat
+/// `Drawables.paragraphs` map, or to assert resolved pseudo-content text.
+/// Reads the pre-raster run text (`ShapedGlyphRun::text`), so it is
+/// font-independent (no glyph inspection).
+fn paragraph_run_text(entry: &fulgur::drawables::ParagraphEntry) -> String {
+    entry
+        .lines
+        .iter()
+        .flat_map(|line| line.items.iter())
+        .filter_map(|item| match item {
+            fulgur::paragraph::LineItem::Text(run) => Some(run.text.as_str()),
+            _ => None,
+        })
+        .collect()
+}
+
 /// Render `html` through the v2 pipeline and assert it produced a valid
 /// PDF that paginated (`>= 2` pages). `what` labels the failure case.
 fn assert_paginates(html: &str, what: &str) {
@@ -680,7 +697,6 @@ fn position_fixed_inside_absolute_relayouts_against_viewport() {
     // produces multiple wrapped lines; with the relayout, the fixed
     // subtree is reshaped against the page area and the sentence fits
     // on one line.
-    use fulgur::paragraph::LineItem;
 
     // The fixed paragraph carries a unique sentence so we can identify
     // it in the flat `Drawables.paragraphs` map by text content. The
@@ -707,18 +723,7 @@ fn position_fixed_inside_absolute_relayouts_against_viewport() {
     let fixed_para = drawables
         .paragraphs
         .values()
-        .find(|p| {
-            let combined: String = p
-                .lines
-                .iter()
-                .flat_map(|l| l.items.iter())
-                .filter_map(|it| match it {
-                    LineItem::Text(run) => Some(run.text.as_str()),
-                    _ => None,
-                })
-                .collect();
-            combined.contains(FIXED_TEXT)
-        })
+        .find(|&p| paragraph_run_text(p).contains(FIXED_TEXT))
         .expect("fixed paragraph must appear in Drawables.paragraphs");
 
     assert_eq!(
@@ -5195,20 +5200,19 @@ fn layout_two_pass_target_counter_returns_drawables_and_geometry() {
     // this assert fails — which the non-empty checks above cannot detect.
     // Reads the pre-raster run text (`ShapedGlyphRun::text`), so it is
     // font-independent (no glyph inspection).
-    let resolved_text: String = out
+    let resolved = out
         .drawables
         .paragraphs
         .values()
-        .flat_map(|entry| &entry.lines)
-        .flat_map(|line| &line.items)
-        .filter_map(|item| match item {
-            fulgur::paragraph::LineItem::Text(run) => Some(run.text.as_str()),
-            _ => None,
-        })
-        .collect();
+        .any(|p| paragraph_run_text(p).contains("(p.2)"));
     assert!(
-        resolved_text.contains("(p.2)"),
+        resolved,
         "pass-2 target-counter should resolve to the real page number \"(p.2)\"; \
-         got run text: {resolved_text:?}"
+         got paragraph texts: {:?}",
+        out.drawables
+            .paragraphs
+            .values()
+            .map(paragraph_run_text)
+            .collect::<Vec<_>>()
     );
 }

--- a/docs/plans/2026-07-04-engine-layout-public-api.md
+++ b/docs/plans/2026-07-04-engine-layout-public-api.md
@@ -88,9 +88,20 @@ fn layout_two_pass_target_counter_returns_drawables_and_geometry() {
         .layout(html)
         .expect("layout 2-pass");
     assert!(!out.geometry.is_empty(), "geometry should record fragments");
+    assert!(!out.drawables.paragraphs.is_empty());
+    // Pass-2-SPECIFIC guard: non-empty checks alone pass even if pass 2 never
+    // fires. Assert the RESOLVED content — `#a` lands on page 2 via
+    // `page-break-before: always`, so `target-counter(attr(href), page)` in the
+    // `a::after` resolves to " (p.2)". On a regression to single-pass this stays
+    // a fixed-width placeholder, never the literal resolved page number. Reads
+    // the pre-raster run text (`ShapedGlyphRun::text`) via the shared
+    // `paragraph_run_text` helper, so it is font-independent.
     assert!(
-        !out.drawables.paragraphs.is_empty(),
-        "the paragraphs should produce draw payloads after 2-pass layout"
+        out.drawables
+            .paragraphs
+            .values()
+            .any(|p| paragraph_run_text(p).contains("(p.2)")),
+        "pass-2 target-counter should resolve to \"(p.2)\""
     );
 }
 ```

--- a/docs/plans/2026-07-04-engine-layout-public-api.md
+++ b/docs/plans/2026-07-04-engine-layout-public-api.md
@@ -1,0 +1,384 @@
+# Public `Engine::layout()` + `LayoutOutput` Implementation Plan
+
+**Goal:** Expose the fulgur layout engine (parse → style → layout → `Drawables`)
+as a public `Engine::layout(&self, html) -> Result<LayoutOutput { drawables,
+geometry }>`, closing the fulgur-2map epic, without changing any PDF byte output.
+
+**Architecture:** Extract the monolithic `render_pass` body into a private
+`layout_to_drawables(&self, html, anchor_map) -> Result<LayoutArtifacts>` helper
+(everything up to and including `dom_to_drawables`). `render_pass` becomes a thin
+wrapper that calls the helper and drives the unchanged `render_v2`. The new
+public `layout()` calls the same helper with `render`'s 2-pass loop and returns
+just `{ drawables, geometry }`. One layout path — PDF and layout()/image/OCR
+never diverge. The extraction is a pure code-move, so goldens stay byte-identical.
+
+**Tech Stack:** Rust, existing fulgur crate (`engine.rs`, `render_v2`,
+`convert::dom_to_drawables`, `pagination_layout`, `drawables`, `units`).
+
+**Design source:** beads `fulgur-2map.10` design field +
+`docs/plans/2026-06-27-engine-layout-api-design.md` §3–§4.
+
+---
+
+## Pre-flight (already done, recorded here for the executor)
+
+Clean baseline on `origin/main` (a96d8808) BEFORE any edit was GREEN:
+
+- `examples_determinism`: 11 passed, 0 failed.
+- VRT (`run_fulgur_vrt` etc.): all passed.
+- `git status --short crates/fulgur-vrt/goldens/`: empty.
+
+This is the load-bearing byte-neutrality baseline. A moved golden after the
+refactor means the extraction was not a pure code-move — investigate, never
+`FULGUR_VRT_UPDATE=1`.
+
+---
+
+## Task 1: Add public `Engine::layout()` + `LayoutOutput` (TDD)
+
+**Files:**
+
+- Modify: `crates/fulgur/src/engine.rs` (add structs, extract helper, add
+  `layout()`)
+- Modify: `crates/fulgur/src/lib.rs:70` (re-export `LayoutOutput`)
+- Test: `crates/fulgur/tests/render_smoke.rs` (two `layout()` smoke tests)
+- Test: `crates/fulgur/tests/public_reachability.rs` (geometry-type reachability
+  guard)
+
+### Step 1: Write the failing tests
+
+Append to `crates/fulgur/tests/render_smoke.rs`:
+
+```rust
+/// Smoke: public `Engine::layout()` single-pass path. A plain document
+/// (no `target-*`) takes the `!needs_pass_two` early return. Asserts the
+/// renderer-agnostic layout output carries drawables + geometry, so an
+/// out-of-core consumer (image / OCR) has something to compose.
+#[test]
+fn layout_single_pass_returns_drawables_and_geometry() {
+    let out = Engine::builder()
+        .build()
+        .layout("<html><body><p>hello layout</p></body></html>")
+        .expect("layout single-pass");
+    assert!(!out.geometry.is_empty(), "geometry should record fragments");
+    assert!(
+        !out.drawables.paragraphs.is_empty(),
+        "the <p> should produce a paragraph draw payload"
+    );
+}
+
+/// Smoke: public `Engine::layout()` 2-pass path. A `target-counter()` in
+/// `::after` forces `needs_pass_two`, so `layout()` falls through the early
+/// return and re-lays out with the pass-1 `AnchorMap`. Covers the else-arm
+/// of the branch for codecov/patch (the single-pass test covers the `return`).
+#[test]
+fn layout_two_pass_target_counter_returns_drawables_and_geometry() {
+    let html = r##"<!doctype html>
+<html><head><style>
+  a::after { content: " (p." target-counter(attr(href), page) ")"; }
+  h2 { page-break-before: always; }
+</style></head>
+<body>
+  <a href="#a">Chapter A</a>
+  <h2 id="a">Chapter A</h2>
+  <p>aaa</p>
+</body></html>"##;
+    let out = Engine::builder()
+        .build()
+        .layout(html)
+        .expect("layout 2-pass");
+    assert!(!out.geometry.is_empty(), "geometry should record fragments");
+    assert!(
+        !out.drawables.paragraphs.is_empty(),
+        "the paragraphs should produce draw payloads after 2-pass layout"
+    );
+}
+```
+
+Append to `crates/fulgur/tests/public_reachability.rs`:
+
+```rust
+/// Regression guard for fulgur-2map.10 (P3b): `LayoutOutput`'s field types
+/// (`Drawables`, `PaginationGeometryTable`) must stay nameable via external
+/// `fulgur::…` paths. `LayoutOutput.geometry` exposes `PaginationGeometryTable`
+/// (→ `PaginationGeometry` → `Fragment` → `units::Px`) publicly for the first
+/// time; if any of that chain is ever privatized, this fails to compile.
+#[test]
+fn layout_output_field_types_are_externally_nameable() {
+    use fulgur::pagination_layout::PaginationGeometryTable;
+    use fulgur::{Engine, LayoutOutput};
+
+    let out: LayoutOutput = Engine::builder()
+        .build()
+        .layout("<p>x</p>")
+        .expect("layout");
+    let _geometry: &PaginationGeometryTable = &out.geometry;
+    let _drawables: &fulgur::drawables::Drawables = &out.drawables;
+    assert!(!out.geometry.is_empty());
+}
+```
+
+### Step 2: Run the tests to verify they fail (RED)
+
+```bash
+cargo test -p fulgur --test render_smoke layout_ 2>&1 | tail -20
+cargo test -p fulgur --test public_reachability 2>&1 | tail -20
+```
+
+Expected: compile error — `no method named layout` / `LayoutOutput` unresolved.
+
+### Step 3: Implement in `crates/fulgur/src/engine.rs`
+
+**3a. Add the two structs.** Put `LayoutOutput` (public) near `RenderPassOutput`
+(after line 37) and `LayoutArtifacts` (private) beside it:
+
+```rust
+/// Renderer-agnostic layout result produced by [`Engine::layout`].
+///
+/// Carries the parse → style → layout → `Drawables` output that both PDF
+/// rendering and out-of-core consumers (image rasterization, OCR label
+/// generation) build on, without pulling PDF serialization into core.
+///
+/// Unit contract: `drawables` coordinates are PDF pt; `geometry` fragments are
+/// CSS px (`units::Px`). See the crate `units` module and
+/// `.claude/rules/coordinate-system.md`.
+pub struct LayoutOutput {
+    pub drawables: crate::drawables::Drawables,
+    pub geometry: crate::pagination_layout::PaginationGeometryTable,
+}
+
+/// Full per-pass output of [`Engine::layout_to_drawables`] — a superset of the
+/// public [`LayoutOutput`] holding every side-channel `render::render_v2`
+/// needs. `fonts` / `system_fonts` are intentionally absent: both are re-derived
+/// from `&self` at the render call site, byte-identically to the old inline path.
+struct LayoutArtifacts {
+    drawables: crate::drawables::Drawables,
+    pagination_geometry: crate::pagination_layout::PaginationGeometryTable,
+    gcpm: crate::gcpm::GcpmContext,
+    running_store: crate::gcpm::running::RunningElementStore,
+    string_set_for_render: HashMap<usize, Vec<(String, String)>>,
+    counter_ops_for_render: BTreeMap<usize, Vec<crate::gcpm::CounterOp>>,
+    html_title: Option<String>,
+    implicit_href_map: BTreeMap<usize, String>,
+    collected_anchor_map: AnchorMap,
+    needs_pass_two: bool,
+}
+```
+
+Note: confirm the `GcpmContext` path compiles — it is defined in
+`crates/fulgur/src/gcpm/mod.rs`, so `crate::gcpm::GcpmContext`. If the compiler
+disagrees, use `crate::gcpm::parser::GcpmContext`.
+
+**3b. Rename `render_pass` → `layout_to_drawables`, change ONLY the tail.**
+Rename the current method (engine.rs:106) and its return type:
+
+```rust
+fn layout_to_drawables(
+    &self,
+    html: &str,
+    anchor_map: Option<&AnchorMap>,
+) -> Result<LayoutArtifacts> {
+```
+
+Leave the entire body (parse, GCPM passes, pagination, anchor/implicit maps,
+`ConvertContext` build, `dom_to_drawables`) UNCHANGED. Replace ONLY the tail —
+the current `let drawables = …; let html_title = …; let pdf = render_v2(…)?;
+Ok(RenderPassOutput { … })` block (engine.rs:598-619) with:
+
+```rust
+        let drawables = crate::convert::dom_to_drawables(&doc, &mut convert_ctx);
+        let html_title = crate::blitz_adapter::extract_html_title(&doc);
+        // Reclaim the post-convert geometry without partially moving
+        // `convert_ctx`, then drop it so its `&running_store` borrow ends and
+        // `running_store` can be moved into the artifacts.
+        let pagination_geometry = std::mem::take(&mut convert_ctx.pagination_geometry);
+        drop(convert_ctx);
+        Ok(LayoutArtifacts {
+            drawables,
+            pagination_geometry,
+            gcpm,
+            running_store,
+            string_set_for_render,
+            counter_ops_for_render,
+            html_title,
+            implicit_href_map,
+            collected_anchor_map,
+            needs_pass_two: needs_anchor_map_for_pass_two,
+        })
+    }
+```
+
+Rationale for `mem::take` + `drop`: `render_v2` previously borrowed
+`&convert_ctx.pagination_geometry`, but the helper must MOVE the geometry out
+while `convert_ctx` still holds `running_store: &running_store`. `mem::take`
+(PaginationGeometryTable is `BTreeMap`, so `Default`) leaves `convert_ctx` fully
+valid; `drop(convert_ctx)` then ends the `&running_store` borrow so it can move.
+No computation changes — `dom_to_drawables` already populated the table.
+
+**3c. Add the thin `render_pass` wrapper** immediately after
+`layout_to_drawables`:
+
+```rust
+/// Single render pass: lay out via [`layout_to_drawables`], then serialize the
+/// pages via the unchanged [`render::render_v2`]. `render`'s 2-pass loop is
+/// untouched. See [`RenderPassOutput`] for the returned fields.
+fn render_pass(&self, html: &str, anchor_map: Option<&AnchorMap>) -> Result<RenderPassOutput> {
+    let LayoutArtifacts {
+        drawables,
+        pagination_geometry,
+        gcpm,
+        running_store,
+        string_set_for_render,
+        counter_ops_for_render,
+        html_title,
+        implicit_href_map,
+        collected_anchor_map,
+        needs_pass_two,
+    } = self.layout_to_drawables(html, anchor_map)?;
+
+    // Re-derive fonts / system_fonts from `&self` — byte-identical to the
+    // value `layout_to_drawables` used for parsing.
+    let fonts = self
+        .assets
+        .as_ref()
+        .map(|a| a.fonts.as_slice())
+        .unwrap_or(&[]);
+
+    let pdf = crate::render::render_v2(
+        &self.config,
+        &pagination_geometry,
+        &drawables,
+        &gcpm,
+        &running_store,
+        fonts,
+        self.system_fonts,
+        &string_set_for_render,
+        &counter_ops_for_render,
+        html_title,
+        self.serialize_settings.clone(),
+        anchor_map,
+        &implicit_href_map,
+    )?;
+    Ok(RenderPassOutput {
+        pdf,
+        anchor_map: collected_anchor_map,
+        needs_pass_two,
+    })
+}
+```
+
+**3d. Add the public `layout()`** inside `impl Engine` (near `render`, e.g.
+after `render_file`):
+
+```rust
+/// Lay out `html` and return the renderer-agnostic per-node draw payloads
+/// (`drawables`) plus the pagination geometry, without serializing a PDF.
+///
+/// Page shape (canvas size, margins, orientation) comes from the builder
+/// configuration, exactly as [`render`](Engine::render) uses it. Documents
+/// with `target-counter()` / `target-counters()` / `target-text()` run the
+/// same internal 2-pass resolution as `render`, so the returned `drawables`
+/// carry resolved cross-reference values, not fixed-width placeholders.
+///
+/// This is the shared layout path behind `render`; a downstream image
+/// rasterizer or OCR-label generator can consume [`LayoutOutput`] without
+/// pulling PDF serialization into core.
+pub fn layout(&self, html: &str) -> Result<LayoutOutput> {
+    // Pass 1, mirroring `render`'s 2-pass loop.
+    let pass1 = self.layout_to_drawables(html, None)?;
+    if !pass1.needs_pass_two {
+        return Ok(LayoutOutput {
+            drawables: pass1.drawables,
+            geometry: pass1.pagination_geometry,
+        });
+    }
+    // Pass 2: re-lay-out with the pass-1 AnchorMap so `target-*` resolve.
+    let pass2 = self.layout_to_drawables(html, Some(&pass1.collected_anchor_map))?;
+    Ok(LayoutOutput {
+        drawables: pass2.drawables,
+        geometry: pass2.pagination_geometry,
+    })
+}
+```
+
+**3e. Re-export from `crates/fulgur/src/lib.rs:70`:**
+
+```rust
+pub use engine::{Engine, EngineBuilder, LayoutOutput};
+```
+
+### Step 4: Run the tests to verify they pass (GREEN)
+
+```bash
+cargo test -p fulgur --test render_smoke layout_ 2>&1 | tail -20
+cargo test -p fulgur --test public_reachability 2>&1 | tail -20
+```
+
+Expected: both `layout_*` smoke tests + the reachability guard PASS.
+
+### Step 5: Build / clippy / fmt clean
+
+```bash
+cargo build -p fulgur 2>&1 | tail -5
+cargo clippy -p fulgur --all-targets -- -D warnings 2>&1 | tail -15
+cargo fmt --check 2>&1 | tail -5
+```
+
+Expected: no errors, no warnings, no fmt diff.
+
+### Step 6: Full lib test suite
+
+```bash
+cargo test -p fulgur --lib 2>&1 | tail -10
+cargo test -p fulgur --test render_smoke 2>&1 | tail -5
+cargo test -p fulgur --test public_reachability 2>&1 | tail -5
+```
+
+Expected: all green (existing ~340 lib tests unaffected — `render_pass`'s
+observable behavior is unchanged).
+
+### Step 7: Commit
+
+```bash
+git add crates/fulgur/src/engine.rs crates/fulgur/src/lib.rs \
+        crates/fulgur/tests/render_smoke.rs \
+        crates/fulgur/tests/public_reachability.rs \
+        docs/plans/2026-07-04-engine-layout-public-api.md
+git commit -m "feat(engine): expose public Engine::layout() + LayoutOutput (fulgur-2map.10)"
+```
+
+---
+
+## Task 2: Prove byte-neutrality (goldens unchanged)
+
+**Files:** none modified — verification only.
+
+### Step 1: Run the load-bearing golden suites
+
+```bash
+export FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf"
+cargo test -p fulgur-cli --test examples_determinism 2>&1 | tail -5
+cargo test -p fulgur-vrt 2>&1 | tail -15
+```
+
+Expected: same GREEN as the pre-flight baseline (determinism 11 passed; VRT all
+passed).
+
+### Step 2: Confirm goldens are byte-identical
+
+```bash
+git status --short -- crates/fulgur-vrt/goldens/
+```
+
+Expected: EMPTY. A non-empty result means the extraction reassociated or dropped
+a computation — investigate the diff; do NOT run `FULGUR_VRT_UPDATE=1`.
+
+---
+
+## Out of scope (do not touch)
+
+- `fulgur-image` / OCR crates, rasterize / encode, CLI `rasterize` subcommand,
+  the glyph-composition single-source helper (design doc §9–§10).
+- Builder `PageSize` / `Margin` typing (permanently out of epic scope).
+- Docs for the `layout()` API → tracked separately as `fulgur-2map.11` (P3c),
+  blocked on this task.


### PR DESCRIPTION
## 概要

fulgur-2map エピックの最終公開ステップ（P3b）。レイアウトエンジン（parse → style → layout → `Drawables`）を公開 API として露出し、外部クレート（画像ラスタライザ / OCR 学習データ生成）が PDF 直列化をコアに持ち込まずにレイアウト結果を再利用できるようにする。

```rust
let out = Engine::builder().page_size(canvas).build().layout(html)?;
// out.drawables / out.geometry を外部クレートが合成・ラスタライズ or ラベル化
```

## 変更内容

- **公開 `Engine::layout(&self, html) -> Result<LayoutOutput { drawables, geometry }>` を追加。** `render` と同じ内部 2-pass（`target-counter()` / `target-counters()` / `target-text()` を pass-1 の `AnchorMap` で解決）を回し、解決済み `Drawables` + `PaginationGeometryTable` を返す。PDF 直列化はしない。
- **モノリシックな `render_pass` を private ヘルパ `layout_to_drawables` に抽出。** 本体（parse / GCPM passes / pagination / convert）は **byte-identical のまま**。tail のみ変更し、`render_v2` を呼ばず 10-field の private `LayoutArtifacts` を返す。`render_pass` はそのヘルパを呼んで `fonts` を `&self` から再導出し、**無改変の `render_v2`** に渡す薄いラッパになった。→ レイアウト経路は 1 本、PDF と画像/OCR でロジック分岐なし。
- `pub struct LayoutOutput`（`#[derive(Debug, Clone)]`）を追加し `lib.rs` から re-export。
- 付随: `fonts()` アクセサで 4 箇所の同一 font 導出を DRY 化、旧 `render_pass` 前提の stale doc/コメントを是正。

設計は beads `fulgur-2map.10`（design フィールド）と `docs/plans/2026-06-27-engine-layout-api-design.md` を参照。本 PR の実装計画は `docs/plans/2026-07-04-engine-layout-public-api.md`。

## byte-neutral の担保

抽出は純粋なコード移動で、tail より上の計算・演算順序は一切変えていない。`mem::take(&mut convert_ctx.pagination_geometry)` + `drop(convert_ctx)` は、`convert_ctx` が保持する `&running_store` 借用を解放して `running_store` を artifacts に move するためのもので、`render_v2` が読む geometry の値は従来と同一（convert 後の populated table）。

- **examples_determinism: 11 passed** / **VRT: 31 passed（全バイナリ）** / **VRT goldens byte-identical**（`FULGUR_VRT_UPDATE` は不使用）
- pre-edit の clean `origin/main` baseline も同一 GREEN であることを事前確認済み

## 公開到達性

`LayoutOutput.geometry` で `PaginationGeometryTable`（→ `PaginationGeometry` → `Fragment` → `units::Px`）を初めて公開するが、transitive な型は全て `pub` で漏れなし（`drawables` 側は P3a / fulgur-2map.9 で解消済み）。`tests/public_reachability.rs` に外部パスでの命名ガードを追加し、将来の private 化はコンパイルエラーになる。

## テスト

- `render_smoke.rs`: `layout()` の single-pass / 2-pass 両分岐の smoke test を追加。2-pass は公開 `ShapedGlyphRun.text` 経由で `target-counter` が `"(p.2)"` に解決されることまで検証（font 非依存・pass-2 特有）。
- `public_reachability.rs`: 到達性ガード + `LayoutOutput` の `Debug`/`Clone` derive を exercise。
- lib + integration 全 pass、`cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` / `markdownlint` clean。
- `cargo llvm-cov` で変更行の未カバー 0 を確認（codecov/patch 対策）。

Closes fulgur-2map.10


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * HTML から最終ページの描画結果とページレイアウト情報をまとめて取得できる新しい公開 API を追加しました。
  * レイアウト処理を PDF 出力から切り離し、再利用しやすくしました。

* **バグ修正**
  * 2 回の処理が必要なケースで、参照先のページ番号が正しく反映されるようになりました。
  * レイアウト結果の外部利用時に、型や内容が安定して扱えるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->