### PR TITLE
test(smoke): surface pdftotext failure via stderr-embedded marker (fulgur-ml3k)

### DIFF
--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -117,28 +117,39 @@ fn tagged_render_with_noto(html: &str) -> Vec<u8> {
 /// Extract text from a PDF via `pdftotext -raw`. `-raw` flattens tagged
 /// PDFs to reading-order content stream text and avoids the column wrap
 /// pdftotext applies in default mode, which would split sentinels like
-/// `[APP: ]` across line breaks. Returns `None` if `pdftotext` is not
-/// installed — callers should gracefully skip in that case (CI has
-/// poppler-utils preinstalled; local dev on macOS needs `brew install
-/// poppler`). If pdftotext is installed but exits non-zero, returns
-/// `Some("[pdftotext failed status=... stderr=...]")` so the caller's
-/// `assert!(text.contains(...))` fires with the underlying stderr in
-/// the panic message instead of silently skipping. pdftotext walks the
-/// font's ToUnicode CMap to recover Unicode from CID-encoded TJ
-/// strings, which lopdf 0.40 cannot do — this is the replacement for
-/// the old ActualText hex grep, which was only viable while the
-/// now-fixed `text_range = 0..text_len` bug triggered Krilla's
-/// whole-paragraph ActualText path.
+/// `[APP: ]` across line breaks. Returns `None` only when the pdftotext
+/// binary is not installed (spawn fails with `ErrorKind::NotFound`) —
+/// callers should gracefully skip in that case (CI has poppler-utils
+/// preinstalled; local dev on macOS needs `brew install poppler`). Any
+/// other spawn error (permission denied, corrupt executable, resource
+/// exhaustion, …) and any non-zero exit both return
+/// `Some("[pdftotext ...]")` with the underlying diagnostic embedded,
+/// so the caller's `assert!(text.contains(...))` fires with the error
+/// visible in the panic message instead of silently skipping.
+/// pdftotext walks the font's ToUnicode CMap to recover Unicode from
+/// CID-encoded TJ strings, which lopdf 0.40 cannot do — this is the
+/// replacement for the old ActualText hex grep, which was only viable
+/// while the now-fixed `text_range = 0..text_len` bug triggered
+/// Krilla's whole-paragraph ActualText path.
 fn extract_pdf_text(pdf: &[u8]) -> Option<String> {
     let dir = tempdir().expect("tempdir");
     let path = dir.path().join("extract.pdf");
     std::fs::write(&path, pdf).expect("write pdf");
-    let output = std::process::Command::new("pdftotext")
+    let output = match std::process::Command::new("pdftotext")
         .arg("-raw")
         .arg(&path)
         .arg("-")
         .output()
-        .ok()?;
+    {
+        Ok(output) => output,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(err) => {
+            return Some(format!(
+                "[pdftotext spawn failed: {err} (kind={:?})]",
+                err.kind()
+            ));
+        }
+    };
     if !output.status.success() {
         return Some(format!(
             "[pdftotext failed status={} stderr={:?}]",

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -120,11 +120,15 @@ fn tagged_render_with_noto(html: &str) -> Vec<u8> {
 /// `[APP: ]` across line breaks. Returns `None` if `pdftotext` is not
 /// installed — callers should gracefully skip in that case (CI has
 /// poppler-utils preinstalled; local dev on macOS needs `brew install
-/// poppler`). pdftotext walks the font's ToUnicode CMap to recover
-/// Unicode from CID-encoded TJ strings, which lopdf 0.40 cannot do —
-/// this is the replacement for the old ActualText hex grep, which was
-/// only viable while the now-fixed `text_range = 0..text_len` bug
-/// triggered Krilla's whole-paragraph ActualText path.
+/// poppler`). If pdftotext is installed but exits non-zero, returns
+/// `Some("[pdftotext failed status=... stderr=...]")` so the caller's
+/// `assert!(text.contains(...))` fires with the underlying stderr in
+/// the panic message instead of silently skipping. pdftotext walks the
+/// font's ToUnicode CMap to recover Unicode from CID-encoded TJ
+/// strings, which lopdf 0.40 cannot do — this is the replacement for
+/// the old ActualText hex grep, which was only viable while the
+/// now-fixed `text_range = 0..text_len` bug triggered Krilla's
+/// whole-paragraph ActualText path.
 fn extract_pdf_text(pdf: &[u8]) -> Option<String> {
     let dir = tempdir().expect("tempdir");
     let path = dir.path().join("extract.pdf");
@@ -136,7 +140,11 @@ fn extract_pdf_text(pdf: &[u8]) -> Option<String> {
         .output()
         .ok()?;
     if !output.status.success() {
-        return None;
+        return Some(format!(
+            "[pdftotext failed status={} stderr={:?}]",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim(),
+        ));
     }
     Some(String::from_utf8_lossy(&output.stdout).to_string())
 }


### PR DESCRIPTION
## Summary

`crates/fulgur/tests/render_smoke.rs` の `extract_pdf_text` ヘルパで pdftotext が非 0 終了した場合の扱いを修正 (fulgur-ml3k)。

これまで `None` が「pdftotext 未インストール (graceful skip)」と「pdftotext は動いたが失敗した (本物のエラー)」の両方を意味しており、呼び出し側が `let Some(text) = extract_pdf_text(&pdf) else { skip; }` パターンで受けているため、後者のケースが黙って skip されて assert 失敗の原因診断が難しくなっていた。

- `None` は「バイナリ未インストール (`Command::new().output().ok()?`)」だけに温存
- 非 0 終了時は `Some("[pdftotext failed status=... stderr=...]")` を返す
  - このマーカーは期待文字列とは絶対に一致しないので、呼び出し側の `assert!(text.contains(...))` が pdftotext の stderr 付きで panic する
- doc コメントに新セマンティクスを追記

gemini-code-assist (medium) と coderabbitai (minor) の PR #442 レビュー指摘への対応。

## Test plan

- [x] `cargo fmt --check -p fulgur`
- [x] `cargo clippy -p fulgur --tests --no-deps` (warning なし)
- [x] `cargo test -p fulgur --test render_smoke` (196 tests passed)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **テスト**
  - `pdftotext` 実行失敗時の扱いを見直し、未インストール（起動不可）の場合は検証をスキップします。
  - 起動できたものの非ゼロ終了となった場合は、終了ステータスと標準エラー内容を含めて報告し、失敗理由が明確に表示されるようにしました。
  - これにより、PDFテキスト抽出での原因調査が容易になりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->