### PR TITLE
test(convert): add coverage for inside-marker empty-li and TTC font break

### DIFF
--- a/crates/fulgur/src/convert/list_item.rs
+++ b/crates/fulgur/src/convert/list_item.rs
@@ -1126,6 +1126,56 @@ mod tests {
         assert!(pdf.starts_with(b"%PDF"));
     }
 
+    // try_convert branch 3 (inside marker, non-inline-root): empty <li> with a
+    // bundled font that covers the bullet character. `find_marker_font` returns
+    // Some this time, so `empty_li_marker_item = Some(LineItem::Text(...))`, and
+    // the standalone marker-paragraph path (lines 177-204) is executed.
+    // Without a bundled font (see `smoke_inside_empty_li_with_marker`),
+    // `find_marker_font` returns None and the inner `if let Some(item)` body
+    // is never entered — those lines stay at coverage count=0.
+    #[test]
+    fn smoke_inside_empty_li_with_bundled_font_triggers_marker_paragraph() {
+        let font_data = load_noto_sans_ttf();
+        let mut bundle = crate::asset::AssetBundle::default();
+        bundle.fonts.push(font_data);
+        let pdf = crate::engine::Engine::builder()
+            .assets(bundle)
+            .build()
+            .render(
+                r#"<!doctype html><html><body>
+                <ul style="list-style-position:inside">
+                    <li></li>
+                </ul>
+                </body></html>"#,
+            )
+            .expect("render failed");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // try_convert branch 3 (inside marker, non-inline-root): empty <li> where the
+    // marker is a list-style-image resolved as an InlineImage rather than a
+    // Text run. `resolve_inside_image_marker` returns Some, so the first arm of
+    // the `or_else` chain is taken and the image is used as the standalone
+    // marker item. Exercises the `LineItem::Image` path via `.map(LineItem::Image)`.
+    #[test]
+    fn smoke_inside_empty_li_with_image_marker() {
+        let mut bundle = crate::asset::AssetBundle::default();
+        bundle.add_image("dot.png", RED_1X1_PNG.to_vec());
+        bundle.add_css(r#"ul { list-style-position: inside; list-style-image: url("dot.png"); }"#);
+        let pdf = crate::engine::Engine::builder()
+            .assets(bundle)
+            .build()
+            .render(
+                r#"<!doctype html><html><body>
+                <ul>
+                    <li></li>
+                </ul>
+                </body></html>"#,
+            )
+            .expect("render failed");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
     // try_convert branch 2 (fallback display:list-item): a <div> styled with
     // `display:list-item` and a bundled `list-style-image` hits the fallback
     // path (lines 76-118) that exists for non-<li> elements.

--- a/crates/fulgur/src/convert/list_marker.rs
+++ b/crates/fulgur/src/convert/list_marker.rs
@@ -544,6 +544,28 @@ mod tests {
         assert_eq!(idx, 0);
     }
 
+    // find_marker_font: when the bundle contains a single-face font (NotoSans) that
+    // does NOT cover the marker character, the inner TTC loop's `else { break }`
+    // (lines 297-299) is triggered at the second `from_index` call:
+    //   idx=0: from_index succeeds; charmap.map(U+E000) is None → continue.
+    //   idx=1: from_index fails (single-face, no sub-font 1) → else { break }.
+    // No Drawables fallback → returns None.
+    //
+    // U+E000 is the first Private Use Area codepoint; standard fonts never map it.
+    #[test]
+    fn find_marker_font_single_face_font_missing_char_hits_ttc_break() {
+        let font_data = load_noto_sans_ttf();
+        let mut bundle = AssetBundle::new();
+        bundle.fonts.push(Arc::clone(&font_data));
+        let drawables = Drawables::new();
+
+        let result = find_marker_font(&Marker::Char('\u{E000}'), Some(&bundle), &drawables);
+        assert!(
+            result.is_none(),
+            "U+E000 (Private Use Area) must not be found in NotoSans or empty drawables"
+        );
+    }
+
     // ── shape_marker_with_skrifa ──────────────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
# Pull Request

## Summary

`convert/list_item.rs` は最低カバレッジファイル（88.44%）でした。カバレッジ計測により、`empty_li_marker_item = Some(...)` になる分岐（lines 177-204）とTTCフォントループの `else { break }` パス（list_marker.rs lines 297-299）が未カバーと判明。今回のPRで両パスをカバーするテストを追加しました。

**測定前後のカバレッジ:**

| ファイル | 変更前 | 変更後 | 増分 |
|---|---|---|---|
| `convert/list_item.rs` | 88.44% | 91.13% | +2.69 pp |
| `convert/list_marker.rs` | 91.99% | 92.49% | +0.50 pp |

## Changes

- `convert/list_item.rs`:
  - `smoke_inside_empty_li_with_bundled_font_triggers_marker_paragraph`: `list-style-position:inside` の空 `<li>` に NotoSans をバンドルして `find_marker_font` が `Some` を返すようにすることで、`empty_li_marker_item = Some(LineItem::Text(...))` となり lines 177-204（スタンドアロン・マーカー段落の生成パス）をカバー。既存の `smoke_inside_empty_li_with_marker` はフォントなしのため `find_marker_font` が `None` を返し、このブロックに到達できなかった。
  - `smoke_inside_empty_li_with_image_marker`: `list-style-image` を設定した inside-position 空 `<li>` で `resolve_inside_image_marker → LineItem::Image` アームを実行。
- `convert/list_marker.rs`:
  - `find_marker_font_single_face_font_missing_char_hits_ttc_break`: U+E000（Private Use Area）をマーカー文字として使用。NotoSans の idx=0 ではチャーマップが U+E000 を持たないためループを継続し、idx=1 で `from_index` が `Err` を返すことで `else { break }` (lines 297-299) を実行。

**意図的に残した未カバー領域（理由付き）:**

- `try_convert` branch 2 (lines 77-119): Blitz が `display:list-item` 要素に `list_item_data` を設定するため、条件 `node.element_data().is_none_or(|e| e.list_item_data.is_none())` が実際の DOM では常に false になり、到達不可能とみられる
- `build_list_item_body` inline-root else (lines 418-424): outside-marker の空 `<li>` で Blitz が Parley マーカーレイアウトを作成しないため `try_convert` が false を返し、`build_list_item_body` 自体が呼ばれない
- `node.primary_styles()` が None の場合 (lines 145-146): 通常の HTML レンダリングでは発生しない防衛的ガード
- `shape_marker_with_skrifa` が `None` を返す `)?` パス (lines 170, 237): 実際に使用されるフォントでは常に `Some` が返るため到達しない

## Test plan

- [x] `cargo test -p fulgur --lib`（1653 tests: 0 failed）
- [x] `cargo clippy -- -D warnings`（warnings なし）
- [x] `cargo fmt --check`（差分なし）

## Contributor License Agreement

By opening this pull request, I confirm that:

- [x] I have read the [Contributing Guide](https://github.com/fulgur-rs/fulgur/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://github.com/fulgur-rs/fulgur/blob/main/CLA.md)
      and agree to its terms. (First-time contributors: the CLA Assistant bot
      will comment on this PR with sign-in instructions.)

## Related issues

本 PR は定期的なカバレッジ改善ルーティンの一環です。


---
_Generated by [Claude Code](https://claude.ai/code/session_01K7wDHxyiLv2YKZHUgZDzb5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * リスト項目の変換処理で、空の箇条書き要素や画像付きマーカーのケースを追加検証し、PDF出力の先頭バイトで動作確認するテストを追加しました。
  * マーカー用フォントの解決処理で、文字が見つからない場合に適切にフォールバックする挙動を確認する新しいテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->