### PR TITLE
chore(comments): remove Pageable v1 references (PR 1/5: orchestration + tests + misc)

### DIFF
--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -1240,8 +1240,8 @@ pub fn extract_vertical_align(node: &blitz_dom::Node) -> crate::paragraph::Verti
             if let Some(pct) = lp.to_percentage() {
                 VerticalAlign::Percent(pct.0)
             } else {
-                // `.px()` here is parley/stylo's CSS-px scalar. The Pageable
-                // tree is in pt, so convert. For calc() with percentage
+                // `.px()` here is parley/stylo's CSS-px scalar. Drawables
+                // consume pt, so convert. For calc() with percentage
                 // components the basis-0 resolve silently drops them —
                 // acceptable because calc() on vertical-align is rare.
                 let px = lp.resolve(style::values::computed::Length::new(0.0)).px();
@@ -2188,7 +2188,7 @@ pub struct CounterPass {
     state: RefCell<CounterState>,
     generated_css: RefCell<String>,
     counter_id: RefCell<usize>,
-    /// Counter ops keyed by node_id, for later use in Pageable markers.
+    /// Counter ops keyed by node_id, for later use in drawable counter markers.
     ops_by_node: RefCell<Vec<(usize, Vec<CounterOp>)>>,
     /// Counter-state snapshot taken at each visited element after the
     /// element's own `counter-reset` / `counter-increment` / `counter-set`
@@ -2276,7 +2276,7 @@ impl CounterPass {
         std::mem::take(&mut *self.node_snapshots.borrow_mut())
     }
 
-    /// Consume self and return (ops_by_node for Pageable markers, generated CSS for body).
+    /// Consume self and return (ops_by_node for drawable counter markers, generated CSS for body).
     pub fn into_parts(self) -> (Vec<(usize, Vec<CounterOp>)>, String) {
         (
             self.ops_by_node.into_inner(),

--- a/crates/fulgur/src/column_css.rs
+++ b/crates/fulgur/src/column_css.rs
@@ -30,13 +30,6 @@
 //!   remain invalid — none of them make sense as a sub-point border width
 //!   without consulting the surrounding box.
 
-// Task 2 wires the production callers of `extract_column_style_table` /
-// `parse_stylesheet` / `build_column_style_table`; Task 5 will consume the
-// `ColumnStyleProps` / `ColumnRuleSpec` / `ColumnFill` fields to wrap
-// multicol containers with `MulticolRulePageable`. Per-item `dead_code`
-// allows live below for surfaces that Task 5 reaches but Task 2 only
-// populates.
-
 use std::collections::BTreeMap;
 
 use cssparser::{

--- a/crates/fulgur/src/draw_primitives.rs
+++ b/crates/fulgur/src/draw_primitives.rs
@@ -567,7 +567,7 @@ impl Default for TagCollector {
 }
 
 /// Wrapper around Krilla Surface for drawing commands.
-/// This decouples Pageable types from Krilla's concrete Surface type.
+/// This decouples drawable payloads from Krilla's concrete Surface type.
 pub struct Canvas<'a, 'b> {
     pub surface: &'a mut krilla::surface::Surface<'b>,
     pub bookmark_collector: Option<&'a mut BookmarkCollector>,

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -471,11 +471,11 @@ impl Engine {
         // Blitz treats multicol containers as plain blocks; route them
         // through fulgur's Taffy hook so columns balance and siblings
         // shift in lockstep. The returned geometry table captures per-
-        // `ColumnGroup` layout for Task 4's `MulticolRulePageable`; we
-        // thread it through `ConvertContext` so the convert pass can
-        // wrap multicol containers with the rule spec + geometry they
-        // need to render. See docs/plans/2026-04-20-css-multicol-design.md
-        // and docs/plans/2026-04-21-fulgur-v7a-column-rule.md.
+        // `ColumnGroup` layout for column-rule rendering; we thread it
+        // through `ConvertContext` so the convert pass can wrap multicol
+        // containers with the rule spec + geometry they need to render.
+        // See docs/plans/2026-04-20-css-multicol-design.md and
+        // docs/plans/2026-04-21-fulgur-v7a-column-rule.md.
         let multicol_geometry = crate::multicol_layout::run_pass(doc.deref_mut(), &column_styles);
 
         // Run the pagination_layout fragmenter (fulgur-4cbc). Walks
@@ -502,15 +502,15 @@ impl Engine {
         // fulgur-s67g Phase 2.2: thread `running_store` so the
         // fragmenter skips `position: running()` named children. They
         // belong in `@page` margin boxes, not body flow, so including
-        // their height would over-count and diverge from Pageable.
+        // their height would over-count body-flow strip height.
         //
         // fulgur-s67g Phase 2.6 (`@page` size / margin resolution):
         // resolve the page-1 size + margin from `gcpm.page_settings`
         // before driving the fragmenter, so its strip height matches
         // `render_to_pdf_with_gcpm`'s `content_height` exactly. Both
-        // sides use the page-1 result for *all* pages — Pageable
-        // does the same in `render.rs:283-291` and does not re-resolve
-        // per-page size for `:left` / `:right` / named selectors.
+        // sides use the page-1 result for *all* pages and do not
+        // re-resolve per-page size for `:left` / `:right` / named
+        // selectors.
         // This lets the parity gates drop the
         // `(content_height - config.content_height()).abs() < 0.001`
         // skip: documents that override page size / margin via
@@ -613,7 +613,7 @@ impl Engine {
             BTreeMap::new()
         };
 
-        // --- Convert DOM to Pageable and render ---
+        // --- Convert DOM to Drawables and render ---
         // Build string-set lookup map
         let string_set_by_node: HashMap<usize, Vec<(String, String)>> = {
             let mut map: HashMap<usize, Vec<(String, String)>> = HashMap::new();

--- a/crates/fulgur/src/gcpm/string_set.rs
+++ b/crates/fulgur/src/gcpm/string_set.rs
@@ -1,7 +1,7 @@
 //! Named string support for CSS Generated Content for Paged Media (GCPM).
 //!
 //! Manages string-set values extracted from the DOM via `string-set: name content(text)`.
-//! Values are stored with their DOM node IDs for later insertion into the Pageable tree.
+//! Values are stored with their DOM node IDs for later insertion into the drawable tree.
 
 /// A single string-set entry extracted from the DOM.
 #[derive(Debug, Clone)]
@@ -10,7 +10,7 @@ pub struct StringSetEntry {
     pub name: String,
     /// The resolved text value.
     pub value: String,
-    /// Blitz DOM node ID, used to position the marker in the Pageable tree.
+    /// Blitz DOM node ID, used to position the marker in the drawable tree.
     pub node_id: usize,
 }
 

--- a/crates/fulgur/src/image.rs
+++ b/crates/fulgur/src/image.rs
@@ -73,7 +73,7 @@ pub struct ImageRender {
     pub opacity: f32,
     pub visible: bool,
     /// fulgur-r6we (Phase 3.2.a): DOM NodeId for `slice_for_page`
-    /// geometry lookup. See `BlockPageable::node_id`.
+    /// geometry lookup.
     pub node_id: Option<usize>,
 }
 

--- a/crates/fulgur/src/svg.rs
+++ b/crates/fulgur/src/svg.rs
@@ -21,7 +21,7 @@ pub struct SvgRender {
     pub opacity: f32,
     pub visible: bool,
     /// fulgur-3vwx (Phase 3.2.b): DOM NodeId for `slice_for_page`
-    /// geometry lookup. See `BlockPageable::node_id`.
+    /// geometry lookup.
     pub node_id: Option<usize>,
 }
 

--- a/crates/fulgur/tests/abs_positioned_pagination.rs
+++ b/crates/fulgur/tests/abs_positioned_pagination.rs
@@ -91,13 +91,13 @@ fn count_blocks_with_size(
 /// flattened — flattening recurses into `collect_positioned_children`,
 /// which now skips abs descendants. Without the flatten guard, the abs
 /// would never reach a `build_absolute_children` hoist and would
-/// silently disappear from the Pageable tree.
+/// silently disappear from the drawable tree.
 ///
 /// `assert!(!pdf.is_empty())` and `page_count == 1` are *not* sufficient
 /// oracles here — both stay true even when the abs child is dropped,
 /// because krilla always serialises a complete PDF and the surrounding
-/// in-flow text alone fills one page. We instead inspect the Pageable
-/// tree directly and assert a 30×30 pt out-of-flow `BlockPageable`
+/// in-flow text alone fills one page. We instead inspect the drawable
+/// tree directly and assert a 30×30 pt out-of-flow `BlockEntry`
 /// (the abs `<div>`) is present (PR #260, CodeRabbit).
 #[test]
 fn abs_inside_zero_size_container_is_not_dropped_by_flatten() {
@@ -106,7 +106,7 @@ fn abs_inside_zero_size_container_is_not_dropped_by_flatten() {
     // `collect_positioned_children`'s flatten branch would otherwise
     // collapse — recursing into its children with no parent to pick the
     // abs back up. Without the flatten guard, the abs `<div>` is silently
-    // dropped from the Pageable tree.
+    // dropped from the drawable tree.
     let html = r#"<!doctype html><html><head><style>
         @page { size: 200pt 200pt; margin: 0; }
         body { margin: 0; }
@@ -135,7 +135,7 @@ fn abs_inside_zero_size_container_is_not_dropped_by_flatten() {
 }
 
 /// Regression for the devin thread on fulgur-aijf: when in-flow children
-/// are followed by out-of-flow children in `BlockPageable::children`,
+/// are followed by out-of-flow children in a block's child list,
 /// `find_split_point`'s break-after / overflow-fallback paths must NOT
 /// return AtIndex pointing at an OOF child — that would corrupt
 /// `split_y` (read from CB-relative OOF.y, often 0) and cut the page

--- a/crates/fulgur/tests/break_inside_avoid.rs
+++ b/crates/fulgur/tests/break_inside_avoid.rs
@@ -47,8 +47,8 @@ fn avoid_block_straddling_boundary_promotes_to_next_page() {
 /// 1ページより大きい avoid block は無限ループせず通常 split へ fallback。
 ///
 /// Note: `.huge` has splittable children (rows). An empty `<div style="height:
-/// 500pt">` would not exercise the fallback because `BlockPageable::split`
-/// cannot synthesise children out of pure CSS-sized boxes; that is a separate
+/// 500pt">` would not exercise the fallback because block splitting cannot
+/// synthesise children out of pure CSS-sized boxes; that is a separate
 /// concern beyond Task 5's scope.
 #[test]
 fn avoid_block_taller_than_page_falls_back_to_split() {

--- a/crates/fulgur/tests/multicol_span_all.rs
+++ b/crates/fulgur/tests/multicol_span_all.rs
@@ -2,8 +2,8 @@
 //!
 //! Covers the "SpanAll child that itself page-breaks" acceptance case
 //! from the issue. When a `column-span: all` subtree is larger than one
-//! page, the existing BlockPageable pagination must split the full-width
-//! block across pages cleanly — no column structure leaks into the spill.
+//! page, block pagination must split the full-width block across pages
+//! cleanly — no column structure leaks into the spill.
 
 use fulgur::{Engine, PageSize};
 

--- a/crates/fulgur/tests/opacity_visibility_test.rs
+++ b/crates/fulgur/tests/opacity_visibility_test.rs
@@ -125,7 +125,7 @@ fn test_visibility_hidden_preserves_layout() {
 
 /// Regression test: styled inline root with visibility:hidden must hide text.
 /// Exercises the convert.rs path where a ParagraphRender is wrapped in a
-/// BlockPageable for background/border — the inner paragraph must inherit visible.
+/// BlockEntry for background/border — the inner paragraph must inherit visible.
 #[test]
 fn test_visibility_hidden_styled_inline_root() {
     let engine = Engine::builder().page_size(PageSize::A4).build();
@@ -144,8 +144,8 @@ fn test_visibility_hidden_styled_inline_root() {
 }
 
 /// Regression test: list item with visibility:hidden must hide marker and body.
-/// Exercises the convert.rs path where ListItemPageable body is built without
-/// the node's visibility — the body must inherit visible.
+/// Exercises the convert.rs path where the list-item body drawable is built
+/// without the node's visibility — the body must inherit visible.
 #[test]
 fn test_visibility_hidden_list_item() {
     let engine = Engine::builder().page_size(PageSize::A4).build();

--- a/crates/fulgur/tests/page_break_wiring.rs
+++ b/crates/fulgur/tests/page_break_wiring.rs
@@ -1,10 +1,10 @@
 //! Integration tests for CSS page-break-after / page-break-before wiring (fulgur-lje5).
 //!
-//! The split algorithm (`BlockPageable::find_split_point`) now detects forced
-//! breaks at arbitrary nesting depth by recursively calling `split()` on each
-//! child even when the child fits within the available page height. This means
-//! both the 4-div overflow scenario and the simpler 2-div non-overflow scenario
-//! correctly honour `page-break-after: always` / `break-after: page`.
+//! The split algorithm detects forced breaks at arbitrary nesting depth by
+//! recursively descending each child even when the child fits within the
+//! available page height. This means both the 4-div overflow scenario and the
+//! simpler 2-div non-overflow scenario correctly honour
+//! `page-break-after: always` / `break-after: page`.
 
 use fulgur::{Engine, Margin, PageSize};
 

--- a/crates/fulgur/tests/pseudo_only_break_before.rs
+++ b/crates/fulgur/tests/pseudo_only_break_before.rs
@@ -73,7 +73,7 @@ fn pseudo_only_inline_root_honours_break_before_page() {
 
 /// 空の `<div>` (子無し、pseudo 無し、style 無し) に `break-before: page`
 /// が付いた場合、新しいページが生成される。
-/// `convert_node_inner` 内の "Plain leaf node" SpacerPageable fallback を
+/// `convert_node_inner` 内の "Plain leaf node" spacer fallback を
 /// exercise する。
 #[test]
 fn empty_leaf_div_honours_break_before_page() {

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -690,7 +690,7 @@ fn position_fixed_inside_absolute_relayouts_against_viewport() {
     // first Taffy pass collapses Fixed → Absolute and sizes the fixed
     // element against the abs's narrow box. The %PDF byte check only
     // proves engine completion; the structural assertion is the real
-    // regression guard — we walk the Pageable tree, find every
+    // regression guard — we walk the drawable tree, find every
     // out-of-flow `ParagraphRender`, and assert the fixed text laid
     // itself out as a single line. Without `relayout_position_fixed`,
     // Parley shapes the long sentence at the abs's ~37.5pt width and
@@ -1507,7 +1507,7 @@ fn render_v2_smoke_positioned_child_height_field_paths() {
     // and `let pseudo_h_pt = ...` assignments need coverage to satisfy
     // codecov patch threshold. This consolidated render exercises:
     //
-    // - inline_root paragraph wrapped in BlockPageable (inline_root.rs:122 / 187)
+    // - inline_root paragraph wrapped in a block drawable (inline_root.rs:122 / 187)
     // - list_item paragraph + inline marker (list_item.rs:204, 268, 378, 433)
     // - block pseudo `::before` / `::after` images (pseudo.rs:253, 263)
     // - abs-positioned pseudo (positioned.rs:631)

--- a/crates/fulgur/tests/style_test.rs
+++ b/crates/fulgur/tests/style_test.rs
@@ -118,8 +118,8 @@ fn test_overflow_scroll_and_auto_also_clip() {
 fn test_overflow_hidden_on_bare_block_without_visual_style() {
     // Regression for the `needs_block_wrapper` fix: a block with overflow
     // as the only non-default style (no background, no border, no padding,
-    // no radius) must still be wrapped in a BlockPageable so that the clip
-    // path is actually emitted.
+    // no radius) must still be wrapped in a block drawable so that the
+    // clip path is actually emitted.
     let engine = fulgur::engine::Engine::builder()
         .page_size(fulgur::config::PageSize::A4)
         .build();
@@ -146,8 +146,8 @@ fn test_overflow_hidden_on_bare_block_without_visual_style() {
 
 #[test]
 fn test_overflow_hidden_on_table_clips() {
-    // Regression for TablePageable::draw clip wiring: a table with
-    // overflow:hidden must clip its cells to the padding box.
+    // Regression for the table clip wiring: a table with overflow:hidden
+    // must clip its cells to the padding box.
     let engine = fulgur::engine::Engine::builder()
         .page_size(fulgur::config::PageSize::A4)
         .build();

--- a/crates/fulgur/tests/svg_test.rs
+++ b/crates/fulgur/tests/svg_test.rs
@@ -55,9 +55,9 @@ fn test_svg_with_border_and_padding_renders() {
     assert!(plain_pdf.starts_with(b"%PDF"));
 
     // The styled SVG must produce a larger PDF than the plain one because
-    // the BlockPageable wrapping branch adds border strokes and a background
-    // fill on top of the same <rect> content. If the has_visual_style()
-    // branch is ever broken, this assertion will catch it.
+    // the block-wrapping branch adds border strokes and a background fill
+    // on top of the same <rect> content. If the has_visual_style() branch
+    // is ever broken, this assertion will catch it.
     assert!(
         styled_pdf.len() > plain_pdf.len(),
         "styled SVG PDF ({} bytes) must exceed plain SVG PDF ({} bytes) \

--- a/crates/fulgur/tests/transform_integration.rs
+++ b/crates/fulgur/tests/transform_integration.rs
@@ -29,9 +29,9 @@ fn entry_from(html: &str) -> TransformEntry {
     first_transform(&drawables).expect("expected a TransformEntry in Drawables")
 }
 
-/// Reproduces the v1 `TransformWrapperPageable::effective_matrix(draw_x, draw_y)`
-/// composition: translate the origin into the draw frame, conjugate the
-/// raw matrix by it, so rotation / scale happen around the chosen origin.
+/// Composes the effective transform matrix for a given draw origin:
+/// translate the origin into the draw frame, conjugate the raw matrix
+/// by it, so rotation / scale happen around the chosen origin.
 fn effective_matrix(entry: &TransformEntry, draw_x: f32, draw_y: f32) -> Affine2D {
     let ox = draw_x + entry.origin.x.to_f32();
     let oy = draw_y + entry.origin.y.to_f32();

--- a/crates/fulgur/tests/unit_semantics.rs
+++ b/crates/fulgur/tests/unit_semantics.rs
@@ -1,6 +1,6 @@
 //! Integration smoke tests confirming the renderer produces a non-empty PDF
 //! for a variety of CSS length units. Precise geometric assertions live in
-//! `convert::unit_oracle_tests` where the Pageable tree is inspectable.
+//! `convert::unit_oracle_tests` where the drawable tree is inspectable.
 
 use fulgur::Engine;
 

--- a/docs/plans/2026-07-12-fulgur-97xz-pageable-comment-cleanup.md
+++ b/docs/plans/2026-07-12-fulgur-97xz-pageable-comment-cleanup.md
@@ -1,0 +1,261 @@
+# fulgur-97xz: Pageable Comment Cleanup Plan
+
+**Goal:** Pageable v1 アーキテクチャ廃止後の残存参照コメント 128 箇所 / 27 ファイルを `crates/fulgur/{src,tests}/` から一掃する。behavior 変更なし、byte-identical。
+
+**Approach:** 5 モジュール束の PR に分割し、小→大の順で実行 (低リスク PR を先に流通させ、判断コスト高な `render.rs` (42) / `pagination_layout.rs` (29) は後半に集約)。各 PR は独立してレビュー可能、全 PR 共通の分類プロトコルを適用。
+
+**Doc-comment (doctest) 対策:** `///` および `//!` の doc comment 内にも Pageable 参照あり (`drawables.rs` の module doc、`pagination_layout.rs` の複数箇所、`tests/opacity_visibility_test.rs`)。全 PR で `cargo test --doc` を検証に追加する。
+
+**関連:** beads fulgur-97xz (design/acceptance 保存済)、前提: fulgur-4cbc (Pageable 廃止)。
+
+---
+
+## 分類プロトコル (全 PR 共通)
+
+各コメントに対し 1 回だけ判定し、以下いずれかに割り当てる。
+
+### Category 1: Pure v1 parity comment → **削除**
+
+対象消滅で意味を失った comment。他モジュール参照の parity 説明が典型。
+
+```rust
+// Before
+// Mirrors BlockPageable::draw ordering at pageable.rs:412
+draw_background(...);
+
+// After
+draw_background(...);
+```
+
+### Category 2: v1→v2 移行進行中前提 → **削除 or 現状表現に書き換え**
+
+移行過渡期の TODO / plan コメント。現在は移行完了しているので削除、または現状事実に書き換え。
+
+```rust
+// Before
+// TODO: migrate one Pageable type at a time and the dispatcher grows
+fn render_v2(...) { ... }
+
+// After
+fn render_v2(...) { ... }
+```
+
+### Category 3: v1 順序制約が behavior の WHY → **CSS spec / 不変式に書き換え**
+
+順序や不変式の理由を語るコメントは残す価値がある。参照先を v1 Pageable/pageable.rs ではなく CSS spec または不変式そのものに差し替える。深追いはしない (1-2 行で十分)。
+
+```rust
+// Before
+// v1's BlockPageable::draw paints outside the clip (pageable.rs:1796-1827),
+// then pushes the clip path, then dispatches self's inner content.
+draw_background(...);
+draw_borders(...);
+push_clip(...);
+draw_content(...);
+
+// After
+// Paint bg/border outside the clip, then push clip, then dispatch contents
+// (overflow: hidden/clip painting order per CSS 2.1 §11.1.1).
+draw_background(...);
+draw_borders(...);
+push_clip(...);
+draw_content(...);
+```
+
+**render.rs の Cat 3 典型パターン** (先行サンプル):
+
+- `v1's BlockPageable::draw for root paints bg on EVERY page` → `Root <html>/<body> background repeats per page (CSS Paged Media §5.4).`
+- `Mirrors BookmarkMarkerWrapperPageable's is_first_page_for slice semantics` → `Emit bookmark on the page where the node's first fragment lands.`
+- `MulticolRulePageable::draw runs AFTER child.draw` → `Column rules paint after column content (CSS Multi-column §4.5).`
+- `Mirrors v1's nested TransformWrapperPageable::draw call chain` → `Nested transforms compose right-to-left; each level pushes its own matrix (CSS Transforms §11).`
+
+**pagination_layout.rs の Cat 3 典型パターン**:
+
+- `Pageable accumulates pc.y + child_h during convert; fragmenter must match` → `Include child margin gaps in body's normal-flow height (CSS 2.1 §10.6.3).`
+- `Pageable's total_height > page_height override at pageable.rs:1165` → `break-inside: avoid is overridden when subtree is oversized (CSS Fragmentation §4.2).`
+
+### 判定に迷ったら
+
+- **Category 1 に倒す** (削除)。読み手のノイズを減らす方が優先。
+- WHY を語り直す価値があるか自信が持てない comment は削除。
+
+---
+
+## 全 PR 共通の検証
+
+各 PR 完成後、以下を全部通す。
+
+```bash
+cargo build --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test -p fulgur --lib
+cargo test -p fulgur --tests
+cargo test -p fulgur --doc
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" cargo test -p fulgur-vrt
+cargo fmt --check
+```
+
+**VRT が byte-identical であること** が最重要 tripwire。コメントは compile 時に stripped されるので PDF 出力を変えることは技術的に不可能 → VRT に差分が出た場合、subagent がコード行を触った or doc comment 内の ```rust コード塊を破壊したことを意味する。
+
+**手動 diff 確認**: 各 PR で `git diff main --stat` と該当ファイルの `git diff main` を目視し、コメント/doc 行のみ変更されていることを確認する (2-stage adversarial review は skip、diff は trivially eyeballable)。
+
+---
+
+## PR 1: orchestration + tests + misc
+
+**Branch:** `task/fulgur-97xz-pageable-1-misc` (このブランチで作業中)
+
+**Files (33 箇所):**
+
+```text
+crates/fulgur/src/engine.rs                  (4)
+crates/fulgur/src/blitz_adapter.rs           (3)
+crates/fulgur/src/gcpm/string_set.rs         (2)
+crates/fulgur/src/svg.rs                     (1)
+crates/fulgur/src/image.rs                   (1)
+crates/fulgur/src/draw_primitives.rs         (1)
+crates/fulgur/src/column_css.rs              (1)
+crates/fulgur/tests/abs_positioned_pagination.rs (5)
+crates/fulgur/tests/style_test.rs            (2)
+crates/fulgur/tests/render_smoke.rs          (2)
+crates/fulgur/tests/opacity_visibility_test.rs (2)
+crates/fulgur/tests/unit_semantics.rs        (1)
+crates/fulgur/tests/transform_integration.rs (1)
+crates/fulgur/tests/svg_test.rs              (1)
+crates/fulgur/tests/pseudo_only_break_before.rs (1)
+crates/fulgur/tests/page_break_wiring.rs     (1)
+crates/fulgur/tests/multicol_span_all.rs     (1)
+crates/fulgur/tests/break_inside_avoid.rs    (1)
+```
+
+**手順:**
+
+1. `rg -n 'Pageable\b' <file>` で各ファイルの該当行を出す
+2. 上下 3 行の context を読んで Category 1/2/3 を判定
+3. Category 1/2 は削除、Category 3 は書き換え
+4. 全ファイル処理後、`rg 'Pageable\b' crates/fulgur/src crates/fulgur/tests` で **0 件** を確認
+5. 検証コマンド全部通す
+6. commit
+7. PR 作成 (`gh pr create`, base: main)
+
+**コミットメッセージ:**
+
+```text
+chore(comments): remove Pageable v1 references (orchestration + tests + misc)
+
+fulgur-97xz PR 1/5. Removes 33 historical comments referencing the
+removed v1 Pageable architecture (fulgur-4cbc) across engine, adapter,
+misc render helpers, and integration tests. Behavior byte-identical
+(VRT green).
+```
+
+---
+
+## PR 2: convert bundle
+
+**Branch base:** main (`git checkout main && git pull && git checkout -b task/fulgur-97xz-pageable-2-convert`)
+
+**Files (10 箇所):**
+
+```text
+crates/fulgur/src/convert/mod.rs          (4)
+crates/fulgur/src/convert/inline_root.rs  (4)
+crates/fulgur/src/convert/list_marker.rs  (1)
+crates/fulgur/src/convert/block.rs        (1)
+```
+
+**手順:** PR 1 と同じ (分類 → 削除/書き換え → 検証 → commit → PR)。
+
+**コミットメッセージ:**
+
+```text
+chore(comments): remove Pageable v1 references (convert bundle)
+
+fulgur-97xz PR 2/5. Removes 10 historical comments in convert/*
+referencing the removed v1 Pageable architecture. Behavior
+byte-identical.
+```
+
+---
+
+## PR 3: draw path bundle
+
+**Branch base:** main (`git checkout main && git pull && git checkout -b task/fulgur-97xz-pageable-3-draw`)
+
+**Files (16 箇所):**
+
+```text
+crates/fulgur/src/drawables.rs        (7)
+crates/fulgur/src/paragraph.rs        (5)
+crates/fulgur/src/multicol_layout.rs  (4)
+```
+
+**手順:** PR 1 と同じ。
+
+**コミットメッセージ:**
+
+```text
+chore(comments): remove Pageable v1 references (draw path bundle)
+
+fulgur-97xz PR 3/5. Removes 16 historical comments in drawables /
+paragraph / multicol_layout referencing the removed v1 Pageable
+architecture. Behavior byte-identical.
+```
+
+---
+
+## PR 4: pagination bundle
+
+**Branch base:** main (`git checkout main && git pull && git checkout -b task/fulgur-97xz-pageable-4-pagination`)
+
+**Files (29 箇所):**
+
+```text
+crates/fulgur/src/pagination_layout.rs  (29)
+```
+
+**手順:** PR 1 と同じ。pagination_layout.rs は v2 パスの本体なので、Category 3 (WHY を語り直す) の comment が多めに残る想定。CSS spec 参照 (fragmentation §3, §4 系) を活用。
+
+**コミットメッセージ:**
+
+```text
+chore(comments): remove Pageable v1 references (pagination_layout)
+
+fulgur-97xz PR 4/5. Removes/rewrites 29 historical comments in
+pagination_layout.rs referencing the removed v1 Pageable architecture.
+CSS Fragmentation spec references replace v1 parity notes where the
+"why" is still worth stating. Behavior byte-identical.
+```
+
+---
+
+## PR 5: render bundle
+
+**Branch base:** main (`git checkout main && git pull && git checkout -b task/fulgur-97xz-pageable-5-render`)
+
+**Files (42 箇所):**
+
+```text
+crates/fulgur/src/render.rs  (42)
+```
+
+**手順:** PR 1 と同じ。render.rs は draw 順序制約の説明が多いため Category 3 が支配的な想定。
+
+**コミットメッセージ:**
+
+```text
+chore(comments): remove Pageable v1 references (render)
+
+fulgur-97xz PR 5/5. Removes/rewrites 42 historical comments in
+render.rs referencing the removed v1 Pageable architecture. CSS 2.1
+painting-order references replace v1 parity notes. Behavior
+byte-identical. Closes fulgur-97xz.
+```
+
+---
+
+## 完了判定
+
+- `rg 'Pageable\b' crates/fulgur/src crates/fulgur/tests` が 0 件
+- 5 PR 全て merge 済 (main で `rg 'Pageable\b' crates/fulgur/src crates/fulgur/tests` = 0 件を確認)
+- fulgur-97xz を `bd close` で閉じる (PR 5 の commit message に "Closes fulgur-97xz" を含める)


### PR DESCRIPTION
## 概要

fulgur-97xz PR 1/5。Pageable v1 アーキテクチャ廃止 (fulgur-4cbc / paginate.rs 削除) 後の残存コメント 128 箇所 / 27 ファイルを 5 PR に分けてクリーンアップする作業の 1st。

この PR は **orchestration + tests + misc** 束を担当:

- `crates/fulgur/src/`: `engine.rs`, `blitz_adapter.rs`, `gcpm/string_set.rs`, `svg.rs`, `image.rs`, `draw_primitives.rs`, `column_css.rs`
- `crates/fulgur/tests/`: `abs_positioned_pagination.rs`, `style_test.rs`, `render_smoke.rs`, `opacity_visibility_test.rs`, `unit_semantics.rs`, `transform_integration.rs`, `svg_test.rs`, `pseudo_only_break_before.rs`, `page_break_wiring.rs`, `multicol_span_all.rs`, `break_inside_avoid.rs`

## 分類プロトコル

各コメントを 3 分類でトリアージ:

1. **Cat 1 (Pure v1 parity)** → 削除
2. **Cat 2 (Migration-in-progress)** → 削除 / 現状表現に書き換え
3. **Cat 3 (v1 順序制約が behavior の WHY)** → CSS spec 参照 / 不変式に書き換え

この PR は Cat 2 支配 (32/33) + Cat 3 が 1 件 (`abs_positioned_pagination.rs` の block child ordering の WHY を保持)。

## 変更内容の代表例

- `engine.rs`: "Convert DOM to Pageable" → "Convert DOM to Drawables" (section header)、"diverge from Pageable" / "Pageable does the same in render.rs:283-291" などの parity 説明を削除、シングル解決の WHY だけ残存
- `column_css.rs`: 移行中の "Task 2 wires... Task 5 will consume..." パラグラフを削除 (Task は完了、dead_code 属性も残っていない)
- `abs_positioned_pagination.rs`: doc comment 内の `Pageable tree` / `BlockPageable` を `drawable tree` / `BlockEntry` に更新、WHY (in-flow-then-OOF ordering が split_y を壊す regression) を保持

## 検証

behavior 変更なし、コメントのみ:

- \`cargo build --workspace\` clean
- \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- \`cargo test -p fulgur --lib\` 1678/1678 pass
- \`cargo test -p fulgur --tests\` 2098/2098 pass
- \`cargo test -p fulgur --doc\` 3/3 pass
- \`FONTCONFIG_FILE=... cargo test -p fulgur-vrt\` **byte-identical (goldens 変更なし)**
- \`cargo fmt --check\` clean

## 残り

PR 2/5 (convert bundle) → PR 3/5 (draw path) → PR 4/5 (pagination_layout.rs 29) → PR 5/5 (render.rs 42、closes fulgur-97xz)。

## 関連

- beads: fulgur-97xz
- 前提: fulgur-4cbc (Pageable 廃止)