### PR TITLE
test(template): add coverage for format_filter fallback paths

### DIFF
--- a/crates/fulgur/src/template.rs
+++ b/crates/fulgur/src/template.rs
@@ -233,6 +233,64 @@ mod tests {
     }
 
     #[test]
+    fn test_format_comma_float_fallback() {
+        // Value is f64 (1234.5 is not exactly representable as i64),
+        // so "," falls back through the as_f64 branch.
+        let tmpl = r#"{{ n | numformat(",") }}"#;
+        let data = json!({"n": 1234.5_f64});
+        let result = render_template("test.html", tmpl, &data).unwrap();
+        assert_eq!(result, "1,234.5");
+    }
+
+    #[test]
+    fn test_format_comma_string_fallback() {
+        // Non-numeric string: both i64 and f64 conversions fail;
+        // returns value.to_string() unchanged.
+        let tmpl = r#"{{ n | numformat(",") }}"#;
+        let data = json!({"n": "hello"});
+        let result = render_template("test.html", tmpl, &data).unwrap();
+        assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn test_format_comma_decimal_non_numeric() {
+        // ",.Nf" with a non-numeric string: as_f64 is None, falls through
+        // all branches and returns value.to_string().
+        let tmpl = r#"{{ n | numformat(",.2f") }}"#;
+        let data = json!({"n": "hello"});
+        let result = render_template("test.html", tmpl, &data).unwrap();
+        assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn test_format_decimal_only_non_numeric() {
+        // ".Nf" with a non-numeric string: as_f64 is None, falls through.
+        let tmpl = r#"{{ n | numformat(".2f") }}"#;
+        let data = json!({"n": "hello"});
+        let result = render_template("test.html", tmpl, &data).unwrap();
+        assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn test_format_zero_pad_float() {
+        // "0Nd" with a float (as_i64 is None for 1.5): condition matched but
+        // inner as_i64 guard fails, falls through to value.to_string().
+        let tmpl = r#"{{ n | numformat("04d") }}"#;
+        let data = json!({"n": 1.5_f64});
+        let result = render_template("test.html", tmpl, &data).unwrap();
+        assert_eq!(result, "1.5");
+    }
+
+    #[test]
+    fn test_format_unknown_spec_fallthrough() {
+        // An unrecognised format spec matches no branch; returns value.to_string().
+        let tmpl = r#"{{ n | numformat("xyz") }}"#;
+        let data = json!({"n": 42});
+        let result = render_template("test.html", tmpl, &data).unwrap();
+        assert_eq!(result, "42");
+    }
+
+    #[test]
     fn test_for_loop_over_string_iterates_chars() {
         // MiniJinja iterates over characters of a string
         let tmpl = "{% for c in items %}[{{ c }}]{% endfor %}";


### PR DESCRIPTION
## Summary

`crates/fulgur/src/template.rs` の `format_filter` 関数にある未カバーブランチにテストを追加する。

対象ファイルのカバレッジ: **93.4% → 99.0%**（ライン）

## Changes

- `test_format_comma_float_fallback`: `","` フォーマット、値が `f64`（`1234.5`）の場合 — `as_i64` が None になり、`as_f64` フォールバックパスを通る
- `test_format_comma_string_fallback`: `","` フォーマット、非数値文字列の場合 — 両変換失敗で `value.to_string()` を返す
- `test_format_comma_decimal_non_numeric`: `",.Nf"` フォーマット、非数値文字列の場合 — `as_f64` が None でネストした `if let` を抜けてフォールスルー
- `test_format_decimal_only_non_numeric`: `".Nf"` フォーマット、非数値文字列の場合 — 同様に `as_f64` が None でフォールスルー
- `test_format_zero_pad_float`: `"0Nd"` フォーマット、`f64` 値（`1.5`）の場合 — `as_i64` が None でフォールスルー
- `test_format_unknown_spec_fallthrough`: 未知のフォーマット指定子 — いずれの分岐にもマッチせず `value.to_string()` で返る

**意図的に除外したブランチ（残り 1% 未カバー行）：**

残り 4 行（62, 63, 72, 81）はすべて `if let` ネストチェーン内の閉じ括弧 `}` で、LLVM カバレッジ計測のアーティファクト。  
具体的には「`if let Ok(prec)` ブロックに入ったが、内側の `if let Some(f) = as_f64` を取らずに抜けた際のブロック出口」を示しており、実際には `test_format_comma_decimal_non_numeric` 等で通過している。  
LLVM がこの暗黙のフォールスルーを独立カウンタとして計上しているため、実用上テスト追加では解消できない計測上のギャップ。

## Test plan

- [x] `cargo test -p fulgur --lib` — 1684 tests passed（新規 6 テスト含む）
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — 差分なし
- [ ] `npx markdownlint-cli2 '**/*.md'` — ドキュメント変更なし、省略

## Contributor License Agreement

By opening this pull request, I confirm that:

- [x] I have read the [Contributing Guide](https://github.com/fulgur-rs/fulgur/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://github.com/fulgur-rs/fulgur/blob/main/CLA.md)
      and agree to its terms. (First-time contributors: the CLA Assistant bot
      will comment on this PR with sign-in instructions.)

## Related issues

なし

---
_Generated by [Claude Code](https://claude.ai/code/session_016vK5vew4u32jcowzLEDZ3d)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 数値フォーマット指定の解釈に失敗した場合や型が一致しない場合に、値が適切にそのまま表示される動作を検証するテストを追加しました。
  * 小数値の千区切り表示など、対応するフォーマットが正しく適用されるケースも確認しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->