### PR TITLE
harden(tagged): guard nested marked-content sequences in tagged PDF path

### DIFF
--- a/crates/fulgur/src/draw_primitives.rs
+++ b/crates/fulgur/src/draw_primitives.rs
@@ -578,6 +578,16 @@ pub struct Canvas<'a, 'b> {
     /// `Arc<LinkSpan>` identity gets its own `start_tagged/end_tagged` region
     /// recorded as a `ParagraphRunItem` under that paragraph's NodeId.
     pub link_run_node_id: Option<crate::drawables::NodeId>,
+    /// True while a Krilla marked-content sequence (opened via
+    /// `surface.start_tagged`) is currently open on `surface`. Krilla panics on
+    /// nested `start_tagged` calls (`can't start marked content twice`), so
+    /// every fulgur entry point that opens a sequence must consult and set this
+    /// flag: skip the open when the flag is set (defer to the outer tag as a
+    /// graceful degradation), and pair a successful open with a matching reset
+    /// in the same scope. The three current entry points are
+    /// `render::try_start_tagged`, `render::draw_list_item_marker_tagged`, and
+    /// `paragraph::RunRegionTracker::transition_to`.
+    pub in_marked_content: bool,
 }
 
 /// Run a draw closure wrapped in opacity guards.
@@ -2427,6 +2437,7 @@ mod dp_unit_tests {
             link_collector: None,
             tag_collector: None,
             link_run_node_id: None,
+            in_marked_content: false,
         };
         f(&mut canvas);
     }

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -590,15 +590,28 @@ impl RunRegionTracker {
     /// Switch to the region identified by `new_span_ptr`, opening/closing
     /// `start_tagged` regions as needed and recording closed regions on
     /// `canvas.tag_collector`.
+    ///
+    /// When `canvas.in_marked_content` is already set (per-run tagging invoked
+    /// under an outer marked-content sequence — e.g. an inline-box dispatched
+    /// from a tagged block's paragraph), the open is skipped: Krilla's
+    /// `start_tagged` is not nestable and would panic. The run's glyphs / images
+    /// still paint, but this run does not get its own `ParagraphRunItem` entry,
+    /// so any link on the run falls through to `emit_link_annotations`'s
+    /// unwired-fallback path (`add_annotation`) — no `add_tagged_annotation`
+    /// call with an OBJR that would fail the later tag-tree consistency check.
     fn transition_to(&mut self, canvas: &mut Canvas<'_, '_>, new_span_ptr: Option<usize>) {
         if self.open_span_ptr == Some(new_span_ptr) {
             return;
         }
         self.close(canvas);
+        if canvas.in_marked_content {
+            return;
+        }
         use krilla::tagging::{ContentTag, SpanTag};
         let id = canvas
             .surface
             .start_tagged(ContentTag::Span(SpanTag::empty()));
+        canvas.in_marked_content = true;
         self.open_span_ptr = Some(new_span_ptr);
         self.open_identifier = Some(id);
     }
@@ -610,6 +623,7 @@ impl RunRegionTracker {
             return;
         };
         canvas.surface.end_tagged();
+        canvas.in_marked_content = false;
         let id = self
             .open_identifier
             .take()
@@ -1082,6 +1096,7 @@ mod tests {
                 link_collector: Some(&mut lc),
                 tag_collector: None,
                 link_run_node_id: None,
+                in_marked_content: false,
             };
             // Draw origin (5, 7) pt; rect must land at (5+2, 7+3, 20, 10).
             draw_shaped_lines(&mut canvas, &[line], 5.0_f32.as_pt(), 7.0_f32.as_pt(), None);

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -213,6 +213,7 @@ pub fn render_v2(
                     link_collector: Some(&mut link_collector),
                     tag_collector: tag_collector.as_mut(),
                     link_run_node_id: None,
+                    in_marked_content: false,
                 };
                 // Root `<html>` + `<body>` background pre-pass. v1's
                 // `BlockPageable::draw` for these elements paints
@@ -304,6 +305,7 @@ pub fn render_v2(
                 link_collector: Some(&mut link_collector),
                 tag_collector: None,
                 link_run_node_id: None,
+                in_marked_content: false,
             };
             let page_content_width = page_size.width - resolved_margin.left - resolved_margin.right;
             margin_box_renderer.render_page(
@@ -912,9 +914,16 @@ fn extract_heading_title(para: &crate::drawables::ParagraphEntry) -> String {
 ///
 /// Returns `Some((tag, id))` on success so that `finish_tagged` can close it.
 /// Returns `None` when tagging is disabled, the node has no recognised
-/// semantic entry, or the node carries no paragraph content (pure containers
+/// semantic entry, the node carries no paragraph content (pure containers
 /// must not call `start_tagged` — it is not nestable and would panic on a
-/// second call before `end_tagged`).
+/// second call before `end_tagged`), OR the canvas is already inside an
+/// outer marked-content sequence (`canvas.in_marked_content == true`). The
+/// last case fires when a tagged inline-root block dispatches an inline-box
+/// whose content would itself want a P/Span/LBody tag; nested opens would
+/// panic in Krilla (`can't start marked content twice`), so the inner tag is
+/// dropped and its sub-tree renders as a graceful, untagged extension of the
+/// outer sequence. Link annotations under the skipped tag still land in the
+/// PDF via `emit_link_annotations`'s unwired-fallback path (`add_annotation`).
 fn try_start_tagged(
     canvas: &mut crate::draw_primitives::Canvas<'_, '_>,
     node_id: usize,
@@ -926,8 +935,11 @@ fn try_start_tagged(
     Option<String>,
 )> {
     canvas.tag_collector.as_ref()?;
+    if canvas.in_marked_content {
+        return None;
+    }
     let semantic = drawables.semantics.get(&node_id)?;
-    match &semantic.tag {
+    let result = match &semantic.tag {
         crate::tagging::PdfTag::P | crate::tagging::PdfTag::Span => {
             use krilla::tagging::{ContentTag, SpanTag};
             let id = canvas
@@ -956,7 +968,11 @@ fn try_start_tagged(
             Some((lbody_id, crate::tagging::PdfTag::LBody, id, None))
         }
         _ => None,
+    };
+    if result.is_some() {
+        canvas.in_marked_content = true;
     }
+    result
 }
 
 /// Close a tagged content sequence opened by `try_start_tagged` and record
@@ -980,6 +996,7 @@ fn finish_tagged(
 ) {
     if let Some((record_id, tag, id, heading_title)) = tag_info {
         canvas.surface.end_tagged();
+        canvas.in_marked_content = false;
         canvas
             .tag_collector
             .as_mut()
@@ -3131,6 +3148,13 @@ fn draw_list_item_marker(
 }
 
 /// List-item marker を描画し、タグ付きモードでは Lbl 構造要素でラップする。
+///
+/// When `canvas.in_marked_content` is already set (a nested tagged marker
+/// inside an outer marked-content sequence — e.g. a `<ul><li>...</li></ul>`
+/// dispatched from a tagged block's inline-box), the Lbl tag is skipped so
+/// Krilla's non-nestable `start_tagged` does not panic. The marker glyphs
+/// / image still paint; only the structural Lbl association is dropped for
+/// the nested case (graceful degradation).
 fn draw_list_item_marker_tagged(
     canvas: &mut crate::draw_primitives::Canvas<'_, '_>,
     li: &crate::drawables::ListItemEntry,
@@ -3143,18 +3167,22 @@ fn draw_list_item_marker_tagged(
         .tag_collector
         .as_ref()
         .and_then(|_| drawables.li_lbl_ids.get(&node_id).copied());
-    let marker_tag_id = lbl_id.map(|_| {
-        canvas
+    let can_open_marker_tag = lbl_id.is_some() && !canvas.in_marked_content;
+    let marker_tag_id = can_open_marker_tag.then(|| {
+        let id = canvas
             .surface
             .start_tagged(krilla::tagging::ContentTag::Span(
                 krilla::tagging::SpanTag::empty(),
-            ))
+            ));
+        canvas.in_marked_content = true;
+        id
     });
 
     draw_list_item_marker(canvas, li, x, y);
 
     if let (Some(lid), Some(id)) = (lbl_id, marker_tag_id) {
         canvas.surface.end_tagged();
+        canvas.in_marked_content = false;
         canvas
             .tag_collector
             .as_mut()

--- a/crates/fulgur/src/svg.rs
+++ b/crates/fulgur/src/svg.rs
@@ -102,6 +102,7 @@ mod tests {
                     link_collector: None,
                     tag_collector: None,
                     link_run_node_id: None,
+                    in_marked_content: false,
                 };
                 svg.draw(
                     &mut canvas,

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -5525,3 +5525,89 @@ fn test_render_html_huge_page_name_is_bounded() {
     let pdf = Engine::builder().build().render(&html).expect("render");
     assert!(!pdf.is_empty());
 }
+
+#[test]
+fn tagged_li_with_inline_block_child_does_not_panic() {
+    // Security regression (fulgur-z28x): a tagged inline-root list item that
+    // contains an inline-block child used to hit Krilla's non-nestable
+    // start_tagged assertion. `draw_list_item_with_block` opens an LBody
+    // marked-content sequence around the paragraph draw; the paragraph then
+    // dispatches the inline-block via `dispatch_inline_box_content`, which
+    // reaches `dispatch_fragment` and calls `try_start_tagged` again while
+    // the outer LBody MCS is still active — Krilla panics.
+    let html = r#"<!DOCTYPE html><html><body>
+        <ul>
+          <li>outer <span style="display:inline-block">inline block</span> after</li>
+        </ul>
+    </body></html>"#;
+    let pdf = Engine::builder()
+        .tagged(true)
+        .build()
+        .render(html)
+        .expect("tagged li with inline-block must render");
+    assert!(!pdf.is_empty());
+    let s = String::from_utf8_lossy(&pdf);
+    assert!(s.contains("/StructTreeRoot"));
+}
+
+#[test]
+fn tagged_paragraph_with_inline_block_child_does_not_panic() {
+    // Security regression (fulgur-z28x): the same nested-MCS assertion fires
+    // for a tagged `<p>` (PdfTag::P) containing an inline-block child. Guards
+    // must live at the choke point, not just for the `<li>` LBody branch.
+    let html = r#"<!DOCTYPE html><html><body>
+        <p>outer <span style="display:inline-block">inline block</span> after</p>
+    </body></html>"#;
+    let pdf = Engine::builder()
+        .tagged(true)
+        .build()
+        .render(html)
+        .expect("tagged p with inline-block must render");
+    assert!(!pdf.is_empty());
+    let s = String::from_utf8_lossy(&pdf);
+    assert!(s.contains("/StructTreeRoot"));
+}
+
+#[test]
+fn tagged_li_with_linked_inline_block_child_does_not_panic() {
+    // Security regression (fulgur-z28x): when the inline-block subtree
+    // contains a link, `dispatch_fragment` sets `link_run_node_id` for the
+    // nested paragraph and per-run tagging via `RunRegionTracker::transition_to`
+    // opens a second MCS while the outer LBody sequence is still active. The
+    // full PDF must round-trip: not just past `start_tagged`, but through
+    // serialization — an unwired tagged annotation would panic later in
+    // krilla's tag-tree consistency check.
+    let html = r#"<!DOCTYPE html><html><body>
+        <ul>
+          <li>outer <span style="display:inline-block"><a href="https://example.test/">linked</a></span> after</li>
+        </ul>
+    </body></html>"#;
+    let pdf = Engine::builder()
+        .tagged(true)
+        .build()
+        .render(html)
+        .expect("tagged li with linked inline-block must render");
+    assert!(!pdf.is_empty());
+    let s = String::from_utf8_lossy(&pdf);
+    assert!(s.contains("/StructTreeRoot"));
+}
+
+#[test]
+fn tagged_p_with_nested_list_in_inline_block_does_not_panic() {
+    // Security regression (fulgur-z28x): a tagged `<p>` opens a P MCS, then
+    // dispatches an inline-block containing `<ul><li>`. Rendering the nested
+    // `<li>` reaches `draw_list_item_marker_tagged` while the outer P MCS is
+    // still active — Krilla's marker-tag `start_tagged` would panic on that
+    // second open without the `in_marked_content` guard.
+    let html = r#"<!DOCTYPE html><html><body>
+        <p>outer <span style="display:inline-block"><ul><li>nested</li></ul></span> after</p>
+    </body></html>"#;
+    let pdf = Engine::builder()
+        .tagged(true)
+        .build()
+        .render(html)
+        .expect("tagged p with nested list in inline-block must render");
+    assert!(!pdf.is_empty());
+    let s = String::from_utf8_lossy(&pdf);
+    assert!(s.contains("/StructTreeRoot"));
+}


### PR DESCRIPTION
## 概要

Tagged PDF / PDF/UA 出力経路で、外側 block が Krilla の marked-content sequence
を開いたまま inline-box の内側でもう一度 `surface.start_tagged` を叩ける経路が
残っており、標準的な HTML パターン + `--tagged` / `--pdf-ua` フラグで render
プロセスがアボートしていた（Krilla 側の "can't start marked content twice"
assertion）。

`Canvas` に `in_marked_content: bool` を追加し、`surface.start_tagged` を呼ぶ
3 サイト全てで nested オープンを skip する。skip されたサブツリーは untagged
として graceful に描画される（link annotation も既存の unwired-fallback を経由
して `add_annotation` に落ちるため、tag tree の consistency も壊れない）。

## Trigger（tagged/pdf-ua モード必須、default は無効）

以下いずれのパターンでも従来は render が abort していた:

- `<li>` + `<span style="display:inline-block">` の子（`try_start_tagged`
  の LBody / P 分岐が nested）
- `<p>` + `<span style="display:inline-block">` の子
- `<li>` + inline-block 内の `<a>`（`RunRegionTracker::transition_to` 経由の
  nested MCS。単なる start_tagged だけでなく serialization 時の
  tag-tree consistency check でも panic しうる）
- `<p>` + inline-block 内の `<ul><li>`（`draw_list_item_marker_tagged` の
  Lbl 分岐が nested）

untagged モードの render には影響しない。

## 変更点

- `crates/fulgur/src/draw_primitives.rs`: `Canvas.in_marked_content` フラグ追加
- `crates/fulgur/src/render.rs`:
  - `try_start_tagged` / `finish_tagged` を flag で guard
  - `draw_list_item_marker_tagged` を flag で guard
  - `render_v2` 内の 2 箇所の Canvas literal に初期値を追加
- `crates/fulgur/src/paragraph.rs`: `RunRegionTracker::transition_to` / `close`
  を flag で guard、既存の Canvas literal に初期値を追加
- `crates/fulgur/src/svg.rs`: 既存の Canvas literal に初期値を追加
- `crates/fulgur/tests/render_smoke.rs`: 4 パターンの回帰テスト追加

## Test plan

- [x] `cargo test -p fulgur` — 全緑
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p fulgur --all-targets -- -D warnings`
- [x] CLI 直叩きで 4 パターンとも有効な PDF が出ることを確認
- [x] 既存の tagged/PDF-UA smoke test (28件) が影響を受けないことを確認

Refs fulgur-z28x.