### PR TITLE
chore(comments): remove Pageable v1 references (PR 3/5: draw path bundle)

### DIFF
--- a/crates/fulgur/src/drawables.rs
+++ b/crates/fulgur/src/drawables.rs
@@ -1,26 +1,9 @@
-//! Phase 4 (fulgur-9t3z): node-keyed side-channel maps that replace the
-//! `Pageable` trait + 17 impls.
-//!
-//! `Drawables` is the data shape that `convert::dom_to_drawables` produces
-//! and `render::render_v2` consumes. Each map holds per-NodeId state for
-//! one draw concern (background, paragraph, image, etc.). The render path
-//! walks `pagination_layout::PaginationGeometryTable` per page and looks
-//! up the node's data in the appropriate map — no trait dispatch, no
+//! Data shape produced by `convert::dom_to_drawables` and consumed by
+//! `render::render_v2`; each map holds per-NodeId state for one draw
+//! concern (background, paragraph, image, etc.). The render path walks
+//! `pagination_layout::PaginationGeometryTable` per page and looks up
+//! the node's data in the appropriate map — no trait dispatch, no
 //! central `DrawOp` enum.
-//!
-//! See `docs/plans/2026-04-30-phase4-design.md` for the full design.
-//!
-//! ## PR sequence note
-//!
-//! This struct is introduced in PR 1 with empty placeholder fields. Each
-//! subsequent PR replaces one placeholder with the real data type:
-//!
-//! - PR 2: `images`, `svgs`, plus the five marker types collapse into
-//!   `bookmark_anchors` (the rest are deleted from the draw path).
-//! - PR 3: `paragraphs`.
-//! - PR 4: `block_styles`.
-//! - PR 5: `tables`, `list_items`.
-//! - PR 6: `transforms`, `multicol_rules`, plus marker wrappers vanish.
 
 use std::collections::BTreeMap;
 
@@ -128,17 +111,10 @@ pub struct DrawMark {
     list_items: usize,
 }
 
-// ── Placeholder entry types ──────────────────────────────────────────
-//
-// Each PR in the Phase 4 sequence replaces one of these with the real
-// per-node data extracted from convert. The placeholder is empty so that
-// the `Drawables` struct compiles before any draw migration starts; the
-// shadow harness can already exercise the pipeline plumbing.
+// ── Entry types ──────────────────────────────────────────────────────
 
-/// Block draw payload for v2. Mirrors the fields `BlockPageable`
-/// holds for paint dispatch — backgrounds, borders, box-shadow,
-/// overflow clip, opacity, and the anchor id used by
-/// `DestinationRegistry`.
+/// Block draw payload: backgrounds, borders, box-shadow, overflow clip,
+/// opacity, and the anchor id used by `DestinationRegistry`.
 #[derive(Debug, Clone)]
 pub struct BlockEntry {
     pub style: crate::draw_primitives::BlockStyle,
@@ -167,12 +143,12 @@ pub struct BlockEntry {
     /// `draw_under_clip` already wraps its descendants in
     /// `draw_with_opacity` so the dual case is covered there).
     ///
-    /// Mirrors v1's `BlockPageable::draw` ordering: opacity wraps
-    /// EVERYTHING — bg/border/shadow + descendants — so a
+    /// CSS `opacity` semantics: the block's opacity wraps EVERYTHING —
+    /// bg / border / shadow + descendants — so a
     /// `<div style="opacity:0.4"><svg>..</svg></div>` produces a
-    /// single transparency group. v2's flat dispatch without this
-    /// scope tracking would emit the svg outside the parent's
-    /// opacity wrap, dropping the parent's opacity from the svg.
+    /// single transparency group. `render_v2`'s flat dispatch would
+    /// otherwise emit the svg outside the parent's opacity wrap and
+    /// drop the parent's opacity from the svg.
     pub opacity_descendants: Vec<NodeId>,
 }
 
@@ -330,9 +306,9 @@ pub struct ColumnRuleGeometry {
 }
 
 /// Multicol column-rule paint spec + per-column-group geometry.
-/// Mirrors the fields `MulticolRulePageable` carries — render at the
-/// container's location after children paint, partitioning `groups`
-/// per page based on the container's fragment cumulative heights.
+/// Rendered at the container's location after children paint,
+/// partitioning `groups` per page based on the container's fragment
+/// cumulative heights.
 #[derive(Debug, Clone)]
 pub struct MulticolRuleEntry {
     pub rule: crate::column_css::ColumnRuleSpec,
@@ -343,8 +319,8 @@ pub struct MulticolRuleEntry {
 /// container. Built from `multicol_layout::ParagraphSplitEntry`. The
 /// per-slice `lines` are pre-rebased so each slice's first line has
 /// `baseline = ascent` (i.e. `y=0` is the slice's top edge), matching
-/// the rebase convention `paragraph::ParagraphPageable::split` uses
-/// for second fragments after a page-break (see commit 9c0e092).
+/// the baseline-rebase convention used for second fragments after a
+/// page-break (see commit 9c0e092).
 #[derive(Debug, Clone, Default)]
 pub struct ParagraphSlicesEntry {
     /// Multicol container's NodeId. `render_v2` looks up the
@@ -384,11 +360,11 @@ impl std::fmt::Debug for ParagraphSlice {
 
 /// CSS transform matrix + origin for a node (and its descendants).
 ///
-/// Mirrors `TransformWrapperPageable`. v1 pushes the surface transform
-/// before drawing `inner.draw(...)` and pops after; v2's flat dispatch
-/// emulates this by recording every descendant `node_id` of the wrapper
-/// at convert time so the render loop can dispatch the wrapper's own
-/// payload + every descendant inside one push/pop pair.
+/// `render_v2`'s flat dispatch loop has no implicit scope: to keep the
+/// transform in effect for every descendant fragment, convert records
+/// every descendant `node_id` of the wrapper here so the render loop
+/// can dispatch the wrapper's own payload + every descendant inside
+/// one push/pop pair.
 #[derive(Debug, Clone)]
 pub struct TransformEntry {
     pub matrix: crate::draw_primitives::Affine2D,
@@ -421,10 +397,6 @@ pub struct LinkSpanEntry;
 // ── Drawables ─────────────────────────────────────────────────────────
 
 /// Node-keyed side-channel maps consumed by `render::render_v2`.
-///
-/// Phase 4 PR 1 ships this with all maps empty — the v2 render path
-/// walks geometry but emits no content for any node. Subsequent PRs
-/// fill each map by migrating one Pageable type at a time.
 #[derive(Debug, Clone)]
 pub struct Drawables {
     /// `body_layout.location.x/y` in pt. Captures the html → body

--- a/crates/fulgur/src/multicol_layout.rs
+++ b/crates/fulgur/src/multicol_layout.rs
@@ -65,10 +65,10 @@ pub struct ParagraphSplitEntry {
 /// Per-`ColumnGroup` geometry recorded by the Taffy multicol hook.
 ///
 /// `layout_column_group` builds one of these every time it balances a run of
-/// columnar children. Consumers (Task 4's `MulticolRulePageable`) use the
-/// geometry to paint `column-rule` lines between adjacent non-empty columns
-/// without re-running layout: the rule at gutter `i ↔ i+1` starts at
-/// `y_offset` and extends `min(col_heights[i], col_heights[i+1])` downward.
+/// columnar children. Consumers use the geometry to paint `column-rule`
+/// lines between adjacent non-empty columns without re-running layout: the
+/// rule at gutter `i ↔ i+1` starts at `y_offset` and extends
+/// `min(col_heights[i], col_heights[i+1])` downward.
 ///
 /// Conventions:
 ///
@@ -79,8 +79,8 @@ pub struct ParagraphSplitEntry {
 /// - `col_w` and `gap` are in CSS pixels (Taffy's native unit), matching the
 ///   rest of the multicol hook.
 /// - `x_offset` / `y_offset` are relative to the multicol container's
-///   **border-box** top-left (same frame as `BlockPageable::draw`'s `x, y`
-///   args). They already include the container's own padding + border.
+///   **border-box** top-left. They already include the container's own
+///   padding + border.
 #[derive(Clone, Debug, Default)]
 pub struct ColumnGroupGeometry {
     /// Horizontal offset from the container's border-box left to column 0's
@@ -713,19 +713,19 @@ pub fn compute_multicol_layout(
     }
 
     // Shift each recorded group geometry into the same border-box frame so
-    // `MulticolRulePageable::draw` (which receives `x, y` at the container's
-    // border-box origin) can use `group.x_offset + col_x_math` and
-    // `group.y_offset` directly without reapplying the container's padding.
+    // downstream column-rule rendering (which receives `x, y` at the
+    // container's border-box origin) can use `group.x_offset + col_x_math`
+    // and `group.y_offset` directly without reapplying the container's padding.
     for group in group_geometries.iter_mut() {
         group.x_offset = inset_left.as_px();
         group.y_offset += inset_top.as_px();
     }
 
-    // Stash the per-container geometry for downstream consumers (Task 4's
-    // `MulticolRulePageable`). We intentionally record the entry even when
-    // the container produced no column groups (all `SpanAll`, or entirely
-    // empty) — the presence of the key lets convert-side code distinguish
-    // "layout hook ran but found nothing balanceable" from "hook never ran".
+    // Stash the per-container geometry for downstream consumers. We
+    // intentionally record the entry even when the container produced no
+    // column groups (all `SpanAll`, or entirely empty) — the presence of the
+    // key lets convert-side code distinguish "layout hook ran but found
+    // nothing balanceable" from "hook never ran".
     tree.geometry.insert(
         usize::from(node_id),
         MulticolGeometry {

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -197,10 +197,10 @@ pub struct ParagraphRender {
     /// HTML `id` attribute of the inline-root element this paragraph was
     /// extracted from. Used by `DestinationRegistry` to resolve `#anchor`
     /// links targeting headings (`<h1 id=..>`) and similar inline-root
-    /// elements that do not gain a `BlockPageable` wrapper.
+    /// elements that do not carry a `BlockEntry`.
     pub id: Option<Arc<String>>,
     /// fulgur-r6we (Phase 3.2.a): DOM NodeId for `slice_for_page`
-    /// geometry lookup. See `BlockPageable::node_id`.
+    /// geometry lookup.
     pub node_id: Option<usize>,
 }
 
@@ -546,9 +546,8 @@ fn draw_line_decorations(
 /// PR 8g: render-side context that lets `draw_shaped_lines` dispatch
 /// inline-box content (`LineItem::InlineBox`) through the v2 dispatcher.
 ///
-/// `None` is passed by the list-item marker text render paths
-/// (`ListItemPageable::draw` in `pageable.rs` and
-/// `render::draw_list_item_marker`), because marker line streams only
+/// `None` is passed by the list-item marker text render path
+/// (`render::draw_list_item_marker`), because marker line streams only
 /// contain Text / Image items — never `LineItem::InlineBox` — and
 /// therefore have no inline-box children to dispatch.
 ///
@@ -1815,15 +1814,6 @@ mod link_span_tests {
         );
     }
 }
-
-// `link_collect_tests` was removed in PR 8i: it exercised the v1
-// `Pageable::draw` path with a `LinkCollector` that the v2 dispatcher
-// supersedes. The behaviour those tests pinned (link annotation
-// emission, dedup across glyph runs, inline-box rect emission) is now
-// covered end-to-end by `crates/fulgur/tests/inline_box_render_test.rs`
-// (PDF byte / `/Link` substring assertions) and the VRT byte-identical
-// fixtures. The Pageable trait + `LinkCollector` are slated for full
-// removal in PR 8j.
 
 #[cfg(test)]
 mod text_decoration_tests {


### PR DESCRIPTION
## 概要

fulgur-97xz PR 3/5。draw path 束 (drawables / paragraph / multicol_layout) の Pageable v1 コメント 16 箇所を整理。

- `crates/fulgur/src/drawables.rs` (7)
- `crates/fulgur/src/paragraph.rs` (5)
- `crates/fulgur/src/multicol_layout.rs` (4)

## 内訳

- Cat 2: 13 — 完了した Phase 4 移行の "PR sequence note" ブロック削除、placeholder コメントを実型を反映した表現に、Task 番号参照を削除
- Cat 3: 3 — 実 CSS/architectural WHY を保持
  - `BlockEntry.opacity_descendants`: opacity semantics (single transparency group wraps everything) を v1 型名なしで説明
  - `ParagraphSlicesEntry` の baseline-rebase convention (継続 fragment 用、commit 9c0e092 anchor 保持)
  - `TransformEntry.descendants` の flat-dispatch 不変式
- Cat 1: 0

## 前提

PR 1 (#625) / PR 2 (#626) と独立。base は main。

## 検証

コメント / doc comment のみ:

- \`cargo build --workspace\` clean
- \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- \`cargo test -p fulgur --lib\` 1678/1678 pass
- \`cargo test -p fulgur --tests\` 2098/2098 pass
- \`cargo test -p fulgur --doc\` 3/3 pass (drawables.rs module doc 書き換え含む)
- \`FONTCONFIG_FILE=... cargo test -p fulgur-vrt\` **byte-identical**
- \`cargo fmt --check\` clean

## 関連

- beads: fulgur-97xz
- 前提: fulgur-4cbc (Pageable 廃止)