### PR TITLE
docs(changelog): backfill 0.27.0 security note (GHSA-395p-pj7r-jm42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file.
 
 <!-- Release notes generated using configuration in .github/release.yml at main -->
 
-
+### Security
+* Fixes an availability (denial-of-service) vulnerability: unbounded CSS `counters()` expansion in generated content could exhaust CPU/memory when rendering untrusted HTML/CSS that uses CSS counters / `bookmark-label` (GCPM). Advisory: [GHSA-395p-pj7r-jm42](https://github.com/fulgur-rs/fulgur/security/advisories/GHSA-395p-pj7r-jm42) (High, CVSS 7.5, CWE-400). Affected: `>= 0.15.0, < 0.27.0`; fixed in 0.27.0.
 
 **Full Changelog**: https://github.com/fulgur-rs/fulgur/compare/v0.26.0...v0.27.0
 


### PR DESCRIPTION
## 概要

v0.27.0 のセキュリティ修正（GHSA-395p-pj7r-jm42）は GHSA temporary private fork マージ（番号付き PR 無し）で着地したため、PR ベースの `generate-notes` が拾えず **CHANGELOG.md の 0.27.0 セクションが空**になっていた。公開済みの GH Release ノート（追記済み）および advisory と一致させるため、Security 項目を backfill する。

`*` マーカー / 見出し直後の空行なし＝他セクション（generate-notes 出力）と同じ書式に揃えている。

## スコープ変更

当初含めていた **release.yml の「GH Release body を CHANGELOG.md 由来にする」変更は本 PR から取り下げ**た。Codex review が指摘した通り、それが可能にする「Release PR の CHANGELOG を手書き」フローは、`release-plz.yml` の aux-sync がマージ前に再走すると version セクションを `generate-notes + origin/main` から再生成・force-push するため上書き消去される（fragile）。

堅牢化（自動生成部をマーカーで囲み手書きを保持する方式 + Release body の CHANGELOG 由来化）は**別 PR**で行う（`fulgur-v94v`）。当面、no-PR ノートは通常の PR 着地で `generate-notes` に拾わせる運用とする。

Refs: GHSA-395p-pj7r-jm42, fulgur-v94v
