### PR TITLE
test(gcpm): cover the foreign-content side of both namespace checks

### DIFF
--- a/crates/fulgur/src/gcpm/running.rs
+++ b/crates/fulgur/src/gcpm/running.rs
@@ -424,6 +424,22 @@ mod tests {
         }
     }
 
+    /// Foreign content is the other side of both namespace checks: SVG
+    /// children may self-close, and SVG `<style>` is *not* raw text — the
+    /// parser decoded its references, so re-encoding them is the correct
+    /// inverse and the foreign-content reparse decodes them again.
+    #[test]
+    fn serialize_node_handles_foreign_content() {
+        let out = serialize_first_div(
+            r#"<div><svg viewBox="0 0 10 10"><circle r="4"/><style>circle &gt; * {fill:red}</style></svg></div>"#,
+        );
+        assert!(out.contains(r#"<circle r="4" />"#), "{out}");
+        assert!(
+            out.contains("<style>circle &gt; * {fill:red}</style>"),
+            "{out}"
+        );
+    }
+
     /// Over-escaping tripwire: `<style>` is a raw text element, so the parser
     /// never decoded references inside it and re-encoding would corrupt the
     /// selector (`.a > b` → `.a &gt; b`).


### PR DESCRIPTION
#666 のフォローアップ（マージ後に書いたテストのため取りこぼしたもの）。テストのみ、プロダクションコードの変更なし。

#666 が `gcpm::running` に入れた 2 つの名前空間チェックは、どちらも非 HTML 側の分岐を通るテストがありませんでした（codecov も #666 で patch 97.87% / 3 行未カバーと報告）。守っているはずの SVG の挙動が未文書・未カバーのままだったので、実測して固定します。

- `accepts_self_closing`: foreign content はソリダスを honor するので `<circle/>` は自己閉じのまま往復する
- `is_raw_text_element`: SVG の `<style>` は raw text **ではない**（foreign content は実体参照を復号する）ので、HTML の同名要素と違ってエスケープ経路を通る。`circle &gt; *` がパース時に `circle > *` へ復号され、シリアライズで再エンコードされ、再パースでまた復号される — 往復が成立していることを確認済み

`cargo test -p fulgur` / `cargo fmt --check` / `cargo clippy -p fulgur --all-targets -- -D warnings` は green です。