### PR TITLE
refactor(fulgur): type Blitz viewport entry points to units::Px (sipv.8, epic-final)

### DIFF
--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -143,22 +143,22 @@ pub mod net {
 /// in CSS px) for an exact match.
 pub fn parse_and_layout(
     html: &str,
-    viewport_width: f32,
-    viewport_height: f32,
+    viewport_width: crate::units::Px,
+    viewport_height: crate::units::Px,
     font_data: &[Arc<Vec<u8>>],
     system_fonts: bool,
 ) -> HtmlDocument {
     let mut doc = parse_inner(
         html,
-        viewport_width,
-        viewport_height as u32,
+        viewport_width.to_f32(),
+        viewport_height.to_f32() as u32,
         font_data,
         system_fonts,
         None,
         None,
     );
     resolve(&mut doc);
-    relayout_position_fixed(&mut doc, viewport_width, viewport_height);
+    relayout_position_fixed(&mut doc, viewport_width.to_f32(), viewport_height.to_f32());
     doc
 }
 
@@ -3413,6 +3413,7 @@ pub(crate) fn apply_link_media_rewrites(doc: &mut HtmlDocument, rewrites: &[Link
 mod tests {
     use super::*;
     use crate::gcpm::TargetTextKind;
+    use crate::units::F32Units;
 
     #[test]
     fn build_static_content_css_serializes_selectors_and_escapes() {
@@ -3671,7 +3672,7 @@ mod tests {
     #[test]
     fn test_parse_and_layout_unchanged() {
         let html = "<html><body><p>Test</p></body></html>";
-        let doc = parse_and_layout(html, 400.0, 600.0, &[], true);
+        let doc = parse_and_layout(html, 400.0_f32.as_px(), 600.0_f32.as_px(), &[], true);
         let root = doc.root_element();
         assert!(!root.children.is_empty());
     }
@@ -5092,7 +5093,7 @@ mod tests {
     #[test]
     fn multicol_props_absent_on_plain_block() {
         let html = r#"<html><body><div id="p">plain</div></body></html>"#;
-        let doc = parse_and_layout(html, 400.0, 2000.0, &[], true);
+        let doc = parse_and_layout(html, 400.0_f32.as_px(), 2000.0_f32.as_px(), &[], true);
         let id = find_element_by_local_name(&doc, "div").expect("div");
         assert!(extract_multicol_props(doc.get_node(id).unwrap()).is_none());
     }
@@ -5102,7 +5103,7 @@ mod tests {
         let html = r#"<html><body>
             <div id="m" style="column-count: 3; column-gap: 12px;">a</div>
         </body></html>"#;
-        let doc = parse_and_layout(html, 400.0, 2000.0, &[], true);
+        let doc = parse_and_layout(html, 400.0_f32.as_px(), 2000.0_f32.as_px(), &[], true);
         let id = find_element_by_local_name(&doc, "div").expect("div");
         let props = extract_multicol_props(doc.get_node(id).unwrap()).expect("should be multicol");
         assert_eq!(props.column_count, Some(3));
@@ -5115,7 +5116,7 @@ mod tests {
         let html = r#"<html><body>
             <div id="m" style="column-width: 180px;">a</div>
         </body></html>"#;
-        let doc = parse_and_layout(html, 400.0, 2000.0, &[], true);
+        let doc = parse_and_layout(html, 400.0_f32.as_px(), 2000.0_f32.as_px(), &[], true);
         let id = find_element_by_local_name(&doc, "div").expect("div");
         let props = extract_multicol_props(doc.get_node(id).unwrap()).expect("should be multicol");
         assert_eq!(props.column_count, None);
@@ -5137,7 +5138,7 @@ mod tests {
         // baselines in paragraph.rs, producing a 4/3-off visual shift. Guards
         // against regression of the PR #101 unit-consolidation.
         let html = r#"<html><body><img style="vertical-align: 8px;" src=""></body></html>"#;
-        let doc = parse_and_layout(html, 400.0, 2000.0, &[], true);
+        let doc = parse_and_layout(html, 400.0_f32.as_px(), 2000.0_f32.as_px(), &[], true);
         let id = find_element_by_local_name(&doc, "img").expect("img");
         let va = extract_vertical_align(doc.get_node(id).unwrap());
         match va {
@@ -5157,7 +5158,7 @@ mod tests {
         // `vertical-align: 50%` still returns a unitless ratio — the px→pt
         // fix on the Length branch must not touch Percent semantics.
         let html = r#"<html><body><img style="vertical-align: 50%;" src=""></body></html>"#;
-        let doc = parse_and_layout(html, 400.0, 2000.0, &[], true);
+        let doc = parse_and_layout(html, 400.0_f32.as_px(), 2000.0_f32.as_px(), &[], true);
         let id = find_element_by_local_name(&doc, "img").expect("img");
         let va = extract_vertical_align(doc.get_node(id).unwrap());
         match va {
@@ -5174,7 +5175,7 @@ mod tests {
             <h1 style="column-span: all;">Big</h1>
             <p>plain</p>
         </body></html>"#;
-        let doc = parse_and_layout(html, 400.0, 2000.0, &[], true);
+        let doc = parse_and_layout(html, 400.0_f32.as_px(), 2000.0_f32.as_px(), &[], true);
         let h1 = find_element_by_local_name(&doc, "h1").expect("h1");
         let p = find_element_by_local_name(&doc, "p").expect("p");
         assert!(has_column_span_all(doc.get_node(h1).unwrap()));
@@ -5365,11 +5366,12 @@ mod transform_tests {
     use super::*;
     use crate::draw_primitives::matrix_test_util::approx;
     use crate::draw_primitives::{Affine2D, Point2};
+    use crate::units::F32Units;
 
     /// Parse a minimal HTML snippet and return the computed transform of
     /// the first `<div>` it contains, via `compute_transform()`.
     fn compute_for_div(html: &str, box_w: f32, box_h: f32) -> Option<(Affine2D, Point2)> {
-        let doc = parse_and_layout(html, 400.0, 2000.0, &[], true);
+        let doc = parse_and_layout(html, 400.0_f32.as_px(), 2000.0_f32.as_px(), &[], true);
         let div_id = find_element_by_tag(&doc, "div")?;
         let node = doc.get_node(div_id)?;
         let styles = node.primary_styles()?;

--- a/crates/fulgur/src/convert/inline_root.rs
+++ b/crates/fulgur/src/convert/inline_root.rs
@@ -1074,7 +1074,13 @@ mod tests {
     // ── Helpers for Blitz-backed tests ────────────────────────────────────────
 
     fn parse_doc(html: &str) -> HtmlDocument {
-        crate::blitz_adapter::parse_and_layout(html, 595.0_f32.as_px(), 842.0_f32.as_px(), &[], false)
+        crate::blitz_adapter::parse_and_layout(
+            html,
+            595.0_f32.as_px(),
+            842.0_f32.as_px(),
+            &[],
+            false,
+        )
     }
 
     fn find_first_by_tag(doc: &BaseDocument, start_id: usize, tag: &str) -> Option<usize> {

--- a/crates/fulgur/src/convert/inline_root.rs
+++ b/crates/fulgur/src/convert/inline_root.rs
@@ -1074,7 +1074,7 @@ mod tests {
     // ── Helpers for Blitz-backed tests ────────────────────────────────────────
 
     fn parse_doc(html: &str) -> HtmlDocument {
-        crate::blitz_adapter::parse_and_layout(html, 595.0, 842.0, &[], false)
+        crate::blitz_adapter::parse_and_layout(html, 595.0_f32.as_px(), 842.0_f32.as_px(), &[], false)
     }
 
     fn find_first_by_tag(doc: &BaseDocument, start_id: usize, tag: &str) -> Option<usize> {

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -62,8 +62,13 @@ pub(crate) fn px_to_pt(v: f32) -> f32 {
     v * PX_TO_PT
 }
 
-/// Convert a PDF-pt scalar to CSS px — use when feeding the Blitz viewport.
+/// Convert a PDF-pt scalar to CSS px. Retained only for the `px_to_pt`
+/// roundtrip test: fulgur-sipv.8 retyped the Blitz-viewport feeders to
+/// `units::Px` (`x.as_pt().in_px()`), so this has no production callers.
+/// Removed together with `px_to_pt` once fulgur-sipv.2 drops the last
+/// `px_to_pt` caller (`shadow.rs`).
 #[inline]
+#[allow(dead_code)] // test-only until fulgur-sipv.2 removes both px_to_pt / pt_to_px
 pub(crate) fn pt_to_px(v: f32) -> f32 {
     v / PX_TO_PT
 }
@@ -1200,7 +1205,13 @@ mod semantics_tests {
         // `parse_and_layout` already runs stylo + Taffy + the
         // `position: fixed` relayout, matching what the engine feeds
         // into convert at this point.
-        let mut doc = crate::blitz_adapter::parse_and_layout(html, 595.0_f32.as_px(), 842.0_f32.as_px(), &[], true);
+        let mut doc = crate::blitz_adapter::parse_and_layout(
+            html,
+            595.0_f32.as_px(),
+            842.0_f32.as_px(),
+            &[],
+            true,
+        );
 
         let column_styles = crate::blitz_adapter::extract_column_style_table(&doc);
         let multicol_geometry = crate::multicol_layout::run_pass(doc.deref_mut(), &column_styles);

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -1191,6 +1191,7 @@ mod semantics_tests {
     //! shape only.
 
     use crate::tagging::PdfTag;
+    use crate::units::F32Units;
     use std::ops::DerefMut;
 
     fn build_drawables(html: &str) -> crate::drawables::Drawables {
@@ -1199,7 +1200,7 @@ mod semantics_tests {
         // `parse_and_layout` already runs stylo + Taffy + the
         // `position: fixed` relayout, matching what the engine feeds
         // into convert at this point.
-        let mut doc = crate::blitz_adapter::parse_and_layout(html, 595.0, 842.0, &[], true);
+        let mut doc = crate::blitz_adapter::parse_and_layout(html, 595.0_f32.as_px(), 842.0_f32.as_px(), &[], true);
 
         let column_styles = crate::blitz_adapter::extract_column_style_table(&doc);
         let multicol_geometry = crate::multicol_layout::run_pass(doc.deref_mut(), &column_styles);

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -67,8 +67,12 @@ pub(crate) fn px_to_pt(v: f32) -> f32 {
 /// `units::Px` (`x.as_pt().in_px()`), so this has no production callers.
 /// Removed together with `px_to_pt` once fulgur-sipv.2 drops the last
 /// `px_to_pt` caller (`shadow.rs`).
+///
+/// Kept present via `#[allow(dead_code)]` rather than `#[cfg(test)]` so the
+/// `PX_TO_PT` doc's `[pt_to_px]` link stays symmetric with the still-live
+/// `[px_to_pt]` sibling until fulgur-sipv.2 removes both together.
 #[inline]
-#[allow(dead_code)] // test-only until fulgur-sipv.2 removes both px_to_pt / pt_to_px
+#[allow(dead_code)]
 pub(crate) fn pt_to_px(v: f32) -> f32 {
     v / PX_TO_PT
 }

--- a/crates/fulgur/src/convert/positioned.rs
+++ b/crates/fulgur/src/convert/positioned.rs
@@ -471,7 +471,7 @@ mod tests {
     // ── helpers ──────────────────────────────────────────────────────
 
     fn parse_doc(html: &str) -> HtmlDocument {
-        crate::blitz_adapter::parse_and_layout(html, 595.0, 842.0, &[], false)
+        crate::blitz_adapter::parse_and_layout(html, 595.0_f32.as_px(), 842.0_f32.as_px(), &[], false)
     }
 
     fn find_first_by_tag(doc: &BaseDocument, start_id: usize, tag: &str) -> Option<usize> {
@@ -633,8 +633,8 @@ mod tests {
                 <div style="position:absolute;width:10px;height:10px;">abs</div>
               </section>
             </body></html>"#,
-            595.0,
-            842.0,
+            595.0_f32.as_px(),
+            842.0_f32.as_px(),
             &[],
             false,
         );
@@ -671,8 +671,8 @@ mod tests {
                 <div>static</div>
               </section>
             </body></html>"#,
-            595.0,
-            842.0,
+            595.0_f32.as_px(),
+            842.0_f32.as_px(),
             &[],
             false,
         );
@@ -704,8 +704,8 @@ mod tests {
                 <div>second</div>
               </section>
             </body></html>"#,
-            595.0,
-            842.0,
+            595.0_f32.as_px(),
+            842.0_f32.as_px(),
             &[],
             false,
         );
@@ -732,8 +732,8 @@ mod tests {
         // visiting any children, even though child_ids is non-empty.
         let mut doc = crate::blitz_adapter::parse_and_layout(
             r#"<!doctype html><html><body><div><p>text</p></div></body></html>"#,
-            595.0,
-            842.0,
+            595.0_f32.as_px(),
+            842.0_f32.as_px(),
             &[],
             false,
         );
@@ -771,8 +771,8 @@ mod tests {
                 <div style="position:absolute;width:5px;height:5px;"></div>
               </section>
             </body></html>"#,
-            595.0,
-            842.0,
+            595.0_f32.as_px(),
+            842.0_f32.as_px(),
             &[],
             false,
         );
@@ -811,8 +811,8 @@ mod tests {
                 <div>content</div>
               </section>
             </body></html>"#,
-            595.0,
-            842.0,
+            595.0_f32.as_px(),
+            842.0_f32.as_px(),
             &[],
             false,
         );
@@ -1050,8 +1050,8 @@ mod tests {
                 <div style="position:absolute;width:20px;height:20px;">abs</div>
               </section>
             </body></html>"#,
-            595.0,
-            842.0,
+            595.0_f32.as_px(),
+            842.0_f32.as_px(),
             &[],
             false,
         );
@@ -1079,8 +1079,8 @@ mod tests {
             r#"<!doctype html><html><body>
               <section><div>static</div></section>
             </body></html>"#,
-            595.0,
-            842.0,
+            595.0_f32.as_px(),
+            842.0_f32.as_px(),
             &[],
             false,
         );
@@ -1107,8 +1107,8 @@ mod tests {
         // so no conversion occurs. Covers the function entry and loop header.
         let mut doc = crate::blitz_adapter::parse_and_layout(
             r#"<!doctype html><html><body><section><div>x</div></section></body></html>"#,
-            595.0,
-            842.0,
+            595.0_f32.as_px(),
+            842.0_f32.as_px(),
             &[],
             false,
         );
@@ -1138,8 +1138,8 @@ mod tests {
                 <div style="position:absolute;width:10px;height:10px;">abs</div>
               </section>
             </body></html>"#,
-            595.0,
-            842.0,
+            595.0_f32.as_px(),
+            842.0_f32.as_px(),
             &[],
             false,
         );
@@ -1178,8 +1178,8 @@ mod tests {
                 <div style="position:absolute;width:10px;height:10px;">abs</div>
               </section>
             </body></html>"#,
-            595.0,
-            842.0,
+            595.0_f32.as_px(),
+            842.0_f32.as_px(),
             &[],
             false,
         );
@@ -1218,8 +1218,8 @@ mod tests {
                 <div style="position:fixed;width:10px;height:10px;">fixed</div>
               </section>
             </body></html>"#,
-            595.0,
-            842.0,
+            595.0_f32.as_px(),
+            842.0_f32.as_px(),
             &[],
             false,
         );
@@ -1281,8 +1281,8 @@ mod tests {
             r#"<!doctype html><html><body>
               <section><div>static</div></section>
             </body></html>"#,
-            595.0,
-            842.0,
+            595.0_f32.as_px(),
+            842.0_f32.as_px(),
             &[],
             false,
         );

--- a/crates/fulgur/src/convert/positioned.rs
+++ b/crates/fulgur/src/convert/positioned.rs
@@ -471,7 +471,13 @@ mod tests {
     // ── helpers ──────────────────────────────────────────────────────
 
     fn parse_doc(html: &str) -> HtmlDocument {
-        crate::blitz_adapter::parse_and_layout(html, 595.0_f32.as_px(), 842.0_f32.as_px(), &[], false)
+        crate::blitz_adapter::parse_and_layout(
+            html,
+            595.0_f32.as_px(),
+            842.0_f32.as_px(),
+            &[],
+            false,
+        )
     }
 
     fn find_first_by_tag(doc: &BaseDocument, start_id: usize, tag: &str) -> Option<usize> {

--- a/crates/fulgur/src/convert/replaced.rs
+++ b/crates/fulgur/src/convert/replaced.rs
@@ -342,7 +342,13 @@ mod tests {
     // ── DOM-based helpers ────────────────────────────────────────────
 
     fn parse_doc(html: &str) -> HtmlDocument {
-        crate::blitz_adapter::parse_and_layout(html, 595.0_f32.as_px(), 842.0_f32.as_px(), &[], false)
+        crate::blitz_adapter::parse_and_layout(
+            html,
+            595.0_f32.as_px(),
+            842.0_f32.as_px(),
+            &[],
+            false,
+        )
     }
 
     fn find_by_tag_inner(doc: &BaseDocument, id: usize, tag: &str) -> Option<usize> {

--- a/crates/fulgur/src/convert/replaced.rs
+++ b/crates/fulgur/src/convert/replaced.rs
@@ -342,7 +342,7 @@ mod tests {
     // ── DOM-based helpers ────────────────────────────────────────────
 
     fn parse_doc(html: &str) -> HtmlDocument {
-        crate::blitz_adapter::parse_and_layout(html, 595.0, 842.0, &[], false)
+        crate::blitz_adapter::parse_and_layout(html, 595.0_f32.as_px(), 842.0_f32.as_px(), &[], false)
     }
 
     fn find_by_tag_inner(doc: &BaseDocument, id: usize, tag: &str) -> Option<usize> {

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -208,8 +208,8 @@ impl Engine {
         // correctly.
         let (mut doc, link_gcpm) = crate::blitz_adapter::parse_html_with_local_resources(
             &html,
-            crate::convert::pt_to_px(self.config.content_width()),
-            crate::convert::pt_to_px(self.config.page_height()) as u32,
+            self.config.content_width().as_pt().in_px().to_f32(),
+            self.config.page_height().as_pt().in_px().to_f32() as u32,
             fonts,
             self.system_fonts,
             self.base_path.as_deref(),
@@ -272,8 +272,8 @@ impl Engine {
         // `set_viewport_size_px` truncates to u32 internally for Blitz's
         // `Viewport.window_size`; Taffy keeps the f32 sub-pixel precision
         // it needs for its layout cache.
-        let resolved_content_width_px = crate::convert::pt_to_px(resolved_content_width_pt);
-        let resolved_content_height_px = crate::convert::pt_to_px(resolved_content_height_pt);
+        let resolved_content_width_px = resolved_content_width_pt.as_pt().in_px().to_f32();
+        let resolved_content_height_px = resolved_content_height_pt.as_pt().in_px().to_f32();
         crate::blitz_adapter::set_viewport_size_px(
             &mut doc,
             resolved_content_width_px,
@@ -849,8 +849,8 @@ impl Engine {
 
         let (mut doc, _link_gcpm) = crate::blitz_adapter::parse_html_with_local_resources(
             html,
-            crate::convert::pt_to_px(self.config.content_width()),
-            crate::convert::pt_to_px(self.config.page_height()) as u32,
+            self.config.content_width().as_pt().in_px().to_f32(),
+            self.config.page_height().as_pt().in_px().to_f32() as u32,
             fonts,
             self.system_fonts,
             self.base_path.as_deref(),
@@ -863,8 +863,8 @@ impl Engine {
         crate::blitz_adapter::resolve(&mut doc);
         crate::blitz_adapter::relayout_position_fixed(
             &mut doc,
-            crate::convert::pt_to_px(self.config.content_width()),
-            crate::convert::pt_to_px(self.config.content_height()),
+            self.config.content_width().as_pt().in_px().to_f32(),
+            self.config.content_height().as_pt().in_px().to_f32(),
         );
         let column_styles = crate::blitz_adapter::extract_column_style_table(&doc);
         let multicol_geometry = crate::multicol_layout::run_pass(doc.deref_mut(), &column_styles);
@@ -887,8 +887,8 @@ impl Engine {
             pagination_geometry,
             link_cache: Default::default(),
             viewport_size_px: Some((
-                crate::convert::pt_to_px(self.config.content_width()),
-                crate::convert::pt_to_px(self.config.content_height()),
+                self.config.content_width().as_pt().in_px().to_f32(),
+                self.config.content_height().as_pt().in_px().to_f32(),
             )),
         };
         crate::convert::dom_to_drawables(&doc, &mut convert_ctx)
@@ -914,8 +914,8 @@ impl Engine {
 
         let (mut doc, _link_gcpm) = crate::blitz_adapter::parse_html_with_local_resources(
             html,
-            crate::convert::pt_to_px(self.config.content_width()),
-            crate::convert::pt_to_px(self.config.page_height()) as u32,
+            self.config.content_width().as_pt().in_px().to_f32(),
+            self.config.page_height().as_pt().in_px().to_f32() as u32,
             fonts,
             self.system_fonts,
             self.base_path.as_deref(),
@@ -928,8 +928,8 @@ impl Engine {
         crate::blitz_adapter::resolve(&mut doc);
         crate::blitz_adapter::relayout_position_fixed(
             &mut doc,
-            crate::convert::pt_to_px(self.config.content_width()),
-            crate::convert::pt_to_px(self.config.content_height()),
+            self.config.content_width().as_pt().in_px().to_f32(),
+            self.config.content_height().as_pt().in_px().to_f32(),
         );
         let column_styles = crate::blitz_adapter::extract_column_style_table(&doc);
         let multicol_geometry = crate::multicol_layout::run_pass(doc.deref_mut(), &column_styles);
@@ -945,8 +945,8 @@ impl Engine {
         // render emits (see the `append_position_fixed_fragments` block
         // in `render`). Without this, the helper would diverge
         // from `render` for documents with `position: fixed`.
-        let content_w_px = crate::convert::pt_to_px(self.config.content_width());
-        let content_h_px = crate::convert::pt_to_px(self.config.content_height());
+        let content_w_px = self.config.content_width().as_pt().in_px().to_f32();
+        let content_h_px = self.config.content_height().as_pt().in_px().to_f32();
         let total_pages = crate::pagination_layout::implied_page_count(&pagination_geometry).max(1);
         crate::pagination_layout::append_position_fixed_fragments(
             &mut pagination_geometry,

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -2,6 +2,7 @@ use crate::asset::AssetBundle;
 use crate::config::{Config, ConfigBuilder, Margin, PageSize};
 use crate::convert::ConvertContext;
 use crate::error::Result;
+use crate::units::F32Units;
 use krilla::SerializeSettings;
 use std::collections::{BTreeMap, HashMap};
 use std::ops::DerefMut;
@@ -869,7 +870,7 @@ impl Engine {
         let multicol_geometry = crate::multicol_layout::run_pass(doc.deref_mut(), &column_styles);
         let pagination_geometry = crate::pagination_layout::run_pass_with_break_styles(
             doc.deref_mut(),
-            crate::convert::pt_to_px(self.config.content_height()),
+            self.config.content_height().as_pt().in_px(),
             &column_styles,
         );
 
@@ -934,7 +935,7 @@ impl Engine {
         let multicol_geometry = crate::multicol_layout::run_pass(doc.deref_mut(), &column_styles);
         let mut pagination_geometry = crate::pagination_layout::run_pass_with_break_styles(
             doc.deref_mut(),
-            crate::convert::pt_to_px(self.config.content_height()),
+            self.config.content_height().as_pt().in_px(),
             &column_styles,
         );
 

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -4441,7 +4441,6 @@ h2 { string-set: chapter-title content(text); }
     #[test]
     fn running_element_node_lands_in_geometry_with_zero_height() {
         use crate::blitz_adapter;
-        use crate::convert::pt_to_px;
         use crate::gcpm::parser::parse_gcpm;
         use std::ops::DerefMut;
         use std::sync::Arc;
@@ -4466,7 +4465,7 @@ h2 { string-set: chapter-title content(text); }
 
         let geometry = run_pass_with_break_and_running(
             doc.deref_mut(),
-            pt_to_px(800.0),
+            800.0_f32.as_pt().in_px().to_f32(),
             &column_styles,
             &store,
         );

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -211,10 +211,10 @@ pub fn run_pass(doc: &mut BaseDocument, page_height_px: f32) -> PaginationGeomet
 /// fit the remaining strip rather than splitting it.
 pub fn run_pass_with_break_styles<'a>(
     doc: &'a mut BaseDocument,
-    page_height_px: f32,
+    page_height_px: crate::units::Px,
     column_styles: &'a crate::column_css::ColumnStyleTable,
 ) -> PaginationGeometryTable {
-    run_pass_inner(doc, page_height_px, Some(column_styles), None)
+    run_pass_inner(doc, page_height_px.to_f32(), Some(column_styles), None)
 }
 
 /// fulgur-s67g Phase 2.2 variant: extends
@@ -4365,7 +4365,6 @@ mod tests {
     #[test]
     fn string_set_carry_across_page_break() {
         use crate::blitz_adapter;
-        use crate::convert::pt_to_px;
         use crate::gcpm::parser::parse_gcpm;
         use std::ops::DerefMut;
         use std::sync::Arc;
@@ -4399,7 +4398,8 @@ h2 { string-set: chapter-title content(text); }
         let store = pass.into_store();
         blitz_adapter::resolve(&mut doc);
         let column_styles = blitz_adapter::extract_column_style_table(&doc);
-        let geometry = run_pass_with_break_styles(doc.deref_mut(), pt_to_px(720.0), &column_styles);
+        let geometry =
+            run_pass_with_break_styles(doc.deref_mut(), 720.0_f32.as_pt().in_px(), &column_styles);
 
         let mut by_node: std::collections::BTreeMap<usize, Vec<(String, String)>> =
             std::collections::BTreeMap::new();
@@ -5304,7 +5304,7 @@ h2 { string-set: chapter-title content(text); }
         let direct_geom = {
             let mut doc = parse(html, 600.0);
             let table = blitz_adapter::extract_column_style_table(&doc);
-            super::run_pass_with_break_styles(doc.deref_mut(), 800.0, &table)
+            super::run_pass_with_break_styles(doc.deref_mut(), 800.0_f32.as_px(), &table)
         };
 
         let taffy_geom = {
@@ -5358,7 +5358,7 @@ h2 { string-set: chapter-title content(text); }
         "#;
         let mut doc = parse(html, 600.0);
         let table = blitz_adapter::extract_column_style_table(&doc);
-        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 800.0, &table);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 800.0_f32.as_px(), &table);
 
         // Filter to fragments whose width is exactly the cell width
         // (100) — that's only the two cards. Grid container has
@@ -5405,7 +5405,7 @@ h2 { string-set: chapter-title content(text); }
         "#;
         let mut doc = parse(html, 600.0);
         let table = blitz_adapter::extract_column_style_table(&doc);
-        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 250.0, &table);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 250.0_f32.as_px(), &table);
 
         let mut candidates: Vec<_> = geom
             .values()
@@ -5452,7 +5452,7 @@ h2 { string-set: chapter-title content(text); }
             .size
             .height = f32::INFINITY;
         let table = blitz_adapter::extract_column_style_table(&doc);
-        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 150.0, &table);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 150.0_f32.as_px(), &table);
         // Load-bearing assertion: without the guard the injected `+inf`
         // reaches a Fragment height and poisons `cursor_y`, so emitted
         // fragments carry non-finite `y` / `height`. The guard zeroes it,
@@ -5492,7 +5492,7 @@ h2 { string-set: chapter-title content(text); }
         "#;
         let mut doc = parse(html, 600.0);
         let table = blitz_adapter::extract_column_style_table(&doc);
-        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 250.0, &table);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 250.0_f32.as_px(), &table);
 
         let mut candidates: Vec<_> = geom
             .values()
@@ -5527,7 +5527,7 @@ h2 { string-set: chapter-title content(text); }
         "#;
         let mut doc = parse(html, 600.0);
         let table = blitz_adapter::extract_column_style_table(&doc);
-        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 250.0, &table);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 250.0_f32.as_px(), &table);
 
         let mut cells: Vec<_> = geom
             .values()
@@ -5567,7 +5567,7 @@ h2 { string-set: chapter-title content(text); }
         "#;
         let mut doc = parse(html, 600.0);
         let table = blitz_adapter::extract_column_style_table(&doc);
-        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 250.0, &table);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 250.0_f32.as_px(), &table);
 
         let mut cells: Vec<_> = geom
             .values()
@@ -5607,7 +5607,7 @@ h2 { string-set: chapter-title content(text); }
         "#;
         let mut doc = parse(html, 600.0);
         let table = blitz_adapter::extract_column_style_table(&doc);
-        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 250.0, &table);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 250.0_f32.as_px(), &table);
 
         let mut page_one_cells: Vec<_> = geom
             .values()
@@ -5643,7 +5643,7 @@ h2 { string-set: chapter-title content(text); }
         "#;
         let mut doc = parse(html, 600.0);
         let table = blitz_adapter::extract_column_style_table(&doc);
-        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 250.0, &table);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 250.0_f32.as_px(), &table);
 
         let mut page_one_cells: Vec<_> = geom
             .values()
@@ -5690,7 +5690,7 @@ h2 { string-set: chapter-title content(text); }
         "#;
         let mut doc = parse(html, 600.0);
         let table = blitz_adapter::extract_column_style_table(&doc);
-        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 800.0, &table);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 800.0_f32.as_px(), &table);
 
         // 100×50 の inner div fragment 4 個を集める。
         let mut inner: Vec<(u32, f32, f32)> = geom
@@ -5760,7 +5760,7 @@ h2 { string-set: chapter-title content(text); }
         "#;
         let mut doc = parse(html, 600.0);
         let table = blitz_adapter::extract_column_style_table(&doc);
-        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 800.0, &table);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 800.0_f32.as_px(), &table);
 
         let mut inner: Vec<(u32, f32, f32)> = geom
             .values()
@@ -5847,7 +5847,7 @@ h2 { string-set: chapter-title content(text); }
         // 600 viewport, 400 page strip (small enough to overflow).
         let mut doc = parse(&html, 600.0);
         let table = blitz_adapter::extract_column_style_table(&doc);
-        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 400.0, &table);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 400.0_f32.as_px(), &table);
         let pages = super::implied_page_count(&geom);
         assert!(
             pages >= 2,
@@ -5880,7 +5880,7 @@ h2 { string-set: chapter-title content(text); }
         "#;
         let mut doc = parse(html, 600.0);
         let table = blitz_adapter::extract_column_style_table(&doc);
-        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 800.0, &table);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 800.0_f32.as_px(), &table);
 
         // Find every fragment with height ≈ 100 on page 1; B is the
         // only such fragment (outer's page-1 fragment height is the
@@ -5917,7 +5917,7 @@ h2 { string-set: chapter-title content(text); }
         "#;
         let mut doc = parse(html, 600.0);
         let table = blitz_adapter::extract_column_style_table(&doc);
-        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 100.0, &table);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 100.0_f32.as_px(), &table);
 
         let second_on_page1: Vec<&Fragment> = geom
             .values()
@@ -6074,7 +6074,7 @@ h2 { string-set: chapter-title content(text); }
         "#;
         let mut doc = parse(html, 600.0);
         let table = blitz_adapter::extract_column_style_table(&doc);
-        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 200.0, &table);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 200.0_f32.as_px(), &table);
         // Page count must be ≥ 2 — without yb27 the trailing inline
         // text never reaches a new page (single fragment, page 0 only).
         let max_page = geom
@@ -6121,7 +6121,7 @@ h2 { string-set: chapter-title content(text); }
         // even when the section itself has no page-0 entry.
         let section_id =
             find_node_by_local_name(&doc, "section").expect("fixture must contain a <section>");
-        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 200.0, &table);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 200.0_f32.as_px(), &table);
         let section_geom = geom.get(&section_id).unwrap_or_else(|| {
             panic!("oc51: <section> (node_id={section_id}) missing from geometry; geom={geom:?}")
         });
@@ -6310,7 +6310,7 @@ h2 { string-set: chapter-title content(text); }
         "#;
         let mut doc = parse(html, 400.0);
         let table = blitz_adapter::extract_column_style_table(&doc);
-        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 100.0, &table);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 100.0_f32.as_px(), &table);
 
         // collect all 60px-tall, 100px-wide fragments (the two leaf cells)
         let mut frags: Vec<(u32, f32, f32)> = geom
@@ -6349,7 +6349,7 @@ h2 { string-set: chapter-title content(text); }
         "#;
         let mut doc = parse(html, 400.0);
         let table = blitz_adapter::extract_column_style_table(&doc);
-        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 100.0, &table);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 100.0_f32.as_px(), &table);
 
         let mut frags: Vec<(u32, f32, f32)> = geom
             .values()
@@ -6404,7 +6404,7 @@ h2 { string-set: chapter-title content(text); }
         "#;
         let mut doc = parse(html, 400.0);
         let table = blitz_adapter::extract_column_style_table(&doc);
-        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 100.0, &table);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 100.0_f32.as_px(), &table);
 
         // inner divs: 40px tall, 100px wide
         let mut inner: Vec<(u32, f32, f32)> = geom
@@ -6458,7 +6458,7 @@ h2 { string-set: chapter-title content(text); }
         "#;
         let mut doc = parse(html, 400.0);
         let table = blitz_adapter::extract_column_style_table(&doc);
-        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 100.0, &table);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 100.0_f32.as_px(), &table);
 
         let mut inner: Vec<(u32, f32, f32)> = geom
             .values()

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -3700,7 +3700,7 @@ impl<'a> MarginBoxRenderer<'a> {
                 let empty_column_styles = crate::column_css::ColumnStyleTable::new();
                 let geometry = crate::pagination_layout::run_pass_with_break_styles(
                     &mut render_doc,
-                    rect.height.in_px().to_f32(),
+                    rect.height.in_px(),
                     &empty_column_styles,
                 );
                 let dummy_store = RunningElementStore::new();

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -3585,8 +3585,8 @@ impl<'a> MarginBoxRenderer<'a> {
                 );
                 let measure_doc = crate::blitz_adapter::parse_and_layout(
                     &measure_html,
-                    crate::convert::pt_to_px(content_width),
-                    crate::convert::pt_to_px(page_size.height),
+                    content_width.as_pt().in_px(),
+                    page_size.height.as_pt().in_px(),
                     self.font_data,
                     self.system_fonts,
                 );
@@ -3620,8 +3620,8 @@ impl<'a> MarginBoxRenderer<'a> {
                 );
                 let measure_doc = crate::blitz_adapter::parse_and_layout(
                     &measure_html,
-                    crate::convert::pt_to_px(fixed_width),
-                    crate::convert::pt_to_px(page_size.height),
+                    fixed_width.as_pt().in_px(),
+                    page_size.height.as_pt().in_px(),
                     self.font_data,
                     self.system_fonts,
                 );
@@ -3692,8 +3692,8 @@ impl<'a> MarginBoxRenderer<'a> {
                 );
                 let mut render_doc = crate::blitz_adapter::parse_and_layout(
                     &render_html,
-                    rect.width.in_px().to_f32(),
-                    rect.height.in_px().to_f32(),
+                    rect.width.in_px(),
+                    rect.height.in_px(),
                     self.font_data,
                     self.system_fonts,
                 );

--- a/docs/plans/2026-07-04-sipv8-viewport-entry-points-px.md
+++ b/docs/plans/2026-07-04-sipv8-viewport-entry-points-px.md
@@ -1,0 +1,214 @@
+# fulgur-sipv.8 — Type Blitz viewport entry points to `units::Px`
+
+**Goal:** Eliminate every remaining `convert::pt_to_px` call site at the Blitz/Taffy
+viewport boundary by typing the two entry-point signatures `parse_and_layout` and
+`run_pass_with_break_styles` to `units::Px`, collapsing each call site to
+`…as_pt().in_px()` (or `.to_f32()` at a still-f32 sink).
+
+**Architecture:** Interpretation **A** (issue-faithful, minimal boundary): type ONLY the
+two functions the issue names. All other f32 sinks
+(`parse_html_with_local_resources`, `set_viewport_size_px`, `relayout_position_fixed`,
+`ConvertContext.viewport_size_px`, `append_position_fixed_fragments`,
+`run_pass_with_break_and_running`, `run_pass`) keep `f32`, so call sites feeding them
+end in `.to_f32()`. This mirrors the pattern sipv.7 already merged.
+
+**Tech stack:** Rust, `crate::units::{Px, Pt, F32Units}`. Conversion identity
+(confirmed at `convert/mod.rs:61-69`): `pt_to_px(v) == v / PX_TO_PT == Pt(v).in_px()`,
+`px_to_pt(v) == v * PX_TO_PT == Px(v).in_pt()`. No reciprocal-multiply → every swap is
+byte-identical.
+
+**Byte-neutral protocol (epic fulgur-sipv, from P2b/sipv.7):** baseline GREEN before any
+edit; VRT goldens byte-identical after (`git status` on `crates/fulgur-vrt/goldens`
+empty; NEVER `FULGUR_VRT_UPDATE=1`); `cargo build`/`clippy -D warnings`/`fmt --check`
+clean; `cargo test -p fulgur --lib` (incl. `render_smoke`) green; `examples_determinism`
+green. Preserve arithmetic operand order (no reassociation).
+
+## The two idioms (advisor's highest-risk trap — categorize per site, NO global sed)
+
+| Source value | Correct swap | Ends in |
+|---|---|---|
+| raw f32 already in **px** (bare literal `595.0`, `800.0`) | `595.0_f32.as_px()` | `Px` |
+| raw f32 in **pt** wrapped in `pt_to_px(x)` | `x.as_pt().in_px()` | `Px` (÷0.75) |
+| `Pt`-typed value fed via `.in_px().to_f32()` (sipv.7) | `.in_px()` | `Px` (drop `.to_f32()`) |
+| Px result but sink is still f32 | append `.to_f32()` | `f32` |
+| Px result but sink is u32 | append `.to_f32() as u32` | `u32` |
+
+Miscategorizing a bare px literal as `.as_pt().in_px()` injects a spurious ÷0.75;
+using `.as_px()` on a `pt_to_px` site drops the ÷0.75. Both rebless goldens. Check each.
+
+---
+
+## Task 1: Type `run_pass_with_break_styles(page_height_px: Px)` + all callers (one atomic commit)
+
+**Files:**
+
+- Modify: `crates/fulgur/src/pagination_layout.rs`
+  - `212-217`: param `page_height_px: f32` → `page_height_px: crate::units::Px`; body
+    `run_pass_inner(doc, page_height_px, …)` → `run_pass_inner(doc, page_height_px.to_f32(), …)`.
+  - Test callers passing **bare px literals** → `.as_px()`:
+    `5307` (800.0), `5361` (800.0), `5408` (250.0), `5455` (150.0), `5495` (250.0),
+    `5530` (250.0), `5570` (250.0), `5610` (250.0), `5646` (250.0), `5693` (800.0),
+    `5763` (800.0), `5850` (400.0), `5883` (800.0), `5920` (100.0), `6077` (200.0),
+    `6124` (200.0), `6313` (100.0), `6352` (100.0), `6407` (100.0), `6461` (100.0).
+    (Line numbers are pre-edit anchors; grep `run_pass_with_break_styles(` to enumerate.)
+  - `4402`: `pt_to_px(720.0)` → `720.0_f32.as_pt().in_px()` (pt-source, ÷0.75). Then the
+    `use crate::convert::pt_to_px;` at `4368` becomes unused → remove it (verify no other
+    use in that `#[test]` fn body).
+- Modify: `crates/fulgur/src/engine.rs`
+  - `872` (`build_drawables_for_testing_no_gcpm`) and `937`
+    (`build_drawables_and_geometry_for_testing_no_gcpm`):
+    `crate::convert::pt_to_px(self.config.content_height())` →
+    `self.config.content_height().as_pt().in_px()` (NO `.to_f32()` — sink is now `Px`).
+- Modify: `crates/fulgur/src/render.rs`
+  - `3703` (feeds `run_pass_with_break_styles`): `rect.height.in_px().to_f32()` →
+    `rect.height.in_px()` (drop `.to_f32()`; `rect.height` is `Pt`).
+
+**Note:** `run_pass` (test-only) and `run_pass_with_break_and_running` (production body
+path) intentionally stay `f32` — only the `styles` variant had `pt_to_px` sites to kill.
+`F32Units` must be in scope where `.as_px()`/`.as_pt()` is used (add
+`use crate::units::F32Units;` to the test module / check existing imports).
+
+**Step 1 — verify baseline green** (done before editing; see baseline task).
+
+**Step 2 — apply the edits above.**
+
+**Step 3 — build + lib test:**
+Run: `cargo build -p fulgur && cargo test -p fulgur --lib 2>&1 | tail`
+Expected: compiles, all lib tests pass. Watch for a byte-diff surfacing as a failing
+pagination fragmentation assertion (would mean an idiom miscategorization at 4402).
+
+**Step 4 — commit:**
+`refactor(fulgur): type run_pass_with_break_styles page_height to units::Px`
+
+---
+
+## Task 2: Type `parse_and_layout(viewport_width: Px, viewport_height: Px)` + all callers (one atomic commit)
+
+**Files:**
+
+- Modify: `crates/fulgur/src/blitz_adapter.rs`
+  - `144-163`: params `viewport_width: f32, viewport_height: f32` →
+    `viewport_width: crate::units::Px, viewport_height: crate::units::Px`. Body:
+    - `parse_inner(html, viewport_width, viewport_height as u32, …)` →
+      `parse_inner(html, viewport_width.to_f32(), viewport_height.to_f32() as u32, …)`
+      (preserve the `as u32` truncation on the SAME f32 value).
+    - `relayout_position_fixed(&mut doc, viewport_width, viewport_height)` →
+      `relayout_position_fixed(&mut doc, viewport_width.to_f32(), viewport_height.to_f32())`.
+  - Test callers passing **bare px literals** → `.as_px()` each arg:
+    `3674` (400.0, 600.0), `5095/5105/5118/5140/5160/5177/5372` (400.0, 2000.0).
+- Modify: `crates/fulgur/src/render.rs`
+  - `3586-3592` (measure): `pt_to_px(content_width)`→`content_width.as_pt().in_px()`,
+    `pt_to_px(page_size.height)`→`page_size.height.as_pt().in_px()`.
+  - `3621-3627` (height measure): `pt_to_px(fixed_width)`→`fixed_width.as_pt().in_px()`,
+    `pt_to_px(page_size.height)`→`page_size.height.as_pt().in_px()`.
+    (`content_width`, `fixed_width`, `page_size.height` are f32 **pt** here.)
+  - `3693-3699` (render): `rect.width.in_px().to_f32()`→`rect.width.in_px()`,
+    `rect.height.in_px().to_f32()`→`rect.height.in_px()` (drop `.to_f32()`; both `Pt`).
+- Modify test callers passing **bare px literals** → `.as_px()`:
+  - `crates/fulgur/src/convert/inline_root.rs:1077` (595.0, 842.0)
+  - `crates/fulgur/src/convert/replaced.rs:345` (595.0, 842.0)
+  - `crates/fulgur/src/convert/mod.rs:1202` (595.0, 842.0)
+  - `crates/fulgur/src/convert/positioned.rs`: `474`, `630`, `667`, `700`, `733`, `768`,
+    `807`, `1047`, `1078`, `1108`, `1135`, `1175`, `1215`, `1280` (each `595.0, 842.0`).
+    Grep `parse_and_layout(` in the file to confirm all sites and multi-line arg layout.
+
+**Step 1 — apply edits.**
+
+**Step 2 — build + lib test:**
+Run: `cargo build -p fulgur && cargo test -p fulgur --lib 2>&1 | tail`
+Expected: compiles green. Ensure `F32Units` is in scope in each edited test module.
+
+**Step 3 — commit:**
+`refactor(fulgur): type parse_and_layout viewport dims to units::Px`
+
+---
+
+## Task 3: Remaining engine.rs viewport `pt_to_px` sites + pagination 4469 + dead_code gate (one atomic commit)
+
+These feed still-f32 sinks → each ends in `.to_f32()` (or `.to_f32() as u32`). After this
+commit, production `pt_to_px` callers = 0.
+
+**Files:**
+
+- Modify: `crates/fulgur/src/engine.rs` — replace `crate::convert::pt_to_px(X)` with
+  `X.as_pt().in_px().to_f32()`; the two `… as u32` sites keep `as u32`:
+  - `210` width → `.to_f32()`; `211` `page_height()` → `.to_f32() as u32` (feeds
+    `parse_html_with_local_resources`).
+  - `274` `resolved_content_width_px = …pt.as_pt().in_px().to_f32()`;
+    `275` `resolved_content_height_px = …pt.as_pt().in_px().to_f32()`
+    (f32 locals reused at 278/463/525-527/548-574/664 — must stay f32).
+  - `851` `.to_f32()`; `852` `.to_f32() as u32` (parse_html, testing helper A).
+  - `865/866` `.to_f32()` (`relayout_position_fixed`).
+  - `889/890` `.to_f32()` (`ConvertContext.viewport_size_px: Some((f32,f32))`).
+  - `916` `.to_f32()`; `917` `.to_f32() as u32` (parse_html, testing helper B).
+  - `930/931` `.to_f32()` (`relayout_position_fixed`).
+  - `947/948` `content_w_px/content_h_px = …to_f32()` (`append_position_fixed_fragments`).
+- Modify: `crates/fulgur/src/pagination_layout.rs`
+  - `4469`: `pt_to_px(800.0)` → `800.0_f32.as_pt().in_px().to_f32()` (feeds
+    `run_pass_with_break_and_running`, which stays f32). Remove the now-unused
+    `use crate::convert::pt_to_px;` at `4444`.
+- Modify: `crates/fulgur/src/convert/mod.rs`
+  - `pt_to_px` (`67-69`) now has zero non-test callers (only the `1623` roundtrip test).
+    Gate it: add `#[cfg(test)]` above `#[inline]`/the fn. Leave `px_to_pt` untouched
+    (shadow.rs still uses it until sipv.2). Confirm `cargo build` (no `--tests`) is warning
+    -clean.
+
+**Step 1 — apply edits.**
+
+**Step 2 — full verification (the gate):**
+
+```bash
+# no pt_to_px symbols remain except the definition + roundtrip test
+grep -rn "convert::pt_to_px\|pt_to_px(" crates/fulgur/src   # expect only mod.rs def + :1623 test
+cargo build -p fulgur                 # non-test build: pt_to_px must not warn dead_code
+cargo build -p fulgur --tests
+cargo clippy -p fulgur --all-targets -- -D warnings
+cargo fmt --check
+cargo test -p fulgur --lib 2>&1 | tail
+```
+
+Expected: all clean/green.
+
+**Step 3 — commit:**
+`refactor(fulgur): type remaining engine viewport feeds to units::Px`
+
+---
+
+## Task 4: Byte-identity + determinism + coverage gate
+
+**Step 1 — VRT byte-identical (the critical gate for this boundary):**
+
+```bash
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur-vrt 2>&1 | tail
+git status --short crates/fulgur-vrt/goldens    # MUST be empty
+```
+
+If any golden diff appears → an idiom was miscategorized (4/3 scale bug). Do NOT
+`FULGUR_VRT_UPDATE=1`; bisect the offending site instead.
+
+**Step 2 — examples determinism:**
+Run: `FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur-cli --test examples_determinism 2>&1 | tail`
+Expected: green.
+
+**Step 3 — coverage check (preempt codecov/patch, per project_units_migration_patch_coverage):**
+The changed PROD lines live in already-covered functions (parse_and_layout / run_pass have
+many test callers; engine 208-280 via `render_smoke`). The classic artifact (assert-arg
+`.to_f32()` cold region) does NOT apply — the new `.to_f32()` sit in hot call-arg
+positions, not panic args. Verify empirically with the CI-equivalent command; if any added
+line intersects an lcov `DA:N,0`, add a targeted non-VRT test (do NOT `FULGUR_VRT_UPDATE`).
+
+```bash
+cargo llvm-cov nextest --workspace --exclude fulgur-vrt --lcov --output-path /tmp/sipv8.lcov 2>&1 | tail
+```
+
+**Step 4 — final commit / open PR** (title English, body Japanese per project convention).
+
+---
+
+## Out of scope (state in PR body to preempt reviewer)
+
+- `run_pass_with_break_and_running` / `run_pass` stay `f32` — only the `styles` variant had
+  `pt_to_px` sites; 4469 feeds the running variant purely for symbol elimination.
+- `fn px_to_pt` and `fn pt_to_px` definitions are NOT deleted — `px_to_pt` is still used by
+  `shadow.rs` (sipv.2, still open). Both defs get removed when sipv.2 lands (px_to_pt's last
+  caller). `pt_to_px` is `#[cfg(test)]`-gated here as interim.


### PR DESCRIPTION
## 概要

`fulgur-sipv` エピック（`px_to_pt`/`pt_to_px` 全廃）の **最後（8/8）** のサブタスク。Blitz/Taffy ビューポート境界に残っていた `convert::pt_to_px` 呼び出しを全廃し、2 つのエントリポイント関数のシグネチャを `units::Px` 化する。座標系で最も繊細な境界（`coordinate-system.md` の "most important"）かつ `as u32` 切り捨てを含むため、エピックの推奨順で **最後** に回されていた箇所。

## アプローチ（interpretation A: issue 準拠の最小境界）

issue が名指しする **2 関数だけ** を `Px` 化する:

- `blitz_adapter::parse_and_layout(viewport_width: Px, viewport_height: Px)`
- `pagination_layout::run_pass_with_break_styles(page_height_px: Px)`

内部では `.to_f32()` / `.to_f32() as u32` で一度だけ f32 へ落とす。その他の f32 シンク（`parse_html_with_local_resources` / `set_viewport_size_px` / `relayout_position_fixed` / `ConvertContext.viewport_size_px` / `append_position_fixed_fragments` / `run_pass_with_break_and_running`）は f32 のまま据え置き、それらへ渡す呼び出し側は `.to_f32()` で終端する（sipv.7 が確立したパターンと同一）。

## 変更内容（3 コミット + /simplify のコメント精緻化 1 コミット）

1. **`run_pass_with_break_styles` → Px**: engine テストヘルパ 2 箇所は `config.content_height().as_pt().in_px()`、render margin-box 段（sipv.7 の `.in_px().to_f32()`）は `.in_px()` に collapse、bare px リテラルのテスト呼び出し 20 箇所は `N.0_f32.as_px()`、pt 由来の 1 箇所（4402）は `720.0_f32.as_pt().in_px()`。
2. **`parse_and_layout` → Px**: render 3 段（measure/height/render）、`parse_and_layout` を直接叩く約 25 のテスト呼び出しを `.as_px()` 化。`viewport_height.to_f32() as u32` で切り捨てを同一 f32 上に温存。
3. **engine 残 16 箇所 + pagination 4469 + dead_code gate**: engine の `pt_to_px(config.foo())` を `config.foo().as_pt().in_px().to_f32()`（`page_height()` 3 箇所は `as u32` 温存）。`pt_to_px` は本番呼び出し 0 になるため `#[allow(dead_code)]` で退避。

## byte-neutral の根拠

`as_pt().in_px() == pt_to_px`（ともに `v / PX_TO_PT`）、`as_px().in_pt() == px_to_pt`（ともに `v * PX_TO_PT`）。逆数乗算ではないので bit 単位で同一（`convert/mod.rs:61-69` で確認）。演算順序の組み替えなし。

## 検証

- `cargo build`（0 warning、`pt_to_px` の dead_code 退避済み）/ `clippy --all-targets -D warnings` / `fmt --check` すべてクリーン
- fulgur 全テスト（lib 1606 + integration 全 binary）: **0 failed**
- **VRT: 11 goldens すべて byte-identical**（`git status crates/fulgur-vrt/goldens` 空 / `FULGUR_VRT_UPDATE` 未使用）— 最も繊細な境界で 4/3 スケールバグが無いことの実証
- `examples_determinism`: 11 passed
- 2 つの `pub fn` の外部クレート呼び出し（bindings / cli bin）が無いことを確認済み（すべて Engine API 経由）
- `/simplify` 4 観点（reuse / simplification / efficiency / altitude）レビュー: コード指摘なし（機械的な型付け diff として clean）

## スコープ外（レビュー先回り）

- `run_pass_with_break_and_running` / `run_pass` は f32 のまま — `pt_to_px` 呼び出しが在ったのは `styles` 変種だけ。4469 が running 変種を叩くのはシンボル除去のためだけで `.to_f32()` 終端。
- `fn px_to_pt` / `fn pt_to_px` の定義は削除しない — `px_to_pt` は `shadow.rs`（fulgur-sipv.2、未完了）が本番利用中。両定義は sipv.2 が最後の `px_to_pt` 呼び出しを落とす際にまとめて削除する。`pt_to_px` を `#[cfg(test)]` ではなく `#[allow(dead_code)]` で退避したのは、`PX_TO_PT` の doc が両兄弟（`[px_to_pt]` / `[pt_to_px]`）を intra-doc link しており、まだ本番稼働の `px_to_pt` 側とリンクの対称性を保つため（両者は sipv.2 で同時に削除）。

Closes fulgur-sipv.8（これによりエピック fulgur-sipv は残り fulgur-sipv.2 のみ）。