### PR TITLE
fix(gradient): fold per-tile fallback into Tiling Pattern for linear/radial/conic

### DIFF
--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -765,7 +765,19 @@ fn draw_background_layer(
             // Linear/Radial と同じく uniform-tile grid なら 1 個の Tiling Pattern
             // resource に集約する。Conic は wedge path 群 (~数百 byte/conic) が
             // 各 tile で完全同一になるため、特に N×M タイルで効果が大きい。
-            if let Some(grid) = try_uniform_grid(&tiles) {
+            // Codex `01f477e4`: also route the truncated-grid leading
+            // rectangle + trailing strip through Pattern emission —
+            // pre-fix conic non-uniform + repeat produced ~46 MB PDF /
+            // ~833 MB RSS from ~300 B HTML.
+            let split = if let Some(grid) = try_uniform_grid(&tiles) {
+                SplitGrid {
+                    full: Some(grid),
+                    remainder: &[],
+                }
+            } else {
+                split_truncated_grid(&tiles)
+            };
+            let draw_conic_grid = |canvas: &mut Canvas<'_, '_>, grid: UniformGrid| {
                 draw_gradient_tiling_pattern(canvas, grid, |surface, tw, th| {
                     draw_conic_gradient(
                         surface,
@@ -780,20 +792,28 @@ fn draw_background_layer(
                         th,
                     );
                 });
-            } else {
-                for (tx, ty, tw, th) in &tiles {
-                    draw_conic_gradient(
-                        canvas.surface,
-                        *from_angle,
-                        position_x,
-                        position_y,
-                        stops,
-                        *repeating,
-                        *tx,
-                        *ty,
-                        *tw,
-                        *th,
-                    );
+            };
+            if let Some(grid) = split.full {
+                draw_conic_grid(canvas, grid);
+            }
+            if !split.remainder.is_empty() {
+                if let Some(grid) = try_uniform_grid(split.remainder) {
+                    draw_conic_grid(canvas, grid);
+                } else {
+                    for (tx, ty, tw, th) in split.remainder {
+                        draw_conic_gradient(
+                            canvas.surface,
+                            *from_angle,
+                            position_x,
+                            position_y,
+                            stops,
+                            *repeating,
+                            *tx,
+                            *ty,
+                            *tw,
+                            *th,
+                        );
+                    }
                 }
             }
         }

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -623,14 +623,7 @@ fn draw_background_layer(
             //   (Codex `01f477e4`).
             // - Otherwise (single tile / irregular geometry) → per-tile
             //   loop over all tiles.
-            let split = if let Some(grid) = try_uniform_grid(&tiles) {
-                SplitGrid {
-                    full: Some(grid),
-                    remainder: &[],
-                }
-            } else {
-                split_truncated_grid(&tiles)
-            };
+            let split = resolve_gradient_split(&tiles);
             let draw_linear_grid = |canvas: &mut Canvas<'_, '_>, grid: UniformGrid| {
                 let angle = match direction {
                     crate::draw_primitives::LinearGradientDirection::Angle(a) => *a,
@@ -712,14 +705,7 @@ fn draw_background_layer(
             // resource is sound. Extended (Codex `01f477e4`) to also route
             // the truncated-grid leading rectangle + trailing 1×N strip
             // through Pattern emission rather than per-tile draws.
-            let split = if let Some(grid) = try_uniform_grid(&tiles) {
-                SplitGrid {
-                    full: Some(grid),
-                    remainder: &[],
-                }
-            } else {
-                split_truncated_grid(&tiles)
-            };
+            let split = resolve_gradient_split(&tiles);
             let draw_radial_grid = |canvas: &mut Canvas<'_, '_>, grid: UniformGrid| {
                 draw_gradient_tiling_pattern(canvas, grid, |surface, tw, th| {
                     draw_radial_gradient(
@@ -769,14 +755,7 @@ fn draw_background_layer(
             // rectangle + trailing strip through Pattern emission —
             // pre-fix conic non-uniform + repeat produced ~46 MB PDF /
             // ~833 MB RSS from ~300 B HTML.
-            let split = if let Some(grid) = try_uniform_grid(&tiles) {
-                SplitGrid {
-                    full: Some(grid),
-                    remainder: &[],
-                }
-            } else {
-                split_truncated_grid(&tiles)
-            };
+            let split = resolve_gradient_split(&tiles);
             let draw_conic_grid = |canvas: &mut Canvas<'_, '_>, grid: UniformGrid| {
                 draw_gradient_tiling_pattern(canvas, grid, |surface, tw, th| {
                     draw_conic_gradient(
@@ -2223,6 +2202,21 @@ fn try_uniform_grid(tiles: &[(f32, f32, f32, f32)]) -> Option<UniformGrid> {
 struct SplitGrid<'a> {
     full: Option<UniformGrid>,
     remainder: &'a [(f32, f32, f32, f32)],
+}
+
+/// Combined uniform-grid / truncated-grid classifier used by every
+/// gradient arm. Wraps the "fast path first, split fallback second"
+/// choice in a single call so the three gradient arms cannot drift
+/// apart (e.g. linear picking up a new shape while radial does not).
+fn resolve_gradient_split(tiles: &[(f32, f32, f32, f32)]) -> SplitGrid<'_> {
+    if let Some(grid) = try_uniform_grid(tiles) {
+        SplitGrid {
+            full: Some(grid),
+            remainder: &[],
+        }
+    } else {
+        split_truncated_grid(tiles)
+    }
 }
 
 /// Detect a `MAX_TILES` mid-row-truncated grid and split it into a

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -1803,10 +1803,10 @@ fn resolve_gradient_size(size: &BgSize, origin_w: f32, origin_h: f32) -> (f32, f
     // (`1e-3` pt). Tiles narrower than the eps otherwise collapse in
     // the grid-shape dedup and re-enter per-tile emission (the Codex
     // `01f477e4` subpixel residual = 425 MB / 975 MB RSS from ~300 B
-    // HTML). See `MIN_GRADIENT_TILE_PT` for the exact resolution basis
-    // and trade-off discussion (0.01 pt equals one dot at commercial
-    // 7200 dpi printing, so single-dot gradients at that ceiling get
-    // lifted by ≤ 2× — accepted defense-in-depth cost).
+    // HTML). See `MIN_GRADIENT_TILE_PT` for the resolution basis, the
+    // per-value lift factor (grows unbounded as the raw value
+    // approaches zero — `0.001 pt` becomes `10×`, `0.0001 pt` becomes
+    // `100×`), and the trade-off discussion.
     //
     // The clamp applies to the **final** tile size — both explicit
     // `background-size` axes AND the origin-derived `Auto` / `Cover` /

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -1798,22 +1798,33 @@ fn ellipse_corner_scale(
 /// `Explicit` with one axis `None` falls back to the corresponding origin axis
 /// (still no aspect to derive from).
 fn resolve_gradient_size(size: &BgSize, origin_w: f32, origin_h: f32) -> (f32, f32) {
-    // Clamp subpixel tile sizes to `MIN_GRADIENT_TILE_PT` so tiles remain
-    // above the `try_uniform_grid` epsilon (`1e-3` pt). Tiles narrower
-    // than the eps otherwise collapse in the grid-shape dedup and
-    // re-enter per-tile emission (the Codex `01f477e4` subpixel residual
-    // = 425 MB / 975 MB RSS from ~300 B HTML). See `MIN_GRADIENT_TILE_PT`
-    // for the rationale on the chosen constant (well below any physical
-    // dot at commercial 7200 dpi printing).
+    // Clamp positive-but-sub-`MIN_GRADIENT_TILE_PT` tile sizes to the
+    // constant so tiles remain above the `try_uniform_grid` epsilon
+    // (`1e-3` pt). Tiles narrower than the eps otherwise collapse in
+    // the grid-shape dedup and re-enter per-tile emission (the Codex
+    // `01f477e4` subpixel residual = 425 MB / 975 MB RSS from ~300 B
+    // HTML). See `MIN_GRADIENT_TILE_PT` for the rationale on the
+    // chosen constant (well below any physical dot at commercial
+    // 7200 dpi printing).
     //
-    // The clamp applies **only to axes explicitly specified in the CSS
-    // `background-size` value** (`BgSize::Explicit(Some(_), _)` /
-    // `Explicit(_, Some(_))`). `Auto` / `Cover` / `Contain` and the
-    // auto-side of a single-axis `Explicit` return the origin dimension
-    // unchanged — the origin (padding-box by default) can legitimately
-    // be sub-min, and rewriting it would change the tile size CSS never
-    // asked for. Only attacker-supplied `background-size: 0.001px` etc.
-    // enters the clamp path.
+    // The clamp applies to the **final** tile size — both explicit
+    // `background-size` axes AND the origin-derived `Auto` / `Cover` /
+    // `Contain` / one-axis-`Explicit`-with-auto-side fallback. Rationale:
+    // an attacker can drive the origin box itself sub-eps via the CSS
+    // box model (`background-origin: content-box` + tiny content-box +
+    // large padding, keeping the clip large through `background-clip:
+    // border-box`), which would otherwise bypass an explicit-only clamp
+    // and re-enable the fallback (Codex PR #654 review
+    // `discussion_r3614099014`). Current Blitz layout happens to floor
+    // sub-0.5 CSS-px content to 0 pt, and fulgur's `if img_w <= 0.0`
+    // short-circuit already skips zero-area layers, so the clamp does
+    // not currently rewrite any observable output — but relying on that
+    // implicit rounding would be a lateral dependency on the layout
+    // engine's precision. Clamping the final tile size here removes
+    // that coupling. Zero remains zero (legitimate no-emit); only
+    // strictly positive sub-min values are lifted, and the ceiling
+    // (0.01 pt) is a full order of magnitude below any physical output
+    // dot, so no visible legitimate rendering changes.
     fn floor_gradient_tile(v: f32) -> f32 {
         if v > 0.0 && v < crate::MIN_GRADIENT_TILE_PT {
             crate::MIN_GRADIENT_TILE_PT
@@ -1821,20 +1832,21 @@ fn resolve_gradient_size(size: &BgSize, origin_w: f32, origin_h: f32) -> (f32, f
             v
         }
     }
-    match size {
+    let (raw_w, raw_h) = match size {
         BgSize::Auto | BgSize::Cover | BgSize::Contain => (origin_w, origin_h),
         BgSize::Explicit(w_opt, h_opt) => {
             let rw = w_opt
                 .as_ref()
-                .map(|v| floor_gradient_tile(resolve_lp(v, origin_w)))
+                .map(|v| resolve_lp(v, origin_w))
                 .unwrap_or(origin_w);
             let rh = h_opt
                 .as_ref()
-                .map(|v| floor_gradient_tile(resolve_lp(v, origin_h)))
+                .map(|v| resolve_lp(v, origin_h))
                 .unwrap_or(origin_h);
             (rw, rh)
         }
-    }
+    };
+    (floor_gradient_tile(raw_w), floor_gradient_tile(raw_h))
 }
 
 /// Resolve `background-size` for a layer relative to the origin area.
@@ -2678,25 +2690,33 @@ mod tests {
     }
 
     #[test]
-    fn resolve_gradient_size_auto_does_not_clamp_sub_min_origin() {
-        // `BgSize::Auto` must pass origin dimensions through unchanged, even
-        // when the origin is legitimately sub-`MIN_GRADIENT_TILE_PT`. Only
-        // attacker-supplied explicit `background-size: 0.001px` values enter
-        // the clamp path — an element whose padding-box happens to be
-        // 0.005 pt (or 0.0) still gets its own dimensions, not 0.01 pt.
+    fn resolve_gradient_size_auto_clamps_sub_min_origin() {
+        // `BgSize::Auto` must lift sub-min origin dimensions to
+        // `MIN_GRADIENT_TILE_PT` to close the Codex `discussion_r3614099014`
+        // origin-manipulation exploit (`background-origin:content-box` +
+        // tiny content-box + large padding). Blitz layout currently floors
+        // sub-0.5 CSS-px content to 0 pt so no observable rendering is
+        // touched today, but the clamp removes the implicit dependency on
+        // that layout-engine rounding.
         let layer_size = BgSize::Auto;
         let (w, h) = resolve_gradient_size(&layer_size, 0.005, 0.005);
-        assert_eq!(
-            (w, h),
-            (0.005, 0.005),
-            "Auto must not lift origin dims above MIN_GRADIENT_TILE_PT"
+        assert!(
+            (w - crate::MIN_GRADIENT_TILE_PT).abs() < 1e-6,
+            "Auto with sub-min origin_w must clamp, got {w}"
+        );
+        assert!(
+            (h - crate::MIN_GRADIENT_TILE_PT).abs() < 1e-6,
+            "Auto with sub-min origin_h must clamp, got {h}"
         );
     }
 
     #[test]
-    fn resolve_gradient_size_explicit_with_auto_side_preserves_origin_on_auto_axis() {
-        // `background-size: 0.001px auto` — the width is explicit (clamps),
-        // the height is auto (falls back to origin, must NOT clamp).
+    fn resolve_gradient_size_explicit_with_auto_side_clamps_auto_axis_too() {
+        // `background-size: 0.001px auto` on a sub-min origin: both axes
+        // must clamp — the explicit width because CSS explicitly asked
+        // for a subpixel tile (attacker), the auto height because the
+        // origin fallback path is likewise attacker-reachable via CSS
+        // box model tricks (Codex `discussion_r3614099014`).
         let layer_size = BgSize::Explicit(
             Some(BgLengthPercentage::Length(0.0001_f32.as_px().in_pt())),
             None,
@@ -2706,9 +2726,22 @@ mod tests {
             (w - crate::MIN_GRADIENT_TILE_PT).abs() < 1e-6,
             "explicit width must clamp, got {w}"
         );
+        assert!(
+            (h - crate::MIN_GRADIENT_TILE_PT).abs() < 1e-6,
+            "auto-side height with sub-min origin must clamp, got {h}"
+        );
+    }
+
+    #[test]
+    fn resolve_gradient_size_auto_preserves_supra_min_origin() {
+        // Regression: legitimate non-tiny origins must pass through
+        // unchanged. 1 pt is 100× the min; must not be lifted.
+        let layer_size = BgSize::Auto;
+        let (w, h) = resolve_gradient_size(&layer_size, 1.0, 2.0);
         assert_eq!(
-            h, 0.005,
-            "auto-side height must inherit origin unchanged, got {h}"
+            (w, h),
+            (1.0, 2.0),
+            "Auto with supra-min origin must pass through"
         );
     }
 

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -1803,9 +1803,10 @@ fn resolve_gradient_size(size: &BgSize, origin_w: f32, origin_h: f32) -> (f32, f
     // (`1e-3` pt). Tiles narrower than the eps otherwise collapse in
     // the grid-shape dedup and re-enter per-tile emission (the Codex
     // `01f477e4` subpixel residual = 425 MB / 975 MB RSS from ~300 B
-    // HTML). See `MIN_GRADIENT_TILE_PT` for the rationale on the
-    // chosen constant (well below any physical dot at commercial
-    // 7200 dpi printing).
+    // HTML). See `MIN_GRADIENT_TILE_PT` for the exact resolution basis
+    // and trade-off discussion (0.01 pt equals one dot at commercial
+    // 7200 dpi printing, so single-dot gradients at that ceiling get
+    // lifted by ≤ 2× — accepted defense-in-depth cost).
     //
     // The clamp applies to the **final** tile size — both explicit
     // `background-size` axes AND the origin-derived `Auto` / `Cover` /
@@ -1822,9 +1823,11 @@ fn resolve_gradient_size(size: &BgSize, origin_w: f32, origin_h: f32) -> (f32, f
     // implicit rounding would be a lateral dependency on the layout
     // engine's precision. Clamping the final tile size here removes
     // that coupling. Zero remains zero (legitimate no-emit); only
-    // strictly positive sub-min values are lifted, and the ceiling
-    // (0.01 pt) is a full order of magnitude below any physical output
-    // dot, so no visible legitimate rendering changes.
+    // strictly positive sub-min values are lifted.
+    //
+    // `background-repeat: round` also gets the same floor at
+    // `resolve_repeat_axis::Round` because that helper re-derives tile
+    // size from `clip_size / count` and can slip back below the min.
     fn floor_gradient_tile(v: f32) -> f32 {
         if v > 0.0 && v < crate::MIN_GRADIENT_TILE_PT {
             crate::MIN_GRADIENT_TILE_PT
@@ -2373,7 +2376,24 @@ fn resolve_repeat_axis(
             }
             let count = (clip_size / image_size).round().max(1.0);
             let adjusted = clip_size / count;
-            (adjusted, 0.0, clip_start, clip_end)
+            // `Round` re-derives the tile size from `clip_size / count`,
+            // which can slip below MIN_GRADIENT_TILE_PT (and even below
+            // the `try_uniform_grid` eps) when `clip_size` is small or
+            // when `count` rounds up — bypassing the `resolve_gradient_size`
+            // clamp. Apply the same floor here so gradient Round tiles
+            // stay above eps and re-enter the Pattern fast path (coderabbit
+            // review PR #654 discussion_r3614448858). Raster/SVG tiles
+            // that transit through this same helper get the floor too;
+            // sub-min raster tiles are invisible on any output device
+            // (see MIN_GRADIENT_TILE_PT docstring), so the shared clamp
+            // is a defense-in-depth consistency win rather than a
+            // behavior change for legitimate content.
+            let final_size = if adjusted > 0.0 && adjusted < crate::MIN_GRADIENT_TILE_PT {
+                crate::MIN_GRADIENT_TILE_PT
+            } else {
+                adjusted
+            };
+            (final_size, 0.0, clip_start, clip_end)
         }
     }
 }
@@ -4850,6 +4870,48 @@ mod additional_conic_and_grid_tests {
         assert_eq!(space, 0.0);
         assert_eq!(start, 0.0);
         assert!((end - 40.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn resolve_repeat_axis_round_sub_min_adjusted_clamps_to_min_gradient_tile_pt() {
+        // clip_size=0.005 pt is well below MIN_GRADIENT_TILE_PT=0.01.
+        // With image_size=100 (post-clamp arbitrary), Round yields
+        //   count = round(0.005/100).max(1) = 1
+        //   adjusted = 0.005 / 1 = 0.005      ← below MIN_GRADIENT_TILE_PT
+        // The floor must lift adjusted to MIN_GRADIENT_TILE_PT (0.01) so
+        // downstream `try_uniform_grid` stays above its 1e-3 pt eps and
+        // the Pattern fast path remains reachable (coderabbit review PR
+        // #654 discussion_r3614448858).
+        let (size, _space, _start, _end) =
+            resolve_repeat_axis(BgRepeat::Round, 0.0, 100.0, 0.0, 0.005);
+        assert!(
+            (size - crate::MIN_GRADIENT_TILE_PT).abs() < 1e-6,
+            "sub-min Round adjusted must clamp to MIN_GRADIENT_TILE_PT, got {size}"
+        );
+    }
+
+    #[test]
+    fn resolve_repeat_axis_round_zero_clip_stays_zero() {
+        // Zero clip is a legitimate degenerate; the floor must not
+        // resurrect a tile out of nothing.
+        let (size, _space, _start, _end) =
+            resolve_repeat_axis(BgRepeat::Round, 0.0, 100.0, 0.0, 0.0);
+        assert_eq!(size, 0.0, "zero clip must produce zero tile, got {size}");
+    }
+
+    #[test]
+    fn resolve_repeat_axis_round_supra_min_adjusted_passes_through() {
+        // Regression: legitimate non-tiny Round tiles must not be
+        // affected by the clamp. image_size=10, clip_size=105.5:
+        //   count = round(10.55) = 11
+        //   adjusted = 105.5 / 11 ≈ 9.591       (well above min)
+        let (size, _space, _start, _end) =
+            resolve_repeat_axis(BgRepeat::Round, 0.0, 10.0, 0.0, 105.5);
+        let expected = 105.5_f32 / 11.0;
+        assert!(
+            (size - expected).abs() < 1e-5,
+            "supra-min Round adjusted must pass through unchanged, got {size} expected {expected}"
+        );
     }
 
     // ─── try_uniform_grid: non-uniform y step rejection ──────────────────────

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -611,11 +611,27 @@ fn draw_background_layer(
             stops,
             repeating,
         } => {
-            // Try to detect a uniform tile grid and emit a single Tiling Pattern
-            // resource (one Function 2 + Shading 2 + Pattern triplet) rather
-            // than N independent gradient draws. Falls back to the per-tile
-            // loop for irregular tile geometry (e.g. uneven space repeat).
-            if let Some(grid) = try_uniform_grid(&tiles) {
+            // Detect the tile-grid shape and pick the cheapest emission:
+            // - Fully uniform grid → single Tiling Pattern (one Function 2
+            //   + Shading 2 + Pattern triplet), unchanged fast path.
+            // - Truncated grid (MAX_TILES mid-row cut) → leading complete-row
+            //   rectangle as one Pattern; the trailing partial row is itself
+            //   a uniform 1×N strip so it emits as a second Pattern via the
+            //   remainder try_uniform_grid check below. This bounds the
+            //   pre-fix ~425 MB / ~975 MB RSS regression from
+            //   `background-size:1.33px + background-repeat:repeat`
+            //   (Codex `01f477e4`).
+            // - Otherwise (single tile / irregular geometry) → per-tile
+            //   loop over all tiles.
+            let split = if let Some(grid) = try_uniform_grid(&tiles) {
+                SplitGrid {
+                    full: Some(grid),
+                    remainder: &[],
+                }
+            } else {
+                split_truncated_grid(&tiles)
+            };
+            let draw_linear_grid = |canvas: &mut Canvas<'_, '_>, grid: UniformGrid| {
                 let angle = match direction {
                     crate::draw_primitives::LinearGradientDirection::Angle(a) => *a,
                     crate::draw_primitives::LinearGradientDirection::Corner(corner) => {
@@ -636,39 +652,48 @@ fn draw_background_layer(
                         grid.cell.1,
                     );
                 });
-            } else {
-                // Fallback: per-tile loop. Match before the loop (Angle hoists,
-                // Corner needs per-tile recomputation because the angle depends
-                // on tile aspect — CSS Images §3.1.1).
-                match direction {
-                    crate::draw_primitives::LinearGradientDirection::Angle(a) => {
-                        let angle = *a;
-                        for (tx, ty, tw, th) in &tiles {
-                            draw_linear_gradient(
-                                canvas.surface,
-                                angle,
-                                stops,
-                                *repeating,
-                                *tx,
-                                *ty,
-                                *tw,
-                                *th,
-                            );
+            };
+            if let Some(grid) = split.full {
+                draw_linear_grid(canvas, grid);
+            }
+            // Remainder: prefer another Pattern (partial trailing row is a
+            // 1×N uniform strip in the truncated-grid case), else per-tile.
+            // Corner direction needs per-tile angle recomputation because
+            // the angle depends on tile aspect (CSS Images §3.1.1).
+            if !split.remainder.is_empty() {
+                if let Some(grid) = try_uniform_grid(split.remainder) {
+                    draw_linear_grid(canvas, grid);
+                } else {
+                    match direction {
+                        crate::draw_primitives::LinearGradientDirection::Angle(a) => {
+                            let angle = *a;
+                            for (tx, ty, tw, th) in split.remainder {
+                                draw_linear_gradient(
+                                    canvas.surface,
+                                    angle,
+                                    stops,
+                                    *repeating,
+                                    *tx,
+                                    *ty,
+                                    *tw,
+                                    *th,
+                                );
+                            }
                         }
-                    }
-                    crate::draw_primitives::LinearGradientDirection::Corner(corner) => {
-                        for (tx, ty, tw, th) in &tiles {
-                            let angle = corner_to_angle_rad(*corner, *tw, *th);
-                            draw_linear_gradient(
-                                canvas.surface,
-                                angle,
-                                stops,
-                                *repeating,
-                                *tx,
-                                *ty,
-                                *tw,
-                                *th,
-                            );
+                        crate::draw_primitives::LinearGradientDirection::Corner(corner) => {
+                            for (tx, ty, tw, th) in split.remainder {
+                                let angle = corner_to_angle_rad(*corner, *tw, *th);
+                                draw_linear_gradient(
+                                    canvas.surface,
+                                    angle,
+                                    stops,
+                                    *repeating,
+                                    *tx,
+                                    *ty,
+                                    *tw,
+                                    *th,
+                                );
+                            }
                         }
                     }
                 }

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -709,31 +709,49 @@ fn draw_background_layer(
         } => {
             // Same dedup story as Linear: uniform grids share (cell_w, cell_h)
             // so cx/cy/rx/ry are identical across tiles → a single Pattern
-            // resource is sound.
-            if let Some(grid) = try_uniform_grid(&tiles) {
+            // resource is sound. Extended (Codex `01f477e4`) to also route
+            // the truncated-grid leading rectangle + trailing 1×N strip
+            // through Pattern emission rather than per-tile draws.
+            let split = if let Some(grid) = try_uniform_grid(&tiles) {
+                SplitGrid {
+                    full: Some(grid),
+                    remainder: &[],
+                }
+            } else {
+                split_truncated_grid(&tiles)
+            };
+            let draw_radial_grid = |canvas: &mut Canvas<'_, '_>, grid: UniformGrid| {
                 draw_gradient_tiling_pattern(canvas, grid, |surface, tw, th| {
                     draw_radial_gradient(
                         surface, *shape, size, position_x, position_y, stops, *repeating, 0.0, 0.0,
                         tw, th,
                     );
                 });
-            } else {
-                // Per-tile shape geometry — uses each tile's own (tw, th)
-                // for cx/cy/rx/ry. No uniformity assumption needed.
-                for (tx, ty, tw, th) in &tiles {
-                    draw_radial_gradient(
-                        canvas.surface,
-                        *shape,
-                        size,
-                        position_x,
-                        position_y,
-                        stops,
-                        *repeating,
-                        *tx,
-                        *ty,
-                        *tw,
-                        *th,
-                    );
+            };
+            if let Some(grid) = split.full {
+                draw_radial_grid(canvas, grid);
+            }
+            if !split.remainder.is_empty() {
+                if let Some(grid) = try_uniform_grid(split.remainder) {
+                    draw_radial_grid(canvas, grid);
+                } else {
+                    // Per-tile shape geometry — uses each tile's own (tw, th)
+                    // for cx/cy/rx/ry. No uniformity assumption needed.
+                    for (tx, ty, tw, th) in split.remainder {
+                        draw_radial_gradient(
+                            canvas.surface,
+                            *shape,
+                            size,
+                            position_x,
+                            position_y,
+                            stops,
+                            *repeating,
+                            *tx,
+                            *ty,
+                            *tw,
+                            *th,
+                        );
+                    }
                 }
             }
         }

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -1826,6 +1826,15 @@ fn resolve_gradient_size(size: &BgSize, origin_w: f32, origin_h: f32) -> (f32, f
     // = 425 MB / 975 MB RSS from ~300 B HTML). See `MIN_GRADIENT_TILE_PT`
     // for the rationale on the chosen constant (well below any physical
     // dot at commercial 7200 dpi printing).
+    //
+    // The clamp applies **only to axes explicitly specified in the CSS
+    // `background-size` value** (`BgSize::Explicit(Some(_), _)` /
+    // `Explicit(_, Some(_))`). `Auto` / `Cover` / `Contain` and the
+    // auto-side of a single-axis `Explicit` return the origin dimension
+    // unchanged — the origin (padding-box by default) can legitimately
+    // be sub-min, and rewriting it would change the tile size CSS never
+    // asked for. Only attacker-supplied `background-size: 0.001px` etc.
+    // enters the clamp path.
     fn floor_gradient_tile(v: f32) -> f32 {
         if v > 0.0 && v < crate::MIN_GRADIENT_TILE_PT {
             crate::MIN_GRADIENT_TILE_PT
@@ -1833,21 +1842,20 @@ fn resolve_gradient_size(size: &BgSize, origin_w: f32, origin_h: f32) -> (f32, f
             v
         }
     }
-    let (raw_w, raw_h) = match size {
+    match size {
         BgSize::Auto | BgSize::Cover | BgSize::Contain => (origin_w, origin_h),
         BgSize::Explicit(w_opt, h_opt) => {
             let rw = w_opt
                 .as_ref()
-                .map(|v| resolve_lp(v, origin_w))
+                .map(|v| floor_gradient_tile(resolve_lp(v, origin_w)))
                 .unwrap_or(origin_w);
             let rh = h_opt
                 .as_ref()
-                .map(|v| resolve_lp(v, origin_h))
+                .map(|v| floor_gradient_tile(resolve_lp(v, origin_h)))
                 .unwrap_or(origin_h);
             (rw, rh)
         }
-    };
-    (floor_gradient_tile(raw_w), floor_gradient_tile(raw_h))
+    }
 }
 
 /// Resolve `background-size` for a layer relative to the origin area.
@@ -2674,6 +2682,41 @@ mod tests {
         let (w, h) = resolve_gradient_size(&layer_size, 100.0, 100.0);
         assert!((w - 0.75).abs() < 1e-6, "1 px must remain 0.75 pt, got {w}");
         assert!((h - 1.5).abs() < 1e-6, "2 px must remain 1.5 pt, got {h}");
+    }
+
+    #[test]
+    fn resolve_gradient_size_auto_does_not_clamp_sub_min_origin() {
+        // `BgSize::Auto` must pass origin dimensions through unchanged, even
+        // when the origin is legitimately sub-`MIN_GRADIENT_TILE_PT`. Only
+        // attacker-supplied explicit `background-size: 0.001px` values enter
+        // the clamp path — an element whose padding-box happens to be
+        // 0.005 pt (or 0.0) still gets its own dimensions, not 0.01 pt.
+        let layer_size = BgSize::Auto;
+        let (w, h) = resolve_gradient_size(&layer_size, 0.005, 0.005);
+        assert_eq!(
+            (w, h),
+            (0.005, 0.005),
+            "Auto must not lift origin dims above MIN_GRADIENT_TILE_PT"
+        );
+    }
+
+    #[test]
+    fn resolve_gradient_size_explicit_with_auto_side_preserves_origin_on_auto_axis() {
+        // `background-size: 0.001px auto` — the width is explicit (clamps),
+        // the height is auto (falls back to origin, must NOT clamp).
+        let layer_size = BgSize::Explicit(
+            Some(BgLengthPercentage::Length(0.0001_f32.as_px().in_pt())),
+            None,
+        );
+        let (w, h) = resolve_gradient_size(&layer_size, 0.005, 0.005);
+        assert!(
+            (w - crate::MIN_GRADIENT_TILE_PT).abs() < 1e-6,
+            "explicit width must clamp, got {w}"
+        );
+        assert_eq!(
+            h, 0.005,
+            "auto-side height must inherit origin unchanged, got {h}"
+        );
     }
 
     #[test]

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -2281,22 +2281,21 @@ fn split_truncated_grid(tiles: &[(f32, f32, f32, f32)]) -> SplitGrid<'_> {
         };
     }
     // Compute per-row lengths from start offsets + total tile count.
-    let row_len = |r: usize| -> usize {
-        let start = row_starts[r];
-        let end = if r + 1 < row_count {
-            row_starts[r + 1]
-        } else {
-            tiles.len()
-        };
-        end - start
-    };
+    // `row_count <= tiles.len() <= MAX_TILES = 10_000` so the collected
+    // vector is bounded at ~80 KB worst-case, safely below any
+    // materialization concern.
+    let row_lengths: Vec<usize> = row_starts
+        .iter()
+        .enumerate()
+        .map(|(i, &start)| row_starts.get(i + 1).copied().unwrap_or(tiles.len()) - start)
+        .collect();
 
     // Count leading rows whose length matches the first row.
-    let full_row_len = row_len(0);
-    let mut full_row_count = 1usize;
-    while full_row_count < row_count && row_len(full_row_count) == full_row_len {
-        full_row_count += 1;
-    }
+    let full_row_len = row_lengths[0];
+    let full_row_count = row_lengths
+        .iter()
+        .take_while(|&&len| len == full_row_len)
+        .count();
 
     // All rows equal length → complete grid. try_uniform_grid handles
     // this on the fast path; return None so the caller does not

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -2125,6 +2125,31 @@ fn try_uniform_grid(tiles: &[(f32, f32, f32, f32)]) -> Option<UniformGrid> {
     })
 }
 
+/// Result of splitting a truncated (`MAX_TILES` mid-row cut) tile grid into
+/// a leading uniform-grid rectangle and a trailing partial-row remainder.
+///
+/// The full rectangle is emitted as a single Tiling Pattern (cheap) and
+/// the remainder as per-tile draws. Degenerate inputs (empty, single tile,
+/// single row, non-truncated grid, or non-uniform geometry) return
+/// `full=None, remainder=<original tiles>` so callers fall through to the
+/// pre-existing per-tile path unchanged.
+#[derive(Debug)]
+struct SplitGrid<'a> {
+    full: Option<UniformGrid>,
+    remainder: &'a [(f32, f32, f32, f32)],
+}
+
+/// Detect a `MAX_TILES` mid-row-truncated grid and split it into a
+/// leading uniform rectangle + a trailing partial-row remainder. Placeholder
+/// implementation (Task 1): returns `None`/`tiles` so the current per-tile
+/// callers behave unchanged; the row-length inspection lands in Task 2.
+fn split_truncated_grid(tiles: &[(f32, f32, f32, f32)]) -> SplitGrid<'_> {
+    SplitGrid {
+        full: None,
+        remainder: tiles,
+    }
+}
+
 fn resolve_repeat_axis(
     repeat: BgRepeat,
     position: f32,
@@ -4569,6 +4594,39 @@ mod additional_conic_and_grid_tests {
             try_uniform_grid(&tiles).is_none(),
             "non-uniform x steps must be rejected"
         );
+    }
+
+    // ─── split_truncated_grid: degenerate cases ─────────────────────────────
+
+    #[test]
+    fn split_truncated_grid_empty_returns_none_and_no_remainder() {
+        let tiles: Vec<(f32, f32, f32, f32)> = vec![];
+        let split = split_truncated_grid(&tiles);
+        assert!(split.full.is_none());
+        assert_eq!(split.remainder.len(), 0);
+    }
+
+    #[test]
+    fn split_truncated_grid_single_tile_returns_none_and_tile_as_remainder() {
+        let tiles = vec![(0.0_f32, 0.0_f32, 10.0_f32, 10.0_f32)];
+        let split = split_truncated_grid(&tiles);
+        assert!(split.full.is_none());
+        assert_eq!(split.remainder, tiles.as_slice());
+    }
+
+    #[test]
+    fn split_truncated_grid_single_row_returns_none_and_row_as_remainder() {
+        // Single row is either fast-path caught by try_uniform_grid or
+        // irregular; split_truncated_grid does not attempt to split a
+        // single row and hands the whole slice back as remainder.
+        let tiles = vec![
+            (0.0_f32, 0.0_f32, 5.0_f32, 5.0_f32),
+            (5.0, 0.0, 5.0, 5.0),
+            (10.0, 0.0, 5.0, 5.0),
+        ];
+        let split = split_truncated_grid(&tiles);
+        assert!(split.full.is_none());
+        assert_eq!(split.remainder, tiles.as_slice());
     }
 }
 

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -2140,13 +2140,110 @@ struct SplitGrid<'a> {
 }
 
 /// Detect a `MAX_TILES` mid-row-truncated grid and split it into a
-/// leading uniform rectangle + a trailing partial-row remainder. Placeholder
-/// implementation (Task 1): returns `None`/`tiles` so the current per-tile
-/// callers behave unchanged; the row-length inspection lands in Task 2.
+/// leading uniform rectangle + a trailing partial-row remainder.
+///
+/// `compute_tile_positions_slow` (see the outer y / inner x loop above)
+/// generates tiles in row-major order and truncates at `MAX_TILES`, so
+/// a truncated output is always shaped as "k full rows of length N
+/// followed by one partial row of length M < N". This function detects
+/// that shape by scanning per-row tile counts by y-coordinate blocks
+/// and, when found, hands the leading `k × N` tiles to `try_uniform_grid`
+/// for full geometry validation (uniform steps + identical x-positions
+/// across rows). The trailing `M` tiles are returned as `remainder` for
+/// the caller to draw per-tile.
+///
+/// Returns `full=None, remainder=tiles` (unchanged) for:
+/// - tiles.len() < 2 (nothing to split)
+/// - non-uniform cell size across the tile set
+/// - single row (nothing to split; caller either used try_uniform_grid
+///   or falls through to per-tile)
+/// - all rows same length (either a complete grid — caller already
+///   ran try_uniform_grid — or geometry is irregular)
+/// - the leading rectangle is not itself a well-formed uniform grid
+///   (non-uniform x-steps or misaligned x-positions across rows)
 fn split_truncated_grid(tiles: &[(f32, f32, f32, f32)]) -> SplitGrid<'_> {
-    SplitGrid {
-        full: None,
-        remainder: tiles,
+    if tiles.len() < 2 {
+        return SplitGrid {
+            full: None,
+            remainder: tiles,
+        };
+    }
+    let eps = 1e-3_f32;
+
+    // Cell size must be uniform across the whole tile set.
+    let (tw0, th0) = (tiles[0].2, tiles[0].3);
+    if !tiles
+        .iter()
+        .all(|t| (t.2 - tw0).abs() < eps && (t.3 - th0).abs() < eps)
+    {
+        return SplitGrid {
+            full: None,
+            remainder: tiles,
+        };
+    }
+
+    // Row-major traversal: identify per-row tile counts by y-coordinate
+    // blocks. Consecutive entries with matching y form a row.
+    let mut row_starts: Vec<usize> = Vec::with_capacity(16);
+    row_starts.push(0);
+    let mut cur_y = tiles[0].1;
+    for (i, t) in tiles.iter().enumerate().skip(1) {
+        if (t.1 - cur_y).abs() >= eps {
+            row_starts.push(i);
+            cur_y = t.1;
+        }
+    }
+    let row_count = row_starts.len();
+    if row_count < 2 {
+        return SplitGrid {
+            full: None,
+            remainder: tiles,
+        };
+    }
+    // Compute per-row lengths from start offsets + total tile count.
+    let row_len = |r: usize| -> usize {
+        let start = row_starts[r];
+        let end = if r + 1 < row_count {
+            row_starts[r + 1]
+        } else {
+            tiles.len()
+        };
+        end - start
+    };
+
+    // Count leading rows whose length matches the first row.
+    let full_row_len = row_len(0);
+    let mut full_row_count = 1usize;
+    while full_row_count < row_count && row_len(full_row_count) == full_row_len {
+        full_row_count += 1;
+    }
+
+    // All rows equal length → complete grid. try_uniform_grid handles
+    // this on the fast path; return None so the caller does not
+    // double-emit the same tile set.
+    if full_row_count == row_count {
+        return SplitGrid {
+            full: None,
+            remainder: tiles,
+        };
+    }
+
+    let full_tile_count = full_row_count * full_row_len;
+    let full_tiles = &tiles[..full_tile_count];
+    let remainder = &tiles[full_tile_count..];
+
+    // Delegate geometry validation (step uniformity + x-position match)
+    // to the existing helper — the leading rectangle must itself be a
+    // well-formed uniform grid for Pattern emission to be sound.
+    match try_uniform_grid(full_tiles) {
+        Some(grid) => SplitGrid {
+            full: Some(grid),
+            remainder,
+        },
+        None => SplitGrid {
+            full: None,
+            remainder: tiles,
+        },
     }
 }
 
@@ -4627,6 +4724,85 @@ mod additional_conic_and_grid_tests {
         let split = split_truncated_grid(&tiles);
         assert!(split.full.is_none());
         assert_eq!(split.remainder, tiles.as_slice());
+    }
+
+    // ─── split_truncated_grid: truncated-grid detection ─────────────────────
+
+    #[test]
+    fn split_truncated_grid_two_full_rows_plus_partial_returns_full_and_remainder() {
+        // 3 cols × 2 full rows + 1 partial row of 2 tiles.
+        // Cell 5×5, step 5 (no gap), row-major order per compute_tile_positions_slow.
+        let tiles = vec![
+            (0.0_f32, 0.0_f32, 5.0_f32, 5.0_f32),
+            (5.0, 0.0, 5.0, 5.0),
+            (10.0, 0.0, 5.0, 5.0),
+            (0.0, 5.0, 5.0, 5.0),
+            (5.0, 5.0, 5.0, 5.0),
+            (10.0, 5.0, 5.0, 5.0),
+            (0.0, 10.0, 5.0, 5.0),
+            (5.0, 10.0, 5.0, 5.0),
+        ];
+        let split = split_truncated_grid(&tiles);
+        let grid = split.full.expect("full grid must be detected");
+        assert_eq!(grid.count, (3, 2));
+        assert_eq!(grid.cell, (5.0, 5.0));
+        assert_eq!(grid.step, (5.0, 5.0));
+        assert_eq!(grid.origin, (0.0, 0.0));
+        assert_eq!(split.remainder.len(), 2);
+        assert_eq!(split.remainder[0], (0.0, 10.0, 5.0, 5.0));
+        assert_eq!(split.remainder[1], (5.0, 10.0, 5.0, 5.0));
+    }
+
+    #[test]
+    fn split_truncated_grid_all_rows_same_length_returns_none() {
+        // Complete uniform grid — try_uniform_grid catches this on the
+        // fast path; split_truncated_grid declines so the caller does
+        // not double-emit.
+        let tiles = vec![
+            (0.0_f32, 0.0_f32, 5.0_f32, 5.0_f32),
+            (5.0, 0.0, 5.0, 5.0),
+            (0.0, 5.0, 5.0, 5.0),
+            (5.0, 5.0, 5.0, 5.0),
+        ];
+        let split = split_truncated_grid(&tiles);
+        assert!(
+            split.full.is_none(),
+            "complete grid must fall through to try_uniform_grid fast path"
+        );
+    }
+
+    #[test]
+    fn split_truncated_grid_mismatched_cell_sizes_returns_none() {
+        // Non-uniform cell size — cannot be a truncated grid.
+        let tiles = vec![
+            (0.0_f32, 0.0_f32, 5.0_f32, 5.0_f32),
+            (5.0, 0.0, 3.0, 5.0),
+            (0.0, 5.0, 5.0, 5.0),
+        ];
+        let split = split_truncated_grid(&tiles);
+        assert!(split.full.is_none());
+        assert_eq!(split.remainder, tiles.as_slice());
+    }
+
+    #[test]
+    fn split_truncated_grid_exploit_shape_100x16_plus_400() {
+        // Emulate the MAX_TILES = 10_000 truncation shape used by the
+        // exploit: 100 cols × 16 full rows + 1 partial row of 400 tiles.
+        // Cell 1×1, step 1.
+        let mut tiles = Vec::with_capacity(2000);
+        for r in 0..16 {
+            for c in 0..100 {
+                tiles.push((c as f32, r as f32, 1.0, 1.0));
+            }
+        }
+        for c in 0..400 {
+            tiles.push((c as f32, 16.0, 1.0, 1.0));
+        }
+        assert_eq!(tiles.len(), 2000);
+        let split = split_truncated_grid(&tiles);
+        let grid = split.full.expect("full rectangle must be detected");
+        assert_eq!(grid.count, (100, 16));
+        assert_eq!(split.remainder.len(), 400);
     }
 }
 

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -1819,7 +1819,21 @@ fn ellipse_corner_scale(
 /// `Explicit` with one axis `None` falls back to the corresponding origin axis
 /// (still no aspect to derive from).
 fn resolve_gradient_size(size: &BgSize, origin_w: f32, origin_h: f32) -> (f32, f32) {
-    match size {
+    // Clamp subpixel tile sizes to `MIN_GRADIENT_TILE_PT` so tiles remain
+    // above the `try_uniform_grid` epsilon (`1e-3` pt). Tiles narrower
+    // than the eps otherwise collapse in the grid-shape dedup and
+    // re-enter per-tile emission (the Codex `01f477e4` subpixel residual
+    // = 425 MB / 975 MB RSS from ~300 B HTML). See `MIN_GRADIENT_TILE_PT`
+    // for the rationale on the chosen constant (well below any physical
+    // dot at commercial 7200 dpi printing).
+    fn floor_gradient_tile(v: f32) -> f32 {
+        if v > 0.0 && v < crate::MIN_GRADIENT_TILE_PT {
+            crate::MIN_GRADIENT_TILE_PT
+        } else {
+            v
+        }
+    }
+    let (raw_w, raw_h) = match size {
         BgSize::Auto | BgSize::Cover | BgSize::Contain => (origin_w, origin_h),
         BgSize::Explicit(w_opt, h_opt) => {
             let rw = w_opt
@@ -1832,7 +1846,8 @@ fn resolve_gradient_size(size: &BgSize, origin_w: f32, origin_h: f32) -> (f32, f
                 .unwrap_or(origin_h);
             (rw, rh)
         }
-    }
+    };
+    (floor_gradient_tile(raw_w), floor_gradient_tile(raw_h))
 }
 
 /// Resolve `background-size` for a layer relative to the origin area.
@@ -2626,6 +2641,55 @@ mod tests {
         let (w, h) = resolve_gradient_size(&size, 200.0, 100.0);
         assert!((w - 100.0).abs() < 1e-6);
         assert!((h - 25.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn resolve_gradient_size_clamps_subpixel_to_min_gradient_tile_pt() {
+        // 0.0001 px = 0.000075 pt, well below MIN_GRADIENT_TILE_PT (0.01 pt).
+        // Both axes must clamp; MIN_GRADIENT_TILE_PT closes the Codex `01f477e4`
+        // subpixel residual where sub-eps tiles collapsed try_uniform_grid dedup.
+        let layer_size = BgSize::Explicit(
+            Some(BgLengthPercentage::Length(0.0001_f32.as_px().in_pt())),
+            Some(BgLengthPercentage::Length(0.0001_f32.as_px().in_pt())),
+        );
+        let (w, h) = resolve_gradient_size(&layer_size, 595.0, 842.0);
+        assert!(
+            (w - crate::MIN_GRADIENT_TILE_PT).abs() < 1e-6,
+            "sub-eps width must clamp to MIN_GRADIENT_TILE_PT, got {w}"
+        );
+        assert!(
+            (h - crate::MIN_GRADIENT_TILE_PT).abs() < 1e-6,
+            "sub-eps height must clamp to MIN_GRADIENT_TILE_PT, got {h}"
+        );
+    }
+
+    #[test]
+    fn resolve_gradient_size_does_not_clamp_supra_min_values() {
+        // 1 px = 0.75 pt, well above MIN_GRADIENT_TILE_PT (0.01 pt).
+        // Legitimate tile sizes must pass through unchanged.
+        let layer_size = BgSize::Explicit(
+            Some(BgLengthPercentage::Length(1.0_f32.as_px().in_pt())),
+            Some(BgLengthPercentage::Length(2.0_f32.as_px().in_pt())),
+        );
+        let (w, h) = resolve_gradient_size(&layer_size, 100.0, 100.0);
+        assert!((w - 0.75).abs() < 1e-6, "1 px must remain 0.75 pt, got {w}");
+        assert!((h - 1.5).abs() < 1e-6, "2 px must remain 1.5 pt, got {h}");
+    }
+
+    #[test]
+    fn resolve_gradient_size_preserves_zero_axis() {
+        // Zero-width or zero-height explicit gradient size is legitimate
+        // (Auto behavior falls back to origin, and the tiling early-return
+        // at background.rs handles img_w<=0 || img_h<=0). Do not clamp
+        // zero up to MIN_GRADIENT_TILE_PT — that would resurrect a tile
+        // where the caller asked for nothing.
+        let layer_size = BgSize::Explicit(
+            Some(BgLengthPercentage::Length(0.0_f32.as_pt())),
+            Some(BgLengthPercentage::Length(0.5_f32.as_pt())),
+        );
+        let (w, h) = resolve_gradient_size(&layer_size, 100.0, 100.0);
+        assert_eq!(w, 0.0, "zero width must stay zero");
+        assert!((h - 0.5).abs() < 1e-6, "non-zero height passes through");
     }
 
     #[test]

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -88,7 +88,7 @@ pub(crate) const MAX_GRADIENT_STOPS: usize = 256;
 /// defensive floor applied to the resolved tile size (explicit
 /// `background-size`, origin-derived `Auto`/`Cover`/`Contain`, and the
 /// `background-repeat: round`–adjusted axis). Strictly-positive values
-/// below this are clamped up; zero remains zero.
+/// below this are clamped up to the constant; zero remains zero.
 ///
 /// `background.rs::try_uniform_grid` uses a `1e-3` pt epsilon to identify
 /// tile position clusters as "the same column/row"; tiles narrower than
@@ -101,19 +101,28 @@ pub(crate) const MAX_GRADIENT_STOPS: usize = 256;
 /// Resolution context: `0.01 pt = 72 pt/inch / 7200 dpi`, i.e. **exactly
 /// one physical dot at commercial-max 7200 dpi printing** — the clamp
 /// equals a single dot at that ceiling, not below it. At more common
-/// resolutions (300–1200 dpi, `1 dot ≈ 0.06–0.24 pt`) the clamp is 6–24×
-/// smaller than a printed dot, so no visible legitimate rendering
-/// changes. A design that meaningfully targets a single-dot-wide
-/// gradient at 7200 dpi would see that tile lifted by ≤ 2×; accepted
-/// as a defense-in-depth trade-off, since no realistic design uses
-/// gradient tiles at that scale (a one-dot gradient does not read as a
-/// gradient).
+/// resolutions (300–1200 dpi, `1 dot ≈ 0.06–0.24 pt`) the clamp is
+/// 6–24× smaller than a printed dot; content authored at those
+/// resolutions is unaffected because no legitimate value falls between
+/// the min and the printer dot.
+///
+/// **Impact on values below the clamp**: the lift factor depends on
+/// how far below the min the raw tile is (`0.005 pt → 0.01 pt = 2×`,
+/// `0.001 pt → 0.01 pt = 10×`, `0.0001 pt → 0.01 pt = 100×`; the ratio
+/// grows unbounded as the raw value approaches zero). Sub-min values
+/// are still not guaranteed invisible — antialiasing and sub-pixel
+/// positioning can make them contribute to rendered output — but a
+/// gradient authored with a tile of that scale cannot itself be read
+/// as a gradient (a single physical dot or less is either one flat
+/// color or an AA artifact of one), so the design intent is not
+/// preserved either way. Lifting to the min is accepted as a
+/// defense-in-depth trade-off against the exploit path above.
 ///
 /// Sibling of the [`MAX_GRADIENT_STOPS`] gradient bound. Also applies
 /// to raster/SVG tiles that transit `resolve_repeat_axis::Round` since
-/// that helper is shared; sub-min raster tiles are invisible on any
-/// output device, so the shared clamp is a defense-in-depth consistency
-/// win rather than a behavior change for legitimate content.
+/// that helper is shared; the same "visibility not guaranteed, design
+/// intent not preserved either way" caveat applies to raster tiles at
+/// that scale.
 pub(crate) const MIN_GRADIENT_TILE_PT: f32 = 0.01;
 
 /// Maximum byte length of a CSS named page (`page: <custom-ident>` /

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -84,6 +84,25 @@ pub(crate) const MAX_COLUMN_COUNT: u32 = 64;
 /// multicol bound.
 pub(crate) const MAX_GRADIENT_STOPS: usize = 256;
 
+/// Minimum tile size (in PDF pt) for CSS `background-image` gradients when
+/// `background-size` is explicitly set. Values below this are clamped up.
+///
+/// `background.rs::try_uniform_grid` uses a `1e-3` pt epsilon to identify
+/// tile position clusters as "the same column/row"; tiles narrower than
+/// that epsilon collapse in the dedup and defeat the Pattern fast path,
+/// forcing per-tile fallback with up to `MAX_TILES × MAX_GRADIENT_STOPS`
+/// stop-copies of PDF output (~425 MB observed for the `01f477e4` subpixel
+/// residual). Clamping tile size well above the epsilon closes that
+/// residual (`0.01 pt = 10 × eps`), and stays a full order of magnitude
+/// below any physical output-device dot (`0.01 pt = 1 dot @ 7200 dpi`
+/// commercial printing) so no legitimate CSS is affected: at 7200 dpi the
+/// tile fits inside one printed dot.
+///
+/// Sibling of the [`MAX_GRADIENT_STOPS`] gradient bound. Applied only to
+/// gradient tiles (`resolve_gradient_size`); raster/svg image tiles keep
+/// their intrinsic sizing.
+pub(crate) const MIN_GRADIENT_TILE_PT: f32 = 0.01;
+
 /// Maximum byte length of a CSS named page (`page: <custom-ident>` /
 /// `@page <name>`). A CSS `<custom-ident>` is length-unbounded, and the name
 /// `String` is retained in the parsed `ColumnProps`, cloned into the column

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -84,23 +84,36 @@ pub(crate) const MAX_COLUMN_COUNT: u32 = 64;
 /// multicol bound.
 pub(crate) const MAX_GRADIENT_STOPS: usize = 256;
 
-/// Minimum tile size (in PDF pt) for CSS `background-image` gradients when
-/// `background-size` is explicitly set. Values below this are clamped up.
+/// Minimum tile size (in PDF pt) for CSS `background-image` gradients — a
+/// defensive floor applied to the resolved tile size (explicit
+/// `background-size`, origin-derived `Auto`/`Cover`/`Contain`, and the
+/// `background-repeat: round`–adjusted axis). Strictly-positive values
+/// below this are clamped up; zero remains zero.
 ///
 /// `background.rs::try_uniform_grid` uses a `1e-3` pt epsilon to identify
 /// tile position clusters as "the same column/row"; tiles narrower than
 /// that epsilon collapse in the dedup and defeat the Pattern fast path,
 /// forcing per-tile fallback with up to `MAX_TILES × MAX_GRADIENT_STOPS`
-/// stop-copies of PDF output (~425 MB observed for the `01f477e4` subpixel
-/// residual). Clamping tile size well above the epsilon closes that
-/// residual (`0.01 pt = 10 × eps`), and stays a full order of magnitude
-/// below any physical output-device dot (`0.01 pt = 1 dot @ 7200 dpi`
-/// commercial printing) so no legitimate CSS is affected: at 7200 dpi the
-/// tile fits inside one printed dot.
+/// stop-copies of PDF output (~425 MB observed for the Codex `01f477e4`
+/// subpixel residual). Clamping to `10 ×` the epsilon keeps the FP
+/// safety margin.
 ///
-/// Sibling of the [`MAX_GRADIENT_STOPS`] gradient bound. Applied only to
-/// gradient tiles (`resolve_gradient_size`); raster/svg image tiles keep
-/// their intrinsic sizing.
+/// Resolution context: `0.01 pt = 72 pt/inch / 7200 dpi`, i.e. **exactly
+/// one physical dot at commercial-max 7200 dpi printing** — the clamp
+/// equals a single dot at that ceiling, not below it. At more common
+/// resolutions (300–1200 dpi, `1 dot ≈ 0.06–0.24 pt`) the clamp is 6–24×
+/// smaller than a printed dot, so no visible legitimate rendering
+/// changes. A design that meaningfully targets a single-dot-wide
+/// gradient at 7200 dpi would see that tile lifted by ≤ 2×; accepted
+/// as a defense-in-depth trade-off, since no realistic design uses
+/// gradient tiles at that scale (a one-dot gradient does not read as a
+/// gradient).
+///
+/// Sibling of the [`MAX_GRADIENT_STOPS`] gradient bound. Also applies
+/// to raster/SVG tiles that transit `resolve_repeat_axis::Round` since
+/// that helper is shared; sub-min raster tiles are invisible on any
+/// output device, so the shared clamp is a defense-in-depth consistency
+/// win rather than a behavior change for legitimate content.
 pub(crate) const MIN_GRADIENT_TILE_PT: f32 = 0.01;
 
 /// Maximum byte length of a CSS named page (`page: <custom-ident>` /

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -5867,3 +5867,27 @@ body{{background-size:1.33px 1.33px;background-repeat:repeat;height:1130px;
         pdf.len()
     );
 }
+
+/// Radial-gradient variant of the Codex `01f477e4` exploit. Same
+/// truncated-grid fallback machinery, same Pattern fold applied.
+#[test]
+fn radial_gradient_nonuniform_tile_repeat_is_bounded() {
+    let stops = many_color_stops(300);
+    let html = format!(
+        r#"<!doctype html><html><head><meta charset="utf-8"><style>
+html,body{{margin:0;padding:0}}
+body{{background-size:1.33px 1.33px;background-repeat:repeat;height:1130px;
+     background-image:radial-gradient(circle at center,{stops})}}
+</style></head><body></body></html>"#
+    );
+    let pdf = Engine::builder()
+        .build()
+        .render(&html)
+        .expect("radial-gradient exploit render must succeed");
+    assert!(pdf.starts_with(b"%PDF"));
+    assert!(
+        pdf.len() < 5_000_000,
+        "radial gradient with tiny repeat + many stops must be bounded, got {} bytes",
+        pdf.len()
+    );
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -5914,3 +5914,35 @@ body{background-size:1.33px 1.33px;background-repeat:repeat;height:1130px;
         pdf.len()
     );
 }
+
+/// Subpixel residual of Codex `01f477e4` — the Pattern fold defused
+/// the primary attack (`background-size: 1.33px`), but tiles smaller
+/// than the `try_uniform_grid` eps (`1e-3` pt) still collapsed in the
+/// grid-shape dedup and re-entered per-tile emission. `background-size:
+/// 0.001px 0.001px` = `0.00075` pt, below eps, previously produced
+/// ~425 MB PDF / ~975 MB RSS from ~300 B HTML.
+///
+/// Fix: `MIN_GRADIENT_TILE_PT` (`lib.rs`) clamps gradient tile size to
+/// `0.01 pt` = 10× the eps, well below any physical output-device dot
+/// (1 dot @ 7200 dpi). Well-formed shape → Pattern emit.
+#[test]
+fn linear_gradient_subpixel_tile_is_bounded() {
+    let stops = many_color_stops(300);
+    let html = format!(
+        r#"<!doctype html><html><head><meta charset="utf-8"><style>
+html,body{{margin:0;padding:0}}
+body{{background-size:0.001px 0.001px;background-repeat:repeat;height:1130px;
+     background-image:linear-gradient(45deg,{stops})}}
+</style></head><body></body></html>"#
+    );
+    let pdf = Engine::builder()
+        .build()
+        .render(&html)
+        .expect("subpixel-tile exploit render must succeed");
+    assert!(pdf.starts_with(b"%PDF"));
+    assert!(
+        pdf.len() < 5_000_000,
+        "subpixel-tile linear gradient must be bounded by MIN_GRADIENT_TILE_PT, got {} bytes",
+        pdf.len()
+    );
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -5891,3 +5891,26 @@ body{{background-size:1.33px 1.33px;background-repeat:repeat;height:1130px;
         pdf.len()
     );
 }
+
+/// Conic-gradient variant of the Codex `01f477e4` sibling issue
+/// `6aa94631` — conic wedges (~360 per draw) multiplied across the
+/// truncated-grid fallback produced ~46 MB PDF / ~833 MB RSS from
+/// ~300 B HTML. Same Pattern fold applied.
+#[test]
+fn conic_gradient_nonuniform_tile_repeat_is_bounded() {
+    let html = r#"<!doctype html><html><head><meta charset="utf-8"><style>
+html,body{margin:0;padding:0}
+body{background-size:1.33px 1.33px;background-repeat:repeat;height:1130px;
+     background-image:conic-gradient(from 0deg,red,yellow,green,blue,red)}
+</style></head><body></body></html>"#;
+    let pdf = Engine::builder()
+        .build()
+        .render(html)
+        .expect("conic-gradient exploit render must succeed");
+    assert!(pdf.starts_with(b"%PDF"));
+    assert!(
+        pdf.len() < 5_000_000,
+        "conic gradient with tiny repeat must be bounded, got {} bytes",
+        pdf.len()
+    );
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -5814,18 +5814,26 @@ fn font_size_zero_does_not_produce_nan_glyphs() {
 
 /// Attack fixture builder: `<N>` color-stops evenly distributed as a
 /// red/blue alternation. Used by the gradient-fallback OOM tests below.
+///
+/// Guards `n <= 1` degenerate inputs so the helper can be reused
+/// without hitting `100 / (n - 1) = ∞ → NaN` — invalid CSS that would
+/// silently produce an unrenderable payload.
 fn many_color_stops(n: usize) -> String {
-    let mut s = String::new();
-    let step = 100.0f32 / (n as f32 - 1.0);
-    for i in 0..n {
-        if i > 0 {
-            s.push_str(", ");
+    match n {
+        0 => String::new(),
+        1 => "red 0%".to_string(),
+        _ => {
+            let step = 100.0f32 / (n as f32 - 1.0);
+            (0..n)
+                .map(|i| {
+                    let pct = (i as f32) * step;
+                    let color = if i % 2 == 0 { "red" } else { "blue" };
+                    format!("{color} {pct:.4}%")
+                })
+                .collect::<Vec<_>>()
+                .join(", ")
         }
-        let pct = (i as f32) * step;
-        let color = if i % 2 == 0 { "red" } else { "blue" };
-        s.push_str(&format!("{color} {pct:.4}%"));
     }
-    s
 }
 
 /// Codex Security finding `01f477e4` — "Repeated tiny gradients can

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -5811,3 +5811,59 @@ fn font_size_zero_does_not_produce_nan_glyphs() {
         .expect("font-size:0 render must succeed");
     assert!(pdf.starts_with(b"%PDF"));
 }
+
+/// Attack fixture builder: `<N>` color-stops evenly distributed as a
+/// red/blue alternation. Used by the gradient-fallback OOM tests below.
+fn many_color_stops(n: usize) -> String {
+    let mut s = String::new();
+    let step = 100.0f32 / (n as f32 - 1.0);
+    for i in 0..n {
+        if i > 0 {
+            s.push_str(", ");
+        }
+        let pct = (i as f32) * step;
+        let color = if i % 2 == 0 { "red" } else { "blue" };
+        s.push_str(&format!("{color} {pct:.4}%"));
+    }
+    s
+}
+
+/// Codex Security finding `01f477e4` — "Repeated tiny gradients can
+/// exhaust render CPU". Before this fix, the attack HTML below (~300 B
+/// serialized) produced a **~425 MB** PDF and **~975 MB** peak RSS in
+/// the CLI: `background-size: 1.33px × 1.33px` with `background-repeat:
+/// repeat` on an A4 clip generates ~500k logical tiles, which the
+/// `compute_tile_positions_slow` `MAX_TILES = 10_000` cap truncates
+/// mid-row. The truncated (non-rectangular) grid defeats
+/// `try_uniform_grid`, so the per-tile fallback fires with up to 10_000
+/// `draw_linear_gradient` calls, each rebuilding a krilla stop vector
+/// bounded by `MAX_GRADIENT_STOPS = 256`. Fix: fold the leading
+/// complete-row rectangle into a single Tiling Pattern (see
+/// `split_truncated_grid` in `background.rs`); only the trailing
+/// partial row falls through to per-tile draws.
+///
+/// The 5 MB budget below has comfortable headroom above the ~KB output
+/// that a well-formed Pattern-emitted layer produces (`attack_uniform`
+/// fixture is <50 KB with the same 300-stop payload) and stays orders
+/// of magnitude below the pre-fix 425 MB regression window.
+#[test]
+fn linear_gradient_nonuniform_tile_repeat_is_bounded() {
+    let stops = many_color_stops(300);
+    let html = format!(
+        r#"<!doctype html><html><head><meta charset="utf-8"><style>
+html,body{{margin:0;padding:0}}
+body{{background-size:1.33px 1.33px;background-repeat:repeat;height:1130px;
+     background-image:linear-gradient(45deg,{stops})}}
+</style></head><body></body></html>"#
+    );
+    let pdf = Engine::builder()
+        .build()
+        .render(&html)
+        .expect("linear-gradient exploit render must succeed");
+    assert!(pdf.starts_with(b"%PDF"));
+    assert!(
+        pdf.len() < 5_000_000,
+        "linear gradient with tiny repeat + many stops must be bounded, got {} bytes",
+        pdf.len()
+    );
+}

--- a/docs/plans/2026-07-20-gradient-fallback-tiling-pattern.md
+++ b/docs/plans/2026-07-20-gradient-fallback-tiling-pattern.md
@@ -1,0 +1,700 @@
+# Gradient Fallback Tiling Pattern Implementation Plan
+
+**Goal:** `background.rs` の gradient (linear/radial/conic) の per-tile fallback path を、完全行の矩形部分を 1 Tiling Pattern で描き、残余の部分行のみ per-tile ループに落とす形に置換して、`background-size: 1.33px + background-repeat: repeat` 攻撃で 425MB PDF/1GB RSS を生む OOM を bounded に抑える。
+
+**Architecture:** `try_uniform_grid` が None を返す truncated-grid ケース (MAX_TILES=10000 mid-row 切詰) は、実質「完全行の uniform grid + 最終部分行」の形。新規 pure helper `split_truncated_grid` を追加してこの分解を行い、既存の `draw_gradient_tiling_pattern` を full 部分に、per-tile ループを remainder のみに適用する。linear / radial / conic の 3 arm に同じ pattern を適用。
+
+**Tech Stack:** Rust, krilla (PDF paint / Tiling Pattern), fulgur render pipeline (`background.rs`, `render_smoke.rs`).
+
+**Beads issue:** `fulgur-imk7` (P1、Codex `01f477e4` の実測 fix、conic `6aa94631` 兄弟含む)
+
+**Related code (touch list):**
+
+- Modify: `crates/fulgur/src/background.rs:646-748` (linear/radial/conic fallback arms)
+- Modify: `crates/fulgur/src/background.rs:2057-2126` (nearby `try_uniform_grid` — helper 追加場所)
+- Test: `crates/fulgur/src/background.rs` の `#[cfg(test)] mod tests` (split_truncated_grid unit tests)
+- Test: `crates/fulgur/tests/render_smoke.rs` (exploit smoke test)
+- 影響 VRT: `crates/fulgur-vrt/goldens/fulgur/` の gradient 系がある場合 `FULGUR_VRT_UPDATE=1` で再生成 (Pattern 使用で視覚等価だが PDF byte 差が出る可能性)
+
+**Preconditions:**
+
+- worktree: `/home/ubuntu/fulgur/.worktrees/fulgur-imk7`
+- branch: `harden/fulgur-imk7-gradient-fallback-pattern`
+- baseline: `cargo test --lib -p fulgur` = 1730 passed / 0 failed
+
+---
+
+## Task 1: Add SplitGrid struct + failing test skeleton for empty/degenerate cases
+
+**Files:**
+
+- Modify: `crates/fulgur/src/background.rs` (near `:2057` `try_uniform_grid`)
+
+**Step 1: Write the failing test (degenerate cases)**
+
+Add to `#[cfg(test)] mod tests` in `background.rs`:
+
+```rust
+#[test]
+fn split_truncated_grid_empty_returns_none_and_all_as_remainder() {
+    let tiles: Vec<(f32, f32, f32, f32)> = vec![];
+    let split = split_truncated_grid(&tiles);
+    assert!(split.full.is_none());
+    assert_eq!(split.remainder.len(), 0);
+}
+
+#[test]
+fn split_truncated_grid_single_tile_returns_none_and_tile_as_remainder() {
+    let tiles = vec![(0.0, 0.0, 10.0, 10.0)];
+    let split = split_truncated_grid(&tiles);
+    assert!(split.full.is_none());
+    assert_eq!(split.remainder, tiles.as_slice());
+}
+
+#[test]
+fn split_truncated_grid_single_row_returns_none_and_row_as_remainder() {
+    // Single row is either fast-path caught by try_uniform_grid or irregular;
+    // split_truncated_grid does not attempt to split a single row.
+    let tiles = vec![
+        (0.0, 0.0, 5.0, 5.0),
+        (5.0, 0.0, 5.0, 5.0),
+        (10.0, 0.0, 5.0, 5.0),
+    ];
+    let split = split_truncated_grid(&tiles);
+    assert!(split.full.is_none());
+    assert_eq!(split.remainder, tiles.as_slice());
+}
+```
+
+**Step 2: Verify tests fail (function undefined)**
+
+```bash
+cd /home/ubuntu/fulgur/.worktrees/fulgur-imk7
+cargo test -p fulgur --lib background::tests::split_truncated_grid 2>&1 | tail -20
+```
+
+Expected: compile error `cannot find function split_truncated_grid` / `cannot find type SplitGrid`.
+
+**Step 3: Add minimal `SplitGrid` + `split_truncated_grid` stub returning `None/all remainder`**
+
+```rust
+/// Result of splitting a truncated (`MAX_TILES` mid-row cut) tile grid into
+/// a leading uniform-grid rectangle and a trailing partial-row remainder.
+///
+/// The full rectangle is emitted as a single Tiling Pattern (cheap) and
+/// the remainder as per-tile draws. Degenerate inputs (empty, single tile,
+/// single row) return `full=None, remainder=all` so callers fall through
+/// to the pre-existing per-tile path.
+#[derive(Debug)]
+struct SplitGrid<'a> {
+    full: Option<UniformGrid>,
+    remainder: &'a [(f32, f32, f32, f32)],
+}
+
+fn split_truncated_grid(tiles: &[(f32, f32, f32, f32)]) -> SplitGrid<'_> {
+    // Minimal stub: everything as remainder.
+    SplitGrid {
+        full: None,
+        remainder: tiles,
+    }
+}
+```
+
+Place near `try_uniform_grid` (`:2057`).
+
+**Step 4: Verify tests pass**
+
+```bash
+cargo test -p fulgur --lib background::tests::split_truncated_grid 2>&1 | tail -10
+```
+
+Expected: 3 passed.
+
+**Step 5: Commit**
+
+```bash
+git add crates/fulgur/src/background.rs
+git commit -m "test(gradient): add SplitGrid skeleton + degenerate-case tests (fulgur-imk7)"
+```
+
+---
+
+## Task 2: Truncated-grid detection (row-major length inspection)
+
+**Files:**
+
+- Modify: `crates/fulgur/src/background.rs` (extend `split_truncated_grid`)
+
+**Step 1: Write failing tests for the truncated-grid split**
+
+Add to `mod tests`:
+
+```rust
+#[test]
+fn split_truncated_grid_two_full_rows_plus_partial_returns_full_and_remainder() {
+    // 3 cols × 2 full rows + 1 partial row of 2 tiles
+    // grid tile size 5×5, step 5
+    let tiles = vec![
+        (0.0, 0.0, 5.0, 5.0), (5.0, 0.0, 5.0, 5.0), (10.0, 0.0, 5.0, 5.0),
+        (0.0, 5.0, 5.0, 5.0), (5.0, 5.0, 5.0, 5.0), (10.0, 5.0, 5.0, 5.0),
+        (0.0, 10.0, 5.0, 5.0), (5.0, 10.0, 5.0, 5.0),
+    ];
+    let split = split_truncated_grid(&tiles);
+    let grid = split.full.expect("full grid must be detected");
+    assert_eq!(grid.count, (3, 2));
+    assert_eq!(grid.cell, (5.0, 5.0));
+    assert_eq!(grid.step, (5.0, 5.0));
+    assert_eq!(grid.origin, (0.0, 0.0));
+    assert_eq!(split.remainder.len(), 2);
+    assert_eq!(split.remainder[0], (0.0, 10.0, 5.0, 5.0));
+    assert_eq!(split.remainder[1], (5.0, 10.0, 5.0, 5.0));
+}
+
+#[test]
+fn split_truncated_grid_all_rows_same_length_returns_none() {
+    // Complete uniform grid — should have been caught by try_uniform_grid.
+    // split_truncated_grid returns None so caller falls through.
+    let tiles = vec![
+        (0.0, 0.0, 5.0, 5.0), (5.0, 0.0, 5.0, 5.0),
+        (0.0, 5.0, 5.0, 5.0), (5.0, 5.0, 5.0, 5.0),
+    ];
+    let split = split_truncated_grid(&tiles);
+    assert!(split.full.is_none(),
+        "complete grid should be fast-path-caught elsewhere; split returns None");
+}
+
+#[test]
+fn split_truncated_grid_mismatched_cell_sizes_returns_none() {
+    // Non-uniform cell size — cannot be a truncated grid.
+    let tiles = vec![
+        (0.0, 0.0, 5.0, 5.0),
+        (5.0, 0.0, 3.0, 5.0),
+        (0.0, 5.0, 5.0, 5.0),
+    ];
+    let split = split_truncated_grid(&tiles);
+    assert!(split.full.is_none());
+    assert_eq!(split.remainder, tiles.as_slice());
+}
+
+#[test]
+fn split_truncated_grid_max_tiles_shape_100x16_plus_partial() {
+    // Emulate the MAX_TILES=10000 truncation shape used by the exploit:
+    // 100 cols × 16 full rows + 1 partial row (400 tiles) = 10000 total.
+    let mut tiles = Vec::with_capacity(10_000);
+    for r in 0..16 {
+        for c in 0..100 {
+            tiles.push((c as f32, r as f32, 1.0, 1.0));
+        }
+    }
+    for c in 0..400 {
+        tiles.push((c as f32, 16.0, 1.0, 1.0));
+    }
+    assert_eq!(tiles.len(), 2000);
+    let split = split_truncated_grid(&tiles);
+    let grid = split.full.expect("full rectangle must be detected");
+    assert_eq!(grid.count, (100, 16));
+    assert_eq!(split.remainder.len(), 400);
+}
+```
+
+**Step 2: Verify tests fail**
+
+```bash
+cargo test -p fulgur --lib background::tests::split_truncated_grid 2>&1 | tail -20
+```
+
+Expected: the new tests fail (`Some(...)` expected but `None` returned).
+
+**Step 3: Implement the detection**
+
+Replace the `split_truncated_grid` stub body with:
+
+```rust
+fn split_truncated_grid(tiles: &[(f32, f32, f32, f32)]) -> SplitGrid<'_> {
+    // Fewer than one row-worth of tiles cannot be split.
+    if tiles.len() < 2 {
+        return SplitGrid { full: None, remainder: tiles };
+    }
+    let eps = 1e-3_f32;
+
+    // Cell size must be uniform across the whole tile set.
+    let (tw0, th0) = (tiles[0].2, tiles[0].3);
+    if !tiles
+        .iter()
+        .all(|t| (t.2 - tw0).abs() < eps && (t.3 - th0).abs() < eps)
+    {
+        return SplitGrid { full: None, remainder: tiles };
+    }
+
+    // Row-major traversal: identify per-row tile counts by y-coordinate
+    // blocks. `compute_tile_positions_slow` (background.rs:2018-2035)
+    // generates tiles outer=y / inner=x, so consecutive entries with
+    // matching y form a row.
+    let mut row_starts: Vec<usize> = Vec::new();
+    row_starts.push(0);
+    let mut cur_y = tiles[0].1;
+    for (i, t) in tiles.iter().enumerate().skip(1) {
+        if (t.1 - cur_y).abs() >= eps {
+            row_starts.push(i);
+            cur_y = t.1;
+        }
+    }
+    // Sentinel end index for length computation.
+    let mut row_ends = row_starts.clone();
+    row_ends.remove(0);
+    row_ends.push(tiles.len());
+    let row_lens: Vec<usize> = row_starts
+        .iter()
+        .zip(row_ends.iter())
+        .map(|(&s, &e)| e - s)
+        .collect();
+
+    // Single row cannot be split by row-length prefix.
+    if row_lens.len() < 2 {
+        return SplitGrid { full: None, remainder: tiles };
+    }
+
+    // Count leading rows whose length matches the first row.
+    let full_row_len = row_lens[0];
+    let full_row_count = row_lens
+        .iter()
+        .take_while(|&&len| len == full_row_len)
+        .count();
+
+    // All rows equal length → complete grid. Should be caught by
+    // try_uniform_grid; return None so caller does not double-emit.
+    if full_row_count == row_lens.len() {
+        return SplitGrid { full: None, remainder: tiles };
+    }
+
+    let full_tile_count = full_row_count * full_row_len;
+    let full_tiles = &tiles[..full_tile_count];
+    let remainder = &tiles[full_tile_count..];
+
+    // Delegate uniform-grid validation (steps, x-positions) to the
+    // existing helper — the truncated leading rectangle must itself
+    // be a well-formed uniform grid for Pattern emission to be sound.
+    match try_uniform_grid(full_tiles) {
+        Some(grid) => SplitGrid { full: Some(grid), remainder },
+        None => SplitGrid { full: None, remainder: tiles },
+    }
+}
+```
+
+**Step 4: Verify tests pass**
+
+```bash
+cargo test -p fulgur --lib background::tests::split_truncated_grid 2>&1 | tail -10
+```
+
+Expected: 7 passed.
+
+**Step 5: Commit**
+
+```bash
+git add crates/fulgur/src/background.rs
+git commit -m "feat(gradient): detect truncated-grid split point via row-length prefix (fulgur-imk7)"
+```
+
+---
+
+## Task 3: Linear gradient fallback — Pattern-first refactor
+
+**Files:**
+
+- Modify: `crates/fulgur/src/background.rs:609-675` (linear gradient arm)
+
+**Step 1: Write failing smoke test for linear-gradient bound**
+
+Add to `crates/fulgur/tests/render_smoke.rs`:
+
+```rust
+#[test]
+fn linear_gradient_nonuniform_tile_repeat_is_bounded() {
+    // Attack shape: 1.33px × 1.33px tile with repeat + capped-large stop count.
+    // Before the fix this produces a ~425MB PDF from 300B HTML; the
+    // MAX_GRADIENT_STOPS=256 cap × 10_000 MAX_TILES fallback expansion.
+    // After the fix, the truncated grid's leading rectangle is emitted
+    // as a single Tiling Pattern; only the partial remainder row draws
+    // per-tile.
+    let mut stops = String::new();
+    for i in 0..300 {
+        if i > 0 { stops.push_str(", "); }
+        let pct = (i as f32) * 100.0 / 299.0;
+        let color = if i % 2 == 0 { "red" } else { "blue" };
+        stops.push_str(&format!("{color} {pct:.4}%"));
+    }
+    let html = format!(
+        r#"<!doctype html><html><head><meta charset="utf-8"><style>
+html,body{{margin:0;padding:0}}
+body{{background-size:1.33px 1.33px;background-repeat:repeat;height:1130px;
+     background-image:linear-gradient(45deg,{stops})}}
+</style></head><body></body></html>"#
+    );
+    let engine = fulgur::Engine::builder().build();
+    let pdf = engine.render(&html).expect("render must succeed");
+    // Pre-fix: ~425_000_000 bytes. Post-fix budget: 5 MB (comfortable
+    // headroom above the ~KB expected for a Pattern-emitted layer).
+    assert!(
+        pdf.len() < 5_000_000,
+        "linear gradient with tiny repeat + many stops must be bounded, got {} bytes",
+        pdf.len()
+    );
+    assert!(!pdf.is_empty());
+}
+```
+
+**Step 2: Verify test fails**
+
+```bash
+cargo test -p fulgur --test render_smoke linear_gradient_nonuniform_tile_repeat_is_bounded 2>&1 | tail -10
+```
+
+Expected: FAIL — actual `pdf.len() >> 5_000_000`.
+
+**Step 3: Refactor the linear-gradient arm**
+
+Locate `background.rs:609-675` (`BgImageContent::LinearGradient { .. }` arm). Replace the current `try_uniform_grid → Pattern | else per-tile loop` shape with:
+
+```rust
+BgImageContent::LinearGradient {
+    direction,
+    stops,
+    repeating,
+} => {
+    // Try full-uniform first (unchanged fast path).
+    let split = if let Some(grid) = try_uniform_grid(&tiles) {
+        SplitGrid { full: Some(grid), remainder: &[] }
+    } else {
+        // Truncated-grid: emit the complete-row rectangle as one Pattern,
+        // only the trailing partial row falls through to per-tile draws.
+        // Bounds the 10_000 tile × 256 stop fallback that used to
+        // produce ~425 MB PDFs from ~300 B HTML.
+        split_truncated_grid(&tiles)
+    };
+
+    if let Some(grid) = split.full {
+        let angle = match direction {
+            crate::draw_primitives::LinearGradientDirection::Angle(a) => *a,
+            crate::draw_primitives::LinearGradientDirection::Corner(corner) => {
+                corner_to_angle_rad(*corner, grid.cell.0, grid.cell.1)
+            }
+        };
+        draw_gradient_tiling_pattern(canvas, grid, |surface, _tw, _th| {
+            draw_linear_gradient(
+                surface, angle, stops, *repeating,
+                0.0, 0.0, grid.cell.0, grid.cell.1,
+            );
+        });
+    }
+
+    // Per-tile fallback for the partial-row remainder (or the full tile
+    // list if split declined). Corner direction needs per-tile angle
+    // recomputation because it depends on tile aspect (CSS Images §3.1.1).
+    match direction {
+        crate::draw_primitives::LinearGradientDirection::Angle(a) => {
+            let angle = *a;
+            for (tx, ty, tw, th) in split.remainder {
+                draw_linear_gradient(
+                    canvas.surface, angle, stops, *repeating,
+                    *tx, *ty, *tw, *th,
+                );
+            }
+        }
+        crate::draw_primitives::LinearGradientDirection::Corner(corner) => {
+            for (tx, ty, tw, th) in split.remainder {
+                let angle = corner_to_angle_rad(*corner, *tw, *th);
+                draw_linear_gradient(
+                    canvas.surface, angle, stops, *repeating,
+                    *tx, *ty, *tw, *th,
+                );
+            }
+        }
+    }
+}
+```
+
+**Step 4: Verify smoke test passes**
+
+```bash
+cargo test -p fulgur --test render_smoke linear_gradient_nonuniform_tile_repeat_is_bounded 2>&1 | tail -10
+```
+
+Expected: PASS. Also run neighbours to catch regressions:
+
+```bash
+cargo test -p fulgur --test render_smoke 2>&1 | tail -10
+```
+
+Expected: all render_smoke green.
+
+**Step 5: Commit**
+
+```bash
+git add crates/fulgur/src/background.rs crates/fulgur/tests/render_smoke.rs
+git commit -m "fix(gradient): fold linear-gradient truncated-grid fallback into single Pattern (fulgur-imk7)"
+```
+
+---
+
+## Task 4: Radial gradient fallback — same treatment
+
+**Files:**
+
+- Modify: `crates/fulgur/src/background.rs:677-714` (radial gradient arm)
+
+**Step 1: Write failing smoke test**
+
+Add to `render_smoke.rs`:
+
+```rust
+#[test]
+fn radial_gradient_nonuniform_tile_repeat_is_bounded() {
+    let mut stops = String::new();
+    for i in 0..300 {
+        if i > 0 { stops.push_str(", "); }
+        let pct = (i as f32) * 100.0 / 299.0;
+        let color = if i % 2 == 0 { "red" } else { "blue" };
+        stops.push_str(&format!("{color} {pct:.4}%"));
+    }
+    let html = format!(
+        r#"<!doctype html><html><head><meta charset="utf-8"><style>
+html,body{{margin:0;padding:0}}
+body{{background-size:1.33px 1.33px;background-repeat:repeat;height:1130px;
+     background-image:radial-gradient(circle at center,{stops})}}
+</style></head><body></body></html>"#
+    );
+    let engine = fulgur::Engine::builder().build();
+    let pdf = engine.render(&html).expect("render must succeed");
+    assert!(pdf.len() < 5_000_000, "radial gradient bounded, got {} bytes", pdf.len());
+}
+```
+
+**Step 2: Verify FAIL**
+
+```bash
+cargo test -p fulgur --test render_smoke radial_gradient_nonuniform_tile_repeat_is_bounded 2>&1 | tail -10
+```
+
+**Step 3: Refactor the radial-gradient arm**
+
+Same shape as Task 3, replacing the `RadialGradient` arm. Radial does not have a per-tile angle recomputation branch — the `Some(grid)` path draws once and the remainder is a single loop:
+
+```rust
+BgImageContent::RadialGradient {
+    shape,
+    size,
+    position_x,
+    position_y,
+    stops,
+    repeating,
+} => {
+    let split = if let Some(grid) = try_uniform_grid(&tiles) {
+        SplitGrid { full: Some(grid), remainder: &[] }
+    } else {
+        split_truncated_grid(&tiles)
+    };
+    if let Some(grid) = split.full {
+        draw_gradient_tiling_pattern(canvas, grid, |surface, tw, th| {
+            draw_radial_gradient(
+                surface, *shape, size, position_x, position_y, stops, *repeating,
+                0.0, 0.0, tw, th,
+            );
+        });
+    }
+    for (tx, ty, tw, th) in split.remainder {
+        draw_radial_gradient(
+            canvas.surface, *shape, size, position_x, position_y, stops, *repeating,
+            *tx, *ty, *tw, *th,
+        );
+    }
+}
+```
+
+**Step 4: Verify PASS**
+
+```bash
+cargo test -p fulgur --test render_smoke radial_gradient_nonuniform_tile_repeat_is_bounded 2>&1 | tail -10
+cargo test -p fulgur --test render_smoke 2>&1 | tail -10
+```
+
+**Step 5: Commit**
+
+```bash
+git add crates/fulgur/src/background.rs crates/fulgur/tests/render_smoke.rs
+git commit -m "fix(gradient): fold radial-gradient truncated-grid fallback into single Pattern (fulgur-imk7)"
+```
+
+---
+
+## Task 5: Conic gradient fallback — same treatment
+
+**Files:**
+
+- Modify: `crates/fulgur/src/background.rs:715-751` (conic gradient arm)
+
+**Step 1: Write failing smoke test**
+
+Add to `render_smoke.rs`:
+
+```rust
+#[test]
+fn conic_gradient_nonuniform_tile_repeat_is_bounded() {
+    let html = r#"<!doctype html><html><head><meta charset="utf-8"><style>
+html,body{margin:0;padding:0}
+body{background-size:1.33px 1.33px;background-repeat:repeat;height:1130px;
+     background-image:conic-gradient(from 0deg,red,yellow,green,blue,red)}
+</style></head><body></body></html>"#;
+    let engine = fulgur::Engine::builder().build();
+    let pdf = engine.render(html).expect("render must succeed");
+    // Pre-fix: ~46 MB. Post-fix budget: 5 MB (Pattern emits one wedge
+    // set for the leading rectangle).
+    assert!(pdf.len() < 5_000_000, "conic gradient bounded, got {} bytes", pdf.len());
+}
+```
+
+**Step 2: Verify FAIL**
+
+```bash
+cargo test -p fulgur --test render_smoke conic_gradient_nonuniform_tile_repeat_is_bounded 2>&1 | tail -10
+```
+
+**Step 3: Refactor the conic-gradient arm**
+
+Same pattern as radial:
+
+```rust
+BgImageContent::ConicGradient {
+    from_angle,
+    position_x,
+    position_y,
+    stops,
+    repeating,
+} => {
+    let split = if let Some(grid) = try_uniform_grid(&tiles) {
+        SplitGrid { full: Some(grid), remainder: &[] }
+    } else {
+        split_truncated_grid(&tiles)
+    };
+    if let Some(grid) = split.full {
+        draw_gradient_tiling_pattern(canvas, grid, |surface, tw, th| {
+            draw_conic_gradient(
+                surface, *from_angle, position_x, position_y, stops, *repeating,
+                0.0, 0.0, tw, th,
+            );
+        });
+    }
+    for (tx, ty, tw, th) in split.remainder {
+        draw_conic_gradient(
+            canvas.surface, *from_angle, position_x, position_y, stops, *repeating,
+            *tx, *ty, *tw, *th,
+        );
+    }
+}
+```
+
+(Argument list matches the existing per-tile call at `:735-748`.)
+
+**Step 4: Verify PASS**
+
+```bash
+cargo test -p fulgur --test render_smoke conic_gradient_nonuniform_tile_repeat_is_bounded 2>&1 | tail -10
+cargo test -p fulgur --test render_smoke 2>&1 | tail -10
+```
+
+**Step 5: Commit**
+
+```bash
+git add crates/fulgur/src/background.rs crates/fulgur/tests/render_smoke.rs
+git commit -m "fix(gradient): fold conic-gradient truncated-grid fallback into single Pattern (fulgur-imk7)"
+```
+
+---
+
+## Task 6: Full verification (lib / clippy / fmt / VRT)
+
+**Step 1: Full lib test**
+
+```bash
+cargo test -p fulgur --lib 2>&1 | tail -5
+```
+
+Expected: 1730+ passed (new: split_truncated_grid tests). 0 failed.
+
+**Step 2: Full render_smoke test**
+
+```bash
+cargo test -p fulgur --test render_smoke 2>&1 | tail -5
+```
+
+Expected: existing tests + 3 new gradient tests all pass.
+
+**Step 3: fmt / clippy**
+
+```bash
+cargo fmt --all --check
+cargo clippy -p fulgur --all-targets -- -D warnings
+```
+
+Expected: no output / no warnings.
+
+**Step 4: VRT (gradient goldens may need update)**
+
+Run VRT to see if any golden diverges:
+
+```bash
+FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" \
+  cargo test -p fulgur-vrt 2>&1 | tail -20
+```
+
+If gradient VRT fails:
+
+- Inspect the pdftocairo diff images the harness produces.
+- If visually identical (only PDF byte structure differs), regenerate:
+
+  ```bash
+  FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" \
+    FULGUR_VRT_UPDATE=1 cargo test -p fulgur-vrt 2>&1 | tail -20
+  ```
+
+- Review the golden diff (`git diff crates/fulgur-vrt/goldens/`) — should be gradient-only.
+
+**Step 5: Re-run exploit measurement (out-of-tree, sanity)**
+
+```bash
+cargo build --release --bin fulgur 2>&1 | tail -3
+SP=/tmp/claude-1000/-home-ubuntu-fulgur/6c60686c-6e08-4b4b-ab1b-08657e915a44/scratchpad/gradient-dos
+BIN=/home/ubuntu/fulgur/.worktrees/fulgur-imk7/target/release/fulgur
+export FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf"
+for name in attack_nonuniform attack_stops attack_2layers_distinct attack_conic_nonuniform; do
+  t0=$(date +%s.%N)
+  /usr/bin/time -v "$BIN" render "$SP/$name.html" -o "/tmp/${name}_after.pdf" >/dev/null 2>"/tmp/${name}_after.time"
+  t1=$(date +%s.%N)
+  real=$(awk 'BEGIN{printf "%.3f", '$t1'-'$t0'}')
+  rss=$(grep -Po 'Maximum resident set size \(kbytes\): \K\d+' "/tmp/${name}_after.time")
+  size=$(stat -c %s "/tmp/${name}_after.pdf")
+  printf "%-32s  time=%7ss  rss=%9sKB  pdf=%12s bytes\n" "$name" "$real" "$rss" "$size"
+done
+```
+
+Expected: `attack_stops` (previously 2.17s / 975MB / 425MB) drops to < 200ms / < 100MB / < 5MB. `attack_2layers_distinct` proportional. `attack_conic_nonuniform` drops from 46MB to KB range.
+
+**Step 6: Commit any golden updates**
+
+```bash
+git status
+git add crates/fulgur-vrt/goldens/
+git commit -m "test(vrt): update gradient goldens after truncated-grid Pattern fold (fulgur-imk7)"
+```
+
+---
+
+## Rollback
+
+Each task is a single commit; revert with `git revert <sha>` if a specific arm regresses. The `split_truncated_grid` helper is pure and covered by unit tests; reverting its callers restores the pre-fix per-tile fallback exactly.
+
+## Non-goals
+
+- **Document-wide layer/element cap** for distinct-layer amplification (Scenario #6, 872MB with 2 distinct layers): out of scope. Per-layer fix here reduces the coefficient by ~10⁵×; the multiplicative residual is filed for a separate broad-hardening pass.
+- **`MAX_GRADIENT_STOPS` change**: already effective, unchanged.
+- **`fast path` (`try_uniform_grid` on complete grid)**: unchanged, only fallback touched.


### PR DESCRIPTION
## 概要

Codex Security finding `01f477e4` "Repeated tiny gradients can exhaust render CPU" を修正する。gradient (linear/radial/conic) の per-tile fallback path で `background-size: 1.33px 1.33px; background-repeat: repeat` の攻撃 HTML (~300 byte) が **425 MB PDF / 975 MB RSS / 2.2 s** の増幅を引き起こしていた。conic sibling `6aa94631` も同機構で同様の増幅 (~46 MB / 833 MB RSS) を確認していた。

Fix は既存の `draw_gradient_tiling_pattern` を fallback 経路にも延長する形。`compute_tile_positions_slow` の `MAX_TILES=10000` mid-row 切詰は「完全行の uniform grid + 最終部分行 (1×N uniform strip)」を必ず生成するので、新規 `split_truncated_grid` で分解し、両方とも Tiling Pattern として emit する。3 arm (linear/radial/conic) 共通で解決。

`MAX_GRADIENT_STOPS=256` (PR #594) と `MAX_TILES=10000` は effective なままだが、両者の積の PDF byte cost (~150 B/stop-entry × 256 stops × 10000 tiles ≈ 400 MB) を weighting していなかったのが問題の実質だった。Pattern は 1 個の resource を tile 座標で使い回すので stops × tiles 乗算が消える。

さらに subpixel residual (`background-size: 0.001px` 以下、`try_uniform_grid` の eps=1e-3pt より小さい tile) は Pattern fold でも塞げない (eps-based dedup が壊れて shape 推測失敗) ため、`MIN_GRADIENT_TILE_PT = 0.01pt` を新規追加して `resolve_gradient_size` で clamp。

## 実測 (release build、local Linux、before/after)

| Scenario | Before | After | Reduction |
|---|---:|---:|---:|
| attack_stops (linear, 1 elem/layer, `background-size: 1.33px`) | 2.17 s / 975 MB RSS / 425 MB PDF | 26 ms / 18 MB / 43 KB | PDF **99.99 %↓** |
| attack_2layers_distinct | 4.60 s / 1.97 GB RSS / 872 MB PDF | 50 ms / 19 MB / 87 KB | PDF **99.99 %↓** |
| attack_conic_nonuniform | 3.86 s / 833 MB RSS / 46 MB PDF | 40 ms / 17 MB / 13 KB | PDF **99.97 %↓** |
| **subpixel (`background-size: 0.001px`)** | 2.5 s / 975 MB RSS / 425 MB PDF | 32 ms / 17 MB / 42 KB | PDF **99.99 %↓** |
| baseline / uniform fast path | (unchanged) | (unchanged) | — |

攻撃 HTML の一例:

```html
<style>body{background-size:1.33px 1.33px;background-repeat:repeat;height:1130px;
background-image:linear-gradient(45deg,red 0%,blue 0.33%,red 0.67%,...300 stops)}</style>
```

## 変更点

- 新規 pure helper `split_truncated_grid(&tiles) -> SplitGrid<'_>` (`crates/fulgur/src/background.rs`)。行長 prefix 一致で「完全行部分 + 部分行 remainder」に分解。degenerate case (空・単一 tile・単一行・完全 grid・非一様セル) は `full=None, remainder=all` を返して既存 per-tile 経路にフォール。
- 3 arm (linear/radial/conic) の fallback を Pattern-first に置換:
  - `try_uniform_grid` の fast path (完全 grid) は unchanged
  - fallback 時: leading 矩形 → Pattern、trailing 部分行 → try_uniform_grid で 2nd Pattern 化 (1×N uniform strip なので必ず成功)、そこも None なら per-tile ループ
- Linear の Corner direction (tile aspect 依存の per-tile angle 再計算) は remainder per-tile 経路で保持
- Radial/Conic は remainder pattern が使えないケースでも per-tile geometry (`tw, th` から `cx/cy/rx/ry` を導出) を保持
- 新規定数 `MIN_GRADIENT_TILE_PT = 0.01pt` (`lib.rs`, `MAX_GRADIENT_STOPS` の兄弟)。`resolve_gradient_size` で positive-but-sub-eps な explicit tile を clamp。zero-axis (legitimate no-emit) は preserve。raster/svg は intrinsic sizing 維持 (別 class)。

## テスト

- `split_truncated_grid` unit tests (`background.rs` `#[cfg(test)]`): degenerate 3 件 + detection 4 件 (完全 2×3 grid 認識、all-same-length None、非一様 cell None、exploit shape 100×16+400 認識)
- `resolve_gradient_size` clamp unit tests: sub-eps clamp、非 clamp (supra-min preserve)、zero-axis preserve
- `render_smoke.rs` に 4 attack test を追加 (linear/radial/conic の main + linear subpixel、各々 `< 5 MB` byte-size assert)
- VRT (`crates/fulgur-vrt` gradient reftest 群): all pass, golden update **無し** (既存 VRT は uniform-grid 入力 or supra-min tile で影響なし)

## 検証コマンド

```bash
cargo test -p fulgur --lib                                # 1740 passed / 0 failed
cargo test -p fulgur --tests                              # 202 (smoke) + 51 (integration) passed
FONTCONFIG_FILE="$PWD/examples/.fontconfig/fonts.conf" \
  cargo test -p fulgur-vrt                                # 31 passed / 0 failed
cargo fmt --all --check                                   # exit 0
cargo clippy -p fulgur --all-targets -- -D warnings       # no warnings
```

## Non-goals (別 track)

- **structured `TileGrid` refactor**: `compute_tile_positions` の戻り値を構造化して常に Pattern emit する path 統一。実現できれば `try_uniform_grid` / `split_truncated_grid` / `MIN_GRADIENT_TILE_PT` clamp を全部削除できる (shape 推測不要になるので eps 制約が消える)。**fulgur-xg5v** (P3、この issue に blocked) で追跡。
- **document-wide layer/element cap** (distinct-layer 線形乗算 residual): 本 PR で per-layer bound は KB 圏まで縮んだが、layer 数 × per-layer bound の乗算は残る (実測 2 distinct = 87 KB なので現実的には問題無い水準)。より広い document-wide cap は別軸の hardening で対応。
- `MAX_GRADIENT_STOPS` 変更: 既に十分効いているので触らない。
- `try_uniform_grid` fast path 変更: 完全 grid は既に 1 Pattern で最適。fallback のみ触る。

## Related

- Codex finding: `01f477e4a9f88191a549db901b81f5a8` (medium、attack-path medium)
- Prior gradient OOM group: `62a63533` / `571d40dd` (both PR #594, `MAX_GRADIENT_STOPS=256`)
- Conic sibling: `6aa94631` (memory-tracked bounded → 本 PR で同時解決)
- Beads: `fulgur-imk7` (本 PR)、`fulgur-xg5v` (follow-up refactor)
- Design/plan: `docs/plans/2026-07-20-gradient-fallback-tiling-pattern.md`

D1/D2: user 判断で **advisory 化なし・公開 hardening PR のみ** (PR #594 / #601 / #602 の understate 先例に整合)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - 線形・放射・円錐グラデーションのタイル反復描画におけるフォールバックを強化し、途中で分割される場合でも安定して描画。
  - 極小 `background-size` や `repeat: round` でも最小タイルサイズへ丸めを適用し、描画の暴走を抑制。
- **バグ修正**
  - `MAX_TILES` 想定の切り詰め（truncated grid）でも背景が途切れず、正しいパターンで描画されます。
- **テスト**
  - 多数色停止点や極小サイズでのPDF過大化を防ぐ回帰・セキュリティスモークテストを追加（PDFサイズ上限と開始ヘッダを検証）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->