### PR TITLE
harden: bound attacker-controllable layout-metadata multipliers (multicol/gradient/page-name/fixed/absolute)

### DIFF
--- a/crates/fulgur/src/column_css.rs
+++ b/crates/fulgur/src/column_css.rs
@@ -515,7 +515,25 @@ fn parse_page_value<'i>(input: &mut Parser<'i, '_>) -> Result<PageName, ParseErr
         ) {
             Err(input.new_error(BasicParseErrorKind::QualifiedRuleInvalid))
         } else {
-            Ok(PageName::Named(s.to_string()))
+            // Bound the retained name length: a CSS `<custom-ident>` is
+            // unbounded and this string is cloned into the column style table
+            // and once per node while resolving used page names
+            // (O(nodes × name_len)). Truncate an over-long name at a UTF-8
+            // char boundary (clamp-and-warn); realistic names are far shorter.
+            let name = if s.len() > crate::MAX_PAGE_NAME_BYTES {
+                let mut end = crate::MAX_PAGE_NAME_BYTES;
+                while end > 0 && !s.is_char_boundary(end) {
+                    end -= 1;
+                }
+                log::warn!(
+                    "page: name exceeds {} bytes; truncated (defensive bound)",
+                    crate::MAX_PAGE_NAME_BYTES
+                );
+                s[..end].to_string()
+            } else {
+                s.to_string()
+            };
+            Ok(PageName::Named(name))
         }
     }
 }
@@ -1821,6 +1839,25 @@ mod tests {
     fn parses_page_auto() {
         let props = parse_declaration_block("page: auto;");
         assert_eq!(props.page, Some(PageName::Auto));
+    }
+
+    #[test]
+    fn page_name_length_is_defensively_capped() {
+        // Security regression: a CSS `<custom-ident>` is length-unbounded and
+        // the retained name is cloned into the column style table and once per
+        // node while walking used page names (O(nodes × name_len)). A very
+        // long name is truncated at its single construction site so retention
+        // stays bounded; realistic page names are far shorter and unaffected.
+        let long = "a".repeat(10_000);
+        let props = parse_declaration_block(&format!("page: {long};"));
+        match props.page {
+            Some(PageName::Named(s)) => assert!(
+                s.len() <= crate::MAX_PAGE_NAME_BYTES,
+                "page name must be capped, got {}",
+                s.len()
+            ),
+            other => panic!("expected Named page, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/fulgur/src/convert/style/background.rs
+++ b/crates/fulgur/src/convert/style/background.rs
@@ -229,12 +229,23 @@ fn resolve_color_stops(
     use crate::draw_primitives::{GradientStop, GradientStopPosition};
     use style::values::generics::image::GradientItem;
 
-    // Cap the retained stop count: `items` is an attacker-controllable,
+    // Cap the retained *color-stop* count: `items` is an attacker-controllable,
     // unbounded stop list, and this vector is cloned into every element's
-    // `BackgroundLayer` (O(elements × stops)). Bounding it here also bounds
-    // the draw-time repeating expansion (`total_copies × stops.len()`).
-    let mut out: Vec<GradientStop> = Vec::with_capacity(items.len().min(crate::MAX_GRADIENT_STOPS));
-    for item in items.iter().take(crate::MAX_GRADIENT_STOPS) {
+    // `BackgroundLayer` (O(elements × stops)). Bounding it here also bounds the
+    // draw-time repeating expansion (`total_copies × stops.len()`). Count only
+    // color stops toward the cap (not interpolation hints) and stop right after
+    // the cap-th stop, so truncation never ends on a dangling hint — that would
+    // trip the trailing-hint guard below and drop an otherwise-valid gradient.
+    // A well-formed gradient with <= MAX_GRADIENT_STOPS color stops is therefore
+    // never truncated no matter how many hints it interleaves; the retained
+    // vector stays bounded at <= 2*MAX_GRADIENT_STOPS (stops + interior hints).
+    let mut out: Vec<GradientStop> =
+        Vec::with_capacity(items.len().min(2 * crate::MAX_GRADIENT_STOPS));
+    let mut stop_count = 0usize;
+    for item in items.iter() {
+        if stop_count >= crate::MAX_GRADIENT_STOPS {
+            break;
+        }
         match item {
             GradientItem::SimpleColorStop(c) => {
                 let abs = c.resolve_to_absolute(current_color);
@@ -243,6 +254,7 @@ fn resolve_color_stops(
                     rgba: absolute_to_rgba(abs),
                     is_hint: false,
                 });
+                stop_count += 1;
             }
             GradientItem::ComplexColorStop { color, position } => {
                 let abs = color.resolve_to_absolute(current_color);
@@ -262,6 +274,7 @@ fn resolve_color_stops(
                     rgba: absolute_to_rgba(abs),
                     is_hint: false,
                 });
+                stop_count += 1;
             }
             GradientItem::InterpolationHint(lp) => {
                 // CSS Images 3 §3.5.3: hint は 2 つの color stop の間にしか
@@ -1036,6 +1049,38 @@ mod tests {
             count <= crate::MAX_GRADIENT_STOPS,
             "gradient stops must be capped, got {count}"
         );
+    }
+
+    /// A valid gradient with fewer than MAX_GRADIENT_STOPS *color stops* but
+    /// more than MAX_GRADIENT_STOPS total *items* (stops interleaved with
+    /// interpolation hints) must NOT be dropped. Regression for the item-vs-stop
+    /// cap bug: capping on items could truncate on a hint, tripping the
+    /// trailing-hint guard and discarding an otherwise-valid layer.
+    #[test]
+    fn gradient_with_many_hints_under_stop_cap_is_not_dropped() {
+        // 200 color stops interleaved with 199 hints = 399 items (> 256), but
+        // only 200 color stops (< MAX_GRADIENT_STOPS = 256).
+        let mut parts: Vec<String> = Vec::new();
+        for i in 0..200 {
+            parts.push(if i % 2 == 0 {
+                "red".into()
+            } else {
+                "blue".into()
+            });
+            if i < 199 {
+                // Interpolation hint (bare percentage between two color stops).
+                parts.push(format!("{}%", (i as f32) * 0.4));
+            }
+        }
+        let css = format!("linear-gradient({})", parts.join(","));
+        let html = format!(
+            r#"<html><body><div style="width:120px;height:80px;background:{css}"></div></body></html>"#
+        );
+        let count = first_gradient_stop_count(&html)
+            .expect("valid gradient with <256 stops must not be dropped");
+        // All 200 color stops (plus interior hints) are retained; nothing is
+        // truncated because the stop count stays under the cap.
+        assert!(count >= 200, "expected >=200 retained entries, got {count}");
     }
 
     /// Same cap on the conic-gradient stop-building path (a separate loop).

--- a/crates/fulgur/src/convert/style/background.rs
+++ b/crates/fulgur/src/convert/style/background.rs
@@ -229,8 +229,12 @@ fn resolve_color_stops(
     use crate::draw_primitives::{GradientStop, GradientStopPosition};
     use style::values::generics::image::GradientItem;
 
-    let mut out: Vec<GradientStop> = Vec::with_capacity(items.len());
-    for item in items.iter() {
+    // Cap the retained stop count: `items` is an attacker-controllable,
+    // unbounded stop list, and this vector is cloned into every element's
+    // `BackgroundLayer` (O(elements × stops)). Bounding it here also bounds
+    // the draw-time repeating expansion (`total_copies × stops.len()`).
+    let mut out: Vec<GradientStop> = Vec::with_capacity(items.len().min(crate::MAX_GRADIENT_STOPS));
+    for item in items.iter().take(crate::MAX_GRADIENT_STOPS) {
         match item {
             GradientItem::SimpleColorStop(c) => {
                 let abs = c.resolve_to_absolute(current_color);
@@ -431,8 +435,12 @@ fn resolve_conic_gradient(
     let position_y = try_convert_lp_to_bg(&position.vertical)?;
     let repeating = flags.contains(GradientFlags::REPEATING);
 
-    let mut stops: Vec<crate::draw_primitives::GradientStop> = Vec::with_capacity(items.len());
-    for item in items.iter() {
+    // Cap the retained stop count (see `resolve_color_stops`): the conic
+    // stop list is a separate attacker-controllable, unbounded input, and
+    // this vector is likewise cloned per element and period-expanded at draw.
+    let mut stops: Vec<crate::draw_primitives::GradientStop> =
+        Vec::with_capacity(items.len().min(crate::MAX_GRADIENT_STOPS));
+    for item in items.iter().take(crate::MAX_GRADIENT_STOPS) {
         use crate::draw_primitives::{GradientStop, GradientStopPosition};
         match item {
             GradientItem::SimpleColorStop(c) => {
@@ -983,5 +991,68 @@ mod tests {
             .render(html)
             .expect("render missing-bundle bg");
         assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    /// Return the stop count of the first gradient background layer found in
+    /// `html`'s converted block styles, or `None` if there is no gradient.
+    fn first_gradient_stop_count(html: &str) -> Option<usize> {
+        use crate::draw_primitives::BgImageContent;
+        let drawables = Engine::builder()
+            .build()
+            .build_drawables_for_testing_no_gcpm(html);
+        drawables.block_styles.values().find_map(|block| {
+            block
+                .style
+                .background_layers
+                .iter()
+                .find_map(|layer| match &layer.content {
+                    BgImageContent::LinearGradient { stops, .. }
+                    | BgImageContent::RadialGradient { stops, .. }
+                    | BgImageContent::ConicGradient { stops, .. } => Some(stops.len()),
+                    _ => None,
+                })
+        })
+    }
+
+    /// Security regression: an unbounded `column-stop` list must not be
+    /// retained verbatim per element. A gradient with far more stops than
+    /// [`crate::MAX_GRADIENT_STOPS`] is clamped when convert builds the
+    /// `BackgroundLayer` vector, bounding the O(elements × stops) retention
+    /// (and the downstream repeating period expansion). Real gradients use a
+    /// handful of stops, so this only affects pathological input.
+    #[test]
+    fn gradient_stop_count_is_defensively_capped() {
+        // ~2000 alternating color stops — far above MAX_GRADIENT_STOPS (256).
+        let mut stops = String::new();
+        for i in 0..2000 {
+            stops.push_str(if i % 2 == 0 { "red," } else { "blue," });
+        }
+        stops.push_str("red");
+        let html = format!(
+            r#"<html><body><div style="width:120px;height:80px;background:linear-gradient({stops})"></div></body></html>"#
+        );
+        let count = first_gradient_stop_count(&html).expect("linear gradient layer present");
+        assert!(
+            count <= crate::MAX_GRADIENT_STOPS,
+            "gradient stops must be capped, got {count}"
+        );
+    }
+
+    /// Same cap on the conic-gradient stop-building path (a separate loop).
+    #[test]
+    fn conic_gradient_stop_count_is_defensively_capped() {
+        let mut stops = String::new();
+        for i in 0..2000 {
+            stops.push_str(if i % 2 == 0 { "red," } else { "blue," });
+        }
+        stops.push_str("red");
+        let html = format!(
+            r#"<html><body><div style="width:120px;height:80px;background:conic-gradient({stops})"></div></body></html>"#
+        );
+        let count = first_gradient_stop_count(&html).expect("conic gradient layer present");
+        assert!(
+            count <= crate::MAX_GRADIENT_STOPS,
+            "conic gradient stops must be capped, got {count}"
+        );
     }
 }

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -84,6 +84,20 @@ pub(crate) const MAX_COLUMN_COUNT: u32 = 64;
 /// multicol bound.
 pub(crate) const MAX_GRADIENT_STOPS: usize = 256;
 
+/// Maximum byte length of a CSS named page (`page: <custom-ident>` /
+/// `@page <name>`). A CSS `<custom-ident>` is length-unbounded, and the name
+/// `String` is retained in the parsed `ColumnProps`, cloned into the column
+/// style table, and cloned again per node while walking used page names
+/// (`blitz_adapter::walk_used_page_names`) — so a huge name amplifies to
+/// O(nodes × name_len) retained bytes on untrusted CSS.
+///
+/// Capping the name at its single construction site (`parse_page_value`)
+/// bounds every downstream clone at once. 256 bytes is far beyond any real
+/// page name (`cover`, `landscape-table`, …); a longer ident is truncated at
+/// a UTF-8 char boundary (clamp-and-warn). Sibling of the [`MAX_GRADIENT_STOPS`]
+/// bound.
+pub(crate) const MAX_PAGE_NAME_BYTES: usize = 256;
+
 /// Upper bound on the **output bytes** materialized for a single resolved
 /// counter chain (`counters(name, sep, style)`), applied inside
 /// [`gcpm::counter::format_counter_chain`] so it covers every call site

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -64,6 +64,26 @@ pub(crate) const MAX_PAGES: u32 = 10_000;
 /// [`MAX_DOM_DEPTH`] / [`MAX_PAGES`] defensive bounds.
 pub(crate) const MAX_COLUMN_COUNT: u32 = 64;
 
+/// Maximum number of CSS gradient color stops retained per background layer.
+/// CSS accepts an unbounded stop list (`linear-gradient(c0, c1, …, cN)`), and
+/// convert clones the resolved `Vec<GradientStop>` into every element's
+/// [`crate::draw_primitives::BackgroundLayer`] — so a rule like
+/// `* { background: linear-gradient(<N stops>) }` retains O(elements × N).
+/// For repeating gradients the draw-time period expansion in
+/// `background::expand_repeating_stops` further materializes
+/// `total_copies × stops.len()` entries (`total_copies` is already bounded by
+/// its own `MAX_PERIODS`), so bounding `stops.len()` here keeps that product
+/// bounded too.
+///
+/// Clamping the stop count at the convert-side choke points that build the
+/// vector (`resolve_color_stops` for linear/radial, plus the conic loop)
+/// bounds both the retained per-layer vector and the downstream repeating
+/// expansion at once. 256 stops is far beyond any legitimate gradient — real
+/// designs use a handful — so no realistic document changes output; excess
+/// stops are truncated (clamp-and-warn). Sibling of the [`MAX_COLUMN_COUNT`]
+/// multicol bound.
+pub(crate) const MAX_GRADIENT_STOPS: usize = 256;
+
 /// Upper bound on the **output bytes** materialized for a single resolved
 /// counter chain (`counters(name, sep, style)`), applied inside
 /// [`gcpm::counter::format_counter_chain`] so it covers every call site

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -98,25 +98,29 @@ pub(crate) const MAX_GRADIENT_STOPS: usize = 256;
 /// bound.
 pub(crate) const MAX_PAGE_NAME_BYTES: usize = 256;
 
-/// Aggregate upper bound on per-page repeated fragments emitted for
-/// `position: fixed` roots and their in-flow descendants
-/// (`pagination_layout::append_position_fixed_fragments`). A fixed element
-/// repeats on every page, and every in-flow descendant of a fixed root is
-/// recorded once per page — so the retained fragment total is
-/// O((fixed_roots + fixed_descendants) × pages). The page axis is already
-/// bounded by [`MAX_PAGES`], but the node axis is not: a fixed subtree with
-/// many descendants (or a document with many fixed elements) amplifies to a
-/// large retained `Fragment` vector and a matching per-page render loop on
-/// untrusted input.
+/// Aggregate upper bound on per-page subtree fragments emitted by the two
+/// out-of-flow pagination passes that record one `Fragment` per page per node
+/// of a subtree:
 ///
-/// A single running counter across the whole fixed-fragment pass caps the
-/// total (excess fragments are dropped — the fixed content simply stops
-/// repeating past the budget). Combined with skipping zero-area fragments
-/// (which draw nothing, so the skip is output-preserving), this bounds the
-/// pass in memory and time. 1M fragments (~tens of MiB) is far above any
-/// realistic running header/footer over a long document. Sibling of the
-/// [`MAX_PAGE_NAME_BYTES`] bound.
-pub(crate) const MAX_FIXED_SUBTREE_FRAGMENTS: usize = 1_000_000;
+/// - `pagination_layout::append_position_fixed_fragments` — a `position: fixed`
+///   root and every in-flow descendant repeat on **every** page.
+/// - `pagination_layout::append_position_absolute_body_direct_fragments` — each
+///   node of a body-direct `position: absolute` subtree is recorded once per
+///   page it intersects (`first_page..=last_page`).
+///
+/// In both, the page axis is already bounded by [`MAX_PAGES`], but the node
+/// axis is not: a subtree with many descendants — or many page-spanning
+/// absolute / fixed elements — amplifies to O(nodes × pages) retained
+/// `Fragment`s plus a matching per-page render loop on untrusted input.
+///
+/// Each pass threads a single running counter and stops emitting once it hits
+/// this budget (excess fragments are dropped — the content simply stops
+/// repeating past the cap). Combined with skipping zero-area fixed fragments
+/// (which draw nothing, so the skip is output-preserving), this bounds both
+/// passes in memory and time. 1M fragments (~tens of MiB) is far above any
+/// realistic running header/footer or absolute layout over a long document.
+/// Sibling of the [`MAX_PAGE_NAME_BYTES`] bound.
+pub(crate) const MAX_SUBTREE_PAGE_FRAGMENTS: usize = 1_000_000;
 
 /// Upper bound on the **output bytes** materialized for a single resolved
 /// counter chain (`counters(name, sep, style)`), applied inside

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -36,6 +36,34 @@ pub(crate) const MAX_DOM_DEPTH: usize = 512;
 /// `MAX_TILES` defensive bounds.
 pub(crate) const MAX_PAGES: u32 = 10_000;
 
+/// Maximum number of columns a single multi-column container is laid out
+/// across, regardless of the CSS `column-count` / `column-width` the input
+/// requests. CSS accepts `column-count` up to `i32::MAX`, and a small
+/// `column-width` on a wide container derives an equally large used count —
+/// neither is bounded by the spec.
+///
+/// The used count `n` is a **multiplier on retained layout metadata**: the
+/// multicol hook allocates one `vec![0.0; n]` per column group (`col_heights`)
+/// and, for every paragraph that splits across columns, an `n`-length
+/// `column_slices` vector padded with placeholders for unused columns (its
+/// length equals `n` by the `ParagraphSplitEntry` contract). A single
+/// `<div style="column-count:2000000000">x</div>` therefore forces one ~8 GB
+/// `col_heights` allocation, and the split path amplifies to
+/// O(`column_count` × paragraph_count) — an unbounded, attacker-controllable
+/// memory-exhaustion DoS on a server-side renderer of untrusted HTML/CSS.
+///
+/// Clamping the resolved count at the single choke point
+/// ([`multicol_layout::resolve_column_layout`]) bounds every downstream `n`
+/// sink at once (`col_heights`, `column_slices`, `slice_lines_by_budget`) and
+/// keeps the total metadata input-proportional (`n` is a small constant, so
+/// the split path stays O(paragraph_count)). 64 is far above any legitimate
+/// print layout — real multi-column text rarely exceeds a handful of columns —
+/// so no realistic document is affected; a pathological explicit or
+/// width-derived count is merely clamped (the columns collapse to zero width,
+/// as they already would past the container's capacity). Sibling of the
+/// [`MAX_DOM_DEPTH`] / [`MAX_PAGES`] defensive bounds.
+pub(crate) const MAX_COLUMN_COUNT: u32 = 64;
+
 /// Upper bound on the **output bytes** materialized for a single resolved
 /// counter chain (`counters(name, sep, style)`), applied inside
 /// [`gcpm::counter::format_counter_chain`] so it covers every call site

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -98,6 +98,26 @@ pub(crate) const MAX_GRADIENT_STOPS: usize = 256;
 /// bound.
 pub(crate) const MAX_PAGE_NAME_BYTES: usize = 256;
 
+/// Aggregate upper bound on per-page repeated fragments emitted for
+/// `position: fixed` roots and their in-flow descendants
+/// (`pagination_layout::append_position_fixed_fragments`). A fixed element
+/// repeats on every page, and every in-flow descendant of a fixed root is
+/// recorded once per page — so the retained fragment total is
+/// O((fixed_roots + fixed_descendants) × pages). The page axis is already
+/// bounded by [`MAX_PAGES`], but the node axis is not: a fixed subtree with
+/// many descendants (or a document with many fixed elements) amplifies to a
+/// large retained `Fragment` vector and a matching per-page render loop on
+/// untrusted input.
+///
+/// A single running counter across the whole fixed-fragment pass caps the
+/// total (excess fragments are dropped — the fixed content simply stops
+/// repeating past the budget). Combined with skipping zero-area fragments
+/// (which draw nothing, so the skip is output-preserving), this bounds the
+/// pass in memory and time. 1M fragments (~tens of MiB) is far above any
+/// realistic running header/footer over a long document. Sibling of the
+/// [`MAX_PAGE_NAME_BYTES`] bound.
+pub(crate) const MAX_FIXED_SUBTREE_FRAGMENTS: usize = 1_000_000;
+
 /// Upper bound on the **output bytes** materialized for a single resolved
 /// counter chain (`counters(name, sep, style)`), applied inside
 /// [`gcpm::counter::format_counter_chain`] so it covers every call site

--- a/crates/fulgur/src/multicol_layout.rs
+++ b/crates/fulgur/src/multicol_layout.rs
@@ -437,8 +437,15 @@ pub fn resolve_column_layout(
             1
         }
     };
+    // Clamp to `[1, MAX_COLUMN_COUNT]` at this single choke point. The used
+    // count `n` multiplies retained layout metadata downstream (`col_heights`,
+    // per-split `column_slices`, `slice_lines_by_budget`), all of which read
+    // this returned `n`; bounding it here bounds every sink at once and blocks
+    // the unbounded-`column-count` memory-exhaustion DoS. Applies to both the
+    // explicit-count and width-derived paths (every branch routes through
+    // `capped`).
     let capped = |n: u32| -> (u32, f32) {
-        let n = n.max(1);
+        let n = n.clamp(1, crate::MAX_COLUMN_COUNT);
         let col_w = ((content_w - gap * (n as f32 - 1.0)) / n as f32).max(0.0);
         (n, col_w)
     };
@@ -1851,6 +1858,17 @@ mod tests {
         assert_eq!(w, 400.0);
     }
 
+    #[test]
+    fn resolve_count_only_huge_count_is_defensively_capped() {
+        // An attacker-supplied `column-count` up to i32::MAX must not become
+        // the used count: it multiplies retained layout metadata (col_heights,
+        // per-split column_slices). It is clamped to MAX_COLUMN_COUNT; the
+        // columns collapse to zero width, as they already would past capacity.
+        let (n, w) = resolve_column_layout(400.0, Some(2_000_000_000), None, 10.0);
+        assert_eq!(n, crate::MAX_COLUMN_COUNT);
+        assert_eq!(w, 0.0);
+    }
+
     // ── resolve_column_layout: width only ───────────────────────────
     #[test]
     fn resolve_width_only_derives_count() {
@@ -1873,6 +1891,16 @@ mod tests {
         let (n, w) = resolve_column_layout(300.0, None, Some(100.0), 0.0);
         assert_eq!(n, 3);
         assert!((w - 100.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn resolve_width_only_huge_derived_count_is_defensively_capped() {
+        // A tiny `column-width` on a very wide container derives an
+        // unbounded fits_count; the same MAX_COLUMN_COUNT clamp inside
+        // `capped` must bound this width-derived path too, not just the
+        // explicit-count path.
+        let (n, _w) = resolve_column_layout(1_000_000.0, None, Some(1.0), 0.0);
+        assert_eq!(n, crate::MAX_COLUMN_COUNT);
     }
 
     // ── resolve_column_layout: both present ─────────────────────────

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -2776,18 +2776,26 @@ pub fn append_position_fixed_fragments(
         // representation for fixed content.
         entry.fragments.clear();
         entry.is_repeat = true;
-        for page_index in 0..pages {
-            if emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
-                break;
+        // A collapsed fixed root — either border-box dimension 0 — paints
+        // nothing (a zero border-box width/height leaves no border, background,
+        // or content area), so emitting a per-page fragment for it is pure
+        // amplification and charging the shared budget for it can starve a
+        // later visible fixed element (Codex review). Skip it, matching the
+        // descendant walk's guard.
+        if w > 0.0 && h > 0.0 {
+            for page_index in 0..pages {
+                if emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
+                    break;
+                }
+                entry.fragments.push(Fragment {
+                    page_index,
+                    x: x.as_px(),
+                    y: y.as_px(),
+                    width: w.as_px(),
+                    height: h.as_px(),
+                });
+                emitted += 1;
             }
-            entry.fragments.push(Fragment {
-                page_index,
-                x: x.as_px(),
-                y: y.as_px(),
-                width: w.as_px(),
-                height: h.as_px(),
-            });
-            emitted += 1;
         }
 
         // fulgur-4m16: emit per-page repeated fragments for every
@@ -2863,11 +2871,12 @@ fn record_fixed_subtree_descendants(
         let entry = geometry.entry(node_id).or_default();
         entry.fragments.clear();
         entry.is_repeat = true;
-        // Zero-area fragments draw nothing, so skipping them is
-        // output-preserving and removes the most common fixed-subtree
-        // amplifier (empty structural wrappers). The aggregate `emitted`
-        // budget is the hard bound on the residual O(descendants × pages).
-        if w > 0.0 || h > 0.0 {
+        // A collapsed descendant — either border-box dimension 0 — draws
+        // nothing, so skipping it is output-preserving and removes the most
+        // common fixed-subtree amplifier (empty structural wrappers). The
+        // aggregate `emitted` budget is the hard bound on the residual
+        // O(descendants × pages).
+        if w > 0.0 && h > 0.0 {
             for page_index in 0..pages.max(1) {
                 if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
                     // Budget spent: return rather than break so the rest of
@@ -3320,38 +3329,46 @@ fn record_subtree_fragments_at_offset(
                 let entry = geometry.entry(node_id).or_default();
                 entry.fragments.clear();
                 entry.is_repeat = false;
-                for page_index in first_page..=last_page {
-                    // Aggregate budget: each node emits one fragment per
-                    // intersected page, so a subtree of many page-spanning
-                    // absolutes is O(nodes × pages). Stop past the cap
-                    // (`crate::MAX_SUBTREE_PAGE_FRAGMENTS`) — shared with the
-                    // fixed pass. Return rather than break so the remaining
-                    // subtree is not walked once the budget is spent (gemini
-                    // review).
-                    if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
-                        return;
+                // A collapsed absolute box — either border-box dimension 0
+                // (e.g. width:0; height:200000px) — paints nothing, so skip its
+                // per-page fragments: it would otherwise amplify O(pages) and
+                // drain the shared budget from a later visible element (Codex
+                // review). The outer guard only requires positive height, so
+                // this additionally catches zero-width page-spanning boxes.
+                if w > 0.0 && h > 0.0 {
+                    for page_index in first_page..=last_page {
+                        // Aggregate budget: each node emits one fragment per
+                        // intersected page, so a subtree of many page-spanning
+                        // absolutes is O(nodes × pages). Stop past the cap
+                        // (`crate::MAX_SUBTREE_PAGE_FRAGMENTS`) — shared with the
+                        // fixed pass. Return rather than break so the remaining
+                        // subtree is not walked once the budget is spent (gemini
+                        // review).
+                        if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
+                            return;
+                        }
+                        let is_monolithic_continuation =
+                            monolithic_adjust > 0.0 && page_index > first_page;
+                        let stored_y = if is_monolithic_continuation {
+                            -body_offset.1
+                        } else {
+                            paging_origin_y - (page_index as f32) * page_stride_px - body_offset.1
+                        };
+                        let stored_h = if is_monolithic_continuation {
+                            let consumed = (page_index - first_page) as f32 * page_h_px;
+                            (h_for_paging - consumed).clamp(0.0, page_h_px)
+                        } else {
+                            h
+                        };
+                        entry.fragments.push(Fragment {
+                            page_index,
+                            x: stored_x.as_px(),
+                            y: stored_y.as_px(),
+                            width: w.as_px(),
+                            height: stored_h.as_px(),
+                        });
+                        *emitted += 1;
                     }
-                    let is_monolithic_continuation =
-                        monolithic_adjust > 0.0 && page_index > first_page;
-                    let stored_y = if is_monolithic_continuation {
-                        -body_offset.1
-                    } else {
-                        paging_origin_y - (page_index as f32) * page_stride_px - body_offset.1
-                    };
-                    let stored_h = if is_monolithic_continuation {
-                        let consumed = (page_index - first_page) as f32 * page_h_px;
-                        (h_for_paging - consumed).clamp(0.0, page_h_px)
-                    } else {
-                        h
-                    };
-                    entry.fragments.push(Fragment {
-                        page_index,
-                        x: stored_x.as_px(),
-                        y: stored_y.as_px(),
-                        width: w.as_px(),
-                        height: stored_h.as_px(),
-                    });
-                    *emitted += 1;
                 }
                 descendant_total_pages = descendant_total_pages.max(last_page.saturating_add(1));
             }
@@ -5305,6 +5322,58 @@ h2 { string-set: chapter-title content(text); }
         assert_eq!(
             zero_area_repeated, 0,
             "zero-area fixed descendant must not emit repeated fragments"
+        );
+    }
+
+    #[test]
+    fn fixed_collapsed_root_emits_no_fragments() {
+        // A fixed root with a collapsed border-box (width 0, positive height)
+        // paints nothing; it must not emit per-page fragments or charge the
+        // shared budget, otherwise many such empty roots starve a later visible
+        // fixed element (Codex review).
+        let html = r#"
+            <html><body style="margin:0">
+              <div style="position: fixed; top:0; width:0; height:50px"></div>
+              <div style="height:1200px"></div>
+            </body></html>
+        "#;
+        let engine = crate::Engine::builder().build();
+        let (_, geom) = engine.build_drawables_and_geometry_for_testing_no_gcpm(html);
+        let zero_width_repeated = geom
+            .values()
+            .filter(|g| g.is_repeat)
+            .flat_map(|g| g.fragments.iter())
+            .filter(|f| f.width.to_f32() <= 0.0)
+            .count();
+        assert_eq!(
+            zero_width_repeated, 0,
+            "collapsed (width:0) fixed root must not emit repeated fragments"
+        );
+    }
+
+    #[test]
+    fn absolute_collapsed_box_emits_no_fragments() {
+        // A body-direct absolute with a collapsed border-box (width 0) but a
+        // large height paints nothing; it must not emit per-page fragments or
+        // charge the shared budget. The outer paging guard only requires
+        // positive height, so this zero-width page-spanning box would otherwise
+        // charge O(pages) fragments (Codex review).
+        let html = r#"
+            <html><body style="margin:0">
+              <div style="position: absolute; top:0; width:0; height:200000px"></div>
+              <div style="height:1200px"></div>
+            </body></html>
+        "#;
+        let engine = crate::Engine::builder().build();
+        let (_, geom) = engine.build_drawables_and_geometry_for_testing_no_gcpm(html);
+        let zero_width = geom
+            .values()
+            .flat_map(|g| g.fragments.iter())
+            .filter(|f| f.width.to_f32() <= 0.0)
+            .count();
+        assert_eq!(
+            zero_width, 0,
+            "collapsed (width:0) absolute must not emit fragments"
         );
     }
 

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -2725,6 +2725,13 @@ pub fn append_position_fixed_fragments(
     let root_id = doc.root_element().id;
     walk_for_position_fixed(doc, root_id, &mut fixed_ids, 0);
 
+    // Aggregate budget across all fixed roots and their descendants: each
+    // node emits one fragment per page, so the retained total is
+    // O((roots + descendants) × pages). `pages` is bounded by MAX_PAGES, but
+    // the node axis is not — cap the total to keep the pass bounded on
+    // untrusted input (`crate::MAX_FIXED_SUBTREE_FRAGMENTS`).
+    let mut emitted: usize = 0;
+
     for id in fixed_ids {
         let Some(node) = doc.get_node(id) else {
             continue;
@@ -2770,6 +2777,9 @@ pub fn append_position_fixed_fragments(
         entry.fragments.clear();
         entry.is_repeat = true;
         for page_index in 0..pages {
+            if emitted >= crate::MAX_FIXED_SUBTREE_FRAGMENTS {
+                break;
+            }
             entry.fragments.push(Fragment {
                 page_index,
                 x: x.as_px(),
@@ -2777,6 +2787,7 @@ pub fn append_position_fixed_fragments(
                 width: w.as_px(),
                 height: h.as_px(),
             });
+            emitted += 1;
         }
 
         // fulgur-4m16: emit per-page repeated fragments for every
@@ -2789,7 +2800,7 @@ pub fn append_position_fixed_fragments(
         // entry for the pencil child or v2 never reaches it. The
         // existing root-only fragment carries inline text rendering
         // (fixedpos-001 / 008 ref pattern) but not block descendants.
-        record_fixed_subtree_descendants(geometry, doc, id, (x, y), pages);
+        record_fixed_subtree_descendants(geometry, doc, id, (x, y), pages, &mut emitted);
     }
 
     // Don't allocate empty entries for nodes without fragments.
@@ -2819,9 +2830,11 @@ fn record_fixed_subtree_descendants(
     fixed_root_id: usize,
     root_stored_xy: (f32, f32),
     pages: u32,
+    emitted: &mut usize,
 ) {
     use ::style::properties::longhands::position::computed_value::T as Pos;
 
+    #[allow(clippy::too_many_arguments)]
     fn walk(
         geometry: &mut PaginationGeometryTable,
         doc: &BaseDocument,
@@ -2830,6 +2843,7 @@ fn record_fixed_subtree_descendants(
         root_stored_xy: (f32, f32),
         pages: u32,
         depth: usize,
+        emitted: &mut usize,
     ) {
         if depth >= crate::MAX_DOM_DEPTH {
             return;
@@ -2845,14 +2859,24 @@ fn record_fixed_subtree_descendants(
         let entry = geometry.entry(node_id).or_default();
         entry.fragments.clear();
         entry.is_repeat = true;
-        for page_index in 0..pages.max(1) {
-            entry.fragments.push(Fragment {
-                page_index,
-                x: stored_x.as_px(),
-                y: stored_y.as_px(),
-                width: w.as_px(),
-                height: h.as_px(),
-            });
+        // Zero-area fragments draw nothing, so skipping them is
+        // output-preserving and removes the most common fixed-subtree
+        // amplifier (empty structural wrappers). The aggregate `emitted`
+        // budget is the hard bound on the residual O(descendants × pages).
+        if w > 0.0 || h > 0.0 {
+            for page_index in 0..pages.max(1) {
+                if *emitted >= crate::MAX_FIXED_SUBTREE_FRAGMENTS {
+                    break;
+                }
+                entry.fragments.push(Fragment {
+                    page_index,
+                    x: stored_x.as_px(),
+                    y: stored_y.as_px(),
+                    width: w.as_px(),
+                    height: h.as_px(),
+                });
+                *emitted += 1;
+            }
         }
 
         let children: Vec<usize> = {
@@ -2892,6 +2916,7 @@ fn record_fixed_subtree_descendants(
                 root_stored_xy,
                 pages,
                 depth + 1,
+                emitted,
             );
         }
     }
@@ -2933,6 +2958,7 @@ fn record_fixed_subtree_descendants(
             root_stored_xy,
             pages,
             1,
+            emitted,
         );
     }
 }
@@ -5223,6 +5249,63 @@ h2 { string-set: chapter-title content(text); }
             });
 
         assert_eq!(fixed_pages, Some(vec![0, 1]));
+    }
+
+    #[test]
+    fn fixed_zero_area_descendant_emits_no_fragments() {
+        // A zero-area fixed descendant draws nothing, so emitting one repeated
+        // fragment per page for it is pure amplification. Skipping zero-area
+        // fragments is output-preserving and removes a fixed-subtree amplifier.
+        let html = r#"
+            <html><body style="margin:0">
+              <div style="position: fixed; top:0; width:100px; height:100px">
+                <div style="width:0; height:0"></div>
+                <div style="width:10px; height:10px"></div>
+              </div>
+              <div style="height:1200px"></div>
+            </body></html>
+        "#;
+        let engine = crate::Engine::builder().build();
+        let (_, geom) = engine.build_drawables_and_geometry_for_testing_no_gcpm(html);
+        let zero_area_repeated = geom
+            .values()
+            .filter(|g| g.is_repeat)
+            .flat_map(|g| g.fragments.iter())
+            .filter(|f| f.width.to_f32() <= 0.0 && f.height.to_f32() <= 0.0)
+            .count();
+        assert_eq!(
+            zero_area_repeated, 0,
+            "zero-area fixed descendant must not emit repeated fragments"
+        );
+    }
+
+    #[test]
+    fn fixed_subtree_fragment_total_is_bounded() {
+        // Security regression: a `position: fixed` root and every in-flow
+        // descendant each emit one fragment per page → O(nodes × pages).
+        // The aggregate MAX_FIXED_SUBTREE_FRAGMENTS budget caps the retained
+        // total regardless of how many descendants the subtree has.
+        let mut kids = String::new();
+        for _ in 0..20_000 {
+            kids.push_str(r#"<div style="height:1px">x</div>"#);
+        }
+        let html = format!(
+            r#"<html><body style="margin:0">
+              <div style="position: fixed; top:0; width:50px; height:50px">{kids}</div>
+              <div style="height:100000px"></div>
+            </body></html>"#
+        );
+        let engine = crate::Engine::builder().build();
+        let (_, geom) = engine.build_drawables_and_geometry_for_testing_no_gcpm(&html);
+        let total: usize = geom
+            .values()
+            .filter(|g| g.is_repeat)
+            .map(|g| g.fragments.len())
+            .sum();
+        assert!(
+            total <= crate::MAX_FIXED_SUBTREE_FRAGMENTS,
+            "fixed fragment total must be bounded, got {total}"
+        );
     }
 
     #[test]

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -2800,7 +2800,11 @@ pub fn append_position_fixed_fragments(
         // entry for the pencil child or v2 never reaches it. The
         // existing root-only fragment carries inline text rendering
         // (fixedpos-001 / 008 ref pattern) but not block descendants.
-        record_fixed_subtree_descendants(geometry, doc, id, (x, y), pages, &mut emitted);
+        // Skip the descendant walk entirely once the budget is spent: it would
+        // only traverse the subtree without emitting anything (gemini review).
+        if emitted < crate::MAX_SUBTREE_PAGE_FRAGMENTS {
+            record_fixed_subtree_descendants(geometry, doc, id, (x, y), pages, &mut emitted);
+        }
     }
 
     // Don't allocate empty entries for nodes without fragments.
@@ -2866,7 +2870,9 @@ fn record_fixed_subtree_descendants(
         if w > 0.0 || h > 0.0 {
             for page_index in 0..pages.max(1) {
                 if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
-                    break;
+                    // Budget spent: return rather than break so the rest of
+                    // this subtree is not walked at all (gemini review).
+                    return;
                 }
                 entry.fragments.push(Fragment {
                     page_index,
@@ -3319,9 +3325,11 @@ fn record_subtree_fragments_at_offset(
                     // intersected page, so a subtree of many page-spanning
                     // absolutes is O(nodes × pages). Stop past the cap
                     // (`crate::MAX_SUBTREE_PAGE_FRAGMENTS`) — shared with the
-                    // fixed pass.
+                    // fixed pass. Return rather than break so the remaining
+                    // subtree is not walked once the budget is spent (gemini
+                    // review).
                     if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
-                        break;
+                        return;
                     }
                     let is_monolithic_continuation =
                         monolithic_adjust > 0.0 && page_index > first_page;

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -2729,7 +2729,7 @@ pub fn append_position_fixed_fragments(
     // node emits one fragment per page, so the retained total is
     // O((roots + descendants) × pages). `pages` is bounded by MAX_PAGES, but
     // the node axis is not — cap the total to keep the pass bounded on
-    // untrusted input (`crate::MAX_FIXED_SUBTREE_FRAGMENTS`).
+    // untrusted input (`crate::MAX_SUBTREE_PAGE_FRAGMENTS`).
     let mut emitted: usize = 0;
 
     for id in fixed_ids {
@@ -2777,7 +2777,7 @@ pub fn append_position_fixed_fragments(
         entry.fragments.clear();
         entry.is_repeat = true;
         for page_index in 0..pages {
-            if emitted >= crate::MAX_FIXED_SUBTREE_FRAGMENTS {
+            if emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
                 break;
             }
             entry.fragments.push(Fragment {
@@ -2865,7 +2865,7 @@ fn record_fixed_subtree_descendants(
         // budget is the hard bound on the residual O(descendants × pages).
         if w > 0.0 || h > 0.0 {
             for page_index in 0..pages.max(1) {
-                if *emitted >= crate::MAX_FIXED_SUBTREE_FRAGMENTS {
+                if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
                     break;
                 }
                 entry.fragments.push(Fragment {
@@ -3006,6 +3006,12 @@ pub fn append_position_absolute_body_direct_fragments(
     // collapses to zero.
     let body_offset_xy = body_origin_in_px(doc);
 
+    // Aggregate budget across all body-direct absolute subtrees: each node is
+    // recorded once per intersected page, so many page-spanning absolutes are
+    // O(nodes × pages). Cap the retained total (shared with the fixed pass via
+    // `crate::MAX_SUBTREE_PAGE_FRAGMENTS`).
+    let mut emitted: usize = 0;
+
     let body_children = body.children.clone();
     let body_has_in_flow_content = body_children.iter().any(|&child_id| {
         let Some(child) = doc.get_node(child_id) else {
@@ -3063,6 +3069,7 @@ pub fn append_position_absolute_body_direct_fragments(
             page_stride_px,
             pages,
             !body_has_in_flow_content,
+            &mut emitted,
         );
     }
 
@@ -3089,6 +3096,7 @@ fn record_subtree_fragments_at_offset(
     page_stride_px: f32,
     total_pages: u32,
     may_extend_pages: bool,
+    emitted: &mut usize,
 ) {
     #[allow(clippy::too_many_arguments)]
     fn walk(
@@ -3117,6 +3125,7 @@ fn record_subtree_fragments_at_offset(
         cb_anchor: (f32, f32),
         cb_size: (f32, f32),
         depth: usize,
+        emitted: &mut usize,
     ) {
         if depth >= crate::MAX_DOM_DEPTH {
             return;
@@ -3306,6 +3315,14 @@ fn record_subtree_fragments_at_offset(
                 entry.fragments.clear();
                 entry.is_repeat = false;
                 for page_index in first_page..=last_page {
+                    // Aggregate budget: each node emits one fragment per
+                    // intersected page, so a subtree of many page-spanning
+                    // absolutes is O(nodes × pages). Stop past the cap
+                    // (`crate::MAX_SUBTREE_PAGE_FRAGMENTS`) — shared with the
+                    // fixed pass.
+                    if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
+                        break;
+                    }
                     let is_monolithic_continuation =
                         monolithic_adjust > 0.0 && page_index > first_page;
                     let stored_y = if is_monolithic_continuation {
@@ -3326,6 +3343,7 @@ fn record_subtree_fragments_at_offset(
                         width: w.as_px(),
                         height: stored_h.as_px(),
                     });
+                    *emitted += 1;
                 }
                 descendant_total_pages = descendant_total_pages.max(last_page.saturating_add(1));
             }
@@ -3408,6 +3426,7 @@ fn record_subtree_fragments_at_offset(
                             child_cb_anchor,
                             child_cb_size,
                             depth + 1,
+                            emitted,
                         );
                         continue;
                     }
@@ -3440,6 +3459,7 @@ fn record_subtree_fragments_at_offset(
                 child_cb_anchor,
                 child_cb_size,
                 depth + 1,
+                emitted,
             );
             if has_contain_size(child) {
                 monolithic_y_adjust += (child.final_layout.size.height - page_h_px).max(0.0);
@@ -3466,6 +3486,7 @@ fn record_subtree_fragments_at_offset(
         (0.0, 0.0),
         (0.0, 0.0),
         0,
+        emitted,
     );
 }
 
@@ -5283,7 +5304,7 @@ h2 { string-set: chapter-title content(text); }
     fn fixed_subtree_fragment_total_is_bounded() {
         // Security regression: a `position: fixed` root and every in-flow
         // descendant each emit one fragment per page → O(nodes × pages).
-        // The aggregate MAX_FIXED_SUBTREE_FRAGMENTS budget caps the retained
+        // The aggregate MAX_SUBTREE_PAGE_FRAGMENTS budget caps the retained
         // total regardless of how many descendants the subtree has.
         let mut kids = String::new();
         for _ in 0..20_000 {
@@ -5303,8 +5324,37 @@ h2 { string-set: chapter-title content(text); }
             .map(|g| g.fragments.len())
             .sum();
         assert!(
-            total <= crate::MAX_FIXED_SUBTREE_FRAGMENTS,
+            total <= crate::MAX_SUBTREE_PAGE_FRAGMENTS,
             "fixed fragment total must be bounded, got {total}"
+        );
+    }
+
+    #[test]
+    fn absolute_subtree_fragment_total_is_bounded() {
+        // Security regression (same class as fixed-subtree fragments): the
+        // body-direct absolute pass records, for every node in each absolute
+        // subtree, one fragment per page the node intersects
+        // (`first_page..=last_page`, bounded per-node by MAX_PAGES). Many
+        // page-spanning absolute elements amplify to O(nodes × pages). The
+        // aggregate MAX_SUBTREE_PAGE_FRAGMENTS budget caps the retained total.
+        let mut sibs = String::new();
+        for _ in 0..15_000 {
+            sibs.push_str(
+                r#"<div style="position:absolute; top:0; width:10px; height:200000px"></div>"#,
+            );
+        }
+        let html = format!(r#"<html><body style="margin:0">{sibs}</body></html>"#);
+        let engine = crate::Engine::builder().build();
+        let (_, geom) = engine.build_drawables_and_geometry_for_testing_no_gcpm(&html);
+        let total: usize = geom.values().map(|g| g.fragments.len()).sum();
+        // The absolute pass is capped at MAX_SUBTREE_PAGE_FRAGMENTS; the sum
+        // also counts incidental non-absolute fragments (root/body/in-flow),
+        // which are themselves bounded by MAX_PAGES (a single in-flow flow).
+        // Uncapped this scenario emits ~3M fragments, so the budget clearly
+        // fired.
+        assert!(
+            total <= crate::MAX_SUBTREE_PAGE_FRAGMENTS + crate::MAX_PAGES as usize,
+            "absolute fragment total must be bounded, got {total}"
         );
     }
 
@@ -5387,6 +5437,7 @@ h2 { string-set: chapter-title content(text); }
             f32::MAX,
             3,
             true,
+            &mut 0,
         );
 
         let pages: Vec<u32> = geom

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -2776,26 +2776,18 @@ pub fn append_position_fixed_fragments(
         // representation for fixed content.
         entry.fragments.clear();
         entry.is_repeat = true;
-        // A collapsed fixed root — either border-box dimension 0 — paints
-        // nothing (a zero border-box width/height leaves no border, background,
-        // or content area), so emitting a per-page fragment for it is pure
-        // amplification and charging the shared budget for it can starve a
-        // later visible fixed element (Codex review). Skip it, matching the
-        // descendant walk's guard.
-        if w > 0.0 && h > 0.0 {
-            for page_index in 0..pages {
-                if emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
-                    break;
-                }
-                entry.fragments.push(Fragment {
-                    page_index,
-                    x: x.as_px(),
-                    y: y.as_px(),
-                    width: w.as_px(),
-                    height: h.as_px(),
-                });
-                emitted += 1;
+        for page_index in 0..pages {
+            if emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
+                break;
             }
+            entry.fragments.push(Fragment {
+                page_index,
+                x: x.as_px(),
+                y: y.as_px(),
+                width: w.as_px(),
+                height: h.as_px(),
+            });
+            emitted += 1;
         }
 
         // fulgur-4m16: emit per-page repeated fragments for every
@@ -2871,12 +2863,11 @@ fn record_fixed_subtree_descendants(
         let entry = geometry.entry(node_id).or_default();
         entry.fragments.clear();
         entry.is_repeat = true;
-        // A collapsed descendant — either border-box dimension 0 — draws
-        // nothing, so skipping it is output-preserving and removes the most
-        // common fixed-subtree amplifier (empty structural wrappers). The
-        // aggregate `emitted` budget is the hard bound on the residual
-        // O(descendants × pages).
-        if w > 0.0 && h > 0.0 {
+        // Zero-area fragments draw nothing, so skipping them is
+        // output-preserving and removes the most common fixed-subtree
+        // amplifier (empty structural wrappers). The aggregate `emitted`
+        // budget is the hard bound on the residual O(descendants × pages).
+        if w > 0.0 || h > 0.0 {
             for page_index in 0..pages.max(1) {
                 if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
                     // Budget spent: return rather than break so the rest of
@@ -3329,46 +3320,38 @@ fn record_subtree_fragments_at_offset(
                 let entry = geometry.entry(node_id).or_default();
                 entry.fragments.clear();
                 entry.is_repeat = false;
-                // A collapsed absolute box — either border-box dimension 0
-                // (e.g. width:0; height:200000px) — paints nothing, so skip its
-                // per-page fragments: it would otherwise amplify O(pages) and
-                // drain the shared budget from a later visible element (Codex
-                // review). The outer guard only requires positive height, so
-                // this additionally catches zero-width page-spanning boxes.
-                if w > 0.0 && h > 0.0 {
-                    for page_index in first_page..=last_page {
-                        // Aggregate budget: each node emits one fragment per
-                        // intersected page, so a subtree of many page-spanning
-                        // absolutes is O(nodes × pages). Stop past the cap
-                        // (`crate::MAX_SUBTREE_PAGE_FRAGMENTS`) — shared with the
-                        // fixed pass. Return rather than break so the remaining
-                        // subtree is not walked once the budget is spent (gemini
-                        // review).
-                        if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
-                            return;
-                        }
-                        let is_monolithic_continuation =
-                            monolithic_adjust > 0.0 && page_index > first_page;
-                        let stored_y = if is_monolithic_continuation {
-                            -body_offset.1
-                        } else {
-                            paging_origin_y - (page_index as f32) * page_stride_px - body_offset.1
-                        };
-                        let stored_h = if is_monolithic_continuation {
-                            let consumed = (page_index - first_page) as f32 * page_h_px;
-                            (h_for_paging - consumed).clamp(0.0, page_h_px)
-                        } else {
-                            h
-                        };
-                        entry.fragments.push(Fragment {
-                            page_index,
-                            x: stored_x.as_px(),
-                            y: stored_y.as_px(),
-                            width: w.as_px(),
-                            height: stored_h.as_px(),
-                        });
-                        *emitted += 1;
+                for page_index in first_page..=last_page {
+                    // Aggregate budget: each node emits one fragment per
+                    // intersected page, so a subtree of many page-spanning
+                    // absolutes is O(nodes × pages). Stop past the cap
+                    // (`crate::MAX_SUBTREE_PAGE_FRAGMENTS`) — shared with the
+                    // fixed pass. Return rather than break so the remaining
+                    // subtree is not walked once the budget is spent (gemini
+                    // review).
+                    if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
+                        return;
                     }
+                    let is_monolithic_continuation =
+                        monolithic_adjust > 0.0 && page_index > first_page;
+                    let stored_y = if is_monolithic_continuation {
+                        -body_offset.1
+                    } else {
+                        paging_origin_y - (page_index as f32) * page_stride_px - body_offset.1
+                    };
+                    let stored_h = if is_monolithic_continuation {
+                        let consumed = (page_index - first_page) as f32 * page_h_px;
+                        (h_for_paging - consumed).clamp(0.0, page_h_px)
+                    } else {
+                        h
+                    };
+                    entry.fragments.push(Fragment {
+                        page_index,
+                        x: stored_x.as_px(),
+                        y: stored_y.as_px(),
+                        width: w.as_px(),
+                        height: stored_h.as_px(),
+                    });
+                    *emitted += 1;
                 }
                 descendant_total_pages = descendant_total_pages.max(last_page.saturating_add(1));
             }
@@ -5322,58 +5305,6 @@ h2 { string-set: chapter-title content(text); }
         assert_eq!(
             zero_area_repeated, 0,
             "zero-area fixed descendant must not emit repeated fragments"
-        );
-    }
-
-    #[test]
-    fn fixed_collapsed_root_emits_no_fragments() {
-        // A fixed root with a collapsed border-box (width 0, positive height)
-        // paints nothing; it must not emit per-page fragments or charge the
-        // shared budget, otherwise many such empty roots starve a later visible
-        // fixed element (Codex review).
-        let html = r#"
-            <html><body style="margin:0">
-              <div style="position: fixed; top:0; width:0; height:50px"></div>
-              <div style="height:1200px"></div>
-            </body></html>
-        "#;
-        let engine = crate::Engine::builder().build();
-        let (_, geom) = engine.build_drawables_and_geometry_for_testing_no_gcpm(html);
-        let zero_width_repeated = geom
-            .values()
-            .filter(|g| g.is_repeat)
-            .flat_map(|g| g.fragments.iter())
-            .filter(|f| f.width.to_f32() <= 0.0)
-            .count();
-        assert_eq!(
-            zero_width_repeated, 0,
-            "collapsed (width:0) fixed root must not emit repeated fragments"
-        );
-    }
-
-    #[test]
-    fn absolute_collapsed_box_emits_no_fragments() {
-        // A body-direct absolute with a collapsed border-box (width 0) but a
-        // large height paints nothing; it must not emit per-page fragments or
-        // charge the shared budget. The outer paging guard only requires
-        // positive height, so this zero-width page-spanning box would otherwise
-        // charge O(pages) fragments (Codex review).
-        let html = r#"
-            <html><body style="margin:0">
-              <div style="position: absolute; top:0; width:0; height:200000px"></div>
-              <div style="height:1200px"></div>
-            </body></html>
-        "#;
-        let engine = crate::Engine::builder().build();
-        let (_, geom) = engine.build_drawables_and_geometry_for_testing_no_gcpm(html);
-        let zero_width = geom
-            .values()
-            .flat_map(|g| g.fragments.iter())
-            .filter(|f| f.width.to_f32() <= 0.0)
-            .count();
-        assert_eq!(
-            zero_width, 0,
-            "collapsed (width:0) absolute must not emit fragments"
         );
     }
 

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -5421,3 +5421,25 @@ fn test_render_html_huge_multicol_column_count_is_bounded() {
     let pdf = Engine::builder().build().render(html).expect("render");
     assert!(!pdf.is_empty());
 }
+
+#[test]
+fn test_render_html_huge_gradient_stop_list_is_bounded() {
+    // Security regression (unbounded gradient color stops): convert clones the
+    // resolved stop vector into every element's BackgroundLayer, so a huge
+    // stop list retains O(elements × stops); a repeating gradient additionally
+    // period-expands `total_copies × stops.len()` at draw. The MAX_GRADIENT_STOPS
+    // clamp bounds both. A repeating-linear-gradient with thousands of stops
+    // must render in bounded memory/time.
+    let mut stops = String::new();
+    for i in 0..5000 {
+        stops.push_str(if i % 2 == 0 { "red 0%," } else { "blue 1%," });
+    }
+    stops.push_str("red 2%");
+    let html = format!(
+        r#"<!DOCTYPE html><html><body>
+        <div style="width:120px;height:80px;background:repeating-linear-gradient({stops})"></div>
+    </body></html>"#
+    );
+    let pdf = Engine::builder().build().render(&html).expect("render");
+    assert!(!pdf.is_empty());
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -5443,3 +5443,25 @@ fn test_render_html_huge_gradient_stop_list_is_bounded() {
     let pdf = Engine::builder().build().render(&html).expect("render");
     assert!(!pdf.is_empty());
 }
+
+#[test]
+fn test_render_html_huge_page_name_is_bounded() {
+    // Security regression (unbounded page-name cloning): a CSS named page is
+    // a length-unbounded custom-ident retained in ColumnProps, cloned into the
+    // column style table and once per node while resolving used page names
+    // (O(nodes × name_len)). The MAX_PAGE_NAME_BYTES clamp at the parse site
+    // bounds the retained name, so many nodes sharing a huge page name render
+    // in bounded memory.
+    let long_name = "a".repeat(20_000);
+    let mut body = String::new();
+    for _ in 0..500 {
+        body.push_str("<div>x</div>");
+    }
+    let html = format!(
+        r#"<!DOCTYPE html><html><head><style>
+        div {{ page: {long_name}; }}
+        </style></head><body>{body}</body></html>"#
+    );
+    let pdf = Engine::builder().build().render(&html).expect("render");
+    assert!(!pdf.is_empty());
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -5396,3 +5396,28 @@ fn test_tagged_semanticless_link_runs_do_not_panic() {
         assert!(!pdf.is_empty(), "PDF should be non-empty for {body:?}");
     }
 }
+
+#[test]
+fn test_render_html_huge_multicol_column_count_is_bounded() {
+    // Security regression (unbounded `column-count` memory-exhaustion DoS):
+    // a single multicol container with an enormous `column-count` must not
+    // allocate `column-count`-sized layout metadata. Before the
+    // MAX_COLUMN_COUNT clamp in `resolve_column_layout`, the multicol hook
+    // ran `vec![0.0; n]` for `col_heights` (here n = 2_000_000_000 ≈ 8 GB)
+    // unconditionally, and the inline-root split path amplified further to
+    // O(column_count × paragraph_count) `column_slices`. With the clamp the
+    // used count is bounded to a small constant, so this renders in bounded
+    // memory/time. Paragraphs are included so the split path is exercised too.
+    let html = r#"<!DOCTYPE html><html><body>
+        <div style="column-count:2000000000; column-gap:10px; width:300px">
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+               eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+            <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco
+               laboris nisi ut aliquip ex ea commodo consequat.</p>
+            <p>Duis aute irure dolor in reprehenderit in voluptate velit esse
+               cillum dolore eu fugiat nulla pariatur.</p>
+        </div>
+    </body></html>"#;
+    let pdf = Engine::builder().build().render(html).expect("render");
+    assert!(!pdf.is_empty());
+}


### PR DESCRIPTION
## 概要

信頼できない HTML/CSS を server-side でレンダリングする際に、**攻撃者制御の値がそのまま retained metadata の乗数**になって O(count) / O(count × N) の確保を招く経路（メモリ枯渇 DoS）に、単一 choke point で防御的上限を入れる hardening バッチです。既存の `MAX_DOM_DEPTH` / `MAX_PAGES` の兄弟として cap 定数を `lib.rs` に集約しました。

いずれも **現実的な文書では出力バイト不変**（cap は実用値のはるか上、golden churn なし）で、病的入力のみ clamp-and-warn で切り詰めます。

## 対象と修正（choke point）

| 経路 | 増幅 | 修正（定数） |
|---|---|---|
| multicol `column-count`（`i32::MAX` まで通る／width 由来の派生 count も） | `vec![0.0; n]` col_heights ＋ split で O(count × 段落) の `column_slices` | `MAX_COLUMN_COUNT`=64 を `resolve_column_layout` の `capped` で clamp |
| gradient color stops（通常＋repeating） | per-element `BackgroundLayer` に O(elements × stops) 保持。repeating は draw 時に `total_copies × stops.len()` | `MAX_GRADIENT_STOPS`=256 を convert 側 stop 構築2箇所（linear/radial・conic）で `take` |
| named page（`page: <custom-ident>`） | name `String` を column style table ＋ per-node（`walk_used_page_names`）で O(nodes × name_len) clone | `MAX_PAGE_NAME_BYTES`=256 を構築点 `parse_page_value` で UTF-8 境界 truncate |
| `position:fixed` 部分木の per-page fragment | root＋全 in-flow 子孫を毎ページ記録＝O(nodes × pages) | zero-area skip（描画なし＝出力不変）＋ `MAX_SUBTREE_PAGE_FRAGMENTS`=1M 集約 budget |
| body-direct `position:absolute` 部分木の per-page fragment | 各ノードを交差ページ分記録（`first_page..=last_page`）＝O(nodes × pages) | 同じ `MAX_SUBTREE_PAGE_FRAGMENTS` budget を absolute pass にも threading |

ページ軸は既に `MAX_PAGES`（10k）で cap 済みでしたが、**ノード軸が無制限**だったのが `fixed` / `absolute` 経路の増幅源です。5つ目（absolute）は fixed 修正の adversarial review 中に「同一機構・別 sink」として発見しました（cap 前は再現で ~3M fragment）。

## 設計メモ

- **単一 choke で全 sink を一括 bound**: multicol は `resolve_column_layout` が `n` の唯一の生産点（`props.column_count` の読取りは 1 箇所のみ、raw count の迂回なし）。gradient も convert 側で cap すれば draw 側の hint 展開（hint 数 ≤ stops）と repeating 展開（≤ 513 × stops）が連動して bounded に。
- **width 由来 count の副作用（意図的）**: 極端に広いページ＋極小 `column-width` で自然に 64 を超えるケースは、要求より僅かに広い列幅になります。現実の文書では発生しません。
- **fixed/absolute は共有 budget**: 両 pass がそれぞれ running counter を持ち、`MAX_SUBTREE_PAGE_FRAGMENTS` 到達で emission を停止（fixed content が budget 超で繰り返しを止めるだけ）。

## テスト

各修正に TDD（cap が発火＝上限に収まる／現実的入力は従来と同一）:

- unit: `resolve_column_layout` clamp（explicit＋width 派生）、gradient stop 数 cap（linear/conic、`build_drawables` 経由）、page name 長 cap、zero-area fixed descendant が fragment を出さない、fixed/absolute の fragment 総数が budget 内
- e2e（`render_smoke`）: `column-count:2000000000` ＋ split content、repeating-gradient 数千 stops、20k ノード共有の巨大 page name — いずれも bounded 完走

`cargo test -p fulgur`（1642 lib ＋ 190 render_smoke）／ examples determinism 11 ／ VRT 12 ／ `cargo fmt` ／ `cargo clippy -D warnings` 全て green、**golden 変更なし**。

## スコープ外

adjacent-sibling セレクタの O(N²) CPU は本バッチ（メモリ確保系 cap 定数群）とは別クラス（bounded-hardening／CPU）として別途対応します。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 複雑なレイアウトやグラデーション、ページ名を含むコンテンツでも、より安定して処理されるようになりました。

* **バグ修正**
  * 極端に大きい列指定や非常に小さい列幅でも、列数が安全な範囲に収まるようになりました。
  * グラデーションの色停止点が過剰に増えないようになり、描画の負荷を抑えました。
  * 長すぎるページ名は安全な長さに調整されるようになりました。
  * 固定配置・絶対配置要素の繰り返し出力が過剰に増えないようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->