### PR TITLE
refactor(fulgur): type GCPM margin-box measure pipeline to units::Pt (P4g)

### DIFF
--- a/crates/fulgur/src/gcpm/margin_box.rs
+++ b/crates/fulgur/src/gcpm/margin_box.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 
 use crate::config::{Margin, PageSize};
+use crate::units::{F32Units, Pt};
 
 /// Which edge of the page a set of margin boxes belongs to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -20,10 +21,10 @@ impl Edge {
 /// Rectangle describing a margin box's position and size in page coordinates (points).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct MarginBoxRect {
-    pub x: f32,
-    pub y: f32,
-    pub width: f32,
-    pub height: f32,
+    pub x: Pt,
+    pub y: Pt,
+    pub width: Pt,
+    pub height: Pt,
 }
 
 /// The 16 CSS page margin box positions.
@@ -91,117 +92,117 @@ impl MarginBoxPosition {
     ///
     /// Coordinates are in page-space points with origin at top-left of page.
     pub fn bounding_rect(&self, page_size: PageSize, margin: Margin) -> MarginBoxRect {
-        let content_width = page_size.width - margin.left - margin.right;
-        let content_height = page_size.height - margin.top - margin.bottom;
+        let content_width = page_size.width.as_pt() - margin.left.as_pt() - margin.right.as_pt();
+        let content_height = page_size.height.as_pt() - margin.top.as_pt() - margin.bottom.as_pt();
         let third_w = content_width / 3.0;
         let third_h = content_height / 3.0;
 
         match self {
             // --- Top edge corners ---
             Self::TopLeftCorner => MarginBoxRect {
-                x: 0.0,
-                y: 0.0,
-                width: margin.left,
-                height: margin.top,
+                x: Pt::ZERO,
+                y: Pt::ZERO,
+                width: margin.left.as_pt(),
+                height: margin.top.as_pt(),
             },
             Self::TopRightCorner => MarginBoxRect {
-                x: page_size.width - margin.right,
-                y: 0.0,
-                width: margin.right,
-                height: margin.top,
+                x: page_size.width.as_pt() - margin.right.as_pt(),
+                y: Pt::ZERO,
+                width: margin.right.as_pt(),
+                height: margin.top.as_pt(),
             },
 
             // --- Top edge positions ---
             Self::TopLeft => MarginBoxRect {
-                x: margin.left,
-                y: 0.0,
+                x: margin.left.as_pt(),
+                y: Pt::ZERO,
                 width: third_w,
-                height: margin.top,
+                height: margin.top.as_pt(),
             },
             Self::TopCenter => MarginBoxRect {
-                x: margin.left,
-                y: 0.0,
+                x: margin.left.as_pt(),
+                y: Pt::ZERO,
                 width: content_width,
-                height: margin.top,
+                height: margin.top.as_pt(),
             },
             Self::TopRight => MarginBoxRect {
-                x: margin.left + 2.0 * third_w,
-                y: 0.0,
+                x: margin.left.as_pt() + 2.0 * third_w,
+                y: Pt::ZERO,
                 width: third_w,
-                height: margin.top,
+                height: margin.top.as_pt(),
             },
 
             // --- Bottom edge corners ---
             Self::BottomLeftCorner => MarginBoxRect {
-                x: 0.0,
-                y: page_size.height - margin.bottom,
-                width: margin.left,
-                height: margin.bottom,
+                x: Pt::ZERO,
+                y: page_size.height.as_pt() - margin.bottom.as_pt(),
+                width: margin.left.as_pt(),
+                height: margin.bottom.as_pt(),
             },
             Self::BottomRightCorner => MarginBoxRect {
-                x: page_size.width - margin.right,
-                y: page_size.height - margin.bottom,
-                width: margin.right,
-                height: margin.bottom,
+                x: page_size.width.as_pt() - margin.right.as_pt(),
+                y: page_size.height.as_pt() - margin.bottom.as_pt(),
+                width: margin.right.as_pt(),
+                height: margin.bottom.as_pt(),
             },
 
             // --- Bottom edge positions ---
             Self::BottomLeft => MarginBoxRect {
-                x: margin.left,
-                y: page_size.height - margin.bottom,
+                x: margin.left.as_pt(),
+                y: page_size.height.as_pt() - margin.bottom.as_pt(),
                 width: third_w,
-                height: margin.bottom,
+                height: margin.bottom.as_pt(),
             },
             Self::BottomCenter => MarginBoxRect {
-                x: margin.left,
-                y: page_size.height - margin.bottom,
+                x: margin.left.as_pt(),
+                y: page_size.height.as_pt() - margin.bottom.as_pt(),
                 width: content_width,
-                height: margin.bottom,
+                height: margin.bottom.as_pt(),
             },
             Self::BottomRight => MarginBoxRect {
-                x: margin.left + 2.0 * third_w,
-                y: page_size.height - margin.bottom,
+                x: margin.left.as_pt() + 2.0 * third_w,
+                y: page_size.height.as_pt() - margin.bottom.as_pt(),
                 width: third_w,
-                height: margin.bottom,
+                height: margin.bottom.as_pt(),
             },
 
             // --- Left edge positions ---
             Self::LeftTop => MarginBoxRect {
-                x: 0.0,
-                y: margin.top,
-                width: margin.left,
+                x: Pt::ZERO,
+                y: margin.top.as_pt(),
+                width: margin.left.as_pt(),
                 height: third_h,
             },
             Self::LeftMiddle => MarginBoxRect {
-                x: 0.0,
-                y: margin.top + third_h,
-                width: margin.left,
+                x: Pt::ZERO,
+                y: margin.top.as_pt() + third_h,
+                width: margin.left.as_pt(),
                 height: third_h,
             },
             Self::LeftBottom => MarginBoxRect {
-                x: 0.0,
-                y: margin.top + 2.0 * third_h,
-                width: margin.left,
+                x: Pt::ZERO,
+                y: margin.top.as_pt() + 2.0 * third_h,
+                width: margin.left.as_pt(),
                 height: third_h,
             },
 
             // --- Right edge positions ---
             Self::RightTop => MarginBoxRect {
-                x: page_size.width - margin.right,
-                y: margin.top,
-                width: margin.right,
+                x: page_size.width.as_pt() - margin.right.as_pt(),
+                y: margin.top.as_pt(),
+                width: margin.right.as_pt(),
                 height: third_h,
             },
             Self::RightMiddle => MarginBoxRect {
-                x: page_size.width - margin.right,
-                y: margin.top + third_h,
-                width: margin.right,
+                x: page_size.width.as_pt() - margin.right.as_pt(),
+                y: margin.top.as_pt() + third_h,
+                width: margin.right.as_pt(),
                 height: third_h,
             },
             Self::RightBottom => MarginBoxRect {
-                x: page_size.width - margin.right,
-                y: margin.top + 2.0 * third_h,
-                width: margin.right,
+                x: page_size.width.as_pt() - margin.right.as_pt(),
+                y: margin.top.as_pt() + 2.0 * third_h,
+                width: margin.right.as_pt(),
                 height: third_h,
             },
         }
@@ -235,9 +236,9 @@ fn edge_positions(edge: Edge) -> (MarginBoxPosition, MarginBoxPosition, MarginBo
 }
 
 /// Distribute available space between two items based on their max-content widths.
-fn flex_distribute(a_max: f32, b_max: f32, available: f32) -> (f32, f32) {
+fn flex_distribute(a_max: Pt, b_max: Pt, available: Pt) -> (Pt, Pt) {
     let total = a_max + b_max;
-    if total == 0.0 {
+    if total == Pt::ZERO {
         return (available / 2.0, available / 2.0);
     }
     let a_factor = a_max / total;
@@ -256,11 +257,11 @@ fn flex_distribute(a_max: f32, b_max: f32, available: f32) -> (f32, f32) {
 /// Distribute available space among up to 3 positions (first, center, last).
 /// Returns the computed size for each defined position.
 fn distribute_sizes(
-    first_max: Option<f32>,
-    center_max: Option<f32>,
-    last_max: Option<f32>,
-    available: f32,
-) -> (Option<f32>, Option<f32>, Option<f32>) {
+    first_max: Option<Pt>,
+    center_max: Option<Pt>,
+    last_max: Option<Pt>,
+    available: Pt,
+) -> (Option<Pt>, Option<Pt>, Option<Pt>) {
     let defined_count =
         first_max.is_some() as u8 + center_max.is_some() as u8 + last_max.is_some() as u8;
 
@@ -279,7 +280,7 @@ fn distribute_sizes(
 
     if let Some(c_max) = center_max {
         // Center defined (with or without first/last)
-        let fl_max = first_max.unwrap_or(0.0) + last_max.unwrap_or(0.0);
+        let fl_max = first_max.unwrap_or(Pt::ZERO) + last_max.unwrap_or(Pt::ZERO);
         let (c_size, fl_size) = flex_distribute(c_max, fl_max, available);
         let half_fl = fl_size / 2.0;
         (
@@ -289,8 +290,8 @@ fn distribute_sizes(
         )
     } else {
         // Center not defined, first + last
-        let f_max = first_max.unwrap_or(0.0);
-        let l_max = last_max.unwrap_or(0.0);
+        let f_max = first_max.unwrap_or(Pt::ZERO);
+        let l_max = last_max.unwrap_or(Pt::ZERO);
         let (f_size, l_size) = flex_distribute(f_max, l_max, available);
         (Some(f_size), None, Some(l_size))
     }
@@ -302,7 +303,7 @@ fn distribute_sizes(
 /// Corner rects are NOT included — compute those separately with `bounding_rect`.
 pub fn compute_edge_layout(
     edge: Edge,
-    defined: &BTreeMap<MarginBoxPosition, f32>,
+    defined: &BTreeMap<MarginBoxPosition, Pt>,
     page_size: PageSize,
     margin: Margin,
 ) -> HashMap<MarginBoxPosition, MarginBoxRect> {
@@ -319,28 +320,28 @@ pub fn compute_edge_layout(
     // cross_extent: size on cross axis (margin height for T/B, margin width for L/R)
     let (available, fixed_origin, cross_origin, cross_extent) = match edge {
         Edge::Top => (
-            page_size.width - margin.left - margin.right,
-            margin.left,
-            0.0,
-            margin.top,
+            page_size.width.as_pt() - margin.left.as_pt() - margin.right.as_pt(),
+            margin.left.as_pt(),
+            Pt::ZERO,
+            margin.top.as_pt(),
         ),
         Edge::Bottom => (
-            page_size.width - margin.left - margin.right,
-            margin.left,
-            page_size.height - margin.bottom,
-            margin.bottom,
+            page_size.width.as_pt() - margin.left.as_pt() - margin.right.as_pt(),
+            margin.left.as_pt(),
+            page_size.height.as_pt() - margin.bottom.as_pt(),
+            margin.bottom.as_pt(),
         ),
         Edge::Left => (
-            page_size.height - margin.top - margin.bottom,
-            margin.top,
-            0.0,
-            margin.left,
+            page_size.height.as_pt() - margin.top.as_pt() - margin.bottom.as_pt(),
+            margin.top.as_pt(),
+            Pt::ZERO,
+            margin.left.as_pt(),
         ),
         Edge::Right => (
-            page_size.height - margin.top - margin.bottom,
-            margin.top,
-            page_size.width - margin.right,
-            margin.right,
+            page_size.height.as_pt() - margin.top.as_pt() - margin.bottom.as_pt(),
+            margin.top.as_pt(),
+            page_size.width.as_pt() - margin.right.as_pt(),
+            margin.right.as_pt(),
         ),
     };
 
@@ -349,7 +350,7 @@ pub fn compute_edge_layout(
     let is_horizontal = matches!(edge, Edge::Top | Edge::Bottom);
 
     // Build rect from primary-axis offset and size
-    let make_rect = |offset: f32, size: f32| -> MarginBoxRect {
+    let make_rect = |offset: Pt, size: Pt| -> MarginBoxRect {
         if is_horizontal {
             MarginBoxRect {
                 x: offset,
@@ -369,7 +370,7 @@ pub fn compute_edge_layout(
 
     if let Some(cs) = c_size {
         // Center-based layout: first_slot | center | last_slot
-        let first_slot = f_size.unwrap_or_else(|| l_size.unwrap_or(0.0));
+        let first_slot = f_size.unwrap_or_else(|| l_size.unwrap_or(Pt::ZERO));
         let o_first = fixed_origin;
         let o_center = o_first + first_slot;
         let o_last = o_center + cs;
@@ -399,6 +400,13 @@ pub fn compute_edge_layout(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Tag an `f32` literal as `Pt` for the size/measure inputs the
+    /// distribution helpers now take. Keeps the test arithmetic readable
+    /// after the `units::Pt` migration.
+    fn pt(v: f32) -> Pt {
+        v.as_pt()
+    }
 
     #[test]
     fn test_from_at_keyword_valid() {
@@ -434,10 +442,10 @@ mod tests {
         let rect = MarginBoxPosition::TopCenter.bounding_rect(page, margin);
 
         let content_width = page.width - margin.left - margin.right;
-        assert!((rect.x - margin.left).abs() < 0.01);
-        assert!((rect.y - 0.0).abs() < 0.01);
-        assert!((rect.width - content_width).abs() < 0.01);
-        assert!((rect.height - margin.top).abs() < 0.01);
+        assert!((rect.x.to_f32() - margin.left).abs() < 0.01);
+        assert!((rect.y.to_f32() - 0.0).abs() < 0.01);
+        assert!((rect.width.to_f32() - content_width).abs() < 0.01);
+        assert!((rect.height.to_f32() - margin.top).abs() < 0.01);
     }
 
     #[test]
@@ -447,10 +455,10 @@ mod tests {
         let rect = MarginBoxPosition::BottomCenter.bounding_rect(page, margin);
 
         let content_width = page.width - margin.left - margin.right;
-        assert!((rect.x - margin.left).abs() < 0.01);
-        assert!((rect.y - (page.height - margin.bottom)).abs() < 0.01);
-        assert!((rect.width - content_width).abs() < 0.01);
-        assert!((rect.height - margin.bottom).abs() < 0.01);
+        assert!((rect.x.to_f32() - margin.left).abs() < 0.01);
+        assert!((rect.y.to_f32() - (page.height - margin.bottom)).abs() < 0.01);
+        assert!((rect.width.to_f32() - content_width).abs() < 0.01);
+        assert!((rect.height.to_f32() - margin.bottom).abs() < 0.01);
     }
 
     #[test]
@@ -464,10 +472,10 @@ mod tests {
         };
         let rect = MarginBoxPosition::TopLeftCorner.bounding_rect(page, margin);
 
-        assert!((rect.x - 0.0).abs() < 0.01);
-        assert!((rect.y - 0.0).abs() < 0.01);
-        assert!((rect.width - 70.0).abs() < 0.01);
-        assert!((rect.height - 50.0).abs() < 0.01);
+        assert!((rect.x.to_f32() - 0.0).abs() < 0.01);
+        assert!((rect.y.to_f32() - 0.0).abs() < 0.01);
+        assert!((rect.width.to_f32() - 70.0).abs() < 0.01);
+        assert!((rect.height.to_f32() - 50.0).abs() < 0.01);
     }
 
     // --- flex_distribute tests ---
@@ -475,43 +483,43 @@ mod tests {
     #[test]
     fn test_flex_distribute_both_fit() {
         // a=100, b=200, available=600 → proportional: a=200, b=400
-        let (a, b) = flex_distribute(100.0, 200.0, 600.0);
-        assert!((a - 200.0).abs() < 0.01);
-        assert!((b - 400.0).abs() < 0.01);
+        let (a, b) = flex_distribute(pt(100.0), pt(200.0), pt(600.0));
+        assert!((a.to_f32() - 200.0).abs() < 0.01);
+        assert!((b.to_f32() - 400.0).abs() < 0.01);
     }
 
     #[test]
     fn test_flex_distribute_overflow() {
         // a=300, b=600, available=450 → proportional shrink: a=150, b=300
-        let (a, b) = flex_distribute(300.0, 600.0, 450.0);
-        assert!((a - 150.0).abs() < 0.01);
-        assert!((b - 300.0).abs() < 0.01);
+        let (a, b) = flex_distribute(pt(300.0), pt(600.0), pt(450.0));
+        assert!((a.to_f32() - 150.0).abs() < 0.01);
+        assert!((b.to_f32() - 300.0).abs() < 0.01);
     }
 
     #[test]
     fn test_flex_distribute_zero() {
-        let (a, b) = flex_distribute(0.0, 0.0, 300.0);
-        assert!((a - 150.0).abs() < 0.01);
-        assert!((b - 150.0).abs() < 0.01);
+        let (a, b) = flex_distribute(pt(0.0), pt(0.0), pt(300.0));
+        assert!((a.to_f32() - 150.0).abs() < 0.01);
+        assert!((b.to_f32() - 150.0).abs() < 0.01);
     }
 
     // --- distribute_sizes tests ---
 
     #[test]
     fn test_distribute_center_only() {
-        let (l, c, r) = distribute_sizes(None, Some(100.0), None, 600.0);
+        let (l, c, r) = distribute_sizes(None, Some(pt(100.0)), None, pt(600.0));
         assert!(l.is_none());
-        assert!((c.unwrap() - 600.0).abs() < 0.01);
+        assert!((c.unwrap().to_f32() - 600.0).abs() < 0.01);
         assert!(r.is_none());
     }
 
     #[test]
     fn test_distribute_left_right() {
-        let (l, c, r) = distribute_sizes(Some(100.0), None, Some(200.0), 600.0);
+        let (l, c, r) = distribute_sizes(Some(pt(100.0)), None, Some(pt(200.0)), pt(600.0));
         assert!(c.is_none());
         // flex_distribute(100, 200, 600) → (200, 400)
-        assert!((l.unwrap() - 200.0).abs() < 0.01);
-        assert!((r.unwrap() - 400.0).abs() < 0.01);
+        assert!((l.unwrap().to_f32() - 200.0).abs() < 0.01);
+        assert!((r.unwrap().to_f32() - 400.0).abs() < 0.01);
     }
 
     #[test]
@@ -521,10 +529,11 @@ mod tests {
         // flex_distribute(200, 100, 600) → total=300, flex_space=300
         //   c_factor = 200/300 = 2/3, c = 200 + 300*2/3 = 400
         //   ac = 100 + 300*1/3 = 200, half_ac = 100
-        let (l, c, r) = distribute_sizes(Some(50.0), Some(200.0), Some(50.0), 600.0);
-        assert!((c.unwrap() - 400.0).abs() < 0.01);
-        assert!((l.unwrap() - 100.0).abs() < 0.01);
-        assert!((r.unwrap() - 100.0).abs() < 0.01);
+        let (l, c, r) =
+            distribute_sizes(Some(pt(50.0)), Some(pt(200.0)), Some(pt(50.0)), pt(600.0));
+        assert!((c.unwrap().to_f32() - 400.0).abs() < 0.01);
+        assert!((l.unwrap().to_f32() - 100.0).abs() < 0.01);
+        assert!((r.unwrap().to_f32() - 100.0).abs() < 0.01);
     }
 
     // --- compute_edge_layout tests ---
@@ -536,15 +545,15 @@ mod tests {
         let content_width = page.width - margin.left - margin.right;
 
         let mut defined = BTreeMap::new();
-        defined.insert(MarginBoxPosition::TopCenter, 100.0);
+        defined.insert(MarginBoxPosition::TopCenter, pt(100.0));
 
         let result = compute_edge_layout(Edge::Top, &defined, page, margin);
         assert_eq!(result.len(), 1);
         let rect = result[&MarginBoxPosition::TopCenter];
-        assert!((rect.x - margin.left).abs() < 0.01);
-        assert!((rect.width - content_width).abs() < 0.01);
-        assert!((rect.y - 0.0).abs() < 0.01);
-        assert!((rect.height - margin.top).abs() < 0.01);
+        assert!((rect.x.to_f32() - margin.left).abs() < 0.01);
+        assert!((rect.width.to_f32() - content_width).abs() < 0.01);
+        assert!((rect.y.to_f32() - 0.0).abs() < 0.01);
+        assert!((rect.height.to_f32() - margin.top).abs() < 0.01);
     }
 
     #[test]
@@ -554,8 +563,8 @@ mod tests {
         let content_width = page.width - margin.left - margin.right;
 
         let mut defined = BTreeMap::new();
-        defined.insert(MarginBoxPosition::TopLeft, 100.0);
-        defined.insert(MarginBoxPosition::TopRight, 200.0);
+        defined.insert(MarginBoxPosition::TopLeft, pt(100.0));
+        defined.insert(MarginBoxPosition::TopRight, pt(200.0));
 
         let result = compute_edge_layout(Edge::Top, &defined, page, margin);
         assert_eq!(result.len(), 2);
@@ -564,11 +573,16 @@ mod tests {
         let right_rect = result[&MarginBoxPosition::TopRight];
 
         // Widths sum to content_width
-        assert!((left_rect.width + right_rect.width - content_width).abs() < 0.01);
+        assert!(
+            (left_rect.width.to_f32() + right_rect.width.to_f32() - content_width).abs() < 0.01
+        );
         // No overlap: right starts where left ends
-        assert!((right_rect.x - (left_rect.x + left_rect.width)).abs() < 0.01);
+        assert!(
+            (right_rect.x.to_f32() - (left_rect.x.to_f32() + left_rect.width.to_f32())).abs()
+                < 0.01
+        );
         // Left starts at margin.left
-        assert!((left_rect.x - margin.left).abs() < 0.01);
+        assert!((left_rect.x.to_f32() - margin.left).abs() < 0.01);
     }
 
     #[test]
@@ -578,9 +592,9 @@ mod tests {
         let content_width = page.width - margin.left - margin.right;
 
         let mut defined = BTreeMap::new();
-        defined.insert(MarginBoxPosition::TopLeft, 50.0);
-        defined.insert(MarginBoxPosition::TopCenter, 200.0);
-        defined.insert(MarginBoxPosition::TopRight, 50.0);
+        defined.insert(MarginBoxPosition::TopLeft, pt(50.0));
+        defined.insert(MarginBoxPosition::TopCenter, pt(200.0));
+        defined.insert(MarginBoxPosition::TopRight, pt(50.0));
 
         let result = compute_edge_layout(Edge::Top, &defined, page, margin);
         assert_eq!(result.len(), 3);
@@ -590,13 +604,15 @@ mod tests {
         let r = result[&MarginBoxPosition::TopRight];
 
         // Widths sum to content_width
-        assert!((l.width + c.width + r.width - content_width).abs() < 0.01);
+        assert!(
+            (l.width.to_f32() + c.width.to_f32() + r.width.to_f32() - content_width).abs() < 0.01
+        );
         // Correct x positions: left starts at margin.left
-        assert!((l.x - margin.left).abs() < 0.01);
+        assert!((l.x.to_f32() - margin.left).abs() < 0.01);
         // Center starts after left
-        assert!((c.x - (l.x + l.width)).abs() < 0.01);
+        assert!((c.x.to_f32() - (l.x.to_f32() + l.width.to_f32())).abs() < 0.01);
         // Right starts after center
-        assert!((r.x - (c.x + c.width)).abs() < 0.01);
+        assert!((r.x.to_f32() - (c.x.to_f32() + c.width.to_f32())).abs() < 0.01);
     }
 
     #[test]
@@ -606,9 +622,9 @@ mod tests {
         let content_height = page.height - margin.top - margin.bottom;
 
         let mut defined = BTreeMap::new();
-        defined.insert(MarginBoxPosition::LeftTop, 50.0);
-        defined.insert(MarginBoxPosition::LeftMiddle, 200.0);
-        defined.insert(MarginBoxPosition::LeftBottom, 50.0);
+        defined.insert(MarginBoxPosition::LeftTop, pt(50.0));
+        defined.insert(MarginBoxPosition::LeftMiddle, pt(200.0));
+        defined.insert(MarginBoxPosition::LeftBottom, pt(50.0));
 
         let result = compute_edge_layout(Edge::Left, &defined, page, margin);
         assert_eq!(result.len(), 3);
@@ -618,16 +634,19 @@ mod tests {
         let b = result[&MarginBoxPosition::LeftBottom];
 
         // Heights sum to content_height
-        assert!((t.height + m.height + b.height - content_height).abs() < 0.01);
+        assert!(
+            (t.height.to_f32() + m.height.to_f32() + b.height.to_f32() - content_height).abs()
+                < 0.01
+        );
         // All have x=0, width=margin.left
-        assert!((t.x - 0.0).abs() < 0.01);
-        assert!((t.width - margin.left).abs() < 0.01);
+        assert!((t.x.to_f32() - 0.0).abs() < 0.01);
+        assert!((t.width.to_f32() - margin.left).abs() < 0.01);
         // Correct y positions: top starts at margin.top
-        assert!((t.y - margin.top).abs() < 0.01);
+        assert!((t.y.to_f32() - margin.top).abs() < 0.01);
         // Middle starts after top
-        assert!((m.y - (t.y + t.height)).abs() < 0.01);
+        assert!((m.y.to_f32() - (t.y.to_f32() + t.height.to_f32())).abs() < 0.01);
         // Bottom starts after middle
-        assert!((b.y - (m.y + m.height)).abs() < 0.01);
+        assert!((b.y.to_f32() - (m.y.to_f32() + m.height.to_f32())).abs() < 0.01);
     }
 
     #[test]
@@ -637,8 +656,8 @@ mod tests {
         let content_height = page.height - margin.top - margin.bottom;
 
         let mut defined = BTreeMap::new();
-        defined.insert(MarginBoxPosition::RightTop, 100.0);
-        defined.insert(MarginBoxPosition::RightBottom, 200.0);
+        defined.insert(MarginBoxPosition::RightTop, pt(100.0));
+        defined.insert(MarginBoxPosition::RightBottom, pt(200.0));
 
         let result = compute_edge_layout(Edge::Right, &defined, page, margin);
         assert_eq!(result.len(), 2);
@@ -647,14 +666,14 @@ mod tests {
         let b = result[&MarginBoxPosition::RightBottom];
 
         // Heights sum to content_height
-        assert!((t.height + b.height - content_height).abs() < 0.01);
+        assert!((t.height.to_f32() + b.height.to_f32() - content_height).abs() < 0.01);
         // x = page_width - margin.right, width = margin.right
-        assert!((t.x - (page.width - margin.right)).abs() < 0.01);
-        assert!((t.width - margin.right).abs() < 0.01);
+        assert!((t.x.to_f32() - (page.width - margin.right)).abs() < 0.01);
+        assert!((t.width.to_f32() - margin.right).abs() < 0.01);
         // Top starts at margin.top
-        assert!((t.y - margin.top).abs() < 0.01);
+        assert!((t.y.to_f32() - margin.top).abs() < 0.01);
         // Bottom starts where top ends
-        assert!((b.y - (t.y + t.height)).abs() < 0.01);
+        assert!((b.y.to_f32() - (t.y.to_f32() + t.height.to_f32())).abs() < 0.01);
     }
 
     #[test]
@@ -664,17 +683,17 @@ mod tests {
         let content_height = page.height - margin.top - margin.bottom;
 
         let mut defined = BTreeMap::new();
-        defined.insert(MarginBoxPosition::LeftMiddle, 100.0);
+        defined.insert(MarginBoxPosition::LeftMiddle, pt(100.0));
 
         let result = compute_edge_layout(Edge::Left, &defined, page, margin);
         assert_eq!(result.len(), 1);
 
         let m = result[&MarginBoxPosition::LeftMiddle];
         // Single slot gets full height
-        assert!((m.height - content_height).abs() < 0.01);
-        assert!((m.x - 0.0).abs() < 0.01);
-        assert!((m.y - margin.top).abs() < 0.01);
-        assert!((m.width - margin.left).abs() < 0.01);
+        assert!((m.height.to_f32() - content_height).abs() < 0.01);
+        assert!((m.x.to_f32() - 0.0).abs() < 0.01);
+        assert!((m.y.to_f32() - margin.top).abs() < 0.01);
+        assert!((m.width.to_f32() - margin.left).abs() < 0.01);
     }
 
     #[test]
@@ -684,8 +703,8 @@ mod tests {
         let content_width = page.width - margin.left - margin.right;
 
         let mut defined = BTreeMap::new();
-        defined.insert(MarginBoxPosition::TopCenter, 200.0);
-        defined.insert(MarginBoxPosition::TopRight, 50.0);
+        defined.insert(MarginBoxPosition::TopCenter, pt(200.0));
+        defined.insert(MarginBoxPosition::TopRight, pt(50.0));
 
         let result = compute_edge_layout(Edge::Top, &defined, page, margin);
         assert_eq!(result.len(), 2);
@@ -696,11 +715,11 @@ mod tests {
         // Widths sum to content_width (center + right + left_slot)
         // Center should NOT start at margin.left — it should be offset
         // by the right slot width to stay centered.
-        assert!(c.x > margin.left);
+        assert!(c.x.to_f32() > margin.left);
         // Right starts after center
-        assert!((r.x - (c.x + c.width)).abs() < 0.01);
+        assert!((r.x.to_f32() - (c.x.to_f32() + c.width.to_f32())).abs() < 0.01);
         // Right ends at content edge
-        assert!((r.x + r.width - (margin.left + content_width)).abs() < 0.01);
+        assert!((r.x.to_f32() + r.width.to_f32() - (margin.left + content_width)).abs() < 0.01);
     }
 
     // --- Edge::is_horizontal ---
@@ -813,8 +832,9 @@ mod tests {
         }
     }
 
-    fn approx(a: f32, b: f32) -> bool {
-        (a - b).abs() < 0.01
+    /// Compare a `Pt` rect field against an expected `f32` (page-space pt).
+    fn approx(a: Pt, b: f32) -> bool {
+        (a.to_f32() - b).abs() < 0.01
     }
 
     #[test]
@@ -954,7 +974,7 @@ mod tests {
 
     #[test]
     fn test_distribute_first_only() {
-        let (f, c, l) = distribute_sizes(Some(80.0), None, None, 400.0);
+        let (f, c, l) = distribute_sizes(Some(pt(80.0)), None, None, pt(400.0));
         assert!(
             approx(f.unwrap(), 400.0),
             "first-only should get full space"
@@ -965,7 +985,7 @@ mod tests {
 
     #[test]
     fn test_distribute_last_only() {
-        let (f, c, l) = distribute_sizes(None, None, Some(80.0), 400.0);
+        let (f, c, l) = distribute_sizes(None, None, Some(pt(80.0)), pt(400.0));
         assert!(f.is_none());
         assert!(c.is_none());
         assert!(approx(l.unwrap(), 400.0), "last-only should get full space");
@@ -973,7 +993,7 @@ mod tests {
 
     #[test]
     fn test_distribute_none_all() {
-        let (f, c, l) = distribute_sizes(None, None, None, 400.0);
+        let (f, c, l) = distribute_sizes(None, None, None, pt(400.0));
         assert!(f.is_none());
         assert!(c.is_none());
         assert!(l.is_none());
@@ -987,7 +1007,7 @@ mod tests {
         let m = Margin::uniform(72.0);
         let content_width = p.width - m.left - m.right;
         let mut defined = BTreeMap::new();
-        defined.insert(MarginBoxPosition::BottomCenter, 100.0);
+        defined.insert(MarginBoxPosition::BottomCenter, pt(100.0));
         let result = compute_edge_layout(Edge::Bottom, &defined, p, m);
         assert_eq!(result.len(), 1);
         let rect = result[&MarginBoxPosition::BottomCenter];
@@ -1002,7 +1022,7 @@ mod tests {
         let m = Margin::uniform(72.0);
         let content_height = p.height - m.top - m.bottom;
         let mut defined = BTreeMap::new();
-        defined.insert(MarginBoxPosition::RightMiddle, 50.0);
+        defined.insert(MarginBoxPosition::RightMiddle, pt(50.0));
         let result = compute_edge_layout(Edge::Right, &defined, p, m);
         assert_eq!(result.len(), 1);
         let rect = result[&MarginBoxPosition::RightMiddle];
@@ -1029,7 +1049,7 @@ mod tests {
         let m = Margin::uniform(72.0);
         let content_width = p.width - m.left - m.right;
         let mut defined = BTreeMap::new();
-        defined.insert(MarginBoxPosition::BottomLeft, 120.0);
+        defined.insert(MarginBoxPosition::BottomLeft, pt(120.0));
         let result = compute_edge_layout(Edge::Bottom, &defined, p, m);
         assert_eq!(result.len(), 1);
         let rect = result[&MarginBoxPosition::BottomLeft];

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -3356,7 +3356,7 @@ fn parse_datetime(s: &str) -> Option<krilla::metadata::DateTime> {
 /// Cached max-content width and render Pageable for margin boxes.
 /// Measure cache: (html, page_height as bits) → max-content width.
 /// Render cache: (html, final_width as bits, final_height as bits) → Pageable.
-type MeasureCache = HashMap<(String, u32, u32), f32>;
+type MeasureCache = HashMap<(String, u32, u32), crate::units::Pt>;
 type RenderCache = HashMap<
     (String, u32, u32),
     (
@@ -3386,7 +3386,7 @@ pub(crate) struct MarginBoxRenderer<'a> {
     pub running_states: Vec<BTreeMap<String, crate::pagination_layout::PageRunningState>>,
     pub counter_states: Vec<BTreeMap<String, i32>>,
     pub measure_cache: MeasureCache,
-    pub height_cache: HashMap<(String, u32, u32), f32>,
+    pub height_cache: HashMap<(String, u32, u32), crate::units::Pt>,
     pub render_cache: RenderCache,
     /// fulgur-qgy7: per-page implicit `href` for
     /// `target-*(attr(href), ...)` evaluated inside `@page` margin
@@ -3630,7 +3630,8 @@ impl<'a> MarginBoxRenderer<'a> {
         }
 
         // Stage 2: distribute each edge's boxes against the page rect.
-        let mut edge_defined: BTreeMap<Edge, BTreeMap<MarginBoxPosition, f32>> = BTreeMap::new();
+        let mut edge_defined: BTreeMap<Edge, BTreeMap<MarginBoxPosition, crate::units::Pt>> =
+            BTreeMap::new();
         for (&pos, html) in &resolved_htmls {
             let edge = match pos.edge() {
                 Some(e) => e,
@@ -3679,7 +3680,11 @@ impl<'a> MarginBoxRenderer<'a> {
                 .copied()
                 .unwrap_or_else(|| pos.bounding_rect(page_size, resolved_margin));
 
-            let cache_key = (html.clone(), width_key(rect.width), width_key(rect.height));
+            let cache_key = (
+                html.clone(),
+                width_key(rect.width.to_f32()),
+                width_key(rect.height.to_f32()),
+            );
             if !self.render_cache.contains_key(&cache_key) {
                 let render_html = format!(
                     "<html><head><style>{}</style></head><body style=\"margin:0;padding:0;\">{}</body></html>",
@@ -3687,15 +3692,15 @@ impl<'a> MarginBoxRenderer<'a> {
                 );
                 let mut render_doc = crate::blitz_adapter::parse_and_layout(
                     &render_html,
-                    crate::convert::pt_to_px(rect.width),
-                    crate::convert::pt_to_px(rect.height),
+                    rect.width.in_px().to_f32(),
+                    rect.height.in_px().to_f32(),
                     self.font_data,
                     self.system_fonts,
                 );
                 let empty_column_styles = crate::column_css::ColumnStyleTable::new();
                 let geometry = crate::pagination_layout::run_pass_with_break_styles(
                     &mut render_doc,
-                    crate::convert::pt_to_px(rect.height),
+                    rect.height.in_px().to_f32(),
                     &empty_column_styles,
                 );
                 let dummy_store = RunningElementStore::new();
@@ -3721,7 +3726,13 @@ impl<'a> MarginBoxRenderer<'a> {
             if let Some((drawables, geometry)) = self.render_cache.get(&cache_key) {
                 if let Some(root_id) = drawables.root_id {
                     if let Some(root_block) = drawables.block_styles.get(&root_id) {
-                        paint_root_block_v2(canvas, root_block, rect.x, rect.y, None);
+                        paint_root_block_v2(
+                            canvas,
+                            root_block,
+                            rect.x.to_f32(),
+                            rect.y.to_f32(),
+                            None,
+                        );
                     }
                 }
                 // `body_offset_pt` is (0, 0) here because the wrapper HTML fixes
@@ -3739,8 +3750,8 @@ impl<'a> MarginBoxRenderer<'a> {
                 draw_v2_page(
                     canvas,
                     0,
-                    rect.x,
-                    rect.y,
+                    rect.x.to_f32(),
+                    rect.y.to_f32(),
                     geometry,
                     drawables,
                     &txd,
@@ -3756,12 +3767,12 @@ impl<'a> MarginBoxRenderer<'a> {
 /// Get a layout dimension of the first non-zero child of `<body>` in a Blitz document.
 /// When `use_width` is true, returns max-content width; otherwise returns height.
 ///
-/// Returned value is in PDF pt. Blitz's internal layout is in CSS px, so we
-/// multiply by `PX_TO_PT` on the way out — matching the convention used at
-/// the convert.rs boundary (`layout_in_pt`). This keeps the GCPM margin-box
-/// measure caches in the same unit (pt) as `page_size` / `margin`, which
-/// `compute_edge_layout` assumes when distributing along the edge.
-fn get_body_child_dimension(doc: &blitz_html::HtmlDocument, use_width: bool) -> f32 {
+/// Returns a [`crate::units::Pt`]. Blitz's internal layout is in CSS px, so the
+/// raw Taffy size is tagged `Px` and converted with `Px::in_pt` on the way out —
+/// matching the convention used at the convert.rs boundary (`layout_in_pt`). This
+/// keeps the GCPM margin-box measure caches in the same unit (pt) as `page_size` /
+/// `margin`, which `compute_edge_layout` assumes when distributing along the edge.
+fn get_body_child_dimension(doc: &blitz_html::HtmlDocument, use_width: bool) -> crate::units::Pt {
     use std::ops::Deref;
     let root = doc.root_element();
     let base_doc = doc.deref();
@@ -3790,7 +3801,7 @@ fn get_body_child_dimension(doc: &blitz_html::HtmlDocument, use_width: bool) -> 
         }
         0.0
     };
-    crate::convert::px_to_pt(px)
+    px.as_px().in_pt()
 }
 
 /// Escape a string for use in an HTML attribute value.

--- a/docs/plans/2026-07-04-sipv7-margin-box-pt.md
+++ b/docs/plans/2026-07-04-sipv7-margin-box-pt.md
@@ -1,0 +1,180 @@
+# P4g: Type GCPM margin-box measure pipeline to `Pt` (fulgur-sipv.7)
+
+**Goal:** Eliminate the 1 `px_to_pt` + 3 `pt_to_px` calls in the GCPM
+margin-box measure/render pipeline by typing `MarginBoxRect`, the measure
+caches, and the edge-distribution math to `units::Pt`. Byte-neutral.
+
+**Architecture:** `get_body_child_dimension` returns a measured dimension
+(`Pt`); it flows through `MeasureCache`/`height_cache` and `edge_defined`
+into `compute_edge_layout`, which builds `MarginBoxRect`s. Because
+`compute_edge_layout` adds positions to sizes (`o_center = o_first + cs`),
+positions and sizes must share a unit — so **all four** `MarginBoxRect`
+fields become `Pt` (not just width/height). The struct is genuinely
+page-space pt; no framing correction (unlike sipv.6 which was actually
+`Px`). Full design is on beads issue `fulgur-sipv.7` (`bd show`).
+
+**Tech Stack:** Rust, `units::{Px, Pt, F32Units}` newtypes, VRT byte-wise
+PDF golden comparison.
+
+**Scope boundary:** The measure-stage viewport feeds
+(`pt_to_px(content_width)` / `pt_to_px(page_size.height)` /
+`pt_to_px(fixed_width)`) read config values, not `MarginBoxRect`, and stay
+untouched — they belong to P4h (fulgur-sipv.8). Only the render-stage feed
+that reads `rect.width` / `rect.height` is in scope here.
+
+**Byte-neutrality invariant:** `px_to_pt(v) = v * PX_TO_PT` is identical to
+`Px::in_pt`; `pt_to_px(v) = v / PX_TO_PT` is identical to `Pt::in_px`.
+Preserve operand order everywhere: keep `2.0 * third_w` (do not flip to
+`third_w * 2.0`), keep left-associative subtraction chains, keep `/ 3.0`.
+Never run `FULGUR_VRT_UPDATE=1`.
+
+---
+
+## Task 1: Type `margin_box.rs` + `render.rs` together
+
+Both files must change in one commit: retyping `MarginBoxRect` breaks
+`render.rs` simultaneously, so they only compile together.
+
+**Files:**
+
+- Modify: `crates/fulgur/src/gcpm/margin_box.rs`
+- Modify: `crates/fulgur/src/render.rs`
+
+**Step 1 — `margin_box.rs`:**
+
+- Add `use crate::units::{F32Units, Pt};` at the top.
+- `MarginBoxRect`: `x`/`y`/`width`/`height` from `f32` to `Pt`.
+- `bounding_rect`: tag every `page_size.*` / `margin.*` read with
+  `.as_pt()`; replace `0.0` field literals with `Pt::ZERO`. All 16 arms.
+  `content_width` / `content_height` / `third_w` / `third_h` become `Pt`.
+- `flex_distribute`: params `a_max`/`b_max`/`available` and return to `Pt`;
+  `total == 0.0` to `total == Pt::ZERO`. `a_factor = a_max / total` stays
+  `f32` (Pt/Pt ratio).
+- `distribute_sizes`: `Option<f32>` to `Option<Pt>`, `available` to `Pt`,
+  `unwrap_or(0.0)` to `unwrap_or(Pt::ZERO)`.
+- `compute_edge_layout`: `defined: &BTreeMap<MarginBoxPosition, Pt>`; the
+  `(available, fixed_origin, cross_origin, cross_extent)` tuple all `Pt`
+  (`0.0` cross-origins to `Pt::ZERO`); `make_rect` closure params
+  `|offset: Pt, size: Pt|`.
+
+**Step 2 — `render.rs`:**
+
+- `type MeasureCache = HashMap<(String, u32, u32), Pt>;`
+- `MarginBoxRenderer.height_cache: HashMap<(String, u32, u32), Pt>`.
+- `get_body_child_dimension(...) -> Pt`; body
+  `crate::convert::px_to_pt(px)` to `px.as_px().in_pt()` (local `px: f32`
+  stays f32). Update the doc comment that says "Returned value is in PDF pt"
+  to reflect the `Pt` type.
+- `edge_defined: BTreeMap<Edge, BTreeMap<MarginBoxPosition, Pt>>`.
+- Consumers:
+  - `width_key(rect.width.to_f32())`, `width_key(rect.height.to_f32())`.
+  - render-stage feed: `pt_to_px(rect.width)` to `rect.width.in_px().to_f32()`
+    and both `pt_to_px(rect.height)` to `rect.height.in_px().to_f32()`.
+  - `paint_root_block_v2(..., rect.x.to_f32(), rect.y.to_f32(), None)`.
+  - `draw_v2_page(..., rect.x.to_f32(), rect.y.to_f32(), ...)`.
+- Ensure `crate::units::{F32Units, Pt}` are in scope where used (module
+  already imports `F32Units`; qualify `Pt` or add to the import).
+
+**Step 3 — update existing tests in `margin_box.rs`** so they compile with
+`Pt` args (pass `<lit>.as_pt()`, compare with `.to_f32()` **inside the hot
+condition**, never in a cold message-arg):
+
+- `test_bounding_rect_*`, `test_flex_distribute_*`, `test_distribute_*`,
+  `test_compute_edge_layout_*`.
+
+**Step 4 — build:**
+
+Run: `cargo build -p fulgur`
+Expected: clean compile, no `px_to_pt`/`pt_to_px` left in `margin_box.rs`
+and the 4 targeted ones gone from the margin-box render path.
+
+**Step 5 — commit** (worktree; source edits need no `--sparse` after
+`sparse-checkout disable`):
+
+```bash
+git add crates/fulgur/src/gcpm/margin_box.rs crates/fulgur/src/render.rs
+git commit -m "refactor(fulgur): type GCPM margin-box measure pipeline to units::Pt"
+```
+
+---
+
+## Task 2: Backfill coverage for changed arms
+
+The migration turns all 16 `bounding_rect` arms and all 4
+`compute_edge_layout` edge arms into changed lines. Current unit tests hit
+only 3/16 positions and `Edge::Top` only; the integration path uses
+`make_rect`, not the `bounding_rect` fallback. Add non-VRT unit tests so
+patch coverage stays at 0 uncovered.
+
+**Files:**
+
+- Modify: `crates/fulgur/src/gcpm/margin_box.rs` (`#[cfg(test)] mod tests`)
+
+**Step 1 — add an all-16-position `bounding_rect` test** iterating every
+`MarginBoxPosition`, asserting each rect's four fields against the expected
+page-space geometry (compare `.to_f32()` in the hot condition).
+
+**Step 2 — add `compute_edge_layout` tests for `Edge::Bottom`,
+`Edge::Left`, `Edge::Right`** (mirror the existing `Edge::Top` tests:
+center-only and first+last), asserting cross-axis origin/extent and
+primary-axis distribution.
+
+**Step 3 — run the unit tests:**
+
+Run: `cargo test -p fulgur --lib gcpm::margin_box`
+Expected: PASS.
+
+**Step 4 — commit:**
+
+```bash
+git add crates/fulgur/src/gcpm/margin_box.rs
+git commit -m "test(fulgur): cover all bounding_rect positions + compute_edge_layout edges"
+```
+
+---
+
+## Task 3: Full verification (epic protocol)
+
+**Step 1 — build + lint + fmt:**
+
+```bash
+cargo build -p fulgur
+cargo clippy -p fulgur --all-targets -- -D warnings
+cargo fmt --check
+```
+
+Expected: all clean. (`cargo fmt` may single-line shortened asserts — run
+`cargo fmt` then re-check.)
+
+**Step 2 — lib + render_smoke + gcpm tests:**
+
+```bash
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur --lib
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur --test render_smoke --test gcpm_integration --test gcpm_snapshot
+```
+
+Expected: all PASS.
+
+**Step 3 — VRT byte-identity (the byte-neutral gate):**
+
+```bash
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur-vrt
+git status --porcelain crates/fulgur-vrt/goldens
+```
+
+Expected: VRT green **and** `git status` on goldens empty (no golden byte
+changed). Never `FULGUR_VRT_UPDATE=1`.
+
+**Step 4 — patch-coverage gate (measured, not reasoned):**
+
+```bash
+cargo llvm-cov nextest --workspace --exclude fulgur-vrt --lcov --output-path lcov.info
+```
+
+Intersect the added lines from `git diff origin/main` with `DA:N,0`
+(uncovered) entries in `lcov.info`. Target: 0 uncovered added PROD lines;
+any residual should be a dev-only assert artifact addressed per the
+`{:?}`/single-line/hot-binding workaround.
+
+**Step 5 — request code review** (`superpowers:requesting-code-review`),
+then finish the branch (`superpowers:finishing-a-development-branch`).


### PR DESCRIPTION
## 概要

epic **fulgur-sipv**（`px_to_pt`/`pt_to_px` 撲滅 = Px/Pt 内部移行の完了）のサブタスク **P4g (fulgur-sipv.7)**。GCPM margin-box の measure/render パイプラインを `units::Pt` に型付けし、対象の変換 **1 × `px_to_pt` + 3 × `pt_to_px`** を消去する。

## 何をしたか

`MarginBoxRect` の**4フィールド全部**（x/y/width/height）を `Pt` に型付けした（width/height だけではない）。理由: `compute_edge_layout` が位置とサイズを加算する（`o_center = o_first + first_slot`, `offset += s`）ため、measure パイプラインから `Pt` で来るサイズと位置は同一単位でなければならない。`MarginBoxRect` は本質的に page-space pt（doc に "page coordinates (points)"、pt 値の `page_size`/`margin` から構築、measure が `px_to_pt` → pt）なので、framing correction は不要（Px だった sipv.6 とは異なる）。

- **margin_box.rs**: `MarginBoxRect` フィールド → `Pt`。`bounding_rect` は `page_size`/`margin` 読みを `.as_pt()` タグ、コーナーの `0.0` を `Pt::ZERO`（全16アーム）。`flex_distribute` / `distribute_sizes` / `compute_edge_layout` のシグネチャと算術を `Pt` 化（`Pt`/`Pt` の比は `f32` のまま）。
- **render.rs**: `MeasureCache` / `height_cache` の値型 → `Pt`、`edge_defined` → `Pt`、`get_body_child_dimension` の返り値 → `Pt`（`px.as_px().in_pt()`）。consumer は still-f32 sink で `.to_f32()` に落とす（`width_key`、render-stage の `parse_and_layout`/`run_pass` viewport feed、`paint_root_block_v2`/`draw_v2_page`）。

## スコープ境界

measure-stage の viewport feed（`content_width` / `page_size.height` / `fixed_width` の `pt_to_px`）は config 値を読むもので `MarginBoxRect` ではないため**温存** → **P4h (fulgur-sipv.8)** の担当。

## テスト

既存の `bounding_rect` / `compute_edge_layout` / `distribute` テスト群が全16ポジション・全 Edge を既にカバーしていたため、入力を `pt()` ヘルパで型付けし、`Pt` フィールドの比較は hot condition 内で `.to_f32()`（`approx()` は `Pt` を取るよう変更）。behavioral test の喪失なし。当初追加した網羅テストは既存ブロックと冗長だったため削除。

## Byte-neutral 検証（epic protocol）

- `px_to_pt(v) = v * PX_TO_PT` ≡ `Px::in_pt`、`pt_to_px(v) = v / PX_TO_PT` ≡ `Pt::in_px`。オペランド順序保存（`2.0 * third_w`、左結合減算、`/3.0`）。
- **VRT goldens byte-identical**（`FULGUR_VRT_UPDATE` 不使用、`git status` on goldens 空）。
- `cargo build --workspace --all-targets` / `clippy -p fulgur --all-targets -- -D warnings` / `cargo fmt --check` クリーン。
- lib 1606 + render_smoke + gcpm_integration + gcpm_snapshot green。
- **patch coverage 実測**: `cargo llvm-cov nextest -p fulgur` で `git diff origin/main` の追加行 ∩ `DA:N,0` = **0**（両ファイル）。

Closes fulgur-sipv.7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * レイアウトと描画の位置・サイズ計算がより一貫した単位で扱われるようになりました。
* **バグ修正**
  * 余白ボックスの表示位置やサイズのずれが起きにくくなりました。
  * 計算結果のキャッシュ精度が向上し、再描画時の差異を抑えました。
* **ドキュメント**
  * 関連変更の実施手順と確認項目を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->