### PR TITLE
fix(inspect): bound content, nesting and output in the PDF inspect path

### DIFF
--- a/crates/fulgur/src/inspect.rs
+++ b/crates/fulgur/src/inspect.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use crate::{
     MAX_PDF_CONTENT_BYTES, MAX_PDF_FONT_NAME_BYTES, MAX_PDF_GS_STACK_DEPTH,
     MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES, MAX_PDF_INSPECT_ITEMS, MAX_PDF_INSPECT_OPERATIONS,
-    MAX_PDF_INSPECT_TEXT_BYTES, MAX_PDF_PARENT_DEPTH,
+    MAX_PDF_INSPECT_TEXT_BYTES, MAX_PDF_PARENT_DEPTH, PDF_CONTENT_STREAM_COST_FLOOR_BYTES,
 };
 
 const IDENTITY: [f32; 6] = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
@@ -56,14 +56,47 @@ pub struct ImageItem {
     pub height_px: u32,
 }
 
+/// The whole-document resource budgets one `inspect` call may spend.
+///
+/// Held in a struct rather than read from the constants directly so that tests
+/// can drive each bound with a small budget. Reaching a production budget means
+/// actually doing the work it allows — 20M operations takes ~70 s in a debug
+/// build — which would otherwise force a choice between an untested bound and a
+/// constant sized for its test rather than for real documents.
+///
+/// [`Default`] is the production configuration; nothing outside tests
+/// constructs it any other way.
+struct InspectLimits {
+    /// See [`MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES`].
+    content_total_bytes: usize,
+    /// See [`MAX_PDF_INSPECT_OPERATIONS`].
+    operations: usize,
+    /// See [`MAX_PDF_INSPECT_TEXT_BYTES`].
+    text_bytes: usize,
+    /// See [`MAX_PDF_INSPECT_ITEMS`].
+    items: usize,
+}
+
+impl Default for InspectLimits {
+    fn default() -> Self {
+        Self {
+            content_total_bytes: MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES,
+            operations: MAX_PDF_INSPECT_OPERATIONS,
+            text_bytes: MAX_PDF_INSPECT_TEXT_BYTES,
+            items: MAX_PDF_INSPECT_ITEMS,
+        }
+    }
+}
+
 pub fn inspect(path: &Path) -> crate::Result<InspectResult> {
     let doc = lopdf::Document::load(path)
         .map_err(|e| crate::Error::Other(format!("Failed to load PDF: {e}")))?;
 
+    let limits = InspectLimits::default();
     let pages = doc.get_pages().len() as u32;
     let metadata = extract_metadata(&doc);
-    let text_items = extract_text_items(&doc)?;
-    let images = extract_image_items(&doc)?;
+    let text_items = extract_text_items(&doc, &limits)?;
+    let images = extract_image_items(&doc, &limits)?;
 
     Ok(InspectResult {
         pages,
@@ -156,11 +189,17 @@ fn gather_page_content(
             Ok(ref d) => d,
             Err(_) => &stream.content,
         };
-        *doc_budget = doc_budget.saturating_sub(bytes.len());
+        // Charge the bytes this stream adds to `content` — its decoded length
+        // plus the separator appended below — but never less than the fixed cost
+        // of having resolved and decoded it at all. Charging only `bytes.len()`
+        // let a stream that decodes to *nothing* be free, so a `/Contents` array
+        // of many zero-length streams, shared across pages by one reference,
+        // could run for free. See `PDF_CONTENT_STREAM_COST_FLOOR_BYTES`.
+        *doc_budget =
+            doc_budget.saturating_sub((bytes.len() + 1).max(PDF_CONTENT_STREAM_COST_FLOOR_BYTES));
         if *doc_budget == 0 {
             return PageContent::Exhausted;
         }
-        // +1 for the `\n` separator appended after every stream.
         if content.len() + bytes.len() + 1 > MAX_PDF_CONTENT_BYTES {
             return PageContent::Skip;
         }
@@ -199,21 +238,21 @@ fn extract_metadata(doc: &lopdf::Document) -> Metadata {
     meta
 }
 
-fn extract_text_items(doc: &lopdf::Document) -> crate::Result<Vec<TextItem>> {
+fn extract_text_items(
+    doc: &lopdf::Document,
+    limits: &InspectLimits,
+) -> crate::Result<Vec<TextItem>> {
     use lopdf::content::Operation;
     let mut items = Vec::new();
     // Whole-document budgets. Page count is bounded only by input size, so the
     // per-page content bound and the record *count* cap both leave a document
     // total unbounded — see the constants for the measured shapes.
-    let mut content_budget = MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES;
-    let mut op_budget = MAX_PDF_INSPECT_OPERATIONS;
+    let mut content_budget = limits.content_total_bytes;
+    let mut op_budget = limits.operations;
     let mut text_bytes: usize = 0;
 
     for (&page_num, &page_id) in &doc.get_pages() {
-        if items.len() >= MAX_PDF_INSPECT_ITEMS
-            || text_bytes >= MAX_PDF_INSPECT_TEXT_BYTES
-            || op_budget == 0
-        {
+        if items.len() >= limits.items || text_bytes >= limits.text_bytes || op_budget == 0 {
             break;
         }
         let content_bytes = match gather_page_content(doc, page_id, &mut content_budget) {
@@ -257,7 +296,7 @@ fn extract_text_items(doc: &lopdf::Document) -> crate::Result<Vec<TextItem>> {
         let mut text_leading: f32 = 0.0;
 
         for Operation { operator, operands } in &content.operations {
-            if items.len() >= MAX_PDF_INSPECT_ITEMS || text_bytes >= MAX_PDF_INSPECT_TEXT_BYTES {
+            if items.len() >= limits.items || text_bytes >= limits.text_bytes {
                 break;
             }
             // Inside a `q` frame dropped for exceeding MAX_PDF_GS_STACK_DEPTH.
@@ -422,24 +461,35 @@ fn extract_text_items(doc: &lopdf::Document) -> crate::Result<Vec<TextItem>> {
     Ok(items)
 }
 
+/// Find the `Resources` dictionary in effect for a page, following `/Parent`
+/// inheritance.
+///
+/// Returns the dictionary *by reference* along with its object id when it was
+/// reached through an indirect reference. Both matter for bounding work: a
+/// resources dictionary is routinely shared by every page in a document, so
+/// cloning it — as this used to — made a page's cost proportional to the
+/// dictionary's size, and the id is what lets the caller recognise the sharing
+/// and scan it only once. `None` for the id means the dictionary is written
+/// inline, in which case no sharing is possible and its cost is already bounded
+/// by the file size.
+///
+/// A fixed depth bound guarantees termination on malformed inputs with cyclic
+/// (`A -> B -> A`) or pathologically long `/Parent` references, without needing
+/// a heap-allocated visited set — real page trees are shallow enough that
+/// [`MAX_PDF_PARENT_DEPTH`] is orders of magnitude above any legitimate document.
 fn resolve_page_resources(
     doc: &lopdf::Document,
     page_id: lopdf::ObjectId,
-) -> Option<lopdf::Dictionary> {
-    // Walk the page's Parent chain to find an inherited Resources dictionary.
-    // A fixed depth bound guarantees termination on malformed inputs with cyclic
-    // (`A -> B -> A`) or pathologically long `/Parent` references, without needing
-    // a heap-allocated visited set — real page trees are shallow enough that
-    // `MAX_PDF_PARENT_DEPTH` is orders of magnitude above any legitimate document.
+) -> Option<(Option<lopdf::ObjectId>, &lopdf::Dictionary)> {
     let mut current_id = page_id;
     for _ in 0..MAX_PDF_PARENT_DEPTH {
         let dict = match doc.get_object(current_id) {
-            Ok(lopdf::Object::Dictionary(d)) => d.clone(),
+            Ok(lopdf::Object::Dictionary(d)) => d,
             _ => return None,
         };
         if let Ok(res) = dict.get(b"Resources") {
-            if let Ok((_, lopdf::Object::Dictionary(resources))) = doc.dereference(res) {
-                return Some(resources.clone());
+            if let Ok((id, lopdf::Object::Dictionary(resources))) = doc.dereference(res) {
+                return Some((id, resources));
             }
         }
         match dict.get(b"Parent").and_then(|p| p.as_reference()) {
@@ -450,60 +500,103 @@ fn resolve_page_resources(
     None
 }
 
-fn transform_point(m: &[f32; 6], x: f32, y: f32) -> (f32, f32) {
-    (m[0] * x + m[2] * y + m[4], m[1] * x + m[3] * y + m[5])
-}
+/// Image XObjects declared by a page's resources: name -> (format, width_px,
+/// height_px).
+type ImageXObjects = std::collections::BTreeMap<String, (String, u32, u32)>;
 
-fn extract_image_items(doc: &lopdf::Document) -> crate::Result<Vec<ImageItem>> {
-    let mut items = Vec::new();
-    // Each pass decodes content independently, so each carries its own
-    // whole-document budget. See `extract_text_items`.
-    let mut content_budget = MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES;
-    let mut op_budget = MAX_PDF_INSPECT_OPERATIONS;
-
-    for (&page_num, &page_id) in &doc.get_pages() {
-        if items.len() >= MAX_PDF_INSPECT_ITEMS || op_budget == 0 {
-            break;
-        }
-        // Step 1: XObject から画像情報を一時 map に収集
-        // Resources は親 /Pages ノードから継承される場合があるため、継承チェーンを辿る。
-        // key = XObject name, value = (format, width_px, height_px)
-        let mut image_xobjects: std::collections::BTreeMap<String, (String, u32, u32)> =
-            std::collections::BTreeMap::new();
-
-        if let Some(resources) = resolve_page_resources(doc, page_id) {
-            if let Ok(xo) = resources.get(b"XObject") {
-                if let Ok((_, lopdf::Object::Dictionary(xobjects))) = doc.dereference(xo) {
-                    for (name, obj_ref) in xobjects.iter() {
-                        if let Ok((_, lopdf::Object::Stream(xobj))) = doc.dereference(obj_ref) {
-                            let subtype = xobj
-                                .dict
-                                .get(b"Subtype")
-                                .ok()
-                                .and_then(|o| obj_as_name_str(o))
-                                .unwrap_or_default();
-                            if subtype == "Image" {
-                                let fmt = detect_image_format(&xobj.dict);
-                                let w_px = xobj
-                                    .dict
-                                    .get(b"Width")
-                                    .ok()
-                                    .and_then(|o| o.as_i64().ok())
-                                    .unwrap_or(0) as u32;
-                                let h_px = xobj
-                                    .dict
-                                    .get(b"Height")
-                                    .ok()
-                                    .and_then(|o| o.as_i64().ok())
-                                    .unwrap_or(0) as u32;
-                                let name_str = String::from_utf8_lossy(name).into_owned();
-                                image_xobjects.insert(name_str, (fmt, w_px, h_px));
-                            }
-                        }
+/// Collect the image XObjects a page's resources declare.
+///
+/// Dereferences every entry of the `/XObject` dictionary to check its
+/// `/Subtype`, so the cost is proportional to that dictionary's size — which is
+/// why [`extract_image_items`] memoises the result rather than repeating this
+/// per page. Non-image XObjects (`/Form`, …) are skipped, so a page can pay the
+/// full scan and collect nothing.
+fn collect_image_xobjects(doc: &lopdf::Document, resources: &lopdf::Dictionary) -> ImageXObjects {
+    let mut image_xobjects = ImageXObjects::new();
+    if let Ok(xo) = resources.get(b"XObject") {
+        if let Ok((_, lopdf::Object::Dictionary(xobjects))) = doc.dereference(xo) {
+            for (name, obj_ref) in xobjects.iter() {
+                if let Ok((_, lopdf::Object::Stream(xobj))) = doc.dereference(obj_ref) {
+                    let subtype = xobj
+                        .dict
+                        .get(b"Subtype")
+                        .ok()
+                        .and_then(|o| obj_as_name_str(o))
+                        .unwrap_or_default();
+                    if subtype == "Image" {
+                        let fmt = detect_image_format(&xobj.dict);
+                        let w_px = xobj
+                            .dict
+                            .get(b"Width")
+                            .ok()
+                            .and_then(|o| o.as_i64().ok())
+                            .unwrap_or(0) as u32;
+                        let h_px = xobj
+                            .dict
+                            .get(b"Height")
+                            .ok()
+                            .and_then(|o| o.as_i64().ok())
+                            .unwrap_or(0) as u32;
+                        let name_str = String::from_utf8_lossy(name).into_owned();
+                        image_xobjects.insert(name_str, (fmt, w_px, h_px));
                     }
                 }
             }
         }
+    }
+    image_xobjects
+}
+
+fn transform_point(m: &[f32; 6], x: f32, y: f32) -> (f32, f32) {
+    (m[0] * x + m[2] * y + m[4], m[1] * x + m[3] * y + m[5])
+}
+
+fn extract_image_items(
+    doc: &lopdf::Document,
+    limits: &InspectLimits,
+) -> crate::Result<Vec<ImageItem>> {
+    let mut items = Vec::new();
+    // Each pass decodes content independently, so each carries its own
+    // whole-document budget. See `extract_text_items`.
+    let mut content_budget = limits.content_total_bytes;
+    let mut op_budget = limits.operations;
+    // Memoised `collect_image_xobjects` results, keyed by the object id of the
+    // resources dictionary they were scanned from.
+    //
+    // A resources dictionary is normally shared by every page in a document, and
+    // scanning it costs one dereference per `/XObject` entry. Without this, a
+    // page's cost is proportional to that dictionary's size even when the scan
+    // finds no image at all — and a page that collects nothing goes on to skip
+    // content decoding, so it charges neither the content nor the operation
+    // budget. Work was therefore proportional to `pages × XObjects` while the
+    // file stores each dimension once. Measured: 4,000 non-image XObjects shared
+    // by 2,400 pages is 0.55 MB on disk, and the cost grew with the page count.
+    let mut xobject_cache: std::collections::BTreeMap<lopdf::ObjectId, Rc<ImageXObjects>> =
+        std::collections::BTreeMap::new();
+
+    for (&page_num, &page_id) in &doc.get_pages() {
+        if items.len() >= limits.items || op_budget == 0 {
+            break;
+        }
+        // Step 1: XObject から画像情報を収集 (共有 resources なら memoise 済みを再利用)
+        // Resources は親 /Pages ノードから継承される場合があるため、継承チェーンを辿る。
+        let Some((resources_id, resources)) = resolve_page_resources(doc, page_id) else {
+            continue;
+        };
+        let image_xobjects: Rc<ImageXObjects> = match resources_id {
+            // Shared via an indirect reference: scan once, reuse per page.
+            Some(id) => match xobject_cache.get(&id) {
+                Some(cached) => Rc::clone(cached),
+                None => {
+                    let scanned = Rc::new(collect_image_xobjects(doc, resources));
+                    xobject_cache.insert(id, Rc::clone(&scanned));
+                    scanned
+                }
+            },
+            // Written inline in the page, so it cannot be shared and its size is
+            // already charged to the file.
+            None => Rc::new(collect_image_xobjects(doc, resources)),
+        };
 
         if image_xobjects.is_empty() {
             continue;
@@ -528,7 +621,7 @@ fn extract_image_items(doc: &lopdf::Document) -> crate::Result<Vec<ImageItem>> {
         // `Q` operators unwind them rather than popping a real entry.
         let mut dropped_pushes: usize = 0;
         for op in &content.operations {
-            if items.len() >= MAX_PDF_INSPECT_ITEMS {
+            if items.len() >= limits.items {
                 break;
             }
             // See `extract_text_items`: the contents of a `q` frame dropped for
@@ -1183,7 +1276,7 @@ mod tests {
             }),
         );
 
-        assert_eq!(resolve_page_resources(&doc, (1, 0)), None);
+        assert!(resolve_page_resources(&doc, (1, 0)).is_none());
     }
 
     // --- Resource bounds on attacker-controlled content streams ---
@@ -1879,6 +1972,10 @@ mod tests {
     /// which the per-page bound cannot: every page re-pays it, and page count is
     /// bounded only by input size.
     ///
+    /// Runs at the production budget, which is affordable here because the filler
+    /// is whitespace. The `limits_*` tests below cover the same stop conditions
+    /// at small budgets; this one additionally pins the real constant.
+    ///
     /// Asserted through the page walk stopping early — later pages carry the
     /// same extractable record as earlier ones, so a document of `pages` pages
     /// yielding fewer than `pages` records can only have been truncated.
@@ -1897,54 +1994,6 @@ mod tests {
             !result.text_items.is_empty(),
             "pages within the budget must still be extracted"
         );
-        assert!(
-            result.text_items.len() < pages,
-            "expected truncation: got {} records from {} pages",
-            result.text_items.len(),
-            pages
-        );
-    }
-
-    /// [`MAX_PDF_INSPECT_OPERATIONS`] bounds operator work, which a byte budget
-    /// cannot do tightly: a `q` is 2 input bytes and ~570 bytes of operation
-    /// list, so operator-dense content buys ~285× the work per byte that
-    /// [`MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES`] is calibrated against.
-    ///
-    /// The page carries a `Tj` so each page within budget yields a record, which
-    /// is what makes the truncation observable; the rest is bare `q` operators.
-    ///
-    /// `#[ignore]`d because tripping this bound means decoding tens of millions
-    /// of operations — ~70 s in a debug build — and there is no cheaper way in:
-    /// the per-page content bound caps a page at ~500k operations, so the budget
-    /// can only be reached by paying for it. Unlike the byte and text budgets,
-    /// this one cannot be exercised quickly, and the constant is chosen for
-    /// where realistic content sits (see [`MAX_PDF_INSPECT_OPERATIONS`]) rather
-    /// than for testability. Run with:
-    ///
-    /// ```text
-    /// cargo test -p fulgur --lib --release aggregate_operation_count -- --ignored
-    /// ```
-    #[test]
-    #[ignore = "decodes >20M operations to reach the bound; ~70s debug, run explicitly"]
-    fn aggregate_operation_count_is_capped_across_pages() {
-        const OPS_PER_PAGE: usize = 64 * 1024;
-        let payload = {
-            let mut p = b"BT /F1 12 Tf (P) Tj ET\n".to_vec();
-            p.extend_from_slice(&b"q\n".repeat(OPS_PER_PAGE));
-            p
-        };
-        assert!(payload.len() <= MAX_PDF_CONTENT_BYTES);
-        // Well under the byte budget at this page count, so only the operation
-        // budget can stop the walk — that is the point of the test.
-        let pages = (MAX_PDF_INSPECT_OPERATIONS / OPS_PER_PAGE) * 3 / 2;
-        assert!(
-            pages * (payload.len() + 1) < MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES,
-            "byte budget must not be the binding constraint here"
-        );
-
-        let result = inspect_bytes(&make_pdf_with_shared_content_stream(pages, payload, false));
-        assert_eq!(result.pages as usize, pages);
-        assert!(!result.text_items.is_empty());
         assert!(
             result.text_items.len() < pages,
             "expected truncation: got {} records from {} pages",
@@ -1973,6 +2022,154 @@ mod tests {
             result.images.len(),
             pages
         );
+    }
+
+    /// Run both extraction passes against explicit [`InspectLimits`].
+    ///
+    /// Small budgets reach a stop condition in milliseconds. The alternative is
+    /// paying for the production budget: 20M operations is ~70 s in a debug
+    /// build, and the per-page content bound caps a page at ~500k operations, so
+    /// there is no shortcut to it.
+    fn inspect_bytes_with_limits(
+        bytes: &[u8],
+        limits: &InspectLimits,
+    ) -> (Vec<TextItem>, Vec<ImageItem>) {
+        let doc = lopdf::Document::load_mem(bytes).expect("test PDF must load");
+        (
+            extract_text_items(&doc, limits).expect("text extraction must not error"),
+            extract_image_items(&doc, limits).expect("image extraction must not error"),
+        )
+    }
+
+    /// A document of `pages` identical pages, each carrying one extractable text
+    /// record and one image placement, plus `ops_per_page` bare `q` operators.
+    fn limits_fixture(pages: usize, ops_per_page: usize) -> Vec<u8> {
+        let mut payload = b"BT /F1 12 Tf (P) Tj ET\nq 50 0 0 50 0 0 cm /Im0 Do Q\n".to_vec();
+        payload.extend_from_slice(&b"q\n".repeat(ops_per_page));
+        make_pdf_with_shared_content_stream(pages, payload, true)
+    }
+
+    /// The operation budget stops the page walk in both passes.
+    ///
+    /// This is the bound a byte budget cannot cover tightly — a `q` is 2 input
+    /// bytes and ~570 bytes of operation list, ~285× the work per byte that
+    /// [`MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES`] is calibrated against — so it
+    /// needs its own coverage. The other budgets are set high enough here that
+    /// only this one can bind.
+    #[test]
+    fn limits_operation_budget_stops_the_page_walk() {
+        const PAGES: usize = 40;
+        const OPS_PER_PAGE: usize = 100;
+        let pdf = limits_fixture(PAGES, OPS_PER_PAGE);
+
+        let limits = InspectLimits {
+            // Enough for a few pages, not for all of them.
+            operations: OPS_PER_PAGE * PAGES / 4,
+            ..InspectLimits::default()
+        };
+        let (text, images) = inspect_bytes_with_limits(&pdf, &limits);
+
+        assert!(
+            !text.is_empty() && text.len() < PAGES,
+            "text {}",
+            text.len()
+        );
+        assert!(
+            !images.is_empty() && images.len() < PAGES,
+            "images {}",
+            images.len()
+        );
+
+        // Same input, ample operation budget: nothing is truncated. This is what
+        // shows the truncation above came from the operation budget and not from
+        // some other property of the fixture.
+        let (text, images) = inspect_bytes_with_limits(&pdf, &InspectLimits::default());
+        assert_eq!(text.len(), PAGES);
+        assert_eq!(images.len(), PAGES);
+    }
+
+    /// The whole-document content budget stops the page walk in both passes.
+    #[test]
+    fn limits_content_budget_stops_the_page_walk() {
+        const PAGES: usize = 40;
+        let pdf = limits_fixture(PAGES, 0);
+
+        let limits = InspectLimits {
+            content_total_bytes: 512,
+            ..InspectLimits::default()
+        };
+        let (text, images) = inspect_bytes_with_limits(&pdf, &limits);
+        assert!(text.len() < PAGES, "text {}", text.len());
+        assert!(images.len() < PAGES, "images {}", images.len());
+    }
+
+    /// The text-byte budget stops extraction, and does so independently of the
+    /// record count — the item budget stays at its default here.
+    #[test]
+    fn limits_text_byte_budget_stops_extraction() {
+        const PAGES: usize = 40;
+        let pdf = limits_fixture(PAGES, 0);
+
+        let limits = InspectLimits {
+            text_bytes: 8,
+            ..InspectLimits::default()
+        };
+        let (text, _) = inspect_bytes_with_limits(&pdf, &limits);
+        assert!(!text.is_empty(), "the first record is always admitted");
+        assert!(text.len() < PAGES, "text {}", text.len());
+    }
+
+    /// A content stream is charged at least
+    /// [`PDF_CONTENT_STREAM_COST_FLOOR_BYTES`] even when it decodes to nothing,
+    /// so a `/Contents` array of many zero-length streams cannot be walked for
+    /// free.
+    ///
+    /// The real text stream sits *after* the empty ones, so it is only reached if
+    /// the empties did not exhaust the budget — which makes the charge
+    /// observable in the extracted output.
+    #[test]
+    fn limits_empty_content_streams_are_charged_a_cost_floor() {
+        const EMPTIES: usize = 200;
+        let mut streams = vec![Vec::new(); EMPTIES];
+        streams.push(b"BT /F1 12 Tf 1 0 0 1 10 800 Tm (Reached) Tj ET".to_vec());
+        let pdf = make_pdf_with_multiple_content_streams(streams);
+
+        // The empty streams alone cost EMPTIES * floor, well over this budget.
+        let starved = InspectLimits {
+            content_total_bytes: EMPTIES * PDF_CONTENT_STREAM_COST_FLOOR_BYTES / 4,
+            ..InspectLimits::default()
+        };
+        let (text, _) = inspect_bytes_with_limits(&pdf, &starved);
+        assert!(
+            text.is_empty(),
+            "zero-length streams must draw down the budget, got {text:?}"
+        );
+
+        // With a budget that covers them, the same document reaches the text.
+        let ample = InspectLimits {
+            content_total_bytes: EMPTIES * PDF_CONTENT_STREAM_COST_FLOOR_BYTES * 4,
+            ..InspectLimits::default()
+        };
+        let (text, _) = inspect_bytes_with_limits(&pdf, &ample);
+        assert_eq!(
+            text.iter().map(|i| i.text.as_str()).collect::<Vec<_>>(),
+            ["Reached"]
+        );
+    }
+
+    /// The item budget stops extraction in both passes.
+    #[test]
+    fn limits_item_budget_stops_extraction() {
+        const PAGES: usize = 40;
+        let pdf = limits_fixture(PAGES, 0);
+
+        let limits = InspectLimits {
+            items: 5,
+            ..InspectLimits::default()
+        };
+        let (text, images) = inspect_bytes_with_limits(&pdf, &limits);
+        assert_eq!(text.len(), 5);
+        assert_eq!(images.len(), 5);
     }
 
     /// The whole-document content budget is charged for pages that are *skipped*

--- a/crates/fulgur/src/inspect.rs
+++ b/crates/fulgur/src/inspect.rs
@@ -140,17 +140,26 @@ fn clamp_font_name(name: &str) -> &str {
 /// `Document::get_page_contents` returns the ids written in a `/Contents` array
 /// without dereferencing them, while `get_object` does follow chains — so two
 /// distinct alias objects pointing at one stream reach the same content, and a
-/// cache keyed on the immediate id would miss for every alias. The loop is
-/// bounded like the `/Parent` walk; a chain longer than the bound yields a
-/// mid-chain id, which costs a cache miss but stays correct.
-fn canonical_object_id(doc: &lopdf::Document, mut id: lopdf::ObjectId) -> lopdf::ObjectId {
+/// cache keyed on the immediate id would miss for every alias.
+///
+/// Returns `None` when the chain does not terminate within
+/// [`MAX_PDF_PARENT_DEPTH`] links, which is what makes this the *only*
+/// dereference deciding the cache key. `get_object` starts a fresh `DEREF_LIMIT`
+/// budget from whatever id it is handed, so stopping mid-chain and letting it
+/// finish the walk would compose two limits: aliases converging past this bound
+/// would each yield a different key while still resolving to one stream, and
+/// every one would re-run its filter chain. Rejecting is also the stricter
+/// direction — no producer emits a `/Contents` chain that deep.
+fn canonical_object_id(doc: &lopdf::Document, mut id: lopdf::ObjectId) -> Option<lopdf::ObjectId> {
     for _ in 0..MAX_PDF_PARENT_DEPTH {
         match doc.objects.get(&id) {
             Some(lopdf::Object::Reference(next)) => id = *next,
-            _ => break,
+            // Not a reference (the target), or absent — either way this is the id
+            // the chain names; a missing object is skipped downstream.
+            _ => return Some(id),
         }
     }
-    id
+    None
 }
 
 /// Decoded content-stream bytes, keyed by *canonical* stream object id, so a
@@ -221,36 +230,27 @@ fn gather_page_content(
     doc_budget: &mut usize,
     decoded_cache: &mut DecodedStreams,
 ) -> PageContent {
-    // A page costs something even with no `/Contents` at all: it is still looked
-    // up and walked. Page objects are the cheapest thing to mass-produce in a
-    // compressed object stream, and a page with no content references never
-    // enters the loop below, so without this the walk advances no budget.
-    *doc_budget = doc_budget.saturating_sub(PDF_CONTENT_STREAM_COST_FLOOR_BYTES);
-    if *doc_budget == 0 {
-        return PageContent::Exhausted;
-    }
-
     let mut content: Vec<u8> = Vec::new();
     for entry_id in doc.get_page_contents(page_id) {
+        // Charge the attempt before anything else — canonicalising, resolving and
+        // decoding all cost a lookup regardless of how they turn out, so an entry
+        // that resolves to nothing, or whose chain is too deep to follow, must not
+        // be free. A `/Contents` array of such entries is shareable across pages
+        // like any other array.
+        *doc_budget = doc_budget.saturating_sub(PDF_CONTENT_STREAM_COST_FLOOR_BYTES);
+        if *doc_budget == 0 {
+            return PageContent::Exhausted;
+        }
         // Alias objects must collapse to the stream they name, or each alias is
         // a fresh cache miss and re-runs the filter chain.
-        let object_id = canonical_object_id(doc, entry_id);
+        let Some(object_id) = canonical_object_id(doc, entry_id) else {
+            continue;
+        };
         let bytes: Rc<Vec<u8>> = match decoded_cache.get(&object_id) {
             // Decoded already for an earlier page: no filter work to charge, only
             // the copy into `content` below.
             Some(cached) => Rc::clone(cached),
             None => {
-                // Charge the floor for *attempting* the reference, before knowing
-                // whether it resolves to a stream. The object lookup costs the
-                // same either way, and a `/Contents` array of references to
-                // dictionaries or missing objects — shareable across pages, like
-                // any other array — would otherwise be walked per page for free.
-                // Unresolvable ids are deliberately not cached, so each
-                // occurrence pays this.
-                *doc_budget = doc_budget.saturating_sub(PDF_CONTENT_STREAM_COST_FLOOR_BYTES);
-                if *doc_budget == 0 {
-                    return PageContent::Exhausted;
-                }
                 let Ok(stream) = doc.get_object(object_id).and_then(lopdf::Object::as_stream)
                 else {
                     continue;
@@ -276,9 +276,9 @@ fn gather_page_content(
         };
         // Charged on every reference, hit or miss: these bytes are copied into
         // this page's `content` even when the decode was cached, so the
-        // concatenation stays bounded independently of the filter work.
-        *doc_budget =
-            doc_budget.saturating_sub((bytes.len() + 1).max(PDF_CONTENT_STREAM_COST_FLOOR_BYTES));
+        // concatenation stays bounded independently of the filter work. The
+        // per-reference floor is already paid at the top of the loop.
+        *doc_budget = doc_budget.saturating_sub(bytes.len() + 1);
         if *doc_budget == 0 {
             return PageContent::Exhausted;
         }
@@ -348,6 +348,13 @@ fn extract_text_items(
 
     for (&page_num, &page_id) in &doc.get_pages() {
         if items.len() >= limits.items || text_bytes >= limits.text_bytes || op_budget == 0 {
+            break;
+        }
+        // Every page costs a floor, charged before any work and before any early
+        // exit, so no page can be walked for free. Page objects are the cheapest
+        // thing to mass-produce in a compressed object stream.
+        content_budget = content_budget.saturating_sub(PDF_CONTENT_STREAM_COST_FLOOR_BYTES);
+        if content_budget == 0 {
             break;
         }
         let content_bytes =
@@ -755,6 +762,14 @@ fn extract_image_items(
 
     for (&page_num, &page_id) in &doc.get_pages() {
         if items.len() >= limits.items || op_budget == 0 {
+            break;
+        }
+        // Charged before resolving resources, which walks the `/Parent` chain and
+        // can `continue` out below. This pass has two early exits ahead of
+        // `gather_page_content`, so a floor charged only in there would leave
+        // resource-free pages free. See `extract_text_items`.
+        content_budget = content_budget.saturating_sub(PDF_CONTENT_STREAM_COST_FLOOR_BYTES);
+        if content_budget == 0 {
             break;
         }
         // Step 1: XObject から画像情報を収集 (共有 resources なら memoise 済みを再利用)
@@ -2846,44 +2861,125 @@ mod tests {
         assert_eq!(cache.len(), 1, "the shared stream must be cached once");
     }
 
-    /// A page with no `/Contents` at all is still charged, so a page set that
-    /// costs nothing to produce cannot be walked for free.
+    /// A page with neither `/Contents` nor `/Resources` is still charged, in
+    /// *both* passes, so a page set that costs nothing to produce cannot be
+    /// walked for free.
+    ///
+    /// The charge lives at the top of each pass's page loop rather than inside
+    /// `gather_page_content`, because the image pass reaches that function only
+    /// after two early exits — resolving no resources, or collecting no images —
+    /// and a floor charged inside it would leave those pages free.
+    ///
+    /// Made observable by putting the cheap pages *first* and a page carrying
+    /// both text and an image last: with a budget the leading pages exhaust, the
+    /// final page is never reached.
     #[test]
-    fn limits_pages_without_content_are_charged() {
-        use lopdf::{Document, Object, dictionary};
+    fn limits_pages_without_content_are_charged_in_both_passes() {
+        use lopdf::{Document, Object, Stream, dictionary};
 
+        const EMPTIES: usize = 200;
         let mut doc = Document::with_version("1.5");
         let pages_id = doc.new_object_id();
-        // No /Contents entry: `get_page_contents` yields nothing.
-        let page_id = doc.add_object(dictionary! {
+        let mut kids = Vec::new();
+        // Neither /Contents nor /Resources: both passes exit early on these.
+        for _ in 0..EMPTIES {
+            kids.push(Object::Reference(doc.add_object(dictionary! {
+                "Type" => "Page",
+                "Parent" => pages_id,
+                "MediaBox" => vec![
+                    Object::Integer(0), Object::Integer(0),
+                    Object::Integer(595), Object::Integer(842),
+                ],
+            })));
+        }
+        let image_id = doc.add_object(Stream::new(
+            dictionary! {
+                "Type" => "XObject", "Subtype" => "Image",
+                "Width" => Object::Integer(4), "Height" => Object::Integer(4),
+                "ColorSpace" => "DeviceGray", "BitsPerComponent" => Object::Integer(8),
+            },
+            vec![0u8; 16],
+        ));
+        let resources_id = doc.add_object(dictionary! {
+            "Font" => dictionary! {
+                "F1" => dictionary! {
+                    "Type" => "Font", "Subtype" => "Type1", "BaseFont" => "Courier",
+                },
+            },
+            "XObject" => dictionary! { "Im0" => Object::Reference(image_id) },
+        });
+        let content_id = doc.add_object(Stream::new(
+            dictionary! {},
+            b"BT /F1 12 Tf 1 0 0 1 10 800 Tm (Reached) Tj ET\nq 50 0 0 50 0 0 cm /Im0 Do Q\n"
+                .to_vec(),
+        ));
+        kids.push(Object::Reference(doc.add_object(dictionary! {
             "Type" => "Page",
             "Parent" => pages_id,
+            "Contents" => content_id,
+            "Resources" => resources_id,
             "MediaBox" => vec![
                 Object::Integer(0), Object::Integer(0),
                 Object::Integer(595), Object::Integer(842),
             ],
-        });
+        })));
+        let count = kids.len() as i64;
         doc.objects.insert(
             pages_id,
             Object::Dictionary(dictionary! {
-                "Type" => "Pages",
-                "Kids" => vec![Object::Reference(page_id)],
-                "Count" => Object::Integer(1),
+                "Type" => "Pages", "Kids" => kids, "Count" => Object::Integer(count),
             }),
         );
         let catalog_id = doc.add_object(dictionary! { "Type" => "Catalog", "Pages" => pages_id });
         doc.trailer.set("Root", Object::Reference(catalog_id));
         let mut buf = Vec::new();
         doc.save_to(&mut buf).unwrap();
-        let loaded = Document::load_mem(&buf).unwrap();
-        let page = *loaded.get_pages().values().next().unwrap();
 
-        let mut budget = PDF_CONTENT_STREAM_COST_FLOOR_BYTES;
-        assert!(matches!(
-            gather_page_content(&loaded, page, &mut budget, &mut DecodedStreams::new()),
-            PageContent::Exhausted
-        ));
-        assert_eq!(budget, 0, "a contentless page must still draw the budget");
+        let starved = InspectLimits {
+            content_total_bytes: EMPTIES * PDF_CONTENT_STREAM_COST_FLOOR_BYTES / 4,
+            ..InspectLimits::default()
+        };
+        let (text, images) = inspect_bytes_with_limits(&buf, &starved);
+        assert!(
+            text.is_empty(),
+            "text pass must charge cheap pages, got {text:?}"
+        );
+        assert!(images.is_empty(), "image pass must charge cheap pages too");
+
+        // With a budget that covers them, the final page is reached by both.
+        let (text, images) = inspect_bytes_with_limits(&buf, &InspectLimits::default());
+        assert_eq!(
+            text.iter().map(|i| i.text.as_str()).collect::<Vec<_>>(),
+            ["Reached"]
+        );
+        assert_eq!(images.len(), 1);
+    }
+
+    /// An alias chain too deep to canonicalise is rejected rather than decoded
+    /// under a non-canonical key.
+    ///
+    /// `get_object` would begin a fresh `DEREF_LIMIT` from wherever the walk
+    /// stopped, so a mid-chain id would still resolve — giving each such alias its
+    /// own cache key for one shared stream.
+    #[test]
+    fn overlong_alias_chains_are_rejected() {
+        use lopdf::{Document, Object, Stream, dictionary};
+
+        let mut doc = Document::with_version("1.5");
+        let real = doc.add_object(Stream::new(dictionary! {}, b"BT ET".to_vec()));
+        // A chain of exactly MAX_PDF_PARENT_DEPTH links resolves.
+        let mut id = real;
+        for _ in 0..MAX_PDF_PARENT_DEPTH - 1 {
+            id = doc.add_object(Object::Reference(id));
+        }
+        assert_eq!(canonical_object_id(&doc, id), Some(real));
+
+        // One link further and it is rejected instead of half-resolved.
+        let too_deep = doc.add_object(Object::Reference(id));
+        assert_eq!(canonical_object_id(&doc, too_deep), None);
+
+        // A plain, non-reference id is its own canonical form.
+        assert_eq!(canonical_object_id(&doc, real), Some(real));
     }
 
     /// An `/XObject` reached through an alias object resolves to the same origin

--- a/crates/fulgur/src/inspect.rs
+++ b/crates/fulgur/src/inspect.rs
@@ -480,12 +480,8 @@ fn extract_text_items(
 /// proportional to the dictionary's size, and the identity is what lets the
 /// caller scan it only once.
 ///
-/// The identity is [`ResourcesOrigin`], not simply the dereferenced object id,
-/// because a resources dictionary can be shared two different ways. An indirect
-/// `/Resources` reference is the obvious one. The other is a *direct* dictionary
-/// written inside a `/Pages` node, which has no object id of its own yet is
-/// inherited by every descendant page — so treating "no reference id" as
-/// "not shared" would rescan it once per page.
+/// The identity is [`ResourcesOrigin`] rather than the dereferenced object id,
+/// because an object id alone does not identify the dictionary — see that type.
 ///
 /// A fixed depth bound guarantees termination on malformed inputs with cyclic
 /// (`A -> B -> A`) or pathologically long `/Parent` references, without needing
@@ -504,13 +500,11 @@ fn resolve_page_resources(
         if let Ok(res) = dict.get(b"Resources") {
             if let Ok((id, lopdf::Object::Dictionary(resources))) = doc.dereference(res) {
                 let origin = match id {
-                    // Indirect: every page naming this reference shares it.
-                    Some(id) => ResourcesOrigin::Shared(id),
-                    // Direct, but written on an ancestor node, so inherited by
-                    // every page beneath it.
-                    None if current_id != page_id => ResourcesOrigin::Shared(current_id),
-                    // Direct on this page: nothing else can reach it.
-                    None => ResourcesOrigin::Unique,
+                    // `/Resources N 0 R`: the dictionary *is* object N.
+                    Some(id) => ResourcesOrigin::Object(id),
+                    // A direct dictionary nested inside the object being examined
+                    // — whether that is the page itself or an ancestor node.
+                    None => ResourcesOrigin::DirectIn(current_id),
                 };
                 return Some((origin, resources));
             }
@@ -523,16 +517,27 @@ fn resolve_page_resources(
     None
 }
 
-/// Whether a page's resources dictionary can be reached by other pages, and if
-/// so under what identity — the cache key for [`collect_image_xobjects`].
-#[derive(Debug, PartialEq, Eq)]
+/// Identity of the resources dictionary in effect for a page — the cache key for
+/// [`collect_image_xobjects`].
+///
+/// An object id alone is not an identity, which is why this is an enum. Object
+/// `N` can name *two different dictionaries* here: as `/Resources N 0 R` the
+/// dictionary is object `N` itself, while as a page-tree node it may hold a
+/// direct `/Resources` sub-dictionary, which is something else entirely. Keying
+/// both on `N` let whichever page was visited first decide the other's images.
+///
+/// Every variant is cacheable — there is no "cannot be shared" case. A direct
+/// dictionary on a page looks unique but is not: a page tree may list the same
+/// `/Page` object more than once, and each occurrence is walked separately, so
+/// leaving it uncached rescans it per occurrence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum ResourcesOrigin {
-    /// Reachable by other pages under this id: either an indirect `/Resources`
-    /// reference, or the page-tree node whose direct `/Resources` is inherited.
-    Shared(lopdf::ObjectId),
-    /// Written directly on the page itself, so no other page can reach it. Not
-    /// worth caching — and caching it would grow the cache once per page.
-    Unique,
+    /// Reached through `/Resources N 0 R` — the dictionary is object `N`.
+    Object(lopdf::ObjectId),
+    /// A direct `/Resources` dictionary written inside object `N`, reachable by
+    /// any page whose `/Parent` walk arrives at `N` — including `N` itself when
+    /// it is the page.
+    DirectIn(lopdf::ObjectId),
 }
 
 /// Image XObjects declared by a page's resources: name -> (format, width_px,
@@ -606,7 +611,7 @@ fn extract_image_items(
     // budget. Work was therefore proportional to `pages × XObjects` while the
     // file stores each dimension once. Measured: 4,000 non-image XObjects shared
     // by 2,400 pages is 0.55 MB on disk, and the cost grew with the page count.
-    let mut xobject_cache: std::collections::BTreeMap<lopdf::ObjectId, Rc<ImageXObjects>> =
+    let mut xobject_cache: std::collections::BTreeMap<ResourcesOrigin, Rc<ImageXObjects>> =
         std::collections::BTreeMap::new();
 
     for (&page_num, &page_id) in &doc.get_pages() {
@@ -618,20 +623,15 @@ fn extract_image_items(
         let Some((origin, resources)) = resolve_page_resources(doc, page_id) else {
             continue;
         };
-        let image_xobjects: Rc<ImageXObjects> = match origin {
-            // Reachable by other pages: scan once, reuse for every page that
-            // shares it.
-            ResourcesOrigin::Shared(id) => match xobject_cache.get(&id) {
-                Some(cached) => Rc::clone(cached),
-                None => {
-                    let scanned = Rc::new(collect_image_xobjects(doc, resources));
-                    xobject_cache.insert(id, Rc::clone(&scanned));
-                    scanned
-                }
-            },
-            // Written directly on this page, so no other page can reach it and
-            // its size is already charged to the file.
-            ResourcesOrigin::Unique => Rc::new(collect_image_xobjects(doc, resources)),
+        // Scan once per distinct dictionary, reused by every page that reaches
+        // it. Every origin is cacheable; see `ResourcesOrigin`.
+        let image_xobjects: Rc<ImageXObjects> = match xobject_cache.get(&origin) {
+            Some(cached) => Rc::clone(cached),
+            None => {
+                let scanned = Rc::new(collect_image_xobjects(doc, resources));
+                xobject_cache.insert(origin, Rc::clone(&scanned));
+                scanned
+            }
         };
 
         if image_xobjects.is_empty() {
@@ -2266,19 +2266,21 @@ mod tests {
         );
     }
 
-    /// A *direct* `/Resources` dictionary on a `/Pages` node has no object id of
-    /// its own, but is inherited by every descendant page — so it is shared, and
-    /// [`resolve_page_resources`] must report it as such or the image pass
-    /// rescans it once per page.
+    /// [`resolve_page_resources`] reports where a dictionary lives, which is what
+    /// makes it a usable cache key.
     ///
-    /// [`ResourcesOrigin::Unique`] is reserved for a dictionary written directly
-    /// on the page itself, which nothing else can reach.
+    /// A direct dictionary on an ancestor is [`ResourcesOrigin::DirectIn`] that
+    /// ancestor — it has no id of its own, yet every descendant inherits it, so
+    /// reporting it as unshared would rescan it per page. A direct dictionary on
+    /// the page itself is `DirectIn` the page, for the same reason: a page tree
+    /// may list the same `/Page` object more than once.
     #[test]
-    fn resources_inherited_from_a_parent_node_are_reported_as_shared() {
+    fn resources_origin_records_where_the_dictionary_lives() {
         use lopdf::{Document, Object, dictionary};
 
         let mut doc = Document::with_version("1.5");
         let pages_id = doc.new_object_id();
+        let shared_resources = doc.add_object(dictionary! { "ProcSet" => vec!["PDF".into()] });
         let inheriting = doc.add_object(dictionary! {
             "Type" => "Page",
             "Parent" => pages_id,
@@ -2289,26 +2291,115 @@ mod tests {
             // Direct dictionary on the page itself.
             "Resources" => dictionary! { "ProcSet" => vec!["PDF".into()] },
         });
+        let by_reference = doc.add_object(dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "Resources" => Object::Reference(shared_resources),
+        });
         doc.objects.insert(
             pages_id,
             Object::Dictionary(dictionary! {
                 "Type" => "Pages",
-                "Kids" => vec![Object::Reference(inheriting), Object::Reference(own_resources)],
-                "Count" => Object::Integer(2),
+                "Kids" => vec![
+                    Object::Reference(inheriting),
+                    Object::Reference(own_resources),
+                    Object::Reference(by_reference),
+                ],
+                "Count" => Object::Integer(3),
                 // Direct dictionary on the shared parent: no id, yet inherited.
                 "Resources" => dictionary! { "ProcSet" => vec!["Text".into()] },
             }),
         );
 
         let (origin, _) = resolve_page_resources(&doc, inheriting).expect("inherited resources");
-        assert_eq!(
-            origin,
-            ResourcesOrigin::Shared(pages_id),
-            "a direct dictionary on an ancestor is shared by every descendant"
-        );
+        assert_eq!(origin, ResourcesOrigin::DirectIn(pages_id));
 
         let (origin, _) = resolve_page_resources(&doc, own_resources).expect("own resources");
-        assert_eq!(origin, ResourcesOrigin::Unique);
+        assert_eq!(origin, ResourcesOrigin::DirectIn(own_resources));
+
+        let (origin, _) = resolve_page_resources(&doc, by_reference).expect("referenced resources");
+        assert_eq!(origin, ResourcesOrigin::Object(shared_resources));
+    }
+
+    /// One object id can name two *different* resources dictionaries, and the
+    /// cache must not conflate them.
+    ///
+    /// Here object `pages_id` is a `/Pages` node holding a direct `/Resources`
+    /// that declares an image, and one page also points `/Resources` straight at
+    /// `pages_id` — for which the resources dictionary is the `/Pages` node
+    /// itself, declaring no image. Keying both on the bare object id let the
+    /// first page visited decide the other's images: with the offending page
+    /// first, the inheriting page silently lost its image.
+    #[test]
+    fn resources_cache_distinguishes_an_object_from_its_nested_dictionary() {
+        use lopdf::{Document, Object, Stream, dictionary};
+
+        let mut doc = Document::with_version("1.5");
+        let pages_id = doc.new_object_id();
+        let image_id = doc.add_object(Stream::new(
+            dictionary! {
+                "Type" => "XObject", "Subtype" => "Image",
+                "Width" => Object::Integer(4), "Height" => Object::Integer(4),
+                "ColorSpace" => "DeviceGray", "BitsPerComponent" => Object::Integer(8),
+            },
+            vec![0u8; 16],
+        ));
+        let content = b"q 50 0 0 50 0 0 cm /Im0 Do Q\n".to_vec();
+        let content_a = doc.add_object(Stream::new(dictionary! {}, content.clone()));
+        let content_b = doc.add_object(Stream::new(dictionary! {}, content));
+
+        // Visited first: its resources dictionary *is* the /Pages node, which
+        // declares no /XObject, so it must contribute no image.
+        let points_at_pages_node = doc.add_object(dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "Resources" => Object::Reference(pages_id),
+            "Contents" => content_a,
+            "MediaBox" => vec![
+                Object::Integer(0), Object::Integer(0),
+                Object::Integer(595), Object::Integer(842),
+            ],
+        });
+        // Visited second: inherits the /Pages node's *nested* dictionary, which
+        // does declare the image.
+        let inheriting = doc.add_object(dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "Contents" => content_b,
+            "MediaBox" => vec![
+                Object::Integer(0), Object::Integer(0),
+                Object::Integer(595), Object::Integer(842),
+            ],
+        });
+        doc.objects.insert(
+            pages_id,
+            Object::Dictionary(dictionary! {
+                "Type" => "Pages",
+                "Kids" => vec![
+                    Object::Reference(points_at_pages_node),
+                    Object::Reference(inheriting),
+                ],
+                "Count" => Object::Integer(2),
+                "Resources" => dictionary! {
+                    "XObject" => dictionary! { "Im0" => Object::Reference(image_id) },
+                },
+            }),
+        );
+        let catalog_id = doc.add_object(dictionary! { "Type" => "Catalog", "Pages" => pages_id });
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+        let mut buf = Vec::new();
+        doc.save_to(&mut buf).unwrap();
+
+        let result = inspect_bytes(&buf);
+        // Page 2 inherits the nested dictionary and must still find its image,
+        // uninfluenced by page 1 having scanned a different dictionary.
+        let pages_with_images: Vec<u32> = result.images.iter().map(|i| i.page).collect();
+        assert_eq!(
+            pages_with_images,
+            [2],
+            "expected exactly page 2 to report an image, got {:?}",
+            result.images
+        );
     }
 
     /// The item budget stops extraction in both passes.

--- a/crates/fulgur/src/inspect.rs
+++ b/crates/fulgur/src/inspect.rs
@@ -94,7 +94,10 @@ pub fn inspect(path: &Path) -> crate::Result<InspectResult> {
         .map_err(|e| crate::Error::Other(format!("Failed to load PDF: {e}")))?;
 
     let limits = InspectLimits::default();
-    let pages = doc.get_pages().len() as u32;
+    // `get_pages()` is `page_iter().enumerate().collect()`, so counting straight
+    // off the iterator is the same walk without materialising a `BTreeMap` whose
+    // size is bounded only by the document's object count.
+    let pages = doc.page_iter().count() as u32;
     let metadata = extract_metadata(&doc);
     let text_items = extract_text_items(&doc, &limits)?;
     let images = extract_image_items(&doc, &limits)?;
@@ -157,16 +160,38 @@ fn clamp_font_name(name: &str) -> &str {
 /// of precisely [`MAX_PDF_PARENT_DEPTH`] references resolves there and must
 /// resolve here too. Returning `None` one link early would silently skip a stream
 /// the previous extraction path read.
-fn canonical_object_id(doc: &lopdf::Document, mut id: lopdf::ObjectId) -> Option<lopdf::ObjectId> {
-    for _ in 0..=MAX_PDF_PARENT_DEPTH {
+fn canonical_object_id(doc: &lopdf::Document, id: lopdf::ObjectId) -> Option<lopdf::ObjectId> {
+    let mut hops = MAX_PDF_PARENT_DEPTH;
+    canonical_object_id_within(doc, id, &mut hops)
+}
+
+/// [`canonical_object_id`] against a caller-owned hop budget, for walks that
+/// canonicalise repeatedly and must bound the *total* rather than each chain.
+///
+/// Spends one hop per reference followed and decrements `hops` in place, so a
+/// caller threading one budget through many calls pays for every hop once.
+/// Probing the target costs nothing, which is what keeps a fresh
+/// `MAX_PDF_PARENT_DEPTH` budget exactly equivalent to lopdf's `DEREF_LIMIT`:
+/// 128 references resolve, 129 do not.
+fn canonical_object_id_within(
+    doc: &lopdf::Document,
+    mut id: lopdf::ObjectId,
+    hops: &mut usize,
+) -> Option<lopdf::ObjectId> {
+    loop {
         match doc.objects.get(&id) {
-            Some(lopdf::Object::Reference(next)) => id = *next,
+            Some(lopdf::Object::Reference(next)) => {
+                if *hops == 0 {
+                    return None;
+                }
+                *hops -= 1;
+                id = *next;
+            }
             // Not a reference (the target), or absent — either way this is the id
             // the chain names; a missing object is skipped downstream.
             _ => return Some(id),
         }
     }
-    None
 }
 
 /// Decoded content-stream bytes, keyed by *canonical* stream object id, so a
@@ -353,7 +378,13 @@ fn extract_text_items(
     let mut text_bytes: usize = 0;
     let mut decoded_cache = DecodedStreams::new();
 
-    for (&page_num, &page_id) in &doc.get_pages() {
+    // Iterated lazily rather than through `get_pages()`, which collects the whole
+    // page tree into a `BTreeMap` before the first budget check can break. Page
+    // entries are cheap to mass-produce, so that traversal and allocation ran in
+    // full even when page 1 exhausted a budget. `get_pages()` numbers pages
+    // `enumerate() + 1` off this same iterator, so the numbering is unchanged.
+    for (i, page_id) in doc.page_iter().enumerate() {
+        let page_num = (i + 1) as u32;
         if items.len() >= limits.items || text_bytes >= limits.text_bytes || op_budget == 0 {
             break;
         }
@@ -589,18 +620,30 @@ fn extract_text_items(
 /// (`A -> B -> A`) or pathologically long `/Parent` references, without needing
 /// a heap-allocated visited set — real page trees are shallow enough that
 /// [`MAX_PDF_PARENT_DEPTH`] is orders of magnitude above any legitimate document.
+///
+/// That bound is a single budget **shared** between the `/Parent` walk and the
+/// alias canonicalisation at each node, not one bound per axis. Nesting them
+/// would multiply: `/Parent` references may themselves be alias chains, so
+/// per-axis bounds let one page occurrence cost `MAX_PDF_PARENT_DEPTH` squared
+/// object lookups — 16k rather than 128 — while the caller charges only the
+/// per-page floor. A page repeated across `/Kids` then replays that cost per
+/// occurrence, and a 1.5 MB file spent 16.7 s here against a 128 MiB budget it
+/// never came close to using. Sharing the budget keeps the total probes per page
+/// a small constant and, since no legitimate document has aliased `/Parent`
+/// links at all, costs real inputs nothing.
 fn resolve_page_resources(
     doc: &lopdf::Document,
     page_id: lopdf::ObjectId,
 ) -> Option<(ResourcesOrigin, &lopdf::Dictionary)> {
     let mut current_id = page_id;
-    for _ in 0..MAX_PDF_PARENT_DEPTH {
+    let mut hops = MAX_PDF_PARENT_DEPTH;
+    loop {
         // Canonicalise before both the lookup and the identity: page-tree `Kids`
         // entries and `/Parent` back-references may be alias objects, and
         // `get_object` follows them silently. Keying `DirectIn` on the immediate
         // id would hand one shared page dictionary a distinct identity per alias,
         // so the cache would rescan and retain a separate map for each.
-        let owner_id = canonical_object_id(doc, current_id)?;
+        let owner_id = canonical_object_id_within(doc, current_id, &mut hops)?;
         let dict = match doc.get_object(owner_id) {
             Ok(lopdf::Object::Dictionary(d)) => d,
             _ => return None,
@@ -617,12 +660,19 @@ fn resolve_page_resources(
                 return Some((origin, resources));
             }
         }
+        // Following `/Parent` is a hop against the same budget, so a chain of
+        // ancestors and a chain of aliases cannot be spent independently.
         match dict.get(b"Parent").and_then(|p| p.as_reference()) {
-            Ok(parent_id) => current_id = parent_id,
+            Ok(parent_id) => {
+                if hops == 0 {
+                    return None;
+                }
+                hops -= 1;
+                current_id = parent_id;
+            }
             Err(_) => return None,
         }
     }
-    None
 }
 
 /// Identity of the resources dictionary in effect for a page — the cache key for
@@ -783,7 +833,9 @@ fn extract_image_items(
     let mut xobject_cache: std::collections::BTreeMap<XObjectsOrigin, Rc<ImageXObjects>> =
         std::collections::BTreeMap::new();
 
-    for (&page_num, &page_id) in &doc.get_pages() {
+    // Lazy for the same reason as the text pass — see there.
+    for (i, page_id) in doc.page_iter().enumerate() {
+        let page_num = (i + 1) as u32;
         if items.len() >= limits.items || op_budget == 0 {
             break;
         }
@@ -1520,6 +1572,76 @@ mod tests {
         );
 
         assert!(resolve_page_resources(&doc, (1, 0)).is_none());
+    }
+
+    /// The `/Parent` walk and the alias canonicalisation at each node draw on one
+    /// shared hop budget, so spending on one axis reduces the other.
+    ///
+    /// Bounding each axis separately multiplies them: `/Parent` references may
+    /// themselves be alias chains, so `MAX_PDF_PARENT_DEPTH` ancestors each
+    /// reached through `MAX_PDF_PARENT_DEPTH` aliases costs that bound *squared*
+    /// in object lookups for a single page, replayed per occurrence when the page
+    /// is repeated across `/Kids` — all for one per-page floor charge.
+    #[test]
+    fn parent_walk_and_alias_hops_share_one_budget() {
+        use lopdf::{Document, Object, dictionary};
+
+        /// Page -> `depth` ancestors, each `/Parent` reference reached through
+        /// `alias` reference objects, with `/Resources` on the last ancestor.
+        /// Reaching it costs `depth` parent hops plus `depth * alias` alias hops.
+        fn resolves(depth: usize, alias: usize) -> bool {
+            let mut doc = Document::new();
+            let resources = doc.add_object(dictionary! { "XObject" => Object::Null });
+            let page_id = doc.new_object_id();
+            let mut prev = page_id;
+            for step in 0..depth {
+                // The ancestor `prev` will point at, behind `alias` aliases.
+                let node = doc.new_object_id();
+                let mut target = node;
+                for _ in 0..alias {
+                    target = doc.add_object(Object::Reference(target));
+                }
+                let dict = if step + 1 == depth {
+                    dictionary! { "Type" => "Pages", "Resources" => resources }
+                } else {
+                    dictionary! { "Type" => "Pages" }
+                };
+                doc.objects.insert(node, Object::Dictionary(dict));
+                let parented = match doc.objects.remove(&prev) {
+                    Some(Object::Dictionary(mut d)) => {
+                        d.set("Parent", Object::Reference(target));
+                        d
+                    }
+                    _ => dictionary! {
+                        "Type" => if prev == page_id { "Page" } else { "Pages" },
+                        "Parent" => Object::Reference(target),
+                    },
+                };
+                doc.objects.insert(prev, Object::Dictionary(parented));
+                prev = node;
+            }
+            resolve_page_resources(&doc, page_id).is_some()
+        }
+
+        // Neither axis alone exceeds the budget.
+        assert!(resolves(4, 0), "4 ancestors, no aliases");
+        assert!(
+            resolves(MAX_PDF_PARENT_DEPTH, 0),
+            "ancestors up to the bound"
+        );
+        assert!(
+            !resolves(MAX_PDF_PARENT_DEPTH + 1, 0),
+            "one ancestor past the bound must be refused",
+        );
+
+        // Combined, they are charged against the same budget. 4 * (31 + 1) is
+        // exactly MAX_PDF_PARENT_DEPTH hops; one alias more is over.
+        assert!(resolves(4, 31), "4 * 32 == MAX_PDF_PARENT_DEPTH hops");
+        assert!(
+            !resolves(4, 32),
+            "4 * 33 hops must be refused — per-axis bounds would allow this, \
+             since 4 ancestors and 32 aliases are each far inside the bound",
+        );
     }
 
     // --- Resource bounds on attacker-controlled content streams ---

--- a/crates/fulgur/src/inspect.rs
+++ b/crates/fulgur/src/inspect.rs
@@ -687,20 +687,30 @@ type ImageXObjects = std::collections::BTreeMap<String, (String, u32, u32)>;
 /// per page. Non-image XObjects (`/Form`, …) are skipped, so a page can pay the
 /// full scan and collect nothing.
 ///
-/// Returns the collected images together with the number of entries examined, so
-/// the caller can charge the scan. Both the work and the retained result scale
-/// with that count, and neither is covered by the content or operation budgets:
-/// a page that collects no image skips content decoding entirely.
+/// Charges `budget` as it goes, one per-object-touch price per entry, and stops
+/// when it runs out. Charging *after* the scan would let a single oversized
+/// dictionary do all of the work — dereferencing every entry and cloning every
+/// image name — before any accounting applied, which is what the budget exists to
+/// prevent. Neither the content nor the operation budget covers this work
+/// otherwise: a page collecting no image skips content decoding entirely.
+///
+/// Returns the collected images and whether the budget survived the scan; `false`
+/// means the caller should stop walking pages.
 fn collect_image_xobjects(
     doc: &lopdf::Document,
     resources: &lopdf::Dictionary,
-) -> (ImageXObjects, usize) {
+    budget: &mut usize,
+) -> (ImageXObjects, bool) {
     let mut image_xobjects = ImageXObjects::new();
-    let mut examined = 0usize;
     if let Ok(xo) = resources.get(b"XObject") {
         if let Ok((_, lopdf::Object::Dictionary(xobjects))) = doc.dereference(xo) {
             for (name, obj_ref) in xobjects.iter() {
-                examined += 1;
+                // Charged before the dereference and the name clone below, so an
+                // over-budget dictionary stops partway instead of completing.
+                *budget = budget.saturating_sub(PDF_CONTENT_STREAM_COST_FLOOR_BYTES);
+                if *budget == 0 {
+                    return (image_xobjects, false);
+                }
                 if let Ok((_, lopdf::Object::Stream(xobj))) = doc.dereference(obj_ref) {
                     let subtype = xobj
                         .dict
@@ -729,7 +739,7 @@ fn collect_image_xobjects(
             }
         }
     }
-    (image_xobjects, examined)
+    (image_xobjects, true)
 }
 
 fn transform_point(m: &[f32; 6], x: f32, y: f32) -> (f32, f32) {
@@ -783,17 +793,15 @@ fn extract_image_items(
         let image_xobjects: Rc<ImageXObjects> = match xobject_cache.get(&origin) {
             Some(cached) => Rc::clone(cached),
             None => {
-                let (scanned, examined) = collect_image_xobjects(doc, resources);
-                // Charge the scan: one dereference per entry, priced like any
-                // other object touch. This is what bounds the cache as well as
-                // the work — every insertion is preceded by a charge
-                // proportional to the entries it retains, so the whole cache is
-                // bounded by the content budget rather than by the page count.
-                content_budget =
-                    content_budget.saturating_sub(examined * PDF_CONTENT_STREAM_COST_FLOOR_BYTES);
+                // The scan charges as it walks, so an over-budget dictionary stops
+                // partway rather than completing and then being billed. This is
+                // what bounds the cache as well as the work: every insertion is
+                // preceded by charges proportional to the entries it retains.
+                let (scanned, within_budget) =
+                    collect_image_xobjects(doc, resources, &mut content_budget);
                 let scanned = Rc::new(scanned);
                 xobject_cache.insert(origin, Rc::clone(&scanned));
-                if content_budget == 0 {
+                if !within_budget {
                     break;
                 }
                 scanned
@@ -3155,6 +3163,19 @@ mod tests {
         };
         let (_, images) = inspect_bytes_with_limits(&buf, &starved);
         assert!(images.is_empty());
+
+        // The scan itself must stop partway rather than complete and then be
+        // billed: with a budget for a quarter of the entries, at most that many
+        // are examined. Asserted directly on `collect_image_xobjects`, since a
+        // completed-then-charged scan is indistinguishable from this one by its
+        // effect on `images` alone.
+        let doc = lopdf::Document::load_mem(&buf).unwrap();
+        let page = *doc.get_pages().values().next().unwrap();
+        let (_, resources) = resolve_page_resources(&doc, page).expect("resources");
+        let mut budget = ENTRIES / 4 * PDF_CONTENT_STREAM_COST_FLOOR_BYTES;
+        let (_, within_budget) = collect_image_xobjects(&doc, resources, &mut budget);
+        assert!(!within_budget, "an over-budget scan must report exhaustion");
+        assert_eq!(budget, 0);
 
         // With the default budget the same document is walked without trouble,
         // and the shared dictionary is scanned once rather than once per page.

--- a/crates/fulgur/src/inspect.rs
+++ b/crates/fulgur/src/inspect.rs
@@ -1,7 +1,10 @@
 use serde::Serialize;
 use std::path::Path;
+use std::rc::Rc;
 
-use crate::MAX_PDF_PARENT_DEPTH;
+use crate::{
+    MAX_PDF_CONTENT_BYTES, MAX_PDF_GS_STACK_DEPTH, MAX_PDF_INSPECT_ITEMS, MAX_PDF_PARENT_DEPTH,
+};
 
 const IDENTITY: [f32; 6] = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
 
@@ -106,10 +109,16 @@ fn extract_text_items(doc: &lopdf::Document) -> crate::Result<Vec<TextItem>> {
     let mut items = Vec::new();
 
     for (&page_num, &page_id) in &doc.get_pages() {
+        if items.len() >= MAX_PDF_INSPECT_ITEMS {
+            break;
+        }
         let content_bytes = match doc.get_page_content(page_id) {
             Ok(b) => b,
             Err(_) => continue,
         };
+        if content_bytes.len() > MAX_PDF_CONTENT_BYTES {
+            continue;
+        }
         let content = match lopdf::content::Content::decode(&content_bytes) {
             Ok(c) => c,
             Err(_) => continue,
@@ -118,8 +127,15 @@ fn extract_text_items(doc: &lopdf::Document) -> crate::Result<Vec<TextItem>> {
         let identity = IDENTITY;
         // Graphics state stack: (CTM, font_name, font_size).
         // Tf is part of the graphics state (PDF §8.4.5 Table 52), so q/Q save/restore it.
-        let mut gs_stack: Vec<([f32; 6], String, f32)> =
-            vec![(identity, "unknown".to_string(), 12.0)];
+        //
+        // The font name is an `Rc<str>` rather than a `String` because `q` saves a
+        // copy of the whole entry: a deep run of `q` operators against a wide
+        // `/Tf` resource name would otherwise duplicate that name once per level.
+        let mut gs_stack: Vec<([f32; 6], Rc<str>, f32)> =
+            vec![(identity, Rc::from("unknown"), 12.0)];
+        // `q` pushes dropped for exceeding MAX_PDF_GS_STACK_DEPTH. Counted so the
+        // matching `Q` operators unwind them instead of popping real entries.
+        let mut dropped_pushes: usize = 0;
         // Text matrix linear components (scale/rotation); updated by Tm, reset by BT.
         let mut tm_a: f32 = 1.0;
         let mut tm_b: f32 = 0.0;
@@ -131,21 +147,30 @@ fn extract_text_items(doc: &lopdf::Document) -> crate::Result<Vec<TextItem>> {
         // Current text origin in page space.
         let mut tx: f32 = 0.0;
         let mut ty: f32 = 0.0;
-        let mut font_name = String::from("unknown");
+        let mut font_name: Rc<str> = Rc::from("unknown");
         let mut font_size: f32 = 12.0;
         let mut text_leading: f32 = 0.0;
 
         for Operation { operator, operands } in &content.operations {
+            if items.len() >= MAX_PDF_INSPECT_ITEMS {
+                break;
+            }
             match operator.as_str() {
+                "q" if gs_stack.len() >= MAX_PDF_GS_STACK_DEPTH => {
+                    dropped_pushes += 1;
+                }
                 "q" => {
                     let top = gs_stack.last().expect("gs_stack non-empty").clone();
                     gs_stack.push(top);
+                }
+                "Q" if dropped_pushes > 0 => {
+                    dropped_pushes -= 1;
                 }
                 "Q" if gs_stack.len() > 1 => {
                     gs_stack.pop();
                     let (_, ref saved_font, saved_size) =
                         *gs_stack.last().expect("gs_stack non-empty after Q");
-                    font_name = saved_font.clone();
+                    font_name = Rc::clone(saved_font);
                     font_size = saved_size;
                 }
                 "cm" if operands.len() == 6 => {
@@ -163,10 +188,10 @@ fn extract_text_items(doc: &lopdf::Document) -> crate::Result<Vec<TextItem>> {
                 }
                 "Tf" => {
                     if let (Some(name_obj), Some(size)) = (operands.first(), operands.get(1)) {
-                        font_name = obj_as_name_str(name_obj).unwrap_or("unknown").to_string();
+                        font_name = Rc::from(obj_as_name_str(name_obj).unwrap_or("unknown"));
                         font_size = obj_to_f32(size);
                         if let Some(gs) = gs_stack.last_mut() {
-                            gs.1 = font_name.clone();
+                            gs.1 = Rc::clone(&font_name);
                             gs.2 = font_size;
                         }
                     }
@@ -235,7 +260,7 @@ fn extract_text_items(doc: &lopdf::Document) -> crate::Result<Vec<TextItem>> {
                                     width: w,
                                     height: font_size,
                                     text,
-                                    font: font_name.clone(),
+                                    font: font_name.to_string(),
                                     font_size,
                                 });
                                 tx += w;
@@ -261,7 +286,7 @@ fn extract_text_items(doc: &lopdf::Document) -> crate::Result<Vec<TextItem>> {
                                     width: w,
                                     height: font_size,
                                     text: combined,
-                                    font: font_name.clone(),
+                                    font: font_name.to_string(),
                                     font_size,
                                 });
                                 tx += w;
@@ -312,6 +337,9 @@ fn extract_image_items(doc: &lopdf::Document) -> crate::Result<Vec<ImageItem>> {
     let mut items = Vec::new();
 
     for (&page_num, &page_id) in &doc.get_pages() {
+        if items.len() >= MAX_PDF_INSPECT_ITEMS {
+            break;
+        }
         // Step 1: XObject から画像情報を一時 map に収集
         // Resources は親 /Pages ノードから継承される場合があるため、継承チェーンを辿る。
         // key = XObject name, value = (format, width_px, height_px)
@@ -361,6 +389,9 @@ fn extract_image_items(doc: &lopdf::Document) -> crate::Result<Vec<ImageItem>> {
             Ok(b) => b,
             Err(_) => continue,
         };
+        if content_bytes.len() > MAX_PDF_CONTENT_BYTES {
+            continue;
+        }
         let content = match lopdf::content::Content::decode(&content_bytes) {
             Ok(c) => c,
             Err(_) => continue,
@@ -368,11 +399,23 @@ fn extract_image_items(doc: &lopdf::Document) -> crate::Result<Vec<ImageItem>> {
 
         let identity = IDENTITY;
         let mut ctm_stack: Vec<[f32; 6]> = vec![identity];
+        // See `extract_text_items`: dropped `q` pushes are counted so the matching
+        // `Q` operators unwind them rather than popping a real entry.
+        let mut dropped_pushes: usize = 0;
         for op in &content.operations {
+            if items.len() >= MAX_PDF_INSPECT_ITEMS {
+                break;
+            }
             match op.operator.as_str() {
+                "q" if ctm_stack.len() >= MAX_PDF_GS_STACK_DEPTH => {
+                    dropped_pushes += 1;
+                }
                 "q" => {
                     let top = *ctm_stack.last().unwrap_or(&identity);
                     ctm_stack.push(top);
+                }
+                "Q" if dropped_pushes > 0 => {
+                    dropped_pushes -= 1;
                 }
                 "Q" if ctm_stack.len() > 1 => {
                     ctm_stack.pop();
@@ -1008,5 +1051,345 @@ mod tests {
         );
 
         assert_eq!(resolve_page_resources(&doc, (1, 0)), None);
+    }
+
+    // --- Resource bounds on attacker-controlled content streams ---
+
+    /// Build a PDF with one page per entry in `page_contents`, each page's
+    /// content stream being exactly those bytes.
+    ///
+    /// Unlike [`make_pdf_with_text_positioning_ops`] this takes pre-encoded
+    /// operator bytes, so a test can hand it a stream that is deliberately
+    /// larger — or more deeply nested — than any operation list it would be
+    /// convenient to build through `lopdf::content::Content`.
+    fn make_pdf_with_raw_contents(page_contents: Vec<Vec<u8>>) -> Vec<u8> {
+        use lopdf::{Document, Object, Stream, dictionary};
+
+        let mut doc = Document::with_version("1.5");
+        let pages_id = doc.new_object_id();
+        let resources_id = doc.add_object(dictionary! {
+            "Font" => dictionary! {
+                "F1" => dictionary! {
+                    "Type" => "Font",
+                    "Subtype" => "Type1",
+                    "BaseFont" => "Courier",
+                },
+            },
+        });
+        let page_count = page_contents.len();
+        let mut kids = Vec::with_capacity(page_count);
+        for raw_content in page_contents {
+            let content_id = doc.add_object(Stream::new(dictionary! {}, raw_content));
+            let page_id = doc.add_object(dictionary! {
+                "Type" => "Page",
+                "Parent" => pages_id,
+                "Contents" => content_id,
+                "Resources" => resources_id,
+                "MediaBox" => vec![
+                    Object::Integer(0),
+                    Object::Integer(0),
+                    Object::Integer(595),
+                    Object::Integer(842),
+                ],
+            });
+            kids.push(Object::Reference(page_id));
+        }
+        doc.objects.insert(
+            pages_id,
+            Object::Dictionary(dictionary! {
+                "Type" => "Pages",
+                "Kids" => kids,
+                "Count" => Object::Integer(page_count as i64),
+            }),
+        );
+        let catalog_id = doc.add_object(dictionary! {
+            "Type" => "Catalog",
+            "Pages" => pages_id,
+        });
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+
+        let mut buf = Vec::new();
+        doc.save_to(&mut buf).unwrap();
+        buf
+    }
+
+    fn make_pdf_with_raw_content(raw_content: Vec<u8>) -> Vec<u8> {
+        make_pdf_with_raw_contents(vec![raw_content])
+    }
+
+    /// Build a single-page PDF carrying one image XObject named `/Im0`, whose
+    /// content stream is exactly `raw_content`.
+    ///
+    /// `extract_image_items` only walks a page's content stream when that page
+    /// resolves at least one image XObject, so the image pass is unreachable
+    /// without a resource dictionary like this one.
+    fn make_pdf_with_image_and_raw_content(raw_content: Vec<u8>) -> Vec<u8> {
+        use lopdf::{Document, Object, Stream, dictionary};
+
+        let mut doc = Document::with_version("1.5");
+        let pages_id = doc.new_object_id();
+        let image_id = doc.add_object(Stream::new(
+            dictionary! {
+                "Type" => "XObject",
+                "Subtype" => "Image",
+                "Width" => Object::Integer(4),
+                "Height" => Object::Integer(4),
+                "ColorSpace" => "DeviceGray",
+                "BitsPerComponent" => Object::Integer(8),
+            },
+            vec![0u8; 16],
+        ));
+        let resources_id = doc.add_object(dictionary! {
+            "XObject" => dictionary! {
+                "Im0" => Object::Reference(image_id),
+            },
+        });
+        let content_id = doc.add_object(Stream::new(dictionary! {}, raw_content));
+        let page_id = doc.add_object(dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "Contents" => content_id,
+            "Resources" => resources_id,
+            "MediaBox" => vec![
+                Object::Integer(0),
+                Object::Integer(0),
+                Object::Integer(595),
+                Object::Integer(842),
+            ],
+        });
+        doc.objects.insert(
+            pages_id,
+            Object::Dictionary(dictionary! {
+                "Type" => "Pages",
+                "Kids" => vec![Object::Reference(page_id)],
+                "Count" => Object::Integer(1),
+            }),
+        );
+        let catalog_id = doc.add_object(dictionary! {
+            "Type" => "Catalog",
+            "Pages" => pages_id,
+        });
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+
+        let mut buf = Vec::new();
+        doc.save_to(&mut buf).unwrap();
+        buf
+    }
+
+    /// A decoded content stream above [`MAX_PDF_CONTENT_BYTES`] is skipped
+    /// instead of being parsed into an operation list.
+    ///
+    /// The stream below carries real `Tj` operators, so without the bound the
+    /// same input yields text items; the assertion is that the cap fires, not
+    /// that the process survives.
+    #[test]
+    fn content_stream_above_byte_cap_is_skipped() {
+        let mut content = b"BT /F1 12 Tf\n".to_vec();
+        while content.len() <= MAX_PDF_CONTENT_BYTES {
+            content.extend_from_slice(b"(A) Tj\n");
+        }
+        content.extend_from_slice(b"ET\n");
+        assert!(content.len() > MAX_PDF_CONTENT_BYTES);
+
+        let result = inspect_bytes(&make_pdf_with_raw_content(content));
+        assert!(
+            result.text_items.is_empty(),
+            "oversized content stream must be skipped, got {} items",
+            result.text_items.len()
+        );
+        // The page itself is still counted; only its content is not parsed.
+        assert_eq!(result.pages, 1);
+    }
+
+    /// A stream just under [`MAX_PDF_CONTENT_BYTES`] is still parsed, so the
+    /// cap does not reject content merely for being large.
+    #[test]
+    fn content_stream_below_byte_cap_is_parsed() {
+        let mut content = b"BT /F1 12 Tf\n".to_vec();
+        while content.len() + 7 <= MAX_PDF_CONTENT_BYTES - 16 {
+            content.extend_from_slice(b"(A) Tj\n");
+        }
+        content.extend_from_slice(b"ET\n");
+        assert!(content.len() <= MAX_PDF_CONTENT_BYTES);
+
+        let result = inspect_bytes(&make_pdf_with_raw_content(content));
+        assert!(
+            !result.text_items.is_empty(),
+            "content stream under the cap must still be parsed"
+        );
+    }
+
+    /// A run of `q` operators deeper than [`MAX_PDF_GS_STACK_DEPTH`] must not
+    /// grow the graphics-state stack past the bound, and the dropped pushes
+    /// must stay balanced against their matching `Q` operators: text drawn
+    /// after the nesting closes has to land where the outer CTM puts it.
+    #[test]
+    fn graphics_state_nesting_beyond_cap_stays_balanced() {
+        let depth = MAX_PDF_GS_STACK_DEPTH + 500;
+
+        // Outer `cm` shifts the page by (100, 700). Then `depth` nested `q`s,
+        // each of which would be dropped past the cap, an inner `cm` that must
+        // be discarded with them, and `depth` matching `Q`s. The trailing text
+        // must therefore be positioned by the *outer* CTM alone.
+        let mut content = b"1 0 0 1 100 700 cm\n".to_vec();
+        for _ in 0..depth {
+            content.extend_from_slice(b"q\n");
+        }
+        content.extend_from_slice(b"1 0 0 1 50 50 cm\n");
+        for _ in 0..depth {
+            content.extend_from_slice(b"Q\n");
+        }
+        content.extend_from_slice(b"BT /F1 12 Tf (Anchor) Tj ET\n");
+
+        let result = inspect_bytes(&make_pdf_with_raw_content(content));
+        let item = result
+            .text_items
+            .first()
+            .expect("text after balanced nesting must still be extracted");
+        assert_eq!(item.text, "Anchor");
+        assert!(
+            (item.x - 100.0).abs() < 0.01 && (item.y - 700.0).abs() < 0.01,
+            "expected outer CTM origin (100, 700), got ({}, {})",
+            item.x,
+            item.y
+        );
+    }
+
+    /// A long `/Tf` resource name must not be duplicated once per `q`: the
+    /// saved graphics states share the name instead of cloning it. Deep
+    /// nesting with a wide name is the highest-amplification shape for this
+    /// module, so the bound is asserted through the restored state.
+    #[test]
+    fn wide_font_name_survives_deep_nesting_and_restore() {
+        let name = "F".repeat(4096);
+        let mut content = format!("BT /{name} 12 Tf\n").into_bytes();
+        for _ in 0..(MAX_PDF_GS_STACK_DEPTH + 500) {
+            content.extend_from_slice(b"q\n");
+        }
+        for _ in 0..(MAX_PDF_GS_STACK_DEPTH + 500) {
+            content.extend_from_slice(b"Q\n");
+        }
+        content.extend_from_slice(b"(Deep) Tj ET\n");
+
+        let result = inspect_bytes(&make_pdf_with_raw_content(content));
+        let item = result
+            .text_items
+            .first()
+            .expect("text after balanced nesting must still be extracted");
+        assert_eq!(
+            item.font, name,
+            "font name must survive save/restore intact"
+        );
+    }
+
+    /// Extraction stops at [`MAX_PDF_INSPECT_ITEMS`] rather than returning a
+    /// result whose size is proportional to the operator count.
+    ///
+    /// The cap is a whole-document total, so the input spreads its items over
+    /// several pages: each page stays comfortably under
+    /// [`MAX_PDF_CONTENT_BYTES`], which isolates the item bound from the byte
+    /// bound and also proves a per-page cap would not have sufficed.
+    #[test]
+    fn text_item_count_is_capped_across_pages() {
+        const ITEMS_PER_PAGE: usize = 50_000;
+        let mut page = b"BT /F1 12 Tf\n".to_vec();
+        page.reserve(ITEMS_PER_PAGE * 7 + 32);
+        for _ in 0..ITEMS_PER_PAGE {
+            page.extend_from_slice(b"(A) Tj\n");
+        }
+        page.extend_from_slice(b"ET\n");
+        assert!(
+            page.len() <= MAX_PDF_CONTENT_BYTES,
+            "each page must stay under the byte cap to isolate the item cap"
+        );
+
+        // One page more than the cap needs, so extraction has to stop mid-document.
+        let pages = MAX_PDF_INSPECT_ITEMS / ITEMS_PER_PAGE + 1;
+        let pdf = make_pdf_with_raw_contents(vec![page; pages]);
+
+        let result = inspect_bytes(&pdf);
+        assert_eq!(result.pages as usize, pages);
+        assert_eq!(result.text_items.len(), MAX_PDF_INSPECT_ITEMS);
+    }
+
+    /// The image pass re-reads the same content stream, so it carries the same
+    /// byte bound: an oversized stream yields no image placements even though
+    /// the page does resolve an image XObject.
+    #[test]
+    fn image_pass_skips_content_stream_above_byte_cap() {
+        let mut content = Vec::new();
+        while content.len() <= MAX_PDF_CONTENT_BYTES {
+            content.extend_from_slice(b"q 1 0 0 1 1 1 cm /Im0 Do Q\n");
+        }
+        assert!(content.len() > MAX_PDF_CONTENT_BYTES);
+
+        let result = inspect_bytes(&make_pdf_with_image_and_raw_content(content));
+        assert!(
+            result.images.is_empty(),
+            "oversized content stream must be skipped, got {} images",
+            result.images.len()
+        );
+        assert_eq!(result.pages, 1);
+    }
+
+    /// The image pass keeps its own CTM stack, so it needs the same balanced
+    /// unwinding of dropped `q` pushes: an image placed after nesting deeper
+    /// than [`MAX_PDF_GS_STACK_DEPTH`] closes must land at the outer CTM.
+    #[test]
+    fn image_placement_survives_graphics_state_nesting_beyond_cap() {
+        let depth = MAX_PDF_GS_STACK_DEPTH + 500;
+
+        let mut content = b"1 0 0 1 100 700 cm\n".to_vec();
+        for _ in 0..depth {
+            content.extend_from_slice(b"q\n");
+        }
+        // Discarded along with the dropped pushes.
+        content.extend_from_slice(b"1 0 0 1 33 44 cm\n");
+        for _ in 0..depth {
+            content.extend_from_slice(b"Q\n");
+        }
+        // Scale the unit image square to 50x50 at the outer origin.
+        content.extend_from_slice(b"50 0 0 50 0 0 cm\n/Im0 Do\n");
+
+        let result = inspect_bytes(&make_pdf_with_image_and_raw_content(content));
+        let img = result
+            .images
+            .first()
+            .expect("image after balanced nesting must still be extracted");
+        assert!(
+            (img.x - 100.0).abs() < 0.01 && (img.y - 700.0).abs() < 0.01,
+            "expected outer CTM origin (100, 700), got ({}, {})",
+            img.x,
+            img.y
+        );
+        assert!((img.width - 50.0).abs() < 0.01, "width {}", img.width);
+        assert!((img.height - 50.0).abs() < 0.01, "height {}", img.height);
+    }
+
+    /// The bounds must not change what a realistic document extracts, and must
+    /// sit far above what one needs.
+    ///
+    /// (The extracted `text` is glyph-id soup rather than readable text because
+    /// `inspect` does not consult the ToUnicode CMap — a separate, pre-existing
+    /// limitation. This test asserts on record structure, which is what the
+    /// bounds can affect.)
+    #[test]
+    fn bounds_do_not_alter_realistic_extraction() {
+        let html = "<html><body>\
+            <h1>Heading</h1>\
+            <p>First paragraph with several words.</p>\
+            <p>Second paragraph, also with words.</p>\
+            </body></html>";
+        let result = inspect_bytes(&render_test_pdf(html));
+        // One record per laid-out line: heading plus the two paragraphs.
+        assert_eq!(result.text_items.len(), 3);
+        for item in &result.text_items {
+            assert_eq!(item.page, 1);
+            assert!(!item.text.is_empty());
+            assert!(item.font_size > 0.0);
+            assert!(item.width > 0.0);
+        }
+        // Headroom check: the caps are orders of magnitude above this document.
+        assert!(result.text_items.len() * 1000 < MAX_PDF_INSPECT_ITEMS);
     }
 }

--- a/crates/fulgur/src/inspect.rs
+++ b/crates/fulgur/src/inspect.rs
@@ -181,6 +181,15 @@ fn gather_page_content(
 ) -> PageContent {
     let mut content: Vec<u8> = Vec::new();
     for object_id in doc.get_page_contents(page_id) {
+        // Charge the floor for *attempting* the reference, before knowing whether
+        // it resolves to a stream. The object lookup costs the same either way,
+        // and a `/Contents` array of references to dictionaries or missing
+        // objects — shareable across pages, like any other array — would
+        // otherwise be walked per page for free.
+        *doc_budget = doc_budget.saturating_sub(PDF_CONTENT_STREAM_COST_FLOOR_BYTES);
+        if *doc_budget == 0 {
+            return PageContent::Exhausted;
+        }
         let Ok(stream) = doc.get_object(object_id).and_then(lopdf::Object::as_stream) else {
             continue;
         };
@@ -189,14 +198,13 @@ fn gather_page_content(
             Ok(ref d) => d,
             Err(_) => &stream.content,
         };
-        // Charge the bytes this stream adds to `content` — its decoded length
-        // plus the separator appended below — but never less than the fixed cost
-        // of having resolved and decoded it at all. Charging only `bytes.len()`
-        // let a stream that decodes to *nothing* be free, so a `/Contents` array
-        // of many zero-length streams, shared across pages by one reference,
-        // could run for free. See `PDF_CONTENT_STREAM_COST_FLOOR_BYTES`.
-        *doc_budget =
-            doc_budget.saturating_sub((bytes.len() + 1).max(PDF_CONTENT_STREAM_COST_FLOOR_BYTES));
+        // Charge whatever this stream adds to `content` — its decoded length plus
+        // the separator appended below — beyond the floor already paid above. The
+        // total per stream is therefore `max(bytes + 1, floor)`: a stream that
+        // decodes to *nothing* still costs the floor, so many zero-length streams
+        // cannot be walked for free. See `PDF_CONTENT_STREAM_COST_FLOOR_BYTES`.
+        *doc_budget = doc_budget
+            .saturating_sub((bytes.len() + 1).saturating_sub(PDF_CONTENT_STREAM_COST_FLOOR_BYTES));
         if *doc_budget == 0 {
             return PageContent::Exhausted;
         }
@@ -464,14 +472,20 @@ fn extract_text_items(
 /// Find the `Resources` dictionary in effect for a page, following `/Parent`
 /// inheritance.
 ///
-/// Returns the dictionary *by reference* along with its object id when it was
-/// reached through an indirect reference. Both matter for bounding work: a
-/// resources dictionary is routinely shared by every page in a document, so
-/// cloning it — as this used to — made a page's cost proportional to the
-/// dictionary's size, and the id is what lets the caller recognise the sharing
-/// and scan it only once. `None` for the id means the dictionary is written
-/// inline, in which case no sharing is possible and its cost is already bounded
-/// by the file size.
+/// Returns the dictionary *by reference*, along with an identity the caller can
+/// use to recognise when two pages share it.
+///
+/// Both matter for bounding work: a resources dictionary is routinely shared by
+/// every page in a document, so cloning it — as this used to — made a page's cost
+/// proportional to the dictionary's size, and the identity is what lets the
+/// caller scan it only once.
+///
+/// The identity is [`ResourcesOrigin`], not simply the dereferenced object id,
+/// because a resources dictionary can be shared two different ways. An indirect
+/// `/Resources` reference is the obvious one. The other is a *direct* dictionary
+/// written inside a `/Pages` node, which has no object id of its own yet is
+/// inherited by every descendant page — so treating "no reference id" as
+/// "not shared" would rescan it once per page.
 ///
 /// A fixed depth bound guarantees termination on malformed inputs with cyclic
 /// (`A -> B -> A`) or pathologically long `/Parent` references, without needing
@@ -480,7 +494,7 @@ fn extract_text_items(
 fn resolve_page_resources(
     doc: &lopdf::Document,
     page_id: lopdf::ObjectId,
-) -> Option<(Option<lopdf::ObjectId>, &lopdf::Dictionary)> {
+) -> Option<(ResourcesOrigin, &lopdf::Dictionary)> {
     let mut current_id = page_id;
     for _ in 0..MAX_PDF_PARENT_DEPTH {
         let dict = match doc.get_object(current_id) {
@@ -489,7 +503,16 @@ fn resolve_page_resources(
         };
         if let Ok(res) = dict.get(b"Resources") {
             if let Ok((id, lopdf::Object::Dictionary(resources))) = doc.dereference(res) {
-                return Some((id, resources));
+                let origin = match id {
+                    // Indirect: every page naming this reference shares it.
+                    Some(id) => ResourcesOrigin::Shared(id),
+                    // Direct, but written on an ancestor node, so inherited by
+                    // every page beneath it.
+                    None if current_id != page_id => ResourcesOrigin::Shared(current_id),
+                    // Direct on this page: nothing else can reach it.
+                    None => ResourcesOrigin::Unique,
+                };
+                return Some((origin, resources));
             }
         }
         match dict.get(b"Parent").and_then(|p| p.as_reference()) {
@@ -498,6 +521,18 @@ fn resolve_page_resources(
         }
     }
     None
+}
+
+/// Whether a page's resources dictionary can be reached by other pages, and if
+/// so under what identity — the cache key for [`collect_image_xobjects`].
+#[derive(Debug, PartialEq, Eq)]
+enum ResourcesOrigin {
+    /// Reachable by other pages under this id: either an indirect `/Resources`
+    /// reference, or the page-tree node whose direct `/Resources` is inherited.
+    Shared(lopdf::ObjectId),
+    /// Written directly on the page itself, so no other page can reach it. Not
+    /// worth caching — and caching it would grow the cache once per page.
+    Unique,
 }
 
 /// Image XObjects declared by a page's resources: name -> (format, width_px,
@@ -580,12 +615,13 @@ fn extract_image_items(
         }
         // Step 1: XObject から画像情報を収集 (共有 resources なら memoise 済みを再利用)
         // Resources は親 /Pages ノードから継承される場合があるため、継承チェーンを辿る。
-        let Some((resources_id, resources)) = resolve_page_resources(doc, page_id) else {
+        let Some((origin, resources)) = resolve_page_resources(doc, page_id) else {
             continue;
         };
-        let image_xobjects: Rc<ImageXObjects> = match resources_id {
-            // Shared via an indirect reference: scan once, reuse per page.
-            Some(id) => match xobject_cache.get(&id) {
+        let image_xobjects: Rc<ImageXObjects> = match origin {
+            // Reachable by other pages: scan once, reuse for every page that
+            // shares it.
+            ResourcesOrigin::Shared(id) => match xobject_cache.get(&id) {
                 Some(cached) => Rc::clone(cached),
                 None => {
                     let scanned = Rc::new(collect_image_xobjects(doc, resources));
@@ -593,9 +629,9 @@ fn extract_image_items(
                     scanned
                 }
             },
-            // Written inline in the page, so it cannot be shared and its size is
-            // already charged to the file.
-            None => Rc::new(collect_image_xobjects(doc, resources)),
+            // Written directly on this page, so no other page can reach it and
+            // its size is already charged to the file.
+            ResourcesOrigin::Unique => Rc::new(collect_image_xobjects(doc, resources)),
         };
 
         if image_xobjects.is_empty() {
@@ -2155,6 +2191,124 @@ mod tests {
             text.iter().map(|i| i.text.as_str()).collect::<Vec<_>>(),
             ["Reached"]
         );
+    }
+
+    /// A `/Contents` reference that does *not* resolve to a stream is still
+    /// charged the cost floor.
+    ///
+    /// The lookup costs the same whether it resolves or not, and a `/Contents`
+    /// array of references to dictionaries or missing objects is as shareable as
+    /// any other array — so skipping the charge would leave `pages × references`
+    /// work unbounded.
+    #[test]
+    fn limits_unresolvable_content_references_are_charged() {
+        use lopdf::{Document, Object, Stream, dictionary};
+
+        let mut doc = Document::with_version("1.5");
+        let pages_id = doc.new_object_id();
+        let resources_id = doc.add_object(dictionary! {
+            "Font" => dictionary! {
+                "F1" => dictionary! {
+                    "Type" => "Font", "Subtype" => "Type1", "BaseFont" => "Courier",
+                },
+            },
+        });
+        // References that resolve to a dictionary rather than a stream, followed
+        // by a real text stream — so the charge is visible in the output.
+        const DUDS: usize = 200;
+        let dud = doc.add_object(dictionary! { "Type" => "ExampleNotAStream" });
+        let mut contents: Vec<Object> = vec![Object::Reference(dud); DUDS];
+        contents.push(Object::Reference(doc.add_object(Stream::new(
+            dictionary! {},
+            b"BT /F1 12 Tf 1 0 0 1 10 800 Tm (Reached) Tj ET".to_vec(),
+        ))));
+        let page_id = doc.add_object(dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "Contents" => contents,
+            "Resources" => resources_id,
+            "MediaBox" => vec![
+                Object::Integer(0), Object::Integer(0),
+                Object::Integer(595), Object::Integer(842),
+            ],
+        });
+        doc.objects.insert(
+            pages_id,
+            Object::Dictionary(dictionary! {
+                "Type" => "Pages",
+                "Kids" => vec![Object::Reference(page_id)],
+                "Count" => Object::Integer(1),
+            }),
+        );
+        let catalog_id = doc.add_object(dictionary! { "Type" => "Catalog", "Pages" => pages_id });
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+        let mut buf = Vec::new();
+        doc.save_to(&mut buf).unwrap();
+
+        let starved = InspectLimits {
+            content_total_bytes: DUDS * PDF_CONTENT_STREAM_COST_FLOOR_BYTES / 4,
+            ..InspectLimits::default()
+        };
+        let (text, _) = inspect_bytes_with_limits(&buf, &starved);
+        assert!(
+            text.is_empty(),
+            "non-stream references must draw down the budget, got {text:?}"
+        );
+
+        let ample = InspectLimits {
+            content_total_bytes: DUDS * PDF_CONTENT_STREAM_COST_FLOOR_BYTES * 4,
+            ..InspectLimits::default()
+        };
+        let (text, _) = inspect_bytes_with_limits(&buf, &ample);
+        assert_eq!(
+            text.iter().map(|i| i.text.as_str()).collect::<Vec<_>>(),
+            ["Reached"]
+        );
+    }
+
+    /// A *direct* `/Resources` dictionary on a `/Pages` node has no object id of
+    /// its own, but is inherited by every descendant page — so it is shared, and
+    /// [`resolve_page_resources`] must report it as such or the image pass
+    /// rescans it once per page.
+    ///
+    /// [`ResourcesOrigin::Unique`] is reserved for a dictionary written directly
+    /// on the page itself, which nothing else can reach.
+    #[test]
+    fn resources_inherited_from_a_parent_node_are_reported_as_shared() {
+        use lopdf::{Document, Object, dictionary};
+
+        let mut doc = Document::with_version("1.5");
+        let pages_id = doc.new_object_id();
+        let inheriting = doc.add_object(dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+        });
+        let own_resources = doc.add_object(dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            // Direct dictionary on the page itself.
+            "Resources" => dictionary! { "ProcSet" => vec!["PDF".into()] },
+        });
+        doc.objects.insert(
+            pages_id,
+            Object::Dictionary(dictionary! {
+                "Type" => "Pages",
+                "Kids" => vec![Object::Reference(inheriting), Object::Reference(own_resources)],
+                "Count" => Object::Integer(2),
+                // Direct dictionary on the shared parent: no id, yet inherited.
+                "Resources" => dictionary! { "ProcSet" => vec!["Text".into()] },
+            }),
+        );
+
+        let (origin, _) = resolve_page_resources(&doc, inheriting).expect("inherited resources");
+        assert_eq!(
+            origin,
+            ResourcesOrigin::Shared(pages_id),
+            "a direct dictionary on an ancestor is shared by every descendant"
+        );
+
+        let (origin, _) = resolve_page_resources(&doc, own_resources).expect("own resources");
+        assert_eq!(origin, ResourcesOrigin::Unique);
     }
 
     /// The item budget stops extraction in both passes.

--- a/crates/fulgur/src/inspect.rs
+++ b/crates/fulgur/src/inspect.rs
@@ -3,7 +3,8 @@ use std::path::Path;
 use std::rc::Rc;
 
 use crate::{
-    MAX_PDF_CONTENT_BYTES, MAX_PDF_GS_STACK_DEPTH, MAX_PDF_INSPECT_ITEMS, MAX_PDF_PARENT_DEPTH,
+    MAX_PDF_CONTENT_BYTES, MAX_PDF_FONT_NAME_BYTES, MAX_PDF_GS_STACK_DEPTH, MAX_PDF_INSPECT_ITEMS,
+    MAX_PDF_PARENT_DEPTH,
 };
 
 const IDENTITY: [f32; 6] = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
@@ -75,6 +76,73 @@ fn obj_as_name_str(obj: &lopdf::Object) -> Option<&str> {
     obj.as_name().ok().and_then(|b| std::str::from_utf8(b).ok())
 }
 
+/// Clamp a `/Tf` font resource name to [`MAX_PDF_FONT_NAME_BYTES`].
+///
+/// Every [`TextItem`] retains a copy of the font name in effect, so an
+/// unclamped name multiplies into the result once per record — see
+/// [`MAX_PDF_FONT_NAME_BYTES`] for why the per-page content bound does not
+/// cover that product.
+///
+/// Truncation rounds *down* to a UTF-8 character boundary, so a name whose
+/// clamp point falls inside a multi-byte character is cut before that
+/// character rather than panicking on a sliced code point.
+fn clamp_font_name(name: &str) -> &str {
+    if name.len() <= MAX_PDF_FONT_NAME_BYTES {
+        return name;
+    }
+    let mut end = MAX_PDF_FONT_NAME_BYTES;
+    while end > 0 && !name.is_char_boundary(end) {
+        end -= 1;
+    }
+    &name[..end]
+}
+
+/// Gather a page's decoded content streams, abandoning the page as soon as the
+/// running total exceeds [`MAX_PDF_CONTENT_BYTES`].
+///
+/// Returns `None` when the page is over budget — the caller skips it, matching
+/// how the module treats every other malformed or oversized structure.
+///
+/// This exists instead of `lopdf::Document::get_page_content` because that
+/// method inflates *every* content stream of the page and concatenates them
+/// before returning: checking the length of its result would bound only what
+/// gets parsed, not what gets allocated. Accumulating with a running budget
+/// bounds the concatenated total.
+///
+/// For a page under the bound the result is byte-for-byte what
+/// `get_page_content` returns, which is what keeps extraction unchanged for
+/// real documents: each stream contributes its decoded bytes — or its raw,
+/// still-encoded bytes when decoding fails, as `lopdf` does — followed by the
+/// `\n` separator that stops tokens merging across a stream boundary
+/// (`…Tj` + `q…` would otherwise lex as `Tjq`). Content stream ids that do not
+/// resolve to a stream object are skipped individually, not treated as
+/// abandoning the page.
+///
+/// The `\n` separators count against the budget, so the accept/reject decision
+/// is identical to testing `get_page_content`'s total: the running total rises
+/// monotonically to exactly that sum, so some prefix exceeds the bound if and
+/// only if the total does.
+fn gather_page_content(doc: &lopdf::Document, page_id: lopdf::ObjectId) -> Option<Vec<u8>> {
+    let mut content: Vec<u8> = Vec::new();
+    for object_id in doc.get_page_contents(page_id) {
+        let Ok(stream) = doc.get_object(object_id).and_then(lopdf::Object::as_stream) else {
+            continue;
+        };
+        let decoded = stream.decompressed_content();
+        let bytes: &[u8] = match decoded {
+            Ok(ref d) => d,
+            Err(_) => &stream.content,
+        };
+        // +1 for the `\n` separator appended after every stream.
+        if content.len() + bytes.len() + 1 > MAX_PDF_CONTENT_BYTES {
+            return None;
+        }
+        content.extend_from_slice(bytes);
+        content.push(b'\n');
+    }
+    Some(content)
+}
+
 fn extract_metadata(doc: &lopdf::Document) -> Metadata {
     let mut meta = Metadata::default();
     let info_id = match doc.trailer.get(b"Info") {
@@ -112,13 +180,10 @@ fn extract_text_items(doc: &lopdf::Document) -> crate::Result<Vec<TextItem>> {
         if items.len() >= MAX_PDF_INSPECT_ITEMS {
             break;
         }
-        let content_bytes = match doc.get_page_content(page_id) {
-            Ok(b) => b,
-            Err(_) => continue,
+        let content_bytes = match gather_page_content(doc, page_id) {
+            Some(b) => b,
+            None => continue,
         };
-        if content_bytes.len() > MAX_PDF_CONTENT_BYTES {
-            continue;
-        }
         let content = match lopdf::content::Content::decode(&content_bytes) {
             Ok(c) => c,
             Err(_) => continue,
@@ -155,6 +220,21 @@ fn extract_text_items(doc: &lopdf::Document) -> crate::Result<Vec<TextItem>> {
             if items.len() >= MAX_PDF_INSPECT_ITEMS {
                 break;
             }
+            // Inside a `q` frame dropped for exceeding MAX_PDF_GS_STACK_DEPTH.
+            // The frame has no stack entry of its own, so a state change here
+            // would mutate the deepest *retained* entry and survive the
+            // matching `Q`, leaking into the enclosing scope. Discard the
+            // frame's contents entirely — only the `q`/`Q` bookkeeping that
+            // finds the end of the frame is honoured — which is what keeps the
+            // outer state exactly restorable.
+            if dropped_pushes > 0 {
+                match operator.as_str() {
+                    "q" => dropped_pushes += 1,
+                    "Q" => dropped_pushes -= 1,
+                    _ => {}
+                }
+                continue;
+            }
             match operator.as_str() {
                 "q" if gs_stack.len() >= MAX_PDF_GS_STACK_DEPTH => {
                     dropped_pushes += 1;
@@ -162,9 +242,6 @@ fn extract_text_items(doc: &lopdf::Document) -> crate::Result<Vec<TextItem>> {
                 "q" => {
                     let top = gs_stack.last().expect("gs_stack non-empty").clone();
                     gs_stack.push(top);
-                }
-                "Q" if dropped_pushes > 0 => {
-                    dropped_pushes -= 1;
                 }
                 "Q" if gs_stack.len() > 1 => {
                     gs_stack.pop();
@@ -188,7 +265,9 @@ fn extract_text_items(doc: &lopdf::Document) -> crate::Result<Vec<TextItem>> {
                 }
                 "Tf" => {
                     if let (Some(name_obj), Some(size)) = (operands.first(), operands.get(1)) {
-                        font_name = Rc::from(obj_as_name_str(name_obj).unwrap_or("unknown"));
+                        font_name = Rc::from(clamp_font_name(
+                            obj_as_name_str(name_obj).unwrap_or("unknown"),
+                        ));
                         font_size = obj_to_f32(size);
                         if let Some(gs) = gs_stack.last_mut() {
                             gs.1 = Rc::clone(&font_name);
@@ -385,13 +464,10 @@ fn extract_image_items(doc: &lopdf::Document) -> crate::Result<Vec<ImageItem>> {
         }
 
         // Step 2: content stream から Do オペレータで位置を取得し、突き合わせて push
-        let content_bytes = match doc.get_page_content(page_id) {
-            Ok(b) => b,
-            Err(_) => continue,
+        let content_bytes = match gather_page_content(doc, page_id) {
+            Some(b) => b,
+            None => continue,
         };
-        if content_bytes.len() > MAX_PDF_CONTENT_BYTES {
-            continue;
-        }
         let content = match lopdf::content::Content::decode(&content_bytes) {
             Ok(c) => c,
             Err(_) => continue,
@@ -406,6 +482,17 @@ fn extract_image_items(doc: &lopdf::Document) -> crate::Result<Vec<ImageItem>> {
             if items.len() >= MAX_PDF_INSPECT_ITEMS {
                 break;
             }
+            // See `extract_text_items`: the contents of a `q` frame dropped for
+            // exceeding MAX_PDF_GS_STACK_DEPTH are discarded with the frame, so
+            // a `cm` inside it cannot leak past the matching `Q`.
+            if dropped_pushes > 0 {
+                match op.operator.as_str() {
+                    "q" => dropped_pushes += 1,
+                    "Q" => dropped_pushes -= 1,
+                    _ => {}
+                }
+                continue;
+            }
             match op.operator.as_str() {
                 "q" if ctm_stack.len() >= MAX_PDF_GS_STACK_DEPTH => {
                     dropped_pushes += 1;
@@ -413,9 +500,6 @@ fn extract_image_items(doc: &lopdf::Document) -> crate::Result<Vec<ImageItem>> {
                 "q" => {
                     let top = *ctm_stack.last().unwrap_or(&identity);
                     ctm_stack.push(top);
-                }
-                "Q" if dropped_pushes > 0 => {
-                    dropped_pushes -= 1;
                 }
                 "Q" if ctm_stack.len() > 1 => {
                     ctm_stack.pop();
@@ -1117,6 +1201,61 @@ mod tests {
         make_pdf_with_raw_contents(vec![raw_content])
     }
 
+    /// Build a *single-page* PDF whose `/Contents` is an array of several
+    /// streams, each carrying pre-encoded operator bytes.
+    ///
+    /// Unlike [`make_pdf_with_raw_contents`], which puts one stream on each of
+    /// several pages, this puts several streams on one page — the shape that
+    /// distinguishes a per-stream content budget from a per-page one.
+    fn make_pdf_with_multiple_content_streams(streams: Vec<Vec<u8>>) -> Vec<u8> {
+        use lopdf::{Document, Object, Stream, dictionary};
+
+        let mut doc = Document::with_version("1.5");
+        let pages_id = doc.new_object_id();
+        let resources_id = doc.add_object(dictionary! {
+            "Font" => dictionary! {
+                "F1" => dictionary! {
+                    "Type" => "Font",
+                    "Subtype" => "Type1",
+                    "BaseFont" => "Courier",
+                },
+            },
+        });
+        let content_refs: Vec<Object> = streams
+            .into_iter()
+            .map(|raw| Object::Reference(doc.add_object(Stream::new(dictionary! {}, raw))))
+            .collect();
+        let page_id = doc.add_object(dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "Contents" => content_refs,
+            "Resources" => resources_id,
+            "MediaBox" => vec![
+                Object::Integer(0),
+                Object::Integer(0),
+                Object::Integer(595),
+                Object::Integer(842),
+            ],
+        });
+        doc.objects.insert(
+            pages_id,
+            Object::Dictionary(dictionary! {
+                "Type" => "Pages",
+                "Kids" => vec![Object::Reference(page_id)],
+                "Count" => Object::Integer(1),
+            }),
+        );
+        let catalog_id = doc.add_object(dictionary! {
+            "Type" => "Catalog",
+            "Pages" => pages_id,
+        });
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+
+        let mut buf = Vec::new();
+        doc.save_to(&mut buf).unwrap();
+        buf
+    }
+
     /// Build a single-page PDF carrying one image XObject named `/Im0`, whose
     /// content stream is exactly `raw_content`.
     ///
@@ -1259,6 +1398,9 @@ mod tests {
     /// saved graphics states share the name instead of cloning it. Deep
     /// nesting with a wide name is the highest-amplification shape for this
     /// module, so the bound is asserted through the restored state.
+    ///
+    /// The name is clamped to [`MAX_PDF_FONT_NAME_BYTES`] on the way in, so what
+    /// must survive the round trip is the clamped form, not the input.
     #[test]
     fn wide_font_name_survives_deep_nesting_and_restore() {
         let name = "F".repeat(4096);
@@ -1277,9 +1419,53 @@ mod tests {
             .first()
             .expect("text after balanced nesting must still be extracted");
         assert_eq!(
-            item.font, name,
-            "font name must survive save/restore intact"
+            item.font,
+            "F".repeat(MAX_PDF_FONT_NAME_BYTES),
+            "clamped font name must survive save/restore intact"
         );
+    }
+
+    /// A `/Tf` name longer than [`MAX_PDF_FONT_NAME_BYTES`] is clamped in every
+    /// emitted record, so the retained size of a result is bounded by
+    /// `items × MAX_PDF_FONT_NAME_BYTES` rather than by the name's length.
+    ///
+    /// A per-page content budget alone does not bound that product: this shape
+    /// spends one page on a wide name plus a run of cheap `Tj` operators, and a
+    /// document may repeat it per page.
+    #[test]
+    fn wide_font_name_is_clamped_in_every_record() {
+        let name = "F".repeat(64 * 1024);
+        let mut content = format!("BT /{name} 12 Tf\n").into_bytes();
+        for _ in 0..1000 {
+            content.extend_from_slice(b"(A) Tj\n");
+        }
+        content.extend_from_slice(b"ET\n");
+
+        let result = inspect_bytes(&make_pdf_with_raw_content(content));
+        assert_eq!(result.text_items.len(), 1000);
+        for item in &result.text_items {
+            assert_eq!(item.font.len(), MAX_PDF_FONT_NAME_BYTES);
+        }
+    }
+
+    /// Clamping a `/Tf` name must round down to a UTF-8 character boundary: a
+    /// name whose clamp point falls inside a multi-byte character is cut before
+    /// that character instead of panicking on a sliced code point.
+    #[test]
+    fn wide_font_name_clamp_respects_char_boundaries() {
+        // 3 bytes per `あ`, so no multiple of 3 lands on 127 — the clamp point
+        // falls strictly inside a character and has to round down to 126.
+        let name = "あ".repeat(128);
+        assert!(name.len() > MAX_PDF_FONT_NAME_BYTES);
+        let content = format!("BT /{name} 12 Tf (Multi) Tj ET\n").into_bytes();
+
+        let result = inspect_bytes(&make_pdf_with_raw_content(content));
+        let item = result
+            .text_items
+            .first()
+            .expect("text with a multi-byte font name must still be extracted");
+        assert_eq!(item.font, "あ".repeat(MAX_PDF_FONT_NAME_BYTES / 3));
+        assert!(item.font.len() <= MAX_PDF_FONT_NAME_BYTES);
     }
 
     /// Extraction stops at [`MAX_PDF_INSPECT_ITEMS`] rather than returning a
@@ -1381,15 +1567,239 @@ mod tests {
             <p>Second paragraph, also with words.</p>\
             </body></html>";
         let result = inspect_bytes(&render_test_pdf(html));
-        // One record per laid-out line: heading plus the two paragraphs.
-        assert_eq!(result.text_items.len(), 3);
+        // At least one record per source block: heading plus the two
+        // paragraphs. The exact count depends on line breaking, which depends
+        // on font metrics, so only the floor is asserted.
+        assert!(
+            result.text_items.len() >= 3,
+            "expected >=3 text items, got {}",
+            result.text_items.len()
+        );
         for item in &result.text_items {
             assert_eq!(item.page, 1);
             assert!(!item.text.is_empty());
             assert!(item.font_size > 0.0);
             assert!(item.width > 0.0);
         }
-        // Headroom check: the caps are orders of magnitude above this document.
-        assert!(result.text_items.len() * 1000 < MAX_PDF_INSPECT_ITEMS);
+        // Headroom check: the cap is orders of magnitude above this document,
+        // so the result must be nowhere near truncation.
+        assert!(result.text_items.len() < MAX_PDF_INSPECT_ITEMS / 1000);
+    }
+
+    /// A `q` past [`MAX_PDF_GS_STACK_DEPTH`] is dropped, so the frame it opens
+    /// has no stack entry of its own. State set inside that frame must not
+    /// survive its matching `Q`: without isolation the `cm` below would mutate
+    /// the deepest *retained* entry, and because that entry is never popped it
+    /// would keep transforming everything that follows.
+    ///
+    /// The existing `graphics_state_nesting_beyond_cap_stays_balanced` closes
+    /// *all* the nesting, which pops the polluted entry and hides the leak; the
+    /// distinguishing shape is closing only the dropped frame.
+    #[test]
+    fn dropped_frame_state_does_not_leak_past_matching_q() {
+        // Fill the stack exactly, then one more `q` — that last one is dropped.
+        let mut content = b"1 0 0 1 100 700 cm\n".to_vec();
+        for _ in 0..MAX_PDF_GS_STACK_DEPTH {
+            content.extend_from_slice(b"q\n");
+        }
+        // Belongs to the dropped frame, and must be discarded with it.
+        content.extend_from_slice(b"1 0 0 1 50 50 cm\n");
+        // Closes only the dropped frame; the real entries stay on the stack.
+        content.extend_from_slice(b"Q\n");
+        content.extend_from_slice(b"BT /F1 12 Tf (Anchor) Tj ET\n");
+
+        let result = inspect_bytes(&make_pdf_with_raw_content(content));
+        let item = result
+            .text_items
+            .first()
+            .expect("text after the dropped frame closes must still be extracted");
+        assert_eq!(item.text, "Anchor");
+        assert!(
+            (item.x - 100.0).abs() < 0.01 && (item.y - 700.0).abs() < 0.01,
+            "dropped-frame `cm` leaked: expected outer CTM (100, 700), got ({}, {})",
+            item.x,
+            item.y
+        );
+    }
+
+    /// The image pass keeps its own CTM stack, so it needs the same isolation of
+    /// dropped-frame state as the text pass.
+    #[test]
+    fn image_dropped_frame_state_does_not_leak_past_matching_q() {
+        let mut content = b"1 0 0 1 100 700 cm\n".to_vec();
+        for _ in 0..MAX_PDF_GS_STACK_DEPTH {
+            content.extend_from_slice(b"q\n");
+        }
+        // Belongs to the dropped frame: a 10x scale that must not reach the `Do`.
+        content.extend_from_slice(b"10 0 0 10 33 44 cm\n");
+        content.extend_from_slice(b"Q\n");
+        // Scale the unit image square to 50x50 at the outer origin.
+        content.extend_from_slice(b"50 0 0 50 0 0 cm\n/Im0 Do\n");
+
+        let result = inspect_bytes(&make_pdf_with_image_and_raw_content(content));
+        let img = result
+            .images
+            .first()
+            .expect("image after the dropped frame closes must still be extracted");
+        assert!(
+            (img.x - 100.0).abs() < 0.01 && (img.y - 700.0).abs() < 0.01,
+            "dropped-frame `cm` leaked: expected outer CTM (100, 700), got ({}, {})",
+            img.x,
+            img.y
+        );
+        assert!((img.width - 50.0).abs() < 0.01, "width {}", img.width);
+        assert!((img.height - 50.0).abs() < 0.01, "height {}", img.height);
+    }
+
+    /// [`MAX_PDF_CONTENT_BYTES`] bounds a page's *whole* content, not each of
+    /// its streams: a page may carry any number of `/Contents` streams, so a
+    /// per-stream check would leave the concatenated total unbounded.
+    #[test]
+    fn page_content_total_is_capped_across_streams() {
+        // Ten streams, each an eighth of the budget: every one is individually
+        // well under the cap, but together they are over it.
+        let mut stream = b"BT /F1 12 Tf\n".to_vec();
+        while stream.len() < MAX_PDF_CONTENT_BYTES / 8 {
+            stream.extend_from_slice(b"(A) Tj\n");
+        }
+        stream.extend_from_slice(b"ET\n");
+        assert!(stream.len() < MAX_PDF_CONTENT_BYTES);
+        let streams = vec![stream; 10];
+        assert!(streams.iter().map(Vec::len).sum::<usize>() > MAX_PDF_CONTENT_BYTES);
+
+        let result = inspect_bytes(&make_pdf_with_multiple_content_streams(streams));
+        assert!(
+            result.text_items.is_empty(),
+            "page over the total budget must be skipped, got {} items",
+            result.text_items.len()
+        );
+        assert_eq!(result.pages, 1);
+    }
+
+    /// Several content streams summing to under [`MAX_PDF_CONTENT_BYTES`] are
+    /// still parsed, and are joined with the separator that keeps tokens from
+    /// merging across the boundary: `…Tj` followed by `q…` must not lex as
+    /// `Tjq`. Each stream's text is extracted, in order.
+    #[test]
+    fn page_content_under_cap_is_joined_across_streams() {
+        let streams = vec![
+            b"BT /F1 12 Tf 1 0 0 1 10 800 Tm (First) Tj".to_vec(),
+            b"1 0 0 1 10 780 Tm (Second) Tj".to_vec(),
+            b"1 0 0 1 10 760 Tm (Third) Tj ET".to_vec(),
+        ];
+
+        let result = inspect_bytes(&make_pdf_with_multiple_content_streams(streams));
+        let texts: Vec<&str> = result.text_items.iter().map(|i| i.text.as_str()).collect();
+        assert_eq!(
+            texts,
+            ["First", "Second", "Third"],
+            "streams must be joined with a separator and parsed in order"
+        );
+    }
+
+    /// A `/Contents` entry that does not resolve to a stream object is skipped
+    /// individually; it must not abandon the rest of the page, matching how
+    /// `lopdf::Document::get_page_content` treats the same input.
+    #[test]
+    fn page_content_skips_entries_that_are_not_streams() {
+        use lopdf::{Document, Object, Stream, dictionary};
+
+        let mut doc = Document::with_version("1.5");
+        let pages_id = doc.new_object_id();
+        let resources_id = doc.add_object(dictionary! {
+            "Font" => dictionary! {
+                "F1" => dictionary! {
+                    "Type" => "Font", "Subtype" => "Type1", "BaseFont" => "Courier",
+                },
+            },
+        });
+        // A dictionary where a content stream is expected, then a real stream.
+        let not_a_stream = doc.add_object(dictionary! { "Type" => "ExampleNotAStream" });
+        let real = doc.add_object(Stream::new(
+            dictionary! {},
+            b"BT /F1 12 Tf 1 0 0 1 10 800 Tm (Survivor) Tj ET".to_vec(),
+        ));
+        let page_id = doc.add_object(dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "Contents" => vec![Object::Reference(not_a_stream), Object::Reference(real)],
+            "Resources" => resources_id,
+            "MediaBox" => vec![
+                Object::Integer(0), Object::Integer(0),
+                Object::Integer(595), Object::Integer(842),
+            ],
+        });
+        doc.objects.insert(
+            pages_id,
+            Object::Dictionary(dictionary! {
+                "Type" => "Pages",
+                "Kids" => vec![Object::Reference(page_id)],
+                "Count" => Object::Integer(1),
+            }),
+        );
+        let catalog_id = doc.add_object(dictionary! { "Type" => "Catalog", "Pages" => pages_id });
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+        let mut buf = Vec::new();
+        doc.save_to(&mut buf).unwrap();
+
+        let result = inspect_bytes(&buf);
+        let texts: Vec<&str> = result.text_items.iter().map(|i| i.text.as_str()).collect();
+        assert_eq!(texts, ["Survivor"]);
+    }
+
+    /// A stream whose filter chain cannot be decoded contributes its raw,
+    /// still-encoded bytes, which is what `lopdf` does — the fallback matters
+    /// because those bytes sometimes still lex as operators.
+    #[test]
+    fn page_content_falls_back_to_raw_bytes_when_decoding_fails() {
+        use lopdf::{Document, Object, Stream, dictionary};
+
+        let mut doc = Document::with_version("1.5");
+        let pages_id = doc.new_object_id();
+        let resources_id = doc.add_object(dictionary! {
+            "Font" => dictionary! {
+                "F1" => dictionary! {
+                    "Type" => "Font", "Subtype" => "Type1", "BaseFont" => "Courier",
+                },
+            },
+        });
+        // `/Crypt` is not among the filters lopdf implements, so
+        // `decompressed_content` reports an error and the raw bytes are used.
+        let mut stream = Stream::new(
+            dictionary! {},
+            b"BT /F1 12 Tf 1 0 0 1 10 800 Tm (Undecoded) Tj ET".to_vec(),
+        );
+        stream.dict.set("Filter", "Crypt");
+        assert!(
+            stream.decompressed_content().is_err(),
+            "test relies on this filter being undecodable by lopdf"
+        );
+        let content_id = doc.add_object(stream);
+        let page_id = doc.add_object(dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "Contents" => content_id,
+            "Resources" => resources_id,
+            "MediaBox" => vec![
+                Object::Integer(0), Object::Integer(0),
+                Object::Integer(595), Object::Integer(842),
+            ],
+        });
+        doc.objects.insert(
+            pages_id,
+            Object::Dictionary(dictionary! {
+                "Type" => "Pages",
+                "Kids" => vec![Object::Reference(page_id)],
+                "Count" => Object::Integer(1),
+            }),
+        );
+        let catalog_id = doc.add_object(dictionary! { "Type" => "Catalog", "Pages" => pages_id });
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+        let mut buf = Vec::new();
+        doc.save_to(&mut buf).unwrap();
+
+        let result = inspect_bytes(&buf);
+        let texts: Vec<&str> = result.text_items.iter().map(|i| i.text.as_str()).collect();
+        assert_eq!(texts, ["Undecoded"]);
     }
 }

--- a/crates/fulgur/src/inspect.rs
+++ b/crates/fulgur/src/inspect.rs
@@ -5,7 +5,8 @@ use std::rc::Rc;
 use crate::{
     MAX_PDF_CONTENT_BYTES, MAX_PDF_FONT_NAME_BYTES, MAX_PDF_GS_STACK_DEPTH,
     MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES, MAX_PDF_INSPECT_ITEMS, MAX_PDF_INSPECT_OPERATIONS,
-    MAX_PDF_INSPECT_TEXT_BYTES, MAX_PDF_PARENT_DEPTH, PDF_CONTENT_STREAM_COST_FLOOR_BYTES,
+    MAX_PDF_INSPECT_TEXT_BYTES, MAX_PDF_METADATA_FIELD_BYTES, MAX_PDF_PARENT_DEPTH,
+    PDF_CONTENT_STREAM_COST_FLOOR_BYTES,
 };
 
 const IDENTITY: [f32; 6] = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
@@ -110,25 +111,28 @@ fn obj_as_name_str(obj: &lopdf::Object) -> Option<&str> {
     obj.as_name().ok().and_then(|b| std::str::from_utf8(b).ok())
 }
 
+/// Truncate `s` to at most `max_bytes`, rounding *down* to a UTF-8 character
+/// boundary so a clamp point inside a multi-byte character cuts before that
+/// character rather than panicking on a sliced code point.
+fn clamp_str_bytes(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
 /// Clamp a `/Tf` font resource name to [`MAX_PDF_FONT_NAME_BYTES`].
 ///
 /// Every [`TextItem`] retains a copy of the font name in effect, so an
 /// unclamped name multiplies into the result once per record — see
 /// [`MAX_PDF_FONT_NAME_BYTES`] for why the per-page content bound does not
 /// cover that product.
-///
-/// Truncation rounds *down* to a UTF-8 character boundary, so a name whose
-/// clamp point falls inside a multi-byte character is cut before that
-/// character rather than panicking on a sliced code point.
 fn clamp_font_name(name: &str) -> &str {
-    if name.len() <= MAX_PDF_FONT_NAME_BYTES {
-        return name;
-    }
-    let mut end = MAX_PDF_FONT_NAME_BYTES;
-    while end > 0 && !name.is_char_boundary(end) {
-        end -= 1;
-    }
-    &name[..end]
+    clamp_str_bytes(name, MAX_PDF_FONT_NAME_BYTES)
 }
 
 /// Outcome of gathering one page's content, which distinguishes "skip this
@@ -198,13 +202,21 @@ fn gather_page_content(
             Ok(ref d) => d,
             Err(_) => &stream.content,
         };
-        // Charge whatever this stream adds to `content` — its decoded length plus
-        // the separator appended below — beyond the floor already paid above. The
-        // total per stream is therefore `max(bytes + 1, floor)`: a stream that
-        // decodes to *nothing* still costs the floor, so many zero-length streams
-        // cannot be walked for free. See `PDF_CONTENT_STREAM_COST_FLOOR_BYTES`.
-        *doc_budget = doc_budget
-            .saturating_sub((bytes.len() + 1).saturating_sub(PDF_CONTENT_STREAM_COST_FLOOR_BYTES));
+        // Charge this stream beyond the floor already paid above, taking the
+        // larger of what it *produced* and what it *consumed*:
+        //
+        // - decoded length plus the separator, the bytes added to `content`;
+        // - encoded length, because a filter reads every one of those bytes even
+        //   when it yields nothing. `/ASCII85Decode` over a megabyte of
+        //   whitespace decodes to zero bytes after scanning all of it, and a
+        //   Flate stream can do the same, so charging only the decoded length
+        //   would let a large encoded stream be re-decoded per page for the
+        //   floor alone.
+        //
+        // The total per stream is therefore `max(decoded + 1, encoded, floor)`.
+        let charge = (bytes.len() + 1).max(stream.content.len());
+        *doc_budget =
+            doc_budget.saturating_sub(charge.saturating_sub(PDF_CONTENT_STREAM_COST_FLOOR_BYTES));
         if *doc_budget == 0 {
             return PageContent::Exhausted;
         }
@@ -231,11 +243,18 @@ fn extract_metadata(doc: &lopdf::Document) -> Metadata {
         _ => return meta,
     };
 
+    // Clamped: an `/Info` dictionary can live inside a Flate-compressed object
+    // stream, so a small file can carry an arbitrarily large `/Title`. This pass
+    // has no per-page or per-record structure for the text and item budgets to
+    // bound, so without a clamp a metadata-only document produces output
+    // proportional to the decompressed payload. See
+    // `MAX_PDF_METADATA_FIELD_BYTES`.
     let get_str = |dict: &lopdf::Dictionary, key: &[u8]| -> Option<String> {
         dict.get(key)
             .ok()
             .and_then(|o| o.as_str().ok())
             .map(decode_pdf_string)
+            .map(|s| clamp_str_bytes(&s, MAX_PDF_METADATA_FIELD_BYTES).to_owned())
     };
 
     meta.title = get_str(info, b"Title");
@@ -540,6 +559,33 @@ enum ResourcesOrigin {
     DirectIn(lopdf::ObjectId),
 }
 
+/// Identity of the `/XObject` dictionary a page's images are scanned from — the
+/// cache key for [`collect_image_xobjects`].
+///
+/// Keyed on the `/XObject` dictionary rather than on the enclosing resources
+/// dictionary, because that is what the scan result actually depends on. The two
+/// differ whenever pages carry *distinct* resources dictionaries that all point
+/// `/XObject` at one shared indirect dictionary: keying on the resources
+/// dictionary would rescan the shared one once per page.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum XObjectsOrigin {
+    /// `/XObject N 0 R` — the dictionary is object `N`, shareable by any number
+    /// of otherwise-unrelated resources dictionaries.
+    Object(lopdf::ObjectId),
+    /// A direct `/XObject` dictionary written inside the resources dictionary
+    /// with this origin — or no `/XObject` entry at all, whose empty result is
+    /// equally a property of that resources dictionary.
+    DirectIn(ResourcesOrigin),
+}
+
+/// The identity of the `/XObject` dictionary reachable from `resources`.
+fn xobjects_origin(resources: &lopdf::Dictionary, origin: ResourcesOrigin) -> XObjectsOrigin {
+    match resources.get(b"XObject").and_then(|o| o.as_reference()) {
+        Ok(id) => XObjectsOrigin::Object(id),
+        Err(_) => XObjectsOrigin::DirectIn(origin),
+    }
+}
+
 /// Image XObjects declared by a page's resources: name -> (format, width_px,
 /// height_px).
 type ImageXObjects = std::collections::BTreeMap<String, (String, u32, u32)>;
@@ -611,7 +657,7 @@ fn extract_image_items(
     // budget. Work was therefore proportional to `pages × XObjects` while the
     // file stores each dimension once. Measured: 4,000 non-image XObjects shared
     // by 2,400 pages is 0.55 MB on disk, and the cost grew with the page count.
-    let mut xobject_cache: std::collections::BTreeMap<ResourcesOrigin, Rc<ImageXObjects>> =
+    let mut xobject_cache: std::collections::BTreeMap<XObjectsOrigin, Rc<ImageXObjects>> =
         std::collections::BTreeMap::new();
 
     for (&page_num, &page_id) in &doc.get_pages() {
@@ -620,11 +666,12 @@ fn extract_image_items(
         }
         // Step 1: XObject から画像情報を収集 (共有 resources なら memoise 済みを再利用)
         // Resources は親 /Pages ノードから継承される場合があるため、継承チェーンを辿る。
-        let Some((origin, resources)) = resolve_page_resources(doc, page_id) else {
+        let Some((res_origin, resources)) = resolve_page_resources(doc, page_id) else {
             continue;
         };
-        // Scan once per distinct dictionary, reused by every page that reaches
-        // it. Every origin is cacheable; see `ResourcesOrigin`.
+        // Scan once per distinct `/XObject` dictionary, reused by every page that
+        // reaches it. Every origin is cacheable; see `XObjectsOrigin`.
+        let origin = xobjects_origin(resources, res_origin);
         let image_xobjects: Rc<ImageXObjects> = match xobject_cache.get(&origin) {
             Some(cached) => Rc::clone(cached),
             None => {
@@ -2125,18 +2172,40 @@ mod tests {
     }
 
     /// The whole-document content budget stops the page walk in both passes.
+    ///
+    /// The budget is a multiple of [`PDF_CONTENT_STREAM_COST_FLOOR_BYTES`], which
+    /// is what each of these small pages costs, so it pays for several pages and
+    /// then runs out — the assertions can require that extraction both *happened*
+    /// and stopped early. At exactly the floor the budget would be spent on the
+    /// first page's first stream, and "0 records" would satisfy a bare
+    /// `len() < PAGES` however broken the mechanism was.
     #[test]
     fn limits_content_budget_stops_the_page_walk() {
         const PAGES: usize = 40;
+        const AFFORDABLE: usize = 10;
         let pdf = limits_fixture(PAGES, 0);
 
         let limits = InspectLimits {
-            content_total_bytes: 512,
+            content_total_bytes: PDF_CONTENT_STREAM_COST_FLOOR_BYTES * AFFORDABLE,
             ..InspectLimits::default()
         };
         let (text, images) = inspect_bytes_with_limits(&pdf, &limits);
-        assert!(text.len() < PAGES, "text {}", text.len());
-        assert!(images.len() < PAGES, "images {}", images.len());
+        assert!(
+            !text.is_empty() && text.len() < PAGES,
+            "expected 1..{PAGES} text records, got {}",
+            text.len()
+        );
+        assert!(
+            !images.is_empty() && images.len() < PAGES,
+            "expected 1..{PAGES} images, got {}",
+            images.len()
+        );
+
+        // Same input, ample budget: nothing is truncated, so the truncation above
+        // is attributable to the content budget and not to the fixture.
+        let (text, images) = inspect_bytes_with_limits(&pdf, &InspectLimits::default());
+        assert_eq!(text.len(), PAGES);
+        assert_eq!(images.len(), PAGES);
     }
 
     /// The text-byte budget stops extraction, and does so independently of the
@@ -2399,6 +2468,185 @@ mod tests {
             [2],
             "expected exactly page 2 to report an image, got {:?}",
             result.images
+        );
+    }
+
+    /// A content stream is charged for the bytes its filter *consumed*, not only
+    /// for what it produced.
+    ///
+    /// `/ASCII85Decode` ignores whitespace, so a stream of nothing but whitespace
+    /// and the `~>` terminator is fully scanned and decodes to zero bytes. Charging
+    /// the decoded length alone would price a megabyte of that at the floor.
+    #[test]
+    fn limits_encoded_bytes_are_charged_even_when_decoding_yields_nothing() {
+        use lopdf::{Document, Object, Stream, dictionary};
+
+        const ENCODED: usize = 64 * 1024;
+        let mut doc = Document::with_version("1.5");
+        let pages_id = doc.new_object_id();
+        let resources_id = doc.add_object(dictionary! {
+            "Font" => dictionary! {
+                "F1" => dictionary! {
+                    "Type" => "Font", "Subtype" => "Type1", "BaseFont" => "Courier",
+                },
+            },
+        });
+        // Whitespace plus the end-of-data marker: scanned in full, decodes empty.
+        let mut a85 = vec![b' '; ENCODED];
+        a85.extend_from_slice(b"~>");
+        let mut a85_stream = Stream::new(dictionary! {}, a85);
+        a85_stream.dict.set("Filter", "ASCII85Decode");
+        assert_eq!(
+            a85_stream.decompressed_content().ok().map(|d| d.len()),
+            Some(0),
+            "test relies on this stream decoding to nothing"
+        );
+        let contents = vec![
+            Object::Reference(doc.add_object(a85_stream)),
+            Object::Reference(doc.add_object(Stream::new(
+                dictionary! {},
+                b"BT /F1 12 Tf 1 0 0 1 10 800 Tm (Reached) Tj ET".to_vec(),
+            ))),
+        ];
+        let page_id = doc.add_object(dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "Contents" => contents,
+            "Resources" => resources_id,
+            "MediaBox" => vec![
+                Object::Integer(0), Object::Integer(0),
+                Object::Integer(595), Object::Integer(842),
+            ],
+        });
+        doc.objects.insert(
+            pages_id,
+            Object::Dictionary(dictionary! {
+                "Type" => "Pages",
+                "Kids" => vec![Object::Reference(page_id)],
+                "Count" => Object::Integer(1),
+            }),
+        );
+        let catalog_id = doc.add_object(dictionary! { "Type" => "Catalog", "Pages" => pages_id });
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+        let mut buf = Vec::new();
+        doc.save_to(&mut buf).unwrap();
+
+        // A budget that the *encoded* length alone exhausts, but which the decoded
+        // length (zero, so just the floor) would leave nearly untouched.
+        let starved = InspectLimits {
+            content_total_bytes: ENCODED / 4,
+            ..InspectLimits::default()
+        };
+        let (text, _) = inspect_bytes_with_limits(&buf, &starved);
+        assert!(
+            text.is_empty(),
+            "encoded bytes must draw down the budget, got {text:?}"
+        );
+
+        let ample = InspectLimits {
+            content_total_bytes: ENCODED * 4,
+            ..InspectLimits::default()
+        };
+        let (text, _) = inspect_bytes_with_limits(&buf, &ample);
+        assert_eq!(
+            text.iter().map(|i| i.text.as_str()).collect::<Vec<_>>(),
+            ["Reached"]
+        );
+    }
+
+    /// One shared indirect `/XObject` dictionary is scanned once even when the
+    /// resources dictionaries pointing at it are all distinct.
+    ///
+    /// The cache is keyed on the `/XObject` dictionary, so distinct per-page
+    /// resources wrappers around one shared dictionary collapse to a single
+    /// origin — the identity that the scan result actually depends on.
+    #[test]
+    fn xobjects_origin_follows_the_shared_dictionary_not_the_wrapper() {
+        use lopdf::{Document, Object, Stream, dictionary};
+
+        let mut doc = Document::with_version("1.5");
+        let pages_id = doc.new_object_id();
+        let image_id = doc.add_object(Stream::new(
+            dictionary! {
+                "Type" => "XObject", "Subtype" => "Image",
+                "Width" => Object::Integer(4), "Height" => Object::Integer(4),
+                "ColorSpace" => "DeviceGray", "BitsPerComponent" => Object::Integer(8),
+            },
+            vec![0u8; 16],
+        ));
+        // One indirect XObject dictionary, wrapped by two *distinct* direct
+        // resources dictionaries.
+        let shared_xobjects = doc.add_object(dictionary! { "Im0" => Object::Reference(image_id) });
+        let mut origins = Vec::new();
+        let mut kids = Vec::new();
+        for _ in 0..2 {
+            let page = doc.add_object(dictionary! {
+                "Type" => "Page",
+                "Parent" => pages_id,
+                "Resources" => dictionary! { "XObject" => Object::Reference(shared_xobjects) },
+            });
+            kids.push(Object::Reference(page));
+        }
+        doc.objects.insert(
+            pages_id,
+            Object::Dictionary(dictionary! {
+                "Type" => "Pages",
+                "Kids" => kids.clone(),
+                "Count" => Object::Integer(2),
+            }),
+        );
+        for kid in &kids {
+            let page_id = kid.as_reference().unwrap();
+            let (res_origin, resources) = resolve_page_resources(&doc, page_id).expect("resources");
+            // Each page's *resources* dictionary is its own.
+            assert_eq!(res_origin, ResourcesOrigin::DirectIn(page_id));
+            origins.push(xobjects_origin(resources, res_origin));
+        }
+        // But both resolve to the same XObject dictionary, so one cache entry.
+        assert_eq!(origins[0], XObjectsOrigin::Object(shared_xobjects));
+        assert_eq!(origins[0], origins[1]);
+    }
+
+    /// `/Info` metadata strings are clamped: the metadata pass has no per-page or
+    /// per-record structure, so the text and item budgets do not reach it.
+    #[test]
+    fn metadata_fields_are_clamped() {
+        use lopdf::{Document, Object, dictionary};
+
+        let long = "T".repeat(MAX_PDF_METADATA_FIELD_BYTES * 4);
+        let multibyte = "あ".repeat(MAX_PDF_METADATA_FIELD_BYTES);
+        let mut doc = Document::with_version("1.5");
+        let pages_id = doc.new_object_id();
+        doc.objects.insert(
+            pages_id,
+            Object::Dictionary(dictionary! {
+                "Type" => "Pages", "Kids" => Vec::<Object>::new(), "Count" => Object::Integer(0),
+            }),
+        );
+        let catalog_id = doc.add_object(dictionary! { "Type" => "Catalog", "Pages" => pages_id });
+        let info_id = doc.add_object(dictionary! {
+            "Title" => Object::string_literal(long.as_str()),
+            "Author" => Object::string_literal(multibyte.as_str()),
+        });
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+        doc.trailer.set("Info", Object::Reference(info_id));
+        let mut buf = Vec::new();
+        doc.save_to(&mut buf).unwrap();
+
+        let result = inspect_bytes(&buf);
+        let title = result.metadata.title.expect("title");
+        assert_eq!(title.len(), MAX_PDF_METADATA_FIELD_BYTES);
+        let author = result.metadata.author.expect("author");
+        assert!(
+            author.len() <= MAX_PDF_METADATA_FIELD_BYTES,
+            "author {} bytes",
+            author.len()
+        );
+        // Latin-1 fallback widens each byte to a 2-byte code point, so the clamp
+        // has to land on a character boundary rather than mid-sequence.
+        assert!(
+            author.chars().all(|c| c != '\u{FFFD}'),
+            "clamped mid-character"
         );
     }
 

--- a/crates/fulgur/src/inspect.rs
+++ b/crates/fulgur/src/inspect.rs
@@ -135,8 +135,27 @@ fn clamp_font_name(name: &str) -> &str {
     clamp_str_bytes(name, MAX_PDF_FONT_NAME_BYTES)
 }
 
-/// Decoded content-stream bytes, keyed by stream object id, so a stream shared
-/// by several pages is decoded once. Retained bytes are bounded by the same
+/// Follow reference aliases to the object an id really names.
+///
+/// `Document::get_page_contents` returns the ids written in a `/Contents` array
+/// without dereferencing them, while `get_object` does follow chains — so two
+/// distinct alias objects pointing at one stream reach the same content, and a
+/// cache keyed on the immediate id would miss for every alias. The loop is
+/// bounded like the `/Parent` walk; a chain longer than the bound yields a
+/// mid-chain id, which costs a cache miss but stays correct.
+fn canonical_object_id(doc: &lopdf::Document, mut id: lopdf::ObjectId) -> lopdf::ObjectId {
+    for _ in 0..MAX_PDF_PARENT_DEPTH {
+        match doc.objects.get(&id) {
+            Some(lopdf::Object::Reference(next)) => id = *next,
+            _ => break,
+        }
+    }
+    id
+}
+
+/// Decoded content-stream bytes, keyed by *canonical* stream object id, so a
+/// stream shared by several pages — directly or through aliases — is decoded
+/// once. Retained bytes are bounded by the same
 /// [`MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES`] budget that charges each distinct
 /// stream as it is decoded.
 type DecodedStreams = std::collections::BTreeMap<lopdf::ObjectId, Rc<Vec<u8>>>;
@@ -212,7 +231,10 @@ fn gather_page_content(
     }
 
     let mut content: Vec<u8> = Vec::new();
-    for object_id in doc.get_page_contents(page_id) {
+    for entry_id in doc.get_page_contents(page_id) {
+        // Alias objects must collapse to the stream they name, or each alias is
+        // a fresh cache miss and re-runs the filter chain.
+        let object_id = canonical_object_id(doc, entry_id);
         let bytes: Rc<Vec<u8>> = match decoded_cache.get(&object_id) {
             // Decoded already for an earlier page: no filter work to charge, only
             // the copy into `content` below.
@@ -293,8 +315,13 @@ fn extract_metadata(doc: &lopdf::Document) -> Metadata {
         dict.get(key)
             .ok()
             .and_then(|o| o.as_str().ok())
-            .map(decode_pdf_string)
-            .map(|s| clamp_str_bytes(&s, MAX_PDF_METADATA_FIELD_BYTES).to_owned())
+            .map(|bytes| {
+                // Decode a bounded *prefix*: decoding the whole value and truncating
+                // afterwards would still allocate all of it, and the Latin-1 path
+                // widens each byte to as much as two UTF-8 bytes on the way.
+                let decoded = decode_pdf_string(metadata_prefix(bytes));
+                clamp_str_bytes(&decoded, MAX_PDF_METADATA_FIELD_BYTES).to_owned()
+            })
     };
 
     meta.title = get_str(info, b"Title");
@@ -652,11 +679,21 @@ type ImageXObjects = std::collections::BTreeMap<String, (String, u32, u32)>;
 /// why [`extract_image_items`] memoises the result rather than repeating this
 /// per page. Non-image XObjects (`/Form`, …) are skipped, so a page can pay the
 /// full scan and collect nothing.
-fn collect_image_xobjects(doc: &lopdf::Document, resources: &lopdf::Dictionary) -> ImageXObjects {
+///
+/// Returns the collected images together with the number of entries examined, so
+/// the caller can charge the scan. Both the work and the retained result scale
+/// with that count, and neither is covered by the content or operation budgets:
+/// a page that collects no image skips content decoding entirely.
+fn collect_image_xobjects(
+    doc: &lopdf::Document,
+    resources: &lopdf::Dictionary,
+) -> (ImageXObjects, usize) {
     let mut image_xobjects = ImageXObjects::new();
+    let mut examined = 0usize;
     if let Ok(xo) = resources.get(b"XObject") {
         if let Ok((_, lopdf::Object::Dictionary(xobjects))) = doc.dereference(xo) {
             for (name, obj_ref) in xobjects.iter() {
+                examined += 1;
                 if let Ok((_, lopdf::Object::Stream(xobj))) = doc.dereference(obj_ref) {
                     let subtype = xobj
                         .dict
@@ -685,7 +722,7 @@ fn collect_image_xobjects(doc: &lopdf::Document, resources: &lopdf::Dictionary) 
             }
         }
     }
-    image_xobjects
+    (image_xobjects, examined)
 }
 
 fn transform_point(m: &[f32; 6], x: f32, y: f32) -> (f32, f32) {
@@ -731,8 +768,19 @@ fn extract_image_items(
         let image_xobjects: Rc<ImageXObjects> = match xobject_cache.get(&origin) {
             Some(cached) => Rc::clone(cached),
             None => {
-                let scanned = Rc::new(collect_image_xobjects(doc, resources));
+                let (scanned, examined) = collect_image_xobjects(doc, resources);
+                // Charge the scan: one dereference per entry, priced like any
+                // other object touch. This is what bounds the cache as well as
+                // the work — every insertion is preceded by a charge
+                // proportional to the entries it retains, so the whole cache is
+                // bounded by the content budget rather than by the page count.
+                content_budget =
+                    content_budget.saturating_sub(examined * PDF_CONTENT_STREAM_COST_FLOOR_BYTES);
+                let scanned = Rc::new(scanned);
                 xobject_cache.insert(origin, Rc::clone(&scanned));
+                if content_budget == 0 {
+                    break;
+                }
                 scanned
             }
         };
@@ -902,6 +950,25 @@ fn decode_pdf_string(bytes: &[u8]) -> String {
         return String::from_utf16_lossy(&chars);
     }
     bytes.iter().map(|&b| b as char).collect()
+}
+
+/// The longest prefix of a raw metadata string worth decoding, bounded so an
+/// oversized `/Info` value cannot force a large allocation before the clamp
+/// applies.
+///
+/// Decoding widens: the Latin-1 fallback turns each high byte into two UTF-8
+/// bytes, so a prefix of [`MAX_PDF_METADATA_FIELD_BYTES`] yields at most twice
+/// that before [`clamp_str_bytes`] trims it. A UTF-16BE value is cut on an even
+/// boundary after its BOM, so a code unit is never split.
+fn metadata_prefix(bytes: &[u8]) -> &[u8] {
+    if bytes.len() <= MAX_PDF_METADATA_FIELD_BYTES {
+        return bytes;
+    }
+    let mut end = MAX_PDF_METADATA_FIELD_BYTES;
+    if bytes.len() >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF && (end - 2) % 2 != 0 {
+        end -= 1;
+    }
+    &bytes[..end]
 }
 
 fn estimate_width(text: &str, font_size: f32) -> f32 {
@@ -2845,6 +2912,158 @@ mod tests {
         assert_eq!(origins[0], XObjectsOrigin::Object(real));
         assert_eq!(origins[0], origins[1]);
         assert_eq!(origins[0], origins[2]);
+    }
+
+    /// A `/Contents` entry that is an *alias* — a reference object pointing at
+    /// the real stream — collapses to the same cache key as the stream itself.
+    ///
+    /// `get_page_contents` returns the ids written in the array without following
+    /// them, so without canonicalisation every alias is a fresh cache miss and
+    /// re-runs the filter chain that the cache exists to avoid.
+    #[test]
+    fn content_stream_aliases_share_one_cache_entry() {
+        use lopdf::{Document, Object, Stream, dictionary};
+
+        const ENCODED: usize = 32 * 1024;
+        const ALIASES: usize = 32;
+        let mut doc = Document::with_version("1.5");
+        let pages_id = doc.new_object_id();
+        let resources_id = doc.add_object(dictionary! {
+            "Font" => dictionary! {
+                "F1" => dictionary! {
+                    "Type" => "Font", "Subtype" => "Type1", "BaseFont" => "Courier",
+                },
+            },
+        });
+        let mut a85 = vec![b' '; ENCODED];
+        a85.extend_from_slice(b"~>");
+        let mut a85_stream = Stream::new(dictionary! {}, a85);
+        a85_stream.dict.set("Filter", "ASCII85Decode");
+        let real = doc.add_object(a85_stream);
+        // Every /Contents entry is its own alias object pointing at `real`.
+        let contents: Vec<Object> = (0..ALIASES)
+            .map(|_| Object::Reference(doc.add_object(Object::Reference(real))))
+            .collect();
+        let page_id = doc.add_object(dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "Contents" => contents,
+            "Resources" => resources_id,
+            "MediaBox" => vec![
+                Object::Integer(0), Object::Integer(0),
+                Object::Integer(595), Object::Integer(842),
+            ],
+        });
+        doc.objects.insert(
+            pages_id,
+            Object::Dictionary(dictionary! {
+                "Type" => "Pages",
+                "Kids" => vec![Object::Reference(page_id)],
+                "Count" => Object::Integer(1),
+            }),
+        );
+        let catalog_id = doc.add_object(dictionary! { "Type" => "Catalog", "Pages" => pages_id });
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+        let mut buf = Vec::new();
+        doc.save_to(&mut buf).unwrap();
+        let loaded = Document::load_mem(&buf).unwrap();
+        let page = *loaded.get_pages().values().next().unwrap();
+
+        let mut budget = ENCODED + ALIASES * PDF_CONTENT_STREAM_COST_FLOOR_BYTES * 3;
+        assert!(
+            budget < ENCODED * ALIASES,
+            "budget must forbid one decode per alias"
+        );
+        let mut cache = DecodedStreams::new();
+        assert!(matches!(
+            gather_page_content(&loaded, page, &mut budget, &mut cache),
+            PageContent::Ready(_)
+        ));
+        assert_eq!(cache.len(), 1, "all aliases must share one cache entry");
+    }
+
+    /// Metadata is decoded from a bounded prefix, so an oversized value cannot
+    /// force a large allocation that the clamp then discards.
+    #[test]
+    fn metadata_prefix_is_bounded_before_decoding() {
+        // Latin-1 high bytes widen to two UTF-8 bytes each, so the prefix bound
+        // is what keeps the intermediate allocation small.
+        let wide = vec![0xFFu8; MAX_PDF_METADATA_FIELD_BYTES * 8];
+        let prefix = metadata_prefix(&wide);
+        assert_eq!(prefix.len(), MAX_PDF_METADATA_FIELD_BYTES);
+        assert!(decode_pdf_string(prefix).len() <= MAX_PDF_METADATA_FIELD_BYTES * 2);
+
+        // UTF-16BE: cut after the BOM on an even boundary so no code unit splits.
+        let mut utf16 = vec![0xFE, 0xFF];
+        utf16.extend(std::iter::repeat_n([0x00, 0x41], MAX_PDF_METADATA_FIELD_BYTES).flatten());
+        let prefix = metadata_prefix(&utf16);
+        assert_eq!((prefix.len() - 2) % 2, 0, "UTF-16 code unit split");
+        assert!(!decode_pdf_string(prefix).contains('\u{FFFD}'));
+
+        // Short values are untouched.
+        assert_eq!(metadata_prefix(b"Title"), b"Title");
+    }
+
+    /// The image XObject scan is charged per entry examined, which bounds both
+    /// the scanning work and the size of the retained cache.
+    ///
+    /// Without this, a page declaring many XObjects but no content emitted no
+    /// records and decoded nothing, so it advanced no budget while its scan
+    /// result stayed cached for the rest of the pass.
+    #[test]
+    fn xobject_scans_are_charged_per_entry() {
+        use lopdf::{Document, Object, dictionary};
+
+        const ENTRIES: usize = 500;
+        let mut doc = Document::with_version("1.5");
+        let pages_id = doc.new_object_id();
+        let mut xobjects = dictionary! {};
+        for i in 0..ENTRIES {
+            // Non-image, so the scan collects nothing and content is skipped.
+            let form = doc.add_object(lopdf::Stream::new(
+                dictionary! { "Type" => "XObject", "Subtype" => "Form" },
+                Vec::new(),
+            ));
+            xobjects.set(format!("X{i}"), Object::Reference(form));
+        }
+        let resources_id = doc.add_object(dictionary! { "XObject" => xobjects });
+        let mut kids = Vec::new();
+        for _ in 0..8 {
+            kids.push(Object::Reference(doc.add_object(dictionary! {
+                "Type" => "Page",
+                "Parent" => pages_id,
+                "Resources" => Object::Reference(resources_id),
+                "MediaBox" => vec![
+                    Object::Integer(0), Object::Integer(0),
+                    Object::Integer(595), Object::Integer(842),
+                ],
+            })));
+        }
+        let count = kids.len() as i64;
+        doc.objects.insert(
+            pages_id,
+            Object::Dictionary(dictionary! {
+                "Type" => "Pages", "Kids" => kids, "Count" => Object::Integer(count),
+            }),
+        );
+        let catalog_id = doc.add_object(dictionary! { "Type" => "Catalog", "Pages" => pages_id });
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+        let mut buf = Vec::new();
+        doc.save_to(&mut buf).unwrap();
+
+        // A budget smaller than one full scan: the pass must stop rather than
+        // scan and retain regardless.
+        let starved = InspectLimits {
+            content_total_bytes: ENTRIES * PDF_CONTENT_STREAM_COST_FLOOR_BYTES / 2,
+            ..InspectLimits::default()
+        };
+        let (_, images) = inspect_bytes_with_limits(&buf, &starved);
+        assert!(images.is_empty());
+
+        // With the default budget the same document is walked without trouble,
+        // and the shared dictionary is scanned once rather than once per page.
+        let (_, images) = inspect_bytes_with_limits(&buf, &InspectLimits::default());
+        assert!(images.is_empty(), "non-image XObjects yield no placements");
     }
 
     /// The item budget stops extraction in both passes.

--- a/crates/fulgur/src/inspect.rs
+++ b/crates/fulgur/src/inspect.rs
@@ -148,10 +148,17 @@ fn clamp_font_name(name: &str) -> &str {
 /// budget from whatever id it is handed, so stopping mid-chain and letting it
 /// finish the walk would compose two limits: aliases converging past this bound
 /// would each yield a different key while still resolving to one stream, and
-/// every one would re-run its filter chain. Rejecting is also the stricter
-/// direction — no producer emits a `/Contents` chain that deep.
+/// every one would re-run its filter chain.
+///
+/// The bound is the *link* budget, so the loop runs one iteration more than that:
+/// the extra pass performs no hop, it only probes the object the last permitted
+/// hop landed on. This matches lopdf exactly — `Document::dereference` increments
+/// after following a reference and fails on `nb_deref > DEREF_LIMIT`, so a chain
+/// of precisely [`MAX_PDF_PARENT_DEPTH`] references resolves there and must
+/// resolve here too. Returning `None` one link early would silently skip a stream
+/// the previous extraction path read.
 fn canonical_object_id(doc: &lopdf::Document, mut id: lopdf::ObjectId) -> Option<lopdf::ObjectId> {
-    for _ in 0..MAX_PDF_PARENT_DEPTH {
+    for _ in 0..=MAX_PDF_PARENT_DEPTH {
         match doc.objects.get(&id) {
             Some(lopdf::Object::Reference(next)) => id = *next,
             // Not a reference (the target), or absent — either way this is the id
@@ -588,7 +595,13 @@ fn resolve_page_resources(
 ) -> Option<(ResourcesOrigin, &lopdf::Dictionary)> {
     let mut current_id = page_id;
     for _ in 0..MAX_PDF_PARENT_DEPTH {
-        let dict = match doc.get_object(current_id) {
+        // Canonicalise before both the lookup and the identity: page-tree `Kids`
+        // entries and `/Parent` back-references may be alias objects, and
+        // `get_object` follows them silently. Keying `DirectIn` on the immediate
+        // id would hand one shared page dictionary a distinct identity per alias,
+        // so the cache would rescan and retain a separate map for each.
+        let owner_id = canonical_object_id(doc, current_id)?;
+        let dict = match doc.get_object(owner_id) {
             Ok(lopdf::Object::Dictionary(d)) => d,
             _ => return None,
         };
@@ -599,7 +612,7 @@ fn resolve_page_resources(
                     Some(id) => ResourcesOrigin::Object(id),
                     // A direct dictionary nested inside the object being examined
                     // — whether that is the page itself or an ancestor node.
-                    None => ResourcesOrigin::DirectIn(current_id),
+                    None => ResourcesOrigin::DirectIn(owner_id),
                 };
                 return Some((origin, resources));
             }
@@ -2963,31 +2976,58 @@ mod tests {
         assert_eq!(images.len(), 1);
     }
 
-    /// An alias chain too deep to canonicalise is rejected rather than decoded
-    /// under a non-canonical key.
+    /// Canonicalisation accepts a chain exactly when lopdf's own `get_object`
+    /// does, and rejects deeper ones rather than decoding under a mid-chain key.
     ///
-    /// `get_object` would begin a fresh `DEREF_LIMIT` from wherever the walk
-    /// stopped, so a mid-chain id would still resolve — giving each such alias its
-    /// own cache key for one shared stream.
+    /// Asserting the *equivalence* rather than a hardcoded link count is the
+    /// point: two independent limits are in play — this loop's and lopdf's
+    /// `DEREF_LIMIT` — and either being one link stricter than the other is a
+    /// silent bug in a different direction. Stricter here skips a stream
+    /// `get_object` would have read; looser hands each alias converging past
+    /// lopdf's bound its own cache key for one shared stream. A sweep over
+    /// lengths straddling the bound pins both edges and cannot drift.
     #[test]
-    fn overlong_alias_chains_are_rejected() {
+    fn canonicalisation_matches_lopdf_dereference_limit() {
         use lopdf::{Document, Object, Stream, dictionary};
 
         let mut doc = Document::with_version("1.5");
         let real = doc.add_object(Stream::new(dictionary! {}, b"BT ET".to_vec()));
-        // A chain of exactly MAX_PDF_PARENT_DEPTH links resolves.
-        let mut id = real;
-        for _ in 0..MAX_PDF_PARENT_DEPTH - 1 {
-            id = doc.add_object(Object::Reference(id));
+        // `chain[k]` is the id whose alias chain reaches `real` in `k` links, so
+        // `chain[0]` is the stream itself — its own canonical form.
+        let mut chain = vec![real];
+        for _ in 0..MAX_PDF_PARENT_DEPTH + 2 {
+            let next = doc.add_object(Object::Reference(*chain.last().unwrap()));
+            chain.push(next);
         }
-        assert_eq!(canonical_object_id(&doc, id), Some(real));
 
-        // One link further and it is rejected instead of half-resolved.
-        let too_deep = doc.add_object(Object::Reference(id));
-        assert_eq!(canonical_object_id(&doc, too_deep), None);
-
-        // A plain, non-reference id is its own canonical form.
-        assert_eq!(canonical_object_id(&doc, real), Some(real));
+        let mut accepted = 0usize;
+        for (links, &id) in chain.iter().enumerate() {
+            let canonical = canonical_object_id(&doc, id);
+            let lopdf_reads_it = doc.get_object(id).is_ok();
+            assert_eq!(
+                canonical.is_some(),
+                lopdf_reads_it,
+                "{links}-link chain: canonicalised to {canonical:?} but get_object \
+                 {}; the two limits have drifted apart",
+                if lopdf_reads_it {
+                    "succeeded"
+                } else {
+                    "failed"
+                },
+            );
+            if canonical.is_some() {
+                assert_eq!(canonical, Some(real), "{links}-link chain resolved short");
+                accepted += 1;
+            }
+        }
+        // Guard the sweep itself: it must straddle the bound, not sit entirely on
+        // one side of it and pass vacuously.
+        assert_eq!(
+            accepted,
+            MAX_PDF_PARENT_DEPTH + 1,
+            "expected chains of 0..={MAX_PDF_PARENT_DEPTH} links to resolve and \
+             longer ones to be rejected",
+        );
     }
 
     /// An `/XObject` reached through an alias object resolves to the same origin
@@ -3016,6 +3056,47 @@ mod tests {
         assert_eq!(origins[0], XObjectsOrigin::Object(real));
         assert_eq!(origins[0], origins[1]);
         assert_eq!(origins[0], origins[2]);
+    }
+
+    /// A page reached through an alias id yields the same origin as the page
+    /// itself, so a shared `/Page` with *direct* `/Resources` is scanned once.
+    ///
+    /// `Kids` entries and `/Parent` back-references may be alias objects, and
+    /// `get_object` follows them silently — so the dictionary is the same one
+    /// every time, but keying on the immediate id would name it differently per
+    /// alias and make the cache rescan and retain a map for each.
+    #[test]
+    fn direct_resources_origin_canonicalises_page_aliases() {
+        use lopdf::{Document, Object, dictionary};
+
+        let mut doc = Document::with_version("1.5");
+        let pages_id = doc.new_object_id();
+        // One page, whose /Resources and /XObject are both direct dictionaries.
+        let page_id = doc.add_object(dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "Resources" => dictionary! { "XObject" => dictionary! { "Im0" => Object::Null } },
+        });
+        // Two Kids ids that are alias objects for that one page.
+        let alias_a = doc.add_object(Object::Reference(page_id));
+        let alias_b = doc.add_object(Object::Reference(page_id));
+
+        let mut origins = Vec::new();
+        for id in [alias_a, alias_b, page_id] {
+            let (res_origin, resources) = resolve_page_resources(&doc, id).expect("resources");
+            origins.push((res_origin, xobjects_origin(&doc, resources, res_origin)));
+        }
+        assert_eq!(
+            origins[0].0,
+            ResourcesOrigin::DirectIn(page_id),
+            "origin must name the page the alias resolves to, not the alias",
+        );
+        assert_eq!(origins[0], origins[1]);
+        assert_eq!(origins[0], origins[2]);
+        assert_eq!(
+            origins[0].1,
+            XObjectsOrigin::DirectIn(ResourcesOrigin::DirectIn(page_id)),
+        );
     }
 
     /// A `/Contents` entry that is an *alias* — a reference object pointing at

--- a/crates/fulgur/src/inspect.rs
+++ b/crates/fulgur/src/inspect.rs
@@ -3,8 +3,9 @@ use std::path::Path;
 use std::rc::Rc;
 
 use crate::{
-    MAX_PDF_CONTENT_BYTES, MAX_PDF_FONT_NAME_BYTES, MAX_PDF_GS_STACK_DEPTH, MAX_PDF_INSPECT_ITEMS,
-    MAX_PDF_PARENT_DEPTH,
+    MAX_PDF_CONTENT_BYTES, MAX_PDF_FONT_NAME_BYTES, MAX_PDF_GS_STACK_DEPTH,
+    MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES, MAX_PDF_INSPECT_ITEMS, MAX_PDF_INSPECT_OPERATIONS,
+    MAX_PDF_INSPECT_TEXT_BYTES, MAX_PDF_PARENT_DEPTH,
 };
 
 const IDENTITY: [f32; 6] = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0];
@@ -97,11 +98,23 @@ fn clamp_font_name(name: &str) -> &str {
     &name[..end]
 }
 
+/// Outcome of gathering one page's content, which distinguishes "skip this
+/// page" from "stop walking pages".
+enum PageContent {
+    /// Decoded content for this page, within both the per-page and the
+    /// whole-document bound.
+    Ready(Vec<u8>),
+    /// This page exceeds [`MAX_PDF_CONTENT_BYTES`]. Later pages are still
+    /// walked — only this one is skipped.
+    Skip,
+    /// The whole-document budget is spent; the caller stops walking pages.
+    Exhausted,
+}
+
 /// Gather a page's decoded content streams, abandoning the page as soon as the
-/// running total exceeds [`MAX_PDF_CONTENT_BYTES`].
-///
-/// Returns `None` when the page is over budget — the caller skips it, matching
-/// how the module treats every other malformed or oversized structure.
+/// running total exceeds [`MAX_PDF_CONTENT_BYTES`] and reporting exhaustion once
+/// `doc_budget` — the document's remaining
+/// [`MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES`] allowance — is spent.
 ///
 /// This exists instead of `lopdf::Document::get_page_content` because that
 /// method inflates *every* content stream of the page and concatenates them
@@ -109,7 +122,7 @@ fn clamp_font_name(name: &str) -> &str {
 /// gets parsed, not what gets allocated. Accumulating with a running budget
 /// bounds the concatenated total.
 ///
-/// For a page under the bound the result is byte-for-byte what
+/// For a page within both bounds the result is byte-for-byte what
 /// `get_page_content` returns, which is what keeps extraction unchanged for
 /// real documents: each stream contributes its decoded bytes — or its raw,
 /// still-encoded bytes when decoding fails, as `lopdf` does — followed by the
@@ -118,11 +131,21 @@ fn clamp_font_name(name: &str) -> &str {
 /// resolve to a stream object are skipped individually, not treated as
 /// abandoning the page.
 ///
-/// The `\n` separators count against the budget, so the accept/reject decision
-/// is identical to testing `get_page_content`'s total: the running total rises
-/// monotonically to exactly that sum, so some prefix exceeds the bound if and
-/// only if the total does.
-fn gather_page_content(doc: &lopdf::Document, page_id: lopdf::ObjectId) -> Option<Vec<u8>> {
+/// The `\n` separators count against the per-page budget, so the per-page
+/// accept/reject decision is identical to testing `get_page_content`'s total:
+/// the running total rises monotonically to exactly that sum, so some prefix
+/// exceeds the bound if and only if the total does.
+///
+/// `doc_budget` is charged for every stream decoded, *before* the per-page
+/// verdict is known, so a page that is about to be skipped still pays for the
+/// work its decoding cost. Charging only usable pages would leave the aggregate
+/// unbounded, since a page can be made to decode a full per-page allowance and
+/// then be rejected.
+fn gather_page_content(
+    doc: &lopdf::Document,
+    page_id: lopdf::ObjectId,
+    doc_budget: &mut usize,
+) -> PageContent {
     let mut content: Vec<u8> = Vec::new();
     for object_id in doc.get_page_contents(page_id) {
         let Ok(stream) = doc.get_object(object_id).and_then(lopdf::Object::as_stream) else {
@@ -133,14 +156,18 @@ fn gather_page_content(doc: &lopdf::Document, page_id: lopdf::ObjectId) -> Optio
             Ok(ref d) => d,
             Err(_) => &stream.content,
         };
+        *doc_budget = doc_budget.saturating_sub(bytes.len());
+        if *doc_budget == 0 {
+            return PageContent::Exhausted;
+        }
         // +1 for the `\n` separator appended after every stream.
         if content.len() + bytes.len() + 1 > MAX_PDF_CONTENT_BYTES {
-            return None;
+            return PageContent::Skip;
         }
         content.extend_from_slice(bytes);
         content.push(b'\n');
     }
-    Some(content)
+    PageContent::Ready(content)
 }
 
 fn extract_metadata(doc: &lopdf::Document) -> Metadata {
@@ -175,19 +202,32 @@ fn extract_metadata(doc: &lopdf::Document) -> Metadata {
 fn extract_text_items(doc: &lopdf::Document) -> crate::Result<Vec<TextItem>> {
     use lopdf::content::Operation;
     let mut items = Vec::new();
+    // Whole-document budgets. Page count is bounded only by input size, so the
+    // per-page content bound and the record *count* cap both leave a document
+    // total unbounded — see the constants for the measured shapes.
+    let mut content_budget = MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES;
+    let mut op_budget = MAX_PDF_INSPECT_OPERATIONS;
+    let mut text_bytes: usize = 0;
 
     for (&page_num, &page_id) in &doc.get_pages() {
-        if items.len() >= MAX_PDF_INSPECT_ITEMS {
+        if items.len() >= MAX_PDF_INSPECT_ITEMS
+            || text_bytes >= MAX_PDF_INSPECT_TEXT_BYTES
+            || op_budget == 0
+        {
             break;
         }
-        let content_bytes = match gather_page_content(doc, page_id) {
-            Some(b) => b,
-            None => continue,
+        let content_bytes = match gather_page_content(doc, page_id, &mut content_budget) {
+            PageContent::Ready(b) => b,
+            PageContent::Skip => continue,
+            PageContent::Exhausted => break,
         };
         let content = match lopdf::content::Content::decode(&content_bytes) {
             Ok(c) => c,
             Err(_) => continue,
         };
+        // Charged after decoding, so this page — already paid for — is still
+        // walked and the *next* page is the one refused.
+        op_budget = op_budget.saturating_sub(content.operations.len());
 
         let identity = IDENTITY;
         // Graphics state stack: (CTM, font_name, font_size).
@@ -217,7 +257,7 @@ fn extract_text_items(doc: &lopdf::Document) -> crate::Result<Vec<TextItem>> {
         let mut text_leading: f32 = 0.0;
 
         for Operation { operator, operands } in &content.operations {
-            if items.len() >= MAX_PDF_INSPECT_ITEMS {
+            if items.len() >= MAX_PDF_INSPECT_ITEMS || text_bytes >= MAX_PDF_INSPECT_TEXT_BYTES {
                 break;
             }
             // Inside a `q` frame dropped for exceeding MAX_PDF_GS_STACK_DEPTH.
@@ -332,6 +372,7 @@ fn extract_text_items(doc: &lopdf::Document) -> crate::Result<Vec<TextItem>> {
                             let text = decode_pdf_string(bytes);
                             if !text.trim().is_empty() {
                                 let w = estimate_width(&text, font_size);
+                                text_bytes += text.len();
                                 items.push(TextItem {
                                     page: page_num,
                                     x: tx,
@@ -358,6 +399,7 @@ fn extract_text_items(doc: &lopdf::Document) -> crate::Result<Vec<TextItem>> {
                             }
                             if !combined.trim().is_empty() {
                                 let w = estimate_width(&combined, font_size);
+                                text_bytes += combined.len();
                                 items.push(TextItem {
                                     page: page_num,
                                     x: tx,
@@ -414,9 +456,13 @@ fn transform_point(m: &[f32; 6], x: f32, y: f32) -> (f32, f32) {
 
 fn extract_image_items(doc: &lopdf::Document) -> crate::Result<Vec<ImageItem>> {
     let mut items = Vec::new();
+    // Each pass decodes content independently, so each carries its own
+    // whole-document budget. See `extract_text_items`.
+    let mut content_budget = MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES;
+    let mut op_budget = MAX_PDF_INSPECT_OPERATIONS;
 
     for (&page_num, &page_id) in &doc.get_pages() {
-        if items.len() >= MAX_PDF_INSPECT_ITEMS {
+        if items.len() >= MAX_PDF_INSPECT_ITEMS || op_budget == 0 {
             break;
         }
         // Step 1: XObject から画像情報を一時 map に収集
@@ -464,14 +510,17 @@ fn extract_image_items(doc: &lopdf::Document) -> crate::Result<Vec<ImageItem>> {
         }
 
         // Step 2: content stream から Do オペレータで位置を取得し、突き合わせて push
-        let content_bytes = match gather_page_content(doc, page_id) {
-            Some(b) => b,
-            None => continue,
+        let content_bytes = match gather_page_content(doc, page_id, &mut content_budget) {
+            PageContent::Ready(b) => b,
+            PageContent::Skip => continue,
+            PageContent::Exhausted => break,
         };
         let content = match lopdf::content::Content::decode(&content_bytes) {
             Ok(c) => c,
             Err(_) => continue,
         };
+        // See `extract_text_items`: charged after decoding this page.
+        op_budget = op_budget.saturating_sub(content.operations.len());
 
         let identity = IDENTITY;
         let mut ctm_stack: Vec<[f32; 6]> = vec![identity];
@@ -1695,6 +1744,264 @@ mod tests {
             ["First", "Second", "Third"],
             "streams must be joined with a separator and parsed in order"
         );
+    }
+
+    /// Build a PDF with `pages` page objects that all share a **single**
+    /// `/Contents` stream object holding `payload`.
+    ///
+    /// This is the shape that distinguishes a per-page bound from a
+    /// whole-document one: page count is bounded only by input size, and
+    /// sharing the stream means each additional page costs ~60 bytes on disk
+    /// while re-paying the full per-page decode and extraction cost.
+    fn make_pdf_with_shared_content_stream(
+        pages: usize,
+        payload: Vec<u8>,
+        with_image: bool,
+    ) -> Vec<u8> {
+        use lopdf::{Document, Object, Stream, dictionary};
+
+        let mut doc = Document::with_version("1.5");
+        let pages_id = doc.new_object_id();
+        let mut resources = dictionary! {
+            "Font" => dictionary! {
+                "F1" => dictionary! {
+                    "Type" => "Font", "Subtype" => "Type1", "BaseFont" => "Courier",
+                },
+            },
+        };
+        if with_image {
+            // `extract_image_items` skips a page that resolves no image XObject,
+            // so the image pass is unreachable without this. Kept opt-in: adding
+            // it unconditionally would make the image pass re-walk the content of
+            // every text-only fixture too.
+            let image_id = doc.add_object(Stream::new(
+                dictionary! {
+                    "Type" => "XObject", "Subtype" => "Image",
+                    "Width" => Object::Integer(4), "Height" => Object::Integer(4),
+                    "ColorSpace" => "DeviceGray", "BitsPerComponent" => Object::Integer(8),
+                },
+                vec![0u8; 16],
+            ));
+            resources.set(
+                "XObject",
+                dictionary! { "Im0" => Object::Reference(image_id) },
+            );
+        }
+        let resources_id = doc.add_object(resources);
+        let shared_content = doc.add_object(Stream::new(dictionary! {}, payload));
+        let mut kids = Vec::with_capacity(pages);
+        for _ in 0..pages {
+            kids.push(Object::Reference(doc.add_object(dictionary! {
+                "Type" => "Page",
+                "Parent" => pages_id,
+                "Contents" => Object::Reference(shared_content),
+                "Resources" => resources_id,
+                "MediaBox" => vec![
+                    Object::Integer(0), Object::Integer(0),
+                    Object::Integer(595), Object::Integer(842),
+                ],
+            })));
+        }
+        doc.objects.insert(
+            pages_id,
+            Object::Dictionary(dictionary! {
+                "Type" => "Pages",
+                "Kids" => kids,
+                "Count" => Object::Integer(pages as i64),
+            }),
+        );
+        let catalog_id = doc.add_object(dictionary! { "Type" => "Catalog", "Pages" => pages_id });
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+
+        let mut buf = Vec::new();
+        doc.save_to(&mut buf).unwrap();
+        buf
+    }
+
+    /// [`MAX_PDF_INSPECT_TEXT_BYTES`] bounds retained payload, which a record
+    /// *count* cannot: one `Tj` operand can be nearly a whole page's content
+    /// allowance, so many pages sharing one such stream retain far more text
+    /// than [`MAX_PDF_INSPECT_ITEMS`] records of realistic size ever would.
+    #[test]
+    fn retained_text_bytes_are_capped_across_pages() {
+        const STRING_LEN: usize = 512 * 1024;
+        let payload = {
+            let mut p = b"BT /F1 12 Tf (".to_vec();
+            p.extend(std::iter::repeat_n(b'A', STRING_LEN));
+            p.extend_from_slice(b") Tj ET\n");
+            p
+        };
+        assert!(
+            payload.len() <= MAX_PDF_CONTENT_BYTES,
+            "page must be in bound"
+        );
+
+        // Twice as many pages as the text budget can hold, so it has to stop
+        // mid-document rather than at the end of the input.
+        let pages = (MAX_PDF_INSPECT_TEXT_BYTES / STRING_LEN) * 2;
+        let result = inspect_bytes(&make_pdf_with_shared_content_stream(pages, payload, false));
+
+        let total: usize = result.text_items.iter().map(|i| i.text.len()).sum();
+        // Bounded, with the overshoot limited to the last record pushed.
+        assert!(
+            total <= MAX_PDF_INSPECT_TEXT_BYTES + STRING_LEN,
+            "retained text {total} exceeds the budget plus one record"
+        );
+        // And it genuinely truncated rather than the input being too small.
+        assert!(
+            result.text_items.len() < pages,
+            "expected truncation: got {} records from {} pages",
+            result.text_items.len(),
+            pages
+        );
+        assert!(
+            !result.text_items.is_empty(),
+            "must still extract some text"
+        );
+    }
+
+    /// A page whose content is mostly filler: one cheap record, then enough
+    /// bytes to spend nearly a full [`MAX_PDF_CONTENT_BYTES`] of the
+    /// whole-document budget.
+    ///
+    /// The filler is whitespace rather than the bare `q` operators an attacker
+    /// would use, because it charges the byte budget identically while costing
+    /// ~240× less to decode (measured: 4 MiB of `q` takes 523 ms, the same
+    /// whitespace 2.2 ms). The bound under test counts bytes, not operators, so
+    /// the cheap filler exercises it just as well and keeps the test fast.
+    fn budget_filler_page(op: &[u8]) -> Vec<u8> {
+        let mut payload = op.to_vec();
+        payload.resize(MAX_PDF_CONTENT_BYTES - 64, b' ');
+        payload
+    }
+
+    /// [`MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES`] bounds aggregate decoding work,
+    /// which the per-page bound cannot: every page re-pays it, and page count is
+    /// bounded only by input size.
+    ///
+    /// Asserted through the page walk stopping early — later pages carry the
+    /// same extractable record as earlier ones, so a document of `pages` pages
+    /// yielding fewer than `pages` records can only have been truncated.
+    #[test]
+    fn aggregate_content_decoding_is_capped_across_pages() {
+        let payload = budget_filler_page(b"BT /F1 12 Tf (P) Tj ET\n");
+        let per_page = payload.len() + 1; // +1 for the stream separator
+        // Half again as many pages as the budget can pay for.
+        let pages = (MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES / per_page) * 3 / 2;
+
+        let result = inspect_bytes(&make_pdf_with_shared_content_stream(pages, payload, false));
+        // Every page is still counted: the page tree is walked cheaply and the
+        // bound is on content decoded, not on pages listed.
+        assert_eq!(result.pages as usize, pages);
+        assert!(
+            !result.text_items.is_empty(),
+            "pages within the budget must still be extracted"
+        );
+        assert!(
+            result.text_items.len() < pages,
+            "expected truncation: got {} records from {} pages",
+            result.text_items.len(),
+            pages
+        );
+    }
+
+    /// [`MAX_PDF_INSPECT_OPERATIONS`] bounds operator work, which a byte budget
+    /// cannot do tightly: a `q` is 2 input bytes and ~570 bytes of operation
+    /// list, so operator-dense content buys ~285× the work per byte that
+    /// [`MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES`] is calibrated against.
+    ///
+    /// The page carries a `Tj` so each page within budget yields a record, which
+    /// is what makes the truncation observable; the rest is bare `q` operators.
+    ///
+    /// `#[ignore]`d because tripping this bound means decoding tens of millions
+    /// of operations — ~70 s in a debug build — and there is no cheaper way in:
+    /// the per-page content bound caps a page at ~500k operations, so the budget
+    /// can only be reached by paying for it. Unlike the byte and text budgets,
+    /// this one cannot be exercised quickly, and the constant is chosen for
+    /// where realistic content sits (see [`MAX_PDF_INSPECT_OPERATIONS`]) rather
+    /// than for testability. Run with:
+    ///
+    /// ```text
+    /// cargo test -p fulgur --lib --release aggregate_operation_count -- --ignored
+    /// ```
+    #[test]
+    #[ignore = "decodes >20M operations to reach the bound; ~70s debug, run explicitly"]
+    fn aggregate_operation_count_is_capped_across_pages() {
+        const OPS_PER_PAGE: usize = 64 * 1024;
+        let payload = {
+            let mut p = b"BT /F1 12 Tf (P) Tj ET\n".to_vec();
+            p.extend_from_slice(&b"q\n".repeat(OPS_PER_PAGE));
+            p
+        };
+        assert!(payload.len() <= MAX_PDF_CONTENT_BYTES);
+        // Well under the byte budget at this page count, so only the operation
+        // budget can stop the walk — that is the point of the test.
+        let pages = (MAX_PDF_INSPECT_OPERATIONS / OPS_PER_PAGE) * 3 / 2;
+        assert!(
+            pages * (payload.len() + 1) < MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES,
+            "byte budget must not be the binding constraint here"
+        );
+
+        let result = inspect_bytes(&make_pdf_with_shared_content_stream(pages, payload, false));
+        assert_eq!(result.pages as usize, pages);
+        assert!(!result.text_items.is_empty());
+        assert!(
+            result.text_items.len() < pages,
+            "expected truncation: got {} records from {} pages",
+            result.text_items.len(),
+            pages
+        );
+    }
+
+    /// The image pass decodes content independently, so it carries its own
+    /// whole-document budget and stops the page walk the same way.
+    #[test]
+    fn aggregate_content_decoding_is_capped_across_pages_for_images() {
+        let payload = budget_filler_page(b"q 50 0 0 50 0 0 cm /Im0 Do Q\n");
+        let per_page = payload.len() + 1;
+        let pages = (MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES / per_page) * 3 / 2;
+
+        let result = inspect_bytes(&make_pdf_with_shared_content_stream(pages, payload, true));
+        assert_eq!(result.pages as usize, pages);
+        assert!(
+            !result.images.is_empty(),
+            "pages within the budget must still be extracted"
+        );
+        assert!(
+            result.images.len() < pages,
+            "expected truncation: got {} images from {} pages",
+            result.images.len(),
+            pages
+        );
+    }
+
+    /// The whole-document content budget is charged for pages that are *skipped*
+    /// for exceeding the per-page bound, not only for usable ones.
+    ///
+    /// Otherwise the aggregate stays unbounded: a page can be made to decode a
+    /// full per-page allowance and then be rejected, paying nothing.
+    #[test]
+    fn skipped_pages_are_charged_against_the_content_budget() {
+        let mut budget = 4096;
+        let over_page = {
+            let mut p = Vec::new();
+            while p.len() <= MAX_PDF_CONTENT_BYTES {
+                p.extend_from_slice(b"(A) Tj\n");
+            }
+            p
+        };
+        let pdf = make_pdf_with_shared_content_stream(1, over_page, false);
+        let doc = lopdf::Document::load_mem(&pdf).unwrap();
+        let page_id = *doc.get_pages().values().next().unwrap();
+
+        // The page is over the per-page bound, so it cannot be used — but the
+        // decoding it cost must still have drawn the budget down to zero, which
+        // is reported as exhaustion rather than a plain skip.
+        assert!(matches!(
+            gather_page_content(&doc, page_id, &mut budget),
+            PageContent::Exhausted
+        ));
+        assert_eq!(budget, 0);
     }
 
     /// A `/Contents` entry that does not resolve to a stream object is skipped

--- a/crates/fulgur/src/inspect.rs
+++ b/crates/fulgur/src/inspect.rs
@@ -135,6 +135,12 @@ fn clamp_font_name(name: &str) -> &str {
     clamp_str_bytes(name, MAX_PDF_FONT_NAME_BYTES)
 }
 
+/// Decoded content-stream bytes, keyed by stream object id, so a stream shared
+/// by several pages is decoded once. Retained bytes are bounded by the same
+/// [`MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES`] budget that charges each distinct
+/// stream as it is decoded.
+type DecodedStreams = std::collections::BTreeMap<lopdf::ObjectId, Rc<Vec<u8>>>;
+
 /// Outcome of gathering one page's content, which distinguishes "skip this
 /// page" from "stop walking pages".
 enum PageContent {
@@ -173,57 +179,91 @@ enum PageContent {
 /// the running total rises monotonically to exactly that sum, so some prefix
 /// exceeds the bound if and only if the total does.
 ///
-/// `doc_budget` is charged for every stream decoded, *before* the per-page
-/// verdict is known, so a page that is about to be skipped still pays for the
-/// work its decoding cost. Charging only usable pages would leave the aggregate
-/// unbounded, since a page can be made to decode a full per-page allowance and
-/// then be rejected.
+/// `doc_budget` is charged *before* the per-page verdict is known, so a page that
+/// is about to be skipped still pays for the work its decoding cost. Charging
+/// only usable pages would leave the aggregate unbounded, since a page can be
+/// made to decode a full per-page allowance and then be rejected.
+///
+/// `decoded_cache` holds each content stream's decoded bytes, so a stream shared
+/// by many pages is decoded once. That matters beyond the saved time: a stream's
+/// *intermediate* filter output is invisible from here — `/Filter [/FlateDecode
+/// /ASCII85Decode]` can expand a small payload into megabytes of whitespace that
+/// the second stage reduces to nothing, leaving both the encoded and decoded
+/// lengths small — so no charge computed from those two lengths can bound
+/// repeated decoding of it. Decoding each stream once reduces that to a single
+/// occurrence per document, which is the same residual as a single oversized
+/// stream (see [`MAX_PDF_CONTENT_BYTES`]).
+///
+/// Charges split accordingly: filter work once per distinct stream, and the copy
+/// into the page's content on every reference to it.
 fn gather_page_content(
     doc: &lopdf::Document,
     page_id: lopdf::ObjectId,
     doc_budget: &mut usize,
+    decoded_cache: &mut DecodedStreams,
 ) -> PageContent {
+    // A page costs something even with no `/Contents` at all: it is still looked
+    // up and walked. Page objects are the cheapest thing to mass-produce in a
+    // compressed object stream, and a page with no content references never
+    // enters the loop below, so without this the walk advances no budget.
+    *doc_budget = doc_budget.saturating_sub(PDF_CONTENT_STREAM_COST_FLOOR_BYTES);
+    if *doc_budget == 0 {
+        return PageContent::Exhausted;
+    }
+
     let mut content: Vec<u8> = Vec::new();
     for object_id in doc.get_page_contents(page_id) {
-        // Charge the floor for *attempting* the reference, before knowing whether
-        // it resolves to a stream. The object lookup costs the same either way,
-        // and a `/Contents` array of references to dictionaries or missing
-        // objects — shareable across pages, like any other array — would
-        // otherwise be walked per page for free.
-        *doc_budget = doc_budget.saturating_sub(PDF_CONTENT_STREAM_COST_FLOOR_BYTES);
-        if *doc_budget == 0 {
-            return PageContent::Exhausted;
-        }
-        let Ok(stream) = doc.get_object(object_id).and_then(lopdf::Object::as_stream) else {
-            continue;
+        let bytes: Rc<Vec<u8>> = match decoded_cache.get(&object_id) {
+            // Decoded already for an earlier page: no filter work to charge, only
+            // the copy into `content` below.
+            Some(cached) => Rc::clone(cached),
+            None => {
+                // Charge the floor for *attempting* the reference, before knowing
+                // whether it resolves to a stream. The object lookup costs the
+                // same either way, and a `/Contents` array of references to
+                // dictionaries or missing objects — shareable across pages, like
+                // any other array — would otherwise be walked per page for free.
+                // Unresolvable ids are deliberately not cached, so each
+                // occurrence pays this.
+                *doc_budget = doc_budget.saturating_sub(PDF_CONTENT_STREAM_COST_FLOOR_BYTES);
+                if *doc_budget == 0 {
+                    return PageContent::Exhausted;
+                }
+                let Ok(stream) = doc.get_object(object_id).and_then(lopdf::Object::as_stream)
+                else {
+                    continue;
+                };
+                let decoded = match stream.decompressed_content() {
+                    Ok(d) => d,
+                    Err(_) => stream.content.clone(),
+                };
+                // Filter work, charged once per distinct stream: the encoded
+                // length, because a filter reads every one of those bytes even
+                // when it yields nothing — `/ASCII85Decode` over a megabyte of
+                // whitespace decodes to zero after scanning all of it.
+                let encoded = stream.content.len();
+                *doc_budget = doc_budget
+                    .saturating_sub(encoded.saturating_sub(PDF_CONTENT_STREAM_COST_FLOOR_BYTES));
+                let cached = Rc::new(decoded);
+                decoded_cache.insert(object_id, Rc::clone(&cached));
+                if *doc_budget == 0 {
+                    return PageContent::Exhausted;
+                }
+                cached
+            }
         };
-        let decoded = stream.decompressed_content();
-        let bytes: &[u8] = match decoded {
-            Ok(ref d) => d,
-            Err(_) => &stream.content,
-        };
-        // Charge this stream beyond the floor already paid above, taking the
-        // larger of what it *produced* and what it *consumed*:
-        //
-        // - decoded length plus the separator, the bytes added to `content`;
-        // - encoded length, because a filter reads every one of those bytes even
-        //   when it yields nothing. `/ASCII85Decode` over a megabyte of
-        //   whitespace decodes to zero bytes after scanning all of it, and a
-        //   Flate stream can do the same, so charging only the decoded length
-        //   would let a large encoded stream be re-decoded per page for the
-        //   floor alone.
-        //
-        // The total per stream is therefore `max(decoded + 1, encoded, floor)`.
-        let charge = (bytes.len() + 1).max(stream.content.len());
+        // Charged on every reference, hit or miss: these bytes are copied into
+        // this page's `content` even when the decode was cached, so the
+        // concatenation stays bounded independently of the filter work.
         *doc_budget =
-            doc_budget.saturating_sub(charge.saturating_sub(PDF_CONTENT_STREAM_COST_FLOOR_BYTES));
+            doc_budget.saturating_sub((bytes.len() + 1).max(PDF_CONTENT_STREAM_COST_FLOOR_BYTES));
         if *doc_budget == 0 {
             return PageContent::Exhausted;
         }
         if content.len() + bytes.len() + 1 > MAX_PDF_CONTENT_BYTES {
             return PageContent::Skip;
         }
-        content.extend_from_slice(bytes);
+        content.extend_from_slice(&bytes);
         content.push(b'\n');
     }
     PageContent::Ready(content)
@@ -277,16 +317,18 @@ fn extract_text_items(
     let mut content_budget = limits.content_total_bytes;
     let mut op_budget = limits.operations;
     let mut text_bytes: usize = 0;
+    let mut decoded_cache = DecodedStreams::new();
 
     for (&page_num, &page_id) in &doc.get_pages() {
         if items.len() >= limits.items || text_bytes >= limits.text_bytes || op_budget == 0 {
             break;
         }
-        let content_bytes = match gather_page_content(doc, page_id, &mut content_budget) {
-            PageContent::Ready(b) => b,
-            PageContent::Skip => continue,
-            PageContent::Exhausted => break,
-        };
+        let content_bytes =
+            match gather_page_content(doc, page_id, &mut content_budget, &mut decoded_cache) {
+                PageContent::Ready(b) => b,
+                PageContent::Skip => continue,
+                PageContent::Exhausted => break,
+            };
         let content = match lopdf::content::Content::decode(&content_bytes) {
             Ok(c) => c,
             Err(_) => continue,
@@ -579,10 +621,23 @@ enum XObjectsOrigin {
 }
 
 /// The identity of the `/XObject` dictionary reachable from `resources`.
-fn xobjects_origin(resources: &lopdf::Dictionary, origin: ResourcesOrigin) -> XObjectsOrigin {
-    match resources.get(b"XObject").and_then(|o| o.as_reference()) {
-        Ok(id) => XObjectsOrigin::Object(id),
-        Err(_) => XObjectsOrigin::DirectIn(origin),
+///
+/// Uses the id `Document::dereference` ends on, not the immediate one, because it
+/// follows reference chains: `/XObject 10 0 R` where object 10 is itself
+/// `11 0 R` reads the dictionary in object 11. Keying on the immediate id would
+/// give every page a distinct key for one shared dictionary whenever each is
+/// handed its own cheap alias object.
+fn xobjects_origin(
+    doc: &lopdf::Document,
+    resources: &lopdf::Dictionary,
+    origin: ResourcesOrigin,
+) -> XObjectsOrigin {
+    match resources.get(b"XObject").and_then(|o| doc.dereference(o)) {
+        // The dictionary is the object the chain ends on.
+        Ok((Some(id), _)) => XObjectsOrigin::Object(id),
+        // Direct dictionary, or a broken/absent entry whose empty result is a
+        // property of this resources dictionary.
+        Ok((None, _)) | Err(_) => XObjectsOrigin::DirectIn(origin),
     }
 }
 
@@ -646,6 +701,7 @@ fn extract_image_items(
     // whole-document budget. See `extract_text_items`.
     let mut content_budget = limits.content_total_bytes;
     let mut op_budget = limits.operations;
+    let mut decoded_cache = DecodedStreams::new();
     // Memoised `collect_image_xobjects` results, keyed by the object id of the
     // resources dictionary they were scanned from.
     //
@@ -671,7 +727,7 @@ fn extract_image_items(
         };
         // Scan once per distinct `/XObject` dictionary, reused by every page that
         // reaches it. Every origin is cacheable; see `XObjectsOrigin`.
-        let origin = xobjects_origin(resources, res_origin);
+        let origin = xobjects_origin(doc, resources, res_origin);
         let image_xobjects: Rc<ImageXObjects> = match xobject_cache.get(&origin) {
             Some(cached) => Rc::clone(cached),
             None => {
@@ -686,11 +742,12 @@ fn extract_image_items(
         }
 
         // Step 2: content stream から Do オペレータで位置を取得し、突き合わせて push
-        let content_bytes = match gather_page_content(doc, page_id, &mut content_budget) {
-            PageContent::Ready(b) => b,
-            PageContent::Skip => continue,
-            PageContent::Exhausted => break,
-        };
+        let content_bytes =
+            match gather_page_content(doc, page_id, &mut content_budget, &mut decoded_cache) {
+                PageContent::Ready(b) => b,
+                PageContent::Skip => continue,
+                PageContent::Exhausted => break,
+            };
         let content = match lopdf::content::Content::decode(&content_bytes) {
             Ok(c) => c,
             Err(_) => continue,
@@ -2600,7 +2657,7 @@ mod tests {
             let (res_origin, resources) = resolve_page_resources(&doc, page_id).expect("resources");
             // Each page's *resources* dictionary is its own.
             assert_eq!(res_origin, ResourcesOrigin::DirectIn(page_id));
-            origins.push(xobjects_origin(resources, res_origin));
+            origins.push(xobjects_origin(&doc, resources, res_origin));
         }
         // But both resolve to the same XObject dictionary, so one cache entry.
         assert_eq!(origins[0], XObjectsOrigin::Object(shared_xobjects));
@@ -2650,6 +2707,146 @@ mod tests {
         );
     }
 
+    /// A shared content stream is decoded once, not once per referring page.
+    ///
+    /// This is what bounds a multi-filter stream whose *intermediate* stage is
+    /// large while both its encoded and decoded lengths are small — no charge
+    /// derived from those two lengths can see that expansion, so the defence is
+    /// to not decode it repeatedly. Asserted through the budget: the same stream
+    /// referenced many times costs its filter work once.
+    #[test]
+    fn shared_content_streams_are_decoded_once() {
+        use lopdf::{Document, Object, Stream, dictionary};
+
+        const ENCODED: usize = 32 * 1024;
+        const REFS: usize = 64;
+        let mut doc = Document::with_version("1.5");
+        let pages_id = doc.new_object_id();
+        let resources_id = doc.add_object(dictionary! {
+            "Font" => dictionary! {
+                "F1" => dictionary! {
+                    "Type" => "Font", "Subtype" => "Type1", "BaseFont" => "Courier",
+                },
+            },
+        });
+        let mut a85 = vec![b' '; ENCODED];
+        a85.extend_from_slice(b"~>");
+        let mut a85_stream = Stream::new(dictionary! {}, a85);
+        a85_stream.dict.set("Filter", "ASCII85Decode");
+        let shared = doc.add_object(a85_stream);
+        // The same stream object referenced many times from one /Contents array.
+        let contents: Vec<Object> = vec![Object::Reference(shared); REFS];
+        let page_id = doc.add_object(dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "Contents" => contents,
+            "Resources" => resources_id,
+            "MediaBox" => vec![
+                Object::Integer(0), Object::Integer(0),
+                Object::Integer(595), Object::Integer(842),
+            ],
+        });
+        doc.objects.insert(
+            pages_id,
+            Object::Dictionary(dictionary! {
+                "Type" => "Pages",
+                "Kids" => vec![Object::Reference(page_id)],
+                "Count" => Object::Integer(1),
+            }),
+        );
+        let catalog_id = doc.add_object(dictionary! { "Type" => "Catalog", "Pages" => pages_id });
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+        let mut buf = Vec::new();
+        doc.save_to(&mut buf).unwrap();
+        let loaded = Document::load_mem(&buf).unwrap();
+        let page = *loaded.get_pages().values().next().unwrap();
+
+        // Enough for one decode of the encoded length plus a floor per reference,
+        // but nowhere near `REFS` decodes of it.
+        let mut budget = ENCODED + REFS * PDF_CONTENT_STREAM_COST_FLOOR_BYTES * 2;
+        assert!(
+            budget < ENCODED * REFS,
+            "budget must be too small for one decode per reference"
+        );
+        let mut cache = DecodedStreams::new();
+        assert!(
+            matches!(
+                gather_page_content(&loaded, page, &mut budget, &mut cache),
+                PageContent::Ready(_)
+            ),
+            "one decode plus per-reference copies must fit the budget"
+        );
+        assert_eq!(cache.len(), 1, "the shared stream must be cached once");
+    }
+
+    /// A page with no `/Contents` at all is still charged, so a page set that
+    /// costs nothing to produce cannot be walked for free.
+    #[test]
+    fn limits_pages_without_content_are_charged() {
+        use lopdf::{Document, Object, dictionary};
+
+        let mut doc = Document::with_version("1.5");
+        let pages_id = doc.new_object_id();
+        // No /Contents entry: `get_page_contents` yields nothing.
+        let page_id = doc.add_object(dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "MediaBox" => vec![
+                Object::Integer(0), Object::Integer(0),
+                Object::Integer(595), Object::Integer(842),
+            ],
+        });
+        doc.objects.insert(
+            pages_id,
+            Object::Dictionary(dictionary! {
+                "Type" => "Pages",
+                "Kids" => vec![Object::Reference(page_id)],
+                "Count" => Object::Integer(1),
+            }),
+        );
+        let catalog_id = doc.add_object(dictionary! { "Type" => "Catalog", "Pages" => pages_id });
+        doc.trailer.set("Root", Object::Reference(catalog_id));
+        let mut buf = Vec::new();
+        doc.save_to(&mut buf).unwrap();
+        let loaded = Document::load_mem(&buf).unwrap();
+        let page = *loaded.get_pages().values().next().unwrap();
+
+        let mut budget = PDF_CONTENT_STREAM_COST_FLOOR_BYTES;
+        assert!(matches!(
+            gather_page_content(&loaded, page, &mut budget, &mut DecodedStreams::new()),
+            PageContent::Exhausted
+        ));
+        assert_eq!(budget, 0, "a contentless page must still draw the budget");
+    }
+
+    /// An `/XObject` reached through an alias object resolves to the same origin
+    /// as one reached directly, so per-page aliases share a cache entry.
+    #[test]
+    fn xobjects_origin_canonicalises_reference_aliases() {
+        use lopdf::{Document, Object, dictionary};
+
+        let mut doc = Document::with_version("1.5");
+        let pages_id = doc.new_object_id();
+        let real = doc.add_object(dictionary! { "Im0" => Object::Null });
+        // Two distinct alias objects, each just a reference to `real`.
+        let alias_a = doc.add_object(Object::Reference(real));
+        let alias_b = doc.add_object(Object::Reference(real));
+        let mut origins = Vec::new();
+        for alias in [alias_a, alias_b, real] {
+            let page = doc.add_object(dictionary! {
+                "Type" => "Page",
+                "Parent" => pages_id,
+                "Resources" => dictionary! { "XObject" => Object::Reference(alias) },
+            });
+            let (res_origin, resources) = resolve_page_resources(&doc, page).expect("resources");
+            origins.push(xobjects_origin(&doc, resources, res_origin));
+        }
+        // All three name the dictionary the chain ends on, not the alias.
+        assert_eq!(origins[0], XObjectsOrigin::Object(real));
+        assert_eq!(origins[0], origins[1]);
+        assert_eq!(origins[0], origins[2]);
+    }
+
     /// The item budget stops extraction in both passes.
     #[test]
     fn limits_item_budget_stops_extraction() {
@@ -2688,7 +2885,7 @@ mod tests {
         // decoding it cost must still have drawn the budget down to zero, which
         // is reported as exhaustion rather than a plain skip.
         assert!(matches!(
-            gather_page_content(&doc, page_id, &mut budget),
+            gather_page_content(&doc, page_id, &mut budget, &mut DecodedStreams::new()),
             PageContent::Exhausted
         ));
         assert_eq!(budget, 0);

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -205,14 +205,14 @@ pub(crate) const MAX_COUNTER_CHAIN_ENTRIES: usize = MAX_DOM_DEPTH;
 /// [`MAX_DOM_DEPTH`] defensive traversal bound.
 pub(crate) const MAX_PDF_PARENT_DEPTH: usize = 128;
 
-/// Upper bound on the size of a single *decoded* page content stream that
+/// Upper bound on the total size of a page's *decoded* content that
 /// [`inspect::inspect`] will hand to `lopdf::content::Content::decode`.
 ///
 /// `Content::decode` materialises the entire operation list up front, at a
 /// measured ~570 bytes of heap per operation for bare `q` operators — which
 /// occupy 2 input bytes each, a ~285× expansion. Page content streams are also
 /// Flate-compressed, so a few kilobytes on disk can decompress into megabytes
-/// of operators, an expansion the caller never sees in the file size. Streams
+/// of operators, an expansion the caller never sees in the file size. Pages
 /// above this bound are skipped rather than parsed.
 ///
 /// 1 MiB is ~22× the largest content stream produced by any document in the
@@ -220,10 +220,46 @@ pub(crate) const MAX_PDF_PARENT_DEPTH: usize = 128;
 /// peak at 47 KB), and bounds the worst-case operation list at roughly 285 MB
 /// — the same order as an extra-large fulgur render. Peak memory stays bounded
 /// *per page* because the decoded operation list is dropped before the next
-/// page is read. The residual per-operation constant belongs to `lopdf`, not
-/// to fulgur; this bound is the only lever over it, since `Content::decode`
-/// has already allocated by the time an operation count could be observed.
+/// page is read.
+///
+/// Enforced *incrementally*, by [`inspect::gather_page_content`], as the page's
+/// content streams are decoded and concatenated. `lopdf`'s own
+/// `Document::get_page_content` inflates every stream of the page and joins
+/// them before returning, so testing the length of its result would bound only
+/// what gets parsed, not what gets allocated: a page carrying many small
+/// compressed streams would still inflate all of them first.
+///
+/// Two residual amplification constants belong to `lopdf` rather than to
+/// fulgur, and this bound is the only lever over either, since both have
+/// already allocated by the time fulgur could observe a size:
+///
+/// - `Content::decode`'s ~570 bytes per operation, above.
+/// - A *single* content stream whose decoded size exceeds this bound is still
+///   inflated in full by `Stream::decompressed_content` before its length can
+///   be measured. Bounding that from fulgur would mean reimplementing the
+///   filter chain (Flate/LZW/ASCII85 plus predictors, and `lopdf`'s raw-deflate
+///   retry for streams with a corrupt adler32 checksum) against a size-limited
+///   reader — which would silently stop inspecting PDFs that decode today.
 pub(crate) const MAX_PDF_CONTENT_BYTES: usize = 1024 * 1024;
+
+/// Upper bound on the length of a `/Tf` font resource name that
+/// [`inspect::inspect`] will retain and report.
+///
+/// Every extracted [`inspect::TextItem`] owns a copy of the font name in
+/// effect, so the retained and serialised size of a result is
+/// `items × name_len`, not `items` alone. [`MAX_PDF_CONTENT_BYTES`] does not
+/// bound that product: it is a *per-page* budget, so a document can spend one
+/// page's budget on a wide `/Tf` name followed by a run of 5-byte `(A) Tj`
+/// operators and repeat that across pages, up to
+/// [`MAX_PDF_INSPECT_ITEMS`] records each pairing with a name of nearly a
+/// megabyte. Clamping the name bounds the product at ~25 MB.
+///
+/// 127 bytes is the architectural limit the PDF specification's implementation
+/// notes give for a name object (ISO 32000-1 Annex C.2), so no name a
+/// conforming producer emits is affected — fulgur's own are `F0`, `F1`, ….
+/// Longer names are truncated on a UTF-8 character boundary rather than
+/// rejected, which keeps a record's other fields usable.
+pub(crate) const MAX_PDF_FONT_NAME_BYTES: usize = 127;
 
 /// Upper bound on graphics-state (`q` / `Q`) nesting depth tracked by
 /// [`inspect::inspect`] while walking a page content stream.
@@ -232,9 +268,15 @@ pub(crate) const MAX_PDF_CONTENT_BYTES: usize = 1024 * 1024;
 /// `q` operators grows a stack that is proportional to the operator count. The
 /// PDF specification's implementation notes put the historical limit at 28
 /// levels and real generators nest a handful, so this bound is orders of
-/// magnitude above any legitimate document. Pushes beyond it are dropped and
-/// counted, so the matching `Q` operators stay balanced. Sibling of
+/// magnitude above any legitimate document. Sibling of
 /// [`MAX_PDF_PARENT_DEPTH`].
+///
+/// A `q` beyond the bound is dropped and counted, so the matching `Q` unwinds
+/// it instead of popping a real entry. The dropped frame's *contents* are
+/// discarded with it: because the frame has no stack entry of its own, a state
+/// change inside it would otherwise mutate the deepest retained entry and
+/// survive the matching `Q`, leaking into the enclosing scope. Discarding is
+/// what makes the outer state exactly restorable.
 pub(crate) const MAX_PDF_GS_STACK_DEPTH: usize = 1024;
 
 /// Upper bound on how many records [`inspect::inspect`] accumulates in each of

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -273,6 +273,23 @@ pub(crate) const MAX_PDF_CONTENT_BYTES: usize = 1024 * 1024;
 /// and this bound never binds first.
 pub(crate) const MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES: usize = 128 * 1024 * 1024;
 
+/// Minimum charge against [`MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES`] for touching
+/// one content stream, regardless of how few bytes it decodes to.
+///
+/// Charging a stream only for its decoded length undercounts it: resolving the
+/// object and calling `decompressed_content` costs the same whether the result
+/// is one byte or none. A `/Contents` array of many *zero-length* streams —
+/// itself shareable across pages by one indirect reference — would otherwise
+/// draw the budget down by ~1 byte per stream, so a 1.8 MB file could keep
+/// `inspect` busy for tens of seconds: measured, 300k such refs across 320 pages
+/// took 9.9 s and grew linearly with the page count.
+///
+/// 512 bytes puts the document-wide ceiling at ~262k streams, which real
+/// documents are nowhere near — a page carries one content stream, or a few
+/// dozen at worst — while keeping the pathological case in the tens of
+/// milliseconds.
+pub(crate) const PDF_CONTENT_STREAM_COST_FLOOR_BYTES: usize = 512;
+
 /// Whole-document budget on how many decoded content-stream *operations*
 /// [`inspect::inspect`] will walk, across all pages, in each of its two passes.
 ///

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -205,6 +205,50 @@ pub(crate) const MAX_COUNTER_CHAIN_ENTRIES: usize = MAX_DOM_DEPTH;
 /// [`MAX_DOM_DEPTH`] defensive traversal bound.
 pub(crate) const MAX_PDF_PARENT_DEPTH: usize = 128;
 
+/// Upper bound on the size of a single *decoded* page content stream that
+/// [`inspect::inspect`] will hand to `lopdf::content::Content::decode`.
+///
+/// `Content::decode` materialises the entire operation list up front, at a
+/// measured ~570 bytes of heap per operation for bare `q` operators — which
+/// occupy 2 input bytes each, a ~285× expansion. Page content streams are also
+/// Flate-compressed, so a few kilobytes on disk can decompress into megabytes
+/// of operators, an expansion the caller never sees in the file size. Streams
+/// above this bound are skipped rather than parsed.
+///
+/// 1 MiB is ~22× the largest content stream produced by any document in the
+/// repository's own corpus (`examples/**` and `crates/fulgur-vrt/goldens/**`
+/// peak at 47 KB), and bounds the worst-case operation list at roughly 285 MB
+/// — the same order as an extra-large fulgur render. Peak memory stays bounded
+/// *per page* because the decoded operation list is dropped before the next
+/// page is read. The residual per-operation constant belongs to `lopdf`, not
+/// to fulgur; this bound is the only lever over it, since `Content::decode`
+/// has already allocated by the time an operation count could be observed.
+pub(crate) const MAX_PDF_CONTENT_BYTES: usize = 1024 * 1024;
+
+/// Upper bound on graphics-state (`q` / `Q`) nesting depth tracked by
+/// [`inspect::inspect`] while walking a page content stream.
+///
+/// Each `q` saves a copy of the current graphics state, so an unbounded run of
+/// `q` operators grows a stack that is proportional to the operator count. The
+/// PDF specification's implementation notes put the historical limit at 28
+/// levels and real generators nest a handful, so this bound is orders of
+/// magnitude above any legitimate document. Pushes beyond it are dropped and
+/// counted, so the matching `Q` operators stay balanced. Sibling of
+/// [`MAX_PDF_PARENT_DEPTH`].
+pub(crate) const MAX_PDF_GS_STACK_DEPTH: usize = 1024;
+
+/// Upper bound on how many records [`inspect::inspect`] accumulates in each of
+/// [`inspect::InspectResult::text_items`] and [`inspect::InspectResult::images`].
+///
+/// Page count is bounded only by input size, so a per-page cap would still
+/// leave the aggregate result unbounded; this is a whole-document total. The
+/// repository corpus averages ~80 text items per page, which puts this bound at
+/// roughly 2,500 pages of realistic content, for ~70 MB of retained records.
+/// Extraction stops once the bound is reached — the result is silently
+/// truncated rather than erroring, matching the module's existing behaviour for
+/// malformed structures.
+pub(crate) const MAX_PDF_INSPECT_ITEMS: usize = 200_000;
+
 /// Total-output budget for the generated CSS that
 /// [`blitz_adapter::CounterPass`] injects for resolved pseudo-element
 /// content. Once the accumulated generated CSS reaches this size, further

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -242,6 +242,78 @@ pub(crate) const MAX_PDF_PARENT_DEPTH: usize = 128;
 ///   reader — which would silently stop inspecting PDFs that decode today.
 pub(crate) const MAX_PDF_CONTENT_BYTES: usize = 1024 * 1024;
 
+/// Whole-document budget on how many bytes of *decoded* page content
+/// [`inspect::inspect`] will parse, across all pages, in each of its two passes.
+///
+/// [`MAX_PDF_CONTENT_BYTES`] is per page, and a page's cost is only ever paid
+/// per page — but the number of pages is bounded by nothing except input size,
+/// and several page objects may share one `/Contents` stream. So a small file
+/// can define a great many pages that each re-pay the full per-page cost:
+/// measured, 200 pages sharing one 256 KB stream of bare `q` operators is 27 KB
+/// on disk and 8.8 s of CPU, scaling linearly with the page count while
+/// [`MAX_PDF_INSPECT_ITEMS`] never fires because such a page emits no records.
+/// Peak memory stays bounded there — it is the repeated work that is not.
+///
+/// Charged as content is decoded, *including* for a page that is then skipped
+/// for exceeding the per-page bound: the decoding work has been done either
+/// way, so charging only usable pages would leave the same hole open. Once the
+/// budget is spent the page walk stops rather than continuing to the next page.
+///
+/// This also bounds retained output that a record *count* cannot: a `Tj`
+/// operand is retained as [`inspect::TextItem::text`], and its bytes appear
+/// literally in the content stream, so total retained text is at most this
+/// budget times the worst-case widening of `decode_pdf_string` (2×, one Latin-1
+/// byte becoming two UTF-8 bytes). [`MAX_PDF_INSPECT_TEXT_BYTES`] bounds that
+/// directly and more tightly; this bound is what makes it unnecessary to trust
+/// that derivation.
+///
+/// 128 MiB is ~2,500 pages at the corpus's largest content stream (47 KB),
+/// matching the ~2,500-page scale [`MAX_PDF_INSPECT_ITEMS`] is calibrated for,
+/// so for realistic documents the item cap is reached at about the same point
+/// and this bound never binds first.
+pub(crate) const MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES: usize = 128 * 1024 * 1024;
+
+/// Whole-document budget on how many decoded content-stream *operations*
+/// [`inspect::inspect`] will walk, across all pages, in each of its two passes.
+///
+/// Sibling of [`MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES`], which bounds decoding by
+/// input bytes. Both are needed because they bound different work and neither
+/// implies the other:
+///
+/// - Bytes alone cannot bound operator work, because work per byte varies by
+///   ~285×: a `q` is 2 bytes and ~570 bytes of operation list. 128 MiB of bare
+///   `q` is ~67M operations, measured at ~26 s — bounded, but a poor bound.
+/// - Operations alone cannot bound decompression work, because a page can
+///   decompress a full [`MAX_PDF_CONTENT_BYTES`] of *whitespace* and decode to
+///   zero operations, paying nothing, and repeat that per page.
+///
+/// Charged after a page's operations are decoded, so the page whose decode was
+/// already paid for is still extracted and the next page is refused. Overshoot
+/// is therefore bounded by one page's operation count.
+///
+/// 20M operations is far above realistic content — a text-heavy page runs to a
+/// few thousand — so the ~2,500-page scale the other bounds target is roughly an
+/// order of magnitude below this. It caps adversarial operator work at ~8 s.
+pub(crate) const MAX_PDF_INSPECT_OPERATIONS: usize = 20_000_000;
+
+/// Whole-document budget on the total bytes of extracted text that
+/// [`inspect::inspect`] will retain in [`inspect::InspectResult::text_items`].
+///
+/// [`MAX_PDF_INSPECT_ITEMS`] counts records but not their payload, and a single
+/// `Tj` operand can be nearly as large as a whole page's content allowance. One
+/// content stream holding one ~900 KB string, shared by many page objects,
+/// therefore yields one very large record per page: measured, 500 pages is
+/// 67 KB on disk, 869 MB of peak RSS and 450 MB of JSON, and it scales with the
+/// page count up to the item cap.
+///
+/// Extraction stops once the budget is spent. The overshoot is bounded by the
+/// last record pushed, itself bounded by [`MAX_PDF_CONTENT_BYTES`].
+///
+/// 64 MiB is far above realistic content — the corpus averages ~80 records per
+/// page of a few dozen bytes each, so the ~2,500-page document
+/// [`MAX_PDF_INSPECT_ITEMS`] targets carries single-digit MB of text.
+pub(crate) const MAX_PDF_INSPECT_TEXT_BYTES: usize = 64 * 1024 * 1024;
+
 /// Upper bound on the length of a `/Tf` font resource name that
 /// [`inspect::inspect`] will retain and report.
 ///

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -229,9 +229,12 @@ pub(crate) const MAX_PDF_PARENT_DEPTH: usize = 128;
 /// what gets parsed, not what gets allocated: a page carrying many small
 /// compressed streams would still inflate all of them first.
 ///
-/// Two residual amplification constants belong to `lopdf` rather than to
-/// fulgur, and this bound is the only lever over either, since both have
-/// already allocated by the time fulgur could observe a size:
+/// Three residual amplifications belong to `lopdf` rather than to fulgur, and
+/// this bound is the only lever over any of them, because each has already
+/// allocated by the time fulgur could observe a size. Reimplementing the
+/// surrounding `lopdf` logic to bound them would risk diverging from it, and the
+/// property being protected here is that `inspect` output stays byte-identical
+/// across the repository corpus:
 ///
 /// - `Content::decode`'s ~570 bytes per operation, above.
 /// - A *single* content stream whose decoded size exceeds this bound is still
@@ -240,6 +243,16 @@ pub(crate) const MAX_PDF_PARENT_DEPTH: usize = 128;
 ///   filter chain (Flate/LZW/ASCII85 plus predictors, and `lopdf`'s raw-deflate
 ///   retry for streams with a corrupt adler32 checksum) against a size-limited
 ///   reader — which would silently stop inspecting PDFs that decode today.
+///   Note that [`inspect::gather_page_content`]'s decoded-stream cache reduces
+///   this to *once per document* rather than once per referring page, including
+///   for a filter chain whose intermediate stage is large while both its encoded
+///   and decoded lengths are small.
+/// - `Document::get_page_contents` materialises a page's whole `/Contents` array
+///   into a `Vec<ObjectId>` before any of it can be charged, so one such build
+///   per pass is unavoidable from here. Measured at ~4 MB for a 500k-reference
+///   array — half of what `lopdf` already holds for the same array — and it does
+///   not scale with page count, because the per-reference charge exhausts the
+///   budget on the first page that walks it.
 pub(crate) const MAX_PDF_CONTENT_BYTES: usize = 1024 * 1024;
 
 /// Whole-document budget on how many bytes of *decoded* page content

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -331,6 +331,23 @@ pub(crate) const MAX_PDF_INSPECT_OPERATIONS: usize = 20_000_000;
 /// [`MAX_PDF_INSPECT_ITEMS`] targets carries single-digit MB of text.
 pub(crate) const MAX_PDF_INSPECT_TEXT_BYTES: usize = 64 * 1024 * 1024;
 
+/// Upper bound on the length of each `/Info` metadata string
+/// ([`inspect::Metadata::title`] and its siblings) that [`inspect::inspect`]
+/// will retain and report.
+///
+/// The metadata pass has no per-page or per-record structure, so neither
+/// [`MAX_PDF_INSPECT_TEXT_BYTES`] nor [`MAX_PDF_INSPECT_ITEMS`] constrains it —
+/// they bound the text and image passes only. An `/Info` dictionary can live
+/// inside a Flate-compressed object stream, so a small file can carry a `/Title`
+/// of arbitrary size, and a metadata-only document would then produce output
+/// proportional to the decompressed payload.
+///
+/// 8 KiB per field is far above anything a producer writes into a title, author
+/// or date — the fields are a line of text each — and bounds all five at 40 KiB.
+/// Longer values are truncated on a UTF-8 character boundary rather than
+/// dropped, so the field stays usable.
+pub(crate) const MAX_PDF_METADATA_FIELD_BYTES: usize = 8 * 1024;
+
 /// Upper bound on the length of a `/Tf` font resource name that
 /// [`inspect::inspect`] will retain and report.
 ///


### PR DESCRIPTION
## Summary

Codex Security backlog の finding &#34;Unbounded PDF inspect enables denial of service&#34; (medium) のトリアージと修正。

`fulgur::inspect::inspect` は、デコード後の content stream サイズ・グラフィックス状態のネスト深さ・出力レコード数のいずれにも上限を持っていなかった。攻撃者が用意した小さな PDF が、ファイルサイズに不釣り合いな CPU / peak memory を引き起こせる。実測 (release build、`fulgur inspect` 経由):

| 入力 | ファイルサイズ | main | この PR |
|---|---|---|---|
| `q` 2M 個 + 4 KB のフォント名 | 4,490 B | **9.09 GB** | 14.2 MB |
| `Tj` 1M 個 | 10,810 B | 740 MB | 23.4 MB |
| Flate stream 200 本 (計 179 MB に展開) | 291 KB | **OOM kill (15.5 GB)** | 10.1 MB |
| 900 KB の文字列 1 本を共有する 500 ページ | 67 KB | 869 MB | 140 MB |
| 256 KB の `q` 列を共有する 1500 ページ | 198 KB | 71.5 s (wall) | 6.8 s |
| 空 stream 30 万参照を共有する 320 ページ | 1.78 MB | 9.7 s | 0.08 s |
| 非画像 XObject 4000 個を共有する 2400 ページ | 0.55 MB | 1.3 s | 0.03 s |

出力側も同様で、10.8 KB の PDF が 172 MB の JSON になっていた。

### finding の記述との差分 2 点

1. **exposure の前提が古い。** attack-path 分析は「CLI に inspect サブコマンドが存在しない」ことを high → medium への引き下げ理由に挙げているが、現行 main には `crates/fulgur-cli/src/main.rs:242` に `fulgur inspect` が存在する。
2. **支配的なシンクは finding が見ていない箇所だった。** rubric は text extraction の `TextItem` 蓄積 (10 万件) を検証しているが、増幅率が桁違いに大きいのはグラフィックス状態スタックのほうで、こちらは fulgur 自身のコードにある。`q` は現在の状態のコピーを保存し、その中の `/Tf` リソース名を `String` として所有していたため、幅の広いフォント名に対する深い `q` の連続がそのフォント名をレベルごとに複製していた。4,490 B → 9.09 GB はこの経路。

超過時は既存の挙動 (壊れた構造を黙ってスキップする) に合わせて、エラーではなく silent truncation にしている。`InspectResult` の serde 形状は変えていない。

## Changes

既存の `MAX_PDF_PARENT_DEPTH` と同じスタイルで境界を追加し、**ページ単位 / 文書全体 × 作業量 / 保持量** の 4 象限に整理した。

**入力側 (作業量の上限)**

- **`MAX_PDF_CONTENT_BYTES` (1 MiB)** — 1 ページのデコード後 content 合計。超過したページはパースせずスキップ。コーパス最大の content stream が 47 KB なので 22 倍の余裕。
- **`MAX_PDF_INSPECT_CONTENT_TOTAL_BYTES` (128 MiB)** — **文書全体**のデコード量。ページ数は入力サイズにしか縛られず、複数の page object が 1 本の `/Contents` を共有できるので、ページ単位の上限だけでは総量が無制限に残る。
- **`PDF_CONTENT_STREAM_COST_FLOOR_BYTES` (512)** — 1 本の content stream に課す最低料金。object を解決して `decompressed_content` を呼ぶコストは、結果が 1 byte でも 0 byte でも同じ。長さだけで課金すると**長さ 0 の stream が無料**になる。
- **`MAX_PDF_INSPECT_OPERATIONS` (20M)** — **文書全体**の操作数。byte 上限では作業量を絞り切れない (`q` は 2 B に対し操作リスト約 570 B、約 285 倍の差) ため別に必要。
- **`MAX_PDF_GS_STACK_DEPTH` (1024)** — `q` のネスト。上限超過で捨てた push は数えておき、対応する `Q` が実エントリを pop する代わりにそれを巻き戻す。PDF 仕様の実装ノートが挙げる歴史的上限は 28。

**出力側 (保持量の上限)**

- **`MAX_PDF_INSPECT_ITEMS` (200k)** — `text_items` / `images` それぞれの文書全体の合計。
- **`MAX_PDF_INSPECT_TEXT_BYTES` (64 MiB)** — 保持するテキストの総 byte。件数上限は payload を数えないので、1 レコードが 1 ページ分の content 相当まで膨らむ形を止められない。
- **`MAX_PDF_FONT_NAME_BYTES` (127)** — `/Tf` リソース名。ISO 32000-1 Annex C.2 が name object に与えるアーキテクチャ上限そのものなので、仕様準拠の producer は影響を受けない (fulgur 自身は `F0`, `F1`, …)。

あわせて 2 つの構造変更:

- グラフィックス状態が持つフォント名を `Rc` にした。状態の保存が名前を複製せず共有するようになる。
- `resolve_page_resources` が dictionary を **clone せず参照で返す**ようになり、image pass は XObject の走査結果を resources の object id で memoise する。**現実の文書に対しても純粋な改善** — 共有 resources を持つ 2,500 ページの PDF は、これまでページごとに deep clone していた。

### レビュー指摘の反映

初版 (`1774283`) に対する Codex / CodeRabbit レビューで 8 つの穴が見つかり、3 commit で修正した。いずれも実測付き。

#### `0834094`

- **content 上限が展開の「後」だった。** `Document::get_page_content` はページの content stream を**全部展開してから**連結して返すので、その戻り値の長さを見ても「パースする量」しか縛れず「確保する量」は縛れていなかった。`gather_page_content` に置き換え、running budget で累積しながら超過した時点でページを捨てる。上限内のページでは `get_page_content` と byte 単位で同一。896 KB へ展開される Flate stream 2000 本 (2.9 MB) で **1723 MB → 14.0 MB**。
- **捨てた `q` フレームの中身が外に漏れていた。** 捨てたフレームは自分のスタックエントリを持たないので、その中の `cm` が最深の**残存**エントリを書き換えてしまい、無関係な `Q` が実エントリを pop するまでその変換が効き続けていた。フレームの中身をフレームごと破棄するよう修正。既存テストは**ネストを全部閉じていたため漏れが見えていなかった**ので、捨てたフレームだけを閉じる新規テストを text / image 両経路に追加。
- **`items × font_name_len` が縛られていなかった。** 186 KB の 1 ページで **peak RSS 1931 MB → 23.3 MB、JSON 1,003 MB → 5.9 MB**。
- **(CodeRabbit)** 現実文書テストの件数厳密一致がフォントメトリクス依存 + ヘッドルーム assertion が恒真。提案どおり下限 assertion に変更。

#### `7608205`

根本原因は 2 件とも **ページ数だけが無制限**だったこと。複数の page object が 1 本の content stream を共有できるので、1 ページ増やす disk コストは約 60 B で、ページ単位のコストは丸ごと再課金される。

- **文書全体の保持テキスト量に上限がなかった。** 900 KB の文字列 1 本を共有する 500 ページ (67 KB) で **peak RSS 869 MB → 140 MB、JSON 450 MB → 67.5 MB**。
- **文書全体のデコード量・作業量に上限がなかった。** レコードを 1 件も出さないページは item cap が効かない。256 KB の `q` 列を共有する 1500 ページ (198 KB) で **71.5 s → 6.8 s**、ページ数に対して線形からフラットへ。

#### `0d431db`

同じ「ページ数 × 共有オブジェクト」の形が、budget を 1 byte も動かさない経路に 2 つ残っていた。

- **長さ 0 の content stream が無料だった。** `bytes.len()` だけで課金していたため、`/Contents` に長さ 0 の stream を大量に並べた配列 (これ自体も 1 参照で全ページ共有可能) をページごとに無料で走査できた。上記の cost floor で対応。**空 stream 30 万参照 × 320 ページ (1.78 MB) で 9.7 s → 0.08 s**、線形からフラットへ。なお `bytes.len() + 1` (セパレータ課金) だけでは不十分で、それだと文書全体の天井が約 1.28 億 stream = 約 14 s のままだった。
- **image pass の resource 走査が無制限だった。** 全ページが共有する `/XObject` dictionary が非画像 XObject だけを持つ場合、走査コストを払ったうえで `image_xobjects.is_empty()` で content decode をスキップするので、content budget も operation budget も動かない。上記の memoise + clone 除去で対応。**非画像 XObject 4000 個 × 2400 ページ (0.55 MB) で 1.3 s → 0.03 s**。

## Test plan

- [x] `cargo test -p fulgur` — 1807 passed / 0 failed / **0 ignored**
- [x] `cargo clippy -p fulgur --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [ ] `npx markdownlint-cli2 '**/*.md'` — **該当なし** (この PR は `.md` を変更していない)

追加で:

- [x] `cargo test -p fulgur-cli` — all green
- [x] **`examples/**` (22) と `crates/fulgur-vrt/goldens/**` (64) の PDF 86 件すべてで inspect 出力が `main` とバイト一致**。4 commit すべてで再確認 (修正前バイナリを別途ビルドして比較)。
- [x] `inspect` の新規テスト計 26 本 (module 全体で 53 本、約 3 s)。byte cap の発火 / 直下は従来どおりパース / ページ内の複数 stream 合計での超過とセパレータ保持 / stream でない `/Contents` エントリと decode 失敗時のフォールバック / 上限超のネストでも外側 CTM が復元される / **捨てたフレームだけを閉じても state が漏れない** (text / image) / フォント名の clamp とマルチバイト文字境界 / item cap が**ページをまたいで**止まる / **文書全体の byte・operation・text・item budget** (skip されたページへの課金、長さ 0 stream への cost floor を含む) / image 経路の byte cap と CTM 復元。

テスト設計について 3 点:

- dropped-frame テストは **isolation を戻すと fail することを確認済み** (`expected (100, 700), got (150, 750)` / `(133, 744)`)。既存の nesting テストはバグのあるコードでも pass していたため。
- byte budget のテストは whitespace filler を使う。byte の課金は同一のまま、デコードコストが攻撃者が使う裸のオペレータの約 1/240 (4 MiB の `q` が 523 ms、同量の whitespace が 2.2 ms)。
- budget は定数を直接読む代わりに **`InspectLimits` struct** (`Default` が production 値) から読む。これでテストが小さい budget で各 bound を駆動でき、`0834094` で `#[ignore]` にしていた operation budget のテスト (20M 操作を実際にデコードするので debug で約 70 s、ページ単位上限が 1 ページ約 50 万操作なので近道がない) を廃止できた。**定数をテストしやすさに合わせて歪めず、かつ ignored test ゼロ**を両立している。

## Contributor License Agreement

`cla-assistant` チェックは green。上記チェックボックスは author による確認事項なので未記入のまま残している。

## Related issues

Refs: fulgur-56bd

### 残課題 (この PR の範囲外)

`lopdf` 側に、fulgur から縛れない増幅定数が 2 つ残る。どちらも「fulgur がサイズを観測できる時点ではすでに確保済み」という同じ形。

1. `lopdf::content::Content::decode` は操作リスト全体を先に materialize する。実測で裸のオペレータ 1 個あたり約 570 B、入力 2 B に対して約 285 倍。`MAX_PDF_INSPECT_OPERATIONS` が**総量**は縛るが、1 ページ分 (約 285 MB) の一時確保は残る。
2. **単一の** content stream が上限を超えて展開されるケースは、`Stream::decompressed_content` が全量を展開しきってからでないと長さが分からない。これを fulgur 側で縛るには filter chain (Flate / LZW / ASCII85 + predictor) をサイズ制限付き reader に対して再実装する必要があり、特に `lopdf` の zlib エラー経路 (`object.rs:849`) が **adler32 が壊れた stream に対して raw deflate で再試行する** 挙動を持つため、これを再現し損ねると**今読めている PDF が黙って読めなくなる**。第三者の PDF を渡す API で、比率上限のある bomb を具体的な regression と引き換えにするのは割に合わないと判断した。

いずれも `MAX_PDF_CONTENT_BYTES` の doc コメントに残課題として明記した。将来 flpdf に移る領域。

### 開示方針

**GHSA advisory は起票せず、この公開 hardening PR で着地させる方針を推奨**。理由は影響バージョン境界が引けないこと — `extract_text_items` は inspect モジュール導入時から上限なしで、コードマーカーで二分すると初出は `v0.5.13`、つまり**リリース済み 56 タグすべて**が該当する。通常入力が fulgur 自身の出力である module に対して、リリース全履歴を affected とする advisory を出すのはエコシステムのノイズになる。

将来この経路が agent 到達可能になるとすれば `fulgur-18kt` (MCP の inspect / redact ツール) 経由なので、その実装時に再評価するのがよい。

## Summary by CodeRabbit

* **改善**
  * 大きすぎるPDFコンテンツや過度に複雑な構造を安全に処理できるよう、解析時のリソース制限を強化しました。
  * 深くネストされた描画状態を含むPDFでも、テキストや画像の位置情報をより正確に抽出できるよう改善しました。
  * 大容量・異常なPDFによる処理負荷や不安定化のリスクを低減しました。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - PDFコンテンツ解析でページ単位/全体予算（バイト・操作・保持データ件数等）を統一し、上限超過時は安全に打ち切り/スキップします。
  - `/Info`・`/Tf`など長い文字列を境界を保ったまま制限し、過剰入力による上限突破を抑止します。
  - テキスト/画像抽出で深い`q/Q`ネストを隔離し、リソース解決の取り違えを防ぎます。
- **テスト**
  - 予算枯渇、フォールバック、境界条件、`q/Q`隔離、キャッシュ同一性を中心に追加/拡充しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->