### PR TITLE
refactor(convert): type ContentBox width/height as units::Px

### DIFF
--- a/crates/fulgur/src/convert/inline_root.rs
+++ b/crates/fulgur/src/convert/inline_root.rs
@@ -57,12 +57,7 @@ pub(super) fn try_convert(
         .and_then(|id| doc.get_node(id))
         .filter(|p| !pseudo::is_block_pseudo(p))
         .and_then(|p| {
-            pseudo::build_inline_pseudo_image(
-                p,
-                content_box.width.as_pt().in_px(),
-                content_box.height.as_pt().in_px(),
-                ctx.assets,
-            )
+            pseudo::build_inline_pseudo_image(p, content_box.width, content_box.height, ctx.assets)
         })
         .map(|mut img| {
             pseudo::attach_link_to_inline_image(&mut img, doc, node.id);
@@ -73,12 +68,7 @@ pub(super) fn try_convert(
         .and_then(|id| doc.get_node(id))
         .filter(|p| !pseudo::is_block_pseudo(p))
         .and_then(|p| {
-            pseudo::build_inline_pseudo_image(
-                p,
-                content_box.width.as_pt().in_px(),
-                content_box.height.as_pt().in_px(),
-                ctx.assets,
-            )
+            pseudo::build_inline_pseudo_image(p, content_box.width, content_box.height, ctx.assets)
         })
         .map(|mut img| {
             pseudo::attach_link_to_inline_image(&mut img, doc, node.id);

--- a/crates/fulgur/src/convert/list_item.rs
+++ b/crates/fulgur/src/convert/list_item.rs
@@ -354,8 +354,8 @@ fn build_list_item_body(
             .and_then(|p| {
                 pseudo::build_inline_pseudo_image(
                     p,
-                    content_box.width.as_pt().in_px(),
-                    content_box.height.as_pt().in_px(),
+                    content_box.width,
+                    content_box.height,
                     ctx.assets,
                 )
             })
@@ -370,8 +370,8 @@ fn build_list_item_body(
             .and_then(|p| {
                 pseudo::build_inline_pseudo_image(
                     p,
-                    content_box.width.as_pt().in_px(),
-                    content_box.height.as_pt().in_px(),
+                    content_box.width,
+                    content_box.height,
                     ctx.assets,
                 )
             })

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -995,6 +995,19 @@ struct ContentBox {
 }
 
 /// Compute the content-box of `node` from its computed style + Taffy layout.
+/// Thin wrapper that projects `Node` + `BlockStyle` to primitives and
+/// delegates the arithmetic to `content_box_from_geometry` (which is unit-
+/// tested).
+fn compute_content_box(node: &Node, style: &BlockStyle) -> ContentBox {
+    let border_w = node.final_layout.size.width.as_px();
+    let border_h = node.final_layout.size.height.as_px();
+    content_box_from_geometry(border_w, border_h, &style.border_widths, &style.padding)
+}
+
+/// Pure arithmetic behind `compute_content_box`. Extracted so the
+/// contract can be locked in by unit tests without fabricating a Blitz
+/// `Node`.
+///
 /// All returned values are in **CSS px** (Blitz/Taffy layout space) — see
 /// `.claude/rules/coordinate-system.md`.
 ///
@@ -1005,15 +1018,18 @@ struct ContentBox {
 /// stopgap performed, so any drift beyond the reordering documented in the
 /// fulgur-bfu9 commit message stays out of the goldens. Do not fold the
 /// two `.in_px()` calls per side into one.
-fn compute_content_box(node: &Node, style: &BlockStyle) -> ContentBox {
+fn content_box_from_geometry(
+    border_w: Px,
+    border_h: Px,
+    border_widths: &[Pt; 4],
+    padding: &[Pt; 4],
+) -> ContentBox {
     // `border_widths` / `padding` are stored in CSS TRBL order:
     // [0]=top, [1]=right, [2]=bottom, [3]=left.
-    let left_inset = style.border_widths[3].in_px() + style.padding[3].in_px();
-    let top_inset = style.border_widths[0].in_px() + style.padding[0].in_px();
-    let right_inset = style.border_widths[1].in_px() + style.padding[1].in_px();
-    let bottom_inset = style.border_widths[2].in_px() + style.padding[2].in_px();
-    let border_w = node.final_layout.size.width.as_px();
-    let border_h = node.final_layout.size.height.as_px();
+    let left_inset = border_widths[3].in_px() + padding[3].in_px();
+    let top_inset = border_widths[0].in_px() + padding[0].in_px();
+    let right_inset = border_widths[1].in_px() + padding[1].in_px();
+    let bottom_inset = border_widths[2].in_px() + padding[2].in_px();
     ContentBox {
         origin_x: left_inset,
         origin_y: top_inset,
@@ -1592,5 +1608,98 @@ mod utility_fn_tests {
         let (w, h) = size_in_pt(size);
         assert_eq!(w, 0.0_f32.as_pt());
         assert_eq!(h, 0.0_f32.as_pt());
+    }
+
+    // --- content_box_from_geometry ---
+    //
+    // The `Node` / `BlockStyle` projection lives in `compute_content_box`;
+    // these tests exercise the pure arithmetic. TRBL order: [0]=top,
+    // [1]=right, [2]=bottom, [3]=left.
+
+    fn tf(v: f32) -> crate::units::Pt {
+        v.as_pt()
+    }
+
+    #[test]
+    fn content_box_from_geometry_zero_insets_matches_border_box() {
+        let cb = content_box_from_geometry(
+            80.0_f32.as_px(),
+            120.0_f32.as_px(),
+            &[tf(0.0); 4],
+            &[tf(0.0); 4],
+        );
+        assert_eq!(cb.origin_x, 0.0_f32.as_px());
+        assert_eq!(cb.origin_y, 0.0_f32.as_px());
+        assert_eq!(cb.width, 80.0_f32.as_px());
+        assert_eq!(cb.height, 120.0_f32.as_px());
+    }
+
+    #[test]
+    fn content_box_from_geometry_respects_trbl_index_mapping() {
+        // Distinct border and padding per side so any transposition of
+        // TRBL indices produces a different origin / width / height.
+        // border TRBL = [1, 2, 3, 4] pt, padding TRBL = [5, 6, 7, 8] pt.
+        let cb = content_box_from_geometry(
+            80.0_f32.as_px(),
+            120.0_f32.as_px(),
+            &[tf(1.0), tf(2.0), tf(3.0), tf(4.0)],
+            &[tf(5.0), tf(6.0), tf(7.0), tf(8.0)],
+        );
+        // origin_x = left  = border[3] + padding[3] = (4 + 8) pt → Px.
+        assert_eq!(cb.origin_x, tf(4.0).in_px() + tf(8.0).in_px());
+        // origin_y = top   = border[0] + padding[0] = (1 + 5) pt → Px.
+        assert_eq!(cb.origin_y, tf(1.0).in_px() + tf(5.0).in_px());
+        // width  = border_w - left - right  = 80px - (4+8)pt.in_px() - (2+6)pt.in_px()
+        let left = tf(4.0).in_px() + tf(8.0).in_px();
+        let right = tf(2.0).in_px() + tf(6.0).in_px();
+        assert_eq!(cb.width, 80.0_f32.as_px() - left - right);
+        // height = border_h - top - bottom = 120px - (1+5)pt.in_px() - (3+7)pt.in_px()
+        let top = tf(1.0).in_px() + tf(5.0).in_px();
+        let bottom = tf(3.0).in_px() + tf(7.0).in_px();
+        assert_eq!(cb.height, 120.0_f32.as_px() - top - bottom);
+    }
+
+    #[test]
+    fn content_box_from_geometry_folds_per_side_bit_identically() {
+        // Guards the docstring's "do not fold" rule: summing then
+        // converting must be bit-identical to converting-then-summing at
+        // the values we actually feed. `Pt` addition uses raw f32 ops so
+        // the equivalence is exact for these small integers, but the
+        // test locks in the observable equality so a future
+        // "cleanup" that changed the order would either have to update
+        // the assertion or fail.
+        let border = [tf(1.0), tf(2.0), tf(3.0), tf(4.0)];
+        let padding = [tf(5.0), tf(6.0), tf(7.0), tf(8.0)];
+        let cb = content_box_from_geometry(80.0_f32.as_px(), 120.0_f32.as_px(), &border, &padding);
+        // Recompute each side out-of-line matching the callee's exact
+        // per-operand `.in_px()` shape.
+        let l = border[3].in_px() + padding[3].in_px();
+        let t = border[0].in_px() + padding[0].in_px();
+        let r = border[1].in_px() + padding[1].in_px();
+        let b = border[2].in_px() + padding[2].in_px();
+        assert_eq!(cb.origin_x, l);
+        assert_eq!(cb.origin_y, t);
+        assert_eq!(
+            cb.width,
+            (80.0_f32.as_px() - l - r).max(crate::units::Px::ZERO)
+        );
+        assert_eq!(
+            cb.height,
+            (120.0_f32.as_px() - t - b).max(crate::units::Px::ZERO),
+        );
+    }
+
+    #[test]
+    fn content_box_from_geometry_clamps_to_zero_when_insets_exceed_box() {
+        // border_w = 10 px, insets = 100 pt/side border + 100 pt/side padding on left+right
+        // → negative content width, must clamp to 0.
+        let cb = content_box_from_geometry(
+            10.0_f32.as_px(),
+            10.0_f32.as_px(),
+            &[tf(100.0); 4],
+            &[tf(100.0); 4],
+        );
+        assert_eq!(cb.width, crate::units::Px::ZERO);
+        assert_eq!(cb.height, crate::units::Px::ZERO);
     }
 }

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -995,7 +995,19 @@ struct ContentBox {
 }
 
 /// Compute the content-box of `node` from its computed style + Taffy layout.
+/// All returned values are in **CSS px** (Blitz/Taffy layout space) — see
+/// `.claude/rules/coordinate-system.md`.
+///
+/// Each inset side runs `.in_px()` on the border and padding operand
+/// *separately* before summing (`(border[i].in_px()) + (padding[i].in_px())`
+/// rather than `(border[i] + padding[i]).in_px()`). This is intentional:
+/// it matches the float-op order that fulgur-m0xl's byte-neutral caller
+/// stopgap performed, so any drift beyond the reordering documented in the
+/// fulgur-bfu9 commit message stays out of the goldens. Do not fold the
+/// two `.in_px()` calls per side into one.
 fn compute_content_box(node: &Node, style: &BlockStyle) -> ContentBox {
+    // `border_widths` / `padding` are stored in CSS TRBL order:
+    // [0]=top, [1]=right, [2]=bottom, [3]=left.
     let left_inset = style.border_widths[3].in_px() + style.padding[3].in_px();
     let top_inset = style.border_widths[0].in_px() + style.padding[0].in_px();
     let right_inset = style.border_widths[1].in_px() + style.padding[1].in_px();

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -20,7 +20,7 @@ use crate::paragraph::{
     InlineImage, LineFontMetrics, LineItem, LinkSpan, LinkTarget, ShapedGlyph, ShapedGlyphRun,
     ShapedLine, TextDecoration, TextDecorationLine, TextDecorationStyle, VerticalAlign,
 };
-use crate::units::{F32Units, Pt};
+use crate::units::{F32Units, Pt, Px};
 use blitz_html::HtmlDocument;
 use skrifa::MetadataProvider;
 use std::collections::HashMap;
@@ -988,23 +988,25 @@ fn is_pseudo_node(doc: &BaseDocument, node: &Node) -> bool {
 #[derive(Clone, Copy)]
 #[allow(dead_code)]
 struct ContentBox {
-    origin_x: f32,
-    origin_y: f32,
-    width: f32,
-    height: f32,
+    origin_x: Px,
+    origin_y: Px,
+    width: Px,
+    height: Px,
 }
 
 /// Compute the content-box of `node` from its computed style + Taffy layout.
 fn compute_content_box(node: &Node, style: &BlockStyle) -> ContentBox {
-    let (left_inset, top_inset) = style.content_inset();
-    let right_inset = style.border_widths[1].to_f32() + style.padding[1].to_f32();
-    let bottom_inset = style.border_widths[2].to_f32() + style.padding[2].to_f32();
-    let (border_w, border_h) = size_in_pt(node.final_layout.size);
+    let left_inset = style.border_widths[3].in_px() + style.padding[3].in_px();
+    let top_inset = style.border_widths[0].in_px() + style.padding[0].in_px();
+    let right_inset = style.border_widths[1].in_px() + style.padding[1].in_px();
+    let bottom_inset = style.border_widths[2].in_px() + style.padding[2].in_px();
+    let border_w = node.final_layout.size.width.as_px();
+    let border_h = node.final_layout.size.height.as_px();
     ContentBox {
         origin_x: left_inset,
         origin_y: top_inset,
-        width: (border_w.to_f32() - left_inset - right_inset).max(0.0),
-        height: (border_h.to_f32() - top_inset - bottom_inset).max(0.0),
+        width: (border_w - left_inset - right_inset).max(Px::ZERO),
+        height: (border_h - top_inset - bottom_inset).max(Px::ZERO),
     }
 }
 

--- a/crates/fulgur/src/convert/pseudo.rs
+++ b/crates/fulgur/src/convert/pseudo.rs
@@ -150,12 +150,7 @@ fn build_block_pseudo_image_entries(
         if is_absolutely_positioned(pseudo) {
             return None;
         }
-        let entry = build_pseudo_image_entry(
-            pseudo,
-            parent_cb.width.as_pt().in_px(),
-            parent_cb.height.as_pt().in_px(),
-            assets,
-        )?;
+        let entry = build_pseudo_image_entry(pseudo, parent_cb.width, parent_cb.height, assets)?;
         Some((id, entry))
     };
     (load(parent.before), load(parent.after))

--- a/docs/plans/2026-07-09-fulgur-bfu9-contentbox-px.md
+++ b/docs/plans/2026-07-09-fulgur-bfu9-contentbox-px.md
@@ -1,0 +1,236 @@
+# fulgur-bfu9: ContentBox width/height as units::Px end-to-end
+
+**Goal:** `convert::ContentBox` の 4 フィールドを全て `units::Px` に型付けし、`compute_content_box` を Px-native に書き直す。fulgur-m0xl の consumer 側に残った `.as_pt().in_px()` の付け足し変換を全部削除する。
+
+**Architecture:** ContentBox の内部単位を Pt f32 → Px に切り替える。compute は Taffy の final_layout.size を `.as_px()` で直取り、insets は `border_widths[i].in_px() + padding[i].in_px()` で Px 化してから減算する。消費側 (`inline_root`, `list_item`, `pseudo::build_block_pseudo_image_entries`) は `content_box.width` / `.height` を Px として直渡し。
+
+**Tech Stack:** Rust, `crates/fulgur/src/units::{Px, Pt}` newtypes、Stylo `LengthPercentage::resolve`、VRT (PDF byte-wise golden) と `examples_determinism` (CLI 例の PDF snapshot)。
+
+**Related:** beads `fulgur-bfu9` (design + acceptance)、prerequisite `fulgur-m0xl` (merged in PR #614)。
+
+---
+
+## Task 1: ContentBox の Px 化 (atomic refactor)
+
+**Files:**
+
+- Modify: `crates/fulgur/src/convert/mod.rs` (`ContentBox` 定義、`compute_content_box`)
+- Modify: `crates/fulgur/src/convert/pseudo.rs` (`build_block_pseudo_image_entries`)
+- Modify: `crates/fulgur/src/convert/inline_root.rs` (2 pseudo call sites)
+- Modify: `crates/fulgur/src/convert/list_item.rs` (2 pseudo call sites)
+
+**Rationale:** 部分 commit だと intermediate state がコンパイル失敗するため atomic。
+
+### Step 1.1: `ContentBox` の 4 フィールドを `Px` に
+
+`crates/fulgur/src/convert/mod.rs:988-995`:
+
+```rust
+#[derive(Clone, Copy)]
+#[allow(dead_code)]
+struct ContentBox {
+    origin_x: Px,
+    origin_y: Px,
+    width: Px,
+    height: Px,
+}
+```
+
+### Step 1.2: `compute_content_box` を Px-native に書き直し
+
+`crates/fulgur/src/convert/mod.rs:998-1009`:
+
+```rust
+fn compute_content_box(node: &Node, style: &BlockStyle) -> ContentBox {
+    let left_inset = style.border_widths[3].in_px() + style.padding[3].in_px();
+    let top_inset = style.border_widths[0].in_px() + style.padding[0].in_px();
+    let right_inset = style.border_widths[1].in_px() + style.padding[1].in_px();
+    let bottom_inset = style.border_widths[2].in_px() + style.padding[2].in_px();
+    let border_w = node.final_layout.size.width.as_px();
+    let border_h = node.final_layout.size.height.as_px();
+    ContentBox {
+        origin_x: left_inset,
+        origin_y: top_inset,
+        width: (border_w - left_inset - right_inset).max(Px::ZERO),
+        height: (border_h - top_inset - bottom_inset).max(Px::ZERO),
+    }
+}
+```
+
+`BlockStyle.content_inset()` の f32-in-Pt 経路は本経路では未使用に (他 caller は無変更)。`size_in_pt` は本 fn からのみ使用外に。他所で残るので削除しない。
+
+### Step 1.3: `pseudo.rs::build_block_pseudo_image_entries` の `.as_pt().in_px()` 削除
+
+`crates/fulgur/src/convert/pseudo.rs:153-158`:
+
+```rust
+        let entry = build_pseudo_image_entry(
+            pseudo,
+            parent_cb.width,
+            parent_cb.height,
+            assets,
+        )?;
+```
+
+fulgur-m0xl で追加した `.as_pt().in_px()` を消して直渡し。
+
+### Step 1.4: `inline_root.rs` の pseudo call sites を直渡しに
+
+`crates/fulgur/src/convert/inline_root.rs:60,71` (現在 4 行 `.as_pt().in_px()`):
+
+```rust
+            pseudo::build_inline_pseudo_image(
+                p,
+                content_box.width,
+                content_box.height,
+                ctx.assets,
+            )
+```
+
+before/after 両方の呼び出しで同様に。
+
+### Step 1.5: `list_item.rs` の pseudo call sites を直渡しに
+
+`crates/fulgur/src/convert/list_item.rs:355-360, 371-376`: 同じパターンで `.as_pt().in_px()` 削除。
+
+### Step 1.6: ビルドと lib test
+
+```bash
+cargo build -p fulgur
+cargo test -p fulgur --lib
+cargo clippy -p fulgur --all-targets -- -D warnings
+cargo fmt --check
+```
+
+Expected: 全 pass (fulgur-m0xl と同様、unit test は寸法 shape の assertion 中心なので pass 予定)。
+
+### Step 1.7: Commit
+
+```
+refactor(convert): type ContentBox width/height as units::Px (fulgur-bfu9)
+
+ContentBox now holds units::Px for origin_x / origin_y / width / height.
+compute_content_box is rewritten in Px space:
+
+- final_layout.size is tagged Px directly (was tagged Px then converted
+  to Pt via size_in_pt)
+- insets are converted Pt->Px individually and summed in Px
+
+Consumers (build_inline_pseudo_image callers in inline_root/list_item
+and build_block_pseudo_image_entries in pseudo.rs) drop the
+`.as_pt().in_px()` stopgap added in fulgur-m0xl and pass the Px values
+straight through.
+
+This is NOT byte-neutral: float operation order changes from
+  (Px * 0.75 - Pt - Pt) / 0.75    (old Pt-space compute, Px cast at
+                                    consumer)
+to
+  Px - Pt / 0.75 - Pt / 0.75      (new Px-native compute)
+
+so ULP-level dimension diffs are expected in pseudo image / list marker
+paths that flow through ContentBox. VRT / examples goldens re-blessed
+in the following commit.
+
+Refs: fulgur-bfu9
+```
+
+---
+
+## Task 2: VRT / examples の byte diff を計測して re-bless
+
+### Step 2.1: VRT を実行、diff scope を確認
+
+```bash
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur-vrt 2>&1 | tail -30
+```
+
+Expected: fail (goldens が更新される必要あり)。`git diff --stat crates/fulgur-vrt/goldens/` で差分ファイルを列挙し、pseudo image / list marker / block padding 系に限定されていることを確認する。もし範囲外の golden に diff が及んでいたら意図しない side effect の可能性 → 停止して調査。
+
+### Step 2.2: VRT goldens を re-bless
+
+```bash
+FULGUR_VRT_UPDATE=1 FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur-vrt 2>&1 | tail -10
+git diff --stat crates/fulgur-vrt/goldens/
+git diff --stat --numstat crates/fulgur-vrt/goldens/ | head -20
+```
+
+### Step 2.3: examples_determinism を確認、失敗すれば regenerate
+
+```bash
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur-cli --test examples_determinism 2>&1 | tail -30
+```
+
+Expected: `examples/pseudo-content-url/` / `examples/list-style-image/` の snapshot が動く可能性。失敗すれば `mise run examples:update` (相当のスクリプト) で PDF を再生成する。
+
+### Step 2.4: (任意) pdftocairo で目視差分を確認
+
+代表 golden で PDF を PNG 化し、before/after の見た目に差が無いことを目視:
+
+```bash
+pdftocairo -png crates/fulgur-vrt/goldens/fulgur/<affected>.pdf /tmp/after.png
+git show HEAD:crates/fulgur-vrt/goldens/fulgur/<affected>.pdf > /tmp/before.pdf
+pdftocairo -png /tmp/before.pdf /tmp/before.png
+# 目視 diff — ULP レベルなら PNG は同一 or 極小差
+```
+
+### Step 2.5: Commit re-bless
+
+```bash
+git add crates/fulgur-vrt/goldens/
+git add examples/*/  # examples PDF が更新された場合
+git commit -m "test(fulgur-vrt): re-bless goldens after ContentBox → Px (fulgur-bfu9)
+
+ContentBox のプロパティを Px-native 計算にした結果、pseudo image と
+list marker 系の goldens が ULP レベルで更新される。差分は <listed
+paths> に限定。目視上の見た目は変わっていない。
+
+Refs: fulgur-bfu9
+"
+```
+
+範囲外の golden 差分が出た場合は commit 前に **必ず** 調査すること。
+
+---
+
+## Task 3: Full verification
+
+### Step 3.1: 全 test suite
+
+```bash
+cargo test -p fulgur --lib
+cargo test -p fulgur --tests
+cargo test -p fulgur-vrt
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur-cli --test examples_determinism
+cargo clippy -p fulgur --all-targets -- -D warnings
+cargo fmt --check
+```
+
+### Step 3.2: fulgur-m0xl の smoke test も pass 継続を確認
+
+```bash
+cargo test -p fulgur --test render_smoke render_v2_smoke_abs_positioned_pseudo_image
+```
+
+Expected: pass (m0xl で追加した Path A 用 smoke)。ContentBox 変更が abs pseudo 経路に副作用を起こしていないことの確認。
+
+---
+
+## Verification checklist (before PR)
+
+- [ ] `cargo test -p fulgur --lib` / `cargo test -p fulgur --tests` / `cargo clippy` / `cargo fmt --check` 全 pass
+- [ ] `cargo test -p fulgur-vrt` pass (re-bless commit 後)
+- [ ] `cargo test -p fulgur-cli --test examples_determinism` pass
+- [ ] VRT / examples の re-bless diff scope が pseudo image / list marker 系に限定 (block padding 経路も可)
+- [ ] pdftocairo で代表 golden の見た目差が無いこと確認済み
+- [ ] `bd show fulgur-bfu9` の acceptance criteria が全て満たされている
+- [ ] commit 分割: (1) refactor (Task 1)、(2) VRT / examples re-bless (Task 2)
+
+## Post-implementation note
+
+Task 2 の byte diff 計測は **実測でゼロ**。原因:
+
+- VRT fixtures には `content: url()` を持つ pseudo-element の fixture が現状不在
+- `examples/pseudo-content-url/` の全 `::before` / `::after` は `width: NNpx` / `height: NNpx` の絶対長指定で、`LengthPercentage::resolve(basis)` が basis に依存しないため、basis を Pt→Px に切り替えても解決結果が bit-identical
+- `examples/list-style-image/` は `list-style-image` プロパティ経由 (別コードパス) で ContentBox の consumer ではない
+
+結果として Task 2 の VRT re-bless / examples 再生成の commit は不要となり、Task 1 の refactor commit + doc polish のみで完了。基底切替の byte-changing 潜在はコード上には残るが (percentage-based pseudo sizing で顕在化する)、`smoke tests` / roborev で保護される。


### PR DESCRIPTION
## 概要

`convert::ContentBox` の 4 フィールドを `units::Px` に型付けし、`compute_content_box` を Px-native に書き直す。fulgur-m0xl (#614) の consumer 側に残っていた `.as_pt().in_px()` の付け足し変換を全部削除する。

Refs: \`fulgur-bfu9\`。prerequisite: \`fulgur-m0xl\` (#614, merged)。

## 変更内容

### struct + compute (`crates/fulgur/src/convert/mod.rs`)

```rust
struct ContentBox {
    origin_x: Px,
    origin_y: Px,
    width: Px,
    height: Px,
}

fn compute_content_box(node: &Node, style: &BlockStyle) -> ContentBox {
    let left_inset = style.border_widths[3].in_px() + style.padding[3].in_px();
    let top_inset = style.border_widths[0].in_px() + style.padding[0].in_px();
    let right_inset = style.border_widths[1].in_px() + style.padding[1].in_px();
    let bottom_inset = style.border_widths[2].in_px() + style.padding[2].in_px();
    let border_w = node.final_layout.size.width.as_px();
    let border_h = node.final_layout.size.height.as_px();
    ContentBox {
        origin_x: left_inset,
        origin_y: top_inset,
        width: (border_w - left_inset - right_inset).max(Px::ZERO),
        height: (border_h - top_inset - bottom_inset).max(Px::ZERO),
    }
}
```

各 inset の \`.in_px()\` を **operand 単位で** 分けたまま加算する pattern を採用 (\`(border + padding).in_px()\` に fold しない)。これは float 演算順序を fulgur-m0xl の \`.as_pt().in_px()\` stopgap と揃えて、re-bless 対象を「commit message が明示した reorder」の範囲に閉じ込めるための意図的選択。docstring と \`Refs\` block でこの意図をコード側に固定化。

### consumer 側 \`.as_pt().in_px()\` 削除

- \`crates/fulgur/src/convert/pseudo.rs::build_block_pseudo_image_entries\`: \`parent_cb.width\` / \`.height\` 直渡し
- \`crates/fulgur/src/convert/inline_root.rs\` × 2: \`content_box.width\` / \`.height\` 直渡し
- \`crates/fulgur/src/convert/list_item.rs\` × 2: 同上

## Byte-neutrality の実測

plan は \`(Px*0.75 - Pt - Pt) / 0.75\` → \`Px - Pt/0.75 - Pt/0.75\` の演算順序変更で byte-changing を想定していたが、**現行 fixture / example corpus では実測 byte diff がゼロ**。

- **VRT** (31 tests、pass): fixture に \`content: url()\` を持つ pseudo-element が現状不在
- **examples_determinism** (11 tests、pass): determinism check (同一 commit 2回実行) なので golden 比較ではない
- **examples/pseudo-content-url/**: 全 \`::before\` / \`::after\` が \`width: 32px; height: 32px\` のような **絶対長**指定で、\`LengthPercentage::resolve(basis)\` が basis に依存しないため basis の Pt→Px 切替が bit-identical
- **examples/list-style-image/**: \`list-style-image\` プロパティ経由 (\`ContentBox\` を consume しない code path)
- \`FONTCONFIG_FILE=... target/release/fulgur render\` で全 example PDF を再生成 → \`git status examples/\` = 空

Basis 切替の byte-changing 潜在は残る (percentage-based pseudo sizing 例で顕在化する) が、追加 fixture が入るまでは golden re-bless 不要。

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy -p fulgur --all-targets -- -D warnings\`
- [x] \`cargo test -p fulgur --lib\` (1670 passed)
- [x] \`cargo test -p fulgur --tests\` (43 binaries、0 failed、192 render_smoke)
- [x] \`cargo test -p fulgur-vrt\` (goldens 無変更)
- [x] \`cargo test -p fulgur-cli --test examples_determinism\` (11 passed)
- [x] \`render_v2_smoke_abs_positioned_pseudo_image\` (fulgur-m0xl の Path A guard) 継続 pass
- [x] roborev review — no issues found (job 2127)
- [x] \`target/release/fulgur render\` で全 example PDF を再生成 → diff ゼロ

## Non-goals

- \`BlockStyle::content_inset()\` の Px 版化 (他 caller への波及が大きい、別 issue)
- \`layout_in_pt\` / \`size_in_pt\` 廃止 (他所で多用、別 issue)
- \`origin_x\` / \`origin_y\` の dead-code 撤去 (design 方針に従い保持)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 擬似要素やリスト項目の画像サイズ計算がより一貫し、表示のずれや不自然なレイアウト差分が起きにくくなりました。
  * コンテンツ領域のサイズ扱いを統一し、レンダリング結果の安定性を改善しました。

* **Documentation**
  * 変更内容、検証手順、確認ポイントをまとめた実施計画を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->