### PR TITLE
harden(tagged): drop invisible heading /T and figure /Alt from tag tree

### DIFF
--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -438,10 +438,26 @@ fn walk_semantics(
                 }
             };
 
+            // `visibility: hidden` / `collapse` excludes the subtree from
+            // the accessibility tree (CSS 2 §11.2 + WAI-ARIA; matched by
+            // Chromium and Firefox), so an invisible <img> must not
+            // surface its `alt` text through the Figure tag's `/Alt`
+            // attribute either. Web-aware authoring uses sr-only
+            // (position:absolute + clip) or aria-hidden to keep alt
+            // available to assistive tech while hiding the visual — not
+            // `visibility: hidden`. Gate here (rather than in
+            // `pdf_tag_to_krilla_tag`) so `SemanticEntry.alt_text` stays
+            // the authoritative value that downstream tag-tree code can
+            // trust.
             let alt_text = if matches!(tag, crate::tagging::PdfTag::Figure) {
-                node.element_data()
-                    .and_then(|e| get_attr(e, "alt"))
-                    .map(|v| v.to_owned())
+                let (_opacity, visible) = extract_opacity_visible(node);
+                if visible {
+                    node.element_data()
+                        .and_then(|e| get_attr(e, "alt"))
+                        .map(|v| v.to_owned())
+                } else {
+                    None
+                }
             } else {
                 None
             };
@@ -1493,6 +1509,45 @@ mod semantics_tests {
             figure_alt("<!DOCTYPE html><html><body><img src='a.png'></body></html>"),
             None,
             "missing alt should be None"
+        );
+    }
+
+    #[test]
+    fn dom_to_drawables_drops_alt_text_on_invisible_figure() {
+        // CSS 2 §11.2 + WAI-ARIA: `visibility: hidden` / `collapse`
+        // excludes the subtree from the accessibility tree (Chromium /
+        // Firefox agreement). The Figure tag's `/Alt` attribute is an
+        // accessibility payload, so an invisible <img> must not surface
+        // its `alt` text through it — same regression class as the
+        // heading `/T` gate (heading_title_of in render.rs).
+        let figure_alt = |html: &str| {
+            let d = build_drawables(html);
+            let figures: Vec<_> = d
+                .semantics
+                .values()
+                .filter(|e| e.tag == PdfTag::Figure)
+                .collect();
+            assert_eq!(figures.len(), 1);
+            figures[0].alt_text.clone()
+        };
+
+        assert_eq!(
+            figure_alt(
+                "<!DOCTYPE html><html><body>\
+                 <img src='a.png' alt='hidden secret' style='visibility:hidden'>\
+                 </body></html>"
+            ),
+            None,
+            "visibility:hidden should drop the alt payload"
+        );
+        assert_eq!(
+            figure_alt(
+                "<!DOCTYPE html><html><body>\
+                 <img src='a.png' alt='collapsed secret' style='visibility:collapse'>\
+                 </body></html>"
+            ),
+            None,
+            "visibility:collapse should drop the alt payload"
         );
     }
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -890,6 +890,29 @@ fn extract_heading_title(para: &crate::drawables::ParagraphEntry) -> String {
         .collect()
 }
 
+/// Compute the `/T` (Title) attribute value for a heading tag, honouring
+/// `ParagraphEntry.visible`.
+///
+/// Returns `None` when the paragraph is invisible (CSS `visibility: hidden`
+/// or `visibility: collapse` — stored as `visible = false`) so that the
+/// heading's text does not leak into the tag tree while the paint path
+/// suppresses it (`draw_paragraph_inner_paint` returns early for
+/// `!entry.visible`). Also returns `None` for a visible-but-empty title,
+/// which keeps `Tag::Hn` from emitting a zero-length `/T`.
+///
+/// Called from both title-extraction sinks — `try_start_tagged` (the normal
+/// paragraph tagging path) and the `build_struct_tree` per-run backfill
+/// (heading whose content is per-run tagged because of an inner link) — so
+/// the same `visible` gate applies to every path that can produce a
+/// heading `/T` attribute.
+fn heading_title_of(para: &crate::drawables::ParagraphEntry) -> Option<String> {
+    if !para.visible {
+        return None;
+    }
+    let title = extract_heading_title(para);
+    (!title.is_empty()).then_some(title)
+}
+
 /// Start a Krilla tagged content sequence for a paragraph-bearing node when
 /// tagging is enabled and the node has a P / H / Span semantic entry.
 ///
@@ -932,7 +955,7 @@ fn try_start_tagged(
             let heading_title = drawables
                 .paragraphs
                 .get(&node_id)
-                .map(extract_heading_title);
+                .and_then(heading_title_of);
             use krilla::tagging::{ContentTag, SpanTag};
             let id = canvas
                 .surface
@@ -3882,17 +3905,20 @@ fn build_struct_tree(
     // Nodes that use per-run tagging (run_entries) bypass try_start_tagged and
     // therefore never record a heading_title through tc_entries. Backfill their
     // titles here so <h1><a href>…</a></h1> still gets the /T attribute.
+    // `heading_title_of` filters out invisible headings so the tag tree does
+    // not leak `visibility: hidden` content that the paint path suppressed.
     for &node_id in run_entries.keys() {
         if heading_titles.contains_key(&node_id) {
             continue;
         }
         if let Some(entry) = drawables.semantics.get(&node_id) {
             if matches!(entry.tag, crate::tagging::PdfTag::H { .. }) {
-                if let Some(para) = drawables.paragraphs.get(&node_id) {
-                    let title = extract_heading_title(para);
-                    if !title.is_empty() {
-                        heading_titles.insert(node_id, title);
-                    }
+                if let Some(title) = drawables
+                    .paragraphs
+                    .get(&node_id)
+                    .and_then(heading_title_of)
+                {
+                    heading_titles.insert(node_id, title);
                 }
             }
         }
@@ -4343,6 +4369,17 @@ mod tests {
         }
     }
 
+    fn make_hidden_para(
+        lines: Vec<crate::paragraph::ShapedLine>,
+    ) -> crate::drawables::ParagraphEntry {
+        crate::drawables::ParagraphEntry {
+            lines,
+            opacity: 1.0,
+            visible: false,
+            id: None,
+        }
+    }
+
     #[test]
     fn para_has_link_runs_empty_paragraph_returns_false() {
         let para = make_para(vec![]);
@@ -4569,6 +4606,59 @@ mod tests {
         ]);
         let para = make_para(vec![line]);
         assert_eq!(extract_heading_title(&para), "text");
+    }
+
+    // --- heading_title_of ---
+    //
+    // `heading_title_of` gates `extract_heading_title` on
+    // `ParagraphEntry.visible` and drops zero-length titles. It is the
+    // single choke point shared by `try_start_tagged` (H arm) and
+    // `build_struct_tree`'s per-run backfill, so a `None` here means the
+    // heading `/T` attribute is never emitted for that paragraph.
+
+    #[test]
+    fn heading_title_of_visible_paragraph_with_text_returns_title() {
+        // Sanity: the visible-with-text path still forwards a title.
+        let line = make_shaped_line(vec![crate::paragraph::LineItem::Text(make_glyph_run(
+            "Chapter", None,
+        ))]);
+        let para = make_para(vec![line]);
+        assert_eq!(heading_title_of(&para), Some("Chapter".to_string()));
+    }
+
+    #[test]
+    fn heading_title_of_visible_empty_paragraph_returns_none() {
+        // An empty paragraph would have produced a zero-length `/T`
+        // before; the helper drops that in a single place so both call
+        // sites see identical behaviour.
+        let para = make_para(vec![]);
+        assert_eq!(heading_title_of(&para), None);
+    }
+
+    #[test]
+    fn heading_title_of_hidden_paragraph_returns_none() {
+        // Core security regression guard: a `visibility: hidden` /
+        // `collapse` paragraph must not surface its text through the tag
+        // tree even though `extract_heading_title` would happily collect
+        // it. Without this gate the text would end up in `Tag::Hn`'s
+        // `/T` attribute for both the normal and per-run backfill sinks
+        // while the paint path skips the same paragraph, leaking hidden
+        // content to any tool that reads the struct tree.
+        let line = make_shaped_line(vec![crate::paragraph::LineItem::Text(make_glyph_run(
+            "hidden secret",
+            None,
+        ))]);
+        let para = make_hidden_para(vec![line]);
+        assert_eq!(heading_title_of(&para), None);
+    }
+
+    #[test]
+    fn heading_title_of_hidden_empty_paragraph_returns_none() {
+        // The visibility gate short-circuits before the text collection,
+        // so an empty-and-hidden paragraph is `None` too — same result
+        // as the visible-empty case, exercised via the other branch.
+        let para = make_hidden_para(vec![]);
+        assert_eq!(heading_title_of(&para), None);
     }
 
     // --- paragraph_lines_for_page ---

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -5457,6 +5457,65 @@ fn test_tagged_semanticless_link_runs_do_not_panic() {
     }
 }
 
+/// Headings and `<img alt>` values with `visibility: hidden` (or
+/// `collapse`) must not leak their text into the tagged PDF struct tree
+/// via `Tag::Hn`'s `/T` (Title) attribute or `Tag::Figure`'s `/Alt`
+/// attribute. CSS 2 §11.2 + WAI-ARIA specify that `visibility: hidden`
+/// excludes the subtree from the accessibility tree (Chromium / Firefox
+/// agreement); tagged PDF is the paged counterpart of that a11y tree so
+/// the same subtree exclusion applies. `pdf_tag_to_krilla_tag` carries
+/// exactly two free-text attributes (heading title, figure alt) — every
+/// other `PdfTag` variant is an enum or nothing — so gating these two
+/// closes the class completely.
+///
+/// Covers all three sinks:
+/// - `try_start_tagged` H arm (heading `/T`, normal paragraph tagging)
+/// - `build_struct_tree` per-run backfill (heading `/T` when an inner
+///   link forces per-run tagging)
+/// - `SemanticEntry.alt_text` extraction (`<img>` Figure `/Alt`)
+#[test]
+fn test_tagged_hidden_heading_omits_title_attribute() {
+    // Sentinel appears in the input HTML only inside elements that are
+    // `visibility: hidden` (or `collapse`). If it shows up in the rendered
+    // PDF bytes, it can only have come from a tag-tree attribute, since
+    // painting is already suppressed for these paragraphs / images.
+    let sentinel = "FULGURHIDDENSECRETXYZ";
+    // Tiny valid 1x1 PNG (raster ping-through so the Figure tag is emitted).
+    let png_data_url = "data:image/png;base64,\
+        iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQAAAAA3bvkkAAAAB0lEQVR42mNgAAAAAgABc3UBGAAAAABJRU5ErkJggg==";
+    let cases = [
+        // Plain hidden heading exercises the `try_start_tagged` path.
+        format!(r#"<h1 style="visibility:hidden">{sentinel}</h1>"#),
+        // Collapsed hidden heading is equivalent per CSS 2.1 §11.2 and
+        // must be gated the same way.
+        format!(r#"<h2 style="visibility:collapse">{sentinel}</h2>"#),
+        // Hidden heading whose only child is a link forces per-run
+        // tagging, exercising the `build_struct_tree` backfill sink.
+        format!(
+            r#"<h3 style="visibility:hidden"><a href="https://example.com">{sentinel}</a></h3>"#
+        ),
+        // Hidden image alt: `Tag::Figure` carries the alt text through
+        // its `/Alt` attribute — the other free-text sink in
+        // `pdf_tag_to_krilla_tag`.
+        format!(r#"<img src="{png_data_url}" alt="{sentinel}" style="visibility:hidden">"#),
+        format!(r#"<img src="{png_data_url}" alt="{sentinel}" style="visibility:collapse">"#),
+    ];
+    for body in cases {
+        let pdf = Engine::builder()
+            .tagged(true)
+            .lang("en")
+            .build()
+            .render(&format!("<html><body>{body}</body></html>"))
+            .unwrap_or_else(|e| panic!("tagged render must not fail for {body:?}: {e:?}"));
+        let needle = sentinel.as_bytes();
+        let leaks = pdf.windows(needle.len()).any(|w| w == needle);
+        assert!(
+            !leaks,
+            "hidden heading text leaked into tagged PDF for {body:?}"
+        );
+    }
+}
+
 #[test]
 fn test_render_html_huge_multicol_column_count_is_bounded() {
     // Security regression (unbounded `column-count` memory-exhaustion DoS):


### PR DESCRIPTION
## 概要

Tagged / PDF-UA 出力の struct tree で、`visibility: hidden` / `collapse` な要素の
テキストが `Tag::Hn` の `/T` (Title) と `Tag::Figure` の `/Alt` 属性に leak して
いた。paint 経路 (`draw_paragraph_inner_paint`) は `!entry.visible` を早期 return
していたので、ページには何も描かれていない状態でも tag tree にだけテキストが
残るのを是正する。

`pdf_tag_to_krilla_tag` を grep すると自由テキストを持つ variant は
`Tag::Hn(_, heading_title)` と `Tag::Figure(alt_text)` の **2 つだけ**（他は
enum か unit）なので、この 2 sink を gate すればクラス全体が閉じる。

## 修正内容

1. `render.rs` に `heading_title_of(&ParagraphEntry) -> Option<String>`
   choke point を新設し、`ParagraphEntry.visible` が false のときは `None` を
   返す。`/T` を emit しうる 2 sink（`try_start_tagged` H arm と
   `build_struct_tree` の per-run backfill）を両方これ経由に切替。
2. `convert/mod.rs::dom_to_drawables` の `<img>` → `PdfTag::Figure` 分岐で
   `extract_opacity_visible(node)` を呼び、invisible なら `alt_text` を `None`
   化。`SemanticEntry.alt_text` を tag-tree 側の authoritative な値として保つ。

## Why this is a hardening PR, not a GHSA advisory

- **信頼境界を越えていない**: leak するのは入力 HTML を書いた本人のテキストを、
  入力全体を見られる立場の受け手に返すだけ。fulgur の脅威モデル（単一
  untrusted input）の外側の author-hides / recipient-extracts 逆転構成でのみ
  刺さる。
- **spec 準拠の正当性バグ**: CSS 2 §11.2 + WAI-ARIA では
  `visibility:hidden` / `collapse` は subtree を accessibility tree から除外
  する（Chromium / Firefox agreement）。tagged PDF はその paged
  counterpart なので同じ挙動にすべき。
- Tagged / PDF-UA は default off の opt-in、cross-request 増幅もなし。
- Codex scanner 由来 + confidentiality 型なので `release-notes:security` で
  changelog / Release ノートに掲載。

前例: fulgur-z28x (tagged PDF nested MCS panic hardening、opt-in default off で
GHSA なし、`release-notes:security` 公開 PR で着地) と同型の判定。

## テスト

- Unit (`render.rs`): `heading_title_of` の visible / hidden × 空 / 非空
  マトリクス 4 本
- Unit (`convert/mod.rs`): `<img>` の `visibility: hidden` / `collapse` で
  `SemanticEntry.alt_text` が `None` になる assertion 2 本
- End-to-end (`render_smoke.rs`):
  `test_tagged_hidden_heading_omits_title_attribute` を全 3 sink
  （両 heading path + figure path）に拡張、payload sentinel の byte
  substring 不在を assert
- VRT byte-comparison: 変化なし（既存 fixtures はどれも tagged 出力を使わず、
  goldens は byte-identical）

## Test plan

- [x] `cargo test -p fulgur --lib` (1729 passed)
- [x] `cargo test -p fulgur` (integration + doc-tests 全 green)
- [x] `cargo test -p fulgur-vrt` (byte-identical goldens)
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p fulgur --all-targets -- -D warnings`
- [x] CLI 実測: PoC HTML (hidden h1 / hidden img alt) を `--tagged` で render →
  `strings -a *.pdf | grep 'FULGUR_...'` = 0 (fix 前は各々 1 hit)

Refs: fulgur-6hp5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 非表示の画像に指定された代替テキストが、PDFのアクセシビリティ構造へ出力されないよう修正しました。
  * 非表示の見出しタイトルが、PDFの構造情報へ出力されないよう修正しました。
  * 空の見出しタイトルによる不要な情報出力を抑止しました。

* **テスト**
  * 非表示の画像・見出し情報がPDFへ漏れないことを確認する回帰テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->