### PR TITLE
harden(tagged): avoid panic on CSS list-item link runs

### DIFF
--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -3033,11 +3033,20 @@ fn draw_list_item_with_block(
             // inline-root li の段落コンテンツを LBody 配下に記録する
             let use_run_tagging = canvas.tag_collector.is_some() && para_has_link_runs(p);
             let tag_info = if use_run_tagging {
-                let lbody_id = *drawables
+                // A semantic `<li>` remaps its link runs under the synthetic
+                // LBody id so they nest correctly in the PDF/UA struct tree.
+                // A non-semantic CSS list item (e.g. `<div
+                // style="display:list-item">`) is present in
+                // `drawables.list_items` but has no LBody entry — only
+                // `PdfTag::Li` allocates one (`convert::walk_semantics`). Fall
+                // back to the node's own id, matching the plain
+                // block-paragraph link-run path in `dispatch_fragment`.
+                let run_tag_node_id = drawables
                     .li_lbody_ids
                     .get(&node_id)
-                    .expect("list-item paragraph must have an LBody id");
-                canvas.link_run_node_id = Some(lbody_id);
+                    .copied()
+                    .unwrap_or(node_id);
+                canvas.link_run_node_id = Some(run_tag_node_id);
                 None
             } else {
                 try_start_tagged(canvas, node_id, drawables)

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -3030,23 +3030,29 @@ fn draw_list_item_with_block(
             draw_block_inner_paint(canvas, b, x, y, frag, is_split);
         }
         if let Some(p) = paragraph {
-            // inline-root li の段落コンテンツを LBody 配下に記録する
-            let use_run_tagging = canvas.tag_collector.is_some() && para_has_link_runs(p);
+            // Pick the struct-tree node that per-run link tags nest under.
+            // A semantic `<li>` remaps to its synthetic LBody id. A CSS
+            // list item that is itself a tagged element (e.g. `<div
+            // style="display:list-item">` → `PdfTag::Div`) uses its own id.
+            // But a CSS list item whose element has no `SemanticEntry` — e.g.
+            // `<a style="display:list-item">` or a custom element, for which
+            // `classify_element` returns `None` — has no struct-tree home:
+            // wiring a link run under it would mark the span wired without its
+            // content ever entering the tag tree, tripping Krilla's "every
+            // tagged annotation appears in the tag tree" invariant (a panic in
+            // `krilla::serialize`). Skip per-run tagging there; the link
+            // annotation is still emitted, just untagged.
+            let run_tag_node_id = drawables.li_lbody_ids.get(&node_id).copied().or_else(|| {
+                drawables
+                    .semantics
+                    .contains_key(&node_id)
+                    .then_some(node_id)
+            });
+            let use_run_tagging = canvas.tag_collector.is_some()
+                && para_has_link_runs(p)
+                && run_tag_node_id.is_some();
             let tag_info = if use_run_tagging {
-                // A semantic `<li>` remaps its link runs under the synthetic
-                // LBody id so they nest correctly in the PDF/UA struct tree.
-                // A non-semantic CSS list item (e.g. `<div
-                // style="display:list-item">`) is present in
-                // `drawables.list_items` but has no LBody entry — only
-                // `PdfTag::Li` allocates one (`convert::walk_semantics`). Fall
-                // back to the node's own id, matching the plain
-                // block-paragraph link-run path in `dispatch_fragment`.
-                let run_tag_node_id = drawables
-                    .li_lbody_ids
-                    .get(&node_id)
-                    .copied()
-                    .unwrap_or(node_id);
-                canvas.link_run_node_id = Some(run_tag_node_id);
+                canvas.link_run_node_id = run_tag_node_id;
                 None
             } else {
                 try_start_tagged(canvas, node_id, drawables)

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -865,6 +865,32 @@ fn para_has_link_runs(entry: &crate::drawables::ParagraphEntry) -> bool {
     })
 }
 
+/// The struct-tree node id that per-run link tags for `node_id` should nest
+/// under, or `None` when the node has no home in the tag tree — in which case
+/// per-run tagging MUST be skipped. Otherwise `RunRegionTracker` records a
+/// `ParagraphRunItem::LinkContent` that marks the span "wired", so
+/// `emit_link_annotations` uses `add_tagged_annotation`, but `build_struct_tree`
+/// only walks ids present in `drawables.semantics`; the annotation's OBJR never
+/// enters the StructTree and Krilla panics during serialization
+/// ("annotation identifier ... doesn't appear in the tag tree").
+///
+/// A semantic `<li>` remaps to its synthetic LBody id. Any other node must
+/// itself be present in `drawables.semantics`. A CSS list item or inline root
+/// whose element has no `SemanticEntry` — `<a>`, a custom element, `<body>`,
+/// etc., for which `classify_element` returns `None` — yields `None` here and
+/// keeps its link annotation untagged.
+fn run_tag_target(
+    drawables: &Drawables,
+    node_id: crate::drawables::NodeId,
+) -> Option<crate::drawables::NodeId> {
+    drawables.li_lbody_ids.get(&node_id).copied().or_else(|| {
+        drawables
+            .semantics
+            .contains_key(&node_id)
+            .then_some(node_id)
+    })
+}
+
 /// Collect the plain-text title from a paragraph's shaped lines.
 ///
 /// Returns the concatenated text of all `Text` run items across all lines.
@@ -1039,11 +1065,13 @@ pub(crate) fn dispatch_fragment(
         let img_for_block = drawables.images.get(&node_id);
         let svg_for_block = drawables.svgs.get(&node_id);
         if para_for_block.is_some() || img_for_block.is_some() || svg_for_block.is_some() {
+            let run_tag_node_id = run_tag_target(drawables, node_id);
             let use_run_tagging = para_for_block
                 .map(|p| canvas.tag_collector.is_some() && para_has_link_runs(p))
-                .unwrap_or(false);
+                .unwrap_or(false)
+                && run_tag_node_id.is_some();
             let tag_info = if use_run_tagging {
-                canvas.link_run_node_id = Some(node_id);
+                canvas.link_run_node_id = run_tag_node_id;
                 None
             } else if para_for_block.is_some() {
                 try_start_tagged(canvas, node_id, drawables)
@@ -1107,9 +1135,11 @@ pub(crate) fn dispatch_fragment(
         return;
     }
     if let Some(para) = drawables.paragraphs.get(&node_id) {
-        let use_run_tagging = canvas.tag_collector.is_some() && para_has_link_runs(para);
+        let run_tag_node_id = run_tag_target(drawables, node_id);
+        let use_run_tagging =
+            canvas.tag_collector.is_some() && para_has_link_runs(para) && run_tag_node_id.is_some();
         let tag_info = if use_run_tagging {
-            canvas.link_run_node_id = Some(node_id);
+            canvas.link_run_node_id = run_tag_node_id;
             None
         } else {
             try_start_tagged(canvas, node_id, drawables)
@@ -1252,13 +1282,15 @@ fn paint_multicol_paragraph_slices(
     // so `is_split() == fragments.len() > 1` for any valid input here.
     // Using the predicate documents the intent.
     let needs_partition = container_geom.is_split();
+    let run_tag_node_id = run_tag_target(drawables, source_node_id);
     let use_run_tagging = canvas.tag_collector.is_some()
         && drawables
             .paragraphs
             .get(&source_node_id)
-            .is_some_and(para_has_link_runs);
+            .is_some_and(para_has_link_runs)
+        && run_tag_node_id.is_some();
     if use_run_tagging {
-        canvas.link_run_node_id = Some(source_node_id);
+        canvas.link_run_node_id = run_tag_node_id;
     }
     draw_with_opacity(canvas, opacity, |canvas| {
         for slice in &slices_entry.slices {
@@ -1739,9 +1771,12 @@ fn draw_under_clip(
         let inner_x = x_pt + inner_inset.0;
         let inner_y = y_pt + inner_inset.1;
         if let Some(p) = para_for_block {
-            let use_run_tagging = canvas.tag_collector.is_some() && para_has_link_runs(p);
+            let run_tag_node_id = run_tag_target(drawables, node_id);
+            let use_run_tagging = canvas.tag_collector.is_some()
+                && para_has_link_runs(p)
+                && run_tag_node_id.is_some();
             let tag_info = if use_run_tagging {
-                canvas.link_run_node_id = Some(node_id);
+                canvas.link_run_node_id = run_tag_node_id;
                 None
             } else {
                 try_start_tagged(canvas, node_id, drawables)
@@ -2099,9 +2134,12 @@ fn draw_under_opacity(
             let inner_x = x_pt + inner_inset.0;
             let inner_y = y_pt + inner_inset.1;
             if let Some(p) = para_for_block {
-                let use_run_tagging = canvas.tag_collector.is_some() && para_has_link_runs(p);
+                let run_tag_node_id = run_tag_target(drawables, node_id);
+                let use_run_tagging = canvas.tag_collector.is_some()
+                    && para_has_link_runs(p)
+                    && run_tag_node_id.is_some();
                 let tag_info = if use_run_tagging {
-                    canvas.link_run_node_id = Some(node_id);
+                    canvas.link_run_node_id = run_tag_node_id;
                     None
                 } else {
                     try_start_tagged(canvas, node_id, drawables)
@@ -3030,24 +3068,7 @@ fn draw_list_item_with_block(
             draw_block_inner_paint(canvas, b, x, y, frag, is_split);
         }
         if let Some(p) = paragraph {
-            // Pick the struct-tree node that per-run link tags nest under.
-            // A semantic `<li>` remaps to its synthetic LBody id. A CSS
-            // list item that is itself a tagged element (e.g. `<div
-            // style="display:list-item">` → `PdfTag::Div`) uses its own id.
-            // But a CSS list item whose element has no `SemanticEntry` — e.g.
-            // `<a style="display:list-item">` or a custom element, for which
-            // `classify_element` returns `None` — has no struct-tree home:
-            // wiring a link run under it would mark the span wired without its
-            // content ever entering the tag tree, tripping Krilla's "every
-            // tagged annotation appears in the tag tree" invariant (a panic in
-            // `krilla::serialize`). Skip per-run tagging there; the link
-            // annotation is still emitted, just untagged.
-            let run_tag_node_id = drawables.li_lbody_ids.get(&node_id).copied().or_else(|| {
-                drawables
-                    .semantics
-                    .contains_key(&node_id)
-                    .then_some(node_id)
-            });
+            let run_tag_node_id = run_tag_target(drawables, node_id);
             let use_run_tagging = canvas.tag_collector.is_some()
                 && para_has_link_runs(p)
                 && run_tag_node_id.is_some();

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -5357,39 +5357,42 @@ fn test_tagged_css_list_item_with_link_does_not_panic() {
     assert!(!pdf.is_empty(), "PDF should be non-empty");
 }
 
-/// Companion guard for the case the LBody fallback must NOT tag: a CSS
-/// list item whose element has no `SemanticEntry` at all. `classify_element`
-/// returns `None` for `<a>` and for custom elements, so neither `<a
-/// style="display:list-item">` nor `<x-foo style="display:list-item">` gets
-/// a semantic entry or an LBody id. Falling back to `node_id` unconditionally
-/// would wire the link run under an id absent from the struct tree, and
-/// Krilla panics in `serialize` ("annotation identifier ... doesn't appear in
-/// the tag tree"). Per-run tagging must be skipped for these, leaving the link
-/// annotation untagged.
+/// Guard for every per-run tagging sink: a link run whose owning element has
+/// no `SemanticEntry` must not be wired into the struct tree. `classify_element`
+/// returns `None` for `<a>`, custom elements and `<body>`, so a link-bearing
+/// element that is itself the paragraph / inline-root node (rather than a child
+/// of a `<p>` / `<div>`) has neither an LBody id nor a semantic entry. Wiring
+/// the link span under such a node marks it "wired" while its content never
+/// enters the tag tree, so Krilla panics in `serialize` ("annotation identifier
+/// ... doesn't appear in the tag tree"). Every rendering path — `dispatch_fragment`
+/// block / paragraph, multicol slices, `draw_under_clip`, list item — routes the
+/// per-run node through `run_tag_target`, which returns `None` for these and
+/// keeps the link annotation untagged. Reported by Codex Review on #592 across
+/// two rounds (list item, then the clipped / block paths).
 #[test]
-fn test_tagged_semanticless_list_item_with_link_does_not_panic() {
-    // `<a>` is itself the CSS list item and carries the link.
-    let a = Engine::builder()
-        .tagged(true)
-        .build()
-        .render(
-            "<html><body>\
-             <a href=\"https://example.com\" style=\"display:list-item; margin-left:40px\">x</a>\
-             </body></html>",
-        )
-        .expect("tagged <a display:list-item> must not panic");
-    assert!(!a.is_empty(), "PDF should be non-empty");
-
-    // Custom element (no semantic entry) wrapping a link.
-    let custom = Engine::builder()
-        .tagged(true)
-        .build()
-        .render(
-            "<html><body>\
-             <x-foo style=\"display:list-item; margin-left:40px\">\
-             <a href=\"https://example.com\">x</a></x-foo>\
-             </body></html>",
-        )
-        .expect("tagged custom-element list-item with a link must not panic");
-    assert!(!custom.is_empty(), "PDF should be non-empty");
+fn test_tagged_semanticless_link_runs_do_not_panic() {
+    // Each body is a link-bearing element with no semantic entry that is itself
+    // the paragraph node, exercising a distinct per-run tagging sink.
+    let bodies = [
+        // `<a>` that is itself a CSS list item (list-item path).
+        r#"<a href="https://example.com" style="display:list-item; margin-left:40px">x</a>"#,
+        // Custom element list item wrapping a link.
+        r#"<x-foo style="display:list-item"><a href="https://example.com">x</a></x-foo>"#,
+        // Clipped CSS list item (draw_under_clip).
+        r#"<a href="https://example.com" style="display:list-item; overflow:hidden">x</a>"#,
+        // Block-level `<a>` (block-with-inner-content path).
+        r#"<a href="https://example.com" style="display:block">x</a>"#,
+        // Clipped block-level `<a>` (draw_under_clip block path).
+        r#"<a href="https://example.com" style="display:block; overflow:hidden">x</a>"#,
+        // Plain inline `<a>` as the sole body content (paragraph path).
+        r#"<a href="https://example.com">x</a>"#,
+    ];
+    for body in bodies {
+        let pdf = Engine::builder()
+            .tagged(true)
+            .build()
+            .render(&format!("<html><body>{body}</body></html>"))
+            .unwrap_or_else(|e| panic!("tagged render must not fail for {body:?}: {e:?}"));
+        assert!(!pdf.is_empty(), "PDF should be non-empty for {body:?}");
+    }
 }

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -5330,3 +5330,29 @@ fn test_render_counters_sibling_reset_is_bounded_smoke() {
         page_count(&pdf)
     );
 }
+
+/// Regression guard: a non-semantic CSS list item (`display:list-item` on a
+/// non-`<li>` element) that contains a hyperlink used to panic under tagged
+/// output. `drawables.list_items` is populated for CSS list-item behaviour,
+/// including non-`<li>` elements, but `li_lbody_ids` is only populated for
+/// semantic `<li>` (`PdfTag::Li`), so `draw_list_item_with_block`'s per-run
+/// tagging path hit `.expect("list-item paragraph must have an LBody id")`
+/// on the missing LBody entry. `<div style="display:list-item"><a href>`
+/// with tagging enabled reproduced a hard panic (CLI exit 101); default
+/// (untagged) output rendered fine. The fix falls back to the node's own id
+/// (matching the plain block-paragraph link-run path) when there is no LBody
+/// remap for the node.
+#[test]
+fn test_tagged_css_list_item_with_link_does_not_panic() {
+    let pdf = Engine::builder()
+        .tagged(true)
+        .build()
+        .render(
+            "<html><body>\
+             <div style=\"display:list-item; margin-left:40px\">\
+             <a href=\"https://example.com\">x</a></div>\
+             </body></html>",
+        )
+        .expect("tagged CSS list-item containing a link must not panic");
+    assert!(!pdf.is_empty(), "PDF should be non-empty");
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -5356,3 +5356,40 @@ fn test_tagged_css_list_item_with_link_does_not_panic() {
         .expect("tagged CSS list-item containing a link must not panic");
     assert!(!pdf.is_empty(), "PDF should be non-empty");
 }
+
+/// Companion guard for the case the LBody fallback must NOT tag: a CSS
+/// list item whose element has no `SemanticEntry` at all. `classify_element`
+/// returns `None` for `<a>` and for custom elements, so neither `<a
+/// style="display:list-item">` nor `<x-foo style="display:list-item">` gets
+/// a semantic entry or an LBody id. Falling back to `node_id` unconditionally
+/// would wire the link run under an id absent from the struct tree, and
+/// Krilla panics in `serialize` ("annotation identifier ... doesn't appear in
+/// the tag tree"). Per-run tagging must be skipped for these, leaving the link
+/// annotation untagged.
+#[test]
+fn test_tagged_semanticless_list_item_with_link_does_not_panic() {
+    // `<a>` is itself the CSS list item and carries the link.
+    let a = Engine::builder()
+        .tagged(true)
+        .build()
+        .render(
+            "<html><body>\
+             <a href=\"https://example.com\" style=\"display:list-item; margin-left:40px\">x</a>\
+             </body></html>",
+        )
+        .expect("tagged <a display:list-item> must not panic");
+    assert!(!a.is_empty(), "PDF should be non-empty");
+
+    // Custom element (no semantic entry) wrapping a link.
+    let custom = Engine::builder()
+        .tagged(true)
+        .build()
+        .render(
+            "<html><body>\
+             <x-foo style=\"display:list-item; margin-left:40px\">\
+             <a href=\"https://example.com\">x</a></x-foo>\
+             </body></html>",
+        )
+        .expect("tagged custom-element list-item with a link must not panic");
+    assert!(!custom.is_empty(), "PDF should be non-empty");
+}


### PR DESCRIPTION
## 概要

tagged / PDF-UA 出力が有効なとき、**非 semantic な CSS list-item にハイパーリンクが含まれる**と renderer が panic する不具合を修正する。

## 根本原因

`drawables.list_items` は CSS の list-item 挙動（`display:list-item`）で populate され、`<li>` 以外の要素（例 `<div style="display:list-item">`）も含まれる。一方 `li_lbody_ids` は **semantic な `<li>`（`PdfTag::Li`）でのみ** 合成 LBody id を割り当てる（`convert::walk_semantics`）。

`draw_list_item_with_block` の per-run tagging 経路は、list-item 段落に link run があると `li_lbody_ids` を無条件に `.expect()` で取り出していたため、LBody を持たない非 semantic list-item で panic した（CLI では exit 101）。

再現:

- `<div style="display:list-item; margin-left:40px"><a href="https://example.com">x</a></div>` を `--tagged` でレンダリング → panic
- 同 HTML を `--tagged` 無し → 正常（tagged 出力 × link run の両方が発火条件）

## 修正

LBody への remap が無いノードでは、そのノード自身の id にフォールバックする（通常の block-paragraph link-run 経路と同じ値）。semantic な `<li>` では `li_lbody_ids` に必ずエントリがあるため取り出す値は不変で、struct tree の nesting は byte-identical。挙動が変わるのは従来 panic していた経路のみ。

## テスト

- TDD（RED: `render.rs` で panic → GREEN）
- `render_smoke.rs` に e2e を追加（tagged × CSS-list-item × link で非空 PDF を assert）
- 既存 tagged / list テスト 28 件パス（`tagged_pdf_link_in_list_item_produces_link_struct_element` 等、semantic `<li>` の LBody remap 回帰なし）
- `cargo fmt --check` / `cargo clippy -p fulgur --lib -- -D warnings` クリーン
- CLI PoC: exit 101 → exit 0

## 分類

self-found の bounded / single-request な availability hardening（tagged 出力は opt-in、panic は catch_unwind / プロセス分離で封じ込め可能）。`harden(tagged)` prefix で `release-notes:security` に分類される。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * タグ付きレンダリングで、リスト項目内のリンク処理が一部のケースで停止しないよう改善しました。
  * `display: list-item` を非標準の要素に適用した場合でも、リンクを含む内容を安定して出力できるようになりました。

* **Tests**
  * 上記の回帰を防ぐため、タグ付きリスト項目とリンクの組み合わせを検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->