### PR TITLE
refactor(fulgur): type gradient BgLengthPercentage coords to units::Pt

### DIFF
--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -8,6 +8,7 @@ use crate::draw_primitives::{
     BackgroundLayer, BgBox, BgClip, BgImageContent, BgLengthPercentage, BgRepeat, BgSize,
     BlockStyle, Canvas,
 };
+use crate::units::{F32Units, Px};
 
 /// Draw outer box-shadows behind the element's background.
 ///
@@ -971,9 +972,9 @@ fn expand_interpolation_hints(stops: Vec<ResolvedStop>) -> Vec<(f32, [u8; 4])> {
 /// Resolve `Vec<GradientStop>` (length / fraction / auto 混在) を krilla の
 /// `Stop` 列に変換する。
 ///
-/// **Unit contract:** `line_length` must be in **CSS px** (matching
+/// **Unit contract:** `line_length` is a [`Px`] (CSS px, matching
 /// `GradientStopPosition::LengthPx`). Callers in pt-space (Krilla draw
-/// surface) convert with `crate::convert::pt_to_px` before invoking.
+/// surface) tag with `.as_pt()` and convert with `.in_px()` before invoking.
 ///
 /// CSS Images Level 3 §3.5.1 の color-stop fixup に従って:
 ///   1. `LengthPx(px)` を `px / line_length` で fraction 化
@@ -988,7 +989,7 @@ fn expand_interpolation_hints(stops: Vec<ResolvedStop>) -> Vec<(f32, [u8; 4])> {
 /// `line_length <= 0` の場合は length stop が解決不能なので None。
 fn resolve_gradient_stops(
     stops: &[crate::draw_primitives::GradientStop],
-    line_length: f32,
+    line_length: Px,
     repeating: bool,
 ) -> Option<Vec<krilla::paint::Stop>> {
     use crate::draw_primitives::GradientStopPosition;
@@ -996,7 +997,7 @@ fn resolve_gradient_stops(
     if stops.len() < 2 {
         return None;
     }
-    if line_length <= 0.0 {
+    if line_length <= Px::ZERO {
         // length-typed stop が一つでもあれば解決不能。fraction-only でも
         // 退化した gradient なので Layer drop 相当 (caller で先に early
         // return しているため通常到達しない)。
@@ -1009,7 +1010,7 @@ fn resolve_gradient_stops(
         .map(|s| match s.position {
             GradientStopPosition::Auto => None,
             GradientStopPosition::Fraction(f) => Some(f),
-            GradientStopPosition::LengthPx(px) => Some(px / line_length),
+            GradientStopPosition::LengthPx(px) => Some(px.as_px() / line_length),
         })
         .collect();
 
@@ -1215,7 +1216,7 @@ fn draw_linear_gradient(
     // CSS px で保持されている。`resolve_gradient_stops` は同一単位空間での
     // `px / line_length` で fraction 化するので、line_length も CSS px に揃える。
     // (例: 400px box → length = 300pt → px 換算で 400 → 50px / 400 = 0.125)
-    let length_px = crate::convert::pt_to_px(length);
+    let length_px = length.as_pt().in_px();
     let Some(krilla_stops) = resolve_gradient_stops(stops, length_px, repeating) else {
         return;
     };
@@ -1341,7 +1342,7 @@ fn draw_radial_gradient(
     // Radial gradient line length = rx (CSS Images §3.6.1, ellipse でも +X 軸)。
     // rx は pt 単位 (ow/oh が pt) なので、`LengthPx` (CSS px) との比較のために
     // CSS px に揃える。
-    let rx_px = crate::convert::pt_to_px(rx);
+    let rx_px = rx.as_pt().in_px();
     let Some(krilla_stops) = resolve_gradient_stops(stops, rx_px, repeating) else {
         return;
     };
@@ -1692,7 +1693,7 @@ fn draw_gradient_tiling_pattern(
 /// CSS では radial-gradient の position percentage は container の幅/高さに対する単純な割合。
 fn resolve_point(lp: &BgLengthPercentage, container: f32) -> f32 {
     match lp {
-        BgLengthPercentage::Length(v) => *v,
+        BgLengthPercentage::Length(v) => v.to_f32(),
         BgLengthPercentage::Percentage(p) => container * p,
     }
 }
@@ -1700,7 +1701,7 @@ fn resolve_point(lp: &BgLengthPercentage, container: f32) -> f32 {
 /// `BgLengthPercentage` を半径として解決 (length はそのまま、percentage は container 基準)。
 fn resolve_length(lp: &BgLengthPercentage, container: f32) -> f32 {
     match lp {
-        BgLengthPercentage::Length(v) => *v,
+        BgLengthPercentage::Length(v) => v.to_f32(),
         BgLengthPercentage::Percentage(p) => container * p,
     }
 }
@@ -1797,7 +1798,7 @@ fn resolve_size(layer: &BackgroundLayer, origin_w: f32, origin_h: f32) -> (f32, 
 
 fn resolve_lp(lp: &BgLengthPercentage, basis: f32) -> f32 {
     match lp {
-        BgLengthPercentage::Length(v) => *v,
+        BgLengthPercentage::Length(v) => v.to_f32(),
         BgLengthPercentage::Percentage(p) => basis * p,
     }
 }
@@ -1805,7 +1806,7 @@ fn resolve_lp(lp: &BgLengthPercentage, basis: f32) -> f32 {
 /// CSS spec: position = (container - image) * percentage, or just length.
 fn resolve_position(lp: &BgLengthPercentage, container: f32, image: f32) -> f32 {
     match lp {
-        BgLengthPercentage::Length(v) => *v,
+        BgLengthPercentage::Length(v) => v.to_f32(),
         BgLengthPercentage::Percentage(p) => (container - image) * p,
     }
 }
@@ -2213,7 +2214,7 @@ mod tests {
 
     #[test]
     fn test_position_length() {
-        let offset = resolve_position(&BgLengthPercentage::Length(30.0), 200.0, 100.0);
+        let offset = resolve_position(&BgLengthPercentage::Length(30.0_f32.as_pt()), 200.0, 100.0);
         assert_eq!(offset, 30.0);
     }
 
@@ -2314,7 +2315,10 @@ mod tests {
 
     #[test]
     fn resolve_lp_length_returns_value() {
-        assert_eq!(resolve_lp(&BgLengthPercentage::Length(42.0), 200.0), 42.0);
+        assert_eq!(
+            resolve_lp(&BgLengthPercentage::Length(42.0_f32.as_pt()), 200.0),
+            42.0
+        );
     }
 
     #[test]
@@ -2333,8 +2337,8 @@ mod tests {
             100.0,
             50.0,
             BgSize::Explicit(
-                Some(BgLengthPercentage::Length(80.0)),
-                Some(BgLengthPercentage::Length(40.0)),
+                Some(BgLengthPercentage::Length(80.0_f32.as_pt())),
+                Some(BgLengthPercentage::Length(40.0_f32.as_pt())),
             ),
         );
         let (w, h) = resolve_size(&layer, 200.0, 200.0);
@@ -2348,7 +2352,7 @@ mod tests {
         let layer = make_layer(
             100.0,
             50.0,
-            BgSize::Explicit(Some(BgLengthPercentage::Length(80.0)), None),
+            BgSize::Explicit(Some(BgLengthPercentage::Length(80.0_f32.as_pt())), None),
         );
         let (w, h) = resolve_size(&layer, 200.0, 200.0);
         assert_eq!(w, 80.0);
@@ -2361,7 +2365,7 @@ mod tests {
         let layer = make_layer(
             100.0,
             50.0,
-            BgSize::Explicit(None, Some(BgLengthPercentage::Length(40.0))),
+            BgSize::Explicit(None, Some(BgLengthPercentage::Length(40.0_f32.as_pt()))),
         );
         let (w, h) = resolve_size(&layer, 200.0, 200.0);
         assert_eq!(w, 80.0);
@@ -2410,7 +2414,7 @@ mod tests {
     #[test]
     fn resolve_gradient_size_explicit_both_resolves() {
         let size = BgSize::Explicit(
-            Some(BgLengthPercentage::Length(50.0)),
+            Some(BgLengthPercentage::Length(50.0_f32.as_pt())),
             Some(BgLengthPercentage::Percentage(0.25)),
         );
         let (w, h) = resolve_gradient_size(&size, 200.0, 100.0);
@@ -2435,7 +2439,7 @@ mod tests {
     #[test]
     fn resolve_gradient_size_explicit_one_auto_uses_origin() {
         // width specified, height auto → height fills origin (no aspect)
-        let size = BgSize::Explicit(Some(BgLengthPercentage::Length(80.0)), None);
+        let size = BgSize::Explicit(Some(BgLengthPercentage::Length(80.0_f32.as_pt())), None);
         let (w, h) = resolve_gradient_size(&size, 200.0, 100.0);
         assert!((w - 80.0).abs() < 1e-6);
         assert!((h - 100.0).abs() < 1e-6);
@@ -3437,7 +3441,7 @@ mod tests {
     #[test]
     fn resolve_point_length_returns_value() {
         assert_eq!(
-            resolve_point(&BgLengthPercentage::Length(42.0), 200.0),
+            resolve_point(&BgLengthPercentage::Length(42.0_f32.as_pt()), 200.0),
             42.0
         );
     }
@@ -3453,7 +3457,7 @@ mod tests {
     #[test]
     fn resolve_length_length_returns_value() {
         assert_eq!(
-            resolve_length(&BgLengthPercentage::Length(15.0), 300.0),
+            resolve_length(&BgLengthPercentage::Length(15.0_f32.as_pt()), 300.0),
             15.0
         );
     }
@@ -3493,7 +3497,7 @@ mod resolve_gradient_stops_tests {
             stop(fr(0.0), [255, 0, 0, 255]),
             stop(fr(1.0), [0, 0, 255, 255]),
         ];
-        let out = resolve_gradient_stops(&stops, 100.0, false).unwrap();
+        let out = resolve_gradient_stops(&stops, 100.0_f32.as_px(), false).unwrap();
         assert_eq!(out.len(), 2);
         assert!((out[0].offset.get() - 0.0).abs() < 1e-6);
         assert!((out[1].offset.get() - 1.0).abs() < 1e-6);
@@ -3506,7 +3510,7 @@ mod resolve_gradient_stops_tests {
             stop(px(50.0), [0, 0, 255, 255]),
         ];
         // line_length = 100 → 50px = 0.5
-        let out = resolve_gradient_stops(&stops, 100.0, false).unwrap();
+        let out = resolve_gradient_stops(&stops, 100.0_f32.as_px(), false).unwrap();
         assert_eq!(out.len(), 2);
         assert!((out[1].offset.get() - 0.5).abs() < 1e-6);
     }
@@ -3514,7 +3518,7 @@ mod resolve_gradient_stops_tests {
     #[test]
     fn auto_position_filled_at_endpoints() {
         let stops = vec![stop(Auto, [255, 0, 0, 255]), stop(Auto, [0, 0, 255, 255])];
-        let out = resolve_gradient_stops(&stops, 100.0, false).unwrap();
+        let out = resolve_gradient_stops(&stops, 100.0_f32.as_px(), false).unwrap();
         assert!((out[0].offset.get() - 0.0).abs() < 1e-6);
         assert!((out[1].offset.get() - 1.0).abs() < 1e-6);
     }
@@ -3526,7 +3530,7 @@ mod resolve_gradient_stops_tests {
             stop(Auto, [0, 255, 0, 255]),
             stop(fr(1.0), [0, 0, 255, 255]),
         ];
-        let out = resolve_gradient_stops(&stops, 100.0, false).unwrap();
+        let out = resolve_gradient_stops(&stops, 100.0_f32.as_px(), false).unwrap();
         assert!((out[1].offset.get() - 0.5).abs() < 1e-6);
     }
 
@@ -3539,7 +3543,7 @@ mod resolve_gradient_stops_tests {
             stop(px(50.0), [0, 0, 255, 255]),
             stop(Auto, [0, 255, 0, 255]),
         ];
-        let out = resolve_gradient_stops(&stops, 100.0, false).unwrap();
+        let out = resolve_gradient_stops(&stops, 100.0_f32.as_px(), false).unwrap();
         assert_eq!(out.len(), 3);
         assert!((out[0].offset.get() - 0.0).abs() < 1e-6);
         assert!((out[1].offset.get() - 0.5).abs() < 1e-6);
@@ -3556,7 +3560,7 @@ mod resolve_gradient_stops_tests {
             stop(fr(0.0), [255, 0, 0, 255]),
             stop(px(50.0), [0, 0, 255, 255]),
         ];
-        let out = resolve_gradient_stops(&stops, 30.0, false).unwrap();
+        let out = resolve_gradient_stops(&stops, 30.0_f32.as_px(), false).unwrap();
         assert_eq!(out.len(), 2, "renormalize keeps 2 stops");
         assert!((out[0].offset.get() - 0.0).abs() < 1e-6);
         assert!((out[1].offset.get() - 1.0).abs() < 1e-6);
@@ -3570,7 +3574,7 @@ mod resolve_gradient_stops_tests {
             stop(fr(-0.1), [255, 0, 0, 255]),
             stop(fr(1.0), [0, 0, 255, 255]),
         ];
-        let out = resolve_gradient_stops(&stops, 100.0, false).unwrap();
+        let out = resolve_gradient_stops(&stops, 100.0_f32.as_px(), false).unwrap();
         assert_eq!(out.len(), 2, "renormalize keeps 2 stops");
         assert!((out[0].offset.get() - 0.0).abs() < 1e-6);
         assert!((out[1].offset.get() - 1.0).abs() < 1e-6);
@@ -3583,7 +3587,7 @@ mod resolve_gradient_stops_tests {
             stop(fr(0.6), [255, 0, 0, 255]),
             stop(fr(0.3), [0, 0, 255, 255]),
         ];
-        let out = resolve_gradient_stops(&stops, 100.0, false).unwrap();
+        let out = resolve_gradient_stops(&stops, 100.0_f32.as_px(), false).unwrap();
         assert!((out[0].offset.get() - 0.6).abs() < 1e-6);
         assert!((out[1].offset.get() - 0.6).abs() < 1e-6);
     }
@@ -3594,7 +3598,7 @@ mod resolve_gradient_stops_tests {
             stop(px(50.0), [255, 0, 0, 255]),
             stop(fr(1.0), [0, 0, 255, 255]),
         ];
-        let out = resolve_gradient_stops(&stops, 0.0, false);
+        let out = resolve_gradient_stops(&stops, 0.0_f32.as_px(), false);
         assert!(out.is_none());
     }
 
@@ -3607,7 +3611,7 @@ mod resolve_gradient_stops_tests {
             stop(fr(0.0), [255, 0, 0, 255]),
             stop(fr(0.25), [0, 0, 255, 255]),
         ];
-        let out = resolve_gradient_stops(&stops, 100.0, true).unwrap();
+        let out = resolve_gradient_stops(&stops, 100.0_f32.as_px(), true).unwrap();
         // 期待: forward = ceil(0.75/0.25) = 3, backward = 0
         // → k = 0, 1, 2, 3 で各周期の (red, blue) を配置
         // (0, red), (0.25, blue), (0.25, red), (0.5, blue), (0.5, red),
@@ -3644,7 +3648,7 @@ mod resolve_gradient_stops_tests {
             stop(fr(0.25), [255, 0, 0, 255]),
             stop(fr(0.5), [0, 0, 255, 255]),
         ];
-        let out = resolve_gradient_stops(&stops, 100.0, true).unwrap();
+        let out = resolve_gradient_stops(&stops, 100.0_f32.as_px(), true).unwrap();
         // backward = ceil(0.25/0.25) = 1, forward = ceil(0.5/0.25) = 2
         // 展開列: k=-1 (0.0 red, 0.25 blue), k=0 (0.25 red, 0.5 blue),
         //         k=1 (0.5 red, 0.75 blue), k=2 (0.75 red, 1.0 blue)
@@ -3666,7 +3670,8 @@ mod resolve_gradient_stops_tests {
             stop(fr(0.0), [255, 0, 0, 255]),
             stop(fr(0.0), [0, 0, 255, 255]),
         ];
-        let out = resolve_gradient_stops(&stops, 100.0, true).expect("solid fill, not None");
+        let out =
+            resolve_gradient_stops(&stops, 100.0_f32.as_px(), true).expect("solid fill, not None");
         // 単色 fill: 2 stops at 0.0/1.0 で同色 (blue)。renormalize の fast path
         // (全 stop in [0, 1]) を通って 2 stops のまま。
         assert_eq!(out.len(), 2);
@@ -3682,8 +3687,8 @@ mod resolve_gradient_stops_tests {
             stop(fr(0.0), [255, 0, 0, 255]),
             stop(fr(1.0), [0, 0, 255, 255]),
         ];
-        let repeat = resolve_gradient_stops(&stops, 100.0, true).unwrap();
-        let plain = resolve_gradient_stops(&stops, 100.0, false).unwrap();
+        let repeat = resolve_gradient_stops(&stops, 100.0_f32.as_px(), true).unwrap();
+        let plain = resolve_gradient_stops(&stops, 100.0_f32.as_px(), false).unwrap();
         // どちらも 2 stops で同じ位置。
         assert_eq!(repeat.len(), plain.len());
         for (r, p) in repeat.iter().zip(plain.iter()) {
@@ -3700,7 +3705,7 @@ mod resolve_gradient_stops_tests {
             stop(Auto, [0, 255, 0, 255]),
             stop(Auto, [0, 0, 255, 255]),
         ];
-        let out = resolve_gradient_stops(&stops, 100.0, true).unwrap();
+        let out = resolve_gradient_stops(&stops, 100.0_f32.as_px(), true).unwrap();
         // forward = backward = 0 → 1 copy = 3 stops
         assert_eq!(out.len(), 3);
         assert!((out[0].offset.get() - 0.0).abs() < 1e-5);
@@ -3716,7 +3721,7 @@ mod resolve_gradient_stops_tests {
             stop(px(0.0), [255, 0, 0, 255]),
             stop(px(25.0), [0, 0, 255, 255]),
         ];
-        let out = resolve_gradient_stops(&stops, 100.0, true).unwrap();
+        let out = resolve_gradient_stops(&stops, 100.0_f32.as_px(), true).unwrap();
         // line_length=100, 25px → 0.25 fraction → repeating_simple_period と
         // 同じ展開: 8 stops
         assert_eq!(out.len(), 8);
@@ -4893,6 +4898,7 @@ mod repeating_stops_tests {
 #[cfg(test)]
 mod gradient_size_tests {
     use super::{BgLengthPercentage, BgSize, resolve_gradient_size};
+    use crate::units::F32Units;
 
     #[test]
     fn auto_returns_origin_size() {
@@ -4921,15 +4927,15 @@ mod gradient_size_tests {
     #[test]
     fn explicit_both_axes_resolved() {
         let size = BgSize::Explicit(
-            Some(BgLengthPercentage::Length(80.0)),
-            Some(BgLengthPercentage::Length(60.0)),
+            Some(BgLengthPercentage::Length(80.0_f32.as_pt())),
+            Some(BgLengthPercentage::Length(60.0_f32.as_pt())),
         );
         assert_eq!(resolve_gradient_size(&size, 300.0, 200.0), (80.0, 60.0));
     }
 
     #[test]
     fn explicit_width_only_height_falls_back_to_origin() {
-        let size = BgSize::Explicit(Some(BgLengthPercentage::Length(150.0)), None);
+        let size = BgSize::Explicit(Some(BgLengthPercentage::Length(150.0_f32.as_pt())), None);
         let (w, h) = resolve_gradient_size(&size, 300.0, 200.0);
         assert_eq!(w, 150.0);
         assert_eq!(h, 200.0); // None → origin_h
@@ -4937,7 +4943,7 @@ mod gradient_size_tests {
 
     #[test]
     fn explicit_height_only_width_falls_back_to_origin() {
-        let size = BgSize::Explicit(None, Some(BgLengthPercentage::Length(50.0)));
+        let size = BgSize::Explicit(None, Some(BgLengthPercentage::Length(50.0_f32.as_pt())));
         let (w, h) = resolve_gradient_size(&size, 300.0, 200.0);
         assert_eq!(w, 300.0); // None → origin_w
         assert_eq!(h, 50.0);
@@ -5176,6 +5182,7 @@ mod ellipse_corner_scale_tests {
 #[cfg(test)]
 mod tile_position_tests {
     use super::{BgRepeat, compute_tile_positions, compute_tile_positions_slow};
+    use crate::units::F32Units;
 
     fn approx(a: f32, b: f32) -> bool {
         (a - b).abs() < 1e-3
@@ -5394,7 +5401,7 @@ mod tile_position_tests {
                 is_hint: false,
             },
         ];
-        let out = resolve_gradient_stops(&stops, 100.0, false).unwrap();
+        let out = resolve_gradient_stops(&stops, 100.0_f32.as_px(), false).unwrap();
         assert_eq!(out.len(), 2);
         assert_eq!(out[0].offset, krilla::num::NormalizedF32::ZERO);
         assert_eq!(out[1].offset, krilla::num::NormalizedF32::ONE);
@@ -5410,7 +5417,7 @@ mod tile_position_tests {
             rgba: [255, 0, 0, 255],
             is_hint: false,
         }];
-        assert!(resolve_gradient_stops(&stops, 100.0, false).is_none());
+        assert!(resolve_gradient_stops(&stops, 100.0_f32.as_px(), false).is_none());
     }
 
     #[test]
@@ -5430,7 +5437,7 @@ mod tile_position_tests {
                 is_hint: false,
             },
         ];
-        assert!(resolve_gradient_stops(&stops, 0.0, false).is_none());
+        assert!(resolve_gradient_stops(&stops, 0.0_f32.as_px(), false).is_none());
     }
 
     #[test]
@@ -5456,7 +5463,7 @@ mod tile_position_tests {
                 is_hint: false,
             },
         ];
-        let out = resolve_gradient_stops(&stops, 100.0, false).unwrap();
+        let out = resolve_gradient_stops(&stops, 100.0_f32.as_px(), false).unwrap();
         assert_eq!(out.len(), 3);
         let mid_offset = out[1].offset.get();
         assert!((mid_offset - 0.5).abs() < 1e-5, "mid offset={mid_offset}");
@@ -5485,7 +5492,7 @@ mod tile_position_tests {
                 is_hint: false,
             },
         ];
-        let out = resolve_gradient_stops(&stops, 100.0, false).unwrap();
+        let out = resolve_gradient_stops(&stops, 100.0_f32.as_px(), false).unwrap();
         assert_eq!(out.len(), 3);
         assert_eq!(out[0].offset, krilla::num::NormalizedF32::ZERO);
         let mid = out[1].offset.get();
@@ -5511,7 +5518,7 @@ mod tile_position_tests {
                 is_hint: false,
             },
         ];
-        let out = resolve_gradient_stops(&stops, 100.0, true).unwrap();
+        let out = resolve_gradient_stops(&stops, 100.0_f32.as_px(), true).unwrap();
         // repeating expands: many copies needed to cover [0, 1]
         assert!(out.len() > 2, "repeating should expand beyond 2 stops");
         assert_eq!(out[0].offset, krilla::num::NormalizedF32::ZERO);

--- a/crates/fulgur/src/convert/style/background.rs
+++ b/crates/fulgur/src/convert/style/background.rs
@@ -1,12 +1,13 @@
 //! background-color and background-image-layers extraction.
 
 use super::{StyleContext, absolute_to_rgba};
-use crate::convert::{extract_asset_name, px_to_pt};
+use crate::convert::extract_asset_name;
 use crate::draw_primitives::{
     BackgroundLayer, BgBox, BgClip, BgImageContent, BgLengthPercentage, BgRepeat, BgSize,
     BlockStyle,
 };
 use crate::image::ImageRender;
+use crate::units::{F32Units, Pt};
 use std::sync::Arc;
 
 pub(super) fn apply_to(style: &mut BlockStyle, ctx: &StyleContext<'_>) {
@@ -343,8 +344,8 @@ fn resolve_radial_gradient(
 
     let (out_shape, out_size) = match shape {
         EndingShape::Circle(Circle::Radius(r)) => {
-            // r: NonNegativeLength = NonNegative<Length>。.0.px() で CSS px、px_to_pt() で pt 化。
-            let len_pt = px_to_pt(r.0.px());
+            // r: NonNegativeLength = NonNegative<Length>。.0.px() で CSS px、.as_px().in_pt() で pt 化。
+            let len_pt = r.0.px().as_px().in_pt();
             (
                 RadialGradientShape::Circle,
                 RadialGradientSize::Explicit {
@@ -531,7 +532,11 @@ fn convert_lp_to_bg(lp: &style::values::computed::LengthPercentage) -> BgLengthP
     if let Some(pct) = lp.to_percentage() {
         BgLengthPercentage::Percentage(pct.0)
     } else {
-        BgLengthPercentage::Length(lp.to_length().map(|l| px_to_pt(l.px())).unwrap_or(0.0))
+        BgLengthPercentage::Length(
+            lp.to_length()
+                .map(|l| l.px().as_px().in_pt())
+                .unwrap_or(Pt::ZERO),
+        )
     }
 }
 
@@ -545,7 +550,7 @@ fn try_convert_lp_to_bg(
         Some(BgLengthPercentage::Percentage(pct.0))
     } else {
         lp.to_length()
-            .map(|l| BgLengthPercentage::Length(px_to_pt(l.px())))
+            .map(|l| BgLengthPercentage::Length(l.px().as_px().in_pt()))
     }
 }
 

--- a/crates/fulgur/src/draw_primitives.rs
+++ b/crates/fulgur/src/draw_primitives.rs
@@ -712,8 +712,8 @@ pub enum Overflow {
 /// A length or percentage value for background positioning/sizing.
 #[derive(Clone, Debug)]
 pub enum BgLengthPercentage {
-    /// Absolute length in points.
-    Length(f32),
+    /// Absolute length in PDF points.
+    Length(crate::units::Pt),
     /// Percentage (0.0–1.0).
     Percentage(f32),
 }

--- a/docs/plans/2026-07-04-fulgur-sipv.4-gradient-coords-pt.md
+++ b/docs/plans/2026-07-04-fulgur-sipv.4-gradient-coords-pt.md
@@ -1,0 +1,124 @@
+# fulgur-sipv.4: Type gradient coords to `Pt` — Implementation Plan
+
+**Goal:** Migrate `draw_primitives::BgLengthPercentage::Length(f32)` to
+`Length(units::Pt)` and collapse the surrounding `px_to_pt` / `pt_to_px`
+call sites to typed `.in_pt()` / `.in_px()`, eliminating 5 raw-`f32`
+conversion sites in the gradient subsystem. **Byte-neutral** per epic
+`fulgur-sipv` protocol.
+
+**Architecture:** `BgLengthPercentage::Length` holds an absolute length that
+is always PDF-pt-valued (producers convert CSS-px → pt at construction). Making
+the payload a `Pt` lets the three producer sites collapse to
+`…px().as_px().in_pt()` and lets the two draw-side `pt_to_px` conversions become
+`…as_pt().in_px()`. `resolve_gradient_stops`'s `line_length` param is retyped to
+`Px` (its natural unit — it divides against CSS-px `LengthPx` stop positions) so
+the call sites stay clean with no reintroduced `.to_f32()`. The four `resolve_*`
+consumers keep their f32 (pt-space) return type — this subtask does **not** type
+the draw geometry — so their `Length(v)` arms become `v.to_f32()`.
+
+**Tech Stack:** Rust, `crate::units::{Px, Pt, F32Units}` newtypes, Krilla,
+Stylo. Verification: `cargo test -p fulgur --lib`, `cargo test -p fulgur-vrt`
+(byte compare), `cargo clippy -D warnings`, `cargo fmt`.
+
+---
+
+## Byte-neutrality invariant (why this is safe)
+
+`convert::px_to_pt(v) = v * PX_TO_PT` is bit-identical to `Px::in_pt = Pt(self.0 * PX_TO_PT)`;
+`convert::pt_to_px(v) = v / PX_TO_PT` is bit-identical to `Pt::in_px = Px(self.0 / PX_TO_PT)`
+(both reference `crate::units::PX_TO_PT`, same operand order). `*v` (f32) and
+`v.to_f32()` (Pt→f32) are the same bits. `px / line_length` (f32/f32) and
+`px.as_px() / line_length` (`Px / Px` → `self.0 / rhs.0`) are the same division.
+**No arithmetic operand order changes anywhere.** Final proof is the VRT byte
+compare; never run `FULGUR_VRT_UPDATE=1`.
+
+## Patch-coverage note
+
+Every changed PROD line is exercised by a **non-VRT lib test** (codecov patch
+runs `--exclude fulgur-vrt`):
+
+| Changed line | Covering lib test |
+|---|---|
+| `convert/style/background.rs:347` (circle radius) | `radial_gradient_circle_explicit_radius` |
+| `:534` (`convert_lp_to_bg` length) | `background-size:50px 40px` case in convert tests |
+| `:548` (`try_convert_lp_to_bg` length) | `radial_gradient_ellipse_explicit_radii` |
+| `background.rs:1012` (`LengthPx` arm) | `resolve_gradient_stops_length_px_converted_to_fraction` |
+| `:1218` / `:1344` (draw locals) | gradient render lib tests (linear/radial) |
+| `:1695/1703/1800/1808` (`resolve_*` arms) | `resolve_point/length/lp/position` unit tests |
+
+No new PROD test is required. Test-side edits must NOT reintroduce cold-path
+`.to_f32()`: compare extracted `Length(v)` as `v == X.as_pt()` (Pt `PartialEq`),
+not `v.to_f32() == X`.
+
+---
+
+## Task 1: Retype the enum payload
+
+**Files:** Modify `crates/fulgur/src/draw_primitives.rs:716`
+
+Change `Length(f32)` → `Length(crate::units::Pt)` (use the path already imported
+in the module, or `units::Pt`). Update the doc comment ("Absolute length in
+points" stays accurate).
+
+**Verify:** `cargo build -p fulgur` — expect compile errors at every producer
+and every `Length(v) => *v` consumer (the compiler is the inventory).
+
+## Task 2: Collapse the three producers (`convert/style/background.rs`)
+
+- `:347` `let len_pt = px_to_pt(r.0.px());` → `let len_pt = r.0.px().as_px().in_pt();`
+- `:534` `Length(lp.to_length().map(|l| px_to_pt(l.px())).unwrap_or(0.0))`
+  → `Length(lp.to_length().map(|l| l.px().as_px().in_pt()).unwrap_or(crate::units::Pt::ZERO))`
+- `:548` `.map(|l| BgLengthPercentage::Length(px_to_pt(l.px())))`
+  → `.map(|l| BgLengthPercentage::Length(l.px().as_px().in_pt()))`
+
+Add `use crate::units::F32Units;` (for `.as_px`) if not already in scope; drop
+the now-unused `px_to_pt` import if it becomes dead.
+
+## Task 3: Retype the four `resolve_*` consumer arms (`background.rs`)
+
+`resolve_point:1695`, `resolve_length:1703`, `resolve_lp:1800`,
+`resolve_position:1808`: `BgLengthPercentage::Length(v) => *v` →
+`BgLengthPercentage::Length(v) => v.to_f32()`. Return types stay `f32`.
+
+## Task 4: Collapse the two draw-side conversions + retype `resolve_gradient_stops`
+
+- `resolve_gradient_stops:991` param `line_length: f32` → `line_length: Px`.
+  - body `:999` `if line_length <= 0.0` → `if line_length <= Px::ZERO`
+  - body `:1012` `GradientStopPosition::LengthPx(px) => Some(px / line_length)`
+    → `Some(px.as_px() / line_length)`
+- `draw_linear_gradient:1218` `let length_px = crate::convert::pt_to_px(length);`
+  → `let length_px = length.as_pt().in_px();`
+- `draw_radial_gradient:1344` `let rx_px = crate::convert::pt_to_px(rx);`
+  → `let rx_px = rx.as_pt().in_px();`
+
+Add `use crate::units::{F32Units, Px};` to `background.rs` as needed. (`length`
+and `rx` stay `f32` — fully typing them cascades into `cx_box - sin*half`
+f32 geometry, out of this subtask's scope; tagging at the boundary satisfies
+"consistently" and stays byte-neutral.)
+
+## Task 5: Fix test constructors / call sites
+
+- `BgLengthPercentage::Length(N.0)` literals (background.rs ~14 test sites:
+  2216, 2317, 2336, 2337, 2351, 2364, 2413, 2438, 3440, 3456, 4924, 4925,
+  4932, 4940) → `Length(N.0_f32.as_pt())`.
+- `resolve_gradient_stops(&stops, N.0, …)` literals (~22 test sites in the two
+  test mods) → second arg `N.0_f32.as_px()`.
+
+## Task 6: Verification gates (all must pass)
+
+```bash
+cargo fmt                       # normalize (fmt may re-single-line shrunken asserts)
+cargo fmt --check
+cargo build -p fulgur
+cargo clippy -p fulgur --all-targets -- -D warnings
+cargo test -p fulgur --lib
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur-vrt
+git status --short crates/fulgur-vrt/goldens   # MUST be empty (byte-identical)
+```
+
+## Task 7: Commit
+
+```bash
+git add -A
+git commit -m "refactor(fulgur): type gradient BgLengthPercentage coords to units::Pt"
+```


### PR DESCRIPTION
## 概要

epic **fulgur-sipv**（`px_to_pt`/`pt_to_px` の内部撲滅 = Px/Pt newtype 移行）のサブタスク **fulgur-sipv.4** です。gradient サブシステムの 5 箇所の raw-`f32` 変換を型付きの `.in_pt()`/`.in_px()` に collapse します。**byte-neutral**（PDF 出力バイト不変）。

## 変更内容

- `draw_primitives::BgLengthPercentage::Length(f32)` → `Length(units::Pt)`（payload は常に PDF pt 値）
- **producer 3 箇所**（`convert/style/background.rs`）:
  - circle radius / `convert_lp_to_bg` / `try_convert_lp_to_bg`
  - `px_to_pt(l.px())` → `l.px().as_px().in_pt()`、`.unwrap_or(0.0)` → `.unwrap_or(Pt::ZERO)`
- **draw 側 2 箇所**（`background.rs`）:
  - `resolve_gradient_stops` の `line_length` パラメータを `Px` 型化（`px / line_length` が `Px / Px` の無次元比に）
  - `pt_to_px(length)` / `pt_to_px(rx)` → `.as_pt().in_px()`
- `resolve_point`/`resolve_length`/`resolve_lp`/`resolve_position` の 4 consumer は f32（pt 空間）返却を維持（`v.to_f32()`）。draw geometry の完全型化は本サブタスク対象外（`cx_box - sin*half` の f32 演算にカスケードするため）で、境界タグに留めて "consistently" を満たす。

## byte-neutrality の根拠

- `convert::px_to_pt = v * PX_TO_PT` は `Px::in_pt` と、`pt_to_px = v / PX_TO_PT` は `Pt::in_px` と bit-identical（同一定数・同一演算順、共に `crate::units::PX_TO_PT` 参照）
- 演算のオペランド順は不変（reassociation なし）
- **決定的証拠: VRT golden byte 比較で差分ゼロ**

## 検証

- `cargo fmt --check` clean
- `cargo clippy -p fulgur --all-targets -- -D warnings` exit 0
- `cargo test -p fulgur`（lib 1604 + 統合テスト render_smoke/gradient/gcpm 等）全 pass
- `cargo test -p fulgur-vrt` byte-identical（`goldens/` 差分なし、`FULGUR_VRT_UPDATE` 不使用）
- patch coverage 実測（`cargo llvm-cov nextest --workspace --exclude fulgur-vrt`）: 追加行 ∩ uncovered = **0**
- public 型変更の影響範囲: `crates/fulgur` 内部限定（外部 consumer なし、crate root 非公開）

Closes fulgur-sipv.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * グラデーションの位置・長さの扱いを統一し、表示ずれや端点計算の不整合を改善しました。
  * 線形・放射グラデーションの座標変換を明確化し、より安定した描画結果になるようにしました。
* **Documentation**
  * グラデーション座標の単位扱いに関する作業計画ドキュメントを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->