### PR TITLE
test(render): add coverage for run_tag_target

### DIFF
--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -4451,6 +4451,64 @@ mod tests {
         assert!(para_has_link_runs(&para));
     }
 
+    // --- run_tag_target ---
+
+    #[test]
+    fn run_tag_target_li_lbody_ids_hit_returns_lbody_id() {
+        // When li_lbody_ids contains node_id, the synthetic LBody id is returned
+        // (which differs from the input node_id).
+        let mut d = Drawables::new();
+        let li_id: crate::drawables::NodeId = 10;
+        let lbody_id: crate::drawables::NodeId = 9999;
+        d.li_lbody_ids.insert(li_id, lbody_id);
+        assert_eq!(run_tag_target(&d, li_id), Some(lbody_id));
+    }
+
+    #[test]
+    fn run_tag_target_li_lbody_ids_returns_mapped_not_input_id() {
+        // The returned id is the LBody synthetic id, NOT the li input id.
+        let mut d = Drawables::new();
+        let li_id: crate::drawables::NodeId = 20;
+        let lbody_id: crate::drawables::NodeId = 8888;
+        d.li_lbody_ids.insert(li_id, lbody_id);
+        let result = run_tag_target(&d, li_id);
+        assert_ne!(result, Some(li_id));
+        assert_eq!(result, Some(lbody_id));
+    }
+
+    #[test]
+    fn run_tag_target_semantics_hit_returns_node_id() {
+        // When only semantics contains node_id, returns Some(node_id) unchanged.
+        let node_id: crate::drawables::NodeId = 5;
+        let d = drawables_with_para(node_id);
+        assert_eq!(run_tag_target(&d, node_id), Some(node_id));
+    }
+
+    #[test]
+    fn run_tag_target_neither_map_returns_none() {
+        // A node absent from both li_lbody_ids and semantics yields None.
+        let d = Drawables::new();
+        assert_eq!(run_tag_target(&d, 42), None);
+    }
+
+    #[test]
+    fn run_tag_target_li_lbody_ids_takes_priority_over_semantics() {
+        // When node_id is in both maps, li_lbody_ids wins and lbody_id is returned.
+        let mut d = Drawables::new();
+        let node_id: crate::drawables::NodeId = 7;
+        let lbody_id: crate::drawables::NodeId = 7777;
+        d.li_lbody_ids.insert(node_id, lbody_id);
+        d.semantics.insert(
+            node_id,
+            crate::tagging::SemanticEntry {
+                tag: crate::tagging::PdfTag::Li,
+                parent: None,
+                alt_text: None,
+            },
+        );
+        assert_eq!(run_tag_target(&d, node_id), Some(lbody_id));
+    }
+
     // --- extract_heading_title ---
 
     #[test]


### PR DESCRIPTION
# Pull Request

## Summary

`render.rs` の `run_tag_target` 関数はリンクアノテーションのタグ付け対象 `NodeId` を解決する純粋関数だが、既存テストスイートに含まれていなかった。本 PR では 5 つのユニットテストを追加し、`render.rs` のリージョンカバレッジを 92.35% → 92.46% に改善する。

## Changes

- `crates/fulgur/src/render.rs` の `#[cfg(test)] mod tests` 内に `// --- run_tag_target ---` セクションを追加
  - `run_tag_target_li_lbody_ids_hit_returns_lbody_id`: `li_lbody_ids` にキーが存在する場合、マップ値（LBody 合成 ID）を返すことを確認
  - `run_tag_target_li_lbody_ids_returns_mapped_not_input_id`: 返値が入力 `node_id` ではなく LBody ID であることを確認
  - `run_tag_target_semantics_hit_returns_node_id`: `semantics` のみにキーが存在する場合、`Some(node_id)` を返すことを確認
  - `run_tag_target_neither_map_returns_none`: 両マップにキーが存在しない場合、`None` を返すことを確認
  - `run_tag_target_li_lbody_ids_takes_priority_over_semantics`: 両マップにキーが存在する場合、`li_lbody_ids` が優先されることを確認

## Test plan

- [x] `cargo test -p fulgur --lib` — 1711 tests passed
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — フォーマット差分なし
- [x] `cargo llvm-cov --package fulgur --lib --summary-only` — render.rs: 92.35% → 92.46%

## Contributor License Agreement

By opening this pull request, I confirm that:

- [x] I have read the [Contributing Guide](https://github.com/fulgur-rs/fulgur/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://github.com/fulgur-rs/fulgur/blob/main/CLA.md)
      and agree to its terms. (First-time contributors: the CLA Assistant bot
      will comment on this PR with sign-in instructions.)

## Related issues

カバレッジ定期改善タスク（自動実行）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01H3SKJ5ei6rYwTCDcfxPQmq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * タグ対象の識別に関する主要なケースを追加検証しました。
  * 合成されたIDの優先、既存IDの返却、対象がない場合の結果を確認できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->