### PR TITLE
refactor(convert): switch inject_marker to Result + codify pattern rule

### DIFF
--- a/.claude/rules/return-item-on-failure.md
+++ b/.claude/rules/return-item-on-failure.md
@@ -111,7 +111,7 @@ if let Err(item) = inject_marker_into_first_paragraph(out, mark, item) {
   2. または [ast-grep](https://ast-grep.github.io/) で
      `pattern: 'if !$FN($$$, $ARG.clone(), $$$) { $$$ }'` 等の AST パターンで検索
 
-  Tests の `assert!(func(x))` → `.is_none()` / `assert!(!func(x))` → `.is_some()` 移行も同時に。
+  Tests の `assert!(func(x))` → `.is_ok()` / `assert!(!func(x))` → `.is_err()` 移行も同時に。
 
 ## Judgment Calls
 

--- a/.claude/rules/return-item-on-failure.md
+++ b/.claude/rules/return-item-on-failure.md
@@ -1,0 +1,134 @@
+# Return the Item on Failure — Avoid Clone-on-Success
+
+Rust で「引数を by-value で消費する関数」を書くときの pattern の 1 つ。
+gemini code assist の Rust review が繰り返し指摘してくるので、書く時点で preempt する。
+
+## Rule
+
+「値を消費するかもしれない関数」で、以下 3 条件が揃ったら
+`fn f(x: T) -> bool` ではなく `fn f(x: T) -> Result<(), T>` を選ぶ。
+
+1. 引数 `x: T` を **by-value** で取り、成功時に `x` を内部で消費する
+2. 失敗パスがある（何らかの理由で `x` を使えないケース）
+3. 呼び出し元は失敗時に **同じ `x` をフォールバックで再利用したい**
+
+戻り値のセマンティクスは:
+
+- `Ok(())` = 成功。関数が `x` を消費した。呼び出し元はもう `x` を持たない。
+- `Err(x)` = 失敗。関数は `x` を触らず（あるいはロールバックして）呼び出し元に返却した。
+
+これにより呼び出し元は `if let Err(x) = f(x) { ...use x... }` の形で書け、
+**成功パスの `x.clone()` が完全に消える**。fulgur は `Result<(), T>` を採用する
+（`Ok`=成功が intuition に沿う）。`Option<T>` (None=成功) を使うと意味論反転で
+読み手が引っかかるため、避ける。
+
+## Why
+
+gemini code assist は Rust review でこの refactor を頻繁に medium-priority で指摘する。
+成功パスが hot path で、`T` が `Vec` / `String` / 大きな Arc payload を含む場合、
+1 clone あたり複数の heap allocation を伴うので、指摘は妥当。指摘 → 修正 → thread
+返信の round trip が発生するので、初回に書き切っておくのが最も効率的。
+
+### 具体例（fulgur PR #605）
+
+**Before:**
+
+```rust
+fn inject_marker_into_first_paragraph(
+    out: &mut Drawables,
+    mark: DrawMark,
+    item: LineItem,
+) -> bool { /* ... */ }
+
+// caller
+if !inject_marker_into_first_paragraph(out, mark, item.clone()) {
+    // failure fallback — uses item
+    let lines = vec![ShapedLine { items: vec![item], .. }];
+    /* ... */
+}
+```
+
+`LineItem::Text` は `Vec<ShapedGlyph>` + `String` を持つので、成功パスで毎回
+2 heap allocation が無駄に発生する。
+
+**After:**
+
+```rust
+/// Returns `Ok(())` on success (item consumed and inserted).
+/// Returns `Err(item)` on failure (item handed back unchanged) — caller
+/// reuses it for the fallback path without paying a clone on success.
+#[must_use = "returns Err(item) on failure; the handed-back item must be reused or explicitly dropped"]
+fn inject_marker_into_first_paragraph(
+    out: &mut Drawables,
+    mark: DrawMark,
+    item: LineItem,
+) -> Result<(), LineItem> { /* ... */ }
+
+// caller
+if let Err(item) = inject_marker_into_first_paragraph(out, mark, item) {
+    // failure fallback — uses handed-back item
+    let lines = vec![ShapedLine { items: vec![item], .. }];
+    /* ... */
+}
+```
+
+- gemini review comment: [PR #605 discussion r3538890283](https://github.com/fulgur-rs/fulgur/pull/605#discussion_r3538890283)
+  （gemini 提案は `Option<T>` だったが、意味論反転を避けて `Result<(), T>` に切り替え）
+- 対応 commits: `946319d8` (perf(convert): return item from inject_marker instead of cloning) →
+  さらに Result 化 + `#[must_use]` 追加の follow-up
+
+## How to Apply
+
+- **新規コード:** 上の 3 条件がそろったら最初から `Result<(), T>` 戻り値で書く。
+  `T` の clone コストが軽い (`Copy` / `Arc` のみ、`usize` 数個の struct など) 場合は
+  保留可 — gemini も指摘してこない可能性が高い。
+- **`#[must_use]` を必ず付ける:**
+
+  ```rust
+  #[must_use = "returns Err(item) on failure; the handed-back item must be reused or explicitly dropped"]
+  fn f(x: T) -> Result<(), T> { /* ... */ }
+  ```
+
+  この付与を忘れると、caller が戻り値を握りつぶした瞬間に「消費したつもりのアイテムが
+  無言で drop される」バグになる。地味だが致命的なので **How to Apply の必須項目**。
+  `Result<(), T>` は clippy `unused_must_use` lint に元々 hook されるので、
+  `#[must_use = "..."]` はメッセージ強化目的（`Option<T>` を使う場合は `#[must_use]`
+  なしだと lint も鳴らないのでより必須）。
+- **Doc コメントで必ず明記:** 「`Ok(())` = 成功で consumed / `Err(t)` = 失敗で t を返却」。
+  `Result<(), T>` は `Ok(())`=成功で intuition に沿うため負担は軽いが、
+  「なぜ `Err` が値を持つか」を一行足すと親切。
+- **`Result<(), T>` vs `Option<T>` の選び方（fulgur は `Result` 標準）:**
+  - **`Result<(), T>` (推奨)**: `Ok(())` = 成功、`Err(t)` = 失敗で t を返却、と
+    intuition に沿う。 `?` 演算子との相性もよい。fulgur では PR #605 でこちらを採用。
+  - **`Option<T>`**: gemini review が suggest してきがちだが、`None = 成功` は
+    意味論反転で読み手を裏切る。避ける（採用しても Doc + `#[must_use]` で厳重にカバーが必要）。
+  - レビュアーの慣れ・関数のリターン哲学が既に `Option<T>` になっているモジュールに
+    合わせる、といった一貫性理由がなければ `Result<(), T>`。
+- **既存コードの refactor:** `if !func(x.clone())` 相当のパターンを検出したいとき、
+  素朴な `rg` だと `x.clone()` の位置がフォーマッタで改行分割されていて拾い逃す
+  ことが多い。実務では次の順:
+  1. まず `rg -n '\.clone\(\)' <path>` で候補全部出して目視
+  2. または [ast-grep](https://ast-grep.github.io/) で
+     `pattern: 'if !$FN($$$, $ARG.clone(), $$$) { $$$ }'` 等の AST パターンで検索
+
+  Tests の `assert!(func(x))` → `.is_none()` / `assert!(!func(x))` → `.is_some()` 移行も同時に。
+
+## Judgment Calls
+
+- **保留可（refactor しなくてよい）**
+  - `T: Copy`（clone がゼロコスト）
+  - `T = Arc<...>`（clone が単なる ref bump）
+  - 失敗パスが cold で hot path が失敗側
+  - **`T` の `Drop` に観測可能な副作用がある場合**（例: file handle を close する型、
+    logging を吐く型、Mutex guard など）。成功パス（関数内で consumed される）と
+    失敗パス（caller に返却され後で drop される）で **副作用の発生タイミングが変わる**
+    ので、consumed 前提のリソース管理が壊れる可能性がある。テストが通っても
+    prod で挙動が変わることがあるので、`Drop` impl を確認してから判断する。
+- **レビュアーの慣れ**: fulgur は `Result<(), T>` 標準にした（PR #605、意味論反転
+  回避が理由）。もしモジュール内で先に `Option<T>` パターンが確立している場合は
+  一貫性優先で合わせてもよい。新規モジュールなら常に `Result<(), T>`。
+
+## Related
+
+- `feedback_plan_doc_no_llm_directive.md`（同じく gemini review 由来の学び — plan doc に
+  `For Claude: REQUIRED SUB-SKILL` 等の LLM 向け directive を書かない）

--- a/crates/fulgur/src/convert/list_item.rs
+++ b/crates/fulgur/src/convert/list_item.rs
@@ -242,7 +242,7 @@ pub(super) fn try_convert(
                 // `inject_marker_into_first_paragraph` returns the item back on
                 // failure (no target paragraph) so we can reuse it here without
                 // cloning on the successful path.
-                if let Some(item) = inject_marker_into_first_paragraph(out, mark, item) {
+                if let Err(item) = inject_marker_into_first_paragraph(out, mark, item) {
                     let lines = vec![ShapedLine {
                         height: line_height,
                         baseline: line_height / DEFAULT_LINE_HEIGHT_RATIO,
@@ -281,8 +281,8 @@ pub(super) fn try_convert(
 /// Inject `item` at the start of the first paragraph entry registered
 /// AFTER `mark` was captured.
 ///
-/// Returns `None` on success (item consumed and prepended to the target
-/// paragraph's first line). Returns `Some(item)` on failure (no paragraph
+/// Returns `Ok(())` on success (item consumed and prepended to the target
+/// paragraph's first line). Returns `Err(item)` on failure (no paragraph
 /// inserted since `mark`, or the target paragraph has no lines) — the
 /// caller receives the unmodified item back and can synthesize a
 /// marker-only paragraph without paying a clone on the successful path.
@@ -295,19 +295,20 @@ pub(super) fn try_convert(
 /// excluded). Byte-identical to the old find-first scan under the
 /// append-only, one-insert-per-NodeId invariant on `TrackedMap` in
 /// convert.
+#[must_use = "returns Err(item) on failure; the handed-back item must be reused or explicitly dropped"]
 fn inject_marker_into_first_paragraph(
     out: &mut crate::drawables::Drawables,
     mark: crate::drawables::DrawMark,
     item: LineItem,
-) -> Option<LineItem> {
+) -> Result<(), LineItem> {
     let Some(target_id) = out.min_paragraph_since(mark) else {
-        return Some(item);
+        return Err(item);
     };
     let Some(entry) = out.paragraphs.get_mut(&target_id) else {
-        return Some(item);
+        return Err(item);
     };
     let Some(first_line) = entry.lines.first_mut() else {
-        return Some(item);
+        return Err(item);
     };
     let shift = match &item {
         LineItem::Text(run) => run
@@ -326,7 +327,7 @@ fn inject_marker_into_first_paragraph(
         }
     }
     first_line.items.insert(0, item);
-    None
+    Ok(())
 }
 
 /// Build the body for a list-item node (outside marker / fallback path).
@@ -525,9 +526,7 @@ mod tests {
     fn inject_returns_false_when_paragraphs_is_empty() {
         let mut out = Drawables::new();
         let mark = out.draw_mark();
-        assert!(
-            inject_marker_into_first_paragraph(&mut out, mark, inline_box(10.0, 0.0)).is_some()
-        );
+        assert!(inject_marker_into_first_paragraph(&mut out, mark, inline_box(10.0, 0.0)).is_err());
     }
 
     #[test]
@@ -537,9 +536,7 @@ mod tests {
         // `min_paragraph_since(mark)` must then return None and injection fails.
         out.paragraphs.insert(1, make_para(vec![make_line(vec![])]));
         let mark = out.draw_mark();
-        assert!(
-            inject_marker_into_first_paragraph(&mut out, mark, inline_box(10.0, 0.0)).is_some()
-        );
+        assert!(inject_marker_into_first_paragraph(&mut out, mark, inline_box(10.0, 0.0)).is_err());
     }
 
     #[test]
@@ -547,9 +544,7 @@ mod tests {
         let mut out = Drawables::new();
         let mark = out.draw_mark();
         out.paragraphs.insert(5, make_para(vec![])); // new (post-mark) but no lines
-        assert!(
-            inject_marker_into_first_paragraph(&mut out, mark, inline_box(10.0, 0.0)).is_some()
-        );
+        assert!(inject_marker_into_first_paragraph(&mut out, mark, inline_box(10.0, 0.0)).is_err());
     }
 
     #[test]
@@ -558,9 +553,7 @@ mod tests {
         let mark = out.draw_mark();
         out.paragraphs
             .insert(5, make_para(vec![make_line(vec![inline_box(20.0, 0.0)])]));
-        assert!(
-            inject_marker_into_first_paragraph(&mut out, mark, inline_box(10.0, 0.0)).is_none()
-        );
+        assert!(inject_marker_into_first_paragraph(&mut out, mark, inline_box(10.0, 0.0)).is_ok());
         let first_line = &out.paragraphs[&5].lines[0];
         assert_eq!(first_line.items.len(), 2);
         // Newly-inserted marker is at index 0.
@@ -577,7 +570,7 @@ mod tests {
         // Existing item at x_offset=5.
         out.paragraphs
             .insert(5, make_para(vec![make_line(vec![inline_box(20.0, 5.0)])]));
-        inject_marker_into_first_paragraph(&mut out, mark, inline_box(10.0, 0.0));
+        assert!(inject_marker_into_first_paragraph(&mut out, mark, inline_box(10.0, 0.0)).is_ok());
         // shift = marker width = 10 → existing item should now be at x_offset = 5 + 10 = 15.
         let LineItem::InlineBox(existing) = &out.paragraphs[&5].lines[0].items[1] else {
             panic!("expected InlineBox at index 1");
@@ -607,7 +600,7 @@ mod tests {
             computed_y: crate::units::Pt::ZERO,
             link: None,
         });
-        assert!(inject_marker_into_first_paragraph(&mut out, mark, image_marker).is_none());
+        assert!(inject_marker_into_first_paragraph(&mut out, mark, image_marker).is_ok());
         // shift = image width = 8 → existing at x_offset=3 → 3 + 8 = 11.
         let LineItem::InlineBox(ib) = &out.paragraphs[&5].lines[0].items[1] else {
             panic!("expected InlineBox at index 1");
@@ -652,7 +645,7 @@ mod tests {
             x_offset: crate::units::Pt::ZERO,
             link: None,
         });
-        inject_marker_into_first_paragraph(&mut out, mark, text_marker);
+        assert!(inject_marker_into_first_paragraph(&mut out, mark, text_marker).is_ok());
         let LineItem::InlineBox(ib) = &out.paragraphs[&5].lines[0].items[1] else {
             panic!("expected InlineBox at index 1");
         };
@@ -673,9 +666,7 @@ mod tests {
         out.paragraphs
             .insert(10, make_para(vec![make_line(vec![])]));
         out.paragraphs.insert(5, make_para(vec![make_line(vec![])]));
-        assert!(
-            inject_marker_into_first_paragraph(&mut out, mark, inline_box(10.0, 0.0)).is_none()
-        );
+        assert!(inject_marker_into_first_paragraph(&mut out, mark, inline_box(10.0, 0.0)).is_ok());
         // Marker went into node 5 (the lower key).
         assert_eq!(out.paragraphs[&5].lines[0].items.len(), 1);
         assert_eq!(out.paragraphs[&10].lines[0].items.len(), 0);
@@ -778,9 +769,7 @@ mod tests {
         let mark = out.draw_mark();
         out.paragraphs
             .insert(5, make_para(vec![make_line(vec![make_text_run(5.0)])]));
-        assert!(
-            inject_marker_into_first_paragraph(&mut out, mark, inline_box(10.0, 0.0)).is_none()
-        );
+        assert!(inject_marker_into_first_paragraph(&mut out, mark, inline_box(10.0, 0.0)).is_ok());
         // marker InlineBox width = 10 → existing text run shifts from 5 to 15.
         let LineItem::Text(shifted) = &out.paragraphs[&5].lines[0].items[1] else {
             panic!("expected Text at index 1");
@@ -802,7 +791,7 @@ mod tests {
             5,
             make_para(vec![make_line(vec![make_image_item(20.0, 3.0)])]),
         );
-        assert!(inject_marker_into_first_paragraph(&mut out, mark, inline_box(8.0, 0.0)).is_none());
+        assert!(inject_marker_into_first_paragraph(&mut out, mark, inline_box(8.0, 0.0)).is_ok());
         // marker width = 8 → existing image shifts from 3 to 11.
         let LineItem::Image(shifted) = &out.paragraphs[&5].lines[0].items[1] else {
             panic!("expected Image at index 1");
@@ -827,9 +816,7 @@ mod tests {
         ]);
         let line1 = make_line(vec![inline_box(5.0, 0.0)]); // second line must not shift
         out.paragraphs.insert(5, make_para(vec![line0, line1]));
-        assert!(
-            inject_marker_into_first_paragraph(&mut out, mark, inline_box(10.0, 0.0)).is_none()
-        );
+        assert!(inject_marker_into_first_paragraph(&mut out, mark, inline_box(10.0, 0.0)).is_ok());
         let items = &out.paragraphs[&5].lines[0].items;
         // Items at indices 1, 2, 3 are the original three (marker inserted at 0).
         let LineItem::Text(t) = &items[1] else {
@@ -886,7 +873,7 @@ mod tests {
             x_offset: crate::units::Pt::ZERO,
             link: None,
         });
-        assert!(inject_marker_into_first_paragraph(&mut out, mark, zero_glyph_marker).is_none());
+        assert!(inject_marker_into_first_paragraph(&mut out, mark, zero_glyph_marker).is_ok());
         // shift = 0 → existing InlineBox stays at x_offset=7.
         let LineItem::InlineBox(ib) = &out.paragraphs[&5].lines[0].items[1] else {
             panic!("expected InlineBox at index 1");


### PR DESCRIPTION
## 概要

PR #605 の post-merge follow-up。#605 で導入した `inject_marker_into_first_paragraph` の戻り値 `Option<LineItem>`（`None`=成功、`Some(item)`=失敗で返却）は意味論反転（`None`=成功が Rust の一般慣習と逆）で読み手を裏切るため、**`Result<(), LineItem>`** に切り替える (`Ok(())`=成功 / `Err(item)`=失敗で返却)。あわせて `#[must_use]` を付けて戻り値握りつぶし事故を防ぐ。

同じ pattern を今後 preempt するため、`.claude/rules/return-item-on-failure.md` として ruleドキュメントを追加。

## 変更内容

### コード (`crates/fulgur/src/convert/list_item.rs`)

- 戻り値: `Option<LineItem>` → `Result<(), LineItem>`
  - `Ok(())` = 成功（item consumed）
  - `Err(item)` = 失敗（item 返却、caller は fallback で再利用）
- `#[must_use = \"returns Err(item) on failure; the handed-back item must be reused or explicitly dropped\"]` を追加
  - clippy 発動により、これまで戻り値を握りつぶしていた 2 つの test の bare 呼び出しを `assert!(...is_ok())` に矯正
- Caller: `if let Some(item) = ...` → `if let Err(item) = ...`
- 12 tests: `.is_none()` / `.is_some()` → `.is_ok()` / `.is_err()`

### ドキュメント (`.claude/rules/return-item-on-failure.md`)

Rust の Rule / Why / How to Apply / Judgment Calls / Related section 構成。要点:

- **Rule**: `fn f(x: T) -> bool` + caller の `f(x.clone())` パターンは書く時点で `Result<(), T>` に refactor
- **Why**: gemini code assist の Rust review が繰り返し medium priority で指摘する pattern（PR #605 comment [r3538890283](https://github.com/fulgur-rs/fulgur/pull/605#discussion_r3538890283) が実例）。preempt すれば round-trip を削減
- **How to Apply**:
  - 新規: 最初から `Result<(), T>` で書く
  - `#[must_use]` 必須 — 忘れると caller が戻り値握りつぶすと item が silent drop
  - Doc で `Ok(())`=成功 / `Err(t)`=失敗返却を明記
  - 既存コード検索は `.clone()` 全 grep 目視 or ast-grep で（naive `rg` はフォーマッタ跨ぎ改行で拾い逃す）
- **Judgment Calls**: `T: Copy` / `T = Arc<...>` / 失敗パスが cold / **`T` の `Drop` に観測可能な副作用**（file handle close / logging / Mutex guard 等）が絡む場合は保留可
- **Result vs Option**: fulgur は `Result<(), T>` 標準。`Option<T>` は意味論反転で読み手を裏切るため避ける

## byte-identical

`Result<(), T>` は制御フローだけ変えて実質同じロジック。fulgur-vrt (64 goldens) で byte-wise 一致確認済み。

## Test Plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy -p fulgur --lib --tests -- -D warnings\` warning 無し
- [x] \`cargo test -p fulgur --lib\` — 1664 passed / 0 failed
- [x] \`cargo test -p fulgur --lib convert::list_item\` — 33 passed (baseline と一致)
- [x] \`FONTCONFIG_FILE=examples/.fontconfig/fonts.conf cargo test -p fulgur-vrt\` — **byte-identical PASS (64 goldens)**

## 関連

- 元 PR: #605 (`cbfd6e4c`)
- gemini review: [PR #605 discussion r3538890283](https://github.com/fulgur-rs/fulgur/pull/605#discussion_r3538890283)
- 対応 commit: `7864fc2b refactor(convert): switch inject_marker return type from Option to Result`
- rule doc commit: `37544377 docs(rules): add return-item-on-failure Rust pattern rule`