### PR TITLE
perf(convert): share paragraph text via Arc<str> in ShapedGlyphRun

### DIFF
--- a/crates/fulgur/src/convert/inline_root.rs
+++ b/crates/fulgur/src/convert/inline_root.rs
@@ -2,6 +2,7 @@ use super::*;
 use super::{list_marker, positioned, pseudo};
 use crate::paragraph::{InlineBoxItem, ParagraphRender};
 use crate::units::F32Units;
+use std::sync::Arc;
 
 /// Dispatcher entry for inline-root nodes (those with `node.flags.is_inline_root()`).
 ///
@@ -449,7 +450,11 @@ pub(super) fn extract_paragraph(
     let text_layout = elem_data.inline_layout_data.as_ref()?;
 
     let parley_layout = &text_layout.layout;
-    let text = &text_layout.text;
+    // Materialize the paragraph text as `Arc<str>` once so each `ShapedGlyphRun`
+    // stores a cheap Arc bump instead of a full String clone. All runs of a
+    // paragraph share the same buffer; Blitz owns the original `String` and
+    // drops it with the DOM, so we can't borrow.
+    let text: Arc<str> = Arc::from(text_layout.text.as_str());
 
     let mut shaped_lines = Vec::new();
     let mut accumulated_line_top = crate::units::Pt::ZERO;
@@ -518,7 +523,7 @@ pub(super) fn extract_paragraph(
                     }
 
                     if !glyphs.is_empty() {
-                        let run_text = text.clone();
+                        let run_text = Arc::clone(&text);
                         let run_x_offset = glyph_run.offset().as_px().in_pt();
                         items.push(LineItem::Text(ShapedGlyphRun {
                             font_data: font_arc,
@@ -653,7 +658,7 @@ mod tests {
             color: [0, 0, 0, 255],
             decoration: TextDecoration::default(),
             glyphs: Vec::new(),
-            text: String::new(),
+            text: Arc::from(""),
             x_offset: crate::units::Pt::ZERO,
             link: None,
         })

--- a/crates/fulgur/src/convert/list_item.rs
+++ b/crates/fulgur/src/convert/list_item.rs
@@ -641,7 +641,7 @@ mod tests {
                     text_range: 1..2,
                 },
             ],
-            text: "• ".to_string(),
+            text: Arc::from("• "),
             x_offset: crate::units::Pt::ZERO,
             link: None,
         });
@@ -740,7 +740,7 @@ mod tests {
             color: [0, 0, 0, 255],
             decoration: TextDecoration::default(),
             glyphs: vec![],
-            text: String::new(),
+            text: Arc::from(""),
             x_offset: x_offset.as_pt(),
             link: None,
         })
@@ -869,7 +869,7 @@ mod tests {
             color: [0, 0, 0, 255],
             decoration: TextDecoration::default(),
             glyphs: vec![],
-            text: String::new(),
+            text: Arc::from(""),
             x_offset: crate::units::Pt::ZERO,
             link: None,
         });

--- a/crates/fulgur/src/convert/list_marker.rs
+++ b/crates/fulgur/src/convert/list_marker.rs
@@ -173,7 +173,7 @@ pub(super) fn extract_marker_lines(
     };
 
     let marker_text: std::sync::Arc<str> =
-        std::sync::Arc::from(marker_to_string(&list_item_data.marker).as_str());
+        std::sync::Arc::from(marker_to_string(&list_item_data.marker));
 
     let mut shaped_lines = Vec::new();
     let mut max_width = crate::units::Pt::ZERO;
@@ -346,7 +346,7 @@ pub(super) fn shape_marker_with_skrifa(
     font_size: crate::units::Pt,
     color: [u8; 4],
 ) -> Option<ShapedGlyphRun> {
-    let text: std::sync::Arc<str> = std::sync::Arc::from(marker_skrifa_text(marker).as_str());
+    let text: std::sync::Arc<str> = std::sync::Arc::from(marker_skrifa_text(marker));
 
     let font_ref = skrifa::FontRef::from_index(font_data, font_index).ok()?;
     let charmap = font_ref.charmap();

--- a/crates/fulgur/src/convert/list_marker.rs
+++ b/crates/fulgur/src/convert/list_marker.rs
@@ -172,7 +172,8 @@ pub(super) fn extract_marker_lines(
         return (Vec::new(), crate::units::Pt::ZERO, crate::units::Pt::ZERO);
     };
 
-    let marker_text = marker_to_string(&list_item_data.marker);
+    let marker_text: std::sync::Arc<str> =
+        std::sync::Arc::from(marker_to_string(&list_item_data.marker).as_str());
 
     let mut shaped_lines = Vec::new();
     let mut max_width = crate::units::Pt::ZERO;
@@ -249,7 +250,7 @@ pub(super) fn extract_marker_lines(
                         color,
                         decoration: Default::default(),
                         glyphs,
-                        text: marker_text.clone(),
+                        text: std::sync::Arc::clone(&marker_text),
                         x_offset: glyph_run.offset().as_px().in_pt(),
                         link: None,
                     }));
@@ -345,7 +346,7 @@ pub(super) fn shape_marker_with_skrifa(
     font_size: crate::units::Pt,
     color: [u8; 4],
 ) -> Option<ShapedGlyphRun> {
-    let text = marker_skrifa_text(marker);
+    let text: std::sync::Arc<str> = std::sync::Arc::from(marker_skrifa_text(marker).as_str());
 
     let font_ref = skrifa::FontRef::from_index(font_data, font_index).ok()?;
     let charmap = font_ref.charmap();
@@ -515,7 +516,7 @@ mod tests {
                 y_offset: 0.0,
                 text_range: 0..1,
             }],
-            text: "A".to_string(),
+            text: Arc::from("A"),
             x_offset: crate::units::Pt::ZERO,
             link: None,
         };
@@ -595,7 +596,7 @@ mod tests {
         assert!(result.is_some());
         let run = result.unwrap();
         assert_eq!(run.glyphs.len(), 2, "bullet + trailing space = 2 glyphs");
-        assert_eq!(run.text, "• ");
+        assert_eq!(&*run.text, "• ");
         assert_eq!(run.font_size.to_f32(), 12.0);
         assert_eq!(run.color, [255, 0, 0, 255]);
         assert_eq!(run.font_index, 0);
@@ -616,7 +617,7 @@ mod tests {
         assert!(result.is_some());
         let run = result.unwrap();
         assert_eq!(run.glyphs.len(), 3, "\"1. \" = 3 chars = 3 glyphs");
-        assert_eq!(run.text, "1. ");
+        assert_eq!(&*run.text, "1. ");
     }
 
     #[test]

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -724,7 +724,7 @@ fn convert_multicol_paragraph_slices(
             let Some(text_layout) = elem.inline_layout_data.as_ref() else {
                 continue;
             };
-            let text = text_layout.text.clone();
+            let text: std::sync::Arc<str> = std::sync::Arc::from(text_layout.text.as_str());
 
             // Hold the rebroken clone alive across the per-line loop in
             // Case A. In Case B the borrowed reference into Blitz is
@@ -864,7 +864,7 @@ fn convert_multicol_paragraph_slices(
 fn shape_paragraph_glyph_runs(
     doc: &BaseDocument,
     parley_layout: &parley::Layout<blitz_dom::node::TextBrush>,
-    text: &str,
+    text: &std::sync::Arc<str>,
     ctx: &mut ConvertContext<'_>,
 ) -> Vec<ShapedLine> {
     let mut shaped_lines = Vec::new();
@@ -922,7 +922,7 @@ fn shape_paragraph_glyph_runs(
                 }
 
                 if !glyphs.is_empty() {
-                    let run_text = text.to_string();
+                    let run_text = std::sync::Arc::clone(text);
                     let run_x_offset = glyph_run.offset().as_px().in_pt();
                     items.push(LineItem::Text(ShapedGlyphRun {
                         font_data: font_arc,

--- a/crates/fulgur/src/convert/pseudo.rs
+++ b/crates/fulgur/src/convert/pseudo.rs
@@ -403,7 +403,7 @@ mod tests {
                 y_offset: 0.0,
                 text_range: 0..1,
             }],
-            text: "a".to_string(),
+            text: Arc::from("a"),
             x_offset: 3.0_f32.as_pt(),
             link: None,
         };
@@ -513,7 +513,7 @@ mod tests {
                     text_range: 1..2,
                 },
             ],
-            text: "ab".to_string(),
+            text: Arc::from("ab"),
             x_offset: 2.0_f32.as_pt(),
             link: None,
         };

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -90,6 +90,12 @@ pub struct LinkSpan {
 }
 
 /// A pre-extracted glyph run (single font + style).
+///
+/// `text` is the paragraph's full source text (identical across every
+/// `ShapedGlyphRun` produced from one paragraph). It is stored as `Arc<str>`
+/// so `extract_paragraph` can bump-clone the same buffer per run rather than
+/// pay a String allocation each time; it is passed by reference to krilla's
+/// `draw_glyphs` and read via `as_str` in `render` — no mutation callers.
 #[derive(Clone, Debug)]
 pub struct ShapedGlyphRun {
     pub font_data: Arc<Vec<u8>>,
@@ -98,7 +104,7 @@ pub struct ShapedGlyphRun {
     pub color: [u8; 4], // RGBA
     pub decoration: TextDecoration,
     pub glyphs: Vec<ShapedGlyph>,
-    pub text: String,
+    pub text: Arc<str>,
     pub x_offset: crate::units::Pt,
     pub link: Option<Arc<LinkSpan>>,
 }
@@ -1487,7 +1493,7 @@ mod tests {
             color: [0, 0, 0, 255],
             decoration: TextDecoration::default(),
             glyphs: Vec::new(),
-            text: String::from("hi"),
+            text: Arc::from("hi"),
             x_offset: crate::units::Pt::ZERO,
             link: None,
         };
@@ -1528,7 +1534,7 @@ mod tests {
             color: [0, 0, 0, 255],
             decoration: TextDecoration::default(),
             glyphs: Vec::new(),
-            text: String::new(),
+            text: Arc::from(""),
             x_offset: crate::units::Pt::ZERO,
             link: None,
         };
@@ -1741,7 +1747,7 @@ mod link_span_tests {
             color: [0, 0, 0, 255],
             decoration: TextDecoration::default(),
             glyphs: Vec::new(),
-            text: String::new(),
+            text: Arc::from(""),
             x_offset: crate::units::Pt::ZERO,
             link: None,
         };

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -901,7 +901,7 @@ fn extract_heading_title(para: &crate::drawables::ParagraphEntry) -> String {
         .iter()
         .flat_map(|line| line.items.iter())
         .filter_map(|item| match item {
-            crate::paragraph::LineItem::Text(run) => Some(run.text.as_str()),
+            crate::paragraph::LineItem::Text(run) => Some(run.text.as_ref()),
             _ => None,
         })
         .collect()
@@ -4320,7 +4320,7 @@ mod tests {
             color: [0, 0, 0, 255],
             decoration: crate::paragraph::TextDecoration::default(),
             glyphs: vec![],
-            text: text.to_string(),
+            text: std::sync::Arc::from(text),
             x_offset: crate::units::Pt::ZERO,
             link,
         }

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -50,7 +50,7 @@ fn paragraph_run_text(entry: &fulgur::drawables::ParagraphEntry) -> String {
         .iter()
         .flat_map(|line| line.items.iter())
         .filter_map(|item| match item {
-            fulgur::paragraph::LineItem::Text(run) => Some(run.text.as_str()),
+            fulgur::paragraph::LineItem::Text(run) => Some(run.text.as_ref()),
             _ => None,
         })
         .collect()


### PR DESCRIPTION
## Summary

`ShapedGlyphRun.text` を `String` から `Arc<str>` に変更し、`extract_paragraph` の各行 / GlyphRun が段落テキスト全体を毎回 `String::clone` していた挙動を、段落単位で 1 つの `Arc<str>` を共有する形に置き換えます。

- 使用箇所は read-only のみ (`&run.text` を krilla の `draw_glyphs` に渡す / `extract_heading_title` で `.as_str()` 相当) なので Arc<str> でセマンティクスは変わらない
- 対応した呼び出し元 4 箇所:
  - `convert::inline_root::extract_paragraph` (メイン段落パス)
  - `convert::mod::shape_paragraph_glyph_runs` (multicol 段組みパス)
  - `convert::list_marker::extract_marker_lines` (list marker parley path)
  - `convert::list_marker::shape_marker_with_skrifa` (skrifa フォールバック)

## Motivation (fulgur-qb93)

xlarge (200p) ドキュメントで peak RSS が 93 MB あった件の PoC。heaptrack でプロファイルを取ったところ:

- 全体 peak の ~65% は上流 (blitz-dom DOM slab 49 MB + parley shape cache 12 MB) で、fulgur 側は ~15-20 MB
- fulgur 側の hot allocation の 1 つが `ShapedGlyphRun.text = text.clone()` (`inline_root.rs:521`) だった

段落テキストは 1 つの inline root につき 1 度取れば全 GlyphRun で使い回せる情報なので、Arc 共有に切り替えます。

## Measurements

xlarge 200-page ドキュメント (200 sections × h2 + p + table + list) を heaptrack でプロファイル:

| Metric | Before | After | Δ |
|---|---:|---:|---:|
| Allocations | 648,997 | 638,754 | −10,243 (−1.6%) |
| Peak heap | 96.73 MB | 96.23 MB | −0.5 MB |
| Peak RSS (median 3 runs) | 95.4 MB | 95.3 MB | ±noise |

絶対値の削減は控えめですが (このベンチの段落テキストは平均 ~280 バイトと短めだったため)、per-run String allocation を無くしたので **段落数 × 行あたり run 数** に応じてスケールする allocation コストが消えます。より長い段落・大量の inline runs があるドキュメントで効果が大きくなる想定。

fulgur-qb93 のより大きな gap (fulgur 93 MB vs リファレンス 58 MB) は peak が `dom_to_drawables` 内で DOM + parley cache + 成長中の Drawables が同時 live の瞬間に発生していることが原因で、per-allocation 最適化では埋まりません。ストリーミング化が別途必要 (別 issue で追跡)。

## Test plan

- [x] `cargo test -p fulgur --lib` (1674 passed)
- [x] `cargo test -p fulgur-vrt --release` (PDF byte-identical golden 比較 pass)
- [x] `cargo clippy -p fulgur --lib --release` (warning なし)
- [x] `cargo fmt --check`
- [x] xlarge / large / medium で PDF サイズが Before と一致することを目視確認
- [ ] CI: fulgur workspace テスト
- [ ] CI: examples determinism テスト (PDF byte 一致)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 段落・リスト・見出しで使用するグリフ実行テキストの保持形式を見直し、同一文字列を共有して扱えるようにしました。
  * これにより、不要な文字列の複製を減らし、生成コストとメモリ効率を改善しました。
* **Tests**
  * 共有方式にあわせて、グリフ実行テキストの生成・検証方法を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->