### PR TITLE
harden: gate PyPI/RubyGems publish on a semver release tag

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -213,12 +213,38 @@ jobs:
           print(f\"OK: {len(pdf)} bytes\")
           "'
 
+  verify-release-tag:
+    name: Verify release tag
+    # PyPI publish must only run for a real `vX.Y.Z` release tag. `release` events
+    # fire for a Release published on ANY tag name, and `github.event_name ==
+    # 'release'` alone does not prove the tag is a semver `v*` tag or that the
+    # release came from the gated release-plz path. The RestrictReleaseTag ruleset
+    # restricts creation of `v[0-9]*.[0-9]*.[0-9]*` tags to the release App, so
+    # requiring a semver tag here ties this publish to the same gated namespace as
+    # crates.io / npm (release.yml's `setup` job does the equivalent check). A
+    # Release published on a non-semver tag — which the ruleset does NOT cover — is
+    # rejected before publish. See docs/RELEASE_SETUP.md.
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject non-semver release tag
+        # $GITHUB_REF_NAME is a runner-set env var, not a ${{ }} template, so the
+        # attacker-influenced tag name cannot inject shell. Keep it quoted.
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::Refusing to publish: release tag '$GITHUB_REF_NAME' is not a vX.Y.Z release tag"
+            exit 1
+          fi
+          echo "Release tag OK: $GITHUB_REF_NAME"
+
   publish:
     name: Publish to PyPI
-    needs: [build-wheels, build-sdist, smoke-test, smoke-test-sdist, smoke-test-musl]
+    needs: [build-wheels, build-sdist, smoke-test, smoke-test-sdist, smoke-test-musl, verify-release-tag]
     # 本番 PyPI publish は release イベント (release.yml がタグから発火) のみ。
     # workflow_dispatch からは任意の ref を publish できないようにする (security)。
-    # 手動検証は publish-testpypi (dry_run=true) を使う。
+    # 手動検証は publish-testpypi (dry_run=true) を使う。加えて verify-release-tag が
+    # semver `v*` タグを要求し、非 semver タグの Release からの publish を塞ぐ。
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     environment: pypi

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -230,9 +230,13 @@ jobs:
       - name: Reject non-semver release tag
         # $GITHUB_REF_NAME is a runner-set env var, not a ${{ }} template, so the
         # attacker-influenced tag name cannot inject shell. Keep it quoted.
+        # Validate the FULL tag INCLUDING the leading `v`. A bare `1.2.3` tag is
+        # NOT covered by the RestrictReleaseTag ruleset (`v[0-9]*.[0-9]*.[0-9]*`),
+        # so it must not pass here either — do not strip `v` first. (release.yml's
+        # `setup` can strip `v` because its `push: tags: v*` trigger already
+        # guarantees the prefix; `release:published` is tag-name-agnostic.)
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+          if ! echo "$GITHUB_REF_NAME" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
             echo "::error::Refusing to publish: release tag '$GITHUB_REF_NAME' is not a vX.Y.Z release tag"
             exit 1
           fi

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -251,9 +251,13 @@ jobs:
       - name: Reject non-semver release tag
         # $GITHUB_REF_NAME is a runner-set env var, not a ${{ }} template, so the
         # attacker-influenced tag name cannot inject shell. Keep it quoted.
+        # Validate the FULL tag INCLUDING the leading `v`. A bare `1.2.3` tag is
+        # NOT covered by the RestrictReleaseTag ruleset (`v[0-9]*.[0-9]*.[0-9]*`),
+        # so it must not pass here either — do not strip `v` first. (release.yml's
+        # `setup` can strip `v` because its `push: tags: v*` trigger already
+        # guarantees the prefix; `release:published` is tag-name-agnostic.)
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+          if ! echo "$GITHUB_REF_NAME" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
             echo "::error::Refusing to publish: release tag '$GITHUB_REF_NAME' is not a vX.Y.Z release tag"
             exit 1
           fi

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -234,14 +234,40 @@ jobs:
             "
           '
 
+  verify-release-tag:
+    name: Verify release tag
+    # RubyGems publish must only run for a real `vX.Y.Z` release tag. `release`
+    # events fire for a Release published on ANY tag name, and `github.event_name
+    # == 'release'` alone does not prove the tag is a semver `v*` tag or that the
+    # release came from the gated release-plz path. The RestrictReleaseTag ruleset
+    # restricts creation of `v[0-9]*.[0-9]*.[0-9]*` tags to the release App, so
+    # requiring a semver tag here ties this publish to the same gated namespace as
+    # crates.io / npm (release.yml's `setup` job does the equivalent check). A
+    # Release published on a non-semver tag — which the ruleset does NOT cover — is
+    # rejected before publish. See docs/RELEASE_SETUP.md.
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject non-semver release tag
+        # $GITHUB_REF_NAME is a runner-set env var, not a ${{ }} template, so the
+        # attacker-influenced tag name cannot inject shell. Keep it quoted.
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::Refusing to publish: release tag '$GITHUB_REF_NAME' is not a vX.Y.Z release tag"
+            exit 1
+          fi
+          echo "Release tag OK: $GITHUB_REF_NAME"
+
   # NOTE: RubyGems publish は release イベント (release.yml がタグから発火) のみ。
   # workflow_dispatch からは任意の ref を push できないようにする (security)。
   # RubyGems には TestPyPI 相当が無いため、workflow_dispatch は build + smoke
   # のみ実行し、OIDC / credential フローの実動作検証は初回本番リリースで行う。
-  # See docs/RELEASE_SETUP.md.
+  # 加えて verify-release-tag が semver `v*` タグを要求し、非 semver タグの Release
+  # からの publish を塞ぐ。See docs/RELEASE_SETUP.md.
   publish:
     name: Publish to RubyGems
-    needs: [build-source-gem, smoke-test-source-gem, build-precompiled, smoke-test, smoke-test-musl]
+    needs: [build-source-gem, smoke-test-source-gem, build-precompiled, smoke-test, smoke-test-musl, verify-release-tag]
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     environment: rubygems

--- a/docs/RELEASE_SETUP.md
+++ b/docs/RELEASE_SETUP.md
@@ -234,7 +234,8 @@ Release flow:
 `release.yml` path. A GitHub Release can be published on *any* tag name, and the
 `release-python.yml` / `release-ruby.yml` workflows fire on `release:published`
 regardless of tag pattern. So each `publish` job additionally requires its
-`verify-release-tag` job to pass (tag must match `^v[0-9]+\.[0-9]+\.[0-9]+…$`),
+`verify-release-tag` job to pass (tag must match
+`^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$`),
 and the `RestrictReleaseTag` ruleset (control #4 below) restricts creation of
 `v[0-9]*.[0-9]*.[0-9]*` tags to the release App. Together these tie the PyPI /
 RubyGems publish to the same App-created, gated `v*` namespace as crates.io / npm
@@ -269,11 +270,13 @@ Environments / Rules) and re-check after edits:
    non-release tag never reaches its publish jobs. `release-python.yml` /
    `release-ruby.yml`, by contrast, trigger on `release:published`, which is
    **tag-name-agnostic** — a GitHub Release created on any tag (e.g. `evil`,
-   `vX`), a name #4's ruleset does **not** restrict, would otherwise reach their
-   `publish` jobs on `if: github.event_name == 'release'` alone. Each `publish`
-   job therefore `needs:` a `verify-release-tag` job that rejects any tag not
-   matching `^v[0-9]+\.[0-9]+\.[0-9]+…$`, tying these publishes to the same
-   App-created `v*` namespace #4 protects. This is an **in-code** control (visible
+   `vX`, or a bare `1.2.3`), a name that #4's ruleset does **not** restrict,
+   would otherwise reach their `publish` jobs on `if: github.event_name ==
+   'release'` alone. Each `publish` job therefore `needs:` a `verify-release-tag`
+   job that rejects any tag not matching
+   `^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$` (the leading `v` is required —
+   the same prefix #4 restricts), tying these publishes to the same App-created
+   `v*` namespace #4 protects. This is an **in-code** control (visible
    in the workflow YAML), not a settings one.
 
 > Status as of 2026-07-07: #1, #2, #3, #4 and #5 are live. #2 = the `crates-io`

--- a/docs/RELEASE_SETUP.md
+++ b/docs/RELEASE_SETUP.md
@@ -225,11 +225,23 @@ Release flow:
    (App token) + npm. Publishing the Release fires `release:published`. No further
    approval — ② already authorized the release.
 4. `release-python.yml` / `release-ruby.yml` publish to PyPI / RubyGems on
-   `release:published`.
+   `release:published`, **but only after their `verify-release-tag` job confirms
+   the tag is a `vX.Y.Z` semver tag** (the equivalent of `release.yml`'s `setup`
+   job for npm).
 
-The OIDC claim scope (repo + workflow + environment) is independent of reviewer
-settings — `if: github.event_name == 'release'` separately blocks publishing from
-arbitrary refs.
+`if: github.event_name == 'release'` proves only the *trigger type* — it does
+**not** prove the tag is a `v*` tag or that the release came from the gated
+`release.yml` path. A GitHub Release can be published on *any* tag name, and the
+`release-python.yml` / `release-ruby.yml` workflows fire on `release:published`
+regardless of tag pattern. So each `publish` job additionally requires its
+`verify-release-tag` job to pass (tag must match `^v[0-9]+\.[0-9]+\.[0-9]+…$`),
+and the `RestrictReleaseTag` ruleset (control #4 below) restricts creation of
+`v[0-9]*.[0-9]*.[0-9]*` tags to the release App. Together these tie the PyPI /
+RubyGems publish to the same App-created, gated `v*` namespace as crates.io / npm
+— a Release published on a non-semver tag (which the ruleset does not cover) is
+rejected before any registry credential is requested. The OIDC claim scope
+(repo + workflow + environment) is independent of reviewer settings and is not
+what enforces this.
 
 ### Security controls (partly GitHub settings, not code)
 
@@ -247,15 +259,29 @@ Environments / Rules) and re-check after edits:
    ruleset's *bypass list* (e.g. the Repository Admin role) sidesteps ① and #3, so
    keep that list to trusted maintainers only.
 4. **A `v*` tag-protection ruleset** (`RestrictReleaseTag`) restricting tag
-   *creation* to the release App. This is the load-bearing control against the one
-   path the gates above can't see: a `v*` tag pushed **directly** to the repo,
-   which bypasses `release-plz.yml` entirely and lands straight on `release.yml` →
-   GitHub Release + npm + PyPI + RubyGems.
+   *creation* to the release App. It targets `refs/tags/v[0-9]*.[0-9]*.[0-9]*` and
+   is the load-bearing control against the one path the gates above can't see: a
+   `v*` tag pushed **directly** to the repo, which bypasses `release-plz.yml`
+   entirely and lands straight on `release.yml` → GitHub Release + npm.
+5. **The `verify-release-tag` job gates PyPI / RubyGems publish in code.**
+   `release.yml` (→ npm) is safe from a rogue tag because it triggers on
+   `push: tags: v*` **and** its `setup` job validates strict semver, so a
+   non-release tag never reaches its publish jobs. `release-python.yml` /
+   `release-ruby.yml`, by contrast, trigger on `release:published`, which is
+   **tag-name-agnostic** — a GitHub Release created on any tag (e.g. `evil`,
+   `vX`), a name #4's ruleset does **not** restrict, would otherwise reach their
+   `publish` jobs on `if: github.event_name == 'release'` alone. Each `publish`
+   job therefore `needs:` a `verify-release-tag` job that rejects any tag not
+   matching `^v[0-9]+\.[0-9]+\.[0-9]+…$`, tying these publishes to the same
+   App-created `v*` namespace #4 protects. This is an **in-code** control (visible
+   in the workflow YAML), not a settings one.
 
-> Status as of 2026-07-02: #1, #2, #3 and #4 are live. #2 = the `crates-io`
+> Status as of 2026-07-07: #1, #2, #3, #4 and #5 are live. #2 = the `crates-io`
 > environment with required reviewers (verified via
-> `gh api repos/fulgur-rs/fulgur/environments/crates-io`); `release` has no
-> reviewers (`…/environments/release` → `[]`). #4 = `RestrictReleaseTag` (bypass =
+> `gh api repos/fulgur-rs/fulgur/environments/crates-io`); `release`, `pypi` and
+> `rubygems` have no reviewers (`…/environments/<name>` → `protection_rules: []`)
+> — the PyPI / RubyGems publish path is gated by #5 (`verify-release-tag`) + #4
+> instead. #4 = `RestrictReleaseTag`, targeting `v[0-9]*.[0-9]*.[0-9]*` (bypass =
 > `fulgur-release-bot` App only, no admin blanket bypass).
 >
 > **Rollout caveat (crates.io TP):** this workflow stamps the OIDC subject

--- a/docs/plans/2026-04-26-versioning-and-release-simplification-design.md
+++ b/docs/plans/2026-04-26-versioning-and-release-simplification-design.md
@@ -1,8 +1,19 @@
 # Versioning Policy & Release Pipeline Simplification — Design
 
 **Date:** 2026-04-26
-**Status:** Approved for implementation
+**Status:** Superseded in part — see note below
 **Scope:** バージョニング方針切替 + release pipeline の approve / skip / changelog 簡略化
+
+> **Superseding note (2026-07-07):** §2.1 のゲート集約 (`pypi` / `rubygems` の
+> `required_reviewers` を剥がし承認を単一ゲートに寄せる) は、**実装時により堅牢な形へ
+> 発展した**。実際に着地したモデルは docs/RELEASE_SETUP.md が正 (source of truth):
+> 承認ゲートは `crates-io` environment (②) に集約しつつ、下流の PyPI / RubyGems publish は
+> **`verify-release-tag` job で semver `v*` タグを要求**し、`RestrictReleaseTag` ruleset
+> (`v[0-9]*.[0-9]*.[0-9]*` の作成を release App に限定) と併せて gated `v*` namespace に
+> 束ねている。**本 doc 中の「`if: github.event_name == 'release'` が任意 ref からの publish を
+> ブロックする」という趣旨の記述は誤りで、正しくは `verify-release-tag` + `RestrictReleaseTag`
+> が担保する。** この doc は当時の設計意図の記録 (flow) として残す — 現行の運用は必ず
+> docs/RELEASE_SETUP.md を参照すること。
 
 ## 背景
 


### PR DESCRIPTION
## 背景 / finding

Codex security finding（PyPI/RubyGems release approval bypass）由来。finding の**文面**（`pypi`/`rubygems` の reviewers 削除の記述・提案パッチ）は 1421 コミット前の `d3a3c43`（2026-04-26）基準で現行 main には存在しないが、**技術的コアは現行 main で live** であることを設定確認（`gh api`）で特定した。

## 何が問題か

- `release-python.yml` / `release-ruby.yml` の `publish` job は `if: github.event_name == 'release'` のみで、reviewers 無しの `pypi` / `rubygems` 環境に入り OIDC publish トークンを取得する（`gh api .../environments/{pypi,rubygems}` → `protection_rules: []` を確認済み）。
- `release: published` は **任意のタグ名**で作成された GitHub Release で発火する。`RestrictReleaseTag` ruleset は `refs/tags/v[0-9]*.[0-9]*.[0-9]*` の作成のみを release App に限定している（`gh api .../rulesets/18431512` で確認済み）。
- したがって **非 semver タグ（例 `evil` / `vX`）で作った Release は ruleset を迂回**し、攻撃者制御 ref からの無承認 publish を発火し得る。
- `release.yml`（→ npm）は `setup` job が strict semver を検証し全 publish job が `needs: setup` のため**既に保護済み**。PyPI / RubyGems 経路だけが非対称に露出していた。

## 修正（コードのみ）

- 両 workflow に `verify-release-tag` job を追加し、`publish` を `needs` で従属させた。判定は `release.yml` の `setup` job と**同一の正規表現** `^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$`（`${GITHUB_REF_NAME#v}` に適用）。
- これで npm / crates.io / PyPI / RubyGems の 3+1 経路すべてが、App 作成の gated `v*` namespace（`RestrictReleaseTag` が保護）に一貫依存する。
- タグ名は攻撃者影響下にあるため、`${{ }}` テンプレートではなく **runner 環境変数 `$GITHUB_REF_NAME` を quote して参照**し、シェルインジェクションを回避。
- `docs/RELEASE_SETUP.md` の誤記述（`github.event_name == 'release'` が任意 ref からの publish をブロックする、という主張）を訂正し、control #5 として in-code guard を追記。誤 premise が残っていた 2026-04-26 設計ドキュメントに superseding note を追加。

## 検証

- workflow YAML パース + `needs` グラフ配線を確認。
- `verify-release-tag` のシェルスニペットをそのままローカル実行し、正規タグ（`v0.31.0` / `v1.0.0-beta.2` 等）は ACCEPT、攻撃タグ（`vX` / `evil` / `v1` / `v1.2` / `$(whoami)` / `; rm -rf /` 等）はすべて REJECT を確認。
- `markdownlint-cli2` clean。
- `workflow_dispatch`（TestPyPI dry-run / Ruby build-smoke）は `verify-release-tag`（`if: release`）で skip されるため無影響。

## disposition

GHSA advisory ではなく**公開 hardening PR**。runtime レンダラの脆弱性ではなく、公開済み crate のどの版のユーザーにも影響しない（affected version 境界が引けない）。`Option A`（`pypi`/`rubygems` に reviewers を追加）は repo が意図的に単一ゲート（② `crates-io`）に集約している設計（`release.yml:158-167` が明示的に環境ゲート追加を戒めている）に鑑み、本 PR では採らず maintainer 判断に委ねる。

beads: fulgur-d1ca

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * リリース公開前に、タグ名がセマンティックバージョン形式であることを確認するようになりました。
  * 不正なタグからの本番公開は失敗し、公開されなくなりました。
  * 本番公開は検証を通過した場合のみ実行されるようになりました。

* **Documentation**
  * リリース手順と公開制御の説明を更新し、実際の公開条件をより明確にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->