### PR TITLE
test(tagging): add coverage for heading-level clamping, SemanticEntry, and classify_element edge cases

### DIFF
--- a/crates/fulgur/src/tagging.rs
+++ b/crates/fulgur/src/tagging.rs
@@ -369,4 +369,155 @@ mod tests {
             TagKind::Link(_)
         ));
     }
+
+    // ── heading level clamping ────────────────────────────────────────────────
+
+    #[test]
+    fn pdf_tag_to_krilla_tag_heading_level_zero_clamped_to_one() {
+        // level=0 is below the valid range; clamp(1,6) must bring it up to 1
+        // so NonZeroU16::new(1) succeeds and we still get an Hn tag.
+        let k = pdf_tag_to_krilla_tag(&PdfTag::H { level: 0 }, None, None);
+        assert!(
+            matches!(k, krilla::tagging::TagKind::Hn(_)),
+            "level=0 should produce Hn after clamping to 1"
+        );
+    }
+
+    #[test]
+    fn pdf_tag_to_krilla_tag_heading_level_above_six_clamped() {
+        // level=7 and level=255 are above the valid range; clamp(1,6) caps at 6.
+        for level in [7u8, 10, 255] {
+            let k = pdf_tag_to_krilla_tag(&PdfTag::H { level }, None, None);
+            assert!(
+                matches!(k, krilla::tagging::TagKind::Hn(_)),
+                "level={level} should produce Hn after clamping to 6"
+            );
+        }
+    }
+
+    #[test]
+    fn pdf_tag_to_krilla_tag_heading_level_clamping_with_title() {
+        // Clamping path with a heading_title to confirm both clamp and title flow.
+        let title = Some("Appendix".to_owned());
+        let k_low = pdf_tag_to_krilla_tag(&PdfTag::H { level: 0 }, title.clone(), None);
+        let k_high = pdf_tag_to_krilla_tag(&PdfTag::H { level: 9 }, title, None);
+        assert!(matches!(k_low, krilla::tagging::TagKind::Hn(_)));
+        assert!(matches!(k_high, krilla::tagging::TagKind::Hn(_)));
+    }
+
+    // ── SemanticEntry ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn semantic_entry_construction_and_clone() {
+        // No parent, no alt text.
+        let e1 = SemanticEntry {
+            tag: PdfTag::P,
+            parent: None,
+            alt_text: None,
+        };
+        assert!(e1.parent.is_none());
+        assert!(e1.alt_text.is_none());
+
+        // With parent NodeId and alt text.
+        let e2 = SemanticEntry {
+            tag: PdfTag::Figure,
+            parent: Some(42_usize),
+            alt_text: Some("company logo".to_owned()),
+        };
+        assert_eq!(e2.parent, Some(42));
+        assert_eq!(e2.alt_text.as_deref(), Some("company logo"));
+
+        // Decorative image: alt_text = Some("").
+        let e3 = SemanticEntry {
+            tag: PdfTag::Figure,
+            parent: None,
+            alt_text: Some(String::new()),
+        };
+        assert_eq!(e3.alt_text.as_deref(), Some(""));
+
+        // Clone reproduces all fields.
+        let e2c = e2.clone();
+        assert_eq!(e2c.parent, e2.parent);
+        assert_eq!(e2c.alt_text, e2.alt_text);
+    }
+
+    // ── PdfTag derives ────────────────────────────────────────────────────────
+
+    #[test]
+    fn pdf_tag_partial_eq_and_clone() {
+        let a = PdfTag::H { level: 3 };
+        let b = a.clone();
+        assert_eq!(a, b);
+
+        assert_ne!(PdfTag::P, PdfTag::Div);
+        assert_ne!(
+            PdfTag::H { level: 1 },
+            PdfTag::H { level: 2 },
+            "different heading levels must not compare equal"
+        );
+        assert_ne!(
+            PdfTag::L {
+                numbering: krilla::tagging::ListNumbering::Disc,
+            },
+            PdfTag::L {
+                numbering: krilla::tagging::ListNumbering::Decimal,
+            },
+            "list numbering variants must not compare equal"
+        );
+        assert_ne!(
+            PdfTag::Th {
+                scope: krilla::tagging::TableHeaderScope::Row,
+            },
+            PdfTag::Th {
+                scope: krilla::tagging::TableHeaderScope::Column,
+            },
+            "different TH scopes must not compare equal"
+        );
+    }
+
+    #[test]
+    fn pdf_tag_debug_is_non_empty() {
+        // Smoke-test that Debug is implemented and produces something legible.
+        assert!(!format!("{:?}", PdfTag::P).is_empty());
+        assert!(!format!("{:?}", PdfTag::H { level: 2 }).is_empty());
+        assert!(
+            !format!(
+                "{:?}",
+                PdfTag::L {
+                    numbering: krilla::tagging::ListNumbering::Disc
+                }
+            )
+            .is_empty()
+        );
+    }
+
+    // ── classify_element edge cases ───────────────────────────────────────────
+
+    #[test]
+    fn classify_element_is_case_sensitive() {
+        // HTML local names are always lowercase in the DOM; uppercase must not match.
+        for tag in ["P", "H1", "DIV", "SPAN", "TABLE", "UL", "LI"] {
+            assert_eq!(
+                classify_element(tag),
+                None,
+                "uppercase '{tag}' should return None (case-sensitive match)"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_element_none_for_interactive_and_metadata_elements() {
+        // Interactive, form, media, and metadata elements carry no PDF semantic tag.
+        for tag in [
+            "form", "input", "button", "select", "textarea", "label", "fieldset", "legend", "head",
+            "body", "html", "meta", "link", "title", "noscript", "iframe", "video", "audio",
+            "source", "canvas", "map", "area",
+        ] {
+            assert_eq!(
+                classify_element(tag),
+                None,
+                "element '{tag}' should return None"
+            );
+        }
+    }
 }

--- a/crates/fulgur/src/tagging.rs
+++ b/crates/fulgur/src/tagging.rs
@@ -437,6 +437,7 @@ mod tests {
 
         // Clone reproduces all fields.
         let e2c = e2.clone();
+        assert_eq!(e2c.tag, e2.tag);
         assert_eq!(e2c.parent, e2.parent);
         assert_eq!(e2c.alt_text, e2.alt_text);
     }

--- a/crates/fulgur/src/tagging.rs
+++ b/crates/fulgur/src/tagging.rs
@@ -374,35 +374,40 @@ mod tests {
 
     #[test]
     fn pdf_tag_to_krilla_tag_heading_level_zero_clamped_to_one() {
-        // level=0 is below the valid range; clamp(1,6) must bring it up to 1
-        // so NonZeroU16::new(1) succeeds and we still get an Hn tag.
+        // level=0 is below the valid range; clamp(1,6) must bring it up to 1.
         let k = pdf_tag_to_krilla_tag(&PdfTag::H { level: 0 }, None, None);
-        assert!(
-            matches!(k, krilla::tagging::TagKind::Hn(_)),
-            "level=0 should produce Hn after clamping to 1"
-        );
+        let krilla::tagging::TagKind::Hn(tag) = k else {
+            panic!("expected TagKind::Hn for level=0");
+        };
+        assert_eq!(tag.level().get(), 1, "level=0 should clamp to 1");
     }
 
     #[test]
     fn pdf_tag_to_krilla_tag_heading_level_above_six_clamped() {
-        // level=7 and level=255 are above the valid range; clamp(1,6) caps at 6.
+        // level=7, 10, 255 are above the valid range; clamp(1,6) caps at 6.
         for level in [7u8, 10, 255] {
             let k = pdf_tag_to_krilla_tag(&PdfTag::H { level }, None, None);
-            assert!(
-                matches!(k, krilla::tagging::TagKind::Hn(_)),
-                "level={level} should produce Hn after clamping to 6"
-            );
+            let krilla::tagging::TagKind::Hn(tag) = k else {
+                panic!("expected TagKind::Hn for level={level}");
+            };
+            assert_eq!(tag.level().get(), 6, "level={level} should clamp to 6");
         }
     }
 
     #[test]
     fn pdf_tag_to_krilla_tag_heading_level_clamping_with_title() {
-        // Clamping path with a heading_title to confirm both clamp and title flow.
+        // Clamping path with a heading_title: confirm both clamp and title flow.
         let title = Some("Appendix".to_owned());
         let k_low = pdf_tag_to_krilla_tag(&PdfTag::H { level: 0 }, title.clone(), None);
         let k_high = pdf_tag_to_krilla_tag(&PdfTag::H { level: 9 }, title, None);
-        assert!(matches!(k_low, krilla::tagging::TagKind::Hn(_)));
-        assert!(matches!(k_high, krilla::tagging::TagKind::Hn(_)));
+        let krilla::tagging::TagKind::Hn(tag_low) = k_low else {
+            panic!("expected Hn for level=0");
+        };
+        let krilla::tagging::TagKind::Hn(tag_high) = k_high else {
+            panic!("expected Hn for level=9");
+        };
+        assert_eq!(tag_low.level().get(), 1, "level=0 should clamp to 1");
+        assert_eq!(tag_high.level().get(), 6, "level=9 should clamp to 6");
     }
 
     // ── SemanticEntry ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## 対象モジュール

`crates/fulgur/src/tagging.rs` — Tagged PDF セマンティックレイヤー

カバレッジ計測時点（2026-07-20）の最低カバレッジ上位 3 ファイル:

| ファイル | Region カバレッジ |
|----------|-----------------|
| `convert/list_item.rs` | 91.36% |
| `render.rs` | 92.46% |
| `tagging.rs` | **93.72%** ← 本 PR |

`render.rs`・`convert/list_item.rs` は Blitz/Krilla 依存が深く本ルーティン（テスト専用）での unit test 追加が困難なため、純粋ロジックのみで構成される `tagging.rs` を選択しました。

## カバレッジ変化

| 指標 | 変更前 | 変更後 | 差分 |
|------|--------|--------|------|
| Region coverage | 93.72% (23 missed / 366 regions) | 94.56% (27 missed / 496 regions) | **+0.84 pp** |
| Line coverage | 99.48% (1 missed / 193 lines) | 99.63% (1 missed / 271 lines) | +0.15 pp |
| Function coverage | 100% (0 missed / 18 fns) | 100% (0 missed / 26 fns) | — |

## 追加したテスト（8 本）

| テスト名 | 対象 |
|----------|------|
| `pdf_tag_to_krilla_tag_heading_level_zero_clamped_to_one` | level=0 → `clamp(1,6)` 下限分岐 |
| `pdf_tag_to_krilla_tag_heading_level_above_six_clamped` | level=7/10/255 → `clamp(1,6)` 上限分岐 |
| `pdf_tag_to_krilla_tag_heading_level_clamping_with_title` | クランプパスで `heading_title` を伴うケース |
| `semantic_entry_construction_and_clone` | `SemanticEntry` フィールド検証・`Clone` |
| `pdf_tag_partial_eq_and_clone` | `PdfTag` `PartialEq`/`Clone` derives。`ListNumbering` と `TableHeaderScope` の非等値ケースも網羅 |
| `pdf_tag_debug_is_non_empty` | `Debug` derive のスモークテスト |
| `classify_element_is_case_sensitive` | 大文字 HTML タグ名（`"P"`, `"H1"` など）が `None` を返すことを確認 |
| `classify_element_none_for_interactive_and_metadata_elements` | `form`, `input`, `video`, `iframe` など 22 要素が `None` を返すことを確認 |

## 意図的に除外したカバレッジ

- **`matches!` マクロの `_ => false` アーム**: 正しいテストでは常に到達不能（unreachable）。追加テストを増やすほど missed regions の絶対数も増えるが、分母も増えるため % は改善する。根本的な解消は不可能。
- **残り 1 missed line**: `pdf_tag_to_krilla_tag_th_scope_variants` 内の `if let TagKind::TH(tag) = k { ... }` の else ブランチ。正しいテストでは `TH` が必ず返るため構造上到達不能。既存テストの書き換えが必要であり、本 PR のスコープ外。
- **`extract_text_content` / `collect_text`**: `blitz_dom::BaseDocument` のインスタンス化が必要で Blitz 依存。本ルーティンはテスト専用のためプロダクションコード変更なし。

## チェックリスト

- [x] `cargo test -p fulgur --lib` — 1733 tests passed
- [x] `cargo clippy -p fulgur -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — 差分なし
- [x] プロダクションコードの変更なし（テストのみ）


---
_Generated by [Claude Code](https://claude.ai/code/session_01VE54AsDtaqmhuMxvE5jo2H)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **テスト**
  - 見出しレベル `H { level }` の変換が正しく検証され、`level=0` の補正や `6` 超のクランプ、さらにタイトル連携の経路も確認。
  - `SemanticEntry`／`PdfTag` の `clone`、等価性判定、デバッグ出力が適切であること、`alt_text = Some("")` が保持されることを検証。
  - 要素分類のエッジケースとして、ローカル名の大小文字一致と、インタラクティブ／非構造要素（フォーム等）で `None` を返すことを確認。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->