### PR TITLE
test(convert/list_marker): add coverage for find_marker_font drawables loop branches and unmapped glyph

### DIFF
--- a/crates/fulgur/src/convert/list_marker.rs
+++ b/crates/fulgur/src/convert/list_marker.rs
@@ -392,6 +392,7 @@ mod tests {
     use crate::blitz_adapter::Marker;
     use crate::drawables::{Drawables, ParagraphEntry};
     use crate::image::ImageFormat;
+    use crate::paragraph::InlineBoxItem;
 
     // Minimal 1×1 red PNG (same bytes as in convert/replaced.rs tests).
     const TEST_PNG_1X1: &[u8] = &[
@@ -669,6 +670,164 @@ mod tests {
         assert_eq!(
             last.text_range.end, text_len,
             "last glyph must reach text end"
+        );
+    }
+
+    // ── find_marker_font: drawables loop branch coverage ─────────────────────
+    //
+    // The drawables fallback in find_marker_font iterates over paragraphs and
+    // skips three kinds of non-contributing items.  The existing
+    // `find_marker_font_fallback_from_drawables_paragraph` test only exercises
+    // the successful-return arm; the three "continue / fall-through" branches
+    // (non-Text item, invalid font bytes, font doesn't cover the char) were
+    // never hit.
+
+    #[test]
+    fn find_marker_font_drawables_inline_box_item_is_skipped() {
+        // A paragraph that contains only InlineBoxItem items must be skipped
+        // entirely — the font search must not crash or return a spurious match.
+        let box_item = LineItem::InlineBox(InlineBoxItem {
+            node_id: None,
+            width: 10.0_f32.as_pt(),
+            height: 10.0_f32.as_pt(),
+            x_offset: crate::units::Pt::ZERO,
+            computed_y: crate::units::Pt::ZERO,
+            link: None,
+            opacity: 1.0,
+            visible: true,
+        });
+        let line = ShapedLine {
+            height: 12.0_f32.as_pt(),
+            baseline: 9.0_f32.as_pt(),
+            items: vec![box_item],
+        };
+        let mut drawables = Drawables::new();
+        drawables.paragraphs.insert(
+            1,
+            ParagraphEntry {
+                lines: vec![line],
+                opacity: 1.0,
+                visible: true,
+                id: None,
+            },
+        );
+        let result = find_marker_font(&Marker::Char('•'), None, &drawables);
+        assert!(
+            result.is_none(),
+            "InlineBoxItem items must not be used as a font source"
+        );
+    }
+
+    #[test]
+    fn find_marker_font_drawables_invalid_font_bytes_are_skipped() {
+        // A Text run whose font_data contains invalid bytes makes
+        // skrifa::FontRef::from_index return Err.  The loop must skip the
+        // corrupt entry without panicking and return None when no other
+        // font is available.
+        let bad_font = Arc::new(vec![0u8; 16]);
+        let glyph_run = ShapedGlyphRun {
+            font_data: Arc::clone(&bad_font),
+            font_index: 0,
+            font_size: 12.0_f32.as_pt(),
+            color: [0, 0, 0, 255],
+            decoration: TextDecoration::default(),
+            glyphs: vec![],
+            text: Arc::from("•"),
+            x_offset: crate::units::Pt::ZERO,
+            link: None,
+        };
+        let line = ShapedLine {
+            height: 12.0_f32.as_pt(),
+            baseline: 9.0_f32.as_pt(),
+            items: vec![LineItem::Text(glyph_run)],
+        };
+        let mut drawables = Drawables::new();
+        drawables.paragraphs.insert(
+            1,
+            ParagraphEntry {
+                lines: vec![line],
+                opacity: 1.0,
+                visible: true,
+                id: None,
+            },
+        );
+        let result = find_marker_font(&Marker::Char('•'), None, &drawables);
+        assert!(
+            result.is_none(),
+            "invalid font bytes in a drawables run must not crash or be returned"
+        );
+    }
+
+    #[test]
+    fn find_marker_font_drawables_font_not_covering_char_is_skipped() {
+        // NotoSans is a valid font but does not cover U+E000 (Private Use Area).
+        // The coverage check inside the drawables loop must detect the miss
+        // and continue iterating rather than returning the non-covering font.
+        let font_data = load_noto_sans_ttf();
+        let glyph_run = ShapedGlyphRun {
+            font_data: Arc::clone(&font_data),
+            font_index: 0,
+            font_size: 12.0_f32.as_pt(),
+            color: [0, 0, 0, 255],
+            decoration: TextDecoration::default(),
+            glyphs: vec![],
+            text: Arc::from("A"),
+            x_offset: crate::units::Pt::ZERO,
+            link: None,
+        };
+        let line = ShapedLine {
+            height: 12.0_f32.as_pt(),
+            baseline: 9.0_f32.as_pt(),
+            items: vec![LineItem::Text(glyph_run)],
+        };
+        let mut drawables = Drawables::new();
+        drawables.paragraphs.insert(
+            1,
+            ParagraphEntry {
+                lines: vec![line],
+                opacity: 1.0,
+                visible: true,
+                id: None,
+            },
+        );
+        // U+E000 is in the Private Use Area; NotoSans does not map it.
+        let result = find_marker_font(&Marker::Char('\u{E000}'), None, &drawables);
+        assert!(
+            result.is_none(),
+            "NotoSans must not be returned for a marker char it does not cover"
+        );
+    }
+
+    // ── shape_marker_with_skrifa: unmapped character falls back to GlyphId 0 ─
+
+    #[test]
+    fn shape_marker_with_skrifa_unmapped_char_uses_glyph_id_zero() {
+        // When a character in the marker text is absent from the font's charmap,
+        // charmap.map() returns None and the code falls back to GlyphId::new(0)
+        // — the OpenType `.notdef` placeholder.  Shaping must still succeed.
+        let font_data = load_noto_sans_ttf();
+        let result = shape_marker_with_skrifa(
+            // marker_skrifa_text(Char(U+E000)) → "\u{E000} " (char + trailing space)
+            &Marker::Char('\u{E000}'),
+            &font_data,
+            0,
+            12.0_f32.as_pt(),
+            [0, 0, 0, 255],
+        );
+        assert!(
+            result.is_some(),
+            "shaping must succeed even when the char is absent from the font"
+        );
+        let run = result.unwrap();
+        assert!(
+            !run.glyphs.is_empty(),
+            "at least one glyph must be produced"
+        );
+        // First glyph is for U+E000, which NotoSans does not have → id must be 0.
+        assert_eq!(
+            run.glyphs[0].id, 0,
+            "U+E000 (absent from NotoSans) must map to glyph ID 0, got {}",
+            run.glyphs[0].id
         );
     }
 }


### PR DESCRIPTION
## Summary

`convert/list_marker.rs` のカバレッジ改善。`find_marker_font` の drawables フォールバックループ内の3つの「スキップ」ブランチと、`shape_marker_with_skrifa` の未マップ文字フォールバックパスが未テストだったため、4つのユニットテストを追加しました。

カバレッジの変化:
- **Line**: 92.51% → 94.27% (+1.76%)
- **Region**: 92.52% → 93.70% (+1.18%)

## Changes

- `crates/fulgur/src/convert/list_marker.rs` にテスト4件追加（プロダクションコードの変更なし）

追加したテスト:

1. **`find_marker_font_drawables_inline_box_item_is_skipped`**  
   段落ラインに `InlineBoxItem` しか存在しない場合、drawables ループが `if let LineItem::Text(run)` の else ブランチ（スキップ）を通ることを検証する。

2. **`find_marker_font_drawables_invalid_font_bytes_are_skipped`**  
   `font_data` が不正バイト列の `Text` ランは `skrifa::FontRef::from_index` が `Err` を返すため、`if let Ok(font_ref)` の else ブランチを通りスキップされることを検証する。

3. **`find_marker_font_drawables_font_not_covering_char_is_skipped`**  
   drawables に有効な NotoSans フォントがあっても、マーカー文字 (U+E000, Private Use Area) を収録していない場合、`if check_chars.iter().all()` が false となりスキップされ `None` が返ることを検証する。

4. **`shape_marker_with_skrifa_unmapped_char_uses_glyph_id_zero`**  
   フォントの charmap に存在しない文字は `charmap.map()` が `None` を返し、`unwrap_or(GlyphId::new(0))` により `.notdef` プレースホルダ (id=0) が使われることを検証する。

意図的に除外したブランチ（1行コメント理由付き）:

- `resolve_list_style_image_asset` / `resolve_list_marker` / `resolve_inside_image_marker` / `extract_marker_lines` 内の未カバー行: すべて Blitz `Node` または `BaseDocument` を引数に取る関数であり、ライブラリの単体テストから Blitz を起動せずにテストするのが困難なため除外。

## Test plan

- [x] `cargo test -p fulgur --lib` — 1699 tests, 0 failures
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — 差分なし

## Contributor License Agreement

By opening this pull request, I confirm that:

- [x] I have read the [Contributing Guide](https://github.com/fulgur-rs/fulgur/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://github.com/fulgur-rs/fulgur/blob/main/CLA.md)
      and agree to its terms. (First-time contributors: the CLA Assistant bot
      will comment on this PR with sign-in instructions.)

## Related issues

<!-- e.g. "Closes #123" or "Part of #456" -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01KQ1jin1XJP37LoWthxZpzH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * リストマーカー用フォント探索のフォールバック動作を拡充しました。
  * 無効なフォントや対象文字を含まないフォントを適切にスキップできることを検証します。
  * 未対応文字のシェイピング時に、既定のグリフへフォールバックできることを確認します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->