### PR TITLE
test(render): add coverage for composite CSS rendering paths

### DIFF
--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -6278,4 +6278,165 @@ mod tests {
         );
         assert!(pdf.starts_with(b"%PDF"));
     }
+
+    // --- paint_multicol_paragraph_slices from dispatch_fragment (Case A) ---
+
+    #[test]
+    fn render_smoke_multicol_self_inline_root_bare_text() {
+        // Exercises paint_multicol_paragraph_slices called from within
+        // dispatch_fragment when the multicol container is itself the inline
+        // root (Case A: bare text directly in the container, no <p> wrapper).
+        // In this case the container has both a block_styles entry and a
+        // paragraph_slices entry; dispatch_fragment must paint the block bg
+        // first and then call paint_multicol_paragraph_slices for the lines.
+        let pdf = render_html(
+            r#"<!doctype html><html><body>
+            <div style="column-count:2;column-gap:10px;width:400px;font-size:14px">
+              alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu
+              nu xi omicron pi rho sigma tau upsilon phi chi psi omega
+            </div>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // --- draw_under_clip: transform / table+clip / opacity branches ---
+
+    #[test]
+    fn render_smoke_transform_inside_overflow_clip() {
+        // Exercises draw_under_clip's descendant loop: when a transformed
+        // child lives inside an overflow:hidden container, draw_under_clip must
+        // call draw_under_transform for that descendant rather than
+        // dispatch_fragment directly.
+        let pdf = render_html(
+            r#"<!doctype html><html><body>
+            <div style="width:120px;height:80px;overflow:hidden;background:#cef">
+              <div style="transform:rotate(8deg);width:80px;height:40px;background:#fce">
+                rotated inside clip
+              </div>
+            </div>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn render_smoke_table_overflow_clip_inside_overflow_clip() {
+        // Exercises draw_under_clip's table-with-overflow-clip branch: a table
+        // with overflow:hidden nested inside an overflow:hidden block forces
+        // draw_under_clip_table to be called from within draw_under_clip's
+        // descendant loop so the table's own clip boundary is pushed correctly.
+        let pdf = render_html(
+            r#"<!doctype html><html><body>
+            <div style="width:200px;height:120px;overflow:hidden;background:#eef">
+              <table style="width:300px;overflow:hidden;border:1px solid #aaa">
+                <tr>
+                  <td style="padding:4px;background:#cef">wide cell overflowing</td>
+                  <td style="padding:4px;background:#fce">second cell</td>
+                </tr>
+              </table>
+            </div>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // --- draw_under_transform: table+clip branch ---
+
+    #[test]
+    fn render_smoke_table_overflow_clip_inside_transform() {
+        // Exercises draw_under_transform's table-with-overflow-clip branch: a
+        // table with overflow:hidden nested inside a transformed element forces
+        // draw_under_clip_table to be called from within draw_under_transform's
+        // descendant loop so the table's clip boundary is pushed under the
+        // transform.
+        let pdf = render_html(
+            r#"<!doctype html><html><body>
+            <div style="transform:translate(10px,5px)">
+              <table style="width:200px;overflow:hidden;border:1px solid #aaa">
+                <tr>
+                  <td style="padding:6px;background:#cef">cell inside transform</td>
+                </tr>
+              </table>
+            </div>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // --- draw_under_opacity: transform / clip / table+clip / nested-opacity branches ---
+
+    #[test]
+    fn render_smoke_transform_inside_opacity_scope() {
+        // Exercises draw_under_opacity's transform-descendant branch: a
+        // transformed child nested inside an opacity-scoped block forces
+        // draw_under_transform to be called from within draw_under_opacity's
+        // descendant loop.
+        let pdf = render_html(
+            r#"<!doctype html><html><body>
+            <div style="opacity:0.7">
+              <div style="transform:rotate(10deg);width:80px;height:40px;background:#fce">
+                rotated inside opacity
+              </div>
+            </div>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn render_smoke_overflow_clip_inside_opacity_scope() {
+        // Exercises draw_under_opacity's overflow-clip descendant branch: an
+        // overflow:hidden child nested inside an opacity-scoped block forces
+        // draw_under_clip to be called from within draw_under_opacity's
+        // descendant loop.
+        let pdf = render_html(
+            r#"<!doctype html><html><body>
+            <div style="opacity:0.7">
+              <div style="overflow:hidden;width:100px;height:60px;background:#cef">
+                <div style="width:200px;height:20px;background:#f99">clipped</div>
+              </div>
+            </div>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn render_smoke_table_overflow_clip_inside_opacity_scope() {
+        // Exercises draw_under_opacity's table-with-overflow-clip descendant
+        // branch: a table with overflow:hidden nested inside an opacity-scoped
+        // block forces draw_under_clip_table to be called from within
+        // draw_under_opacity's descendant loop.
+        let pdf = render_html(
+            r#"<!doctype html><html><body>
+            <div style="opacity:0.65">
+              <table style="width:200px;overflow:hidden;border:1px solid #aaa">
+                <tr>
+                  <td style="padding:4px;background:#cef">opacity+table+clip</td>
+                </tr>
+              </table>
+            </div>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn render_smoke_nested_opacity_inside_opacity_scope() {
+        // Exercises draw_under_opacity's nested-opacity descendant branch: an
+        // opacity-scoped child nested inside another opacity-scoped block forces
+        // a recursive draw_under_opacity call from within the outer
+        // draw_under_opacity's descendant loop.
+        let pdf = render_html(
+            r##"<!doctype html><html><body>
+            <div style="opacity:0.8">
+              <div style="opacity:0.5">
+                <div style="background:#c9f;width:60px;height:40px">double-faded</div>
+              </div>
+            </div>
+            </body></html>"##,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
 }


### PR DESCRIPTION
## Summary

`render.rs` のカバレッジ向上を目的に、複合 CSS レンダリングパスをカバーするスモークテストを 8 本追加しました。

対象モジュール: `crates/fulgur/src/render.rs`

| 指標 | 変更前 | 変更後 |
|------|--------|--------|
| 行カバレッジ | 89.97% | 93.07% |
| 関数カバレッジ | 90.10% | 94.39% |
| 領域カバレッジ | 90.39% | 92.51% |

ミス行数: 433 → 306（-127 行）

## Changes

新規追加テスト一覧（すべて `render::tests` インラインブロック）:

- `render_smoke_multicol_self_inline_root_bare_text`  
  `dispatch_fragment` 内の `paint_multicol_paragraph_slices` 呼び出し（Case A: コンテナ自体がインラインルート、行 1071-1079）をカバー。

- `render_smoke_transform_inside_overflow_clip`  
  `draw_under_clip` の descendant ループ内で `draw_under_transform` を呼ぶアーム（行 1848-1862）をカバー。

- `render_smoke_table_overflow_clip_inside_overflow_clip`  
  `draw_under_clip` の descendant ループ内で `draw_under_clip_table` を呼ぶアーム（行 1901-1912）をカバー。

- `render_smoke_table_overflow_clip_inside_transform`  
  `draw_under_transform` の descendant ループ内で `draw_under_clip_table` を呼ぶアーム（行 1480-1499）をカバー。

- `render_smoke_transform_inside_opacity_scope`  
  `draw_under_opacity` の descendant ループ内で `draw_under_transform` を呼ぶアーム（行 2187-2201）をカバー。

- `render_smoke_overflow_clip_inside_opacity_scope`  
  `draw_under_opacity` の descendant ループ内で `draw_under_clip` を呼ぶアーム（行 2202-2221）をカバー。

- `render_smoke_table_overflow_clip_inside_opacity_scope`  
  `draw_under_opacity` の descendant ループ内で `draw_under_clip_table` を呼ぶアーム（行 2222-2241）をカバー。

- `render_smoke_nested_opacity_inside_opacity_scope`  
  `draw_under_opacity` の descendant ループ内で再帰的 `draw_under_opacity` を呼ぶアーム（行 2242-2260）をカバー。

## 意図的に除外した未カバーブランチ

- **行 82** (`continue` when `geom.fragments.first() == None`): 有効なドキュメントでは fragment は必ず存在するため、正常入力では到達不能。
- **行 514** (`continue` when `node_id == root_id`): 常に通過するが、llvm-cov の計装タイミングにより `--lib` では計測されないケース。
- **行 2016-2037** (list-item defensive guard in `draw_under_opacity`): コード内コメントで「unreachable」と明示されており、設計上の防衛コード。テストで強制的にカバーする価値なし。

## Test plan

- [x] `cargo test -p fulgur --lib` — 1642 tests passed
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — フォーマット合格
- [ ] `npx markdownlint-cli2 '**/*.md'` — ドキュメント変更なし（スキップ）

## Contributor License Agreement

- [x] I have read the [Contributing Guide](https://github.com/fulgur-rs/fulgur/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://github.com/fulgur-rs/fulgur/blob/main/CLA.md) and agree to its terms.

## Related issues

自動スケジュール実行による定期カバレッジ改善タスク（2026-07-06）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFzZfZDh7zE5tQrbyRxewa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * レンダリングの重要な分岐をカバーするスモークテストを追加しました。
  * クリップ、変換、透過、テーブルを含む複雑なレイアウトでも、PDF 出力が正常に生成されることを確認できるようになりました。
  * これにより、描画まわりの品質と回帰検知が強化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->