### PR TITLE
docs(readme): document Engine::layout() API and link design doc (fulgur-2map.11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ serialization into the core crate.
 use fulgur::engine::{Engine, LayoutOutput};
 use fulgur::config::PageSize;
 
+let html = "<h1>Hello</h1>";
 let engine = Engine::builder().page_size(PageSize::A4).build();
 let out: LayoutOutput = engine.layout(html)?;
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,37 @@ let engine = Engine::builder()
 let pdf = engine.render(html)?;
 ```
 
+### Layout output (advanced)
+
+`Engine::layout()` exposes the shared parse → style → layout stage as a
+renderer-agnostic `LayoutOutput`, letting out-of-core consumers (image
+rasterization, OCR label generation) reuse Fulgur's layout without pulling PDF
+serialization into the core crate.
+
+```rust
+use fulgur::engine::{Engine, LayoutOutput};
+use fulgur::config::PageSize;
+
+let engine = Engine::builder().page_size(PageSize::A4).build();
+let out: LayoutOutput = engine.layout(html)?;
+
+// `LayoutOutput` is `#[non_exhaustive]`: read its fields, do not destructure it.
+let drawables = &out.drawables; // per-node draw payloads — coordinates in PDF pt
+let geometry = &out.geometry;   // pagination fragments — coordinates in CSS px
+```
+
+`layout()` runs the same two-pass resolution as `render()`, so `target-counter()`
+/ `target-text()` cross-references are already resolved in the returned
+`drawables`.
+
+**Limitations:** `LayoutOutput` carries **body** layout only. `@page` margin
+boxes and `position: running()` headers/footers are painted render-side and are
+not included, and the resolved page box (after `@page { size / margin }`
+overrides) is not yet surfaced — a consumer must not assume `Engine::config()`
+alone describes the canvas. See the design doc for the full contract and the
+consumer split (core owns unit conversion; consumers own composition):
+[`docs/plans/2026-06-27-engine-layout-api-design.md`](docs/plans/2026-06-27-engine-layout-api-design.md).
+
 ## Tagged PDF
 
 Fulgur can embed a semantic structure tree in the PDF output, required for accessibility tools and PDF/UA-1 conformance.


### PR DESCRIPTION
## 概要

Library Usage に **Layout output (advanced)** サブセクションを追加し、#566 でマージされた公開 API `Engine::layout() -> LayoutOutput` をドキュメント化する（epic `fulgur-2map` の P3c）。

- フィールドアクセスの利用例を提示。`LayoutOutput` は `#[non_exhaustive]` なので、外部 consumer は**フィールドを読む**（デストラクチャ不可）ことを明示。
- `drawables` = PDF pt / `geometry` = CSS px という単位契約を記載。
- `render()` と同じ 2-pass 解決を回すため `target-counter()` / `target-text()` が解決済みで返る点を記載。
- **body レイアウトのみ**という限界（`@page` margin box・`position: running()` は render-side で非包含、解決済み page box は未 surface）を記載。
- design doc `docs/plans/2026-06-27-engine-layout-api-design.md` へクロスリファレンス（P3c の明示的な受け入れ項目）。

## 変更点

- `README.md` に 31 行のサブセクションを追加（コード変更なし）。

## テスト計画

- [x] `npx markdownlint-cli2 'README.md'` → 0 errors
- [x] design doc リンク先 `docs/plans/2026-06-27-engine-layout-api-design.md` の実在を確認
- [x] スニペットの API 整合性を確認（`layout(&self, html: &str) -> Result<LayoutOutput>`、`page_size(PageSize)`、再エクスポート `fulgur::engine::{Engine, LayoutOutput}` / `fulgur::config::PageSize`）
- [x] README は doctest 非対象（`include_str!` なし）のため、スニペットは説明用でコンパイルゲートなし

Closes fulgur-2map.11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * `LayoutOutput` を使ったレイアウト結果の参照方法について、`layout()` の利用例を追加しました。
  * `drawables` と `geometry` の参照方法を明示し、`render()` と同様に参照解決済みの結果が得られることを説明しました。
  * `LayoutOutput` に含まれない情報や前提条件を追記し、設計ドキュメントへの案内を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->