### PR TITLE
chore(comments): remove Pageable v1 references (PR 2/5: convert bundle)

### DIFF
--- a/crates/fulgur/src/convert/block.rs
+++ b/crates/fulgur/src/convert/block.rs
@@ -47,11 +47,10 @@ pub(super) fn convert(
     let opacity_scope = !clipping && opacity < 1.0;
     let mark = (clipping || opacity_scope).then(|| out.draw_mark());
 
-    // Always insert the block entry — the v2 dispatcher silently no-ops
+    // Always insert the block entry — the dispatcher silently no-ops
     // when neither paint nor clip nor opacity applies, so leaving an
     // unstyled entry costs nothing and keeps abs/fixed descendants able
-    // to look up their CB at render time. Mirrors v1's behavior of
-    // always emitting a `BlockPageable` for container nodes.
+    // to look up their CB at render time.
     insert_block_entry(node, style, width, height, out);
 
     // Walk in-flow children.

--- a/crates/fulgur/src/convert/inline_root.rs
+++ b/crates/fulgur/src/convert/inline_root.rs
@@ -28,18 +28,14 @@ pub(super) fn try_convert(
     }
     let (width, height) = size_in_pt(node.final_layout.size);
 
-    // PR 8i: snapshot taken BEFORE `extract_paragraph` because the latter
+    // Snapshot must be taken BEFORE `extract_paragraph` because the latter
     // recurses into inline-box children (registering their drawable
-    // entries into `out`). Pre-PR-8i, `extract_drawables_from_pageable`
-    // walked the v1 `BlockPageable` subtree and collected every nested
-    // node into `clip_descendants`/`opacity_descendants`; placing the
-    // snapshot after `extract_paragraph` would miss those exact nodes.
-    // The `id != node_id` filter on the diff drops the inline-root's
-    // own id from the descendant list; nested inline-box subtree
-    // members are intentionally NOT filtered against
-    // `inline_box_subtree_skip` so the render path's
-    // `draw_under_clip` re-dispatches them inside the clip group —
-    // mirroring the v1 ordering the golden PDFs encode.
+    // entries into `out`); placing the snapshot after would miss those
+    // exact nodes in the `clip_descendants`/`opacity_descendants` diff.
+    // The `id != node_id` filter drops the inline-root's own id from the
+    // descendant list; nested inline-box subtree members are intentionally
+    // NOT filtered against `inline_box_subtree_skip` so the render path's
+    // `draw_under_clip` re-dispatches them inside the clip group.
     let style = extract_block_style(node, ctx.assets);
     let (opacity, visible) = extract_opacity_visible(node);
     let needs_block_pre = style.needs_block_wrapper()
@@ -338,13 +334,12 @@ pub(super) fn inline_box_baseline_offset_from_drawables(
 }
 
 /// Recursive worker for `inline_box_baseline_offset_from_drawables`.
-/// Mirrors the pre-PR-8i `pageable_last_baseline` walk over
-/// `BlockPageable.children` in REVERSE — except the children list is
-/// derived from `node.layout_children` / `node.children` (Taffy DOM)
-/// instead of the Pageable tree. `top_inset` of each container adds its
-/// own `border-top + padding-top`; child layout `location.y` adds the
-/// child's offset within the container; the recursive call returns the
-/// inner baseline relative to the child's top edge.
+/// Walks the block's child list in REVERSE, deriving children from
+/// `node.layout_children` / `node.children` (Taffy DOM). `top_inset` of
+/// each container adds its own `border-top + padding-top`; child layout
+/// `location.y` adds the child's offset within the container; the
+/// recursive call returns the inner baseline relative to the child's top
+/// edge.
 fn pageable_last_baseline_from_drawables(
     doc: &BaseDocument,
     out: &crate::drawables::Drawables,
@@ -366,8 +361,7 @@ fn pageable_last_baseline_from_drawables(
             return Some(top_inset + line.baseline);
         }
     }
-    // 2) Otherwise walk DOM children in REVERSE, mirroring v1's
-    //    `BlockPageable::children.iter().rev()` search. Use Blitz's
+    // 2) Otherwise walk DOM children in REVERSE. Use Blitz's
     //    `layout_children` when available so anonymous block wrappers
     //    around inline-level siblings are visited correctly.
     let node = doc.get_node(node_id)?;

--- a/crates/fulgur/src/convert/list_marker.rs
+++ b/crates/fulgur/src/convert/list_marker.rs
@@ -197,8 +197,8 @@ pub(super) fn extract_marker_lines(
                 let font_ref = run.font();
                 let font_index = font_ref.index;
                 let font_arc = ctx.get_or_insert_font(font_ref);
-                // Parley reports font size in CSS px; the Pageable tree is
-                // in pt. See `extract_paragraph` for the matching
+                // Parley reports font size in CSS px; Drawables / Krilla
+                // consume pt. See `extract_paragraph` for the matching
                 // conversion. Glyph ratios stay unitless by dividing by
                 // the original parley value.
                 let font_size_parley = run.font_size();

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -1,12 +1,9 @@
 //! Convert a Blitz DOM (after style resolution + layout) into a `Drawables`
-//! struct holding per-NodeId draw payload (Phase 4 PR 8i).
+//! struct holding per-NodeId draw payload.
 //!
-//! Phase 4 PR 8i replaced the previous "build a Pageable tree, then walk it
-//! to extract Drawables" scaffold with a single DOM walk that writes
-//! directly into `Drawables`'s per-NodeId maps. The intermediate Pageable
-//! tree (and the orphan-marker / wrapper machinery that supported it) is
-//! gone; bookmark / string-set / counter-op / running-element side-channels
-//! are read from their respective stores by the fragmenter and render pass
+//! A single DOM walk writes directly into `Drawables`'s per-NodeId maps.
+//! Bookmark / string-set / counter-op / running-element side-channels are
+//! read from their respective stores by the fragmenter and render pass
 //! independently.
 
 use crate::asset::AssetBundle;
@@ -660,8 +657,8 @@ fn record_multicol_rule(
 /// For every `ParagraphSplitEntry` recorded by `multicol_layout` against
 /// this container, materialise one `ParagraphSlice` per non-empty column.
 /// Each slice carries `Vec<ShapedLine>` rebased to the slice's own top
-/// edge, mirroring the `ParagraphPageable::split` convention used for
-/// continuation fragments after a page break (commit 9c0e092).
+/// edge, using the same rebase convention as continuation fragments after
+/// a page break (commit 9c0e092).
 ///
 /// Two source-layout sources, distinguished by whether
 /// `source_node_id == node_id`:
@@ -786,8 +783,8 @@ fn convert_multicol_paragraph_slices(
                 }
 
                 // Rebase per-line baselines into slice-local space.
-                // This mirrors `ParagraphPageable::split`'s rebase for
-                // continuation fragments (commit 9c0e092):
+                // Same rebase used for continuation fragments after a page
+                // break (commit 9c0e092):
                 //
                 // 1. `line.baseline -= consumed` shifts each line's
                 //    baseline from parley-layout space (paragraph top →


### PR DESCRIPTION
## 概要

fulgur-97xz PR 2/5。Pageable v1 コメント整理シリーズの convert 束を担当。

- `crates/fulgur/src/convert/`: `mod.rs`, `inline_root.rs`, `list_marker.rs`, `block.rs`
- 4 files, 9 comment sites (10 rg hits) 整理

## 内訳

- Cat 2 (migration-in-progress): 8 sites — task-doc の Task 番号参照、v1→v2 移行時のコメントを削除 or 現状表現に書き換え
- Cat 3 (WHY 保持): 1 site — `list_marker.rs:200` の CSS px vs PDF pt 変換の WHY。`Pageable tree is in pt` → `Drawables / Krilla consume pt` に更新 (現行 v2 パイプラインの終端を反映)
- Cat 1: 0

## 前提

PR 1 (#625) と独立。base は main。この PR は `convert/` 配下のみに閉じる。残り 3 PR (draw path / pagination / render) は main から独立して cut 予定。

## 検証

コメントのみ:

- \`cargo build --workspace\` clean
- \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- \`cargo test -p fulgur --lib\` 1678/1678 pass
- \`cargo test -p fulgur --tests\` 2098/2098 pass
- \`cargo test -p fulgur --doc\` 3/3 pass
- \`FONTCONFIG_FILE=... cargo test -p fulgur-vrt\` **byte-identical**
- \`cargo fmt --check\` clean

## Follow-up (別 issue 候補)

`inline_root.rs:348` の `pageable_last_baseline_from_drawables` 関数名は lowercase `pageable_` prefix が v1 型の名残 (シンボル、コメントではない)。関数は現在 Drawables を操作するので prefix が不整合だが、この PR は comment-only scope なので rename は別枠。

## 関連

- beads: fulgur-97xz
- 前提: fulgur-4cbc (Pageable 廃止)