### PR TITLE
chore(ci): pin CLA Assistant action to fulgur-rs self-fork on Node 24

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: CLA Assistant
-        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        uses: fulgur-rs/cla-assistant-lite@a4b4fee802dfbe0bbad78557fdcf78b31c1006d7 # fulgur-rs fork of v2.6.1 with Node 24 runtime
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## 概要

CLA Assistant workflow で pin している `contributor-assistant/github-action` の upstream が **2026-03-23 に archived / no longer maintained** されており、`action.yml` が `runs.using: node20` のまま。GitHub Actions runner は Node 20 deprecation で強制的に Node 24 で走らせているが、warning が出続けており、将来 Node 20 runtime 完全撤去で action 自体が壊れる。

upstream はもう fix を受け付けないため、**fulgur-rs org 配下に self-fork を作成**して pin を差し替える。

## Fork の内容

- Fork: [fulgur-rs/cla-assistant-lite](https://github.com/fulgur-rs/cla-assistant-lite) branch `node24`
- Baseline: upstream v2.6.1 tag (`ca4a40a7d1004f18d9960b404b97e5f30a505a08`)
- 追加 commit (v2.6.1 からの差分は 2 commit のみ):
  - `ci: target Node 24 runtime` — `action.yml` の `runs.using` を `node20` → `node24` に変更
  - `docs: note this is a fulgur-rs Node 24 fork of v2.6.1` — README に fork 由来を追記
- `dist/index.js` は再ビルドせず (Node 20 で書かれた JS は Node 24 でも動くため。OpenMapX/cla-assistant-action の node24 fork も同じ判断)
- diff: `action.yml` +1/-1, `README.md` +9/-1

## この PR の変更

`.github/workflows/cla.yml` の pin を差し替えるのみ:

\`\`\`diff
-        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        uses: fulgur-rs/cla-assistant-lite@a4b4fee802dfbe0bbad78557fdcf78b31c1006d7 # fulgur-rs fork of v2.6.1 with Node 24 runtime
\`\`\`

CLA workflow の設定 (input options / allowlist / custom comment / signatures path) は一切変更なし。挙動は完全に同じで、runtime だけが Node 24 になる。

## Alternatives (却下)

- **放置** — Node 20 が完全撤去された時点で CLA workflow が壊れる。マージ受付が止まるリスク。
- **DCO 切り替え (dcoapp/app)** — governance 変更 (Any License §2.3 再ライセンス経路) が必要な大きな判断で、この PR のスコープ外。
- **cla-assistant.io SaaS 移行** — 本家も 2024-06 以降 pushed_at 停止、SaaS 依存増、DB 移行必要。
- **外部 fork (OpenMapX/iainmcgin 等) を pin** — supply chain が個人 fork 依存になる。self-fork なら fulgur-rs org 内で完結し、将来 upstream に fix が来ても cherry-pick で取り込める。

## 検証

- Fork の `action.yml` が `runs.using: node24` になっていることを API で確認済み
- CLA workflow は本 PR に対しても走るので、この PR のチェック緑化で end-to-end 動作確認になる

Refs `fulgur-t9qt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * コントリビューターライセンス同意確認の仕組みを更新しました。
  * 既存の署名文書、対象ブランチ、設定内容は変更ありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->