### PR TITLE
refactor(fulgur): type absolute-positioning CB geometry to units::Px

### DIFF
--- a/crates/fulgur/src/convert/positioned.rs
+++ b/crates/fulgur/src/convert/positioned.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::units::{F32Units, Pt, Px};
 
 /// Walk a parent node's child id list, recursing into each via
 /// `convert_node`. Replaces v1's `collect_positioned_children`: instead of
@@ -74,21 +75,21 @@ fn is_position_static(node: &Node) -> bool {
 #[derive(Clone, Copy)]
 #[allow(dead_code)]
 pub(super) struct AbsCb {
-    pub(super) padding_box_size: (f32, f32),
-    pub(super) border_top_left: (f32, f32),
+    pub(super) padding_box_size: (Px, Px),
+    pub(super) border_top_left: (Px, Px),
     pub(super) parent_offset_in_cb_bp: (f32, f32),
 }
 
-fn cb_padding_box(node: &Node) -> ((f32, f32), (f32, f32)) {
+fn cb_padding_box(node: &Node) -> ((Px, Px), (Px, Px)) {
     let style = extract_block_style(node, None);
-    let bl_pt = style.border_widths[3].to_f32();
-    let br_pt = style.border_widths[1].to_f32();
-    let bt_pt = style.border_widths[0].to_f32();
-    let bb_pt = style.border_widths[2].to_f32();
+    let bl_pt = style.border_widths[3];
+    let br_pt = style.border_widths[1];
+    let bt_pt = style.border_widths[0];
+    let bb_pt = style.border_widths[2];
     let sz = node.final_layout.size;
-    let pb_w = (sz.width - pt_to_px(bl_pt + br_pt)).max(0.0);
-    let pb_h = (sz.height - pt_to_px(bt_pt + bb_pt)).max(0.0);
-    ((pb_w, pb_h), (pt_to_px(bl_pt), pt_to_px(bt_pt)))
+    let pb_w = (sz.width.as_px() - (bl_pt + br_pt).in_px()).max(Px::ZERO);
+    let pb_h = (sz.height.as_px() - (bt_pt + bb_pt).in_px()).max(Px::ZERO);
+    ((pb_w, pb_h), (bl_pt.in_px(), bt_pt.in_px()))
 }
 
 fn resolve_cb_for_absolute(
@@ -122,11 +123,11 @@ fn resolve_cb_for_absolute(
             if elem.name.local.as_ref() == "body" {
                 let (mut padding_box_size, border_top_left) = cb_padding_box(cur);
                 if let Some((vw, vh)) = viewport_size_px {
-                    if padding_box_size.0 <= 0.0 {
-                        padding_box_size.0 = vw;
+                    if padding_box_size.0 <= Px::ZERO {
+                        padding_box_size.0 = vw.as_px();
                     }
-                    if padding_box_size.1 <= 0.0 {
-                        padding_box_size.1 = vh;
+                    if padding_box_size.1 <= Px::ZERO {
+                        padding_box_size.1 = vh.as_px();
                     }
                 }
                 body_fallback = Some(AbsCb {
@@ -164,12 +165,14 @@ fn resolve_cb_for_absolute(
 // origin, no size dependence).
 fn resolve_inset_px(
     inset: &::style::values::computed::position::Inset,
-    basis_px: f32,
-) -> Option<f32> {
+    basis_px: Px,
+) -> Option<Px> {
     use ::style::values::computed::Length;
     use ::style::values::generics::position::GenericInset;
     match inset {
-        GenericInset::LengthPercentage(lp) => Some(lp.resolve(Length::new(basis_px)).px()),
+        GenericInset::LengthPercentage(lp) => {
+            Some(lp.resolve(Length::new(basis_px.to_f32())).px().as_px())
+        }
         _ => None,
     }
 }
@@ -178,7 +181,7 @@ fn resolve_inset_px(
 /// `pagination_geometry` for a textless `content: url(...)` abs pseudo
 /// whose `right` or `bottom` inset was specified.
 ///
-/// `pseudo_w_pt` / `pseudo_h_pt` come from the just-built `ImageEntry`,
+/// `pseudo_w` / `pseudo_h` (pt) come from the just-built `ImageEntry`,
 /// which sized the image from the pseudo's CSS `width` / `height`
 /// (via `build_pseudo_image_entry`). For pseudos that didn't set a
 /// `right` or `bottom` inset, this is a no-op — Taffy's location is
@@ -199,8 +202,8 @@ fn maybe_apply_abs_pseudo_inset_correction(
     pseudo_id: usize,
     parent_id: usize,
     cb: AbsCb,
-    pseudo_w_pt: f32,
-    pseudo_h_pt: f32,
+    pseudo_w: Pt,
+    pseudo_h: Pt,
     ctx: &mut ConvertContext<'_>,
 ) {
     // Defer to `append_position_fixed_fragments` for `position: fixed`:
@@ -264,11 +267,11 @@ fn maybe_apply_abs_pseudo_inset_correction(
     else {
         return;
     };
-    let parent_x_px = parent_frag.x.to_f32();
-    let parent_y_px = parent_frag.y.to_f32();
+    let parent_x_px = parent_frag.x;
+    let parent_y_px = parent_frag.y;
 
-    let pseudo_w_px = pt_to_px(pseudo_w_pt);
-    let pseudo_h_px = pt_to_px(pseudo_h_pt);
+    let pseudo_w_px = pseudo_w.in_px();
+    let pseudo_h_px = pseudo_h.in_px();
 
     // CSS 2.1 §10.3.7 / §10.6.4: when start-side is auto, end-side
     // determines position. Use the pseudo's effective image size
@@ -279,12 +282,12 @@ fn maybe_apply_abs_pseudo_inset_correction(
         cb_w_px - pseudo_w_px - right.unwrap()
     } else {
         // left is Some (or both auto -> 0)
-        left.unwrap_or(0.0)
+        left.unwrap_or(Px::ZERO)
     };
     let y_in_pp_px = if needs_bottom {
         cb_h_px - pseudo_h_px - bottom.unwrap()
     } else {
-        top.unwrap_or(0.0)
+        top.unwrap_or(Px::ZERO)
     };
 
     // Padding-box frame → CB border-box frame → parent's frame.
@@ -294,8 +297,8 @@ fn maybe_apply_abs_pseudo_inset_correction(
     // CB" case this is `(0, 0)`.
     let (bl_px, bt_px) = cb.border_top_left;
     let (ox_px, oy_px) = cb.parent_offset_in_cb_bp;
-    let pseudo_local_x_px = x_in_pp_px + bl_px - ox_px;
-    let pseudo_local_y_px = y_in_pp_px + bt_px - oy_px;
+    let pseudo_local_x_px = x_in_pp_px + bl_px - ox_px.as_px();
+    let pseudo_local_y_px = y_in_pp_px + bt_px - oy_px.as_px();
 
     let new_x_px = parent_x_px + pseudo_local_x_px;
     let new_y_px = parent_y_px + pseudo_local_y_px;
@@ -306,10 +309,10 @@ fn maybe_apply_abs_pseudo_inset_correction(
     entry.fragments.clear();
     entry.fragments.push(crate::pagination_layout::Fragment {
         page_index: parent_frag.page_index,
-        x: new_x_px.as_px(),
-        y: new_y_px.as_px(),
-        width: pseudo_w_px.as_px(),
-        height: pseudo_h_px.as_px(),
+        x: new_x_px,
+        y: new_y_px,
+        width: pseudo_w_px,
+        height: pseudo_h_px,
     });
 }
 
@@ -368,7 +371,7 @@ pub(super) fn walk_absolute_pseudo_children(
             // and shifts the image off by its own w/h. Re-apply the
             // inset against the pseudo's effective image size and
             // overwrite the fragmenter's wrong placement.
-            let (img_w_pt, img_h_pt) = (img.width.to_f32(), img.height.to_f32());
+            let (img_w, img_h) = (img.width, img.height);
             out.images.insert(pseudo_id, img);
             if let Some(cb_resolved) = _cb {
                 maybe_apply_abs_pseudo_inset_correction(
@@ -376,8 +379,8 @@ pub(super) fn walk_absolute_pseudo_children(
                     pseudo_id,
                     node.id,
                     cb_resolved,
-                    img_w_pt,
-                    img_h_pt,
+                    img_w,
+                    img_h,
                     ctx,
                 );
             }
@@ -445,11 +448,11 @@ pub(super) fn try_build_absolute_pseudo_image(
     }
     let (basis_w_pt, basis_h_pt) = if let Some(cb) = cb {
         let (w_px, h_px) = cb.padding_box_size;
-        (px_to_pt(w_px), px_to_pt(h_px))
+        (w_px.in_pt(), h_px.in_pt())
     } else {
         (
-            px_to_pt(parent.final_layout.size.width),
-            px_to_pt(parent.final_layout.size.height),
+            parent.final_layout.size.width.as_px().in_pt(),
+            parent.final_layout.size.height.as_px().in_pt(),
         )
     };
     pseudo::build_pseudo_image_entry(pseudo, basis_w_pt, basis_h_pt, assets)
@@ -855,6 +858,7 @@ mod tests {
         let div_id = find_tag(&doc, "div");
         let node = doc.get_node(div_id).unwrap();
         let ((pb_w, pb_h), (bl, bt)) = cb_padding_box(node);
+        let (pb_w, pb_h, bl, bt) = (pb_w.to_f32(), pb_h.to_f32(), bl.to_f32(), bt.to_f32());
         let sz = node.final_layout.size;
         // No border → pb_w == sz.width, pb_h == sz.height.
         assert!(
@@ -889,6 +893,7 @@ mod tests {
         let div_id = find_tag(&doc, "div");
         let node = doc.get_node(div_id).unwrap();
         let ((pb_w, _pb_h), (bl, bt)) = cb_padding_box(node);
+        let (pb_w, bl, bt) = (pb_w.to_f32(), bl.to_f32(), bt.to_f32());
         let sz = node.final_layout.size;
         // With 10px border on each side, the border-box is 120×120px and the
         // padding box (content) is 100×100px.
@@ -923,7 +928,7 @@ mod tests {
         );
         let cb = result.unwrap();
         assert!(
-            cb.padding_box_size.0 > 0.0,
+            cb.padding_box_size.0 > Px::ZERO,
             "CB padding-box width should be > 0 (section has explicit width)"
         );
     }
@@ -949,10 +954,35 @@ mod tests {
         // Body is viewport-wide (~579px after default margins), which is wider
         // than the 200px div. Asserting > 200 proves the function used the body
         // CB and did not stop at the static div ancestor.
+        let cb_w = cb.padding_box_size.0.to_f32();
         assert!(
-            cb.padding_box_size.0 > 200.0,
-            "body padding-box width should exceed the 200px static div, confirming body fallback was used; got {}",
-            cb.padding_box_size.0
+            cb_w > 200.0,
+            "body padding-box width should exceed the 200px static div, confirming body fallback was used; got {cb_w}"
+        );
+    }
+
+    #[test]
+    fn resolve_cb_for_absolute_zero_width_body_substitutes_viewport_width() {
+        // A body forced to zero width: `cb_padding_box().0 == 0`, so the body
+        // fallback substitutes the viewport width. Exercises the
+        // `padding_box_size.0 = vw.as_px()` branch (the width sibling of the
+        // height fallback already covered by the tests above).
+        let doc = parse_doc(
+            r#"<!doctype html><html><body style="width:0;">
+                <div style="width:200px;height:100px;">
+                    <span>text</span>
+                </div>
+            </body></html>"#,
+        );
+        let span_id = find_tag(&doc, "span");
+        let span_node = doc.get_node(span_id).unwrap();
+        let result = resolve_cb_for_absolute(doc.deref(), span_node, false, Some((595.0, 842.0)));
+        let cb = result.expect("body fallback should produce Some");
+        // Body width resolved to 0 → replaced with the viewport width (595).
+        assert_eq!(
+            cb.padding_box_size.0,
+            595.0_f32.as_px(),
+            "zero-width body must substitute the viewport width"
         );
     }
 
@@ -977,10 +1007,10 @@ mod tests {
         // Body is viewport-wide (~579px after default margins), which is wider
         // than the 200px section. Asserting > 200 proves the function skipped
         // the relative section and used the body CB instead.
+        let cb_w = cb.padding_box_size.0.to_f32();
         assert!(
-            cb.padding_box_size.0 > 200.0,
-            "fixed: body padding-box width should exceed the 200px relative section, confirming it was skipped; got {}",
-            cb.padding_box_size.0
+            cb_w > 200.0,
+            "fixed: body padding-box width should exceed the 200px relative section, confirming it was skipped; got {cb_w}"
         );
     }
 
@@ -1235,7 +1265,7 @@ mod tests {
         );
         // The body width in a 595-px viewport should be > 0.
         assert!(
-            result.unwrap().padding_box_size.0 > 0.0,
+            result.unwrap().padding_box_size.0 > Px::ZERO,
             "body padding-box width must be positive"
         );
     }
@@ -1307,8 +1337,8 @@ mod tests {
             .get_node(before_id)
             .expect("::before node should be retrievable");
         let ab_cb = AbsCb {
-            padding_box_size: (100.0, 100.0),
-            border_top_left: (0.0, 0.0),
+            padding_box_size: (100.0_f32.as_px(), 100.0_f32.as_px()),
+            border_top_left: (Px::ZERO, Px::ZERO),
             parent_offset_in_cb_bp: (0.0, 0.0),
         };
         let result = try_build_absolute_pseudo_image(before_node, div_node, Some(ab_cb), None);

--- a/crates/fulgur/src/convert/pseudo.rs
+++ b/crates/fulgur/src/convert/pseudo.rs
@@ -10,8 +10,8 @@ use crate::units::F32Units;
 /// Returns `None` under the same conditions as the v1 `build_pseudo_image`.
 pub(super) fn build_pseudo_image_entry(
     pseudo_node: &Node,
-    parent_content_width: f32,
-    parent_content_height: f32,
+    parent_content_width: Pt,
+    parent_content_height: Pt,
     assets: Option<&AssetBundle>,
 ) -> Option<crate::drawables::ImageEntry> {
     let assets = assets?;
@@ -150,7 +150,12 @@ fn build_block_pseudo_image_entries(
         if is_absolutely_positioned(pseudo) {
             return None;
         }
-        let entry = build_pseudo_image_entry(pseudo, parent_cb.width, parent_cb.height, assets)?;
+        let entry = build_pseudo_image_entry(
+            pseudo,
+            parent_cb.width.as_pt(),
+            parent_cb.height.as_pt(),
+            assets,
+        )?;
         Some((id, entry))
     };
     (load(parent.before), load(parent.after))
@@ -172,8 +177,8 @@ pub(super) fn build_inline_pseudo_image(
     let format = ImageRender::detect_format(&data)?;
 
     let styles = pseudo_node.primary_styles()?;
-    let css_w = resolve_pseudo_size(&styles.clone_width(), parent_content_width);
-    let css_h = resolve_pseudo_size(&styles.clone_height(), parent_content_height);
+    let css_w = resolve_pseudo_size(&styles.clone_width(), parent_content_width.as_pt());
+    let css_h = resolve_pseudo_size(&styles.clone_height(), parent_content_height.as_pt());
     let (w, h) = resolve_image_dimensions(&data, format, css_w, css_h);
     let (opacity, visible) = extract_opacity_visible(pseudo_node);
     let vertical_align = crate::blitz_adapter::extract_vertical_align(pseudo_node);
@@ -250,13 +255,19 @@ pub(super) fn inject_inline_pseudo_images(
 
 /// Resolve a stylo `Size` (`width` / `height`) to an absolute `f32` in pt,
 /// or `None` for `auto` and intrinsic keywords.
-fn resolve_pseudo_size(size: &::style::values::computed::Size, parent_width: f32) -> Option<f32> {
+fn resolve_pseudo_size(size: &::style::values::computed::Size, parent_width: Pt) -> Option<f32> {
     use ::style::values::computed::Length;
     use ::style::values::generics::length::GenericSize;
     match size {
         GenericSize::LengthPercentage(lp) => {
-            let basis_px = pt_to_px(parent_width);
-            Some(px_to_pt(lp.0.resolve(Length::new(basis_px)).px()))
+            let basis_px = parent_width.in_px();
+            Some(
+                lp.0.resolve(Length::new(basis_px.to_f32()))
+                    .px()
+                    .as_px()
+                    .in_pt()
+                    .to_f32(),
+            )
         }
         _ => None,
     }

--- a/crates/fulgur/src/units.rs
+++ b/crates/fulgur/src/units.rs
@@ -165,10 +165,9 @@ impl_unit_arith!(Px);
 impl_unit_arith!(Pt);
 
 impl Px {
-    /// The zero length. Use instead of `0.0_f32.as_px()` for sign comparisons
-    /// (`x > Px::ZERO`); the private field means `Px(0.0)` is not
-    /// constructible outside this module. (`Px` has no `max`/`min` yet —
-    /// add them, mirroring `Pt`, when a clamp idiom first needs them.)
+    /// The zero length. Use instead of `0.0_f32.as_px()` for clamp idioms
+    /// (`x.max(Px::ZERO)`) and sign comparisons (`x > Px::ZERO`); the private
+    /// field means `Px(0.0)` is not constructible outside this module.
     pub const ZERO: Px = Px(0.0);
 
     /// Raw `f32` value. Use only at FFI boundaries.
@@ -181,6 +180,19 @@ impl Px {
     #[inline]
     pub fn in_pt(self) -> Pt {
         Pt(self.0 * PX_TO_PT)
+    }
+
+    /// Larger of two lengths. Mirrors `f32::max` (same NaN handling) so a
+    /// migrated `x.max(y)` stays byte-identical.
+    #[inline]
+    pub fn max(self, other: Px) -> Px {
+        Px(self.0.max(other.0))
+    }
+
+    /// Smaller of two lengths. Mirrors `f32::min`.
+    #[inline]
+    pub fn min(self, other: Px) -> Px {
+        Px(self.0.min(other.0))
     }
 }
 
@@ -299,6 +311,15 @@ mod tests {
         assert!(Px(1.0) > Px::ZERO);
         // boundary: zero is not strictly greater than zero (the `> Px::ZERO` idiom)
         assert!(Px(0.0) <= Px::ZERO);
+    }
+
+    #[test]
+    fn px_max_min_mirror_f32() {
+        assert_eq!(Px(1.0).max(Px(2.0)), Px(2.0));
+        assert_eq!(Px(1.0).min(Px(2.0)), Px(1.0));
+        // identical to f32::max/min, including the 0.0 clamp idiom
+        assert_eq!(Px(-3.0).max(Px::ZERO), Px::ZERO);
+        assert_eq!(Px(-3.0).min(Px::ZERO), Px(-3.0));
     }
 
     #[test]

--- a/docs/plans/2026-07-04-fulgur-sipv.6-positioned-cb-px.md
+++ b/docs/plans/2026-07-04-fulgur-sipv.6-positioned-cb-px.md
@@ -1,0 +1,93 @@
+# fulgur-sipv.6: Type absolute-positioning CB geometry to `Px` — Implementation Plan
+
+**Goal:** Eliminate the ~11 `px_to_pt`/`pt_to_px` calls in the absolute-positioning
+CB / pseudo-image sizing paths (`convert/positioned.rs`, `convert/pseudo.rs`) by
+typing the CSS-px geometry to `units::Px` and the pt basis to `units::Pt`.
+**Byte-neutral** per epic `fulgur-sipv` protocol.
+
+**Framing correction (Px, not Pt):** the issue title says "to Pt" but the issue's
+own CONSUMER AUDIT is correct: `AbsCb.padding_box_size` / `border_top_left` /
+`cb_padding_box` live in **CSS px (Taffy)** space, not pt — `sz.width -
+pt_to_px(border)` is px − px = px, consumers are named `cb_w_px`/`bl_px`, and the
+sink `Fragment.x` is already `units::Px`. Target = **`units::Px`**.
+
+**Round-trip deferral:** the audit's point 3 (px→pt→px round-trip via
+`positioned.rs:448` `px_to_pt` → `resolve_pseudo_size:258` `pt_to_px`) is
+**preserved, not deleted**, in this PR. Deleting it removes a real `×0.75 ÷0.75`
+float op — `(x*0.75)/0.75 != x` in general — which is a behavioural change, not a
+type migration, and would violate the byte-neutral protocol. Typing it as
+`w_px.in_pt().in_px()` is bit-identical to `pt_to_px(px_to_pt(w_px))`. The
+round-trip cleanup is tracked as a separate (non-byte-neutral) follow-up.
+
+---
+
+## Task 0: `Px::max` / `Px::min` (done)
+
+`units.rs`: add `Px::max` / `Px::min` mirroring `Pt` (the `.max(0.0)` clamps at
+`cb_padding_box` are the first `Px` clamp need), update the `Px::ZERO` doc, add
+`px_max_min_mirror_f32` test (covers the new method bodies — codecov patch).
+
+## Task 1: `AbsCb` + `cb_padding_box` (positioned.rs)
+
+- `AbsCb.padding_box_size: (Px, Px)`, `border_top_left: (Px, Px)`.
+  `parent_offset_in_cb_bp` **stays `(f32, f32)`** (Taffy location; tagged at its
+  single use site — smaller diff, avoids touching the 3 `AbsCb` construction
+  sites + the offset-accumulation loop).
+- `cb_padding_box(node) -> ((Px, Px), (Px, Px))`:
+  - keep `bl_pt`/`br_pt`/`bt_pt`/`bb_pt` as `Pt` (drop `.to_f32()`)
+  - `pb_w = (sz.width.as_px() - (bl_pt + br_pt).in_px()).max(Px::ZERO)`
+  - `((pb_w, pb_h), (bl_pt.in_px(), bt_pt.in_px()))`
+- `resolve_cb_for_absolute`: `padding_box_size.0 <= 0.0` → `<= Px::ZERO`;
+  `padding_box_size.0 = vw` → `vw.as_px()` (viewport params stay f32).
+
+## Task 2: inset-correction math (positioned.rs)
+
+- `resolve_inset_px(inset, basis: Px) -> Option<Px>`: `Length::new(basis.to_f32())`
+  (sanctioned Stylo px FFI), result `.px().as_px()`.
+- `maybe_apply_abs_pseudo_inset_correction(..., pseudo_w: Pt, pseudo_h: Pt, ...)`:
+  - `pseudo_w_px = pseudo_w.in_px()` (was `pt_to_px(pseudo_w_pt)`)
+  - `parent_x_px = parent_frag.x` (already `Px`; drop `.to_f32()`)
+  - `left/top/right/bottom: Option<Px>`; `x_in_pp_px`/`y_in_pp_px`: `Px`
+    (`left.unwrap_or(Px::ZERO)`)
+  - `ox_px.as_px()` / `oy_px.as_px()` at the one use site (parent_offset stays f32)
+  - `Fragment { x: new_x_px, y: new_y_px, width: pseudo_w_px, height: pseudo_h_px }`
+    (all `Px` now; drop the `.as_px()` tags)
+  - update the caller to pass the just-built `ImageEntry` w/h as `Pt`.
+
+## Task 3: pseudo-image sizing (positioned.rs + pseudo.rs)
+
+- `try_build_absolute_pseudo_image` (positioned.rs:446-455):
+  - `(w_px, h_px) = cb.padding_box_size` (`Px`); basis `(w_px.in_pt(), h_px.in_pt())`
+  - else branch: `parent.final_layout.size.width.as_px().in_pt()`
+  - `build_pseudo_image_entry(pseudo, basis_w_pt: Pt, basis_h_pt: Pt, ...)`
+- `build_pseudo_image_entry(parent_content_width: Pt, parent_content_height: Pt)`:
+  - caller `build_block_pseudo_image_entries` (pseudo.rs:153) passes
+    `parent_cb.width.as_pt()` (`ContentBox.width` is f32, out of scope)
+- `resolve_pseudo_size(size, parent_width: Pt) -> Option<f32>` (return stays
+  `Option<f32>` — `make_image_entry` takes `Option<f32>`):
+  - `basis_px = parent_width.in_px()`; `Length::new(basis_px.to_f32())`
+  - `Some(resolved.px().as_px().in_pt().to_f32())`
+- `build_inline_pseudo_image` (pseudo.rs:175-176): **signature stays f32**; tag at
+  the call: `resolve_pseudo_size(&styles.clone_width(), parent_content_width.as_pt())`
+  (avoids cascading into its callers).
+
+## Task 4: Verification gates
+
+```bash
+cargo fmt && cargo fmt --check
+cargo build -p fulgur
+cargo clippy -p fulgur --all-targets -- -D warnings
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur   # lib + integration
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur-vrt
+git status --short crates/fulgur-vrt/goldens   # MUST be empty
+# patch coverage: llvm-cov nextest --workspace --exclude fulgur-vrt, intersect added ∩ DA:N,0 == 0
+```
+
+Every changed PROD site is covered by non-VRT lib tests (`cb_padding_box_*`,
+`try_build_absolute_pseudo_image_*`, `smoke_abs_pseudo_content_url_*`,
+`resolve_pseudo_size` LengthPercentage tests) — verified pre-edit.
+
+## Task 5: PR + follow-up issue
+
+PR (title EN / body JA), note the Px reframe + round-trip deferral. `bd create`
+a follow-up for the round-trip rationalization (non-byte-neutral cleanup).


### PR DESCRIPTION
## 概要

epic **fulgur-sipv**（`px_to_pt`/`pt_to_px` の内部撲滅 = Px/Pt newtype 移行）のサブタスク **fulgur-sipv.6** です。絶対配置 CB / pseudo-image sizing 経路（`convert/positioned.rs`, `convert/pseudo.rs`）の ~11 箇所の `px_to_pt`/`pt_to_px` 呼び出しを、CSS px 幾何を `units::Px`・pt basis を `units::Pt` に型付けして撲滅します。**byte-neutral**。

## framing 訂正（Pt → **Px**）

issue title は「to Pt」でしたが、issue 自身の CONSUMER AUDIT が正しい: `AbsCb.padding_box_size` / `border_top_left` / `cb_padding_box` は **CSS px (Taffy) 空間**であり pt ではありません（`sz.width - pt_to_px(border)` は px − px = px、sink の `Fragment.x` は既に `units::Px`）。従って target は **`units::Px`**。title も訂正済み。

## 変更内容

- **units**: `Px::max` / `Px::min` を追加（`Pt` をミラー、`cb_padding_box` の `.max(0.0)` が最初の Px clamp 需要）+ `px_max_min_mirror_f32` test
- **positioned**:
  - `AbsCb.padding_box_size` / `border_top_left`: `(Px, Px)`、`cb_padding_box` 戻り値 `Px` 化
  - `resolve_inset_px` の basis/戻り値を `Px` 化
  - inset-correction math を `Px` 化（`parent_offset_in_cb_bp` は f32 のまま、使用点で `.as_px()` タグ → diff 最小化）
- **pseudo**:
  - `build_pseudo_image_entry` の parent dims を `Pt` 化
  - `resolve_pseudo_size` の `parent_width` を `Pt` 化（戻り値は `make_image_entry` に合わせ `Option<f32>` 維持）
  - `build_inline_pseudo_image` は署名を f32 維持し、呼び出し点で `.as_pt()` タグ（カスケード最小化）

## round-trip について（follow-up に切り出し）

`cb.padding_box_size`(Px) → `positioned.rs` `try_build_absolute_pseudo_image` の `.in_pt()` → `resolve_pseudo_size` の `.in_px()` という px→pt→px の round-trip は **保持**しています（`w_px.in_pt().in_px()` は旧 `pt_to_px(px_to_pt(w_px))` と bit-identical）。削除すると `×0.75 ÷0.75` の float 往復が消えて一部の値で bit が変わる（挙動変更）ため、byte-neutral protocol の外で別 PR として扱います → **fulgur-m0xl** で追跡。

## 検証

- `cargo fmt --check` clean / `cargo clippy -p fulgur --all-targets -- -D warnings` exit 0
- `cargo test -p fulgur`（lib 1606 + 統合テスト）全 pass
- `cargo test -p fulgur-vrt` byte-identical（`goldens/` 差分なし、`FULGUR_VRT_UPDATE` 不使用）
- patch coverage 実測（`cargo llvm-cov nextest --workspace --exclude fulgur-vrt`）: 追加行 ∩ uncovered = **0**
  - body 幅0 → viewport 幅補完の rare branch（`positioned.rs:127`）を新規 lib test `resolve_cb_for_absolute_zero_width_body_substitutes_viewport_width` で behavioral にカバー
- public 型変更なし（`AbsCb` は `pub(super)`、crate 内部限定）

Closes fulgur-sipv.6