### PR TITLE
perf(convert): linearize inside-marker list-item paragraph lookup

### DIFF
--- a/crates/fulgur/src/convert/list_item.rs
+++ b/crates/fulgur/src/convert/list_item.rs
@@ -211,15 +211,15 @@ pub(super) fn try_convert(
             // paragraph descendant we synthesize a marker-only paragraph
             // at the li level.
             //
-            // Snapshot existing paragraph ids before the child walk so
+            // Capture a DrawMark before the child walk so
             // `inject_marker_into_first_paragraph` only considers
             // paragraphs registered for *this* list-item's subtree.
-            // Without the snapshot, the first paragraph key would be the
+            // Without the mark, the lowest paragraph key would be the
             // lowest NodeId in the entire document (e.g. an earlier `<p>`
             // or a previous `<li>`), prepending the marker to unrelated
-            // content.
-            let pre_paragraph_ids: std::collections::BTreeSet<usize> =
-                out.paragraphs.keys().copied().collect();
+            // content. O(1) capture vs the old O(paragraphs_so_far)
+            // BTreeSet snapshot (fulgur-un8f).
+            let mark = out.draw_mark();
             positioned::walk_children_into_drawables(doc, children, ctx, depth, out);
             pseudo::register_pseudo_content(doc, node, ctx, depth, content_box, out);
 
@@ -239,7 +239,7 @@ pub(super) fn try_convert(
                     });
 
             if let Some(item) = marker_item {
-                if !inject_marker_into_first_paragraph(out, &pre_paragraph_ids, item.clone()) {
+                if !inject_marker_into_first_paragraph(out, mark, item.clone()) {
                     let lines = vec![ShapedLine {
                         height: line_height,
                         baseline: line_height / DEFAULT_LINE_HEIGHT_RATIO,
@@ -276,28 +276,23 @@ pub(super) fn try_convert(
 }
 
 /// Inject `item` at the start of the first paragraph entry registered
-/// AFTER `pre_existing_ids` was captured, returning `true` on success.
-/// The first-paragraph search is iteration-order over
-/// `BTreeMap<NodeId, ...>` so ordering is deterministic — matches v1's
-/// depth-first walk for the inside-marker fallback path. Restricting to
-/// post-snapshot ids keeps the marker scoped to the current list
-/// item's subtree (a sibling list item or earlier `<p>` that registered
-/// before the snapshot is excluded).
+/// AFTER `mark` was captured, returning `true` on success.
+///
+/// Uses [`crate::drawables::Drawables::min_paragraph_since`] — the lowest
+/// `NodeId` inserted after `mark` — which matches v1's depth-first walk
+/// for the inside-marker fallback path. Restricting to post-mark ids
+/// keeps the marker scoped to the current list item's subtree (a sibling
+/// list item or earlier `<p>` that registered before `mark` is
+/// excluded). Byte-identical to the old
+/// `pre_paragraph_ids: BTreeSet<usize>` snapshot scan under the
+/// append-only, one-insert-per-NodeId invariant on `TrackedMap` in
+/// convert.
 fn inject_marker_into_first_paragraph(
     out: &mut crate::drawables::Drawables,
-    pre_existing_ids: &std::collections::BTreeSet<usize>,
+    mark: crate::drawables::DrawMark,
     item: LineItem,
 ) -> bool {
-    // `keys()` iterates ascending (BTreeMap via `Deref`), so the first key
-    // not in `pre_existing_ids` is the lowest new-paragraph NodeId — the same
-    // entry `iter_mut().find(..)` used to land on. `get_mut` then takes the
-    // single mutable borrow (`TrackedMap` has no `DerefMut`/`iter_mut`).
-    let Some(target_id) = out
-        .paragraphs
-        .keys()
-        .copied()
-        .find(|id| !pre_existing_ids.contains(id))
-    else {
+    let Some(target_id) = out.min_paragraph_since(mark) else {
         return false;
     };
     let Some(entry) = out.paragraphs.get_mut(&target_id) else {
@@ -472,7 +467,6 @@ mod tests {
         TextDecoration, VerticalAlign,
     };
     use crate::units::F32Units;
-    use std::collections::BTreeSet;
     use std::sync::Arc;
 
     fn make_line(items: Vec<LineItem>) -> ShapedLine {
@@ -522,10 +516,10 @@ mod tests {
     #[test]
     fn inject_returns_false_when_paragraphs_is_empty() {
         let mut out = Drawables::new();
-        let pre = BTreeSet::new();
+        let mark = out.draw_mark();
         assert!(!inject_marker_into_first_paragraph(
             &mut out,
-            &pre,
+            mark,
             inline_box(10.0, 0.0)
         ));
     }
@@ -533,11 +527,13 @@ mod tests {
     #[test]
     fn inject_returns_false_when_all_paragraphs_pre_existing() {
         let mut out = Drawables::new();
+        // Insert the paragraph BEFORE capturing the mark so id 1 is pre-mark;
+        // `min_paragraph_since(mark)` must then return None and injection fails.
         out.paragraphs.insert(1, make_para(vec![make_line(vec![])]));
-        let pre: BTreeSet<usize> = [1].into();
+        let mark = out.draw_mark();
         assert!(!inject_marker_into_first_paragraph(
             &mut out,
-            &pre,
+            mark,
             inline_box(10.0, 0.0)
         ));
     }
@@ -545,11 +541,11 @@ mod tests {
     #[test]
     fn inject_returns_false_when_new_paragraph_has_no_lines() {
         let mut out = Drawables::new();
-        out.paragraphs.insert(5, make_para(vec![])); // new but no lines
-        let pre: BTreeSet<usize> = BTreeSet::new();
+        let mark = out.draw_mark();
+        out.paragraphs.insert(5, make_para(vec![])); // new (post-mark) but no lines
         assert!(!inject_marker_into_first_paragraph(
             &mut out,
-            &pre,
+            mark,
             inline_box(10.0, 0.0)
         ));
     }
@@ -557,12 +553,12 @@ mod tests {
     #[test]
     fn inject_inline_box_marker_is_prepended_to_first_line() {
         let mut out = Drawables::new();
+        let mark = out.draw_mark();
         out.paragraphs
             .insert(5, make_para(vec![make_line(vec![inline_box(20.0, 0.0)])]));
-        let pre: BTreeSet<usize> = BTreeSet::new();
         assert!(inject_marker_into_first_paragraph(
             &mut out,
-            &pre,
+            mark,
             inline_box(10.0, 0.0)
         ));
         let first_line = &out.paragraphs[&5].lines[0];
@@ -577,11 +573,11 @@ mod tests {
     #[test]
     fn inject_shifts_existing_inline_box_by_marker_width() {
         let mut out = Drawables::new();
+        let mark = out.draw_mark();
         // Existing item at x_offset=5.
         out.paragraphs
             .insert(5, make_para(vec![make_line(vec![inline_box(20.0, 5.0)])]));
-        let pre: BTreeSet<usize> = BTreeSet::new();
-        inject_marker_into_first_paragraph(&mut out, &pre, inline_box(10.0, 0.0));
+        inject_marker_into_first_paragraph(&mut out, mark, inline_box(10.0, 0.0));
         // shift = marker width = 10 → existing item should now be at x_offset = 5 + 10 = 15.
         let LineItem::InlineBox(existing) = &out.paragraphs[&5].lines[0].items[1] else {
             panic!("expected InlineBox at index 1");
@@ -596,9 +592,9 @@ mod tests {
     #[test]
     fn inject_image_marker_shifts_existing_by_image_width() {
         let mut out = Drawables::new();
+        let mark = out.draw_mark();
         out.paragraphs
             .insert(5, make_para(vec![make_line(vec![inline_box(20.0, 3.0)])]));
-        let pre: BTreeSet<usize> = BTreeSet::new();
         let image_marker = LineItem::Image(InlineImage {
             data: Arc::new(vec![]),
             format: crate::image::ImageFormat::Png,
@@ -613,7 +609,7 @@ mod tests {
         });
         assert!(inject_marker_into_first_paragraph(
             &mut out,
-            &pre,
+            mark,
             image_marker
         ));
         // shift = image width = 8 → existing at x_offset=3 → 3 + 8 = 11.
@@ -630,9 +626,9 @@ mod tests {
     #[test]
     fn inject_text_marker_shifts_by_sum_of_advance_times_font_size() {
         let mut out = Drawables::new();
+        let mark = out.draw_mark();
         out.paragraphs
             .insert(5, make_para(vec![make_line(vec![inline_box(20.0, 0.0)])]));
-        let pre: BTreeSet<usize> = BTreeSet::new();
         // Two glyphs, each x_advance=0.5, font_size=12 → shift = 2 × 0.5 × 12 = 12.
         let text_marker = LineItem::Text(ShapedGlyphRun {
             font_data: Arc::new(vec![]),
@@ -660,7 +656,7 @@ mod tests {
             x_offset: crate::units::Pt::ZERO,
             link: None,
         });
-        inject_marker_into_first_paragraph(&mut out, &pre, text_marker);
+        inject_marker_into_first_paragraph(&mut out, mark, text_marker);
         let LineItem::InlineBox(ib) = &out.paragraphs[&5].lines[0].items[1] else {
             panic!("expected InlineBox at index 1");
         };
@@ -672,16 +668,18 @@ mod tests {
     }
 
     #[test]
-    fn inject_picks_lowest_new_node_id_via_btreemap_ordering() {
-        // BTreeMap iterates in ascending key order → node 5 is picked before node 10.
+    fn inject_picks_lowest_new_node_id_via_min_paragraph_since() {
+        // `min_paragraph_since` returns the min of the since-mark tail regardless
+        // of insertion order → node 5 is picked over node 10 even when inserted
+        // second.
         let mut out = Drawables::new();
+        let mark = out.draw_mark();
         out.paragraphs
             .insert(10, make_para(vec![make_line(vec![])]));
         out.paragraphs.insert(5, make_para(vec![make_line(vec![])]));
-        let pre: BTreeSet<usize> = BTreeSet::new();
         assert!(inject_marker_into_first_paragraph(
             &mut out,
-            &pre,
+            mark,
             inline_box(10.0, 0.0)
         ));
         // Marker went into node 5 (the lower key).
@@ -783,12 +781,12 @@ mod tests {
         // Existing item in the line is LineItem::Text. The shift loop's Text arm
         // (`run.x_offset += shift`) must update it when a marker is prepended.
         let mut out = Drawables::new();
+        let mark = out.draw_mark();
         out.paragraphs
             .insert(5, make_para(vec![make_line(vec![make_text_run(5.0)])]));
-        let pre: BTreeSet<usize> = BTreeSet::new();
         assert!(inject_marker_into_first_paragraph(
             &mut out,
-            &pre,
+            mark,
             inline_box(10.0, 0.0)
         ));
         // marker InlineBox width = 10 → existing text run shifts from 5 to 15.
@@ -807,14 +805,14 @@ mod tests {
         // Existing item in the line is LineItem::Image. The shift loop's Image arm
         // (`i.x_offset += shift`) must update it when a marker is prepended.
         let mut out = Drawables::new();
+        let mark = out.draw_mark();
         out.paragraphs.insert(
             5,
             make_para(vec![make_line(vec![make_image_item(20.0, 3.0)])]),
         );
-        let pre: BTreeSet<usize> = BTreeSet::new();
         assert!(inject_marker_into_first_paragraph(
             &mut out,
-            &pre,
+            mark,
             inline_box(8.0, 0.0)
         ));
         // marker width = 8 → existing image shifts from 3 to 11.
@@ -833,6 +831,7 @@ mod tests {
         // First line has Text + Image + InlineBox. After injection all three must
         // be shifted by the marker's width; only the first line is affected.
         let mut out = Drawables::new();
+        let mark = out.draw_mark();
         let line0 = make_line(vec![
             make_text_run(1.0),
             make_image_item(15.0, 2.0),
@@ -840,10 +839,9 @@ mod tests {
         ]);
         let line1 = make_line(vec![inline_box(5.0, 0.0)]); // second line must not shift
         out.paragraphs.insert(5, make_para(vec![line0, line1]));
-        let pre: BTreeSet<usize> = BTreeSet::new();
         assert!(inject_marker_into_first_paragraph(
             &mut out,
-            &pre,
+            mark,
             inline_box(10.0, 0.0)
         ));
         let items = &out.paragraphs[&5].lines[0].items;
@@ -888,9 +886,9 @@ mod tests {
         // A Text marker with no glyphs has advance sum = 0, so existing items
         // keep their x_offset while the marker is still prepended.
         let mut out = Drawables::new();
+        let mark = out.draw_mark();
         out.paragraphs
             .insert(5, make_para(vec![make_line(vec![inline_box(20.0, 7.0)])]));
-        let pre: BTreeSet<usize> = BTreeSet::new();
         let zero_glyph_marker = LineItem::Text(ShapedGlyphRun {
             font_data: Arc::new(vec![]),
             font_index: 0,
@@ -904,7 +902,7 @@ mod tests {
         });
         assert!(inject_marker_into_first_paragraph(
             &mut out,
-            &pre,
+            mark,
             zero_glyph_marker
         ));
         // shift = 0 → existing InlineBox stays at x_offset=7.

--- a/crates/fulgur/src/convert/list_item.rs
+++ b/crates/fulgur/src/convert/list_item.rs
@@ -239,7 +239,10 @@ pub(super) fn try_convert(
                     });
 
             if let Some(item) = marker_item {
-                if !inject_marker_into_first_paragraph(out, mark, item.clone()) {
+                // `inject_marker_into_first_paragraph` returns the item back on
+                // failure (no target paragraph) so we can reuse it here without
+                // cloning on the successful path.
+                if let Some(item) = inject_marker_into_first_paragraph(out, mark, item) {
                     let lines = vec![ShapedLine {
                         height: line_height,
                         baseline: line_height / DEFAULT_LINE_HEIGHT_RATIO,
@@ -276,30 +279,35 @@ pub(super) fn try_convert(
 }
 
 /// Inject `item` at the start of the first paragraph entry registered
-/// AFTER `mark` was captured, returning `true` on success.
+/// AFTER `mark` was captured.
+///
+/// Returns `None` on success (item consumed and prepended to the target
+/// paragraph's first line). Returns `Some(item)` on failure (no paragraph
+/// inserted since `mark`, or the target paragraph has no lines) — the
+/// caller receives the unmodified item back and can synthesize a
+/// marker-only paragraph without paying a clone on the successful path.
 ///
 /// Uses [`crate::drawables::Drawables::min_paragraph_since`] — the lowest
 /// `NodeId` inserted after `mark` — which matches v1's depth-first walk
 /// for the inside-marker fallback path. Restricting to post-mark ids
 /// keeps the marker scoped to the current list item's subtree (a sibling
 /// list item or earlier `<p>` that registered before `mark` is
-/// excluded). Byte-identical to the old
-/// `pre_paragraph_ids: BTreeSet<usize>` snapshot scan under the
+/// excluded). Byte-identical to the old find-first scan under the
 /// append-only, one-insert-per-NodeId invariant on `TrackedMap` in
 /// convert.
 fn inject_marker_into_first_paragraph(
     out: &mut crate::drawables::Drawables,
     mark: crate::drawables::DrawMark,
     item: LineItem,
-) -> bool {
+) -> Option<LineItem> {
     let Some(target_id) = out.min_paragraph_since(mark) else {
-        return false;
+        return Some(item);
     };
     let Some(entry) = out.paragraphs.get_mut(&target_id) else {
-        return false;
+        return Some(item);
     };
     let Some(first_line) = entry.lines.first_mut() else {
-        return false;
+        return Some(item);
     };
     let shift = match &item {
         LineItem::Text(run) => run
@@ -318,7 +326,7 @@ fn inject_marker_into_first_paragraph(
         }
     }
     first_line.items.insert(0, item);
-    true
+    None
 }
 
 /// Build the body for a list-item node (outside marker / fallback path).
@@ -517,11 +525,9 @@ mod tests {
     fn inject_returns_false_when_paragraphs_is_empty() {
         let mut out = Drawables::new();
         let mark = out.draw_mark();
-        assert!(!inject_marker_into_first_paragraph(
-            &mut out,
-            mark,
-            inline_box(10.0, 0.0)
-        ));
+        assert!(
+            inject_marker_into_first_paragraph(&mut out, mark, inline_box(10.0, 0.0)).is_some()
+        );
     }
 
     #[test]
@@ -531,11 +537,9 @@ mod tests {
         // `min_paragraph_since(mark)` must then return None and injection fails.
         out.paragraphs.insert(1, make_para(vec![make_line(vec![])]));
         let mark = out.draw_mark();
-        assert!(!inject_marker_into_first_paragraph(
-            &mut out,
-            mark,
-            inline_box(10.0, 0.0)
-        ));
+        assert!(
+            inject_marker_into_first_paragraph(&mut out, mark, inline_box(10.0, 0.0)).is_some()
+        );
     }
 
     #[test]
@@ -543,11 +547,9 @@ mod tests {
         let mut out = Drawables::new();
         let mark = out.draw_mark();
         out.paragraphs.insert(5, make_para(vec![])); // new (post-mark) but no lines
-        assert!(!inject_marker_into_first_paragraph(
-            &mut out,
-            mark,
-            inline_box(10.0, 0.0)
-        ));
+        assert!(
+            inject_marker_into_first_paragraph(&mut out, mark, inline_box(10.0, 0.0)).is_some()
+        );
     }
 
     #[test]
@@ -556,11 +558,9 @@ mod tests {
         let mark = out.draw_mark();
         out.paragraphs
             .insert(5, make_para(vec![make_line(vec![inline_box(20.0, 0.0)])]));
-        assert!(inject_marker_into_first_paragraph(
-            &mut out,
-            mark,
-            inline_box(10.0, 0.0)
-        ));
+        assert!(
+            inject_marker_into_first_paragraph(&mut out, mark, inline_box(10.0, 0.0)).is_none()
+        );
         let first_line = &out.paragraphs[&5].lines[0];
         assert_eq!(first_line.items.len(), 2);
         // Newly-inserted marker is at index 0.
@@ -607,11 +607,7 @@ mod tests {
             computed_y: crate::units::Pt::ZERO,
             link: None,
         });
-        assert!(inject_marker_into_first_paragraph(
-            &mut out,
-            mark,
-            image_marker
-        ));
+        assert!(inject_marker_into_first_paragraph(&mut out, mark, image_marker).is_none());
         // shift = image width = 8 → existing at x_offset=3 → 3 + 8 = 11.
         let LineItem::InlineBox(ib) = &out.paragraphs[&5].lines[0].items[1] else {
             panic!("expected InlineBox at index 1");
@@ -677,11 +673,9 @@ mod tests {
         out.paragraphs
             .insert(10, make_para(vec![make_line(vec![])]));
         out.paragraphs.insert(5, make_para(vec![make_line(vec![])]));
-        assert!(inject_marker_into_first_paragraph(
-            &mut out,
-            mark,
-            inline_box(10.0, 0.0)
-        ));
+        assert!(
+            inject_marker_into_first_paragraph(&mut out, mark, inline_box(10.0, 0.0)).is_none()
+        );
         // Marker went into node 5 (the lower key).
         assert_eq!(out.paragraphs[&5].lines[0].items.len(), 1);
         assert_eq!(out.paragraphs[&10].lines[0].items.len(), 0);
@@ -784,11 +778,9 @@ mod tests {
         let mark = out.draw_mark();
         out.paragraphs
             .insert(5, make_para(vec![make_line(vec![make_text_run(5.0)])]));
-        assert!(inject_marker_into_first_paragraph(
-            &mut out,
-            mark,
-            inline_box(10.0, 0.0)
-        ));
+        assert!(
+            inject_marker_into_first_paragraph(&mut out, mark, inline_box(10.0, 0.0)).is_none()
+        );
         // marker InlineBox width = 10 → existing text run shifts from 5 to 15.
         let LineItem::Text(shifted) = &out.paragraphs[&5].lines[0].items[1] else {
             panic!("expected Text at index 1");
@@ -810,11 +802,7 @@ mod tests {
             5,
             make_para(vec![make_line(vec![make_image_item(20.0, 3.0)])]),
         );
-        assert!(inject_marker_into_first_paragraph(
-            &mut out,
-            mark,
-            inline_box(8.0, 0.0)
-        ));
+        assert!(inject_marker_into_first_paragraph(&mut out, mark, inline_box(8.0, 0.0)).is_none());
         // marker width = 8 → existing image shifts from 3 to 11.
         let LineItem::Image(shifted) = &out.paragraphs[&5].lines[0].items[1] else {
             panic!("expected Image at index 1");
@@ -839,11 +827,9 @@ mod tests {
         ]);
         let line1 = make_line(vec![inline_box(5.0, 0.0)]); // second line must not shift
         out.paragraphs.insert(5, make_para(vec![line0, line1]));
-        assert!(inject_marker_into_first_paragraph(
-            &mut out,
-            mark,
-            inline_box(10.0, 0.0)
-        ));
+        assert!(
+            inject_marker_into_first_paragraph(&mut out, mark, inline_box(10.0, 0.0)).is_none()
+        );
         let items = &out.paragraphs[&5].lines[0].items;
         // Items at indices 1, 2, 3 are the original three (marker inserted at 0).
         let LineItem::Text(t) = &items[1] else {
@@ -900,11 +886,7 @@ mod tests {
             x_offset: crate::units::Pt::ZERO,
             link: None,
         });
-        assert!(inject_marker_into_first_paragraph(
-            &mut out,
-            mark,
-            zero_glyph_marker
-        ));
+        assert!(inject_marker_into_first_paragraph(&mut out, mark, zero_glyph_marker).is_none());
         // shift = 0 → existing InlineBox stays at x_offset=7.
         let LineItem::InlineBox(ib) = &out.paragraphs[&5].lines[0].items[1] else {
             panic!("expected InlineBox at index 1");

--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -585,6 +585,18 @@ impl Drawables {
         ids
     }
 
+    /// Minimum paragraph `NodeId` inserted since `mark`. `None` if no paragraph
+    /// was inserted after `mark`. **O(paragraphs inserted since mark)**.
+    ///
+    /// Drop-in replacement for the old
+    /// `paragraphs.keys().copied().find(|id| !pre.contains(id))` scan (which was
+    /// O(all paragraphs)) — same NodeId under the convert invariant that each
+    /// DOM NodeId is inserted at most once per map, so the `since` tail cannot
+    /// contain an id that was already in the map before `mark`. See [`TrackedMap`].
+    pub fn min_paragraph_since(&self, mark: DrawMark) -> Option<NodeId> {
+        self.paragraphs.since(mark.paragraphs).iter().copied().min()
+    }
+
     /// 合成 NodeId を 1 つ割り当てる。
     /// `usize::MAX / 2` から始まり降順に割り当てるので DOM NodeId と衝突しない。
     pub fn alloc_synthetic_id(&mut self) -> NodeId {
@@ -786,5 +798,50 @@ mod tests {
         assert!(d.paragraphs.contains_key(&42));
         assert!(d.paragraphs.get(&42).is_some());
         assert_eq!(d.paragraphs.keys().copied().collect::<Vec<_>>(), vec![42]);
+    }
+
+    // ── min_paragraph_since (fulgur-un8f) ─────────────────────────────
+
+    fn block_entry() -> BlockEntry {
+        BlockEntry {
+            style: crate::draw_primitives::BlockStyle::default(),
+            opacity: 1.0,
+            visible: true,
+            id: None,
+            layout_size: None,
+            clip_descendants: vec![],
+            opacity_descendants: vec![],
+        }
+    }
+
+    #[test]
+    fn min_paragraph_since_none_when_no_paragraphs_inserted_after_mark() {
+        let mut d = Drawables::default();
+        d.paragraphs.insert(5, para());
+        let mark = d.draw_mark();
+        // 挿入なし → None
+        assert_eq!(d.min_paragraph_since(mark), None);
+    }
+
+    #[test]
+    fn min_paragraph_since_returns_lowest_new_node_id() {
+        let mut d = Drawables::default();
+        d.paragraphs.insert(1, para()); // pre-mark
+        let mark = d.draw_mark();
+        d.paragraphs.insert(10, para()); // 挿入順に依存せず
+        d.paragraphs.insert(5, para());
+        d.paragraphs.insert(20, para());
+        // 挿入順 (10, 5, 20) だが min は 5
+        assert_eq!(d.min_paragraph_since(mark), Some(5));
+    }
+
+    #[test]
+    fn min_paragraph_since_ignores_other_maps() {
+        let mut d = Drawables::default();
+        let mark = d.draw_mark();
+        d.block_styles.insert(1, block_entry());
+        d.paragraphs.insert(7, para());
+        // block_styles は無視、paragraphs のみ
+        assert_eq!(d.min_paragraph_since(mark), Some(7));
     }
 }


### PR DESCRIPTION
## 概要

`list-style-position: inside` の `<li>` を含むドキュメントにおいて、`convert/list_item.rs` の inside-marker 経路が `out.paragraphs.keys()` を毎 item ごとに `BTreeSet<usize>` に snapshot し、その後の `inject_marker_into_first_paragraph` も paragraph key を線形 scan していたため、累積 paragraph 数に対して O(paragraphs_so_far) の走査が item ごとに発生していた。N 個の inside-marker `<li>` を含む文書では **O(N² · paragraphs)** となる。

本 PR は fulgur-vrkv PR で導入した `TrackedMap` insertion-log を利用し、O(1) の `Drawables::draw_mark()` キャプチャと O(inserts-since) の `Drawables::min_paragraph_since()` に置き換える。**PDF byte-identical を保ちながら** O(N × new-paragraphs-per-item) にする。

Refs beads issue: `fulgur-un8f`

## 変更内容

- `crates/fulgur/src/drawables.rs`
  - `Drawables::min_paragraph_since(mark: DrawMark) -> Option<NodeId>` を追加（O(inserts-since) で `paragraphs.since(mark)` tail の min を返す）
  - 3 unit tests + `block_entry()` test helper
- `crates/fulgur/src/convert/list_item.rs`
  - inside-marker 経路の `pre_paragraph_ids: BTreeSet<usize> = out.paragraphs.keys().copied().collect()` を `let mark = out.draw_mark();` に置換（O(paragraphs_so_far) → O(1)）
  - `inject_marker_into_first_paragraph` シグネチャ: `pre_existing_ids: &BTreeSet<usize>` → `mark: DrawMark`、内部で `min_paragraph_since` を使用
  - 12 unit tests を `DrawMark` 化（`inject_picks_lowest_new_node_id_via_btreemap_ordering` → `..._via_min_paragraph_since` にリネーム）
  - `use std::collections::BTreeSet;` 削除

## byte-identical の根拠

convert は各 DOM NodeId を `TrackedMap` に**高々 1 回** insert する (append-only invariant, `drawables.rs` の "Invariants that keep PDF output byte-identical" 節参照)。したがって `paragraphs.since(mark)` の tail に pre-mark id が現れず、tail の min は旧 `keys().find(|id| !pre.contains(id))` と同じ NodeId を返す。fulgur-vrt reftest（64 goldens）で全 byte 一致を確認。

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p fulgur --lib --tests -- -D warnings` warning 無し
- [x] `cargo test -p fulgur --lib` — 1664 passed / 0 failed
  - drawables::tests 15 passed（既存 12 + 新規 3）
  - convert::list_item 33 passed（baseline と一致）
- [x] `FONTCONFIG_FILE=examples/.fontconfig/fonts.conf cargo test -p fulgur-vrt` — 全 golden PASS（**byte-identical**）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * マーカー挿入の対象段落を、直近の挿入位置から正確に特定できるようになりました。
* **Bug Fixes**
  * 箇条書き項目で、画像やインライン要素が混在しても意図しない段落へ挿入される問題を改善しました。
  * 段落以外の変更の影響を受けにくくし、挿入先の判定を安定化しました。
* **Tests**
  * マーカー挿入と対象段落判定の挙動を検証するテストを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->