### PR TITLE
test(gcpm/parser): add coverage for prelude error paths, page-size edge cases, and target-url failures

### DIFF
--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -3259,4 +3259,117 @@ mod tests {
         assert!(ctx.cleaned_css.contains("body { color: red; }"));
         assert!(ctx.cleaned_css.contains("p { margin: 0; }"));
     }
+
+    // --- prelude error paths (lines 148-149, 164, 190-191) ---
+
+    #[test]
+    fn test_selector_delimiter_first_token_is_skipped() {
+        // A delimiter like `>` as the first token in a rule is not a
+        // recognised simple selector; the block must be drained and the rule
+        // silently ignored (lines 148-149 of prelude parser).
+        let ctx = parse_gcpm("> p { position: running(header); }");
+        assert!(ctx.running_mappings.is_empty());
+    }
+
+    #[test]
+    fn test_unknown_pseudo_element_is_not_registered() {
+        // `::first-line` is a valid CSS pseudo-element but is not mapped to
+        // Before/After, so the rule should be ignored (line 164).
+        let ctx = parse_gcpm("h1::first-line { position: running(header); }");
+        assert!(ctx.running_mappings.is_empty());
+    }
+
+    #[test]
+    fn test_compound_selector_block_is_drained() {
+        // `.foo.bar` is a compound selector — our parser only handles simple
+        // selectors. When the prelude returns None, the block must be drained
+        // and the rule ignored (lines 190-191).
+        let ctx = parse_gcpm(".foo.bar { position: running(header); }");
+        assert!(ctx.running_mappings.is_empty());
+    }
+
+    // --- page-size error paths (lines 336, 355-357, 363) ---
+
+    #[test]
+    fn test_page_size_keyword_followed_by_non_ident_is_rejected() {
+        // `A4 100pt` — after the keyword `A4`, the next token is a Dimension,
+        // not an orientation ident. The orientation try_parse fails (line 336)
+        // and the token is put back. The trailing-token guard then fires and
+        // rejects the whole size declaration.
+        assert_no_page_settings("@page { size: A4 100pt; }");
+    }
+
+    #[test]
+    fn test_page_size_second_dim_invalid_unit_is_ignored() {
+        // `100pt 200em` — the second dimension uses `em`, which `css_unit_to_pt`
+        // does not support (relative units are unknown at parse time). The
+        // filter returns None, making the whole size declaration None
+        // (lines 355-357).
+        assert_no_page_settings("@page { size: 100pt 200em; }");
+    }
+
+    #[test]
+    fn test_page_size_string_literal_is_ignored() {
+        // A quoted string is not a valid first token for `size:`, so
+        // `parse_page_size_value` must return None (line 363 catch-all).
+        assert_no_page_settings(r#"@page { size: "A4"; }"#);
+    }
+
+    // --- @page unknown declaration (line 539) ---
+
+    #[test]
+    fn test_page_unknown_property_is_skipped() {
+        // An unrecognised property inside @page should be silently skipped
+        // (line 539: `while input.next().is_ok() {}`). The rule must still be
+        // parsed so that a subsequent `size:` or `margin:` is honoured.
+        let ctx = parse_gcpm("@page { color: red; size: A4; }");
+        assert_eq!(ctx.page_settings.len(), 1);
+        assert_eq!(
+            ctx.page_settings[0].size,
+            Some(PageSizeDecl::Keyword("A4".to_string()))
+        );
+    }
+
+    // --- counter-reset: none (line 1058) ---
+
+    #[test]
+    fn test_counter_reset_none_produces_no_ops() {
+        // `counter-reset: none` must produce zero counter ops (line 1057-1058
+        // breaks immediately), so no CounterMapping is recorded.
+        let ctx = parse_gcpm("p { counter-reset: none; }");
+        assert!(ctx.counter_mappings.is_empty());
+    }
+
+    // --- target-counter / target-counters invalid URL (lines 1005, 1010, 1162) ---
+
+    #[test]
+    fn test_target_counter_url_with_extra_token_drops_item() {
+        // `url("a" "b")` — the url() block contains two tokens; `is_exhausted`
+        // is false after parsing "a", so parse_nested_block returns Err and
+        // parse_target_url returns None (line 1005). The target-counter item
+        // is not recorded.
+        let css = r#"a::after { content: target-counter(url("a" "b"), page); }"#;
+        let ctx = parse_gcpm(css);
+        assert!(ctx.content_counter_mappings.is_empty());
+    }
+
+    #[test]
+    fn test_target_counter_numeric_first_arg_drops_item() {
+        // A bare number `42` is not a recognised url form (not attr/string/url/
+        // unquoted-url), so parse_target_url hits the catch-all Err arm
+        // (line 1010) and returns None. The target-counter item is not recorded.
+        let css = r#"a::after { content: target-counter(42, page); }"#;
+        let ctx = parse_gcpm(css);
+        assert!(ctx.content_counter_mappings.is_empty());
+    }
+
+    #[test]
+    fn test_target_counters_invalid_url_drops_item() {
+        // Same catch-all path (line 1162) for target-counters: a bare number
+        // as the URL argument causes parse_target_url to return None, so the
+        // item is silently dropped.
+        let css = r#"a::after { content: target-counters(42, section, "."); }"#;
+        let ctx = parse_gcpm(css);
+        assert!(ctx.content_counter_mappings.is_empty());
+    }
 }

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -3267,16 +3267,40 @@ mod tests {
         // A delimiter like `>` as the first token in a rule is not a
         // recognised simple selector; the block must be drained and the rule
         // silently ignored (lines 148-149 of prelude parser).
-        let ctx = parse_gcpm("> p { position: running(header); }");
-        assert!(ctx.running_mappings.is_empty());
+        // A valid rule that follows must still be parsed to prove the block
+        // was drained and parsing continued (not short-circuited).
+        let ctx =
+            parse_gcpm("> p { position: running(header); } .valid { position: running(footer); }");
+        assert!(
+            !ctx.running_mappings
+                .iter()
+                .any(|m| m.running_name == "header")
+        );
+        assert!(
+            ctx.running_mappings
+                .iter()
+                .any(|m| m.running_name == "footer")
+        );
     }
 
     #[test]
     fn test_unknown_pseudo_element_is_not_registered() {
         // `::first-line` is a valid CSS pseudo-element but is not mapped to
         // Before/After, so the rule should be ignored (line 164).
-        let ctx = parse_gcpm("h1::first-line { position: running(header); }");
-        assert!(ctx.running_mappings.is_empty());
+        // The follow-up valid rule must still register to prove parsing continued.
+        let ctx = parse_gcpm(
+            "h1::first-line { position: running(header); } .valid { position: running(footer); }",
+        );
+        assert!(
+            !ctx.running_mappings
+                .iter()
+                .any(|m| m.running_name == "header")
+        );
+        assert!(
+            ctx.running_mappings
+                .iter()
+                .any(|m| m.running_name == "footer")
+        );
     }
 
     #[test]
@@ -3284,8 +3308,21 @@ mod tests {
         // `.foo.bar` is a compound selector — our parser only handles simple
         // selectors. When the prelude returns None, the block must be drained
         // and the rule ignored (lines 190-191).
-        let ctx = parse_gcpm(".foo.bar { position: running(header); }");
-        assert!(ctx.running_mappings.is_empty());
+        // The follow-up valid rule must still register to prove the block was
+        // drained and parsing continued.
+        let ctx = parse_gcpm(
+            ".foo.bar { position: running(header); } .valid { position: running(footer); }",
+        );
+        assert!(
+            !ctx.running_mappings
+                .iter()
+                .any(|m| m.running_name == "header")
+        );
+        assert!(
+            ctx.running_mappings
+                .iter()
+                .any(|m| m.running_name == "footer")
+        );
     }
 
     // --- page-size error paths (lines 336, 355-357, 363) ---


### PR DESCRIPTION
## 概要

`crates/fulgur/src/gcpm/parser.rs` のテストカバレッジを向上させるため、従来未到達だったブランチ・パスに対してユニットテストを追加します。

追加テスト数: **11件**

カバレッジ改善:
- `gcpm/parser.rs` ライン: 96.48%（本 PR 以前より向上）

---

### 追加したテストと対応コード

#### プレリュードエラーパス（lines 148–149, 164, 190–191）

| テスト名 | 対象パス |
|---|---|
| `test_selector_delimiter_first_token_is_skipped` | 先頭トークンが `>` などデリミタのとき、ブロックをドレインして `None` を返す |
| `test_unknown_pseudo_element_is_not_registered` | `::first-line` 等の未対応疑似要素は `new_error` で棄却 |
| `test_compound_selector_block_is_drained` | `.foo.bar` 等の複合セレクタはプレリュード `None` → ブロック全ドレイン |

#### `@page size` エラーパス（lines 336, 355–357, 363, 539）

| テスト名 | 対象パス |
|---|---|
| `test_page_size_keyword_followed_by_non_ident_is_rejected` | キーワード後に Dimension が続く場合、orientation `try_parse` が line 336 で失敗しトークンが戻る。その後トレーリングトークン検出で宣言全体を棄却 |
| `test_page_size_second_dim_invalid_unit_is_ignored` | 第2寸法に `em` 等の相対単位 → `css_unit_to_pt` が `None` を返し `size` 宣言を棄却 |
| `test_page_size_string_literal_is_ignored` | 文字列リテラルを先頭トークンにした場合のキャッチオール `None`（line 363） |
| `test_page_unknown_property_is_skipped` | `@page` 内の未知プロパティをドレイン（line 539）、後続の `size:` は正常解析される |

#### カウンター ops（line 1058）

| テスト名 | 対象パス |
|---|---|
| `test_counter_reset_none_produces_no_ops` | `counter-reset: none` で即 `break`（line 1057–1058）し、`CounterMapping` が記録されない |

#### `parse_target_url` / `target-counters` エラーパス（lines 1005, 1010, 1162）

| テスト名 | 対象パス |
|---|---|
| `test_target_counter_url_with_extra_token_drops_item` | `url("a" "b")` — `is_exhausted` が false で `Err`（line 1005）、アイテム非記録 |
| `test_target_counter_numeric_first_arg_drops_item` | 数値 `42` がキャッチオール `Err`（line 1010）、`parse_target_url` が `None` |
| `test_target_counters_invalid_url_drops_item` | `target-counters` での無効 URL パス（line 1162） |

---

### 変更ファイル

- `crates/fulgur/src/gcpm/parser.rs` — テストのみ追加（プロダクションコード変更なし）

---

### チェック結果

```text
cargo test -p fulgur --lib   → 1695 passed; 0 failed
cargo clippy -- -D warnings  → 警告なし
cargo fmt --check            → フォーマット差分なし
cargo llvm-cov (gcpm/parser.rs) → line 96.48%, branch 94.72%, function 97.93%
```

---
_Generated by [Claude Code](https://claude.ai/code/session_0156X9ygxm1mXfRTASqT1pDJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 無効なCSSセレクターや未対応の疑似要素を解析結果へ登録しないようにしました。
  * `@page` の不正な指定や未認識プロパティを適切にスキップし、有効な `size` が反映されるようにしました。
  * 不正なカウンター指定やリンク指定を無視し、不要なカウンター情報を生成しないようにしました。
* **テスト**
  * 無効入力時の挙動（無視・スキップ・反映）を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->