### PR TITLE
fix(security): sanitize element tag prefix in CounterPass-generated CSS

### DIFF
--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -3017,15 +3017,21 @@ pub(crate) fn build_static_content_css(mappings: &[StaticContentMapping]) -> Str
 /// raises the rule's specificity so a surviving author rule on the same
 /// element (the inline-`<style>` case in fulgur-da3u) loses the cascade.
 ///
-/// `id`, `class`, and the tag name all come from arbitrary HTML attributes
-/// and are routed through [`css_escape_ident`]. For the tag prefix the
-/// escaped form is compared against the lowercased source: when it round-
-/// trips unchanged the tag is a plain CSS identifier and is emitted as-is
-/// (the common case for `div`, `h2`, custom-element names, …). Anything
-/// else — a tag name html5ever accepted verbatim that contains CSS
-/// metacharacters — is dropped from the prefix. `[data-fulgur-cid="N"]` on
-/// its own still pins the element uniquely, so specificity is preserved
-/// even without the type selector.
+/// `id` and `class` come from arbitrary HTML attributes; the tag name
+/// comes from `elem.name.local` (the element name html5ever produced).
+/// All three are routed through [`css_escape_ident`]. For the tag prefix
+/// the escaped form is compared against the lowercased source: when it
+/// round-trips unchanged the tag is a plain CSS identifier and is
+/// emitted as-is (the common case for `div`, `h2`, custom-element
+/// names, …). Anything else — a tag name html5ever accepted verbatim
+/// that contains CSS metacharacters — is dropped from the prefix.
+///
+/// Omitting the tag lowers the *type-selector* specificity component
+/// (one type selector = specificity (0,0,1)), but `[data-fulgur-cid="N"]`
+/// still pins the element uniquely and contributes an attribute-selector
+/// specificity (0,1,0), which is what carries the cascade over a
+/// surviving author rule on the same element (id/class prefixes stack
+/// on top of that).
 fn element_specificity_prefix(element: Option<&blitz_dom::node::ElementData>) -> String {
     let Some(elem) = element else {
         return String::new();

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -2983,9 +2983,14 @@ pub(crate) fn build_static_content_css(mappings: &[StaticContentMapping]) -> Str
     let mut css = String::new();
     for m in mappings {
         let selector = match &m.parsed {
-            // Tag names come from the HTML parser as valid identifiers and
-            // match case-insensitively for HTML — lowercased for good measure
-            // (mirrors `element_specificity_prefix`).
+            // Selector components here come from the trusted author CSS via
+            // `gcpm::parser` (`Token::Ident` in cssparser), not from
+            // arbitrary HTML. Tag names are lowercased to match HTML's
+            // case-insensitive convention; id/class are still escaped
+            // because a hostile author can craft a bare token containing
+            // metacharacters via CSS escapes — defense in depth on the
+            // trusted side, and required by `element_specificity_prefix`
+            // for the untrusted case (fulgur-ka6c).
             ParsedSelector::Tag(name) => name.to_ascii_lowercase(),
             ParsedSelector::Class(name) => format!(".{}", css_escape_ident(name)),
             ParsedSelector::Id(name) => format!("#{}", css_escape_ident(name)),
@@ -3012,14 +3017,25 @@ pub(crate) fn build_static_content_css(mappings: &[StaticContentMapping]) -> Str
 /// raises the rule's specificity so a surviving author rule on the same
 /// element (the inline-`<style>` case in fulgur-da3u) loses the cascade.
 ///
-/// `id` / `class` values come from arbitrary HTML attributes and are
-/// escaped with [`css_escape_ident`]. Tag names from the HTML parser are
-/// already valid identifiers; they are lowercased for good measure.
+/// `id`, `class`, and the tag name all come from arbitrary HTML attributes
+/// and are routed through [`css_escape_ident`]. For the tag prefix the
+/// escaped form is compared against the lowercased source: when it round-
+/// trips unchanged the tag is a plain CSS identifier and is emitted as-is
+/// (the common case for `div`, `h2`, custom-element names, …). Anything
+/// else — a tag name html5ever accepted verbatim that contains CSS
+/// metacharacters — is dropped from the prefix. `[data-fulgur-cid="N"]` on
+/// its own still pins the element uniquely, so specificity is preserved
+/// even without the type selector.
 fn element_specificity_prefix(element: Option<&blitz_dom::node::ElementData>) -> String {
     let Some(elem) = element else {
         return String::new();
     };
-    let mut prefix = elem.name.local.as_ref().to_ascii_lowercase();
+    let tag_lower = elem.name.local.as_ref().to_ascii_lowercase();
+    let mut prefix = if css_escape_ident(&tag_lower) == tag_lower {
+        tag_lower
+    } else {
+        String::new()
+    };
     if let Some(id) = get_attr(elem, "id").filter(|s| !s.is_empty()) {
         prefix.push('#');
         prefix.push_str(&css_escape_ident(id));
@@ -5863,6 +5879,88 @@ mod tests {
             css.contains("div[data-fulgur-cid=\"0\"]::before"),
             "injected selector for a bare element must carry the tag prefix, \
              got: {css}"
+        );
+    }
+
+    #[test]
+    fn counter_pass_specificity_prefix_never_breaks_out_of_the_selector() {
+        // fulgur-ka6c: `element_specificity_prefix` reconstructs the target
+        // element's simple compound (tag + id + classes) so a surviving author
+        // rule loses the cascade. `id` and `class` values are already routed
+        // through `css_escape_ident`; the tag prefix must also be sanitized so
+        // no attribute reached from arbitrary HTML can inject brace-terminated
+        // rule bodies into the generated stylesheet.
+        //
+        // The concrete regression this pins is a class-selector content mapping
+        // (author-trusted) matching an element whose tag name contains raw CSS
+        // punctuation. Without escaping, the generated rule prefixes the class
+        // selector with the raw tag and turns
+        //     .x[data-fulgur-cid="0"]::before { … }
+        // into a two-rule cascade the author never wrote.
+        use crate::gcpm::{ContentCounterMapping, ContentItem, ParsedSelector, PseudoElement};
+
+        let html = concat!(
+            r#"<html><body>"#,
+            r#"<x{}body{color:red} class="x">payload</x{}body{color:red}>"#,
+            r#"</body></html>"#,
+        );
+        let mut doc = parse(html, 400.0, &[]);
+        let content_mappings = vec![ContentCounterMapping {
+            parsed: ParsedSelector::Class("x".into()),
+            pseudo: PseudoElement::Before,
+            content: vec![ContentItem::String("marker".into())],
+        }];
+        let pass = CounterPass::new(Vec::new(), content_mappings);
+        let ctx = PassContext { font_data: &[] };
+        pass.apply(&mut doc, &ctx);
+        let css = pass.generated_css();
+
+        assert!(
+            !css.contains("body{color:red}"),
+            "generated CSS must not include a rule body the author never wrote; got: {css}"
+        );
+        assert!(
+            !css.contains("{}"),
+            "generated CSS must not include an empty rule block leaked from a tag name; got: {css}"
+        );
+    }
+
+    #[test]
+    fn element_specificity_prefix_escapes_tag_metacharacters() {
+        // Direct unit for the escaping contract: any character in the tag name
+        // that is not `css_escape_ident`-safe must either be dropped or
+        // escaped so it cannot terminate the generated selector.
+        //
+        // A tag name that does not survive as a valid CSS identifier is
+        // simply omitted from the prefix — the `[data-fulgur-cid]` attribute
+        // still pins the element uniquely, so specificity is preserved even
+        // without the type selector.
+        let html = r#"<html><body><x{}body{color:red}></x{}body{color:red}></body></html>"#;
+        let doc = parse(html, 400.0, &[]);
+        fn find_crafted_tag(doc: &HtmlDocument, node_id: usize, depth: usize) -> Option<usize> {
+            if depth >= MAX_DOM_DEPTH {
+                return None;
+            }
+            let node = doc.get_node(node_id)?;
+            if let Some(el) = node.element_data() {
+                if el.name.local.as_ref().contains('{') {
+                    return Some(node_id);
+                }
+            }
+            for &child_id in &node.children {
+                if let Some(hit) = find_crafted_tag(doc, child_id, depth + 1) {
+                    return Some(hit);
+                }
+            }
+            None
+        }
+        let node_id = find_crafted_tag(&doc, doc.root_element().id, 0)
+            .expect("html5ever preserves the crafted tag name verbatim");
+        let elem = doc.get_node(node_id).and_then(|n| n.element_data());
+        let prefix = element_specificity_prefix(elem);
+        assert!(
+            !prefix.contains('{') && !prefix.contains('}'),
+            "prefix must not carry raw braces from the tag name; got: {prefix}"
         );
     }
 

--- a/crates/fulgur/tests/gcpm_integration.rs
+++ b/crates/fulgur/tests/gcpm_integration.rs
@@ -388,3 +388,33 @@ fn test_counter_page_still_works() {
 }
 
 // Snapshot tests (inline <style> variants + migrated integration tests): see crates/fulgur/tests/gcpm_snapshot.rs
+
+#[test]
+fn counter_pass_survives_element_names_with_css_metacharacters() {
+    // fulgur-ka6c: CounterPass reconstructs a specificity prefix from the
+    // matched element's tag/id/classes. The tag prefix must not carry raw
+    // characters through to the generated stylesheet — otherwise a class
+    // pseudo-content rule matching an element with a crafted tag name
+    // could seed unrelated declarations into the Stylo cascade.
+    //
+    // End-to-end guard for the escape contract: rendering must succeed and
+    // produce a well-formed PDF even when html5ever preserves an odd tag
+    // name verbatim.
+    let mut assets = AssetBundle::new();
+    assets.add_css(
+        r#"
+        body { counter-reset: c 0; }
+        .x::before { content: counter(c); }
+        "#,
+    );
+    let engine = Engine::builder().assets(assets).build();
+    let html = concat!(
+        "<html><body>",
+        r#"<x{}body{color:red} class="x">payload</x{}body{color:red}>"#,
+        "</body></html>",
+    );
+    let pdf = engine
+        .render(html)
+        .expect("render must succeed even with crafted tag names");
+    assert!(pdf.starts_with(b"%PDF-"), "output should be a PDF");
+}


### PR DESCRIPTION
## 概要

CounterPass が生成する CSS の specificity prefix に、element の生 tag 名がそのまま書き出されていた。id/class は `css_escape_ident` で escape 済みだが、tag 名は「html5ever は valid CSS identifier しか返さない」という誤った前提で escape 省略。html5ever は crafted tag 名を verbatim 保存するため、trusted な GCPM counter pseudo-content CSS (`.foo::before { content: counter(x); }`) が untrusted HTML の class 一致要素にマッチすると、その要素の奇妙な tag 名が生成 stylesheet にそのまま流れ込む。

Refs: `fulgur-ka6c`

## 経路

1. author が trusted CSS で `.x::before { content: counter(c); }` を書く（GCPM counter pseudo-content）
2. attacker HTML: `<x{}body{color:red} class=\"x\">payload</x{}body{color:red}>`
3. html5ever が奇妙な tag 名 `x{}body{color:red}` を `elem.name.local` として verbatim 保存
4. CounterPass が class 一致で content mapping を発火、`element_specificity_prefix` が tag 名を prefix に prepend
5. 生成 CSS: `x{}body{color:red}.x[data-fulgur-cid=\"0\"]::before{content:\"0\"}` — attacker bytes が生 stylesheet に混入
6. `InjectCssPass` が `<style>` として document に注入、Stylo が cascade に載せる

Stylo の error-recovery で `body{color:red}` が実 rule として cascade に載るかは未検証（output byte 検証は escape 契約違反そのものを assert、実際の描画影響までは追わない）。ただし「attacker bytes が生 stylesheet に混入する」こと自体が escape 契約違反であり、下流の Stylo 挙動に依存させず塞ぐ。

## 修正

`element_specificity_prefix` で:

- tag 名を `css_escape_ident` に通し、round-trip で不変なら prefix に採用（通常の `div` / `h2` / custom-element `x-foo` はすべて素通り、既存挙動を維持）
- escape で変わった場合は prefix から省略。`[data-fulgur-cid=\"N\"]` が element を一意に pin しているので specificity 効果は保存される（id/class の escape 済み prefix も残る）
- doc コメントで契約を明記

`build_static_content_css` にも同型の raw tag emit が残るが、こちらは trusted author CSS（`gcpm::parser` の `Token::Ident`）由来で attack surface 外。scope creep 回避のため fix はせず、trust boundary を comment で明示するに留めた。

## Advisory 判断

**GHSA は起票しない、公開 hardening PR で対応**（本 PR）。理由:

- integrity-only（RCE / DoS / data disclosure なし、Codex 判定も medium・attack-path medium）
- 前例 `fulgur-z28x`（tagged/PDF-UA nested MCS panic、availability・CVSS 7.5）も同型で no-GHSA / hardening 判定
- 発火条件が narrow（trusted GCPM counter CSS + untrusted HTML + parser が奇妙な tag を受理する経路の同時成立）

CWE 分類は CWE-116（improper output escaping）。

## テスト

- `element_specificity_prefix_escapes_tag_metacharacters`（unit）: 奇妙な tag 名を含む DOM で prefix に生 `{` `}` が漏れないことを assert
- `counter_pass_specificity_prefix_never_breaks_out_of_the_selector`（unit）: CounterPass 生成 CSS 全体に `body{color:red}` / `{}` が現れないことを assert
- `counter_pass_survives_element_names_with_css_metacharacters`（integration, `gcpm_integration.rs`）: `Engine::render` end-to-end で panic せず PDF が生成されることを smoke で担保（Coverage scope の rule に従い lib 側にも smoke test を配置）
- 既存の `counter_pass_injected_selector_reconstructs_element_compound` / `counter_pass_injected_selector_for_bare_element_uses_tag` は fix 後も pass（通常 tag 名の挙動は不変）

## Verification

- [x] `cargo test -p fulgur --lib` — 1748 tests pass
- [x] `cargo test -p fulgur --test gcpm_integration` — smoke pass
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p fulgur --all-targets -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * CSSメタ文字を含むHTML要素名でも、生成CSSのセレクタや特異性プレフィックスを安全に組み立てるよう改善しました。
  * 不正なCSS内容（ルール本文やブロック）の混入を防ぎ、対象要素の識別性を維持します。  
* **テスト**
  * CSSメタ文字を含む要素名を含むケースで、レンダリング成功とPDF生成を確認する統合テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->