### PR TITLE
perf(convert): read cb_padding_box borders from final_layout directly

### DIFF
--- a/crates/fulgur/src/convert/positioned.rs
+++ b/crates/fulgur/src/convert/positioned.rs
@@ -81,15 +81,16 @@ pub(super) struct AbsCb {
 }
 
 fn cb_padding_box(node: &Node) -> ((Px, Px), (Px, Px)) {
-    let style = extract_block_style(node, None);
-    let bl_pt = style.border_widths[3];
-    let br_pt = style.border_widths[1];
-    let bt_pt = style.border_widths[0];
-    let bb_pt = style.border_widths[2];
+    // Reads border widths straight from Taffy's layout instead of routing
+    // through `extract_block_style`, which also clones/iterates
+    // attacker-controlled `box-shadow` lists. `resolve_cb_for_absolute` calls
+    // this per ancestor per node with an absolute pseudo, so a full-style
+    // extraction here amplifies box-shadow processing by the ancestor walk.
+    let border = node.final_layout.border;
     let sz = node.final_layout.size;
-    let pb_w = (sz.width.as_px() - (bl_pt + br_pt).in_px()).max(Px::ZERO);
-    let pb_h = (sz.height.as_px() - (bt_pt + bb_pt).in_px()).max(Px::ZERO);
-    ((pb_w, pb_h), (bl_pt.in_px(), bt_pt.in_px()))
+    let pb_w = (sz.width - border.left - border.right).max(0.0).as_px();
+    let pb_h = (sz.height - border.top - border.bottom).max(0.0).as_px();
+    ((pb_w, pb_h), (border.left.as_px(), border.top.as_px()))
 }
 
 fn resolve_cb_for_absolute(


### PR DESCRIPTION
## 概要

`crates/fulgur/src/convert/positioned.rs` の `cb_padding_box` は、絶対配置擬似要素の containing block 解決のために border 幅 4 スカラーを取り出す目的で `extract_block_style(node, None)` を呼んでいた。`extract_block_style` は視覚スタイル全体の抽出器で、副作用として `box-shadow` リストを clone / iterate し、対応外の inset / blur には `log::warn!` を吐く。

`resolve_cb_for_absolute` は positioned ancestor を登りながら該当ごと + body fallback に対しこの helper を呼ぶ。多くのノードで `::before` / `::after` が絶対配置になる文書を描画すると、ancestor のスタイルが繰り返し再処理される — 各ノードで ancestor の box-shadow リスト処理が走り、blur / inset があれば warn も乗算的に増える。

Taffy はまさに同じ border 幅を `node.final_layout.border` として既に持っている。ここから直接読めば、計算済みスタイルに触れず等価な値が得られる。

## 変更

- `cb_padding_box` を `extract_block_style` 経由から `node.final_layout.border` 直読みに変更
- 挙動は等価。既存 `cb_padding_box_*` / `resolve_cb_for_absolute_*` 単体テストと VRT byte golden はいずれも変化なし

## 検証

- `cargo test -p fulgur --lib` (1660 tests) green
- `cargo test -p fulgur --lib convert::positioned` (39 tests) green
- `FONTCONFIG_FILE=... cargo test -p fulgur-vrt` green (byte-exact)
- `cargo fmt --check` clean
- `cargo clippy -p fulgur --all-targets -- -D warnings` clean

Refs beads fulgur-vo8f.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * レイアウト計算でのパディングボックスの算出を改善し、要素の幅・高さや位置がより正確に反映されるようになりました。
  * 境界線の影響を直接考慮するようになり、表示のずれやはみ出しが起きにくくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->