### PR TITLE
perf(convert): linear clip/opacity/transform descendant tracking via insertion log

### DIFF
--- a/crates/fulgur/src/convert/block.rs
+++ b/crates/fulgur/src/convert/block.rs
@@ -45,7 +45,7 @@ pub(super) fn convert(
     // descendants in `draw_with_opacity`, so the dual case is covered
     // there and recording it again would double-track.
     let opacity_scope = !clipping && opacity < 1.0;
-    let snapshot = (clipping || opacity_scope).then(|| collect_drawables_node_ids(out));
+    let mark = (clipping || opacity_scope).then(|| out.draw_mark());
 
     // Always insert the block entry — the v2 dispatcher silently no-ops
     // when neither paint nor clip nor opacity applies, so leaving an
@@ -59,11 +59,10 @@ pub(super) fn convert(
     // Walk pseudo + absolutely-positioned descendants.
     pseudo::register_pseudo_content(doc, node, ctx, depth, content_box, out);
 
-    if let Some(before) = snapshot {
-        let after = collect_drawables_node_ids(out);
-        let descendants: Vec<usize> = after
-            .difference(&before)
-            .copied()
+    if let Some(mark) = mark {
+        let descendants: Vec<usize> = out
+            .drawn_since(mark)
+            .into_iter()
             .filter(|&id| id != node_id)
             .collect();
         if let Some(entry) = out.block_styles.get_mut(&node_id) {

--- a/crates/fulgur/src/convert/inline_root.rs
+++ b/crates/fulgur/src/convert/inline_root.rs
@@ -46,7 +46,7 @@ pub(super) fn try_convert(
         || pseudo::node_has_absolute_pseudo(doc, node);
     let clipping_pre = needs_block_pre && style.has_overflow_clip();
     let opacity_scope_pre = needs_block_pre && !clipping_pre && opacity < 1.0;
-    let pre_snapshot = (clipping_pre || opacity_scope_pre).then(|| collect_drawables_node_ids(out));
+    let pre_mark = (clipping_pre || opacity_scope_pre).then(|| out.draw_mark());
 
     let paragraph_opt = extract_paragraph(doc, node, ctx, depth, out);
     let content_box = compute_content_box(node, &style);
@@ -137,11 +137,10 @@ pub(super) fn try_convert(
             );
             // Register pseudo content (block-pseudo images + abs children).
             pseudo::register_pseudo_content(doc, node, ctx, depth, content_box, out);
-            if let Some(before) = pre_snapshot.as_ref() {
-                let after = collect_drawables_node_ids(out);
-                let descendants: Vec<usize> = after
-                    .difference(before)
-                    .copied()
+            if let Some(mark) = pre_mark {
+                let descendants: Vec<usize> = out
+                    .drawn_since(mark)
+                    .into_iter()
                     .filter(|&id| id != node_id)
                     .collect();
                 if let Some(entry) = out.block_styles.get_mut(&node_id) {
@@ -197,11 +196,10 @@ pub(super) fn try_convert(
                 },
             );
             pseudo::register_pseudo_content(doc, node, ctx, depth, content_box, out);
-            if let Some(before) = pre_snapshot.as_ref() {
-                let after = collect_drawables_node_ids(out);
-                let descendants: Vec<usize> = after
-                    .difference(before)
-                    .copied()
+            if let Some(mark) = pre_mark {
+                let descendants: Vec<usize> = out
+                    .drawn_since(mark)
+                    .into_iter()
                     .filter(|&id| id != node_id)
                     .collect();
                 if let Some(entry) = out.block_styles.get_mut(&node_id) {
@@ -544,19 +542,17 @@ pub(super) fn extract_paragraph(
                             continue;
                         }
                     }
-                    // Snapshot before recursing so we can compute the
-                    // inline-box descendant set for the v2 dispatcher's
-                    // skip table.
-                    let before = collect_drawables_node_ids(out);
+                    // Mark before recursing so we can compute the inline-box
+                    // descendant set for the v2 dispatcher's skip table.
+                    let mark = out.draw_mark();
                     let content = convert_inline_box_node(doc, node_id, ctx, depth, out);
-                    let after = collect_drawables_node_ids(out);
                     // Record the descendants the paragraph render path
                     // owns under its offset transform. Filter against
                     // already-recorded skip entries so nested inline-boxes
                     // don't double-register.
-                    let descendants: Vec<crate::drawables::NodeId> = after
-                        .difference(&before)
-                        .copied()
+                    let descendants: Vec<crate::drawables::NodeId> = out
+                        .drawn_since(mark)
+                        .into_iter()
                         .filter(|id| *id != node_id)
                         .filter(|id| !out.inline_box_subtree_skip.contains(id))
                         .collect();

--- a/crates/fulgur/src/convert/list_item.rs
+++ b/crates/fulgur/src/convert/list_item.rs
@@ -61,9 +61,9 @@ pub(super) fn try_convert(
         let content_box = compute_content_box(node, &style);
         let clipping = style.has_overflow_clip();
         let opacity_scope = !clipping && opacity < 1.0;
-        let snapshot = (clipping || opacity_scope).then(|| collect_drawables_node_ids(out));
+        let mark = (clipping || opacity_scope).then(|| out.draw_mark());
         build_list_item_body(doc, node, style, visible, content_box, ctx, depth, out);
-        record_li_clip_opacity_descendants(node_id, clipping, snapshot, out);
+        record_li_clip_opacity_descendants(node_id, clipping, mark, out);
         return true;
     }
 
@@ -112,9 +112,9 @@ pub(super) fn try_convert(
             let content_box = compute_content_box(node, &style);
             let clipping = style.has_overflow_clip();
             let opacity_scope = !clipping && opacity < 1.0;
-            let snapshot = (clipping || opacity_scope).then(|| collect_drawables_node_ids(out));
+            let mark = (clipping || opacity_scope).then(|| out.draw_mark());
             build_list_item_body(doc, node, style, visible, content_box, ctx, depth, out);
-            record_li_clip_opacity_descendants(node_id, clipping, snapshot, out);
+            record_li_clip_opacity_descendants(node_id, clipping, mark, out);
             return true;
         }
     }
@@ -214,10 +214,10 @@ pub(super) fn try_convert(
             // Snapshot existing paragraph ids before the child walk so
             // `inject_marker_into_first_paragraph` only considers
             // paragraphs registered for *this* list-item's subtree.
-            // Without the snapshot, `out.paragraphs.iter_mut().next()`
-            // picks the lowest NodeId in the entire document (e.g. an
-            // earlier `<p>` or a previous `<li>`), prepending the
-            // marker to unrelated content.
+            // Without the snapshot, the first paragraph key would be the
+            // lowest NodeId in the entire document (e.g. an earlier `<p>`
+            // or a previous `<li>`), prepending the marker to unrelated
+            // content.
             let pre_paragraph_ids: std::collections::BTreeSet<usize> =
                 out.paragraphs.keys().copied().collect();
             positioned::walk_children_into_drawables(doc, children, ctx, depth, out);
@@ -288,11 +288,19 @@ fn inject_marker_into_first_paragraph(
     pre_existing_ids: &std::collections::BTreeSet<usize>,
     item: LineItem,
 ) -> bool {
-    let Some((_, entry)) = out
+    // `keys()` iterates ascending (BTreeMap via `Deref`), so the first key
+    // not in `pre_existing_ids` is the lowest new-paragraph NodeId — the same
+    // entry `iter_mut().find(..)` used to land on. `get_mut` then takes the
+    // single mutable borrow (`TrackedMap` has no `DerefMut`/`iter_mut`).
+    let Some(target_id) = out
         .paragraphs
-        .iter_mut()
-        .find(|(id, _)| !pre_existing_ids.contains(id))
+        .keys()
+        .copied()
+        .find(|id| !pre_existing_ids.contains(id))
     else {
+        return false;
+    };
+    let Some(entry) = out.paragraphs.get_mut(&target_id) else {
         return false;
     };
     let Some(first_line) = entry.lines.first_mut() else {
@@ -431,20 +439,19 @@ fn build_list_item_body(
 }
 
 /// Fill in `clip_descendants` / `opacity_descendants` on an already-inserted
-/// `BlockEntry` keyed by `node_id`, using the before/after snapshot diff.
-/// `snapshot` is `Some` only when the caller decided this node has a clip
-/// or opacity scope worth tracking.
+/// `BlockEntry` keyed by `node_id`, using the NodeIds inserted since `mark`.
+/// `mark` is `Some` only when the caller decided this node has a clip or
+/// opacity scope worth tracking. See [`crate::drawables::Drawables::drawn_since`].
 fn record_li_clip_opacity_descendants(
     node_id: usize,
     clipping: bool,
-    snapshot: Option<std::collections::BTreeSet<usize>>,
+    mark: Option<crate::drawables::DrawMark>,
     out: &mut crate::drawables::Drawables,
 ) {
-    let Some(before) = snapshot else { return };
-    let after = collect_drawables_node_ids(out);
-    let descendants: Vec<usize> = after
-        .difference(&before)
-        .copied()
+    let Some(mark) = mark else { return };
+    let descendants: Vec<usize> = out
+        .drawn_since(mark)
+        .into_iter()
         .filter(|&id| id != node_id)
         .collect();
     if let Some(entry) = out.block_styles.get_mut(&node_id) {
@@ -685,7 +692,7 @@ mod tests {
     // ── record_li_clip_opacity_descendants ────────────────────────────
 
     #[test]
-    fn record_none_snapshot_is_noop() {
+    fn record_none_mark_is_noop() {
         let mut out = Drawables::new();
         out.block_styles.insert(1, make_block_entry());
         record_li_clip_opacity_descendants(1, true, None, &mut out);
@@ -696,15 +703,13 @@ mod tests {
     #[test]
     fn record_clipping_true_fills_clip_descendants_and_excludes_self() {
         let mut out = Drawables::new();
-        out.block_styles.insert(10, make_block_entry()); // parent
-        out.block_styles.insert(20, make_block_entry()); // child 1
-        out.block_styles.insert(30, make_block_entry()); // child 2
-        // Snapshot captured before the children were walked — only node 10 existed then.
-        let pre: BTreeSet<usize> = [10].into();
-        record_li_clip_opacity_descendants(10, true, Some(pre), &mut out);
-        let mut got = out.block_styles[&10].clip_descendants.clone();
-        got.sort_unstable();
-        assert_eq!(got, vec![20usize, 30]);
+        out.block_styles.insert(10, make_block_entry()); // parent (pre-mark)
+        let mark = out.draw_mark();
+        out.block_styles.insert(20, make_block_entry()); // child 1 (post-mark)
+        out.block_styles.insert(30, make_block_entry()); // child 2 (post-mark)
+        record_li_clip_opacity_descendants(10, true, Some(mark), &mut out);
+        // drawn_since already yields ascending unique ids; no sort needed.
+        assert_eq!(out.block_styles[&10].clip_descendants, vec![20usize, 30]);
         assert!(out.block_styles[&10].opacity_descendants.is_empty());
     }
 
@@ -712,9 +717,9 @@ mod tests {
     fn record_clipping_false_fills_opacity_descendants_and_excludes_self() {
         let mut out = Drawables::new();
         out.block_styles.insert(10, make_block_entry());
+        let mark = out.draw_mark();
         out.block_styles.insert(11, make_block_entry());
-        let pre: BTreeSet<usize> = [10].into();
-        record_li_clip_opacity_descendants(10, false, Some(pre), &mut out);
+        record_li_clip_opacity_descendants(10, false, Some(mark), &mut out);
         assert_eq!(out.block_styles[&10].opacity_descendants, vec![11usize]);
         assert!(out.block_styles[&10].clip_descendants.is_empty());
     }
@@ -722,21 +727,22 @@ mod tests {
     #[test]
     fn record_missing_block_entry_does_not_panic() {
         let mut out = Drawables::new();
+        let mark = out.draw_mark();
         out.block_styles.insert(20, make_block_entry());
-        let pre: BTreeSet<usize> = BTreeSet::new();
         // node_id 10 has no entry in block_styles — must not panic.
-        record_li_clip_opacity_descendants(10, true, Some(pre), &mut out);
+        record_li_clip_opacity_descendants(10, true, Some(mark), &mut out);
     }
 
     #[test]
-    fn record_excludes_node_id_even_when_snapshot_does_not_contain_it() {
-        // pre is empty, so after − before = {10, 11}. The `.filter(|&id| id != node_id)`
-        // guard must drop 10 so clip_descendants contains only the child.
+    fn record_excludes_node_id_even_when_inserted_after_mark() {
+        // Both 10 and 11 are inserted after the mark, so `drawn_since` yields
+        // {10, 11}. The `.filter(|&id| id != node_id)` guard must drop 10
+        // (self) so clip_descendants contains only the child.
         let mut out = Drawables::new();
+        let mark = out.draw_mark();
         out.block_styles.insert(10, make_block_entry());
         out.block_styles.insert(11, make_block_entry());
-        let pre: BTreeSet<usize> = BTreeSet::new();
-        record_li_clip_opacity_descendants(10, true, Some(pre), &mut out);
+        record_li_clip_opacity_descendants(10, true, Some(mark), &mut out);
         assert_eq!(out.block_styles[&10].clip_descendants, vec![11usize]);
         assert!(out.block_styles[&10].opacity_descendants.is_empty());
     }

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -269,26 +269,8 @@ fn extract_root_dir_rtl(doc: &HtmlDocument) -> bool {
         .is_some_and(|s| matches!(s.get_inherited_box().clone_direction(), Dir::Rtl))
 }
 
-/// Snapshot the union of `NodeId` keys currently present in `out`'s
-/// per-NodeId maps. Used by `record_transform`, `block::convert`,
-/// `table::try_convert`, and `inline_root::extract_paragraph` to compute
-/// `descendants = after - before` so wrappers (transform / clip / opacity /
-/// inline-box) can list every node added by walking their inner subtree.
-pub(super) fn collect_drawables_node_ids(
-    out: &crate::drawables::Drawables,
-) -> std::collections::BTreeSet<usize> {
-    let mut ids = std::collections::BTreeSet::new();
-    ids.extend(out.block_styles.keys().copied());
-    ids.extend(out.paragraphs.keys().copied());
-    ids.extend(out.images.keys().copied());
-    ids.extend(out.svgs.keys().copied());
-    ids.extend(out.tables.keys().copied());
-    ids.extend(out.list_items.keys().copied());
-    ids
-}
-
 /// O(1) probe answering "did *any* per-NodeId map grow?" — sums `.len()`
-/// across the same six maps `collect_drawables_node_ids` unions. Callers
+/// across the same six maps `Drawables::draw_mark` / `drawn_since` track. Callers
 /// that only need the boolean "produced anything?" answer (not the
 /// descendant set) should compare this value before/after a recursion
 /// instead of constructing two `BTreeSet<usize>`s. Convert never removes
@@ -392,12 +374,12 @@ pub(super) fn convert_node(
     // copying every NodeId already inserted, summing to ~N²/2 inserts
     // for N nodes). Gate the snapshot on the transform check so the
     // common case stays O(N). (fulgur-v1cm)
-    let before = node_has_transform(doc, node_id).then(|| collect_drawables_node_ids(out));
+    let mark = node_has_transform(doc, node_id).then(|| out.draw_mark());
     convert_node_inner(doc, node_id, ctx, depth, out);
     record_multicol_rule(doc, node_id, ctx, out);
     convert_multicol_paragraph_slices(doc, node_id, ctx, out);
-    if let Some(before) = before {
-        record_transform(doc, node_id, &before, out);
+    if let Some(mark) = mark {
+        record_transform(doc, node_id, mark, out);
     }
 }
 
@@ -599,15 +581,15 @@ fn convert_node_inner(
 }
 
 /// Register a `TransformEntry` for `node_id` if its computed style
-/// resolves to a non-identity transform. `before` is the set of
-/// `NodeId`s present in `out` at the start of this node's walk; the
-/// difference between that and the post-walk set (excluding `node_id`
-/// itself) is the strict descendant list the render pass needs to paint
-/// inside the transform's `push_transform` / `pop` group.
+/// resolves to a non-identity transform. `mark` was captured before this
+/// node's walk; the `NodeId`s inserted since then (excluding `node_id`
+/// itself) are the strict descendant list the render pass needs to paint
+/// inside the transform's `push_transform` / `pop` group. See
+/// [`crate::drawables::Drawables::drawn_since`].
 fn record_transform(
     doc: &BaseDocument,
     node_id: usize,
-    before: &std::collections::BTreeSet<usize>,
+    mark: crate::drawables::DrawMark,
     out: &mut crate::drawables::Drawables,
 ) {
     let Some(node) = doc.get_node(node_id) else {
@@ -640,10 +622,9 @@ fn record_transform(
     else {
         return;
     };
-    let after = collect_drawables_node_ids(out);
-    let descendants: Vec<usize> = after
-        .difference(before)
-        .copied()
+    let descendants: Vec<usize> = out
+        .drawn_since(mark)
+        .into_iter()
         .filter(|&id| id != node_id)
         .collect();
     out.transforms.insert(

--- a/crates/fulgur/src/convert/table.rs
+++ b/crates/fulgur/src/convert/table.rs
@@ -48,7 +48,7 @@ fn convert_table(
         },
     );
 
-    let snapshot = clipping.then(|| collect_drawables_node_ids(out));
+    let mark = clipping.then(|| out.draw_mark());
 
     // Walk table children to recurse cells.
     for &child_id in &node.children {
@@ -59,11 +59,10 @@ fn convert_table(
         collect_table_cells(doc, child_id, is_thead, ctx, depth, out);
     }
 
-    if let Some(before) = snapshot {
-        let after = collect_drawables_node_ids(out);
-        let descendants: Vec<usize> = after
-            .difference(&before)
-            .copied()
+    if let Some(mark) = mark {
+        let descendants: Vec<usize> = out
+            .drawn_since(mark)
+            .into_iter()
             .filter(|&id| id != node.id)
             .collect();
         if let Some(entry) = out.tables.get_mut(&node.id) {

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -568,14 +568,21 @@ impl Drawables {
     /// the set difference; see [`TrackedMap`]. Callers still apply their own
     /// `id != node_id` / skip-set filters on top.
     pub fn drawn_since(&self, mark: DrawMark) -> Vec<NodeId> {
-        let mut ids: std::collections::BTreeSet<NodeId> = std::collections::BTreeSet::new();
+        // Collect the six tails into a flat `Vec`, then `sort_unstable` +
+        // `dedup` to get the same ascending-unique result a `BTreeSet` would
+        // — but with one contiguous allocation instead of a per-node B-tree
+        // allocation, which matters precisely because this runs once per
+        // clip/opacity/transform scope. Tails are typically small.
+        let mut ids: Vec<NodeId> = Vec::new();
         ids.extend(self.block_styles.since(mark.block_styles).iter().copied());
         ids.extend(self.paragraphs.since(mark.paragraphs).iter().copied());
         ids.extend(self.images.since(mark.images).iter().copied());
         ids.extend(self.svgs.since(mark.svgs).iter().copied());
         ids.extend(self.tables.since(mark.tables).iter().copied());
         ids.extend(self.list_items.since(mark.list_items).iter().copied());
-        ids.into_iter().collect()
+        ids.sort_unstable();
+        ids.dedup();
+        ids
     }
 
     /// 合成 NodeId を 1 つ割り当てる。

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -28,6 +28,106 @@ use std::collections::BTreeMap;
 /// `pagination_layout::PaginationGeometryTable`'s key.
 pub type NodeId = usize;
 
+/// A `BTreeMap<NodeId, V>` that also records the *order* keys were inserted,
+/// so a caller can recover "which NodeIds were inserted since an earlier
+/// point" in O(inserted-since) time instead of scanning the whole map.
+///
+/// ## Why this exists (fulgur-vrkv)
+///
+/// Several convert passes need the set of drawable NodeIds produced while
+/// converting one node's subtree — the clip / opacity / transform *descendant*
+/// lists and the inline-box skip table. The original implementation
+/// snapshot-diffed *every* drawable map before and after the recursion
+/// (`collect_drawables_node_ids`): O(total drawables) per scope, and therefore
+/// O(N²) across a document with N such scopes (e.g. N sibling
+/// `opacity < 1` blocks). `fulgur-v1cm` gated the transform snapshot and
+/// `fulgur-vrkv` replaced the boolean "did anything change?" probes with the
+/// O(1) `drawables_total_len`, but the passes that need the actual *set* of
+/// new NodeIds were left on the quadratic path.
+///
+/// `TrackedMap` makes that set recoverable in O(inserted-since):
+/// [`insert`](TrackedMap::insert) appends to an insertion log,
+/// [`Drawables::draw_mark`] captures the current log lengths, and
+/// [`Drawables::drawn_since`] unions the six logs' tails.
+///
+/// ## Invariants that keep PDF output byte-identical
+///
+/// - `insert` is the *only* way to add a key: there is no `DerefMut`, so any
+///   other mutation path (`.entry`, `.extend`, `iter_mut`) fails to compile
+///   rather than silently bypassing the log. `get_mut` mutates an existing
+///   entry's value and never adds a key, so it does not log.
+/// - Convert never removes entries, so the maps are append-only and a log's
+///   tail after a mark is exactly the keys inserted since that mark.
+/// - [`Drawables::drawn_since`] returns keys **sorted ascending,
+///   deduplicated** — matching the old `BTreeSet::difference` output so the
+///   descendant `Vec`s (which drive painter-order PDF emission) keep the same
+///   byte layout.
+#[derive(Debug, Clone)]
+pub struct TrackedMap<V> {
+    map: BTreeMap<NodeId, V>,
+    /// Append-only log of every key passed to `insert`, in call order. May
+    /// contain duplicates when a key is re-inserted (overwritten); readers of
+    /// a tail deduplicate via `Drawables::drawn_since`.
+    order: Vec<NodeId>,
+}
+
+impl<V> Default for TrackedMap<V> {
+    fn default() -> Self {
+        Self {
+            map: BTreeMap::new(),
+            order: Vec::new(),
+        }
+    }
+}
+
+impl<V> std::ops::Deref for TrackedMap<V> {
+    type Target = BTreeMap<NodeId, V>;
+    fn deref(&self) -> &Self::Target {
+        &self.map
+    }
+}
+
+impl<V> TrackedMap<V> {
+    /// Insert `value` for `key`, recording the insertion in the order log.
+    /// Deliberately shadows `BTreeMap::insert` (otherwise reachable only via a
+    /// `DerefMut` this type intentionally does not provide) so every
+    /// insertion — current or future — is logged automatically.
+    pub fn insert(&mut self, key: NodeId, value: V) -> Option<V> {
+        self.order.push(key);
+        self.map.insert(key, value)
+    }
+
+    /// Mutable access to an existing entry's value. Adds no key, so it is not
+    /// logged. Returns `None` when `key` is absent.
+    pub fn get_mut(&mut self, key: &NodeId) -> Option<&mut V> {
+        self.map.get_mut(key)
+    }
+
+    /// Current insertion-log length (a mark for [`Self::since`]). Distinct
+    /// from the map's `len` — the log counts insertion *events*, including
+    /// re-inserts of an existing key.
+    fn mark(&self) -> usize {
+        self.order.len()
+    }
+
+    /// Keys inserted after `mark`, in raw call order (may contain duplicates).
+    fn since(&self, mark: usize) -> &[NodeId] {
+        &self.order[mark..]
+    }
+}
+
+/// Opaque snapshot of every tracked map's insertion-log length, captured by
+/// [`Drawables::draw_mark`] and consumed by [`Drawables::drawn_since`].
+#[derive(Debug, Clone, Copy)]
+pub struct DrawMark {
+    block_styles: usize,
+    paragraphs: usize,
+    images: usize,
+    svgs: usize,
+    tables: usize,
+    list_items: usize,
+}
+
 // ── Placeholder entry types ──────────────────────────────────────────
 //
 // Each PR in the Phase 4 sequence replaces one of these with the real
@@ -361,8 +461,8 @@ pub struct Drawables {
     /// and `body_offset_pt` for the margin offset), then skipping
     /// body in the main dispatch loop to avoid double-painting.
     pub body_id: Option<NodeId>,
-    pub block_styles: BTreeMap<NodeId, BlockEntry>,
-    pub paragraphs: BTreeMap<NodeId, ParagraphEntry>,
+    pub block_styles: TrackedMap<BlockEntry>,
+    pub paragraphs: TrackedMap<ParagraphEntry>,
     /// Per-source-paragraph multicol slicing emitted by
     /// `convert::convert_multicol_paragraph_slices` from
     /// `multicol_layout::MulticolGeometry::paragraph_splits`. When a
@@ -370,10 +470,10 @@ pub struct Drawables {
     /// one entry per non-empty column slice at the slice origin instead of
     /// the default single-rectangle path that uses `paragraphs[node_id]`.
     pub paragraph_slices: BTreeMap<NodeId, ParagraphSlicesEntry>,
-    pub images: BTreeMap<NodeId, ImageEntry>,
-    pub svgs: BTreeMap<NodeId, SvgEntry>,
-    pub tables: BTreeMap<NodeId, TableEntry>,
-    pub list_items: BTreeMap<NodeId, ListItemEntry>,
+    pub images: TrackedMap<ImageEntry>,
+    pub svgs: TrackedMap<SvgEntry>,
+    pub tables: TrackedMap<TableEntry>,
+    pub list_items: TrackedMap<ListItemEntry>,
     pub multicol_rules: BTreeMap<NodeId, MulticolRuleEntry>,
     pub transforms: BTreeMap<NodeId, TransformEntry>,
     pub bookmark_anchors: BTreeMap<NodeId, BookmarkAnchorEntry>,
@@ -417,13 +517,13 @@ impl Default for Drawables {
             root_dir_rtl: false,
             root_id: None,
             body_id: None,
-            block_styles: BTreeMap::new(),
-            paragraphs: BTreeMap::new(),
+            block_styles: TrackedMap::default(),
+            paragraphs: TrackedMap::default(),
             paragraph_slices: BTreeMap::new(),
-            images: BTreeMap::new(),
-            svgs: BTreeMap::new(),
-            tables: BTreeMap::new(),
-            list_items: BTreeMap::new(),
+            images: TrackedMap::default(),
+            svgs: TrackedMap::default(),
+            tables: TrackedMap::default(),
+            list_items: TrackedMap::default(),
             multicol_rules: BTreeMap::new(),
             transforms: BTreeMap::new(),
             bookmark_anchors: BTreeMap::new(),
@@ -441,6 +541,41 @@ impl Default for Drawables {
 impl Drawables {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Capture the current insertion-log position of every tracked map. Pass
+    /// the result to [`Self::drawn_since`] after converting a subtree to
+    /// recover the NodeIds inserted in between. O(1).
+    pub fn draw_mark(&self) -> DrawMark {
+        DrawMark {
+            block_styles: self.block_styles.mark(),
+            paragraphs: self.paragraphs.mark(),
+            images: self.images.mark(),
+            svgs: self.svgs.mark(),
+            tables: self.tables.mark(),
+            list_items: self.list_items.mark(),
+        }
+    }
+
+    /// NodeIds inserted into any tracked map since `mark`, **sorted ascending
+    /// and deduplicated**.
+    ///
+    /// Drop-in replacement for the old
+    /// `collect_drawables_node_ids(out).difference(&before)` snapshot diff:
+    /// identical result set *and* order (both yield ascending unique keys),
+    /// but O(inserted-since) instead of O(total drawables). The append-only
+    /// invariant (convert never removes entries) makes the log tail equal to
+    /// the set difference; see [`TrackedMap`]. Callers still apply their own
+    /// `id != node_id` / skip-set filters on top.
+    pub fn drawn_since(&self, mark: DrawMark) -> Vec<NodeId> {
+        let mut ids: std::collections::BTreeSet<NodeId> = std::collections::BTreeSet::new();
+        ids.extend(self.block_styles.since(mark.block_styles).iter().copied());
+        ids.extend(self.paragraphs.since(mark.paragraphs).iter().copied());
+        ids.extend(self.images.since(mark.images).iter().copied());
+        ids.extend(self.svgs.since(mark.svgs).iter().copied());
+        ids.extend(self.tables.since(mark.tables).iter().copied());
+        ids.extend(self.list_items.since(mark.list_items).iter().copied());
+        ids.into_iter().collect()
     }
 
     /// 合成 NodeId を 1 つ割り当てる。
@@ -553,5 +688,96 @@ mod tests {
         assert!(id2 > id3, "IDs must decrease");
         assert_ne!(id1, id2);
         assert_ne!(id2, id3);
+    }
+
+    // ── TrackedMap / draw_mark / drawn_since (fulgur-vrkv) ─────────────
+
+    fn para() -> ParagraphEntry {
+        ParagraphEntry {
+            lines: Vec::new(),
+            opacity: 1.0,
+            visible: true,
+            id: None,
+        }
+    }
+
+    fn list_item() -> ListItemEntry {
+        ListItemEntry {
+            marker: ListItemMarker::Text {
+                lines: Vec::new(),
+                width: 0.0_f32.as_pt(),
+            },
+            marker_line_height: 12.0_f32.as_pt(),
+            opacity: 1.0,
+            visible: true,
+        }
+    }
+
+    #[test]
+    fn drawn_since_returns_only_the_tail_sorted_and_unique() {
+        let mut d = Drawables::new();
+        d.paragraphs.insert(7, para());
+        d.paragraphs.insert(3, para());
+        let mark = d.draw_mark();
+        // Insert descendants out of key order; a duplicate re-insert too.
+        d.paragraphs.insert(30, para());
+        d.paragraphs.insert(10, para());
+        d.paragraphs.insert(30, para()); // re-insert same key
+        // Only post-mark keys, ascending, deduplicated — matches the old
+        // `BTreeSet::difference` output the consumers relied on.
+        assert_eq!(d.drawn_since(mark), vec![10, 30]);
+    }
+
+    #[test]
+    fn drawn_since_is_independent_of_pre_mark_size() {
+        // The anti-quadratic guarantee: work done per scope depends only on
+        // what was inserted *since* the mark, never on how much accumulated
+        // before it. A document of N such scopes is therefore O(total nodes),
+        // not O(N²). Two marks over identical post-mark inserts but wildly
+        // different pre-mark sizes must yield the same result.
+        let mut small = Drawables::new();
+        small.paragraphs.insert(1, para());
+        let m_small = small.draw_mark();
+        small.paragraphs.insert(1000, para());
+
+        let mut big = Drawables::new();
+        for id in 0..500 {
+            big.paragraphs.insert(id, para());
+        }
+        let m_big = big.draw_mark();
+        big.paragraphs.insert(1000, para());
+
+        assert_eq!(small.drawn_since(m_small), vec![1000]);
+        assert_eq!(big.drawn_since(m_big), vec![1000]);
+    }
+
+    #[test]
+    fn drawn_since_unions_all_tracked_maps() {
+        let mut d = Drawables::new();
+        let mark = d.draw_mark();
+        d.paragraphs.insert(5, para());
+        d.list_items.insert(2, list_item());
+        d.paragraphs.insert(9, para());
+        // Keys from different maps merge into one ascending unique list.
+        assert_eq!(d.drawn_since(mark), vec![2, 5, 9]);
+    }
+
+    #[test]
+    fn drawn_since_empty_when_nothing_inserted_after_mark() {
+        let mut d = Drawables::new();
+        d.paragraphs.insert(1, para());
+        let mark = d.draw_mark();
+        assert!(d.drawn_since(mark).is_empty());
+    }
+
+    #[test]
+    fn tracked_map_reads_pass_through_via_deref() {
+        let mut d = Drawables::new();
+        d.paragraphs.insert(42, para());
+        // len / get / contains_key / keys reach BTreeMap through Deref.
+        assert_eq!(d.paragraphs.len(), 1);
+        assert!(d.paragraphs.contains_key(&42));
+        assert!(d.paragraphs.get(&42).is_some());
+        assert_eq!(d.paragraphs.keys().copied().collect::<Vec<_>>(), vec![42]);
     }
 }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -396,7 +396,7 @@ fn build_page_skip_sets(
 
     let mut clipped_descendants: std::collections::BTreeSet<usize> =
         std::collections::BTreeSet::new();
-    for (&node_id, block) in &drawables.block_styles {
+    for (&node_id, block) in drawables.block_styles.iter() {
         // Exclude body and root: body's only fragment lives on
         // page 0 (so `draw_under_clip(body)` only fires there) and
         // root is never recorded in `geometry`. Including either
@@ -417,7 +417,7 @@ fn build_page_skip_sets(
 
     let mut opacity_wrapped_descendants: std::collections::BTreeSet<usize> =
         std::collections::BTreeSet::new();
-    for (&node_id, block) in &drawables.block_styles {
+    for (&node_id, block) in drawables.block_styles.iter() {
         if !block.opacity_descendants.is_empty()
             && Some(node_id) != drawables.body_id
             && Some(node_id) != drawables.root_id

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -1016,6 +1016,35 @@ fn render_v2_smoke_list_item_overflow_clip_with_opacity() {
 }
 
 #[test]
+fn render_v2_smoke_many_opacity_clip_transform_scopes_are_bounded() {
+    // fulgur-vrkv hardening: every clip / opacity / transform / inline-box
+    // scope used to snapshot-diff *all* accumulated drawables to compute its
+    // descendant list, making a document of N such sibling scopes O(N²).
+    // `TrackedMap`'s insertion log makes each scope O(its own subtree).
+    // This drives all six migrated sinks at once (block opacity, block clip,
+    // table clip, list-item opacity, transform, inline-box) with many
+    // siblings so the linear path is exercised end-to-end; correctness of the
+    // descendant sets themselves is pinned byte-for-byte by fulgur-vrt.
+    let n = 40;
+    let mut body = String::from("<ul>");
+    for _ in 0..n {
+        body.push_str(r#"<li style="opacity:.99">x</li>"#);
+    }
+    body.push_str("</ul>");
+    for _ in 0..n {
+        body.push_str(r#"<div style="opacity:.99">o</div>"#);
+        body.push_str(r#"<div style="overflow:hidden"><span>c</span></div>"#);
+        body.push_str(r#"<div style="transform:translateX(1px)">t</div>"#);
+        body.push_str(r#"<p><span style="display:inline-block;opacity:.9">i</span></p>"#);
+        body.push_str(r#"<table style="overflow:hidden"><tr><td>y</td></tr></table>"#);
+    }
+    let html = format!("<!DOCTYPE html><html><body>{body}</body></html>");
+    let engine = fulgur::engine::Engine::builder().build();
+    let pdf = engine.render(&html).expect("v2 render");
+    assert!(!pdf.is_empty());
+}
+
+#[test]
 fn render_v2_smoke_overflow_clip_inside_transform() {
     // Regression for PR #309 follow-up Devin: an `overflow:hidden`
     // descendant of a `transform` ancestor must enter


### PR DESCRIPTION
## 背景 (fulgur-vrkv)

clip / opacity / transform / inline-box の各「descendant」リスト（`clip_descendants` / `opacity_descendants` / `TransformEntry.descendants` / `inline_box_subtree_descendants`）は、これまでノードのサブツリー walk の**前後で全 drawable マップを snapshot して差分**を取る `collect_drawables_node_ids` で計算していた。これは 1 スコープあたり O(総 drawable 数) で、そのようなスコープが N 個並ぶ文書（例: `opacity < 1` なブロックが N 個）で **O(N²)** になる。

`fulgur-v1cm` は transform の snapshot を条件ゲートし、`fulgur-vrkv` は boolean 判定を O(1) の `drawables_total_len` に置換したが、**実際に「新規 NodeId の集合」を必要とする 6 経路**は quadratic なまま残っていた。

## 変更

- `drawables.rs` に **`TrackedMap<V>`** を導入。`BTreeMap<NodeId, V>` に加えてキーの挿入順ログを持つ。
  - `Drawables::draw_mark()` が 6 マップのログ長を O(1) で捕捉。
  - `drawn_since(mark)` が各ログの tail を union し、**昇順・重複排除**して返す（旧 `after.difference(&before)` と同一の集合・同一の順序）。各スコープが O(自サブツリー) になり、convert 全体が O(総ノード数)。
- 6 つの snapshot-diff consumer をすべて `draw_mark` / `drawn_since` に移行：block(clip/opacity)・table(clip)・list-item(clip/opacity)・inline-root(clip/opacity)・inline-box subtree・transform。`collect_drawables_node_ids` は削除。
- `TrackedMap` は **`DerefMut` を実装しない**ため、キー追加は `insert` のみ（read は `Deref` で従来通り）。他の挿入経路はコンパイルエラーになり、ログの取りこぼしが構造的に起きない。

## 等価性の検証（出力は byte 完全一致）

- **fulgur-vrt golden スイート**を golden 更新なしで通過（`overflow-nested` 等の入れ子 clip が `clip_descendants` 非空を pin）。
- さらに **旧コード(HEAD~1) vs 新コードの生 PDF byte 比較**を、全 sink を含む fixture（入れ子 clip / opacity＋子 / transform＋子 / clip table＋セル / opacity `<li>`＋子 / inside-marker `<li>` / inline-block）で実施し **byte 完全一致**を確認（golden が薄い transform・table-clip・list-item 経路も直接カバー）。
- lib 1650 + 統合テスト全通過。`record_li_clip_opacity_descendants` / `TrackedMap` / `drawn_since` の unit test を追加（`drawn_since` の結果がマーク以前の蓄積量に依存しない＝反 quadratic 性を assert）。多 sink の end-to-end smoke を追加。

## 残課題

inside-marker list-item（`list-style-position:inside`）の `pre_paragraph_ids` は依然 O(paragraphs) の find-first スキャン。これは descendant 集合ではなく「最初の新規段落」を求める別機構のため本 PR には含めず、**fulgur-un8f** に切り出した。したがって fulgur-vrkv はクローズせず継続。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * クリッピング・不透明度・変形が組み合わさる複雑なレイアウトでの描画の安定性を向上しました。
  * リスト／表／インライン要素／ブロック要素のスコープ境界にまたがる描画の取りこぼしやずれを改善しました。
* **Tests**
  * 多数の兄弟要素を含むケースで、クリップ／透明度／変形スコープが過剰に広がらず適切に描画されることを確認するスモークテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->