### PR TITLE
fix(fulgur): collapse tall non-painting replaced elements to close blank-page DoS

### DIFF
--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -980,43 +980,60 @@ impl<'a> PaginationLayoutTree<'a> {
                 // fulgur-ezst: a CHILDLESS block whose slicing would exceed
                 // the cap is a pathological amplifier — `<div
                 // style="height:99999999px">` is a web-only spacer/overflow
-                // idiom that prints nothing but blank pages. Emit only its
-                // first slice: skip the per-page fragment pushes while
-                // leaving the loop's page_index / cursor_y / remaining math
-                // untouched, so following in-flow siblings keep their exact
-                // positions (no reflow) and a trailing block collapses for
-                // free (`implied_page_count` reads the max fragment index).
-                // Background / border presence does NOT gate this — nobody
-                // authors a >MAX_PAGES-tall filled band on purpose. A
-                // content-bearing block, or a childless band that fits
-                // within the cap, is not collapsed and takes the
-                // truncate-and-warn path below unchanged.
+                // idiom that prints nothing but blank pages. Collapse it to
+                // its single first slice: emit only that slice AND bound the
+                // space it occupies (resume following content on the next
+                // page) so the document does not balloon. Background / border
+                // presence does NOT gate this — nobody authors a
+                // >MAX_PAGES-tall filled band on purpose. A content-bearing
+                // block, or a childless band that fits within the cap, is not
+                // collapsed and takes the truncate-and-warn path below
+                // unchanged.
                 //
                 // fulgur-c8re (security): a replaced element (`<img>` /
-                // `<svg>`) is NOT special-cased out of this collapse. It only
-                // reaches this branch when it is taller than `MAX_PAGES` pages
-                // (~10M px) — a range no legitimate single image occupies — so
-                // collapsing a non-painting one (unresolved `src`,
-                // `visibility:hidden`, undecodable format, empty `<svg>`) to a
-                // single clipped page loses nothing real, while gating on tag
-                // name alone (the removed `is_replaced_content`) let such a
-                // node amplify a few bytes of HTML into ~`MAX_PAGES` blank
-                // pages (a validated high-severity DoS).
+                // `<svg>`) is NOT special-cased out of this collapse —
+                // painting or not. It only reaches this branch when it is
+                // taller than `MAX_PAGES` pages (~10M px), a range no
+                // legitimate single image occupies, so clipping it to one page
+                // loses nothing real — even a *resolved* image, because a 1×1
+                // bitmap stretched with `height:99999999px` is the same
+                // amplifier as an unresolved `src`. Gating on tag name alone
+                // (the removed `is_replaced_content`) let such a node amplify a
+                // few bytes of HTML into ~`MAX_PAGES` blank pages (a validated
+                // high-severity DoS).
                 let collapse_childless = self.page_height_px > 0.0
                     && (remaining / self.page_height_px).ceil() > crate::MAX_PAGES as f32
                     && !subtree_has_rendered_content(self.doc, child_id, 0);
-                // fulgur-2m6w: cap the per-page-strip slicing at
-                // `MAX_PAGES`. `child_h` is attacker-controlled CSS
-                // (`height` / `vh`), so without this bound a few bytes of
-                // HTML (`<div style="height:99999999px">`) generate ~10^5
-                // fragments — and a non-finite height would never reduce
-                // `remaining`, looping forever. The `page_index` ceiling is
-                // load-bearing on its own (it stops the loop even when
-                // `remaining` is `+inf`); content past the cap is truncated.
-                while remaining > 0.0 && page_index < crate::MAX_PAGES {
+                if collapse_childless {
+                    // fulgur-c8re (Codex P1 on PR #575): bound the OCCUPIED
+                    // SPACE, not just the fragment pushes. `implied_page_count`
+                    // reads the max fragment index across ALL nodes, so if the
+                    // slice loop advanced `page_index` to `MAX_PAGES` a trailing
+                    // in-flow sibling (`<div huge></div><p>after</p>`) would be
+                    // stranded on a deep page and re-inflate the PDF to
+                    // ~`MAX_PAGES` blank pages. The first slice already emitted
+                    // above fills the current strip, so resume following content
+                    // on the next page.
+                    log::warn!(
+                        "pagination: collapsed a childless block of height \
+                         {child_h}px (slicing would exceed the {}-page limit) \
+                         to a single page (fulgur-ezst)",
+                        crate::MAX_PAGES,
+                    );
                     page_index += 1;
-                    last_slice_h = remaining.min(self.page_height_px);
-                    if !collapse_childless {
+                    cursor_y = 0.0;
+                } else {
+                    // fulgur-2m6w: cap the per-page-strip slicing at
+                    // `MAX_PAGES`. `child_h` is attacker-controlled CSS
+                    // (`height` / `vh`), so without this bound a few bytes of
+                    // HTML (`<div style="height:99999999px">`) generate ~10^5
+                    // fragments — and a non-finite height would never reduce
+                    // `remaining`, looping forever. The `page_index` ceiling is
+                    // load-bearing on its own (it stops the loop even when
+                    // `remaining` is `+inf`); content past the cap is truncated.
+                    while remaining > 0.0 && page_index < crate::MAX_PAGES {
+                        page_index += 1;
+                        last_slice_h = remaining.min(self.page_height_px);
                         self.geometry
                             .entry(child_id)
                             .or_default()
@@ -1028,18 +1045,9 @@ impl<'a> PaginationLayoutTree<'a> {
                                 width: child_w.as_px(),
                                 height: last_slice_h.as_px(),
                             });
+                        remaining -= last_slice_h;
                     }
-                    remaining -= last_slice_h;
-                }
-                if remaining > 0.0 {
-                    if collapse_childless {
-                        log::warn!(
-                            "pagination: collapsed a childless block of \
-                             height {child_h}px (slicing would exceed the \
-                             {}-page limit) to a single page (fulgur-ezst)",
-                            crate::MAX_PAGES,
-                        );
-                    } else {
+                    if remaining > 0.0 {
                         log::warn!(
                             "pagination: block height {child_h}px exceeds the \
                              {}-page limit; truncating remaining content to \
@@ -1047,12 +1055,12 @@ impl<'a> PaginationLayoutTree<'a> {
                             crate::MAX_PAGES,
                         );
                     }
+                    cursor_y = if child_h - first_slice_h > 0.0 {
+                        last_slice_h
+                    } else {
+                        cursor_y + first_slice_h
+                    };
                 }
-                cursor_y = if child_h - first_slice_h > 0.0 {
-                    last_slice_h
-                } else {
-                    cursor_y + first_slice_h
-                };
                 emitted += 1;
                 prev_bottom_y_in_body = this_top_in_body + child_h;
                 if !is_float {
@@ -4267,19 +4275,19 @@ mod tests {
         );
     }
 
-    /// fulgur-ezst: pins the no-reflow / no-free-page-reduction mechanism of
-    /// the childless collapse. The collapse skips only the per-page fragment
-    /// pushes — it deliberately leaves the slice loop's `page_index` counter
-    /// advancing all the way to `MAX_PAGES` — so a following in-flow sibling
-    /// lands on the SAME deep page it would occupy without the collapse (the
-    /// document is not silently shortened, and siblings do not reflow up to
-    /// page 0). If someone "optimizes" the loop to break early once the
-    /// collapse is decided, the `<p>` would jump to page ~0/1 and this test
-    /// fails. Asserts: the tall div contributes exactly one fragment
-    /// (collapse fired) while the `<p>` sibling's fragment stays at
-    /// `page_index >= MAX_PAGES`.
+    /// fulgur-c8re (security, Codex P1 on PR #575): the childless collapse must
+    /// bound the SPACE the pathological element occupies, not just skip its
+    /// per-page fragment pushes. The predecessor behaviour left the slice loop
+    /// advancing `page_index` all the way to `MAX_PAGES`, so a following in-flow
+    /// sibling was stranded on a deep page and `implied_page_count` — which
+    /// reads the max fragment index across ALL nodes — re-inflated the document
+    /// to ~`MAX_PAGES` blank pages (`<div huge></div><p>after</p>`), defeating
+    /// the collapse. The element now consumes only its single first slice and
+    /// following content reflows onto the next page. Asserts: the tall div
+    /// contributes exactly one fragment (collapse fired) AND the `<p>` sibling
+    /// lands on a bounded page, so the whole document stays a handful of pages.
     #[test]
-    fn childless_collapse_does_not_reflow_following_sibling() {
+    fn childless_collapse_reflows_following_sibling() {
         use std::ops::DerefMut;
         let html = r#"<html><body><div id="tall" style="height: 99999999px"></div><p id="after">after</p></body></html>"#;
         let mut doc = parse(html, 600.0);
@@ -4301,10 +4309,33 @@ mod tests {
             .fragments[0]
             .page_index;
         assert!(
-            after_page >= crate::MAX_PAGES,
-            "following sibling must stay on its deep page (>= MAX_PAGES {}); got {after_page} \
-             — an early loop break would reflow it near page 0",
-            crate::MAX_PAGES,
+            after_page <= 1,
+            "collapsed spacer must reflow its trailing sibling onto a bounded page \
+             (<= 1), not strand it ~MAX_PAGES deep; got {after_page}",
+        );
+        assert!(
+            implied_page_count(&table) <= 2,
+            "a childless spacer followed by content must stay a handful of pages; got {}",
+            implied_page_count(&table),
+        );
+    }
+
+    /// fulgur-c8re (security, Codex P1 on PR #575): the replaced-element
+    /// collapse must bound trailing content too. A non-painting tall image
+    /// (`<img src="missing.png" height:99999999px>`) followed by a `<p>` must
+    /// not amplify into ~`MAX_PAGES` blank pages — the same trailing-sibling
+    /// vector as `childless_collapse_reflows_following_sibling`, but exercising
+    /// the replaced-element path that the `is_replaced_content` removal opened.
+    #[test]
+    fn replaced_tall_collapse_bounds_trailing_sibling() {
+        let html = r#"<html><body><img src="missing.png" style="display:block;width:10px;height:99999999px"><p>after</p></body></html>"#;
+        let mut doc = parse(html, 600.0);
+        let table = run_pass(&mut doc, 800.0);
+        assert!(
+            implied_page_count(&table) <= 2,
+            "a non-painting tall replaced element followed by content must \
+             collapse without amplifying; got {} pages",
+            implied_page_count(&table),
         );
     }
 

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -991,10 +991,20 @@ impl<'a> PaginationLayoutTree<'a> {
                 // content-bearing block, or a childless band that fits
                 // within the cap, is not collapsed and takes the
                 // truncate-and-warn path below unchanged.
+                //
+                // fulgur-c8re (security): a replaced element (`<img>` /
+                // `<svg>`) is NOT special-cased out of this collapse. It only
+                // reaches this branch when it is taller than `MAX_PAGES` pages
+                // (~10M px) — a range no legitimate single image occupies — so
+                // collapsing a non-painting one (unresolved `src`,
+                // `visibility:hidden`, undecodable format, empty `<svg>`) to a
+                // single clipped page loses nothing real, while gating on tag
+                // name alone (the removed `is_replaced_content`) let such a
+                // node amplify a few bytes of HTML into ~`MAX_PAGES` blank
+                // pages (a validated high-severity DoS).
                 let collapse_childless = self.page_height_px > 0.0
                     && (remaining / self.page_height_px).ceil() > crate::MAX_PAGES as f32
-                    && !subtree_has_rendered_content(self.doc, child_id, 0)
-                    && !is_replaced_content(self.doc, child_id);
+                    && !subtree_has_rendered_content(self.doc, child_id, 0);
                 // fulgur-2m6w: cap the per-page-strip slicing at
                 // `MAX_PAGES`. `child_h` is attacker-controlled CSS
                 // (`height` / `vh`), so without this bound a few bytes of
@@ -1119,19 +1129,6 @@ impl<'a> PaginationLayoutTree<'a> {
 
         emitted
     }
-}
-
-/// fulgur-ezst (Codex P2 on PR #553): true if `node_id` is a replaced
-/// element that paints its own box content — `<img>` / `<svg>`, matching
-/// `convert::replaced`'s dispatch. Such a node has no rendered *descendants*
-/// yet is visible content in its own right, so a pathologically tall one
-/// must NOT be collapsed like a blank spacer (the collapse would clip the
-/// image to a single page). A background / border is decoration, not
-/// replaced content, and stays collapsible by design (see `MAX_PAGES`).
-fn is_replaced_content(doc: &BaseDocument, node_id: usize) -> bool {
-    doc.get_node(node_id)
-        .and_then(|n| n.element_data())
-        .is_some_and(|el| matches!(el.name.local.as_ref(), "img" | "svg"))
 }
 
 /// fulgur-ezst: true if `parent_id`'s subtree renders any VISIBLE box (a
@@ -4204,25 +4201,40 @@ mod tests {
         ));
     }
 
-    /// fulgur-ezst (Codex P2 on PR #553): a replaced element (`<img>`/`<svg>`)
-    /// has no descendants but paints its own box, so a pathologically tall
-    /// one must NOT collapse (that would clip the image to one page) — it
-    /// takes the cap path like any content-bearing block.
+    /// fulgur-c8re (security): a pathologically tall CHILDLESS replaced
+    /// element (`<img>` / `<svg>`) that paints nothing must collapse like any
+    /// blank spacer. "Paints nothing" covers the common offline-first case of
+    /// an unresolved `src` (no matching `AssetBundle` entry), a
+    /// `visibility:hidden` image, an undecodable format, and an empty `<svg>`.
+    ///
+    /// The predecessor `is_replaced_content` exception (Codex P2 on PR #553 /
+    /// fulgur-ezst) gated the collapse on tag name alone, so such a
+    /// non-painting node disabled the collapse and amplified a few bytes of
+    /// HTML into ~`MAX_PAGES` blank pages (a validated high-severity DoS). It
+    /// was removed: a replaced element only reaches this branch when it is
+    /// taller than `MAX_PAGES` pages (~10M px), a range no legitimate single
+    /// image occupies, so clipping it to one page loses no real content.
     #[test]
-    fn replaced_tall_block_is_not_collapsed() {
-        let html = r#"<html><body><img style="display:block;width:10px;height:99999999px" src="x.png"></body></html>"#;
-        let mut doc = parse(html, 600.0);
-        let table = run_pass(&mut doc, 800.0);
-        let pages = implied_page_count(&table);
-        assert!(
-            pages > 1_000,
-            "a replaced element paints its own content and must not collapse; got {pages}",
-        );
-        assert!(
-            pages <= crate::MAX_PAGES + 1,
-            "still clamped to ~MAX_PAGES ({}); got {pages}",
-            crate::MAX_PAGES,
-        );
+    fn replaced_tall_childless_block_collapses() {
+        for tag in [
+            // Unresolved `src`: no `AssetBundle` on this test path, so the
+            // image paints nothing — yet it is still a pathological amplifier.
+            r#"<img src="missing.png" style="display:block;width:10px;height:99999999px">"#,
+            // `visibility:hidden`: occupies layout, paints nothing.
+            r#"<img src="x.png" style="display:block;visibility:hidden;width:10px;height:99999999px">"#,
+            // Empty `<svg>`: no drawable content.
+            r#"<svg style="display:block;width:10px;height:99999999px"></svg>"#,
+        ] {
+            let html = format!(r#"<html><body>{tag}</body></html>"#);
+            let mut doc = parse(&html, 600.0);
+            let table = run_pass(&mut doc, 800.0);
+            assert_eq!(
+                implied_page_count(&table),
+                1,
+                "a non-painting tall replaced element must collapse, not \
+                 amplify into blank pages: {tag}",
+            );
+        }
     }
 
     /// fulgur-ezst (Codex P2 on PR #553): a `visibility:hidden` descendant

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -4857,6 +4857,35 @@ fn childless_cap_exceeding_block_collapses_end_to_end() {
     );
 }
 
+/// fulgur-c8re (security): a tall CHILDLESS *replaced* element that paints
+/// nothing — an unresolved `src` (the common offline-first case, no matching
+/// `AssetBundle` entry), a `visibility:hidden` image, or an empty `<svg>` —
+/// must collapse end-to-end just like the blank `<div>` above, not amplify
+/// into ~10k blank pages. Guards the full `render.rs` per-page-allocation
+/// path the DoS finding exploited; the pagination unit test only checks
+/// `implied_page_count`. A tag-only replaced-element exception previously
+/// disabled the collapse here — uncollapsed, this 79-byte input rendered
+/// ~10k pages / ~3 MB; collapsed it is a single ~KB page.
+#[test]
+fn replaced_childless_cap_exceeding_block_collapses_end_to_end() {
+    let html = r#"<!doctype html><html><body><img src="missing.png" style="display:block;width:1px;height:99999999px"></body></html>"#;
+    let pdf = Engine::builder()
+        .build()
+        .render(html)
+        .expect("render must terminate and succeed");
+    assert!(pdf.starts_with(b"%PDF"), "expected a valid PDF");
+    assert_eq!(
+        page_count(&pdf),
+        1,
+        "a non-painting tall replaced element must collapse to a single page",
+    );
+    assert!(
+        pdf.len() < 500_000,
+        "collapsed render must be small (single page); got {} bytes",
+        pdf.len(),
+    );
+}
+
 /// fulgur-2qpt: deprecated aliases `render_html` and `render_html_to_file`
 /// must delegate to the renamed methods and produce valid PDFs.
 #[test]


### PR DESCRIPTION
## 概要

セキュリティトリアージ（high / attack-path high）で報告された、**微小な HTML 入力を ~1万ページの空白 PDF に増幅できる可用性の脆弱性**を修正します。

`pagination_layout.rs` の childless-collapse 防御（`fulgur-ezst` / PR #553）は、`is_replaced_content()` という **タグ名だけの判定**で `<img>` / `<svg>` を collapse 対象から除外していました。しかしこの判定は「その要素が実際に描画するか」を見ていないため、**何も描画しない replaced 要素**が collapse を無効化し、増幅を起こしていました。

## 提案パッチではなく例外の削除を採った理由

報告に添付されていた提案パッチは `visibility:hidden` チェックを足すだけで、**`missing-src` ベクタが残ります**:

- offline-first の fulgur では、`AssetBundle` に未登録の `src` を持つ `<img>` は `convert_image` が `false` を返し**何も描画しません**。これは特殊ケースではなく最も一般的なケースです。
- したがって `<img src="nope" style="display:block;height:99999999px">`（可視・未解決）だけで、提案パッチ適用後も依然 ~1万ページに増幅します。

そこで **`is_replaced_content()` とその gate 項を丸ごと削除**しました。gate 条件 `(remaining / page_height).ceil() > MAX_PAGES` により、この分岐に到達する replaced 要素は**高さが約1万ページ相当（~1000万px）を超えるものだけ**です。この領域に正当な単一画像は存在せず、「1ページにクリップ」しても失うものはありません。削除により以下を**一括**で塞ぎます:

- 未解決 `src`（`missing.png` 等）
- `visibility:hidden` の画像
- デコード不能なフォーマット
- 空の `<svg>`

あわせて `convert::replaced` とのロジック重複（コメントが懸念していたドリフト源）も解消されます。

## 挙動の変更

`MAX_PAGES` 超（~1000万px）の **childless な replaced 要素**が、従来の「~1万ページにスライス」から「1ページにクリップ」へ変わります。それ未満の高さの画像は従来どおり通常のスライス経路を通り、影響ありません。

これは `fulgur-ezst` / PR #553 の Codex P2 フォローアップを覆す変更です。既存テスト `replaced_tall_block_is_not_collapsed`（未解決 img で「collapse しない」を assert していた＝過剰近似というバグそのものを固定化）は、collapse する方向へ反転しました。

## 検証

TDD で実施（RED → GREEN を確認）。

- 新テスト `replaced_tall_childless_block_collapses`: RED `10001` → GREEN `1`（未解決 img / `visibility:hidden` img / 空 svg の3ケース）
- `cargo test -p fulgur`（lib 1606件 + 統合 render_smoke 182件ほか）: 緑
- `cargo test -p fulgur-cli`（`examples_determinism` バイト比較含む）: 緑
- `cargo test -p fulgur-vrt`（PDF バイト比較 golden）: **バイト一致**
- `cargo clippy` / `cargo fmt --check`: クリーン
- エンドツーエンド（CLI, 報告と同経路）: PoC が **10001ページ / 3,079,430バイト → 1ページ / 1575バイト**

Closes `fulgur-c8re`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 描画されない画像やSVGを含む場合でも、不要なページ分割が大量に発生しないように改善しました。
  * 特定の条件でページ数が膨らみすぎる問題を抑え、極端な負荷や不安定動作のリスクを低減しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->