### PR TITLE
harden(gcpm): re-escape text nodes when serializing running elements

### DIFF
--- a/crates/fulgur/src/gcpm/running.rs
+++ b/crates/fulgur/src/gcpm/running.rs
@@ -84,11 +84,17 @@ impl RunningElementStore {
 /// handles styling in the re-layout pass.
 pub fn serialize_node(doc: &blitz_dom::BaseDocument, node_id: usize) -> String {
     let mut output = String::new();
-    write_node(doc, node_id, &mut output, 0);
+    write_node(doc, node_id, &mut output, 0, false);
     output
 }
 
-fn write_node(doc: &blitz_dom::BaseDocument, node_id: usize, writer: &mut String, depth: usize) {
+fn write_node(
+    doc: &blitz_dom::BaseDocument,
+    node_id: usize,
+    writer: &mut String,
+    depth: usize,
+    in_raw_text: bool,
+) {
     use crate::MAX_DOM_DEPTH;
     use blitz_dom::NodeData;
 
@@ -101,7 +107,11 @@ fn write_node(doc: &blitz_dom::BaseDocument, node_id: usize, writer: &mut String
 
     match &node.data {
         NodeData::Text(text_data) => {
-            writer.push_str(&text_data.content);
+            if in_raw_text {
+                writer.push_str(&text_data.content);
+            } else {
+                escape_text_content(&text_data.content, writer);
+            }
         }
         NodeData::Element(elem) => {
             let tag = elem.name.local.as_ref();
@@ -122,8 +132,9 @@ fn write_node(doc: &blitz_dom::BaseDocument, node_id: usize, writer: &mut String
                 writer.push_str(" />");
             } else {
                 writer.push('>');
+                let children_are_raw_text = is_raw_text_element(elem);
                 for &child_id in &node.children {
-                    write_node(doc, child_id, writer, depth + 1);
+                    write_node(doc, child_id, writer, depth + 1, children_are_raw_text);
                 }
                 writer.push_str("</");
                 writer.push_str(tag);
@@ -132,6 +143,47 @@ fn write_node(doc: &blitz_dom::BaseDocument, node_id: usize, writer: &mut String
         }
         _ => {
             // Document, Comment, AnonymousBlock — skip
+        }
+    }
+}
+
+/// HTML "raw text elements" (HTML §13.2.5.1): `<style>` and `<script>` in the
+/// HTML namespace. The tokenizer does **not** decode character references
+/// inside them, so for their children a verbatim write-back already is the
+/// parser's inverse — escaping would corrupt the CSS/JS rather than preserve
+/// it (`.a > b` would come back as `.a &gt; b`, which the reparse hands to
+/// Stylo verbatim).
+///
+/// The namespace check matters: `<style>` in the SVG namespace is *not* raw
+/// text — foreign content decodes references normally — so it takes the
+/// escaping path like any other element.
+///
+/// `<textarea>` and `<title>` are deliberately absent: they are *escapable*
+/// raw text, where the tokenizer does decode references, so they need the
+/// same escaping as ordinary text.
+fn is_raw_text_element(elem: &blitz_dom::node::ElementData) -> bool {
+    elem.name.ns == blitz_dom::ns!(html) && matches!(elem.name.local.as_ref(), "style" | "script")
+}
+
+/// Escape a text node's content for safe HTML embedding.
+///
+/// The HTML parser decodes character references on the way in, so writing a
+/// text node back verbatim is **not** its inverse: content that reached the
+/// DOM as the escaped string `&lt;a href="…"&gt;` would be handed to the
+/// margin-box reparse as a live anchor. That turns an escaped-by-construction
+/// value — e.g. a `{{ variable }}` run through the forced
+/// `AutoEscape::Html` of [`crate::template`] — back into markup, defeating
+/// the escaping. Re-encoding here restores the round trip.
+///
+/// `>` is not strictly required in a text context, but is escaped anyway to
+/// match [`escape_attribute_value`] and to neutralise `]]>` sequences.
+fn escape_text_content(value: &str, writer: &mut String) {
+    for ch in value.chars() {
+        match ch {
+            '&' => writer.push_str("&amp;"),
+            '<' => writer.push_str("&lt;"),
+            '>' => writer.push_str("&gt;"),
+            _ => writer.push(ch),
         }
     }
 }
@@ -196,6 +248,109 @@ mod tests {
         assert_eq!(store.instance_count(), 1);
         store.register(2, "header".to_string(), "<h1>B</h1>".to_string());
         assert_eq!(store.instance_count(), 2);
+    }
+
+    // --- serialize_node round trip ---
+
+    /// Parse `body_html` and serialize the first `<div>` in it, i.e. the same
+    /// shape `RunningElementPass` hands to `serialize_node`.
+    fn serialize_first_div(body_html: &str) -> String {
+        let html = format!("<html><body>{body_html}</body></html>");
+        let doc = crate::blitz_adapter::parse(&html, 600.0, &[]);
+        let root_id = doc.root_element().id;
+        let div_id = find_first_tag(&doc, root_id, "div", 0).expect("no <div> in fixture");
+        serialize_node(&doc, div_id)
+    }
+
+    fn find_first_tag(
+        doc: &blitz_dom::BaseDocument,
+        node_id: usize,
+        tag: &str,
+        depth: usize,
+    ) -> Option<usize> {
+        if depth >= crate::MAX_DOM_DEPTH {
+            return None;
+        }
+        let node = doc.get_node(node_id)?;
+        if let Some(elem) = node.element_data() {
+            if elem.name.local.as_ref() == tag {
+                return Some(node_id);
+            }
+        }
+        node.children
+            .iter()
+            .find_map(|&child| find_first_tag(doc, child, tag, depth + 1))
+    }
+
+    /// Text that reached the DOM as escaped markup — the shape produced by
+    /// `template::render_template`'s forced `AutoEscape::Html` — must be
+    /// handed back as text, not as live markup for the margin-box reparse.
+    #[test]
+    fn serialize_node_re_escapes_markup_in_text_nodes() {
+        let out = serialize_first_div(
+            r#"<div>Report for &lt;a href=&quot;javascript:alert(1)&quot;&gt;x&lt;/a&gt;</div>"#,
+        );
+        assert!(
+            !out.contains("<a "),
+            "escaped anchor was resurrected as markup: {out}"
+        );
+        assert!(
+            out.contains("&lt;a href=") && out.contains("&gt;x&lt;/a&gt;"),
+            "anchor text was not re-escaped: {out}"
+        );
+    }
+
+    #[test]
+    fn serialize_node_escapes_bare_ampersand_in_text() {
+        let out = serialize_first_div("<div>Tom &amp; Jerry</div>");
+        assert!(out.contains("Tom &amp; Jerry"), "{out}");
+    }
+
+    /// Authored elements are DOM elements, not text — escaping text nodes
+    /// must leave them alone, or legitimate running-element markup breaks.
+    #[test]
+    fn serialize_node_keeps_authored_elements_intact() {
+        let out =
+            serialize_first_div(r#"<div><b>bold</b> <a href="https://ok.test">link</a></div>"#);
+        assert!(out.contains("<b>bold</b>"), "{out}");
+        assert!(
+            out.contains(r#"<a href="https://ok.test">link</a>"#),
+            "{out}"
+        );
+    }
+
+    /// Over-escaping tripwire: `<style>` is a raw text element, so the parser
+    /// never decoded references inside it and re-encoding would corrupt the
+    /// selector (`.a > b` → `.a &gt; b`).
+    #[test]
+    fn serialize_node_keeps_raw_text_of_style_element_verbatim() {
+        let out = serialize_first_div("<div><style>.a > b { color: red }</style><b>x</b></div>");
+        assert!(
+            out.contains(".a > b { color: red }"),
+            "style CSS was corrupted by escaping: {out}"
+        );
+    }
+
+    // --- escape_text_content ---
+
+    fn escape_text(s: &str) -> String {
+        let mut out = String::new();
+        escape_text_content(s, &mut out);
+        out
+    }
+
+    #[test]
+    fn escape_text_content_escapes_markup_specials() {
+        assert_eq!(escape_text("a<b>c"), "a&lt;b&gt;c");
+        assert_eq!(escape_text("a&b"), "a&amp;b");
+        assert_eq!(escape_text("&<>"), "&amp;&lt;&gt;");
+    }
+
+    #[test]
+    fn escape_text_content_leaves_quotes_and_plain_text_alone() {
+        // Text context — quotes need no escaping there.
+        assert_eq!(escape_text(r#"say "hi" 123"#), r#"say "hi" 123"#);
+        assert_eq!(escape_text(""), "");
     }
 
     // --- escape_attribute_value ---

--- a/crates/fulgur/src/gcpm/running.rs
+++ b/crates/fulgur/src/gcpm/running.rs
@@ -147,22 +147,38 @@ fn write_node(
     }
 }
 
-/// HTML "raw text elements" (HTML §13.2.5.1): `<style>` and `<script>` in the
-/// HTML namespace. The tokenizer does **not** decode character references
-/// inside them, so for their children a verbatim write-back already is the
-/// parser's inverse — escaping would corrupt the CSS/JS rather than preserve
-/// it (`.a > b` would come back as `.a &gt; b`, which the reparse hands to
-/// Stylo verbatim).
+/// Elements whose children the HTML tokenizer reads **without** decoding
+/// character references — `<style>` / `<script>` (raw text, HTML §13.2.5.1),
+/// the elements the tree builder routes through generic raw text parsing
+/// (`<xmp>`, `<iframe>`, `<noembed>`, `<noframes>`), and `<plaintext>`, which
+/// switches the tokenizer to PLAINTEXT for the rest of the input.
+///
+/// For their children a verbatim write-back already is the parser's inverse.
+/// Escaping would corrupt them instead of preserving them: `.a > b` inside a
+/// `<style>` would come back as `.a &gt; b` and be handed to Stylo that way,
+/// and `A &amp; B` inside an `<xmp>` — which never got decoded — would be
+/// re-encoded to `A &amp;amp; B` and rendered with the extra entity visible.
 ///
 /// The namespace check matters: `<style>` in the SVG namespace is *not* raw
 /// text — foreign content decodes references normally — so it takes the
 /// escaping path like any other element.
 ///
-/// `<textarea>` and `<title>` are deliberately absent: they are *escapable*
-/// raw text, where the tokenizer does decode references, so they need the
+/// Deliberately absent, all verified against blitz's parser rather than
+/// assumed: `<textarea>` and `<title>` are *escapable* raw text, where the
+/// tokenizer does decode references; `<noscript>` only becomes raw text when
+/// scripting is enabled, and blitz parses with it disabled. All three need the
 /// same escaping as ordinary text.
+///
+/// `<plaintext>` cannot round-trip at all — it consumes everything to EOF, so
+/// the end tag written after it reparses as more text — but it belongs here
+/// regardless: not double-encoding its contents is strictly closer to the
+/// input than escaping them.
 fn is_raw_text_element(elem: &blitz_dom::node::ElementData) -> bool {
-    elem.name.ns == blitz_dom::ns!(html) && matches!(elem.name.local.as_ref(), "style" | "script")
+    elem.name.ns == blitz_dom::ns!(html)
+        && matches!(
+            elem.name.local.as_ref(),
+            "style" | "script" | "xmp" | "iframe" | "noembed" | "noframes" | "plaintext"
+        )
 }
 
 /// Whether a childless element may be written as `<tag />`.
@@ -377,6 +393,35 @@ mod tests {
     fn serialize_node_keeps_void_elements_self_closing() {
         let out = serialize_first_div("<div>a<br>b</div>");
         assert!(out.contains("<br />"), "{out}");
+    }
+
+    /// The tree builder routes several more elements through raw text
+    /// parsing, so their contents were never decoded either and must not be
+    /// re-encoded. Escaping `<xmp>A &amp; B</xmp>` would render the entity
+    /// itself in the header.
+    #[test]
+    fn serialize_node_keeps_every_raw_text_mode_verbatim() {
+        for tag in ["style", "script", "xmp", "iframe", "noembed", "noframes"] {
+            let out = serialize_first_div(&format!("<div><{tag}>A &amp; B</{tag}></div>"));
+            assert!(
+                out.contains(&format!("<{tag}>A &amp; B</{tag}>")),
+                "{tag} content was re-encoded: {out}"
+            );
+        }
+    }
+
+    /// The counterpart: *escapable* raw text and, with scripting disabled,
+    /// `<noscript>` all get decoded on the way in, so they take the escaping
+    /// path like ordinary text.
+    #[test]
+    fn serialize_node_escapes_escapable_raw_text_elements() {
+        for tag in ["textarea", "title", "noscript"] {
+            let out = serialize_first_div(&format!("<div><{tag}>A &amp; B</{tag}></div>"));
+            assert!(
+                out.contains(&format!("<{tag}>A &amp; B</{tag}>")),
+                "{tag} content lost its escaping: {out}"
+            );
+        }
     }
 
     /// Over-escaping tripwire: `<style>` is a raw text element, so the parser

--- a/crates/fulgur/src/gcpm/running.rs
+++ b/crates/fulgur/src/gcpm/running.rs
@@ -128,7 +128,7 @@ fn write_node(
                 writer.push('"');
             }
 
-            if !has_children {
+            if !has_children && accepts_self_closing(elem) {
                 writer.push_str(" />");
             } else {
                 writer.push('>');
@@ -163,6 +163,40 @@ fn write_node(
 /// same escaping as ordinary text.
 fn is_raw_text_element(elem: &blitz_dom::node::ElementData) -> bool {
     elem.name.ns == blitz_dom::ns!(html) && matches!(elem.name.local.as_ref(), "style" | "script")
+}
+
+/// Whether a childless element may be written as `<tag />`.
+///
+/// Only HTML void elements and foreign content (SVG / MathML) may. The HTML
+/// tokenizer ignores the trailing solidus on any other HTML start tag, so
+/// `<div />` reparses as an *open* `<div>` that swallows every following
+/// sibling as a child. For a raw text element the damage is worse:
+/// `<style />` reparses as an open `<style>` and the rest of the margin box
+/// becomes CSS text — an empty `<style>` in a running element used to erase
+/// the header it sat in.
+///
+/// Foreign content is the exception the spec grants: the solidus *is*
+/// honoured there, so `<path />` round-trips.
+fn accepts_self_closing(elem: &blitz_dom::node::ElementData) -> bool {
+    if elem.name.ns != blitz_dom::ns!(html) {
+        return true;
+    }
+    matches!(
+        elem.name.local.as_ref(),
+        "area"
+            | "base"
+            | "br"
+            | "col"
+            | "embed"
+            | "hr"
+            | "img"
+            | "input"
+            | "link"
+            | "meta"
+            | "source"
+            | "track"
+            | "wbr"
+    )
 }
 
 /// Escape a text node's content for safe HTML embedding.
@@ -317,6 +351,32 @@ mod tests {
             out.contains(r#"<a href="https://ok.test">link</a>"#),
             "{out}"
         );
+    }
+
+    /// `<tag />` only reparses as an empty element for void elements. Any
+    /// other childless HTML element must get an explicit end tag or the
+    /// reparse treats it as open and nests its following siblings inside it.
+    #[test]
+    fn serialize_node_closes_childless_non_void_elements() {
+        let out = serialize_first_div("<div><span></span><b>X</b></div>");
+        assert!(out.contains("<span></span>"), "{out}");
+        assert!(out.contains("<b>X</b>"), "{out}");
+        assert!(!out.contains("<span />"), "{out}");
+    }
+
+    /// The raw text variant of the above: `<style />` would make the reparse
+    /// swallow everything after it as CSS text.
+    #[test]
+    fn serialize_node_closes_empty_style_element() {
+        let out = serialize_first_div("<div><style></style><b>X</b></div>");
+        assert!(out.contains("<style></style>"), "{out}");
+        assert!(!out.contains("<style />"), "{out}");
+    }
+
+    #[test]
+    fn serialize_node_keeps_void_elements_self_closing() {
+        let out = serialize_first_div("<div>a<br>b</div>");
+        assert!(out.contains("<br />"), "{out}");
     }
 
     /// Over-escaping tripwire: `<style>` is a raw text element, so the parser

--- a/crates/fulgur/tests/gcpm_integration.rs
+++ b/crates/fulgur/tests/gcpm_integration.rs
@@ -471,11 +471,31 @@ fn running_element_escaped_text_does_not_become_margin_box_markup() {
     // Comparing against the same markup *authored* as elements is the check
     // — before the fix both serialized to the same string, so the two PDFs
     // were byte-identical.
+    //
+    // Asserting on the drawn text directly would be sharper, but `inspect`
+    // cannot recover it: lopdf 0.40 does not read krilla's `ToUnicode` CMap
+    // (no `/CMapVersion` / `/WMode` support), so extracted text comes back as
+    // raw glyph ids. Byte comparison against a known-good control is the
+    // available signal until that lands.
     let injected = render_with_running_header("Status: &lt;b&gt;APPROVED&lt;/b&gt;");
     let authored = render_with_running_header("Status: <b>APPROVED</b>");
     assert_ne!(
         injected, authored,
         "escaped markup still rendered as authored markup in the margin box"
+    );
+}
+
+/// `<style />` reparses as an *open* `<style>`, so an empty `<style>` in a
+/// running element used to turn the rest of its margin box into CSS text —
+/// the header simply vanished. Same round-trip requirement as the escaping
+/// above: the serializer has to be the parser's inverse.
+#[test]
+fn running_element_empty_style_does_not_erase_the_margin_box() {
+    let with_empty_style = render_with_running_header("<style></style><b>X</b>");
+    let without = render_with_running_header("<b>X</b>");
+    assert_eq!(
+        with_empty_style, without,
+        "an empty <style> swallowed the rest of the margin box"
     );
 }
 

--- a/crates/fulgur/tests/gcpm_integration.rs
+++ b/crates/fulgur/tests/gcpm_integration.rs
@@ -418,3 +418,76 @@ fn counter_pass_survives_element_names_with_css_metacharacters() {
         .expect("render must succeed even with crafted tag names");
     assert!(pdf.starts_with(b"%PDF-"), "output should be a PDF");
 }
+
+/// Running elements are serialized back to HTML and reparsed for the margin
+/// box, so the serializer has to be the parser's inverse. It used not to be
+/// for text nodes: the parser decodes character references on the way in and
+/// nothing re-encoded them on the way out, so text that arrived escaped came
+/// back as live markup in the header/footer.
+///
+/// That defeats `template::render_template`'s forced `AutoEscape::Html`,
+/// which `docs/security/threat-model.md` V1 lists as an existing mitigation
+/// for the trusted-template / untrusted-data shape.
+fn render_with_running_header(header_body: &str) -> Vec<u8> {
+    let mut assets = AssetBundle::new();
+    assets.add_css(
+        r#"
+        .header { position: running(pageHeader); }
+        @page { margin: 2cm; @top-center { content: element(pageHeader); } }
+    "#,
+    );
+    let engine = Engine::builder().assets(assets).build();
+    engine
+        .render(&format!(
+            r#"<!DOCTYPE html><html><body>
+  <div class="header">{header_body}</div>
+  <p>body</p>
+</body></html>"#
+        ))
+        .expect("render must succeed")
+}
+
+#[test]
+fn running_element_escaped_text_does_not_become_a_margin_box_link() {
+    // `&lt;a href=…&gt;` is what MiniJinja's HTML autoescape emits for a
+    // `{{ variable }}` holding an anchor — it must stay text.
+    let pdf = render_with_running_header(
+        "Report for &lt;a href=&quot;javascript:alert(1)&quot;&gt;click&lt;/a&gt;",
+    );
+    let bytes = String::from_utf8_lossy(&pdf);
+    assert!(
+        !bytes.contains("javascript:alert(1)"),
+        "escaped anchor became a live PDF URI action"
+    );
+    assert!(
+        !bytes.contains("/URI"),
+        "escaped anchor produced a link annotation"
+    );
+}
+
+#[test]
+fn running_element_escaped_text_does_not_become_margin_box_markup() {
+    // Beyond links: escaped text must not render as the markup it spells.
+    // Comparing against the same markup *authored* as elements is the check
+    // — before the fix both serialized to the same string, so the two PDFs
+    // were byte-identical.
+    let injected = render_with_running_header("Status: &lt;b&gt;APPROVED&lt;/b&gt;");
+    let authored = render_with_running_header("Status: <b>APPROVED</b>");
+    assert_ne!(
+        injected, authored,
+        "escaped markup still rendered as authored markup in the margin box"
+    );
+}
+
+/// Over-escaping tripwire at the render level: `<style>` is a raw text
+/// element, so its CSS must survive serialization unescaped.
+#[test]
+fn running_element_style_child_survives_serialization() {
+    let with_style =
+        render_with_running_header("<style>.hl { color: red }</style><span class=\"hl\">X</span>");
+    let without_style = render_with_running_header("<span class=\"hl\">X</span>");
+    assert_ne!(
+        with_style, without_style,
+        "<style> inside a running element stopped applying — CSS was corrupted by escaping"
+    );
+}

--- a/docs/security/threat-model.ja.md
+++ b/docs/security/threat-model.ja.md
@@ -84,6 +84,14 @@ URL が含まれ、fulgur が JS ランタイムを獲得した場合や、生�
 - **[既存]** MiniJinja 自動エスケープ (`AutoEscape::Html`) が
   `{{ variable }}` 出力の `<`, `>`, `&`, `"` をエスケープ
   (`crates/fulgur/src/template.rs:90`)
+- **[既存]** GCPM running element は HTML に再シリアライズしてマージンボックス
+  で再パースされるため、この往復で上記のエスケープが保存される必要がある。
+  `gcpm::running::serialize_node` がテキストノードを再エンコードする
+  (`crates/fulgur/src/gcpm/running.rs`)。これが無いと、
+  `position: running()` + `content: element()` でヘッダ / フッタに渡った
+  エスケープ済みデータが生のマークアップとして復元される。
+  `<style>` / `<script>` の子は
+  パーサが実体参照を復号しないため対象外。
 
 ### V2 — サーバーサイドリクエストフォージェリ (SSRF)
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -88,6 +88,13 @@ warranted because:
 - **[Existing]** MiniJinja auto-escaping (`AutoEscape::Html`) escapes
   `<`, `>`, `&`, `"` in all `{{ variable }}` output
   (`crates/fulgur/src/template.rs:90`)
+- **[Existing]** GCPM running elements are serialized back to HTML and
+  reparsed for their margin box, so that round trip must preserve the
+  escaping above. `gcpm::running::serialize_node` re-encodes text nodes
+  (`crates/fulgur/src/gcpm/running.rs`); without it, escaped data reaching
+  a header/footer via `position: running()` + `content: element()` would
+  come back as live markup. `<style>` / `<script>` children are exempt
+  because the parser never decoded references inside them
 
 ### V2 — Server-Side Request Forgery (SSRF)
 


### PR DESCRIPTION
Codex Security finding「Margin-box links activate escaped running-element HTML」のトリアージから。closes fulgur-4f5u

## 何が壊れていたか

running element は HTML に再シリアライズされ、`@page` マージンボックスのレイアウトのために再パースされます。つまり `gcpm::running::serialize_node` は **HTML パーサの逆写像**でなければなりません。テキストノードについてそうなっていませんでした — 属性値はエスケープしていた一方 `NodeData::Text` は verbatim で書き戻しており、パース時にはすでに実体参照が復号されています。

結果、エスケープ済みマークアップとして DOM に届いたテキストが、マージンボックス再パースに**生のマークアップとして**戻されます。

実害は `template::render_template` の強制 `AutoEscape::Html` が、`position: running()` + `content: element()` でヘッダ / フッタに流れるデータについて成立しなくなることです。これは `docs/security/threat-model.md` の V1 が緩和策として挙げている当のコントロールです。エスケープ済みの `<a href="javascript:…">` が本物のアンカーとして復活し、マージンボックスが独自の `LinkCollector` を持つようになって以降はクリック可能な `/URI` annotation にもなります。

修正前の実測（autoescape 済みテンプレートデータからの経路）:

```text
has /URI      : true
has javascript: true
has /Link     : true
```

## 影響範囲

コード側マーカーで確定（タグ containment ではなく）:

| 影響 | 下限 | マーカー |
|---|---|---|
| マージンボックスへの HTML injection | v0.1.1〜（全リリース） | `push_str(&text_data.content)` が全 56 タグに存在 |
| クリック可能な `/URI` annotation | v0.12.0〜 | `link_collector: None`（マージン canvas）が v0.12.0 で消失 |

上限側の緩和要因:

- `serialize_node` の呼び出し元は `blitz_adapter.rs` の1箇所のみ → blast radius は running element → マージンボックスに限定
- マージンボックス再パースは NetProvider も base path も持たない（`parse_and_layout(…, None, None)` / `assets: None`）ため、そこからローカルリソース経路には到達しない
- fulgur に JS ランタイムは無く、主要 PDF ビューアは `/URI` の `javascript:` を実行しない

実質的な影響は integrity のみ（ヘッダ / フッタの内容偽装 + 攻撃者制御のクリック可能リンク、UI:R）。CVSS 3.1 `AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N` = 4.3 Medium、CWE-116。

## 修正

テキストノードの `&`, `<`, `>` をエスケープします。ただし **HTML 名前空間の `<style>` / `<script>` の子は verbatim のまま**にします — これらは raw text 要素でトークナイザが実体参照を復号しないため、verbatim が既に逆写像であり、エスケープすると CSS が壊れます（`.a > b` → `.a &gt; b`）。`<textarea>` / `<title>` は escapable raw text なのでエスケープ側に残します。名前空間チェックは SVG の `<style>` を区別するためのものです（foreign content では通常どおり復号される）。

## GHSA を切らない判断

`fulgur-z28x`（tagged PDF nested MCS panic, **CVSS 7.5**）を「opt-in で default off」を根拠に GHSA 不要と判断した前例に合わせています。本件も `position: running()` + `content: element()` という opt-in な GCPM 構成でしか経路が通らず、severity は 4.3 とさらに低いため、7.5 に advisory を出さなかった以上ここで出すのは一貫しません。`release-notes:security` ラベルで Release ノートの Security セクションに載せます。

URI スキーム allowlist は**本 PR に含めません**。pre-existing かつ body 全体に及ぶ別問題で、完全 untrusted HTML モデルでは no-op、`mailto:` / `tel:` の互換コストもあります。fulgur-d8f9 に分離済み（threat-model V1 が既に計画しているサニタイザ DomPass fulgur-me2 に寄せるかも含めて判断）。

## 隣接して見つかった往復バグも同 PR で修正

`write_node` は子なし要素を一律 `<tag />` で書いていましたが、foreign content 以外では HTML トークナイザが末尾のソリダスを無視します。つまり `<div />` は**開いた** `<div>` として再パースされ後続の兄弟を全部子に取り込み、`<style />` は開いた raw text 要素になってマージンボックスの残りを CSS テキストとして飲み込みます。**running element 内の空の `<style>` がヘッダを丸ごと消していました**（13302B → 7704B、後続の `<b>X</b>` が消失）。

`<tag />` を HTML void 要素と foreign content（ソリダスが有効で `<path />` が往復する）に限定し、それ以外には明示的な終了タグを出します。テキストノードのエスケープと同じ「シリアライザはパーサの逆写像」という要件の別ケースなので、同じ関数・同じ主張として本 PR に含めました。

## テスト

TDD で修正前に落ちることを確認済み（round-trip テストは FAIL、over-escaping tripwire は両方で PASS）:

- serializer unit: エスケープ済みマークアップがテキストとして往復する / 素の `&` がエスケープされる
- serializer unit（tripwire）: authored な `<b>` `<a>` 要素は無傷 / `<style>` の CSS が verbatim で残る
- e2e: エスケープ済みアンカーが `/URI` を生まない
- e2e: エスケープ済みマークアップの PDF が、同じマークアップを authored で書いた PDF と**一致しない**（リンク以外の injection もカバー）
- e2e（tripwire）: running element 内の `<style>` が効き続ける
- serializer unit / e2e: 空の `<style>` `<span>` が終了タグ付きで往復し、`<br>` は `<br />` のまま / 空の `<style>` がマージンボックスを消さない

既存の `margin_box_running_element_link_keeps_pdf_annotation`（authored アンカーは annotation を保つ）は引き続き PASS。VRT golden と examples determinism も差分なし＝正当なコンテンツを過剰エスケープしていないことの裏付けです。
