### PR TITLE
test(lib): add coverage for convert_html

### DIFF
--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -380,11 +380,7 @@ mod tests {
     fn convert_html_basic_html_returns_pdf() {
         let pdf = convert_html("<html><body><h1>Hello, fulgur</h1><p>World</p></body></html>")
             .expect("convert_html failed on basic HTML");
-        assert!(
-            pdf.starts_with(b"%PDF"),
-            "expected PDF header; got {} bytes",
-            pdf.len()
-        );
+        assert!(pdf.starts_with(b"%PDF"), "expected PDF header");
     }
 
     #[test]

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -367,3 +367,38 @@ pub fn convert_html(html: &str) -> Result<Vec<u8>> {
     let engine = Engine::builder().build();
     engine.render(html)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::convert_html;
+
+    /// `convert_html` is a thin public-API wrapper over `Engine::builder().build().render()`.
+    /// These smoke tests ensure the function is reachable from lib-mode coverage and that
+    /// the default-settings path produces valid PDF output for representative inputs.
+
+    #[test]
+    fn convert_html_basic_html_returns_pdf() {
+        let pdf = convert_html("<html><body><h1>Hello, fulgur</h1><p>World</p></body></html>")
+            .expect("convert_html failed on basic HTML");
+        assert!(
+            pdf.starts_with(b"%PDF"),
+            "expected PDF header; got {} bytes",
+            pdf.len()
+        );
+    }
+
+    #[test]
+    fn convert_html_empty_body_returns_pdf() {
+        let pdf =
+            convert_html("<html><body></body></html>").expect("convert_html failed on empty body");
+        assert!(!pdf.is_empty(), "expected non-empty PDF for empty body");
+    }
+
+    #[test]
+    fn convert_html_minimal_fragment_returns_pdf() {
+        // A bare fragment without explicit <html>/<body> tags is valid HTML5.
+        let pdf =
+            convert_html("<h2>Section</h2><ul><li>item</li></ul>").expect("convert_html failed");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+}


### PR DESCRIPTION
# Pull Request

## Summary

`crates/fulgur/src/lib.rs` の公開便利 API `convert_html` は、`Engine::builder().build().render(html)` の薄いラッパーだが、`#[cfg(test)]` モジュールが存在せず `cargo llvm-cov --package fulgur --lib` 計測でカバレッジ 0% だった。3 つのスモークテストを追加して lib-mode カバレッジを回復する。

カバレッジ変化（`--lib` 計測）:

| 指標 | 変更前 | 変更後 |
|------|--------|--------|
| Region カバレッジ | 0.00% | **94.87%** |
| Function カバレッジ | 0.00% | **100.00%** |
| Line カバレッジ | 0.00% | **95.24%** |

## Changes

- `crates/fulgur/src/lib.rs` に `#[cfg(test)] mod tests` を新設
- `convert_html_basic_html_returns_pdf` — 基本 HTML 文書（h1 + p）が `%PDF` ヘッダ付き PDF を返すことを確認
- `convert_html_empty_body_returns_pdf` — 空 `<body>` でも非空 PDF が返ることを確認
- `convert_html_minimal_fragment_returns_pdf` — `<html>`/`<body>` タグなしの裸フラグメントが HTML5 として処理されることを確認

## Test plan

- [x] `cargo test -p fulgur --lib` — 1749 passed（新規 3 件を含む）
- [x] `cargo clippy -p fulgur -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — 差分なし

## Contributor License Agreement

By opening this pull request, I confirm that:

- [x] I have read the [Contributing Guide](https://github.com/fulgur-rs/fulgur/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://github.com/fulgur-rs/fulgur/blob/main/CLA.md)
      and agree to its terms. (First-time contributors: the CLA Assistant bot
      will comment on this PR with sign-in instructions.)

## Related issues

テスト専用の定期カバレッジ改善ルーティン（スタンドアロン）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * HTMLからPDFへの変換について、基本的なHTML、空の本文、最小HTMLフラグメントのケースを検証するスモークテストを追加しました。
  * 生成されたPDFが有効な形式であり、空でないことを確認できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->