### PR TITLE
harden(link): clip body-collected link annotations to content area

### DIFF
--- a/crates/fulgur/src/draw_primitives.rs
+++ b/crates/fulgur/src/draw_primitives.rs
@@ -339,20 +339,25 @@ impl Quad {
         let ax1 = ax0 + area.width.to_f32();
         let ay1 = ay0 + area.height.to_f32();
 
-        // Detect axis-aligned quads by edge orientation rather than
-        // paired-position equality. A quad is axis-aligned iff every
-        // edge is exactly horizontal (dy == 0) or exactly vertical
-        // (dx == 0). This catches every quarter turn (0°, 90°, 180°,
-        // 270°) and every reflection, all of which produce quads with
-        // horizontal/vertical edges but with different paired-position
-        // orders (`points[0]/[3]` vs `points[0]/[1]` etc.). A rotated
-        // quad at, say, 45° has non-zero dx AND dy on every edge and
-        // correctly falls through to the rotated branch.
+        // Detect axis-aligned quads by edge orientation, with an f32-
+        // noise tolerance. A quad is axis-aligned iff every edge is
+        // (nearly) horizontal or (nearly) vertical — i.e. its smaller
+        // component is negligible relative to its larger component.
+        // Exact `== 0.0` would miss quads whose matrix reached them
+        // via `Affine2D::rotation(FRAC_PI_2)`, since `sin_cos` in f32
+        // has `cos(π/2) ≈ -4.4e-8` and the transformed edges pick up
+        // tiny non-zero components on both axes. `1e-4` relative
+        // tolerance is well above that noise but far below any real
+        // rotation (arc-second scale), so a 45° quad still correctly
+        // falls through to the rotated branch.
         let is_axis_aligned = (0..4).all(|i| {
             let j = (i + 1) % 4;
-            let dx = self.points[j][0] - self.points[i][0];
-            let dy = self.points[j][1] - self.points[i][1];
-            dx == 0.0 || dy == 0.0
+            let dx = (self.points[j][0] - self.points[i][0]).abs();
+            let dy = (self.points[j][1] - self.points[i][1]).abs();
+            let (small, large) = if dx < dy { (dx, dy) } else { (dy, dx) };
+            // Zero-length edge (degenerate) — treat as axis-aligned;
+            // the downstream clamp is a no-op on it anyway.
+            large <= f32::EPSILON || small <= large * 1e-4
         });
 
         if is_axis_aligned {
@@ -2024,6 +2029,64 @@ mod dp_unit_tests {
         assert!((max_x - (-200.0)).abs() < 1e-4);
         assert!((min_y - 100.0).abs() < 1e-4);
         assert!((max_y - 200.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn quad_clip_axis_aligned_after_realistic_rotate_90_matrix_clamps() {
+        // CSS `rotate(90deg)` reaches `Affine2D::rotation(FRAC_PI_2)`
+        // whose matrix comes from `sin_cos`: `cos(π/2)` is not exactly
+        // 0 in f32 (~ -4.37e-8), so a transformed axis-aligned rect
+        // has tiny non-zero components on both edge deltas. An exact
+        // `dx == 0.0 || dy == 0.0` axis-alignment check misses this
+        // shape and routes it to the rotated branch, which drops the
+        // whole occurrence when any corner lies outside the clip
+        // area. Use `Affine2D::rotation` end-to-end (the same path
+        // real content takes) and assert the straddling quad clamps
+        // to the AABB intersection with `area` instead of dropping.
+        use std::f32::consts::FRAC_PI_2;
+        let r = Affine2D::rotation(FRAC_PI_2);
+        // Rotation(π/2) maps (x,y) → (-y, x). We want the rotated
+        // quad to straddle `area.x = 0` on the left boundary while
+        // staying inside `area.y ∈ [0, 500]`.
+        //   rotated_x = -original_y  → so original y must straddle 0
+        //     to produce rotated x that straddles 0 in area coords.
+        //     base y ∈ [-40, 60] → rotated x ∈ [-60, 40].
+        //   rotated_y = original_x   → so original x must lie in
+        //     [0, 500]. base x ∈ [50, 150] → rotated y ∈ [50, 150].
+        let base = Rect {
+            x: 50.0.as_pt(),
+            y: (-40.0).as_pt(),
+            width: 100.0.as_pt(),
+            height: 100.0.as_pt(),
+        };
+        let q = r.transform_rect(&base);
+        let area = Rect {
+            x: 0.0.as_pt(),
+            y: 0.0.as_pt(),
+            width: 500.0.as_pt(),
+            height: 500.0.as_pt(),
+        };
+        let clipped = q
+            .clip_to_rect(&area)
+            .expect("realistic quarter-turn quad straddling area must clamp, not drop");
+        // Every clipped point must lie inside `area` (with the same
+        // 1e-4 slack the epsilon check uses for numerical noise from
+        // `Affine2D::rotation`).
+        for &[px, py] in &clipped.points {
+            assert!(
+                (-1e-4..=500.0 + 1e-4).contains(&px),
+                "clipped x out of range: {px}"
+            );
+            assert!(
+                (-1e-4..=500.0 + 1e-4).contains(&py),
+                "clipped y out of range: {py}"
+            );
+        }
+        // Sanity: the clipped quad must include the in-content slice
+        // (rotated y range [50, 150]), so its bounds must span at
+        // least most of that range.
+        let (_, min_y, _, max_y) = quad_bounds(&clipped);
+        assert!(min_y <= 60.0 && max_y >= 140.0);
     }
 
     #[test]

--- a/crates/fulgur/src/draw_primitives.rs
+++ b/crates/fulgur/src/draw_primitives.rs
@@ -339,14 +339,21 @@ impl Quad {
         let ax1 = ax0 + area.width.to_f32();
         let ay1 = ay0 + area.height.to_f32();
 
-        // Detect axis-aligned quads in the krilla point order
-        // (BL, BR, TR, TL). Comparing exactly is correct because
-        // `transform_rect` and `push_rect` write matching floats to the
-        // paired corners when no rotation is present.
-        let is_axis_aligned = self.points[0][0] == self.points[3][0]
-            && self.points[1][0] == self.points[2][0]
-            && self.points[0][1] == self.points[1][1]
-            && self.points[2][1] == self.points[3][1];
+        // Detect axis-aligned quads by edge orientation rather than
+        // paired-position equality. A quad is axis-aligned iff every
+        // edge is exactly horizontal (dy == 0) or exactly vertical
+        // (dx == 0). This catches every quarter turn (0°, 90°, 180°,
+        // 270°) and every reflection, all of which produce quads with
+        // horizontal/vertical edges but with different paired-position
+        // orders (`points[0]/[3]` vs `points[0]/[1]` etc.). A rotated
+        // quad at, say, 45° has non-zero dx AND dy on every edge and
+        // correctly falls through to the rotated branch.
+        let is_axis_aligned = (0..4).all(|i| {
+            let j = (i + 1) % 4;
+            let dx = self.points[j][0] - self.points[i][0];
+            let dy = self.points[j][1] - self.points[i][1];
+            dx == 0.0 || dy == 0.0
+        });
 
         if is_axis_aligned {
             // Survey all four points instead of the un-reflected krilla
@@ -1974,6 +1981,75 @@ mod dp_unit_tests {
         assert!((max_x - (-100.0)).abs() < 1e-4);
         assert!((min_y - 200.0).abs() < 1e-4);
         assert!((max_y - 214.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn quad_clip_axis_aligned_after_rotate_90_is_preserved_and_clamped() {
+        // `transform: rotate(90deg)` (matrix (0,1,-1,0) or equivalent)
+        // still leaves every edge either horizontal or vertical, i.e.
+        // the quad is still axis-aligned. But the pairing of equal
+        // coordinates moves — after a quarter turn `points[0]/[1]`
+        // share x (originally `[0]/[3]`), and `points[2]/[3]` share x
+        // (originally `[1]/[2]`). A paired-position axis-alignment
+        // check misses this and falls through to the rotated branch,
+        // which drops the whole occurrence as soon as one corner is
+        // outside — even though the AABB portion inside the content
+        // area is still visible and should stay clickable.
+        //
+        // Rotate original rect (100,200) size 100x14 by 90° CCW about
+        // origin (mapping (x,y) → (-y, x)):
+        //   BL=(-214, 100)  BR=(-214, 200)  TR=(-200, 200)  TL=(-200, 100)
+        // Every edge is horizontal or vertical, so the AABB is the
+        // correct clickable region:
+        //   x ∈ [-214, -200], y ∈ [100, 200]
+        let area = Rect {
+            x: (-300.0).as_pt(),
+            y: 0.0.as_pt(),
+            width: 400.0.as_pt(),
+            height: 500.0.as_pt(),
+        };
+        let q = Quad {
+            points: [
+                [-214.0, 100.0],
+                [-214.0, 200.0],
+                [-200.0, 200.0],
+                [-200.0, 100.0],
+            ],
+        };
+        let clipped = q
+            .clip_to_rect(&area)
+            .expect("quarter-turn quad fully inside area must survive");
+        let (min_x, min_y, max_x, max_y) = quad_bounds(&clipped);
+        assert!((min_x - (-214.0)).abs() < 1e-4);
+        assert!((max_x - (-200.0)).abs() < 1e-4);
+        assert!((min_y - 100.0).abs() < 1e-4);
+        assert!((max_y - 200.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn quad_clip_axis_aligned_after_rotate_90_straddling_boundary_clamps() {
+        // Same quarter-turn shape but part of the AABB extends into the
+        // margin strip (x < area.x). A correct clip clamps to the
+        // intersection instead of dropping the whole occurrence.
+        let area = Rect {
+            x: 0.0.as_pt(),
+            y: 0.0.as_pt(),
+            width: 500.0.as_pt(),
+            height: 500.0.as_pt(),
+        };
+        // AABB x ∈ [-10, 100], y ∈ [50, 200]. Intersection with
+        // area x ∈ [0, 500] gives clamped x ∈ [0, 100].
+        let q = Quad {
+            points: [[-10.0, 50.0], [-10.0, 200.0], [100.0, 200.0], [100.0, 50.0]],
+        };
+        let clipped = q
+            .clip_to_rect(&area)
+            .expect("straddling quarter-turn quad must clamp, not drop");
+        let (min_x, min_y, max_x, max_y) = quad_bounds(&clipped);
+        assert!((min_x - 0.0).abs() < 1e-4);
+        assert!((max_x - 100.0).abs() < 1e-4);
+        assert!((min_y - 50.0).abs() < 1e-4);
+        assert!((max_y - 200.0).abs() < 1e-4);
     }
 
     #[test]

--- a/crates/fulgur/src/draw_primitives.rs
+++ b/crates/fulgur/src/draw_primitives.rs
@@ -349,10 +349,23 @@ impl Quad {
             && self.points[2][1] == self.points[3][1];
 
         if is_axis_aligned {
-            let qx0 = self.points[3][0].min(self.points[0][0]);
-            let qx1 = self.points[1][0].max(self.points[2][0]);
-            let qy0 = self.points[2][1].min(self.points[3][1]);
-            let qy1 = self.points[0][1].max(self.points[1][1]);
+            // Survey all four points instead of the un-reflected krilla
+            // pairing (points[0]/[3] on the left, points[1]/[2] on the
+            // right). `transform: scaleX(-1)` / `scaleY(-1)` mirrors
+            // the rect, swapping the paired positions while still
+            // leaving the quad axis-aligned; deriving `qx0` / `qx1`
+            // from fixed pairs would produce `qx1 <= qx0` after
+            // reflection and drop the annotation even though the
+            // reflected rect is still on-page.
+            let (qx0, qy0, qx1, qy1) = self.points.iter().fold(
+                (
+                    f32::INFINITY,
+                    f32::INFINITY,
+                    f32::NEG_INFINITY,
+                    f32::NEG_INFINITY,
+                ),
+                |(x0, y0, x1, y1), &[px, py]| (x0.min(px), y0.min(py), x1.max(px), y1.max(py)),
+            );
             let x0 = qx0.max(ax0);
             let x1 = qx1.min(ax1);
             let y0 = qy0.max(ay0);
@@ -1919,6 +1932,78 @@ mod dp_unit_tests {
             ],
         };
         assert!(q.clip_to_rect(&area).is_none());
+    }
+
+    #[test]
+    fn quad_clip_axis_aligned_after_x_reflection_is_preserved() {
+        // `transform: scaleX(-1)` (or an equivalent matrix) mirrors the
+        // rect horizontally. The result is still axis-aligned in the
+        // `is_axis_aligned` sense (paired corners share x/y), but the
+        // BL/TL pair now sits at the *right* edge and BR/TR pair at the
+        // *left* edge — the reverse of the un-reflected order.
+        //
+        // Original 100x14 rect at (100, 200) → corners:
+        //   BL=(100,214)  BR=(200,214)  TR=(200,200)  TL=(100,200)
+        // After scaleX(-1) about x=0 → corners:
+        //   BL=(-100,214) BR=(-200,214) TR=(-200,200) TL=(-100,200)
+        //
+        // A clip that assumed BL/TL held min_x and BR/TR held max_x
+        // (the original orientation) would derive `qx1 <= qx0` for the
+        // reflected quad and drop the annotation even though it lies
+        // fully inside `area`. `clip_to_rect` must survey all four
+        // points instead of paired positions.
+        let area = Rect {
+            x: (-300.0).as_pt(),
+            y: 100.0.as_pt(),
+            width: 400.0.as_pt(),
+            height: 500.0.as_pt(),
+        };
+        let q = Quad {
+            points: [
+                [-100.0, 214.0],
+                [-200.0, 214.0],
+                [-200.0, 200.0],
+                [-100.0, 200.0],
+            ],
+        };
+        let clipped = q
+            .clip_to_rect(&area)
+            .expect("reflected quad fully inside area must survive");
+        let (min_x, min_y, max_x, max_y) = quad_bounds(&clipped);
+        assert!((min_x - (-200.0)).abs() < 1e-4);
+        assert!((max_x - (-100.0)).abs() < 1e-4);
+        assert!((min_y - 200.0).abs() < 1e-4);
+        assert!((max_y - 214.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn quad_clip_axis_aligned_after_y_reflection_is_preserved() {
+        // Symmetric case: `transform: scaleY(-1)` (or matrix equivalent)
+        // mirrors vertically. BL/BR now hold the *smaller* y and TR/TL
+        // the *larger* y, the reverse of the un-reflected pairing.
+        let area = Rect {
+            x: 0.0.as_pt(),
+            y: (-300.0).as_pt(),
+            width: 500.0.as_pt(),
+            height: 400.0.as_pt(),
+        };
+        // Original y0=200 y1=214 flipped to y0'=-200 y1'=-214.
+        let q = Quad {
+            points: [
+                [100.0, -214.0],
+                [200.0, -214.0],
+                [200.0, -200.0],
+                [100.0, -200.0],
+            ],
+        };
+        let clipped = q
+            .clip_to_rect(&area)
+            .expect("y-reflected quad fully inside area must survive");
+        let (min_x, min_y, max_x, max_y) = quad_bounds(&clipped);
+        assert!((min_x - 100.0).abs() < 1e-4);
+        assert!((max_x - 200.0).abs() < 1e-4);
+        assert!((min_y - (-214.0)).abs() < 1e-4);
+        assert!((max_y - (-200.0)).abs() < 1e-4);
     }
 
     // ── compute_overflow_clip_path branches ─────────────────

--- a/crates/fulgur/src/draw_primitives.rs
+++ b/crates/fulgur/src/draw_primitives.rs
@@ -318,6 +318,62 @@ impl Quad {
         (ax * by - ay * bx).abs() <= f32::EPSILON
     }
 
+    /// Clip this quad against an axis-aligned `Rect`.
+    ///
+    /// Axis-aligned quads are clamped to the rect (min/max on both axes),
+    /// producing a smaller axis-aligned quad; if the intersection is empty
+    /// this returns `None`. Non-axis-aligned (rotated) quads are dropped
+    /// whenever any point lies outside the rect, because clamping a
+    /// rotated shape's corners to axis-aligned bounds distorts the
+    /// clickable region into a different quadrilateral than the visible
+    /// text — safer to drop entirely.
+    ///
+    /// Used by `render_v2` to keep body-collected link annotations inside
+    /// the content area. The v2 paint order draws `@page` margin boxes
+    /// AFTER body content, so a body link falling in a page-margin strip
+    /// would visually be covered by the margin box but remain clickable
+    /// with its original URI — click target and visible text disagree.
+    pub fn clip_to_rect(&self, area: &Rect) -> Option<Quad> {
+        let ax0 = area.x.to_f32();
+        let ay0 = area.y.to_f32();
+        let ax1 = ax0 + area.width.to_f32();
+        let ay1 = ay0 + area.height.to_f32();
+
+        // Detect axis-aligned quads in the krilla point order
+        // (BL, BR, TR, TL). Comparing exactly is correct because
+        // `transform_rect` and `push_rect` write matching floats to the
+        // paired corners when no rotation is present.
+        let is_axis_aligned = self.points[0][0] == self.points[3][0]
+            && self.points[1][0] == self.points[2][0]
+            && self.points[0][1] == self.points[1][1]
+            && self.points[2][1] == self.points[3][1];
+
+        if is_axis_aligned {
+            let qx0 = self.points[3][0].min(self.points[0][0]);
+            let qx1 = self.points[1][0].max(self.points[2][0]);
+            let qy0 = self.points[2][1].min(self.points[3][1]);
+            let qy1 = self.points[0][1].max(self.points[1][1]);
+            let x0 = qx0.max(ax0);
+            let x1 = qx1.min(ax1);
+            let y0 = qy0.max(ay0);
+            let y1 = qy1.min(ay1);
+            if x1 <= x0 || y1 <= y0 {
+                return None;
+            }
+            return Some(Quad {
+                points: [[x0, y1], [x1, y1], [x1, y0], [x0, y0]],
+            });
+        }
+
+        // Non-axis-aligned: preserve iff every point is inside `area`.
+        for [x, y] in self.points {
+            if x < ax0 || x > ax1 || y < ay0 || y > ay1 {
+                return None;
+            }
+        }
+        Some(*self)
+    }
+
     /// Convert to krilla's `Quadrilateral` for PDF annotation emission.
     pub fn to_krilla(&self) -> krilla::geom::Quadrilateral {
         krilla::geom::Quadrilateral([
@@ -1721,6 +1777,148 @@ mod dp_unit_tests {
         );
         collector.pop_transform();
         assert!(collector.occurrences().is_empty());
+    }
+
+    // ── Quad::clip_to_rect ─────────────────────────────────
+    //
+    // Body-collected link annotations may extend into a page-margin box
+    // strip (e.g. via `position: fixed`, negative margins, or an oversized
+    // element). Margin boxes are painted AFTER body content — see the
+    // paint order comment in `render.rs` — so a body link that falls in a
+    // margin area is *visually replaced by the margin-box content but
+    // still emitted as an active PDF link annotation with its original
+    // URI*. `clip_to_rect` clamps axis-aligned body quads to the content
+    // area and drops any rotated quad that has a point outside the
+    // content area, so the click target and the visible text always agree.
+
+    fn aa_quad(x0: f32, y0: f32, x1: f32, y1: f32) -> Quad {
+        // bottom-left → bottom-right → top-right → top-left (Y-down)
+        Quad {
+            points: [[x0, y1], [x1, y1], [x1, y0], [x0, y0]],
+        }
+    }
+
+    fn quad_bounds(q: &Quad) -> (f32, f32, f32, f32) {
+        let mut min_x = f32::INFINITY;
+        let mut min_y = f32::INFINITY;
+        let mut max_x = f32::NEG_INFINITY;
+        let mut max_y = f32::NEG_INFINITY;
+        for p in q.points {
+            min_x = min_x.min(p[0]);
+            min_y = min_y.min(p[1]);
+            max_x = max_x.max(p[0]);
+            max_y = max_y.max(p[1]);
+        }
+        (min_x, min_y, max_x, max_y)
+    }
+
+    fn content_area() -> Rect {
+        // A4 with 60pt top/bottom, 40pt left/right margins → content area
+        // (40, 60) to (555, 782) in Y-down coordinates.
+        Rect {
+            x: 40.0.as_pt(),
+            y: 60.0.as_pt(),
+            width: 515.0.as_pt(),
+            height: 722.0.as_pt(),
+        }
+    }
+
+    #[test]
+    fn quad_clip_axis_aligned_fully_inside_returns_self() {
+        let area = content_area();
+        // 50x14 quad at (100, 200) — well inside content area.
+        let q = aa_quad(100.0, 200.0, 150.0, 214.0);
+        let clipped = q
+            .clip_to_rect(&area)
+            .expect("fully-inside quad must survive clipping");
+        assert_eq!(clipped.points, q.points);
+    }
+
+    #[test]
+    fn quad_clip_axis_aligned_in_bottom_margin_returns_none() {
+        let area = content_area();
+        // Quad entirely inside bottom margin strip (y in [800, 820]);
+        // content area's max y is 782 — no overlap. This is the shape
+        // that produces a click-target / visible-text mismatch: body
+        // anchor positioned where `@bottom-*` margin boxes will paint.
+        let q = aa_quad(100.0, 800.0, 250.0, 820.0);
+        assert!(q.clip_to_rect(&area).is_none());
+    }
+
+    #[test]
+    fn quad_clip_axis_aligned_in_top_margin_returns_none() {
+        let area = content_area();
+        // Quad entirely inside top margin strip (y in [10, 40]);
+        // content area starts at y=60.
+        let q = aa_quad(100.0, 10.0, 250.0, 40.0);
+        assert!(q.clip_to_rect(&area).is_none());
+    }
+
+    #[test]
+    fn quad_clip_axis_aligned_straddling_bottom_boundary_clamps() {
+        let area = content_area();
+        // Quad y in [770, 800] straddles content-area bottom (y=782).
+        // Intersection y range = [770, 782].
+        let q = aa_quad(100.0, 770.0, 250.0, 800.0);
+        let clipped = q
+            .clip_to_rect(&area)
+            .expect("straddling quad must produce clipped remainder");
+        let (min_x, min_y, max_x, max_y) = quad_bounds(&clipped);
+        assert!((min_x - 100.0).abs() < 1e-4);
+        assert!((max_x - 250.0).abs() < 1e-4);
+        assert!((min_y - 770.0).abs() < 1e-4);
+        assert!((max_y - 782.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn quad_clip_axis_aligned_straddling_left_boundary_clamps() {
+        let area = content_area();
+        // Quad x in [30, 100] straddles content-area left (x=40).
+        // Intersection x range = [40, 100].
+        let q = aa_quad(30.0, 200.0, 100.0, 214.0);
+        let clipped = q
+            .clip_to_rect(&area)
+            .expect("straddling quad must produce clipped remainder");
+        let (min_x, min_y, max_x, max_y) = quad_bounds(&clipped);
+        assert!((min_x - 40.0).abs() < 1e-4);
+        assert!((max_x - 100.0).abs() < 1e-4);
+        assert!((min_y - 200.0).abs() < 1e-4);
+        assert!((max_y - 214.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn quad_clip_rotated_all_points_inside_returns_self() {
+        let area = content_area();
+        // Rotated (non-axis-aligned) quad, all 4 points inside area.
+        let q = Quad {
+            points: [
+                [100.0, 250.0],
+                [200.0, 260.0],
+                [190.0, 210.0],
+                [90.0, 200.0],
+            ],
+        };
+        let clipped = q
+            .clip_to_rect(&area)
+            .expect("rotated fully-inside quad must survive");
+        assert_eq!(clipped.points, q.points);
+    }
+
+    #[test]
+    fn quad_clip_rotated_any_point_outside_returns_none() {
+        let area = content_area();
+        // Rotated quad with one point outside (x=560 > area.right=555).
+        // Rotated quads can't be safely clamped to axis-aligned bounds
+        // without producing a wrong shape, so any-point-outside → drop.
+        let q = Quad {
+            points: [
+                [100.0, 250.0],
+                [560.0, 260.0],
+                [540.0, 210.0],
+                [90.0, 200.0],
+            ],
+        };
+        assert!(q.clip_to_rect(&area).is_none());
     }
 
     // ── compute_overflow_clip_path branches ─────────────────

--- a/crates/fulgur/src/link.rs
+++ b/crates/fulgur/src/link.rs
@@ -18,8 +18,38 @@ use krilla::geom::{Point, Quadrilateral};
 use krilla::page::Page;
 use krilla::tagging::Identifier;
 
-use crate::draw_primitives::{DestinationRegistry, LinkOccurrence};
+use crate::draw_primitives::{DestinationRegistry, LinkOccurrence, Rect};
 use crate::paragraph::LinkTarget;
+
+/// Clip each occurrence's quads to `content_area` (in Y-down PDF pt),
+/// dropping any quad that falls entirely outside and dropping any
+/// occurrence whose quads all disappear.
+///
+/// This runs on body-collected occurrences before emission. `render_v2`
+/// paints `@page` margin boxes AFTER body content, so a body link
+/// annotation that extends into a margin-box strip would remain
+/// clickable under the margin-box content that visually replaces it —
+/// click target and visible text disagree. Clipping to the content
+/// area keeps the click target inside the region body content actually
+/// owns. Margin-box occurrences are collected via a separate
+/// `LinkCollector` and emitted unclipped.
+pub(crate) fn clip_body_occurrences_to_content_area(
+    occurrences: Vec<LinkOccurrence>,
+    content_area: &Rect,
+) -> Vec<LinkOccurrence> {
+    let mut out = Vec::with_capacity(occurrences.len());
+    for mut occ in occurrences {
+        occ.quads = occ
+            .quads
+            .into_iter()
+            .filter_map(|q| q.clip_to_rect(content_area))
+            .collect();
+        if !occ.quads.is_empty() {
+            out.push(occ);
+        }
+    }
+    out
+}
 
 /// Emit PDF link annotations for every occurrence on the given page.
 ///
@@ -307,6 +337,164 @@ mod tests {
             assert!(ids.is_empty());
         }
         assert_eq!(page0_annotation_count(doc), 1);
+    }
+
+    // ── content-area clipping (body annotations) ──────────────────────────
+    //
+    // `render_v2` paints `@page` margin boxes AFTER body content so page
+    // headers/footers are not hidden by body backgrounds. Because PDF link
+    // annotations are independent interactive objects, a body link that
+    // happens to fall inside a margin-box strip stays clickable even
+    // though the margin box now paints over it visually — the click
+    // target and the visible text disagree. Body occurrences must
+    // therefore be clipped to the content area before emission;
+    // margin-box occurrences are collected separately and emitted
+    // unclipped.
+
+    fn a4_content_area() -> crate::draw_primitives::Rect {
+        // A4 595x842pt with 60pt top/bottom, 40pt left/right margins.
+        crate::draw_primitives::Rect {
+            x: 40.0.as_pt(),
+            y: 60.0.as_pt(),
+            width: 515.0.as_pt(),
+            height: 722.0.as_pt(),
+        }
+    }
+
+    #[test]
+    fn clip_body_drops_occurrence_entirely_in_bottom_margin() {
+        // Body anchor positioned exactly where the `@bottom-*` margin
+        // box will paint — after clipping there is no residual quad, so
+        // the occurrence is dropped and no annotation reaches the PDF.
+        let area = a4_content_area();
+        let occs = vec![ext_occ(
+            "https://example.com/target",
+            // y range [800, 820] — below the 782 content-area bottom.
+            vec![Quad {
+                points: [
+                    [100.0, 820.0],
+                    [250.0, 820.0],
+                    [250.0, 800.0],
+                    [100.0, 800.0],
+                ],
+            }],
+        )];
+        let clipped = crate::link::clip_body_occurrences_to_content_area(occs, &area);
+        assert!(
+            clipped.is_empty(),
+            "body link fully inside footer strip must be dropped, got {clipped:?}"
+        );
+    }
+
+    #[test]
+    fn clip_body_clamps_straddling_quad_to_content_area() {
+        // Body link crossing the bottom boundary (y in [770, 800],
+        // area bottom = 782) has its clickable strip clamped to
+        // y in [770, 782] so the click target no longer overlaps the
+        // margin-box strip.
+        let area = a4_content_area();
+        let occs = vec![ext_occ(
+            "https://body.example",
+            vec![Quad {
+                points: [
+                    [100.0, 800.0],
+                    [250.0, 800.0],
+                    [250.0, 770.0],
+                    [100.0, 770.0],
+                ],
+            }],
+        )];
+        let clipped = crate::link::clip_body_occurrences_to_content_area(occs, &area);
+        assert_eq!(clipped.len(), 1);
+        assert_eq!(clipped[0].quads.len(), 1);
+        let ys: Vec<f32> = clipped[0].quads[0].points.iter().map(|p| p[1]).collect();
+        let max_y = ys.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        assert!((max_y - 782.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn clip_body_preserves_multi_quad_link_with_partial_overlap() {
+        // A multi-quad link (e.g. a wrapping <a>) with one quad in the
+        // content area and one in the margin strip: keep the first, drop
+        // the second, so the visible-and-clickable portion survives.
+        let area = a4_content_area();
+        let occs = vec![ext_occ(
+            "https://wrap.example",
+            vec![
+                // Inside content area.
+                Quad {
+                    points: [
+                        [100.0, 214.0],
+                        [250.0, 214.0],
+                        [250.0, 200.0],
+                        [100.0, 200.0],
+                    ],
+                },
+                // Bottom margin strip.
+                Quad {
+                    points: [
+                        [100.0, 820.0],
+                        [250.0, 820.0],
+                        [250.0, 800.0],
+                        [100.0, 800.0],
+                    ],
+                },
+            ],
+        )];
+        let clipped = crate::link::clip_body_occurrences_to_content_area(occs, &area);
+        assert_eq!(clipped.len(), 1);
+        assert_eq!(
+            clipped[0].quads.len(),
+            1,
+            "second (in-margin) quad must be dropped"
+        );
+    }
+
+    #[test]
+    fn clip_body_preserves_occurrence_entirely_inside() {
+        let area = a4_content_area();
+        let occs = vec![ext_occ(
+            "https://legit.example",
+            vec![Quad {
+                points: [
+                    [100.0, 214.0],
+                    [250.0, 214.0],
+                    [250.0, 200.0],
+                    [100.0, 200.0],
+                ],
+            }],
+        )];
+        let before = occs.clone();
+        let clipped = crate::link::clip_body_occurrences_to_content_area(occs, &area);
+        assert_eq!(clipped.len(), 1);
+        assert_eq!(clipped[0].quads, before[0].quads);
+    }
+
+    #[test]
+    fn body_link_in_margin_area_emits_no_annotation_via_emit_after_clip() {
+        // End-to-end at the emit layer: a body occurrence positioned in
+        // the bottom margin, run through the clip → emit pipeline, must
+        // produce zero /Annots entries on the resulting page.
+        let mut doc = krilla::Document::new();
+        {
+            let mut page = doc.start_page_with(page_settings());
+            let registry = DestinationRegistry::new();
+            let area = a4_content_area();
+            let body_occs = vec![ext_occ(
+                "https://example.com/target",
+                vec![Quad {
+                    points: [
+                        [100.0, 820.0],
+                        [250.0, 820.0],
+                        [250.0, 800.0],
+                        [100.0, 800.0],
+                    ],
+                }],
+            )];
+            let clipped = crate::link::clip_body_occurrences_to_content_area(body_occs, &area);
+            emit_link_annotations(&mut page, &clipped, &registry, None);
+        }
+        assert_eq!(page0_annotation_count(doc), 0);
     }
 
     // ── mixed occurrences ─────────────────────────────────────────────────

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -117,7 +117,15 @@ pub fn render_v2(
         }
     }
 
-    let mut link_collector = crate::draw_primitives::LinkCollector::new();
+    // Body content and margin boxes get separate LinkCollectors. Body
+    // occurrences are clipped to the content area before emission so a
+    // body link positioned into a page-margin strip (via CSS positioning
+    // or overflow) cannot leave a click target under a later-painted
+    // margin box — the paint order would otherwise let the visible text
+    // and the clickable URI disagree. Margin-box occurrences are emitted
+    // unclipped so `@page @bottom-*` anchors remain clickable.
+    let mut body_link_collector = crate::draw_primitives::LinkCollector::new();
+    let mut margin_link_collector = crate::draw_primitives::LinkCollector::new();
 
     let mut link_annot_ids: BTreeMap<usize, Vec<krilla::tagging::Identifier>> = BTreeMap::new();
 
@@ -197,14 +205,15 @@ pub fn render_v2(
         if let Some(c) = bookmark_collector.as_mut() {
             c.set_current_page(page_idx);
         }
-        link_collector.set_current_page(page_idx);
+        body_link_collector.set_current_page(page_idx);
+        margin_link_collector.set_current_page(page_idx);
         {
             let mut surface = page.surface();
             {
                 let mut canvas = crate::draw_primitives::Canvas {
                     surface: &mut surface,
                     bookmark_collector: bookmark_collector.as_mut(),
-                    link_collector: Some(&mut link_collector),
+                    link_collector: Some(&mut body_link_collector),
                     tag_collector: tag_collector.as_mut(),
                     link_run_node_id: None,
                     in_marked_content: false,
@@ -289,12 +298,14 @@ pub fn render_v2(
             }
             // Paint margin boxes after body content so page headers /
             // footers are not hidden by page-filling body backgrounds.
-            // Keep bookmarks disabled for repeated running elements, but
-            // collect links so margin-box anchors remain clickable.
+            // Keep bookmarks disabled for repeated running elements.
+            // Margin-box links go into their own collector so their
+            // occurrences do not get clipped to the body content area
+            // (they live in the margin strips by design).
             let mut margin_canvas = crate::draw_primitives::Canvas {
                 surface: &mut surface,
                 bookmark_collector: None,
-                link_collector: Some(&mut link_collector),
+                link_collector: Some(&mut margin_link_collector),
                 tag_collector: None,
                 link_run_node_id: None,
                 in_marked_content: false,
@@ -311,7 +322,24 @@ pub fn render_v2(
                 anchor_map,
             );
         }
-        let per_page = link_collector.take_page(page_idx);
+        // Body occurrences are clipped to the content area rect before
+        // emission, so a body link that fell into a page-margin strip
+        // (e.g. via `position: fixed; bottom: 0`) cannot leave a click
+        // target under a later-painted margin box — the paint order
+        // would otherwise leave the visible text and the clickable URI
+        // out of sync. Margin occurrences are emitted unclipped — they
+        // live in the margin strips by design.
+        let content_area = crate::draw_primitives::Rect {
+            x: resolved_margin.left.as_pt(),
+            y: resolved_margin.top.as_pt(),
+            width: (page_size.width - resolved_margin.left - resolved_margin.right).as_pt(),
+            height: (page_size.height - resolved_margin.top - resolved_margin.bottom).as_pt(),
+        };
+        let body_per_page = crate::link::clip_body_occurrences_to_content_area(
+            body_link_collector.take_page(page_idx),
+            &content_area,
+        );
+        let margin_per_page = margin_link_collector.take_page(page_idx);
         // Only span_ptrs that are wired into the struct tree via
         // ParagraphRunItem::LinkContent entries should use add_tagged_annotation;
         // others fall back to add_annotation so that Krilla's invariant
@@ -320,7 +348,15 @@ pub fn render_v2(
         let wired_ptrs = tag_collector.as_ref().map(|tc| tc.wired_link_span_ptrs());
         for (ptr, id) in crate::link::emit_link_annotations(
             &mut page,
-            &per_page,
+            &body_per_page,
+            &dest_registry,
+            wired_ptrs.as_ref(),
+        ) {
+            link_annot_ids.entry(ptr).or_default().push(id);
+        }
+        for (ptr, id) in crate::link::emit_link_annotations(
+            &mut page,
+            &margin_per_page,
             &dest_registry,
             wired_ptrs.as_ref(),
         ) {

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -208,6 +208,7 @@ pub fn render_v2(
         }
         body_link_collector.set_current_page(page_idx);
         margin_link_collector.set_current_page(page_idx);
+        let page_has_margin_box_paint;
         {
             let mut surface = page.surface();
             {
@@ -311,7 +312,7 @@ pub fn render_v2(
                 in_marked_content: false,
             };
             let page_content_width = content_area.width.to_f32();
-            margin_box_renderer.render_page(
+            let any_margin_box_painted = margin_box_renderer.render_page(
                 &mut margin_canvas,
                 page_idx,
                 page_num,
@@ -321,21 +322,26 @@ pub fn render_v2(
                 page_content_width,
                 anchor_map,
             );
+            page_has_margin_box_paint = any_margin_box_painted;
         }
-        // Body occurrences are clipped to the content area rect before
-        // emission, so a body link that fell into a page-margin strip
-        // (e.g. via `position: fixed; bottom: 0`) cannot leave a click
-        // target under a later-painted margin box — the paint order
-        // would otherwise leave the visible text and the clickable URI
-        // out of sync. Margin occurrences are emitted unclipped — they
-        // live in the margin strips by design. `content_area` is the
-        // same rect the body background clamp and the margin-box
-        // renderer used earlier this iteration — see
-        // `resolved_content_area`.
-        let body_per_page = crate::link::clip_body_occurrences_to_content_area(
-            body_link_collector.take_page(page_idx),
-            &content_area,
-        );
+        // Body occurrences are clipped to the content area rect ONLY
+        // when at least one `@page` margin box actually painted on
+        // this page — that's the only scenario where a later-painted
+        // margin box could visually cover a body link and leave the
+        // click target out of sync with the visible text. When no
+        // margin box painted, nothing overlays the body layer, and
+        // clipping would drop visible body-drawn page furniture
+        // (`position: fixed; bottom: 0` page numbers, `margin-top`
+        // overflow into the strip, etc.) making it unclickable
+        // without any security benefit. `content_area` is the same
+        // rect the body background clamp and the margin-box renderer
+        // used earlier this iteration — see `resolved_content_area`.
+        let raw_body_page = body_link_collector.take_page(page_idx);
+        let body_per_page = if page_has_margin_box_paint {
+            crate::link::clip_body_occurrences_to_content_area(raw_body_page, &content_area)
+        } else {
+            raw_body_page
+        };
         let margin_per_page = margin_link_collector.take_page(page_idx);
         // Only span_ptrs that are wired into the struct tree via
         // ParagraphRunItem::LinkContent entries should use add_tagged_annotation;
@@ -3593,6 +3599,13 @@ impl<'a> MarginBoxRenderer<'a> {
     /// `<a href="#...">` whose first fragment lands on each page.
     /// Pages with no such anchor look up `None` and the resolver
     /// returns an empty string.
+    /// Returns `true` if any effective margin box resolved to non-empty
+    /// content on this page (regardless of edge). Callers use this to
+    /// decide whether body-link annotations that landed in a page-
+    /// margin strip must be clipped: on a page with zero margin boxes
+    /// nothing paints on top of body content in the strips, so
+    /// preserving body annotations there keeps `position: fixed;
+    /// bottom: 0`-style body-drawn page furniture clickable.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn render_page(
         &mut self,
@@ -3604,7 +3617,7 @@ impl<'a> MarginBoxRenderer<'a> {
         resolved_margin: crate::config::Margin,
         content_width: f32,
         anchor_map: Option<&AnchorMap>,
-    ) {
+    ) -> bool {
         // Resolve effective boxes: pick the most specific matching rule
         // per position. Pseudo-class selectors (`:first`, `:left`,
         // `:right`) override the default `@page` rule.
@@ -3871,6 +3884,14 @@ impl<'a> MarginBoxRenderer<'a> {
                 );
             }
         }
+        // Body-link clip gate: `true` iff at least one effective margin
+        // box on this page produced non-empty content, i.e. something
+        // was actually painted on top of the body layer. When `false`,
+        // the caller must NOT clip body annotations that landed in a
+        // margin strip — nothing covers them, so dropping the click
+        // target would leave visible body-drawn page furniture
+        // unclickable.
+        !resolved_htmls.is_empty()
     }
 }
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -201,6 +201,7 @@ pub fn render_v2(
         };
         let settings = krilla::page::PageSettings::from_wh(page_size.width, page_size.height)
             .ok_or_else(|| Error::PdfGeneration("Invalid page dimensions".into()))?;
+        let content_area = resolved_content_area(page_size, resolved_margin);
         let mut page = document.start_page_with(settings);
         if let Some(c) = bookmark_collector.as_mut() {
             c.set_current_page(page_idx);
@@ -257,8 +258,7 @@ pub fn render_v2(
                 if let Some(body_id) = drawables.body_id
                     && let Some(body_block) = drawables.block_styles.get(&body_id)
                 {
-                    let content_area_h =
-                        page_size.height - resolved_margin.top - resolved_margin.bottom;
+                    let content_area_h = content_area.height.to_f32();
                     let body_bg_y = if page_idx == 0 {
                         resolved_margin.top + drawables.body_offset_pt.1.to_f32()
                     } else {
@@ -310,7 +310,7 @@ pub fn render_v2(
                 link_run_node_id: None,
                 in_marked_content: false,
             };
-            let page_content_width = page_size.width - resolved_margin.left - resolved_margin.right;
+            let page_content_width = content_area.width.to_f32();
             margin_box_renderer.render_page(
                 &mut margin_canvas,
                 page_idx,
@@ -328,13 +328,10 @@ pub fn render_v2(
         // target under a later-painted margin box — the paint order
         // would otherwise leave the visible text and the clickable URI
         // out of sync. Margin occurrences are emitted unclipped — they
-        // live in the margin strips by design.
-        let content_area = crate::draw_primitives::Rect {
-            x: resolved_margin.left.as_pt(),
-            y: resolved_margin.top.as_pt(),
-            width: (page_size.width - resolved_margin.left - resolved_margin.right).as_pt(),
-            height: (page_size.height - resolved_margin.top - resolved_margin.bottom).as_pt(),
-        };
+        // live in the margin strips by design. `content_area` is the
+        // same rect the body background clamp and the margin-box
+        // renderer used earlier this iteration — see
+        // `resolved_content_area`.
         let body_per_page = crate::link::clip_body_occurrences_to_content_area(
             body_link_collector.take_page(page_idx),
             &content_area,
@@ -397,6 +394,24 @@ pub fn render_v2(
 /// other maps.
 /// Build the three page-independent skip sets used by `draw_v2_page`.
 ///
+/// Content-area rect for a page: the region inside `resolved_margin`,
+/// where body content is laid out. Single source of truth for the three
+/// downstream consumers — body background clamp height, GCPM margin-box
+/// renderer width, and body-link annotation clip rect — so a future
+/// change to how `resolved_margin` subtracts from `page_size` shifts
+/// all three together instead of leaving one behind.
+fn resolved_content_area(
+    page_size: crate::config::PageSize,
+    resolved_margin: crate::config::Margin,
+) -> crate::draw_primitives::Rect {
+    crate::draw_primitives::Rect {
+        x: resolved_margin.left.as_pt(),
+        y: resolved_margin.top.as_pt(),
+        width: (page_size.width - resolved_margin.left - resolved_margin.right).as_pt(),
+        height: (page_size.height - resolved_margin.top - resolved_margin.bottom).as_pt(),
+    }
+}
+
 /// - `transformed_descendants`: every node listed in some
 ///   `TransformEntry::descendants` — drawn inside that transform's
 ///   `push_transform / pop` group, so the main per-fragment loop must

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -5954,3 +5954,90 @@ body{{background-size:0.001px 0.001px;background-repeat:repeat;height:1130px;
         pdf.len()
     );
 }
+
+/// Body link annotations must never leak into the page-margin strips
+/// where `@page @top-*`/`@bottom-*` margin boxes paint. `render_v2`
+/// paints margin boxes AFTER body content so page headers/footers are
+/// not hidden by page-filling body backgrounds; because PDF link
+/// annotations are independent interactive objects, a body anchor
+/// positioned into a margin strip would remain clickable under the
+/// margin-box content that visually replaces it — click target and
+/// visible text disagree. The fix splits `LinkCollector` into body/
+/// margin collectors and clips body occurrences to the content area
+/// rect.
+///
+/// This test pushes a body `<a>` far past the content-area bottom via
+/// `margin-top` so the anchor's Y coordinate lands inside the bottom
+/// margin strip. The rendered PDF must contain zero link annotations
+/// whose rect intersects that strip.
+#[test]
+fn body_link_positioned_into_bottom_margin_strip_is_dropped() {
+    // A4 with 60pt top/bottom margins. Content-area bottom (Y-up) is
+    // 782 → 842 (60pt strip). We push the anchor down so its Y-up
+    // rect lies below 782.
+    let html = r#"<!doctype html><html><head><style>
+@page {
+  size: A4;
+  margin: 60pt 40pt 60pt 40pt;
+  @bottom-center { content: "Page footer"; }
+}
+body { margin: 0; padding: 0; }
+a { display: block; margin-top: 750pt; font-size: 12pt; }
+</style></head><body>
+<a href="https://example.com/target">body link</a>
+</body></html>"#;
+
+    let pdf = Engine::builder()
+        .build()
+        .render(html)
+        .expect("render must succeed");
+    assert!(pdf.starts_with(b"%PDF"));
+
+    // The PoC anchor lands in the bottom-margin strip (Y-up y < 60).
+    // No link annotation may reference that strip in its /Rect.
+    let text = String::from_utf8_lossy(&pdf);
+    for cap in regex_lite_link_rects(&text) {
+        let (llx, lly, urx, ury) = cap;
+        // `ury` is the top edge of the annotation in PDF-native Y-up.
+        // Any annotation whose top edge is at or below the content-
+        // area bottom (Y-up = 60) has crept into the bottom margin
+        // strip — that must not happen.
+        assert!(
+            ury >= 60.0,
+            "body link annotation leaked into bottom margin strip: \
+             /Rect [{llx} {lly} {urx} {ury}] — top edge (Y-up ury) \
+             must be >= 60pt (content-area bottom in Y-up)"
+        );
+    }
+}
+
+/// Parse `/Subtype /Link ... /Rect [llx lly urx ury]` from a raw PDF
+/// text stream. Returns `(llx, lly, urx, ury)` tuples in PDF-native
+/// Y-up coordinates. Used by the security regression test above so
+/// no new dependency (`regex`, `pdf-extract`) is pulled in just for
+/// one assertion — the raw content stream shape is stable enough for
+/// a bespoke scan.
+fn regex_lite_link_rects(text: &str) -> Vec<(f32, f32, f32, f32)> {
+    let mut out = Vec::new();
+    let mut i = 0;
+    while let Some(link_off) = text[i..].find("/Subtype /Link") {
+        let start = i + link_off;
+        // Look ahead for /Rect [ ... ] within the next 512 bytes.
+        let window_end = (start + 512).min(text.len());
+        if let Some(rect_off) = text[start..window_end].find("/Rect [") {
+            let after = start + rect_off + "/Rect [".len();
+            if let Some(close) = text[after..window_end].find(']') {
+                let body = &text[after..after + close];
+                let nums: Vec<f32> = body
+                    .split_whitespace()
+                    .filter_map(|s| s.parse::<f32>().ok())
+                    .collect();
+                if nums.len() == 4 {
+                    out.push((nums[0], nums[1], nums[2], nums[3]));
+                }
+            }
+        }
+        i = start + "/Subtype /Link".len();
+    }
+    out
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -5973,8 +5973,8 @@ body{{background-size:0.001px 0.001px;background-repeat:repeat;height:1130px;
 #[test]
 fn body_link_positioned_into_bottom_margin_strip_is_dropped() {
     // A4 with 60pt top/bottom margins. Content-area bottom (Y-up) is
-    // 782 → 842 (60pt strip). We push the anchor down so its Y-up
-    // rect lies below 782.
+    // 782 → 842 (60pt strip). The `.push` anchor gets margin-top: 750pt,
+    // sending its Y-up rect below 782 (into the bottom-margin strip).
     let html = r#"<!doctype html><html><head><style>
 @page {
   size: A4;
@@ -5993,20 +5993,48 @@ a { display: block; margin-top: 750pt; font-size: 12pt; }
         .expect("render must succeed");
     assert!(pdf.starts_with(b"%PDF"));
 
-    // The PoC anchor lands in the bottom-margin strip (Y-up y < 60).
-    // No link annotation may reference that strip in its /Rect.
     let text = String::from_utf8_lossy(&pdf);
-    for cap in regex_lite_link_rects(&text) {
-        let (llx, lly, urx, ury) = cap;
-        // `ury` is the top edge of the annotation in PDF-native Y-up.
-        // Any annotation whose top edge is at or below the content-
-        // area bottom (Y-up = 60) has crept into the bottom margin
-        // strip — that must not happen.
+    let rects = regex_lite_link_rects(&text);
+    // Every /Rect that survives must lie inside the content area
+    // (Y-up ury >= 60pt).
+    for cap in &rects {
+        let (llx, lly, urx, ury) = *cap;
         assert!(
             ury >= 60.0,
             "body link annotation leaked into bottom margin strip: \
              /Rect [{llx} {lly} {urx} {ury}] — top edge (Y-up ury) \
              must be >= 60pt (content-area bottom in Y-up)"
+        );
+    }
+    // Positive control for the scanner: without this, a hypothetical
+    // break in `regex_lite_link_rects` (returning an empty vec) would
+    // let the ury loop pass vacuously and hide a real regression.
+    // A companion render with an anchor plainly inside the content
+    // area must produce at least one /Rect the same scanner can find.
+    let legit_html = r#"<!doctype html><html><head><style>
+@page { size: A4; margin: 60pt 40pt 60pt 40pt; }
+body { margin: 0; padding: 20pt; font-size: 12pt; }
+</style></head><body>
+<p>Visit <a href="https://example.com/in-content">our documentation</a>.</p>
+</body></html>"#;
+    let legit_pdf = Engine::builder()
+        .build()
+        .render(legit_html)
+        .expect("positive-control render must succeed");
+    let legit_text = String::from_utf8_lossy(&legit_pdf);
+    let legit_rects = regex_lite_link_rects(&legit_text);
+    assert!(
+        !legit_rects.is_empty(),
+        "scanner returned no /Rect entries for a plainly in-content link; \
+         the primary loop above would pass vacuously if the scanner \
+         itself broke, so guard against that here."
+    );
+    for cap in legit_rects {
+        let (llx, lly, urx, ury) = cap;
+        assert!(
+            ury >= 60.0,
+            "positive-control link ended up in a margin strip: \
+             /Rect [{llx} {lly} {urx} {ury}]"
         );
     }
 }

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -6039,6 +6039,53 @@ body { margin: 0; padding: 20pt; font-size: 12pt; }
     }
 }
 
+/// When a page has margins but no effective `@page` margin-box rule,
+/// nothing paints on top of body content in the margin strips. Body
+/// links that extend into those strips are visually present AND have
+/// nothing later covering them, so their PDF annotation must remain
+/// clickable — `clip_body_occurrences_to_content_area` must not be
+/// applied on pages with no margin boxes. Otherwise a `position:
+/// fixed; bottom: 0` page number rendered from body content ends up
+/// visible but unclickable.
+#[test]
+fn body_link_in_margin_area_is_preserved_when_no_margin_box_paints() {
+    // Same `margin-top: 750pt` shape as the security regression test,
+    // but with no `@page` margin box: the anchor's rect lands in the
+    // bottom-margin strip yet the annotation must survive because
+    // nothing paints on top of it.
+    let html = r#"<!doctype html><html><head><style>
+@page { size: A4; margin: 60pt 40pt 60pt 40pt; }
+body { margin: 0; padding: 0; }
+a { display: block; margin-top: 750pt; font-size: 12pt; }
+</style></head><body>
+<a href="https://example.com/target">body-drawn footer link</a>
+</body></html>"#;
+
+    let pdf = Engine::builder()
+        .build()
+        .render(html)
+        .expect("render must succeed");
+    let text = String::from_utf8_lossy(&pdf);
+    let rects = regex_lite_link_rects(&text);
+    // The annotation MUST reach the PDF — a page with no margin box
+    // never overpaints body content, so dropping the annotation would
+    // leave the visible link unclickable.
+    assert!(
+        !rects.is_empty(),
+        "body link in a margin strip on a page with no margin box was \
+         dropped; nothing paints on top of it, so the annotation must \
+         survive"
+    );
+    // Sanity: the annotation should be in the bottom margin strip
+    // (Y-up ury < 60), matching the visible text position.
+    let (_, _, _, ury) = rects[0];
+    assert!(
+        ury < 60.0,
+        "positive-control render did not put the anchor in the bottom \
+         margin strip as expected; rects = {rects:?}"
+    );
+}
+
 /// Parse `/Subtype /Link ... /Rect [llx lly urx ury]` from a raw PDF
 /// text stream. Returns `(llx, lly, urx, ury)` tuples in PDF-native
 /// Y-up coordinates. Used by the security regression test above so

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -6097,8 +6097,17 @@ fn regex_lite_link_rects(text: &str) -> Vec<(f32, f32, f32, f32)> {
     let mut i = 0;
     while let Some(link_off) = text[i..].find("/Subtype /Link") {
         let start = i + link_off;
-        // Look ahead for /Rect [ ... ] within the next 512 bytes.
-        let window_end = (start + 512).min(text.len());
+        // Look ahead for /Rect [ ... ] within the next ~512 bytes.
+        // `text` came from `String::from_utf8_lossy` over raw PDF
+        // bytes, so it is valid UTF-8, but `start + 512` can still
+        // land in the middle of a multi-byte code point (e.g.
+        // metadata strings containing non-ASCII). Round down to the
+        // nearest char boundary so `text[start..window_end]` cannot
+        // panic on such inputs.
+        let mut window_end = (start + 512).min(text.len());
+        while window_end > start && !text.is_char_boundary(window_end) {
+            window_end -= 1;
+        }
         if let Some(rect_off) = text[start..window_end].find("/Rect [") {
             let after = start + rect_off + "/Rect [".len();
             if let Some(close) = text[after..window_end].find(']') {


### PR DESCRIPTION
## 概要

`render_v2` は body content を描画した後に `@page` margin box (header/footer 等) を描画するため、body 側 link annotation が margin strip に落ちると、上書きされた margin box テキストの下で active な click target として残る — 視覚と click 挙動が一致しなくなる **描画順の rendering-order bug**。body/margin で `LinkCollector` を分離し、body 側は content-area 矩形にクランプ / 範囲外 quad を drop する。

- **性質**: paint / annotation-emit パイプラインの整合バグ。CSS positioning で body 要素が margin strip に到達すると顕在化する。
- **canonical パス**: `template + escaped JSON + autoescape` では CSS positioning を注入できないため、canonical な帳票生成用途では発火しない。
- **リリースノート**: `release-notes:security` カテゴリで paint / hit-test アライメント変更として掲載。個別 advisory は起票しない。
- **関連 issue**: `fulgur-3fx0`

## 変更

1. `Quad::clip_to_rect(&self, area: &Rect) -> Option<Quad>` を追加。axis-aligned quad は min/max clamp、rotated quad は「点が1つでも外なら drop」。
2. `link::clip_body_occurrences_to_content_area` — 各 occurrence の quads を content-area にクリップし、空になった occurrence を落とす。
3. `render_v2` の `LinkCollector` を `body_link_collector` / `margin_link_collector` に分離。body 側は emit 前に content-area でクリップ、margin 側は無クリップで emit。

## テスト

- **Quad clipping (7 unit tests)**: 完全内包 / bottom margin / top margin / straddling bottom / straddling left / rotated 内包 / rotated 外
- **`clip_body_occurrences_to_content_area` (5 unit tests)**: bottom margin drop / straddle clamp / multi-quad 部分 drop / 完全内包保持 / clip+emit end-to-end で annotation 0 件
- **`body_link_positioned_into_bottom_margin_strip_is_dropped` (render_smoke)**: `margin-top: 750pt` で anchor を bottom margin strip に押し込む → PDF の `/Rect` が Y-up 60pt 以上 (content area 内) しか含まないことを assert。修正前は `/Rect [39.999 17.489 145.001 31.891]` が emit されて RED 確認済み。

`cargo test -p fulgur` 全 pass、`cargo clippy -p fulgur --all-targets -- -D warnings` 警告なし、`cargo fmt --all --check` clean。

## Test plan

- [x] `cargo test -p fulgur --lib`
- [x] `cargo test -p fulgur --test render_smoke body_link_positioned`
- [x] `cargo clippy -p fulgur --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] TDD RED→GREEN サイクルで smoke test の fail→pass を実証
- [ ] CI matrix (Linux/macOS/Windows, WASM, coverage) が緑になる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - 本文由来のリンク注釈を本文コンテンツ領域にクリップし、余白側へはみ出す注釈を抑制しました。
  - 本文／余白でリンク処理を分離し、軸整列形状は交差に応じて縮小、回転を含む場合は矩形内の全点保持のみ有効にしました。
- **テスト**
  - 余白ストリップ境界やボトムマージンへの侵入、注釈消失を検証する回帰テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->