### PR TITLE
ci: map harden prefix to release-notes:security and add Security category

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,6 +4,9 @@ changelog:
       - release-notes:internal
       - dependencies
   categories:
+    - title: Security
+      labels:
+        - release-notes:security
     - title: Features
       labels:
         - release-notes:feature

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -47,6 +47,7 @@ jobs:
             const map = {
               feat: 'release-notes:feature',
               fix: 'release-notes:fix',
+              harden: 'release-notes:security',
               docs: 'release-notes:docs',
               chore: 'release-notes:internal',
               test: 'release-notes:internal',

--- a/docs/RELEASE_SETUP.md
+++ b/docs/RELEASE_SETUP.md
@@ -36,6 +36,7 @@ commits. `.github/release.yml` defines the category mapping.
 
 | Label | Category |
 |-------|----------|
+| `release-notes:security` | Security (auto-applied from a `harden:` title prefix) |
 | `release-notes:feature` | Features |
 | `release-notes:fix` | Bug Fixes |
 | `release-notes:docs` | Documentation |


### PR DESCRIPTION
## 概要

`harden(gcpm):` prefix の security hardening PR を pr-labeler が自動で `release-notes:security` に分類し、リリースノート／CHANGELOG に **Security** セクションとして表出させる。

## 背景

- security hardening PR には `harden` prefix を使っている（GCPM の DoS/メモリ境界修正など、直近で 7 件）が、pr-labeler の map に未登録だった。
- そのため `release-notes:*` が付かず "Other Changes" 落ち → 実際には手動で `release-notes:fix` を貼って **Bug Fixes** に入れていた（例: 0.28.0 の #582）。
- 0.27.0 の `### Security` セクションも自動分類ではなく**手動 backfill**（#581）だった。

## 変更

| ファイル | 変更 |
|---|---|
| `.github/workflows/pr-labeler.yml` | map に `harden: 'release-notes:security'` を追加 |
| `.github/release.yml` | `Security` カテゴリを追加（`"*"` catch-all より前、先頭に配置） |
| `docs/RELEASE_SETUP.md` | ラベル表に `release-notes:security` 行を追記 |

ラベル文字列 `release-notes:security` は 2 ファイルで byte 一致。GitHub は最初にマッチしたカテゴリに割り当てるため、`Security` を catch-all より前に置いている。

## レビュー観点（要判断）

この変更で **`harden` PR の分類先が Bug Fixes → Security に切り替わる**。`harden(...)（review）` のような細かい follow-up も Security 見出しに載るのが望ましくなければ、その点だけ veto してください（map から外す／個別に手動ラベル運用に戻す等）。

## 動作

pr-labeler は既存の相互排他ロジックに乗る（`release-notes:*` を 1 つに揃え、stale を除去）。手動でのラベル上書き（UI 編集）は従来どおり保持される。

Closes fulgur-w7mk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * リリースノートに「Security」カテゴリが追加され、セキュリティ関連の更新が分かりやすくなりました。
  * `harden:` で始まるPRは自動的に Security カテゴリに分類されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->