### PR TITLE
fix(convert): guard font_size divisions against font-size:0 NaN (#639)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ HTML string → Blitz (parse/style/layout) → Drawables / PaginationGeometryTab
 
 ### Key Modules (fulgur)
 
-- **engine.rs** — `Engine` builder: configures and executes `render_html()`
+- **engine.rs** — `Engine` builder: configures and executes `render()`
 - **blitz_adapter.rs** — Thin adapter isolating Blitz API changes from the rest of the codebase
 - **convert.rs** — Transforms Blitz DOM nodes into `Drawables` and geometry records
 - **draw_primitives.rs** — Primitive geometry, canvas, style, and drawing-helper types (`Size`, `Rect`, `Canvas`, `BlockStyle`, background/gradient types, etc.)
@@ -138,10 +138,10 @@ callers don't get this guarantee by default — see the tracking issue
   **VRT reftest だけでカバーした draw 経路は codecov の patch coverage に乗らない**。
   新しい draw / convert / pageable ロジックを書くときは VRT に加えて lib 側にもテストを置く:
   - 純関数 (helper, fixup, math) → 当該モジュールの `#[cfg(test)] mod tests` に unit test
-  - レンダリング経路 (`draw_background_layer` の match arm 等、`Engine::render_html` を通って初めて
+  - レンダリング経路 (`draw_background_layer` の match arm 等、`Engine::render` を通って初めて
     叩かれる箇所) → `crates/fulgur/tests/render_smoke.rs` に end-to-end smoke test
-    (`Engine::builder().build().render_html(html)` で `assert!(!pdf.is_empty())`)
+    (`Engine::builder().build().render(html)` で `assert!(!pdf.is_empty())`)
   VRT を後付けで足すと codecov に再指摘されて lib 側 smoke test を追加する手戻りが発生する
   (PR #244 で実例)。最初から両方書くこと。
-- **`Engine` is a builder**: `Engine::builder().page_size(PageSize::A4).base_path(root).build()` + single-arg `render_html(html)`. There is no `Engine::new().with_*()`.
+- **`Engine` is a builder**: `Engine::builder().page_size(PageSize::A4).base_path(root).build()` + single-arg `render(html)`. `render_html(html)` still exists as a `#[deprecated(since = "0.19.0")]` alias — do not use it in new code. There is no `Engine::new().with_*()`.
 - **VRT は PDF byte 比較**: `crates/fulgur-vrt` は HTML → PDF を生成して `goldens/fulgur/**/*.pdf` と byte-wise 比較する (`crates/fulgur-cli/tests/examples_determinism.rs` と同じ哲学)。pdftocairo は失敗時の diff 画像生成のみで使う。golden 更新は `FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" FULGUR_VRT_UPDATE=1 cargo test -p fulgur-vrt`。

--- a/crates/fulgur/src/convert/inline_root.rs
+++ b/crates/fulgur/src/convert/inline_root.rs
@@ -509,9 +509,12 @@ pub(super) fn extract_paragraph(
                         run_glyph_offset += 1;
                         glyphs.push(ShapedGlyph {
                             id: g.id,
-                            x_advance: g.advance / font_size_parley,
-                            x_offset: g.x / font_size_parley,
-                            y_offset: g.y / font_size_parley,
+                            x_advance: ShapedGlyph::normalize_by_font_size(
+                                g.advance,
+                                font_size_parley,
+                            ),
+                            x_offset: ShapedGlyph::normalize_by_font_size(g.x, font_size_parley),
+                            y_offset: ShapedGlyph::normalize_by_font_size(g.y, font_size_parley),
                             text_range,
                         });
                     }

--- a/crates/fulgur/src/convert/list_marker.rs
+++ b/crates/fulgur/src/convert/list_marker.rs
@@ -235,9 +235,9 @@ pub(super) fn extract_marker_lines(
                     line_width += g.advance.as_px().in_pt();
                     glyphs.push(ShapedGlyph {
                         id: g.id,
-                        x_advance: g.advance / font_size_parley,
-                        x_offset: g.x / font_size_parley,
-                        y_offset: g.y / font_size_parley,
+                        x_advance: ShapedGlyph::normalize_by_font_size(g.advance, font_size_parley),
+                        x_offset: ShapedGlyph::normalize_by_font_size(g.x, font_size_parley),
+                        y_offset: ShapedGlyph::normalize_by_font_size(g.y, font_size_parley),
                         text_range,
                     });
                 }
@@ -364,7 +364,7 @@ pub(super) fn shape_marker_with_skrifa(
         let advance = glyph_metrics.advance_width(gid).unwrap_or(0.0);
         glyphs.push(ShapedGlyph {
             id: gid.to_u32(),
-            x_advance: advance / font_size.to_f32(),
+            x_advance: ShapedGlyph::normalize_by_font_size(advance, font_size.to_f32()),
             x_offset: 0.0,
             y_offset: 0.0,
             text_range: byte_offset..byte_offset + ch_len,

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -911,9 +911,9 @@ fn shape_paragraph_glyph_runs(
                     run_glyph_offset += 1;
                     glyphs.push(ShapedGlyph {
                         id: g.id,
-                        x_advance: g.advance / font_size_parley,
-                        x_offset: g.x / font_size_parley,
-                        y_offset: g.y / font_size_parley,
+                        x_advance: ShapedGlyph::normalize_by_font_size(g.advance, font_size_parley),
+                        x_offset: ShapedGlyph::normalize_by_font_size(g.x, font_size_parley),
+                        y_offset: ShapedGlyph::normalize_by_font_size(g.y, font_size_parley),
                         text_range,
                     });
                 }

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -79,14 +79,74 @@ impl ShapedGlyph {
     /// Normalize a raw glyph advance/offset by `font_size` to the unit-less
     /// ratio stored in `x_advance`/`x_offset`/`y_offset` (see the fulgur
     /// convention documented at the four glyph-construction sites in
-    /// `crates/fulgur/src/convert/`). Returns `0.0` when `font_size` is not
-    /// strictly positive, which covers `font-size: 0` (a valid CSS state
-    /// used e.g. to suppress whitespace between inline children) as well as
-    /// stray NaN/negative inputs — a plain division would otherwise produce
-    /// NaN and propagate into the PDF `Tm`/`TJ` operators (issue #639).
+    /// `crates/fulgur/src/convert/`).
+    ///
+    /// Returns `0.0` in every case that would otherwise leak a non-finite
+    /// value into the PDF `Tm`/`TJ` operators (issue #639):
+    /// - `font_size == 0.0` (the reported repro — `font-size: 0` is a
+    ///   valid CSS state used e.g. to suppress whitespace between inline
+    ///   children) → the bare division would produce `NaN`.
+    /// - `font_size < 0.0` or `NaN` — stray inputs from upstream bugs.
+    /// - Subnormal / very small `font_size` where `v / font_size`
+    ///   overflows to `±Infinity`.
+    /// - Non-finite `v` (also propagated to `0.0` via the trailing
+    ///   `is_finite` gate).
     #[inline]
     pub(crate) fn normalize_by_font_size(v: f32, font_size: f32) -> f32 {
-        if font_size > 0.0 { v / font_size } else { 0.0 }
+        if font_size > 0.0 {
+            let ratio = v / font_size;
+            if ratio.is_finite() {
+                return ratio;
+            }
+        }
+        0.0
+    }
+}
+
+#[cfg(test)]
+mod normalize_by_font_size_tests {
+    use super::ShapedGlyph;
+
+    #[test]
+    fn positive_divisor_returns_ratio() {
+        assert_eq!(ShapedGlyph::normalize_by_font_size(10.0, 5.0), 2.0);
+        assert_eq!(ShapedGlyph::normalize_by_font_size(0.0, 5.0), 0.0);
+        assert_eq!(ShapedGlyph::normalize_by_font_size(-3.0, 6.0), -0.5);
+    }
+
+    #[test]
+    fn zero_divisor_returns_zero_not_nan() {
+        assert_eq!(ShapedGlyph::normalize_by_font_size(0.0, 0.0), 0.0);
+        assert_eq!(ShapedGlyph::normalize_by_font_size(10.0, 0.0), 0.0);
+    }
+
+    #[test]
+    fn negative_divisor_returns_zero() {
+        assert_eq!(ShapedGlyph::normalize_by_font_size(10.0, -5.0), 0.0);
+    }
+
+    #[test]
+    fn nan_divisor_returns_zero() {
+        assert_eq!(ShapedGlyph::normalize_by_font_size(10.0, f32::NAN), 0.0);
+    }
+
+    #[test]
+    fn subnormal_divisor_that_would_overflow_returns_zero() {
+        let subnormal = f32::from_bits(1);
+        assert!(subnormal > 0.0 && subnormal < f32::MIN_POSITIVE);
+        assert!(!(1.0f32 / subnormal).is_finite());
+        assert_eq!(
+            ShapedGlyph::normalize_by_font_size(1.0, subnormal),
+            0.0,
+            "1.0 / subnormal overflows to Infinity; helper must not leak it \
+             into `x_advance`",
+        );
+    }
+
+    #[test]
+    fn non_finite_numerator_returns_zero() {
+        assert_eq!(ShapedGlyph::normalize_by_font_size(f32::NAN, 5.0), 0.0);
+        assert_eq!(ShapedGlyph::normalize_by_font_size(f32::INFINITY, 5.0), 0.0);
     }
 }
 

--- a/crates/fulgur/src/paragraph.rs
+++ b/crates/fulgur/src/paragraph.rs
@@ -75,6 +75,21 @@ pub struct ShapedGlyph {
     pub text_range: std::ops::Range<usize>,
 }
 
+impl ShapedGlyph {
+    /// Normalize a raw glyph advance/offset by `font_size` to the unit-less
+    /// ratio stored in `x_advance`/`x_offset`/`y_offset` (see the fulgur
+    /// convention documented at the four glyph-construction sites in
+    /// `crates/fulgur/src/convert/`). Returns `0.0` when `font_size` is not
+    /// strictly positive, which covers `font-size: 0` (a valid CSS state
+    /// used e.g. to suppress whitespace between inline children) as well as
+    /// stray NaN/negative inputs — a plain division would otherwise produce
+    /// NaN and propagate into the PDF `Tm`/`TJ` operators (issue #639).
+    #[inline]
+    pub(crate) fn normalize_by_font_size(v: f32, font_size: f32) -> f32 {
+        if font_size > 0.0 { v / font_size } else { 0.0 }
+    }
+}
+
 /// Target for a clickable link in PDF output.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LinkTarget {

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -5611,3 +5611,122 @@ fn tagged_p_with_nested_list_in_inline_block_does_not_panic() {
     let s = String::from_utf8_lossy(&pdf);
     assert!(s.contains("/StructTreeRoot"));
 }
+
+/// Regression for issue #639 (fulgur-rkfu): `font-size: 0` on an element with
+/// text used to divide `parley` (or `skrifa`) glyph advances by `0.0`,
+/// producing `NaN` glyph fields that propagated into the PDF `Tm`/`TJ`
+/// operators. `pdftocairo` rejected the resulting stream with `Unknown
+/// operator 'NaN'`.
+///
+/// Four convert-time sites normalize glyph advance/offsets by `font_size`
+/// (see `ShapedGlyph::normalize_by_font_size` in `paragraph.rs`); the HTML
+/// below is deliberately shaped to drive all four so a regression at any
+/// single one fails this test:
+///
+/// - `<p>invisible <span>visible</span> …</p>` → `inline_root.rs` shaping
+///   (the plain inline paragraph path).
+/// - `<div class="mc">…</div>` with `columns: 2` → `convert/mod.rs`'s
+///   `shape_paragraph_glyph_runs` (the multicol per-slice re-shape path).
+/// - `<ul><li>outside</li></ul>` (default `list-style-position: outside`)
+///   → `list_marker.rs::extract_marker_lines` (parley marker shaping).
+/// - `<ul style="list-style-position:inside"><li>inside</li></ul>` →
+///   `list_marker.rs::shape_marker_with_skrifa` (skrifa marker fallback).
+///
+/// Empirically verified by reverting each of the four guards one at a time
+/// while running this test — each revert flips the test red.
+#[test]
+fn font_size_zero_does_not_produce_nan_glyphs() {
+    let html = r#"<!DOCTYPE html><html><head><style>
+        p, .mc, ul, ul li, ul li div { font-size: 0; }
+        p > span { font-size: 9pt; }
+        .mc { columns: 2; column-gap: 20pt; width: 400pt; }
+        ul.inside { list-style-position: inside; }
+    </style></head><body>
+        <p>invisible <span>visible</span> also-invisible</p>
+        <div class="mc">multicol invisible text spanning two columns of layout</div>
+        <ul><li>outside marker item</li></ul>
+        <ul class="inside"><li><div>inside marker with block child</div></li></ul>
+    </body></html>"#;
+
+    let out = Engine::builder()
+        .build()
+        .layout(html)
+        .expect("font-size:0 layout must succeed");
+
+    fn check_lines(lines: &[fulgur::paragraph::ShapedLine], source: &str, seen_zero: &mut u32) {
+        for line in lines {
+            for item in &line.items {
+                let fulgur::paragraph::LineItem::Text(run) = item else {
+                    continue;
+                };
+                if run.font_size.to_f32() == 0.0 {
+                    *seen_zero += 1;
+                }
+                for g in &run.glyphs {
+                    assert!(
+                        g.x_advance.is_finite(),
+                        "{source}: x_advance must be finite even at font-size:0 (got {})",
+                        g.x_advance,
+                    );
+                    assert!(
+                        g.x_offset.is_finite(),
+                        "{source}: x_offset must be finite even at font-size:0 (got {})",
+                        g.x_offset,
+                    );
+                    assert!(
+                        g.y_offset.is_finite(),
+                        "{source}: y_offset must be finite even at font-size:0 (got {})",
+                        g.y_offset,
+                    );
+                }
+            }
+        }
+    }
+
+    // Three separate counters so a coverage regression (e.g. multicol
+    // slice path stops emitting) fails loudly instead of silently
+    // shrinking the site coverage of this test.
+    let mut para_runs = 0u32;
+    let mut slice_runs = 0u32;
+    let mut marker_runs = 0u32;
+
+    for entry in out.drawables.paragraphs.values() {
+        check_lines(&entry.lines, "paragraphs", &mut para_runs);
+    }
+    for entry in out.drawables.paragraph_slices.values() {
+        for slice in &entry.slices {
+            check_lines(&slice.lines, "paragraph_slices", &mut slice_runs);
+        }
+    }
+    for entry in out.drawables.list_items.values() {
+        if let fulgur::drawables::ListItemMarker::Text { lines, .. } = &entry.marker {
+            check_lines(lines, "list_items.marker", &mut marker_runs);
+        }
+    }
+
+    assert!(
+        para_runs > 0,
+        "expected inline_root (paragraphs) to emit at least one font-size:0 run",
+    );
+    assert!(
+        slice_runs > 0,
+        "expected multicol (paragraph_slices) to emit at least one font-size:0 run",
+    );
+    assert!(
+        marker_runs > 0,
+        "expected list-item markers (list_items.marker) to emit at least one \
+         font-size:0 run",
+    );
+
+    // Full pipeline still produces a well-formed PDF (no NaN → no `Unknown
+    // operator 'NaN'` from pdftocairo). We do not decompress and grep for
+    // the substring "NaN" here because that would require a decompression
+    // dev-dep; the layout assertion above already pins the source of the
+    // NaN, and a `%PDF` prefix + non-empty body confirms rendering
+    // completed without panic.
+    let pdf = Engine::builder()
+        .build()
+        .render(html)
+        .expect("font-size:0 render must succeed");
+    assert!(pdf.starts_with(b"%PDF"));
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -5659,7 +5659,8 @@ fn font_size_zero_does_not_produce_nan_glyphs() {
                 let fulgur::paragraph::LineItem::Text(run) = item else {
                     continue;
                 };
-                if run.font_size.to_f32() == 0.0 {
+                let font_size_zero = run.font_size.to_f32() == 0.0;
+                if font_size_zero {
                     *seen_zero += 1;
                 }
                 for g in &run.glyphs {
@@ -5678,6 +5679,27 @@ fn font_size_zero_does_not_produce_nan_glyphs() {
                         "{source}: y_offset must be finite even at font-size:0 (got {})",
                         g.y_offset,
                     );
+                    // Pin the *contract* of `normalize_by_font_size` at
+                    // `font_size == 0.0`: not merely finite (which a
+                    // regression to `raw / very_small_positive` could
+                    // still satisfy at a garbage value) but exactly
+                    // `0.0`. Downstream `x_advance * run.font_size` will
+                    // multiply by zero anyway, so the only value that
+                    // preserves the round-trip is `0.0` itself.
+                    if font_size_zero {
+                        assert_eq!(
+                            g.x_advance, 0.0,
+                            "{source}: x_advance at font-size:0 must be exactly 0.0"
+                        );
+                        assert_eq!(
+                            g.x_offset, 0.0,
+                            "{source}: x_offset at font-size:0 must be exactly 0.0"
+                        );
+                        assert_eq!(
+                            g.y_offset, 0.0,
+                            "{source}: y_offset at font-size:0 must be exactly 0.0"
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

- GitHub issue #639 の再現修正。`font-size: 0` を宣言した要素にテキストがあると、fulgur が生成する PDF の `Tm`/`TJ` オペランドが NaN になり、`pdftocairo` が `Unknown operator 'NaN'` で失敗していた。
- `ShapedGlyph::normalize_by_font_size` ヘルパを新設し、`convert/` 配下 4 箇所の `raw / font_size` 割り算を全てこれに置換 (`0` / 負 / NaN な font_size を全て `0.0` に畳む)。
- `font-size: 0` は browser と同じ挙動 — テキストは zero-advance glyph として emit され、view 上は不可視だが構造として存在する (text extraction / 将来の tagged PDF 用の a11y を保つ)。

## 根本原因

`ShapedGlyph.{x_advance, x_offset, y_offset}` は unit-less ratio (`raw / font_size`) として保持する fulgur convention (下流で `x_advance * font_size` として復元) がある。`font_size == 0` のとき `0 / 0 = NaN` が生成され、そのまま krilla → PDF ストリームまで伝播していた。

修正した 4 サイト:

- `crates/fulgur/src/convert/inline_root.rs` — plain な inline paragraph
- `crates/fulgur/src/convert/mod.rs` — multicol container の per-slice reshape (`shape_paragraph_glyph_runs`)
- `crates/fulgur/src/convert/list_marker.rs` (parley path) — outside list marker
- `crates/fulgur/src/convert/list_marker.rs` (skrifa path) — inside list marker + fallback

## 再現 (issue #639 より)

```html
<style>p { font-size: 0; }</style>
<p>text</p>
```

修正前:

```text
$ pdftocairo -png repro.pdf out
Syntax Error: Unknown operator 'NaN'
Syntax Error: Too few (0) args to 'Tm' operator
```

修正後: `pdftocairo` が warning (`font matrix not invertible`, ゼロ倍行列なので数学的に正当) のみで完走。issue 報告者が想定していた `p { font-size: 0 } / p > * { font-size: 9pt }` パターンも期待どおり動作 (親の空白は不可視、子の span テキストは表示)。

## Test plan

- [x] 新規 regression smoke test `font_size_zero_does_not_produce_nan_glyphs` を `crates/fulgur/tests/render_smoke.rs` に追加。`paragraphs` / `paragraph_slices` / `list_items.marker` の 3 コレクションを全て走査し、各 `ShapedGlyph` の x_advance / x_offset / y_offset が finite であることを検証。
- [x] test HTML は 4 サイトを全て発火するように shape 済 — 各 guard を 1 サイトずつ revert して test が実際に落ちることを確認済 (advisor 指摘対応、4/4)。
- [x] `cargo test -p fulgur` (unit + integration + doc-tests): 2102 passed / 0 failed
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p fulgur --lib --tests` clean

Closes fulgur-rkfu.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * フォントサイズ 0 や異常値でも、段落・リストマーカーの文字位置計算で無効な数値が PDF に混入しにくくなりました。
* **テスト**
  * font-size:0 を含む HTML で、グリフ座標が有限であること、PDF が正常に生成されることを確認する回帰テストを追加しました。
* **ドキュメント**
  * レンダリング手順の説明を、推奨 API（render）中心に更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->