### PR TITLE
test(gcpm/string_set): add coverage for DoS budget enforcement and Default impl

### DIFF
--- a/crates/fulgur/src/gcpm/string_set.rs
+++ b/crates/fulgur/src/gcpm/string_set.rs
@@ -179,4 +179,120 @@ mod tests {
         assert_eq!(normalize_whitespace("   "), "");
         assert_eq!(normalize_whitespace("no-whitespace"), "no-whitespace");
     }
+
+    #[test]
+    fn default_produces_empty_store() {
+        let store = StringSetStore::default();
+        assert!(store.is_empty());
+        assert_eq!(store.entries().len(), 0);
+    }
+
+    #[test]
+    fn push_drops_entry_when_budget_exceeded() {
+        let mut store = StringSetStore::new();
+
+        // Fill the store to just below the limit with one large entry whose
+        // name + value payload + STRING_ENTRY_OVERHEAD_BYTES equals exactly
+        // MAX_STRING_SET_STORE_BYTES.  The exact payload size needed:
+        //   payload = MAX_STRING_SET_STORE_BYTES - STRING_ENTRY_OVERHEAD_BYTES
+        let budget = crate::MAX_STRING_SET_STORE_BYTES;
+        let overhead = crate::STRING_ENTRY_OVERHEAD_BYTES;
+        let payload = budget - overhead; // name.len() + value.len()
+        let value = "x".repeat(payload);
+        store.push(StringSetEntry {
+            name: String::new(),
+            value,
+            node_id: 1,
+        });
+        assert_eq!(store.entries().len(), 1, "first entry should fit exactly");
+
+        // A second entry of any size must be dropped — the budget is now full.
+        store.push(StringSetEntry {
+            name: "overflow".into(),
+            value: "ignored".into(),
+            node_id: 2,
+        });
+        assert_eq!(
+            store.entries().len(),
+            1,
+            "entry over budget must be silently dropped"
+        );
+    }
+
+    #[test]
+    fn push_allows_small_entries_after_earlier_large_entry_fails() {
+        let mut store = StringSetStore::new();
+
+        let budget = crate::MAX_STRING_SET_STORE_BYTES;
+        let overhead = crate::STRING_ENTRY_OVERHEAD_BYTES;
+
+        // Push an entry that is just one byte over the budget: it must be
+        // dropped because the total would exceed MAX_STRING_SET_STORE_BYTES.
+        let too_large = "x".repeat(budget - overhead + 1);
+        store.push(StringSetEntry {
+            name: String::new(),
+            value: too_large,
+            node_id: 1,
+        });
+        assert!(store.is_empty(), "over-budget entry must be dropped");
+
+        // A small entry should still be accepted since the budget wasn't consumed.
+        store.push(StringSetEntry {
+            name: "k".into(),
+            value: "v".into(),
+            node_id: 2,
+        });
+        assert_eq!(
+            store.entries().len(),
+            1,
+            "small entry must be accepted after a dropped entry"
+        );
+        assert_eq!(store.entries()[0].node_id, 2);
+    }
+
+    #[test]
+    fn push_tracks_total_bytes_correctly() {
+        let mut store = StringSetStore::new();
+        let overhead = crate::STRING_ENTRY_OVERHEAD_BYTES;
+
+        // Push two entries whose combined size is well within the budget.
+        store.push(StringSetEntry {
+            name: "a".into(),   // 1 byte
+            value: "bb".into(), // 2 bytes
+            node_id: 1,
+        });
+        store.push(StringSetEntry {
+            name: "cc".into(),   // 2 bytes
+            value: "ddd".into(), // 3 bytes
+            node_id: 2,
+        });
+
+        // Both entries should be present; total_bytes = 2*(overhead) + 1+2+2+3.
+        assert_eq!(store.entries().len(), 2);
+
+        // Now push an entry whose size alone equals the remaining budget.
+        // Expected total after the two entries: 2*overhead + 8
+        let consumed = 2 * overhead + 8;
+        let remaining = crate::MAX_STRING_SET_STORE_BYTES - consumed;
+        // Subtract overhead for the new entry's accounting.
+        let fill_value = "y".repeat(remaining - overhead);
+        store.push(StringSetEntry {
+            name: String::new(),
+            value: fill_value,
+            node_id: 3,
+        });
+        assert_eq!(store.entries().len(), 3, "third entry must fit");
+
+        // Now the budget is full — a fourth entry must be dropped.
+        store.push(StringSetEntry {
+            name: "x".into(),
+            value: "x".into(),
+            node_id: 4,
+        });
+        assert_eq!(
+            store.entries().len(),
+            3,
+            "fourth entry must be dropped when budget is full"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`gcpm/string_set.rs` のカバレッジを改善するためのテスト追加 PR です。

**対象モジュール**: `crates/fulgur/src/gcpm/string_set.rs`

**カバレッジ変化** (`cargo llvm-cov --package fulgur --lib --summary-only`):

| 指標 | 変更前 | 変更後 |
|------|--------|--------|
| Regions | 95.48% (7 missed) | 98.48% (4 missed) |
| Functions | 90.91% (1 missed) | **100.00%** (0 missed) |
| Lines | 93.00% (7 missed) | 97.73% (4 missed) |

## Changes

- `gcpm/string_set.rs` に 4 つのテストを追加

## ターゲット選定の経緯

3 つの最低カバレッジファイルは以下の通りです:

1. `convert/list_item.rs` — 91.36% (Blitz DOM ノード変換。Blitz を起動しないとテスト不可)
2. `render.rs` — 92.53% (6626 行・Blitz 依存の巨大レンダリングパス。テスト困難)
3. `tagging.rs` — 93.72% (調査したところ、23 の missed regions がすべてテストコード内の `matches!` マクロの偽ブランチによるもの。プロダクションコードは実質 100% カバー済み)

上記 3 ファイルはいずれも今回の追加が難しいため、次に実質的な改善が見込める `gcpm/string_set.rs` を選択しました。

## 追加したテスト

| テスト名 | 検証内容 |
|---------|---------|
| `default_produces_empty_store` | `StringSetStore::default()` が正しく空のストアを返す（1 つの未テスト関数をカバー） |
| `push_drops_entry_when_budget_exceeded` | `push()` のバジェット超過時の `return` ブランチ（DoS 防御）をカバー |
| `push_allows_small_entries_after_earlier_large_entry_fails` | 大きなエントリがドロップされた後も小さなエントリは受け入れられること（`total_bytes` が汚染されないことを確認） |
| `push_tracks_total_bytes_correctly` | 複数の `push()` 呼び出し後に累積バイト計算が正確であることを確認し、バジェット満杯時に次のエントリがドロップされることを検証 |

## 意図的にスキップしたブランチ

- `extract_text_content` / `collect_text`: `blitz_dom::BaseDocument` を引数に取るため、Blitz エンジンを起動しないとテスト不可。残り 4 missed regions の原因。

## Test plan

- [x] `cargo test -p fulgur --lib` — 1765 tests passed
- [x] `cargo clippy -- -D warnings` — warnings なし
- [x] `cargo fmt --check` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3LV1GvX5dc2aon6jh8RDF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **テスト**
  - 文字列セットの初期状態、容量上限を超えたエントリの扱い、追加失敗後の再追加を検証するテストを追加しました。
  - 保存容量の合計値が正しく積算されることや、境界条件で保持されるエントリが期待どおりであることを確認します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->