### PR TITLE
refactor(fulgur): type BoxShadow fields to units::Pt and drop px_to_pt/pt_to_px

### DIFF
--- a/.claude/rules/coordinate-system.md
+++ b/.claude/rules/coordinate-system.md
@@ -7,13 +7,13 @@ Always consult this file when writing or reviewing rendering code.
 ## Unit layers in the pipeline
 
 ```text
-Blitz/Taffy (CSS px) ──px_to_pt()──► Pageable tree / Krilla (PDF pt)
-                     ◄──pt_to_px()──
+Blitz/Taffy (CSS px) ──Px::in_pt()──► Pageable tree / Krilla (PDF pt)
+                     ◄──Pt::in_px()──
 ```
 
 | Layer | Unit | Notes |
 |-------|------|-------|
-| Blitz input (viewport, width) | CSS px | convert with `pt_to_px(v)` before passing |
+| Blitz input (viewport, width) | CSS px | convert pt-valued input via `v.as_pt().in_px()` before passing |
 | Taffy `final_layout` | CSS px | extract via `layout_in_pt()` / `size_in_pt()` |
 | Pageable tree internals | PDF pt | |
 | Krilla Surface | PDF pt | |
@@ -21,7 +21,8 @@ Blitz/Taffy (CSS px) ──px_to_pt()──► Pageable tree / Krilla (PDF pt)
 | `Margin::uniform(v)` | **pt** | |
 | `Margin::uniform_mm(v)` | **mm** | |
 
-Conversion constant: `1 CSS px = 0.75 PDF pt` (`PX_TO_PT = 0.75`, `convert.rs:35`)
+Conversion constant: `1 CSS px = 0.75 PDF pt` (`PX_TO_PT = 0.75`, defined in
+`crates/fulgur/src/units.rs`; applied via `units::Px::in_pt` / `units::Pt::in_px`).
 
 ## Reading the `Px` / `Pt` vocabulary in a diff
 
@@ -56,23 +57,31 @@ docstring (`crates/fulgur/src/units.rs`).
 Forgetting a conversion produces a **4/3× or 3/4× scale bug**.
 
 ```rust
-// WRONG: pass pt value directly
+// WRONG: pass pt value directly (a bare f32 with no unit witness)
 parse_html_with_local_resources(html, config.content_width(), ...)
 
-// CORRECT: convert pt → CSS px first
-parse_html_with_local_resources(html, pt_to_px(config.content_width()), ...)
+// CORRECT: tag as Pt at the source and convert to Px explicitly. The trailing
+// `.to_f32()` is only there because the Blitz FFI still takes bare `f32`;
+// keep the typed hop above it so the unit intent is visible in the diff.
+parse_html_with_local_resources(
+    html,
+    config.content_width().as_pt().in_px().to_f32(),
+    ...,
+)
 ```
 
 ```rust
 // WRONG: use Taffy layout values directly
 let width = node.final_layout.size.width;
 
-// CORRECT: go through px_to_pt / size_in_pt
+// CORRECT: go through the typed size_in_pt / layout_in_pt helpers, which
+// tag Taffy's raw f32 as Px and drop to Pt in one step (Px::in_pt)
 let (width, height) = size_in_pt(node.final_layout.size);
 let (x, y, width, height) = layout_in_pt(&node.final_layout);
 ```
 
-Helper definitions: `convert.rs:37-63`
+Helper definitions: `size_in_pt` / `layout_in_pt` in `crates/fulgur/src/convert/mod.rs`;
+`units::{Px, Pt, F32Units}` and `PX_TO_PT` in `crates/fulgur/src/units.rs`.
 
 ## Exception: `compute_transform` arguments
 

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -80,15 +80,19 @@ fn draw_single_box_shadow(
     w: f32,
     h: f32,
 ) {
-    if shadow.blur > 0.0 {
+    let offset_x = shadow.offset_x.to_f32();
+    let offset_y = shadow.offset_y.to_f32();
+    let blur = shadow.blur.to_f32();
+    let spread = shadow.spread.to_f32();
+    if blur > 0.0 {
         draw_blur_box_shadow(canvas, style, shadow, x, y, w, h);
         return;
     }
 
-    let sx = x + shadow.offset_x - shadow.spread;
-    let sy = y + shadow.offset_y - shadow.spread;
-    let sw = w + 2.0 * shadow.spread;
-    let sh = h + 2.0 * shadow.spread;
+    let sx = x + offset_x - spread;
+    let sy = y + offset_y - spread;
+    let sw = w + 2.0 * spread;
+    let sh = h + 2.0 * spread;
     if sw <= 0.0 || sh <= 0.0 {
         return;
     }
@@ -97,7 +101,7 @@ fn draw_single_box_shadow(
     let shadow_path = if style.has_radius() {
         let radii = expand_radii(
             &style.border_radii.map(|p| p.map(crate::units::Pt::to_f32)),
-            shadow.spread,
+            spread,
         );
         crate::draw_primitives::build_rounded_rect_path(sx, sy, sw, sh, &radii)
     } else {
@@ -158,16 +162,19 @@ fn draw_blur_box_shadow(
     w: f32,
     h: f32,
 ) {
-    let blur = shadow.blur;
+    let offset_x = shadow.offset_x.to_f32();
+    let offset_y = shadow.offset_y.to_f32();
+    let blur = shadow.blur.to_f32();
+    let spread = shadow.spread.to_f32();
     if blur <= 0.0 {
         return;
     }
 
     // inner rect: shadow shape after spread
-    let ix = x + shadow.offset_x - shadow.spread;
-    let iy = y + shadow.offset_y - shadow.spread;
-    let iw = w + 2.0 * shadow.spread;
-    let ih = h + 2.0 * shadow.spread;
+    let ix = x + offset_x - spread;
+    let iy = y + offset_y - spread;
+    let iw = w + 2.0 * spread;
+    let ih = h + 2.0 * spread;
     if iw <= 0.0 || ih <= 0.0 {
         return;
     }
@@ -181,7 +188,7 @@ fn draw_blur_box_shadow(
     // Corner radii for the inner rect (after spread)
     let r_inner = expand_radii(
         &style.border_radii.map(|p| p.map(crate::units::Pt::to_f32)),
-        shadow.spread,
+        spread,
     );
 
     let mask_stops = blur_stops_mask(shadow.color[3], 16);

--- a/crates/fulgur/src/convert/inline_root.rs
+++ b/crates/fulgur/src/convert/inline_root.rs
@@ -636,7 +636,7 @@ mod tests {
     /// A line with no items (text-only placeholder) and a paragraph-relative
     /// baseline. `baseline` here is the offset from the paragraph top, matching
     /// the convention used by `extract_paragraph` (which stores
-    /// `px_to_pt(parley_metrics.baseline)` — a paragraph-relative value).
+    /// `parley_metrics.baseline.as_px().in_pt()` — a paragraph-relative value).
     fn text_line(height: f32, baseline: f32) -> ShapedLine {
         ShapedLine {
             height: height.as_pt(),

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -45,38 +45,6 @@ mod table;
 
 use self::style::{absolute_to_rgba, extract_block_style, extract_opacity_visible};
 
-/// CSS px → PDF pt conversion factor (1 CSS px = 0.75 PDF pt).
-///
-/// Taffy lays out in CSS px (because we feed Blitz a CSS px viewport), but
-/// the Drawables / Krilla render path works in pt. Values cross the boundary
-/// through [`px_to_pt`] / [`pt_to_px`] and the tuple helpers
-/// [`layout_in_pt`] / [`size_in_pt`].
-// Single source of the px↔pt constant lives in `crate::units`; alias it here
-// so `px_to_pt` / `pt_to_px` and `units::{Px::in_pt, Pt::in_px}` can never
-// drift (fulgur-2map.1).
-const PX_TO_PT: f32 = crate::units::PX_TO_PT;
-
-/// Convert a CSS-px scalar to PDF pt.
-#[inline]
-pub(crate) fn px_to_pt(v: f32) -> f32 {
-    v * PX_TO_PT
-}
-
-/// Convert a PDF-pt scalar to CSS px. Retained only for the `px_to_pt`
-/// roundtrip test: fulgur-sipv.8 retyped the Blitz-viewport feeders to
-/// `units::Px` (`x.as_pt().in_px()`), so this has no production callers.
-/// Removed together with `px_to_pt` once fulgur-sipv.2 drops the last
-/// `px_to_pt` caller (`shadow.rs`).
-///
-/// Kept present via `#[allow(dead_code)]` rather than `#[cfg(test)]` so the
-/// `PX_TO_PT` doc's `[pt_to_px]` link stays symmetric with the still-live
-/// `[px_to_pt]` sibling until fulgur-sipv.2 removes both together.
-#[inline]
-#[allow(dead_code)]
-pub(crate) fn pt_to_px(v: f32) -> f32 {
-    v / PX_TO_PT
-}
-
 /// Convert a Taffy `Layout` (CSS px) to PDF pt as `(x, y, width, height)`.
 #[inline]
 fn layout_in_pt(layout: &taffy::Layout) -> (Pt, Pt, Pt, Pt) {
@@ -1610,28 +1578,5 @@ mod utility_fn_tests {
         let (w, h) = size_in_pt(size);
         assert_eq!(w, 0.0_f32.as_pt());
         assert_eq!(h, 0.0_f32.as_pt());
-    }
-
-    // --- px_to_pt / pt_to_px roundtrip ---
-
-    #[test]
-    fn px_pt_roundtrip() {
-        for &v in &[0.0f32, 1.0, 12.0, 96.0, 595.0] {
-            let roundtripped = pt_to_px(px_to_pt(v));
-            assert!(
-                (roundtripped - v).abs() < 1e-3,
-                "roundtrip failed for {v}: got {roundtripped}"
-            );
-        }
-    }
-
-    #[test]
-    fn px_to_pt_known_values() {
-        // 1 px = 0.75 pt
-        assert_eq!(px_to_pt(1.0), 0.75);
-        // 4 px = 3 pt
-        assert_eq!(px_to_pt(4.0), 3.0);
-        // 96 px (1 in) = 72 pt
-        assert_eq!(px_to_pt(96.0), 72.0);
     }
 }

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -1528,7 +1528,7 @@ mod utility_fn_tests {
     // --- layout_in_pt ---
 
     #[test]
-    fn layout_in_pt_converts_px_to_pt() {
+    fn layout_in_pt_converts_px_pt() {
         // 1 CSS px = 0.75 PDF pt, so 4 px → 3 pt, 100 px → 75 pt.
         let layout = taffy::Layout {
             location: taffy::geometry::Point { x: 4.0, y: 8.0 },
@@ -1558,7 +1558,7 @@ mod utility_fn_tests {
     // --- size_in_pt ---
 
     #[test]
-    fn size_in_pt_converts_px_to_pt() {
+    fn size_in_pt_converts_px_pt() {
         // 80 px → 60 pt, 120 px → 90 pt
         let size = taffy::geometry::Size {
             width: 80.0,

--- a/crates/fulgur/src/convert/replaced.rs
+++ b/crates/fulgur/src/convert/replaced.rs
@@ -361,7 +361,7 @@ mod tests {
     // `resolve_pseudo_size` → pt). The fold to pt keeps auto and
     // explicit-size sibling renders spatially consistent.
     #[test]
-    fn resolve_image_dimensions_intrinsic_arm_folds_device_px_to_pt() {
+    fn resolve_image_dimensions_intrinsic_arm_folds_device_px_via_in_pt() {
         // 1x1 device px intrinsic → 1 CSS px → 0.75 pt.
         let (w, h) =
             resolve_image_dimensions(TEST_PNG_1X1, crate::image::ImageFormat::Png, None, None);

--- a/crates/fulgur/src/convert/style/border.rs
+++ b/crates/fulgur/src/convert/style/border.rs
@@ -88,7 +88,7 @@ mod tests {
     use style::values::specified::BorderStyle as BS;
 
     #[test]
-    fn resolve_radius_absolute_px_to_pt() {
+    fn resolve_radius_absolute_via_in_pt() {
         // An absolute 8 CSS px radius converts to 8 * 0.75 = 6 pt, and the
         // basis is irrelevant for an absolute length (pass a nonzero basis to
         // prove it is ignored).

--- a/crates/fulgur/src/convert/style/box_metrics.rs
+++ b/crates/fulgur/src/convert/style/box_metrics.rs
@@ -24,7 +24,7 @@ mod tests {
     use crate::draw_primitives::BlockStyle;
 
     #[test]
-    fn px_to_pt_conversion_top_right_bottom_left() {
+    fn px_pt_conversion_top_right_bottom_left() {
         // 1 CSS px = 0.75 pt; pick distinct px values so an off-by-one
         // axis swap would surface in the assertion.
         let layout = taffy::Layout {

--- a/crates/fulgur/src/convert/style/shadow.rs
+++ b/crates/fulgur/src/convert/style/shadow.rs
@@ -6,8 +6,8 @@
 //! a `log::warn!`.
 
 use super::{StyleContext, absolute_to_rgba};
-use crate::convert::px_to_pt;
 use crate::draw_primitives::BlockStyle;
+use crate::units::F32Units;
 
 pub(super) fn apply_to(style: &mut BlockStyle, ctx: &StyleContext<'_>) {
     let shadow_list = ctx.styles.clone_box_shadow();
@@ -22,10 +22,10 @@ pub(super) fn apply_to(style: &mut BlockStyle, ctx: &StyleContext<'_>) {
             continue; // fully transparent — skip
         }
         style.box_shadows.push(crate::draw_primitives::BoxShadow {
-            offset_x: px_to_pt(shadow.base.horizontal.px()),
-            offset_y: px_to_pt(shadow.base.vertical.px()),
-            blur: px_to_pt(blur_px),
-            spread: px_to_pt(shadow.spread.px()),
+            offset_x: shadow.base.horizontal.px().as_px().in_pt(),
+            offset_y: shadow.base.vertical.px().as_px().in_pt(),
+            blur: blur_px.as_px().in_pt(),
+            spread: shadow.spread.px().as_px().in_pt(),
             color: rgba,
             inset: false,
         });
@@ -103,7 +103,7 @@ mod tests {
         );
     }
 
-    /// Non-zero spread radius is stored via `px_to_pt(shadow.spread.px())`.
+    /// Non-zero spread radius is stored via `shadow.spread.px().as_px().in_pt()`.
     /// The shadow is actually drawn, so the PDF must differ from the no-shadow baseline.
     #[test]
     fn shadow_with_spread_radius() {

--- a/crates/fulgur/src/draw_primitives.rs
+++ b/crates/fulgur/src/draw_primitives.rs
@@ -614,13 +614,13 @@ pub fn draw_with_opacity(
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct BoxShadow {
     /// Horizontal offset in points.
-    pub offset_x: f32,
+    pub offset_x: crate::units::Pt,
     /// Vertical offset in points.
-    pub offset_y: f32,
+    pub offset_y: crate::units::Pt,
     /// Blur radius in points. Currently unused for rendering (v0.4.5 draws blur=0).
-    pub blur: f32,
+    pub blur: crate::units::Pt,
     /// Spread radius in points. Negative values shrink the shadow.
-    pub spread: f32,
+    pub spread: crate::units::Pt,
     /// Shadow color as RGBA.
     pub color: [u8; 4],
     /// Whether this is an inset shadow. Currently unsupported (skipped at draw time).

--- a/crates/fulgur/src/draw_primitives.rs
+++ b/crates/fulgur/src/draw_primitives.rs
@@ -617,13 +617,16 @@ pub struct BoxShadow {
     pub offset_x: crate::units::Pt,
     /// Vertical offset in points.
     pub offset_y: crate::units::Pt,
-    /// Blur radius in points. Currently unused for rendering (v0.4.5 draws blur=0).
+    /// Blur radius in points. When `> 0`, rendered via a luminosity soft-mask
+    /// + 9-slice gradient in `background::draw_blur_box_shadow`.
     pub blur: crate::units::Pt,
     /// Spread radius in points. Negative values shrink the shadow.
     pub spread: crate::units::Pt,
     /// Shadow color as RGBA.
     pub color: [u8; 4],
-    /// Whether this is an inset shadow. Currently unsupported (skipped at draw time).
+    /// Whether this is an inset shadow. Inset shadows are currently unsupported
+    /// and filtered out upstream in `convert::style::shadow::apply_to`, so this
+    /// field is always `false` in resolved `BlockStyle::box_shadows`.
     pub inset: bool,
 }
 

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -74,8 +74,7 @@ use taffy::{
 /// `x`, `y`, `width`, `height` are type-enforced CSS pixels
 /// ([`crate::units::Px`]) — Taffy's native unit — and `y` is measured from
 /// the page's content-box top. The convert / draw layer is responsible for
-/// `px_to_pt` conversion ([`crate::units::Px::in_pt`]) before reaching
-/// Krilla.
+/// px→pt conversion ([`crate::units::Px::in_pt`]) before reaching Krilla.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Fragment {
     pub page_index: u32,

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -821,7 +821,7 @@ pub fn draw_shaped_lines(
                         // opacity on the inline-block are honoured. The
                         // helpers compute descendant positions from
                         // body-relative geometry as
-                        // `margin + body_offset + px_to_pt(frag.x)`, so we
+                        // `margin + body_offset + frag.x.in_pt()`, so we
                         // dispatch at the body-relative `geo_pt` and use
                         // `push_transform(translate(off_x, off_y))` to
                         // shift the whole subtree to the inline-flow

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -729,7 +729,7 @@ fn draw_v2_page(
 ///
 /// Called by `paragraph::draw_shaped_lines` for `LineItem::InlineBox`.
 /// `(x_pt, y_pt)` is the body-relative dispatch position
-/// (`margin + body_offset + px_to_pt(content_frag.x)`); the active
+/// (`margin + body_offset + content_frag.x.in_pt()`); the active
 /// translate transform shifts the entire subtree to the inline-flow
 /// position computed by the paragraph render path.
 #[allow(clippy::too_many_arguments)]
@@ -1174,7 +1174,7 @@ pub(crate) fn dispatch_fragment(
 /// in PDF pt (per the `ParagraphSlice` doc on `drawables.rs`). Resolve
 /// the container's body-relative page position via
 /// `geometry[container_node_id]` — same shape as the main loop's
-/// `(margin_left_pt + px_to_pt(frag.x), margin_top_pt + px_to_pt(frag.y))`
+/// `(margin_left_pt + frag.x.in_pt(), margin_top_pt + frag.y.in_pt())`
 /// — and add the slice origin. Honour the source paragraph's `visible`
 /// and `opacity` exactly like `draw_paragraph_v2`. `lines` are
 /// pre-rebased (Task 7) so each slice's first line has
@@ -4544,7 +4544,7 @@ mod tests {
 
     #[test]
     fn paragraph_lines_for_page_not_split_returns_all_lines() {
-        // px_to_pt(64px) ≈ 48pt (3 × 16pt lines). Non-split path returns
+        // 64px × 0.75 ≈ 48pt (3 × 16pt lines). Non-split path returns
         // all lines unchanged — baseline values are preserved as-is.
         let lines = vec![
             make_line(16.0, 12.0),
@@ -4565,7 +4565,7 @@ mod tests {
     #[test]
     fn paragraph_lines_for_page_split_first_page_returns_first_lines() {
         // Lines are 12pt each. Fragment heights are in CSS px;
-        // px_to_pt(16px) = 12pt (PX_TO_PT = 0.75), so 16px per line.
+        // 16px × PX_TO_PT (0.75) = 12pt, so 16px per line.
         // Page 0: consumed = 0, baseline unchanged.
         let lines = vec![make_line(12.0, 9.0), make_line(12.0, 21.0)];
         let fragments = vec![
@@ -4827,18 +4827,18 @@ mod tests {
     }
 
     #[test]
-    fn table_box_size_no_layout_size_nonzero_frag_uses_px_to_pt_height() {
-        // frag.height = 40 CSS px → px_to_pt(40) = 30 PDF pt (factor 0.75)
+    fn table_box_size_no_layout_size_nonzero_frag_uses_in_pt_height() {
+        // frag.height = 40 CSS px → 40 × 0.75 = 30 PDF pt (via Px::in_pt)
         let entry = make_table_entry_for_size(None, 150.0, 99.0);
         let frag = make_frag_with_height(40.0);
         let (w, h) = table_box_size(&entry, &frag);
         assert!((w - 150.0).abs() < 0.001, "width falls back to entry.width");
-        assert!((h - 30.0).abs() < 0.01, "height = px_to_pt(frag.height)");
+        assert!((h - 30.0).abs() < 0.01, "height = frag.height.in_pt()");
     }
 
     #[test]
     fn table_box_size_no_layout_size_zero_frag_falls_back_to_cached_height() {
-        // When frag.height is 0, px_to_pt(0) = 0.0 which fails the `> 0.0`
+        // When frag.height is 0, Px(0).in_pt() = Pt(0.0) which fails the `> 0.0`
         // guard, so cached_height is used instead.
         let entry = make_table_entry_for_size(None, 150.0, 55.0);
         let frag = make_frag_with_height(0.0);
@@ -5131,9 +5131,9 @@ mod tests {
     #[test]
     fn paragraph_lines_for_page_split_rebases_inline_image_computed_y() {
         // Two 12pt lines (each corresponds to a 16px CSS-px fragment).
-        // px_to_pt(16px) = 12pt (PX_TO_PT = 0.75).
+        // 16px × PX_TO_PT (0.75) = 12pt.
         // Line 1 contains an Image whose computed_y = 15.0 is paragraph-absolute.
-        // On page 1: consumed = px_to_pt(16px) = 12pt.
+        // On page 1: consumed = Px(16).in_pt() = 12pt.
         // After rebasing: img.computed_y = 15.0 − 12.0 = 3.0.
         let img = crate::paragraph::InlineImage {
             data: Arc::new(vec![]),

--- a/crates/fulgur/src/units.rs
+++ b/crates/fulgur/src/units.rs
@@ -266,7 +266,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn px_to_pt_and_back() {
+    fn px_pt_roundtrip() {
         assert_eq!(Px(4.0).in_pt(), Pt(3.0));
         assert_eq!(Pt(3.0).in_px(), Px(4.0));
     }

--- a/crates/fulgur/tests/pseudo_absolute_content_url.rs
+++ b/crates/fulgur/tests/pseudo_absolute_content_url.rs
@@ -184,7 +184,7 @@ fn absolute_pseudo_with_right_bottom_offsets_by_image_size() {
 
 /// Regression: percentage `width` / `height` on an abs `content: url(...)`
 /// pseudo must resolve against the CB's padding-box in **pt** -- the
-/// `build_pseudo_image` helper does `pt_to_px(parent_width)` internally.
+/// `build_pseudo_image` helper divides by `PX_TO_PT` (pt→px) internally.
 /// Passing CSS-px dims (as `cb.padding_box_size` is documented) makes the
 /// percentage 4/3x too large.
 #[test]
@@ -199,8 +199,8 @@ fn absolute_pseudo_percentage_size_resolves_against_padding_box_in_pt() {
 
     // Parent: position:relative, 400 px wide. CB padding-box width = 400 px = 300 pt.
     // Pseudo: width: 50%; -> expected = 150 pt.
-    // Bug case: basis treated as pt, pt_to_px(400) = ~533, then *50%/2 ->
-    // px_to_pt(266) = 200 pt. (4/3x too large.)
+    // Bug case: basis treated as pt, 400 / 0.75 = ~533 (pt→px), then *50%/2 ->
+    // 266 * 0.75 = 200 pt (px→pt). (4/3x too large.)
     //
     // We do NOT specify height -- let the image use its intrinsic 1px (=1pt)
     // height to keep the assertion focused on width.


### PR DESCRIPTION
## 概要

`fulgur-sipv` エピック最後のサブタスク `fulgur-sipv.2`。`BoxShadow` の `offset_x` / `offset_y` / `blur` / `spread` を `f32` → `units::Pt` に型付けし、`convert::px_to_pt` の最後のプロダクション caller (`convert/style/shadow.rs`) を `.as_px().in_pt()` に collapse する。

これにより `convert::px_to_pt` / `convert::pt_to_px` / 内部 mirror `const PX_TO_PT` の 3 つが全て dead になるので同時削除。**px↔pt 変換は `units::{Px::in_pt, Pt::in_px}` の一箇所のみ**になり、エピックのゴール "Eliminate px_to_pt/pt_to_px" が完遂する。

## 変更点

- `draw_primitives::BoxShadow`: 4 f32 field を `units::Pt` に
- `convert/style/shadow.rs`: `use convert::px_to_pt` を drop、`F32Units` trait 経由で `.as_px().in_pt()` パターンに
- `background.rs` の `draw_single_box_shadow` / `draw_blur_box_shadow`: 関数入口で `.to_f32()` locals として bind、下流の arithmetic はそのまま (byte-neutral)
- `convert/mod.rs`: `fn px_to_pt`, `fn pt_to_px`（`#[allow(dead_code)]`）, `const PX_TO_PT` mirror、ドックブロックを削除。`px_pt_roundtrip` と `px_to_pt_known_values` テストも削除（`units::tests::px_to_pt_and_back` で定数はカバー済み）

## Byte-neutrality

epic `fulgur-sipv` protocol 準拠:

- VRT goldens **完全 byte-identical**（`FULGUR_VRT_UPDATE` 未使用、`git status crates/fulgur-vrt/goldens` 空）
- arithmetic operand order 保持（reassociation なし）
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test -p fulgur --lib`: 1670 pass (0 fail)、削除 2 test 分だけ差
- `cargo test -p fulgur-vrt`: pass
- `cargo test -p fulgur-cli --test examples_determinism`: 11 pass
- `cargo fmt --check`: clean

## Test plan

- [x] fulgur lib tests (1670 pass)
- [x] fulgur integration tests
- [x] fulgur-vrt reftests
- [x] examples_determinism byte comparison
- [x] clippy `-D warnings`
- [x] rustfmt

## 関連

- Epic: `fulgur-sipv` (この PR merge で 8/8 complete、close 可能)
- Precedent: #558 (P2b), #561 (P4a/c), #564 (P4e), #569 (P4d), #571 (P4f), #572 (P4g), #574 (P4h)

Closes fulgur-sipv.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ボックスシャドウ（オフセット／ぼかし／広がり）の計算を単位変換に合わせて見直し、ブラーあり・なしでの表示ズレや不自然な見た目を抑えて精度を改善しました。
* **Documentation**
  * px↔pt変換の説明文言や注記、関連コメントを更新しました。
* **Tests**
  * 一部テスト名を調整しました（期待値や振る舞いの変更はありません）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->