### PR TITLE
test(convert): cover inline-root else-branch in build_list_item_body

### DIFF
--- a/crates/fulgur/src/convert/list_item.rs
+++ b/crates/fulgur/src/convert/list_item.rs
@@ -1324,4 +1324,56 @@ mod tests {
             .expect("render failed");
         assert!(pdf.starts_with(b"%PDF"));
     }
+
+    // build_list_item_body (outside marker, inline-root): empty <li> with a
+    // ::before pseudo whose `content` is an image URL, but NO assets are
+    // provided so `build_inline_pseudo_image` returns None. The <li> is still
+    // an inline root (the inline pseudo-element creates an IFC), but both
+    // `paragraph_opt` and `before_inline` are None — exercising the final
+    // `else` branch at lines 429-436 (fall-through to non-inline-root walk).
+    #[test]
+    fn smoke_outside_marker_inline_before_unresolved_url_no_assets() {
+        let pdf = render_list_html(
+            r#"<!doctype html><html><head>
+            <style>li::before { content: url("dot.png"); width: 8px; height: 8px; }</style>
+            </head><body>
+            <ul><li></li></ul>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // build_list_item_body (outside marker, inline-root): same as above but via
+    // ::after. Verifies that the else-branch at lines 429-436 is also reached
+    // when `after_inline` (not `before_inline`) is the unresolved pseudo.
+    #[test]
+    fn smoke_outside_marker_inline_after_unresolved_url_no_assets() {
+        let pdf = render_list_html(
+            r#"<!doctype html><html><head>
+            <style>li::after { content: url("dot.png"); width: 8px; height: 8px; }</style>
+            </head><body>
+            <ul><li></li></ul>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // build_list_item_body (outside marker, inline-root): empty <li> with both
+    // ::before AND ::after inline-image pseudos whose URLs are unresolved.
+    // `before_inline` and `after_inline` are both None, exercising the
+    // lines 429-436 path with two simultaneous unresolved pseudo-images.
+    #[test]
+    fn smoke_outside_marker_both_pseudos_unresolved_url_no_assets() {
+        let pdf = render_list_html(
+            r#"<!doctype html><html><head>
+            <style>
+            li::before { content: url("before.png"); width: 6px; height: 6px; }
+            li::after  { content: url("after.png");  width: 6px; height: 6px; }
+            </style>
+            </head><body>
+            <ul><li></li></ul>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
 }


### PR DESCRIPTION
## 概要 / Summary

`convert/list_item.rs` の `build_list_item_body` 関数内の未カバーパス（lines 429–436）を3つのスモークテストでカバーします。

## 対象ファイル / Target file

`crates/fulgur/src/convert/list_item.rs`

カバレッジ改善: **93.10% → 94.07%**（62 → 55 missed lines）

## 追加したテスト / Tests added

3 tests added to the existing `#[cfg(test)] mod tests` block:

| テスト名 | 狙い |
|---|---|
| `smoke_outside_marker_inline_before_unresolved_url_no_assets` | `::before` にアセット未登録の `url(...)` を設定し、`before_inline = None` とすることで lines 429–436 を通過 |
| `smoke_outside_marker_inline_after_unresolved_url_no_assets` | 同様だが `::after` 側で検証 |
| `smoke_outside_marker_both_pseudos_unresolved_url_no_assets` | `::before` と `::after` の両方が未解決の場合を検証 |

## カバレッジギャップの分析 / Coverage gap analysis

Lines 429–436 は `build_list_item_body` 内の最後の `else` 分岐です：

```rust
} else {
    // Inline root with no text and no inline pseudo images — fall
    // through to non-inline-root walk.
    let layout_children_guard_1 = node.layout_children.borrow();
    let children = layout_children_guard_1.as_deref().unwrap_or(&node.children);
    positioned::walk_children_into_drawables(doc, children, ctx, depth, out);
    pseudo::register_pseudo_content(doc, node, ctx, depth, content_box, out);
}
```

この分岐は **`<li>` がインラインルート（inline `::before` 疑似要素によって IFC が形成される）** だが、`extract_paragraph` が `None`（空ボディ）かつ `before_inline`/`after_inline` がともに `None`（アセットバンドル未提供のため画像が解決されない）のときに到達します。

既存テスト `smoke_outside_marker_empty_li_with_inline_before_image` はアセットありで `before_inline = Some` → line 406 のパスを通りますが、アセットなしのケースは未テストでした。

## 意図的に省略したギャップ / Deliberate omissions

以下のミスは意図的にテストを追加しませんでした：

- **Lines 77–119** (branch 2 fallback): Blitz が `display: list-item` 要素すべてに `list_item_data` を生成するため実質 unreachable
- **Lines 18, 145–146, 308**: 防御的ガード（`doc.get_node()` や `primary_styles()` が `None` を返す場合）、テストから制御不可能
- **Lines 170, 237** (`)?;`): `shape_marker_with_skrifa` は有効なフォント時に常に `Some` を返すため、`None` パスは到達不能
- **Lines 561, 576, 606, 650, 775, 797, 823, 831, 839, 848, 879, 909**: テストコード内の `panic!` アーム（`matches!` の成功側を検証するため、失敗側は意図的に dead）

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8piNoz1TnBrc1VGwoZtQe)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * リスト項目内の未解決URLやインライン擬似要素に関するケースを追加検証しました。
  * 該当ケースでもPDFが正常に生成され、正しいPDF形式で出力されることを確認しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->