### PR TITLE
perf(convert): drop redundant style.clone() on block + table entry inserts

### DIFF
--- a/crates/fulgur/src/convert/block.rs
+++ b/crates/fulgur/src/convert/block.rs
@@ -52,7 +52,7 @@ pub(super) fn convert(
     // unstyled entry costs nothing and keeps abs/fixed descendants able
     // to look up their CB at render time. Mirrors v1's behavior of
     // always emitting a `BlockPageable` for container nodes.
-    insert_block_entry(node, style.clone(), width, height, out);
+    insert_block_entry(node, style, width, height, out);
 
     // Walk in-flow children.
     positioned::walk_children_into_drawables(doc, children, ctx, depth, out);

--- a/crates/fulgur/src/convert/table.rs
+++ b/crates/fulgur/src/convert/table.rs
@@ -37,7 +37,7 @@ fn convert_table(
     out.tables.insert(
         node.id,
         crate::drawables::TableEntry {
-            style: style.clone(),
+            style,
             opacity,
             visible,
             id: extract_block_id(node),


### PR DESCRIPTION
## 概要

convert 経路の 2 兄弟 call site で `style: BlockStyle` を clone した後 `style` を再利用していない dead clone を除去。`BlockStyle` は `Vec<BackgroundLayer>` + `Vec<BoxShadow>` を持つ owned 型なので、1 clone あたり 2 heap allocation。

Closes fulgur-xl14 fulgur-ghod

## 変更内容

### `crates/fulgur/src/convert/block.rs:55`

```diff
- insert_block_entry(node, style.clone(), width, height, out);
+ insert_block_entry(node, style, width, height, out);
```

`insert_block_entry` はもともと `style: BlockStyle` を by-value で受けており、call 後 `style` は再参照されていない。move で十分。**per-container-block** で発火する hot path。

### `crates/fulgur/src/convert/table.rs:40`

```diff
- style: style.clone(),
+ style,
```

`TableEntry.style` フィールドは `BlockStyle` owned。struct field-init shorthand 化 (field 名 = variable 名) で clone 除去。**per-`<table>` node** で発火。

## byte-identical

移動と clone のオブジェクト内容は同一 → PDF byte 変化なし。fulgur-vrt (64 goldens) で確認。

## Test Plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy -p fulgur --lib --tests -- -D warnings\` warning 無し（clippy `redundant_clone` も追加 detect なし）
- [x] \`cargo test -p fulgur --lib\` — 1665 passed / 0 failed
- [x] \`FONTCONFIG_FILE=examples/.fontconfig/fonts.conf cargo test -p fulgur-vrt\` — byte-identical PASS (64 goldens)

## 背景

PR #608 の \`.claude/rules/return-item-on-failure.md\` sweep 中に副次発見された redundant clone 2 件。「return item on failure」パターンではなく単純な dead clone。fulgur-3gx3 (\`expand_repeating_stops\` dead Option) は別 refactor 領域なので別 issue で扱う。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 内部処理を見直し、スタイル情報の受け渡しをより効率的にしました。
  * 余分な複製を減らし、変換処理の軽量化を図りました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->