### PR TITLE
harden(gcpm): bound string-set snapshot + store memory (DoS)

### DIFF
--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -2051,21 +2051,36 @@ impl StringSetPass {
             // Mirrors `CounterPass`'s per-node snapshot timing. Gated
             // on `record_node_snapshots` so non-bookmark renders skip
             // the clone (fulgur-70c). The `snapshot_bytes` budget bounds
-            // the *aggregate* retained string bytes across nodes: the
-            // running values are attacker-controlled (`content(text)` /
-            // `attr()`), so cloning a large value at every one of N nodes
-            // is O(N × value_size) memory. Once the budget is reached,
+            // the *aggregate* retained memory across nodes: the running
+            // values are attacker-controlled (`content(text)` / `attr()`),
+            // so cloning a large value at every one of N nodes is
+            // O(N × value_size) memory. Each snapshot is charged its string
+            // payload plus a per-snapshot `STRING_ENTRY_OVERHEAD_BYTES`
+            // (recording is unconditional per visited element, so an empty
+            // running map would otherwise retain ~N near-zero-byte snapshots
+            // — bounding the count as well as the bytes). The size is
+            // measured BEFORE cloning and the snapshot is skipped when it
+            // would push the aggregate past the cap — a hard ceiling that
+            // also avoids ever cloning an over-budget map. Once reached,
             // later nodes record nothing (their `string()` in
             // `bookmark-label` degrades to the CSS default "" — acceptable
             // under adversarial input). String twin of the CounterPass
             // `MAX_COUNTER_SNAPSHOT_ENTRIES` guard.
-            if self.record_node_snapshots
-                && self.snapshot_bytes.get() < crate::MAX_STRING_SNAPSHOT_BYTES
-            {
-                let snapshot = self.running.borrow().clone();
-                let bytes: usize = snapshot.iter().map(|(k, v)| k.len() + v.len()).sum();
-                self.snapshot_bytes.set(self.snapshot_bytes.get() + bytes);
-                self.node_snapshots.borrow_mut().insert(node_id, snapshot);
+            if self.record_node_snapshots {
+                let running = self.running.borrow();
+                let cost: usize = crate::STRING_ENTRY_OVERHEAD_BYTES
+                    + running
+                        .iter()
+                        .map(|(k, v)| k.len() + v.len())
+                        .sum::<usize>();
+                if self.snapshot_bytes.get().saturating_add(cost)
+                    <= crate::MAX_STRING_SNAPSHOT_BYTES
+                {
+                    self.snapshot_bytes.set(self.snapshot_bytes.get() + cost);
+                    self.node_snapshots
+                        .borrow_mut()
+                        .insert(node_id, running.clone());
+                }
             }
         }
 
@@ -5090,11 +5105,12 @@ mod tests {
             .flat_map(|m| m.iter())
             .map(|(k, v)| k.len() + v.len())
             .sum();
-        // The guard checks the budget *before* adding, so one final snapshot can
-        // overshoot by up to one full running map (here a single BIG value).
-        let slack = BIG + 64;
+        // The guard measures each snapshot BEFORE cloning and skips any that
+        // would exceed the cap, so the aggregate is a hard ceiling (no overshoot)
+        // — the counted bytes never exceed the budget, and the payload measured
+        // here is a subset of those counted bytes.
         assert!(
-            total <= crate::MAX_STRING_SNAPSHOT_BYTES + slack,
+            total <= crate::MAX_STRING_SNAPSHOT_BYTES,
             "total stored snapshot bytes {total} exceeded budget {}",
             crate::MAX_STRING_SNAPSHOT_BYTES
         );
@@ -5152,6 +5168,88 @@ mod tests {
         assert!(
             store.entries().len() < MATCHES,
             "budget did not engage: {} entries for {MATCHES} matches",
+            store.entries().len()
+        );
+    }
+
+    /// DoS hardening (snapshot count): with recording enabled a snapshot is
+    /// taken at every visited element even when the running map is empty
+    /// (payload bytes = 0), so the byte budget alone would retain ~N empty
+    /// `BTreeMap` snapshots. The per-snapshot `STRING_ENTRY_OVERHEAD_BYTES` base
+    /// charge bounds the count.
+    #[test]
+    fn string_set_pass_snapshot_bounds_count_for_empty_values() {
+        use crate::gcpm::StringSetValue;
+
+        let ceiling = crate::MAX_STRING_SNAPSHOT_BYTES / crate::STRING_ENTRY_OVERHEAD_BYTES;
+        let n = ceiling + 500;
+        let mut html = String::from("<html><body>");
+        for _ in 0..n {
+            html.push_str("<p></p>");
+        }
+        html.push_str("</body></html>");
+        let mut doc = parse(&html, 400.0, &[]);
+
+        // Selector matches nothing → running map stays empty → every per-node
+        // snapshot is an empty map (zero payload bytes), while recording is on.
+        let mappings = vec![StringSetMapping {
+            parsed: ParsedSelector::Tag("h9".into()),
+            name: "x".into(),
+            values: vec![StringSetValue::ContentText],
+        }];
+        let pass = StringSetPass::new(mappings).with_snapshot_recording();
+        let ctx = PassContext { font_data: &[] };
+        pass.apply(&mut doc, &ctx);
+        let snapshots = pass.take_node_snapshots();
+
+        assert!(
+            snapshots.len() <= ceiling + 1,
+            "snapshot count {} not bounded by overhead budget (ceiling {ceiling})",
+            snapshots.len()
+        );
+        assert!(
+            snapshots.len() < n,
+            "budget did not engage: {} snapshots for {n} elements",
+            snapshots.len()
+        );
+    }
+
+    /// DoS hardening (store entry count): empty / tiny `string-set` values must
+    /// not let the byte budget admit an unbounded number of records. The
+    /// per-record `STRING_ENTRY_OVERHEAD_BYTES` charge bounds the *count* too,
+    /// not just payload bytes — otherwise `p { string-set: x "" }` matched by N
+    /// elements retains ~N `StringSetEntry` records at near-zero counted bytes.
+    #[test]
+    fn string_set_store_bounds_entry_count_for_empty_values() {
+        use crate::gcpm::StringSetValue;
+
+        let ceiling = crate::MAX_STRING_SET_STORE_BYTES / crate::STRING_ENTRY_OVERHEAD_BYTES;
+        let matches = ceiling + 500;
+        let mut html = String::from("<html><body>");
+        for _ in 0..matches {
+            html.push_str("<p class=\"m\"></p>");
+        }
+        html.push_str("</body></html>");
+        let mut doc = parse(&html, 400.0, &[]);
+
+        let mappings = vec![StringSetMapping {
+            parsed: ParsedSelector::Class("m".into()),
+            name: "x".into(),
+            values: vec![StringSetValue::Literal(String::new())],
+        }];
+        let pass = StringSetPass::new(mappings);
+        let ctx = PassContext { font_data: &[] };
+        pass.apply(&mut doc, &ctx);
+        let store = pass.into_store();
+
+        assert!(
+            store.entries().len() <= ceiling + 1,
+            "store entry count {} not bounded by overhead budget (ceiling {ceiling})",
+            store.entries().len()
+        );
+        assert!(
+            store.entries().len() < matches,
+            "budget did not engage: {} entries for {matches} matches",
             store.entries().len()
         );
     }

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -2068,10 +2068,15 @@ impl StringSetPass {
             // `MAX_COUNTER_SNAPSHOT_ENTRIES` guard.
             if self.record_node_snapshots {
                 let running = self.running.borrow();
+                // Charge a base (the empty-map node_snapshots slot) plus the
+                // per-record overhead for EACH cloned (name, value) B-tree entry
+                // — the map's entry count equals the number of distinct named
+                // strings, so many tiny distinct strings would otherwise retain
+                // hundreds of entries per snapshot counted as only their payload.
                 let cost: usize = crate::STRING_ENTRY_OVERHEAD_BYTES
                     + running
                         .iter()
-                        .map(|(k, v)| k.len() + v.len())
+                        .map(|(k, v)| crate::STRING_ENTRY_OVERHEAD_BYTES + k.len() + v.len())
                         .sum::<usize>();
                 if self.snapshot_bytes.get().saturating_add(cost)
                     <= crate::MAX_STRING_SNAPSHOT_BYTES
@@ -5210,6 +5215,53 @@ mod tests {
         assert!(
             snapshots.len() < n,
             "budget did not engage: {} snapshots for {n} elements",
+            snapshots.len()
+        );
+    }
+
+    /// DoS hardening (snapshot per-entry overhead): a per-node snapshot clones a
+    /// `BTreeMap` whose entry count equals the number of distinct named strings
+    /// (attacker-definable via many `string-set` rules). The budget must charge
+    /// the per-record overhead for EACH map entry, not once per snapshot — else
+    /// many distinct tiny named strings retain hundreds of B-tree entries per
+    /// snapshot while being charged only their payload plus one base overhead.
+    #[test]
+    fn string_set_pass_snapshot_charges_per_map_entry_overhead() {
+        use crate::gcpm::StringSetValue;
+
+        // 1000 distinct named strings, all set (to empty values) on the first
+        // <div>, so every subsequent per-node snapshot clones a 1000-entry map.
+        const NAMES: usize = 1000;
+        let mut mappings = Vec::with_capacity(NAMES);
+        for i in 0..NAMES {
+            mappings.push(StringSetMapping {
+                parsed: ParsedSelector::Tag("div".into()),
+                name: format!("n{i}"),
+                values: vec![StringSetValue::Literal(String::new())],
+            });
+        }
+
+        // Enough following elements that the base-only charge would admit far
+        // more snapshots than the per-entry charge allows.
+        let n = 2500;
+        let mut html = String::from("<html><body><div></div>");
+        for _ in 0..n {
+            html.push_str("<p></p>");
+        }
+        html.push_str("</body></html>");
+        let mut doc = parse(&html, 400.0, &[]);
+
+        let pass = StringSetPass::new(mappings).with_snapshot_recording();
+        let ctx = PassContext { font_data: &[] };
+        pass.apply(&mut doc, &ctx);
+        let snapshots = pass.take_node_snapshots();
+
+        // With per-entry overhead each 1000-entry snapshot costs
+        // ~NAMES × STRING_ENTRY_OVERHEAD_BYTES, so far fewer than `n` snapshots
+        // fit; a base-only charge (~NAMES × name_len) would admit thousands.
+        assert!(
+            snapshots.len() < 500,
+            "per-entry overhead not charged: {} snapshots retained (n={n}, names={NAMES})",
             snapshots.len()
         );
     }

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -1958,6 +1958,12 @@ pub struct StringSetPass {
     /// Gate for `node_snapshots`. Mirrors `CounterPass`. Off by default
     /// so renders that do not emit bookmarks skip the per-element clone.
     record_node_snapshots: bool,
+    /// Running total of string bytes stored across all `node_snapshots`,
+    /// enforcing the [`crate::MAX_STRING_SNAPSHOT_BYTES`] budget so per-node
+    /// snapshots of attacker-controlled named-string values cannot accumulate
+    /// unbounded memory (see the recording site in `walk_tree`). String twin of
+    /// `CounterPass::snapshot_entries`.
+    snapshot_bytes: std::cell::Cell<usize>,
 }
 
 impl StringSetPass {
@@ -1968,6 +1974,7 @@ impl StringSetPass {
             running: RefCell::new(BTreeMap::new()),
             node_snapshots: RefCell::new(BTreeMap::new()),
             record_node_snapshots: false,
+            snapshot_bytes: std::cell::Cell::new(0),
         }
     }
 
@@ -2043,11 +2050,22 @@ impl StringSetPass {
             // element should observe its own string-set value.
             // Mirrors `CounterPass`'s per-node snapshot timing. Gated
             // on `record_node_snapshots` so non-bookmark renders skip
-            // the clone (fulgur-70c).
-            if self.record_node_snapshots {
-                self.node_snapshots
-                    .borrow_mut()
-                    .insert(node_id, self.running.borrow().clone());
+            // the clone (fulgur-70c). The `snapshot_bytes` budget bounds
+            // the *aggregate* retained string bytes across nodes: the
+            // running values are attacker-controlled (`content(text)` /
+            // `attr()`), so cloning a large value at every one of N nodes
+            // is O(N × value_size) memory. Once the budget is reached,
+            // later nodes record nothing (their `string()` in
+            // `bookmark-label` degrades to the CSS default "" — acceptable
+            // under adversarial input). String twin of the CounterPass
+            // `MAX_COUNTER_SNAPSHOT_ENTRIES` guard.
+            if self.record_node_snapshots
+                && self.snapshot_bytes.get() < crate::MAX_STRING_SNAPSHOT_BYTES
+            {
+                let snapshot = self.running.borrow().clone();
+                let bytes: usize = snapshot.iter().map(|(k, v)| k.len() + v.len()).sum();
+                self.snapshot_bytes.set(self.snapshot_bytes.get() + bytes);
+                self.node_snapshots.borrow_mut().insert(node_id, snapshot);
             }
         }
 
@@ -5031,6 +5049,110 @@ mod tests {
             snapshots.get(&p2).and_then(|m| m.get("title").cloned()),
             Some("Second".to_string()),
             "second <p> should see title=Second (set by preceding h1)"
+        );
+    }
+
+    /// DoS hardening (snapshot storage): the per-node running-map clone stores
+    /// attacker-controlled named-string values at every visited element. Without
+    /// an aggregate budget, one large `string-set` value snapshotted at N nodes
+    /// is O(N × value_size) retained memory. `MAX_STRING_SNAPSHOT_BYTES` caps the
+    /// aggregate; recording stops once the budget is reached. String twin of
+    /// `counter_pass_snapshot_bounds_total_stored_entries`.
+    #[test]
+    fn string_set_pass_snapshot_bounds_total_stored_bytes() {
+        use crate::gcpm::StringSetValue;
+
+        // One heading sets a large named string; each following sibling triggers
+        // a per-node snapshot clone of that value. Enough siblings that the
+        // aggregate would blow past the budget without the guard.
+        const BIG: usize = 64 * 1024; // 64 KiB value
+        const SIBLINGS: usize = crate::MAX_STRING_SNAPSHOT_BYTES / BIG + 500;
+        let big_text = "x".repeat(BIG);
+        let mut html = format!("<html><body><h1>{big_text}</h1>");
+        for _ in 0..SIBLINGS {
+            html.push_str("<p></p>");
+        }
+        html.push_str("</body></html>");
+        let mut doc = parse(&html, 400.0, &[]);
+
+        let mappings = vec![StringSetMapping {
+            parsed: ParsedSelector::Tag("h1".into()),
+            name: "title".into(),
+            values: vec![StringSetValue::ContentText],
+        }];
+        let pass = StringSetPass::new(mappings).with_snapshot_recording();
+        let ctx = PassContext { font_data: &[] };
+        pass.apply(&mut doc, &ctx);
+        let snapshots = pass.take_node_snapshots();
+
+        let total: usize = snapshots
+            .values()
+            .flat_map(|m| m.iter())
+            .map(|(k, v)| k.len() + v.len())
+            .sum();
+        // The guard checks the budget *before* adding, so one final snapshot can
+        // overshoot by up to one full running map (here a single BIG value).
+        let slack = BIG + 64;
+        assert!(
+            total <= crate::MAX_STRING_SNAPSHOT_BYTES + slack,
+            "total stored snapshot bytes {total} exceeded budget {}",
+            crate::MAX_STRING_SNAPSHOT_BYTES
+        );
+        assert!(
+            snapshots.len() < SIBLINGS,
+            "budget did not engage: {} snapshots for {SIBLINGS} siblings",
+            snapshots.len()
+        );
+    }
+
+    /// DoS hardening (store output): a repeated `string-set` literal matched by
+    /// N elements pushes N copies of the value into the store — O(N × value_size)
+    /// retained (and cloned again downstream into the per-node render map), on
+    /// the *default* render path with no bookmark / target-ref opt-in (the store
+    /// is ungated, unlike the snapshot). `MAX_STRING_SET_STORE_BYTES` caps the
+    /// aggregate stored value bytes at the source push. Store sibling of
+    /// `string_set_pass_snapshot_bounds_total_stored_bytes`.
+    #[test]
+    fn string_set_store_bounds_total_value_bytes() {
+        use crate::gcpm::StringSetValue;
+
+        // One large literal matched by many sibling elements: each match pushes
+        // a full copy of the literal into the store from a single-copy input.
+        const BIG: usize = 64 * 1024; // 64 KiB literal
+        const MATCHES: usize = crate::MAX_STRING_SET_STORE_BYTES / BIG + 500;
+        let big_literal = "y".repeat(BIG);
+        let mut html = String::from("<html><body>");
+        for _ in 0..MATCHES {
+            html.push_str("<p class=\"m\"></p>");
+        }
+        html.push_str("</body></html>");
+        let mut doc = parse(&html, 400.0, &[]);
+
+        let mappings = vec![StringSetMapping {
+            parsed: ParsedSelector::Class("m".into()),
+            name: "x".into(),
+            values: vec![StringSetValue::Literal(big_literal)],
+        }];
+        // No `.with_snapshot_recording()` — the store fills on the default path.
+        let pass = StringSetPass::new(mappings);
+        let ctx = PassContext { font_data: &[] };
+        pass.apply(&mut doc, &ctx);
+        let store = pass.into_store();
+
+        let total: usize = store
+            .entries()
+            .iter()
+            .map(|e| e.name.len() + e.value.len())
+            .sum();
+        assert!(
+            total <= crate::MAX_STRING_SET_STORE_BYTES,
+            "total store value bytes {total} exceeded budget {}",
+            crate::MAX_STRING_SET_STORE_BYTES
+        );
+        assert!(
+            store.entries().len() < MATCHES,
+            "budget did not engage: {} entries for {MATCHES} matches",
+            store.entries().len()
         );
     }
 

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -330,9 +330,20 @@ impl Engine {
         // empty strings even though `attr(href), page` still works
         // via `AnchorEntry.page_num`. Compute the gate once here so
         // each pass can opt out of the per-element clone otherwise.
-        let record_node_snapshots = (self.config.effective_bookmarks()
-            && !gcpm.bookmark_mappings.is_empty())
-            || has_target_refs;
+        let bookmark_active =
+            self.config.effective_bookmarks() && !gcpm.bookmark_mappings.is_empty();
+        // Counter snapshots feed BOTH bookmark `counter()` resolution and
+        // the target-ref anchor map, so record them for either trigger.
+        let record_counter_snapshots = bookmark_active || has_target_refs;
+        // String snapshots are consumed ONLY by BookmarkPass's `string()`
+        // resolution — `build_anchor_map` reads counter snapshots, not
+        // string ones — so recording them for a target-ref-only render is
+        // pure waste and, before the `MAX_STRING_SNAPSHOT_BYTES` budget,
+        // an attacker-reachable amplification sink via inline `target-*`
+        // CSS with no bookmark opt-in. Gate them on bookmarks alone.
+        // NOTE: if a future feature makes `string()` resolve in a
+        // target-ref / `running()` context (fulgur-ejw9), widen this gate.
+        let record_string_snapshots = bookmark_active;
 
         // Extract string-set values via DomPass.
         // Also harvest per-node `name -> latest value` snapshots that the
@@ -341,7 +352,7 @@ impl Engine {
         let (string_set_store, string_snapshots) = if !gcpm.string_set_mappings.is_empty() {
             let mut pass =
                 crate::blitz_adapter::StringSetPass::new(gcpm.string_set_mappings.clone());
-            if record_node_snapshots {
+            if record_string_snapshots {
                 pass = pass.with_snapshot_recording();
             }
             crate::blitz_adapter::apply_single_pass(&pass, &mut doc, &ctx);
@@ -367,7 +378,7 @@ impl Engine {
                     gcpm.counter_mappings.clone(),
                     gcpm.content_counter_mappings.clone(),
                 );
-                if record_node_snapshots {
+                if record_counter_snapshots {
                     pass = pass.with_snapshot_recording();
                 }
                 if let Some(map) = anchor_map {
@@ -415,9 +426,8 @@ impl Engine {
         // resolve to the chain at the destination. `BookmarkPass`
         // consumes the map by value, so when both gates fire we have to
         // clone first; the clone cost is paid only when bookmarks +
-        // `target-*` are active simultaneously.
-        let bookmark_active =
-            self.config.effective_bookmarks() && !gcpm.bookmark_mappings.is_empty();
+        // `target-*` are active simultaneously. `bookmark_active` is
+        // computed once above (shared with the snapshot-recording gates).
         let target_refs_active = has_target_refs;
         let (counter_snapshots_for_bookmark, counter_snapshots_for_anchor) =
             match (bookmark_active, target_refs_active) {

--- a/crates/fulgur/src/gcpm/string_set.rs
+++ b/crates/fulgur/src/gcpm/string_set.rs
@@ -17,16 +17,37 @@ pub struct StringSetEntry {
 /// Stores string-set entries collected during DOM traversal.
 pub struct StringSetStore {
     entries: Vec<StringSetEntry>,
+    /// Running total of stored `name` + `value` bytes, enforcing the
+    /// [`crate::MAX_STRING_SET_STORE_BYTES`] budget in [`Self::push`].
+    total_bytes: usize,
 }
 
 impl StringSetStore {
     pub fn new() -> Self {
         Self {
             entries: Vec::new(),
+            total_bytes: 0,
         }
     }
 
+    /// Record a resolved `string-set` assignment.
+    ///
+    /// DoS budget: `string-set` values are attacker-controlled and one entry is
+    /// pushed per (element, matching rule), so a repeated literal
+    /// (`p { string-set: x "BIG" }` matched by N elements) accumulates
+    /// O(N × value_size) here from a single-copy input — and the values are
+    /// cloned again downstream into the per-node render map. Once a new entry
+    /// would push the aggregate past [`crate::MAX_STRING_SET_STORE_BYTES`], it is
+    /// dropped (its `string()` degrades to the last recorded value — acceptable
+    /// under adversarial input). Capping at this source point bounds the
+    /// downstream clones dependently. Smaller later entries can still fit, so the
+    /// aggregate is a hard ceiling (no overshoot).
     pub fn push(&mut self, entry: StringSetEntry) {
+        let add = entry.name.len() + entry.value.len();
+        if self.total_bytes.saturating_add(add) > crate::MAX_STRING_SET_STORE_BYTES {
+            return;
+        }
+        self.total_bytes += add;
         self.entries.push(entry);
     }
 

--- a/crates/fulgur/src/gcpm/string_set.rs
+++ b/crates/fulgur/src/gcpm/string_set.rs
@@ -36,14 +36,19 @@ impl StringSetStore {
     /// pushed per (element, matching rule), so a repeated literal
     /// (`p { string-set: x "BIG" }` matched by N elements) accumulates
     /// O(N × value_size) here from a single-copy input — and the values are
-    /// cloned again downstream into the per-node render map. Once a new entry
-    /// would push the aggregate past [`crate::MAX_STRING_SET_STORE_BYTES`], it is
-    /// dropped (its `string()` degrades to the last recorded value — acceptable
-    /// under adversarial input). Capping at this source point bounds the
-    /// downstream clones dependently. Smaller later entries can still fit, so the
-    /// aggregate is a hard ceiling (no overshoot).
+    /// cloned again downstream into the per-node render map. Each entry is
+    /// charged its `name` + `value` payload plus a per-record
+    /// [`crate::STRING_ENTRY_OVERHEAD_BYTES`], so the budget bounds the entry
+    /// *count* as well as payload bytes (empty / tiny values such as
+    /// `p { string-set: x "" }` would otherwise admit millions of near-zero-byte
+    /// records). Once a new entry would push the aggregate past
+    /// [`crate::MAX_STRING_SET_STORE_BYTES`], it is dropped (its `string()`
+    /// degrades to the last recorded value — acceptable under adversarial input).
+    /// Capping at this source point bounds the downstream clones dependently.
+    /// Smaller later entries can still fit, so the aggregate is a hard ceiling
+    /// (no overshoot).
     pub fn push(&mut self, entry: StringSetEntry) {
-        let add = entry.name.len() + entry.value.len();
+        let add = crate::STRING_ENTRY_OVERHEAD_BYTES + entry.name.len() + entry.value.len();
         if self.total_bytes.saturating_add(add) > crate::MAX_STRING_SET_STORE_BYTES {
             return;
         }

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -134,6 +134,23 @@ pub(crate) const MAX_COUNTER_SNAPSHOT_ENTRIES: usize = 8 * 1024 * 1024;
 /// nodes past the cap, which is acceptable.
 pub(crate) const MAX_STRING_SNAPSHOT_BYTES: usize = 8 * 1024 * 1024;
 
+/// Approximate per-record heap + struct overhead charged against the
+/// [`MAX_STRING_SNAPSHOT_BYTES`] / [`MAX_STRING_SET_STORE_BYTES`] budgets in
+/// addition to each record's `name` + `value` payload bytes.
+///
+/// Both budgets otherwise counted only string payload, so empty / tiny named
+/// strings (`p { string-set: x "" }` matched by N elements, or a per-node
+/// snapshot recorded at every visited element while the running map is still
+/// empty) accumulated near-zero *counted* bytes while retaining millions of
+/// `StringSetEntry` / `BTreeMap` records — each of which costs `String` headers,
+/// a node id, and B-tree / `Vec` slot overhead that dwarfs a zero-length value.
+/// Charging this per-record constant makes the byte budget bound the record
+/// *count* as well (ceiling ≈ `budget / this`, ~131 K records at 8 MiB), matching
+/// the entry-count guard of the sibling [`MAX_COUNTER_SNAPSHOT_ENTRIES`]. Sized
+/// to conservatively cover two `String` structs (24 B each) plus a node id and
+/// container slot; realistic bookmark documents stay far below the ceiling.
+pub(crate) const STRING_ENTRY_OVERHEAD_BYTES: usize = 64;
+
 /// Total-storage budget (in bytes) for the resolved `string-set` values that
 /// [`gcpm::string_set::StringSetStore`] accumulates during
 /// [`blitz_adapter::StringSetPass`]. Once the accumulated stored value bytes

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -116,6 +116,45 @@ pub(crate) const MAX_OUTLINE_LABEL_BYTES: usize = 8 * 1024 * 1024;
 /// [`MAX_PAGES`]. ~8M values ≈ 32 MiB — far above any realistic document.
 pub(crate) const MAX_COUNTER_SNAPSHOT_ENTRIES: usize = 8 * 1024 * 1024;
 
+/// Total-storage budget (in bytes) for the per-node named-string snapshots that
+/// [`blitz_adapter::StringSetPass`] harvests for `BookmarkPass` `string(name)`
+/// resolution inside `bookmark-label`. Once the accumulated stored string bytes
+/// reach this bound, no further node snapshots are recorded.
+///
+/// Snapshot recording clones the *full* running `name -> value` map at every
+/// visited element, and the values are attacker-controlled strings resolved
+/// from element text / attributes (`string-set: title content(text)`). A single
+/// large value snapshotted at N nodes is O(N × value_size) retained memory — a
+/// resource-exhaustion sink independent of any output budget, and the string
+/// twin of the counter-chain [`MAX_COUNTER_SNAPSHOT_ENTRIES`] guard. This budget
+/// bounds the aggregate across all nodes regardless of N, mirroring the
+/// additive-not-multiplicative rationale of [`MAX_PAGES`]. Kept generous (8 MiB)
+/// so no realistic bookmark-bearing document (short named strings × headings) is
+/// clipped; adversarial input degrades `string()` to the CSS default ("") for
+/// nodes past the cap, which is acceptable.
+pub(crate) const MAX_STRING_SNAPSHOT_BYTES: usize = 8 * 1024 * 1024;
+
+/// Total-storage budget (in bytes) for the resolved `string-set` values that
+/// [`gcpm::string_set::StringSetStore`] accumulates during
+/// [`blitz_adapter::StringSetPass`]. Once the accumulated stored value bytes
+/// would exceed this bound, further assignments are dropped.
+///
+/// Unlike the [`MAX_STRING_SNAPSHOT_BYTES`] snapshot (a bookmark-only aux gated
+/// on `record_node_snapshots`), the store is populated *unconditionally* on the
+/// default render path — one entry per (element, matching `string-set` rule) —
+/// and its values are cloned again downstream into the per-node render map
+/// (`Engine::render_html`'s `string_set_by_node` / `string_set_for_render`). A
+/// single repeated literal (`p { string-set: x "BIG" }` matched by N sibling
+/// elements) pushes N copies of `BIG` from a single-copy input — an
+/// O(N × value_size) breadth-unbounded amplification independent of any output
+/// budget. Capping the aggregate at the source push bounds the downstream clones
+/// dependently (peak ≈ 3× this budget). Kept generous (8 MiB) so no realistic
+/// document (headings / figures with short named strings, even thousands of
+/// them) is clipped; past the cap, `string()` reads the last recorded value —
+/// a stale/absent-value degradation acceptable under adversarial input. Store
+/// sibling of [`MAX_STRING_SNAPSHOT_BYTES`].
+pub(crate) const MAX_STRING_SET_STORE_BYTES: usize = 8 * 1024 * 1024;
+
 /// Per-call cap on the bytes materialized while resolving a single content /
 /// label list (`::before` / `::after`, `bookmark-label`, margin-box running
 /// content) into one string.

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -3335,6 +3335,48 @@ fn bookmark_label_string_appears_in_outline() {
     assert_eq!(titles, vec!["Alpha".to_string(), "Beta".to_string()]);
 }
 
+/// End-to-end coverage-scope companion (CLAUDE.md "Coverage scope") for the
+/// `StringSetPass` per-node snapshot budget (`MAX_STRING_SNAPSHOT_BYTES`,
+/// unit-tested in `string_set_pass_snapshot_bounds_total_stored_bytes`). The
+/// lib test drives the pass in isolation via `.with_snapshot_recording()`; this
+/// drives the *engine* gate → pass → budget path on the amplification shape:
+/// one large `string-set` value followed by many elements that each snapshot it.
+/// Asserts the render stays bounded (completes, non-empty PDF) and that the
+/// heading's `string(title)` label still resolves — the budget clips only the
+/// per-node snapshot storage, never the first-seen value.
+#[test]
+fn string_set_snapshot_bounded_render_does_not_blow_up() {
+    let big = "A".repeat(48 * 1024); // one large named-string source value
+    let mut html = String::from(
+        "<!doctype html><html><head><style>\
+         h1 { string-set: title content(text); bookmark-level: 1; bookmark-label: string(title); }\
+         </style></head><body>",
+    );
+    html.push_str(&format!("<h1>{big}</h1>"));
+    // Many following siblings each trigger a per-node snapshot clone of `title`
+    // through the engine's `record_string_snapshots` gate; without the budget
+    // this is O(N × value_size) retained memory.
+    for _ in 0..400 {
+        html.push_str("<p>x</p>");
+    }
+    html.push_str("</body></html>");
+
+    let pdf = Engine::builder()
+        .bookmarks(true)
+        .build()
+        .render(&html)
+        .expect("render");
+    assert!(
+        !pdf.is_empty(),
+        "adversarial string-set doc should still render"
+    );
+    let titles = outline_titles(&pdf);
+    assert!(
+        titles.iter().any(|t| t == &big),
+        "the heading's string(title) label must still resolve"
+    );
+}
+
 /// Regression test for fulgur-v1cm + fulgur-vrkv: render time must not
 /// blow up quadratically with section/table count.
 ///


### PR DESCRIPTION
## 概要

`string-set` の値（`content(text)` による要素テキスト、`attr()`、CSS 文字列リテラルから解決＝**攻撃者制御**）が、メモリ予算なしに要素ごとに蓄積される**2箇所**を bound する。信頼できない HTML/CSS を server-side でレンダリングするデプロイ（[[主要ターゲット]]のマルチテナント帳票生成等）で、可用性（メモリ/CPU）の増幅 DoS になりうる経路を塞ぐ。

Codex finding「String-set snapshots enable render-time memory DoS」のトリアージから起点。finding は snapshot の「無条件クローン」を主張していたが、リリース版（v0.14.0 以降）は常に `record_node_snapshots` ゲート付き（無条件版は未リリース）＝**過大評価**。トリアージで同一機構の 2 sink を確定し、両方を bound した。

## 2つの sink と修正

### sink 1: `StringSetPass` per-node snapshot（`node_snapshots`）

bookmark / target-ref が有効なとき、訪問する全要素で running `name -> value` マップを丸ごと clone する。値が MiB 級だと `O(N × value_size)`。sibling の `CounterPass` には `MAX_COUNTER_SNAPSHOT_ENTRIES` 予算があるのに、string 版が取りこぼされていた。

- **`MAX_STRING_SNAPSHOT_BYTES`（8 MiB, 集約 byte 予算）** を追加し、上限到達後は記録を停止。
- **ゲートを分離**: string snapshot は `BookmarkPass` の `string()` でしか消費されない（`build_anchor_map` は counter snapshot のみ参照）。よって target-ref 単独のレンダリングでは記録しない（`record_string_snapshots = bookmark_active`）。これで「何も消費しないのに inline `target-*` CSS だけで攻撃者が有効化できる」経路を除去。

### sink 2: `StringSetStore`（`entries` Vec、より古く・広い）

**ゲート外・デフォルト経路**で (要素 × マッチした rule) ごとに push され、downstream で per-node レンダリングマップに ~3× clone される。`p { string-set: x "BIG" }` を N 個の兄弟にマッチさせると、単一コピーの入力から N コピーを蓄積する **breadth 無制限の `O(N × value_size)`** 増幅。

- **`MAX_STRING_SET_STORE_BYTES`（8 MiB）** を `StringSetStore::push`（source 1点）で強制。超過する assignment は drop（下流の clone は従属的に bound）。

両予算とも generous（8 MiB）で、現実的な文書（見出し/図に短い名前付き文字列、数千個あっても）は clip されない。上限超過後は `string()` が直近の記録値に degrade する（敵対的入力下でのみ発生、許容範囲）。

## テスト（TDD）

- `string_set_pass_snapshot_bounds_total_stored_bytes`（unit）— snapshot 予算が敵対的入力で bounded に収まる（cap 発火）
- `string_set_store_bounds_total_value_bytes`（unit）— store 予算をリテラル反復ベクタ・デフォルト経路で検証
- `string_set_snapshot_bounded_render_does_not_blow_up`（render_smoke e2e）— engine ゲート → pass → 予算の経路全体が bounded に完了し、`string(title)` が引き続き解決する
- 既存の可逆性テスト（`bookmark_label_string_appears_in_outline` / `render_with_string_set_css` / `gcpm_snapshot`）が regression ガード

`cargo test -p fulgur`（1600+ tests）/ `cargo fmt --check` / `cargo clippy -- -D warnings` すべて green。

fulgur-cbsq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 文字列関連の保存量に上限が追加され、極端に大きい内容が大量に複製されるケースでもメモリ使用量が抑えられるようになりました。
  * レンダリング中のスナップショット記録が整理され、必要な種類だけを記録するようになりました。
* **バグ修正**
  * 大きな文字列や多数の要素がある場合でも、レンダリングが不安定になりにくくなりました。
* **テスト**
  * 上限内で動作し、出力が正常に生成されることを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->