### PR TITLE
harden(fixed/absolute): reduce subtree fragment budget to aggregate cap only

### DIFF
--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -2800,11 +2800,12 @@ pub fn append_position_fixed_fragments(
         // entry for the pencil child or v2 never reaches it. The
         // existing root-only fragment carries inline text rendering
         // (fixedpos-001 / 008 ref pattern) but not block descendants.
-        // Skip the descendant walk entirely once the budget is spent: it would
-        // only traverse the subtree without emitting anything (gemini review).
-        if emitted < crate::MAX_SUBTREE_PAGE_FRAGMENTS {
-            record_fixed_subtree_descendants(geometry, doc, id, (x, y), pages, &mut emitted);
-        }
+        // Always walk the subtree (even once the budget is spent): the walk
+        // clears every descendant's entry, which is required because this
+        // fixed pass runs a second time after the absolute pass and must not
+        // leave stale fragments from the first pass behind (Codex review). The
+        // per-node push is itself bounded by the `emitted` budget.
+        record_fixed_subtree_descendants(geometry, doc, id, (x, y), pages, &mut emitted);
     }
 
     // Don't allocate empty entries for nodes without fragments.
@@ -2863,26 +2864,26 @@ fn record_fixed_subtree_descendants(
         let entry = geometry.entry(node_id).or_default();
         entry.fragments.clear();
         entry.is_repeat = true;
-        // Zero-area fragments draw nothing, so skipping them is
-        // output-preserving and removes the most common fixed-subtree
-        // amplifier (empty structural wrappers). The aggregate `emitted`
-        // budget is the hard bound on the residual O(descendants × pages).
-        if w > 0.0 || h > 0.0 {
-            for page_index in 0..pages.max(1) {
-                if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
-                    // Budget spent: return rather than break so the rest of
-                    // this subtree is not walked at all (gemini review).
-                    return;
-                }
-                entry.fragments.push(Fragment {
-                    page_index,
-                    x: stored_x.as_px(),
-                    y: stored_y.as_px(),
-                    width: w.as_px(),
-                    height: h.as_px(),
-                });
-                *emitted += 1;
+        // Per-page repeat fragments, bounded by the aggregate `emitted` budget
+        // (the hard cap on O(descendants × pages)). Use `break`, not `return`,
+        // and do not skip zero-area nodes: the walk must visit and clear every
+        // descendant (the fixed pass runs twice — before and after the absolute
+        // pass — so a later node can hold stale fragments from the first pass),
+        // and a zero-size wrapper's fragment can still scope a visible child via
+        // transform / opacity dispatch, which reads the wrapper's geometry
+        // (Codex review).
+        for page_index in 0..pages.max(1) {
+            if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
+                break;
             }
+            entry.fragments.push(Fragment {
+                page_index,
+                x: stored_x.as_px(),
+                y: stored_y.as_px(),
+                width: w.as_px(),
+                height: h.as_px(),
+            });
+            *emitted += 1;
         }
 
         let children: Vec<usize> = {
@@ -3325,11 +3326,12 @@ fn record_subtree_fragments_at_offset(
                     // intersected page, so a subtree of many page-spanning
                     // absolutes is O(nodes × pages). Stop past the cap
                     // (`crate::MAX_SUBTREE_PAGE_FRAGMENTS`) — shared with the
-                    // fixed pass. Return rather than break so the remaining
-                    // subtree is not walked once the budget is spent (gemini
+                    // fixed pass. Use `break`, not `return`: the walk must keep
+                    // visiting (and clearing) the rest of the subtree so no
+                    // stale fragments survive from an earlier pass (Codex
                     // review).
                     if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
-                        return;
+                        break;
                     }
                     let is_monolithic_continuation =
                         monolithic_adjust > 0.0 && page_index > first_page;
@@ -5278,34 +5280,6 @@ h2 { string-set: chapter-title content(text); }
             });
 
         assert_eq!(fixed_pages, Some(vec![0, 1]));
-    }
-
-    #[test]
-    fn fixed_zero_area_descendant_emits_no_fragments() {
-        // A zero-area fixed descendant draws nothing, so emitting one repeated
-        // fragment per page for it is pure amplification. Skipping zero-area
-        // fragments is output-preserving and removes a fixed-subtree amplifier.
-        let html = r#"
-            <html><body style="margin:0">
-              <div style="position: fixed; top:0; width:100px; height:100px">
-                <div style="width:0; height:0"></div>
-                <div style="width:10px; height:10px"></div>
-              </div>
-              <div style="height:1200px"></div>
-            </body></html>
-        "#;
-        let engine = crate::Engine::builder().build();
-        let (_, geom) = engine.build_drawables_and_geometry_for_testing_no_gcpm(html);
-        let zero_area_repeated = geom
-            .values()
-            .filter(|g| g.is_repeat)
-            .flat_map(|g| g.fragments.iter())
-            .filter(|f| f.width.to_f32() <= 0.0 && f.height.to_f32() <= 0.0)
-            .count();
-        assert_eq!(
-            zero_area_repeated, 0,
-            "zero-area fixed descendant must not emit repeated fragments"
-        );
     }
 
     #[test]

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -2861,6 +2861,9 @@ fn record_fixed_subtree_descendants(
         let w = node.final_layout.size.width;
         let h = node.final_layout.size.height;
 
+        let entry = geometry.entry(node_id).or_default();
+        entry.fragments.clear();
+        entry.is_repeat = true;
         // Per-page repeat fragments, bounded by the aggregate `emitted` budget
         // (the hard cap on O(descendants × pages)). Use `break`, not `return`,
         // and do not skip zero-area nodes: the walk must visit and clear every
@@ -2869,34 +2872,18 @@ fn record_fixed_subtree_descendants(
         // and a zero-size wrapper's fragment can still scope a visible child via
         // transform / opacity dispatch, which reads the wrapper's geometry
         // (Codex review).
-        //
-        // Once the budget is spent, do NOT `or_default()` a fresh entry for the
-        // remaining nodes — that would grow the geometry map to O(subtree) even
-        // though every such entry ends up empty (dropped by the later
-        // `retain`). Only clear an already-present entry so no stale fragment
-        // from the earlier pass survives; this keeps the retained map bounded
-        // by the budget, not the subtree size (gemini review).
-        if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
-            if let Some(entry) = geometry.get_mut(&node_id) {
-                entry.fragments.clear();
+        for page_index in 0..pages.max(1) {
+            if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
+                break;
             }
-        } else {
-            let entry = geometry.entry(node_id).or_default();
-            entry.fragments.clear();
-            entry.is_repeat = true;
-            for page_index in 0..pages.max(1) {
-                if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
-                    break;
-                }
-                entry.fragments.push(Fragment {
-                    page_index,
-                    x: stored_x.as_px(),
-                    y: stored_y.as_px(),
-                    width: w.as_px(),
-                    height: h.as_px(),
-                });
-                *emitted += 1;
-            }
+            entry.fragments.push(Fragment {
+                page_index,
+                x: stored_x.as_px(),
+                y: stored_y.as_px(),
+                width: w.as_px(),
+                height: h.as_px(),
+            });
+            *emitted += 1;
         }
 
         let children: Vec<usize> = {
@@ -3331,51 +3318,42 @@ fn record_subtree_fragments_at_offset(
                 } else {
                     final_y_for_paging
                 };
-                // Aggregate budget: each node emits one fragment per intersected
-                // page, so a subtree of many page-spanning absolutes is
-                // O(nodes × pages). Stop past the cap
-                // (`crate::MAX_SUBTREE_PAGE_FRAGMENTS`) — shared with the fixed
-                // pass. Use `break`, not `return`: the walk must keep visiting
-                // (and clearing) the rest of the subtree so no stale fragments
-                // survive from an earlier pass (Codex review). Once the budget
-                // is spent, only clear an already-present entry rather than
-                // `or_default()`-ing a fresh one, so the retained geometry map
-                // stays bounded by the budget, not the subtree size (gemini
-                // review).
-                if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
-                    if let Some(entry) = geometry.get_mut(&node_id) {
-                        entry.fragments.clear();
+                let entry = geometry.entry(node_id).or_default();
+                entry.fragments.clear();
+                entry.is_repeat = false;
+                for page_index in first_page..=last_page {
+                    // Aggregate budget: each node emits one fragment per
+                    // intersected page, so a subtree of many page-spanning
+                    // absolutes is O(nodes × pages). Stop past the cap
+                    // (`crate::MAX_SUBTREE_PAGE_FRAGMENTS`) — shared with the
+                    // fixed pass. Use `break`, not `return`: the walk must keep
+                    // visiting (and clearing) the rest of the subtree so no
+                    // stale fragments survive from an earlier pass (Codex
+                    // review).
+                    if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
+                        break;
                     }
-                } else {
-                    let entry = geometry.entry(node_id).or_default();
-                    entry.fragments.clear();
-                    entry.is_repeat = false;
-                    for page_index in first_page..=last_page {
-                        if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
-                            break;
-                        }
-                        let is_monolithic_continuation =
-                            monolithic_adjust > 0.0 && page_index > first_page;
-                        let stored_y = if is_monolithic_continuation {
-                            -body_offset.1
-                        } else {
-                            paging_origin_y - (page_index as f32) * page_stride_px - body_offset.1
-                        };
-                        let stored_h = if is_monolithic_continuation {
-                            let consumed = (page_index - first_page) as f32 * page_h_px;
-                            (h_for_paging - consumed).clamp(0.0, page_h_px)
-                        } else {
-                            h
-                        };
-                        entry.fragments.push(Fragment {
-                            page_index,
-                            x: stored_x.as_px(),
-                            y: stored_y.as_px(),
-                            width: w.as_px(),
-                            height: stored_h.as_px(),
-                        });
-                        *emitted += 1;
-                    }
+                    let is_monolithic_continuation =
+                        monolithic_adjust > 0.0 && page_index > first_page;
+                    let stored_y = if is_monolithic_continuation {
+                        -body_offset.1
+                    } else {
+                        paging_origin_y - (page_index as f32) * page_stride_px - body_offset.1
+                    };
+                    let stored_h = if is_monolithic_continuation {
+                        let consumed = (page_index - first_page) as f32 * page_h_px;
+                        (h_for_paging - consumed).clamp(0.0, page_h_px)
+                    } else {
+                        h
+                    };
+                    entry.fragments.push(Fragment {
+                        page_index,
+                        x: stored_x.as_px(),
+                        y: stored_y.as_px(),
+                        width: w.as_px(),
+                        height: stored_h.as_px(),
+                    });
+                    *emitted += 1;
                 }
                 descendant_total_pages = descendant_total_pages.max(last_page.saturating_add(1));
             }

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -2861,9 +2861,6 @@ fn record_fixed_subtree_descendants(
         let w = node.final_layout.size.width;
         let h = node.final_layout.size.height;
 
-        let entry = geometry.entry(node_id).or_default();
-        entry.fragments.clear();
-        entry.is_repeat = true;
         // Per-page repeat fragments, bounded by the aggregate `emitted` budget
         // (the hard cap on O(descendants × pages)). Use `break`, not `return`,
         // and do not skip zero-area nodes: the walk must visit and clear every
@@ -2872,18 +2869,34 @@ fn record_fixed_subtree_descendants(
         // and a zero-size wrapper's fragment can still scope a visible child via
         // transform / opacity dispatch, which reads the wrapper's geometry
         // (Codex review).
-        for page_index in 0..pages.max(1) {
-            if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
-                break;
+        //
+        // Once the budget is spent, do NOT `or_default()` a fresh entry for the
+        // remaining nodes — that would grow the geometry map to O(subtree) even
+        // though every such entry ends up empty (dropped by the later
+        // `retain`). Only clear an already-present entry so no stale fragment
+        // from the earlier pass survives; this keeps the retained map bounded
+        // by the budget, not the subtree size (gemini review).
+        if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
+            if let Some(entry) = geometry.get_mut(&node_id) {
+                entry.fragments.clear();
             }
-            entry.fragments.push(Fragment {
-                page_index,
-                x: stored_x.as_px(),
-                y: stored_y.as_px(),
-                width: w.as_px(),
-                height: h.as_px(),
-            });
-            *emitted += 1;
+        } else {
+            let entry = geometry.entry(node_id).or_default();
+            entry.fragments.clear();
+            entry.is_repeat = true;
+            for page_index in 0..pages.max(1) {
+                if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
+                    break;
+                }
+                entry.fragments.push(Fragment {
+                    page_index,
+                    x: stored_x.as_px(),
+                    y: stored_y.as_px(),
+                    width: w.as_px(),
+                    height: h.as_px(),
+                });
+                *emitted += 1;
+            }
         }
 
         let children: Vec<usize> = {
@@ -3318,42 +3331,51 @@ fn record_subtree_fragments_at_offset(
                 } else {
                     final_y_for_paging
                 };
-                let entry = geometry.entry(node_id).or_default();
-                entry.fragments.clear();
-                entry.is_repeat = false;
-                for page_index in first_page..=last_page {
-                    // Aggregate budget: each node emits one fragment per
-                    // intersected page, so a subtree of many page-spanning
-                    // absolutes is O(nodes × pages). Stop past the cap
-                    // (`crate::MAX_SUBTREE_PAGE_FRAGMENTS`) — shared with the
-                    // fixed pass. Use `break`, not `return`: the walk must keep
-                    // visiting (and clearing) the rest of the subtree so no
-                    // stale fragments survive from an earlier pass (Codex
-                    // review).
-                    if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
-                        break;
+                // Aggregate budget: each node emits one fragment per intersected
+                // page, so a subtree of many page-spanning absolutes is
+                // O(nodes × pages). Stop past the cap
+                // (`crate::MAX_SUBTREE_PAGE_FRAGMENTS`) — shared with the fixed
+                // pass. Use `break`, not `return`: the walk must keep visiting
+                // (and clearing) the rest of the subtree so no stale fragments
+                // survive from an earlier pass (Codex review). Once the budget
+                // is spent, only clear an already-present entry rather than
+                // `or_default()`-ing a fresh one, so the retained geometry map
+                // stays bounded by the budget, not the subtree size (gemini
+                // review).
+                if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
+                    if let Some(entry) = geometry.get_mut(&node_id) {
+                        entry.fragments.clear();
                     }
-                    let is_monolithic_continuation =
-                        monolithic_adjust > 0.0 && page_index > first_page;
-                    let stored_y = if is_monolithic_continuation {
-                        -body_offset.1
-                    } else {
-                        paging_origin_y - (page_index as f32) * page_stride_px - body_offset.1
-                    };
-                    let stored_h = if is_monolithic_continuation {
-                        let consumed = (page_index - first_page) as f32 * page_h_px;
-                        (h_for_paging - consumed).clamp(0.0, page_h_px)
-                    } else {
-                        h
-                    };
-                    entry.fragments.push(Fragment {
-                        page_index,
-                        x: stored_x.as_px(),
-                        y: stored_y.as_px(),
-                        width: w.as_px(),
-                        height: stored_h.as_px(),
-                    });
-                    *emitted += 1;
+                } else {
+                    let entry = geometry.entry(node_id).or_default();
+                    entry.fragments.clear();
+                    entry.is_repeat = false;
+                    for page_index in first_page..=last_page {
+                        if *emitted >= crate::MAX_SUBTREE_PAGE_FRAGMENTS {
+                            break;
+                        }
+                        let is_monolithic_continuation =
+                            monolithic_adjust > 0.0 && page_index > first_page;
+                        let stored_y = if is_monolithic_continuation {
+                            -body_offset.1
+                        } else {
+                            paging_origin_y - (page_index as f32) * page_stride_px - body_offset.1
+                        };
+                        let stored_h = if is_monolithic_continuation {
+                            let consumed = (page_index - first_page) as f32 * page_h_px;
+                            (h_for_paging - consumed).clamp(0.0, page_h_px)
+                        } else {
+                            h
+                        };
+                        entry.fragments.push(Fragment {
+                            page_index,
+                            x: stored_x.as_px(),
+                            y: stored_y.as_px(),
+                            width: w.as_px(),
+                            height: stored_h.as_px(),
+                        });
+                        *emitted += 1;
+                    }
                 }
                 descendant_total_pages = descendant_total_pages.max(last_page.saturating_add(1));
             }


### PR DESCRIPTION
## 概要

PR #594 / 0.30.0 で入れた fixed/absolute の per-page fragment budget（`MAX_SUBTREE_PAGE_FRAGMENTS`）に**上乗せしていた最適化2つが correctness edge を生んでいた**ため、これらを撤去して「aggregate budget のみ」の証明可能に正しい core に簡素化します。指摘は #594 のマージ直後に届いた Codex review 由来です（DoS 対策の本体は 0.30.0 で released 済み、本 PR は残った描画バグの修正）。

## 修正した2つの edge

- **zero-area fixed-descendant skip（実害のある描画バグ）**: `0×0` の fixed wrapper が `transform` / `opacity` で可視子を scope する場合、render は当該子を main loop で skip し、wrapper の geometry を使って `draw_under_transform` / `draw_under_opacity` で描き直します。zero-area skip で wrapper の fragment を落とすと、この dispatch が起きず**子が描画されず消えます**。
- **budget 枯渇時の early-return / call-skip（攻撃時 edge）**: fixed pass は absolute pass の前後で**2回**呼ばれます（`engine.rs:555`/`580`）。2回目で budget を使い切ると early-return / call-guard が rebuild を飛ばし、visited でないノードは `clear()` されないため**1回目の stale fragment が残り**、orphaned copy が描かれます。

## 修正方針

aggregate `MAX_SUBTREE_PAGE_FRAGMENTS` budget を**素の loop `break`** で適用するだけに戻しました:

- walk は常に全ノードを訪問し各 entry を `clear()` する → 2回目 pass でも stale fragment が残らない
- zero-area ノードも skip しない → scoping wrapper の geometry が保持される
- per-node の push は budget で bound されたまま → **DoS 上限は不変**

撤去したのは #594 に乗っていた gemini early-return / call-guard と zero-area guard（および obsolete な zero-area test）のみ。gradient の color-stop cap 修正（Codex comment 2）は別ファイルで無関係、そのまま。

## 検証

- `cargo test -p fulgur`（1650 lib、budget 上限 test 含む）／ examples determinism 11 ／ VRT 12 ／ `cargo fmt` ／ `cargo clippy -D warnings` 0、**golden churn なし**
- WPT（CI）: zero-area skip 撤去は `0×0` fixed descendant の挙動のみ変え、no-op fragment は pixel 不変なので regression は想定なし（PR #594 で fixedpos-004/008 を壊した absolute の skip とは別で、本 PR は skip を**入れない**方向）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 固定要素や絶対位置要素のページ分割処理で、上限に達した後も後続要素の走査とクリアを継続するよう改善しました。
  * 以前の処理で残ることがあった古い断片が、再実行時に残りにくくなりました。

* **Tests**
  * 仕様変更に合わせて、不要になったテストを削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->