### PR TITLE
fix(render): narrow the scope-walk inline-box skip to paragraph-owned boxes

### DIFF
--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -4585,6 +4585,100 @@ mod tests {
         assert!(!para_has_link_runs(&para));
     }
 
+    /// Build a paragraph carrying one inline box with the given node id.
+    fn para_with_inline_box(node_id: Option<usize>) -> crate::drawables::ParagraphEntry {
+        let item = crate::paragraph::InlineBoxItem {
+            node_id,
+            width: 10.0_f32.as_pt(),
+            height: 10.0_f32.as_pt(),
+            x_offset: crate::units::Pt::ZERO,
+            computed_y: crate::units::Pt::ZERO,
+            link: None,
+            opacity: 1.0,
+            visible: true,
+        };
+        make_para(vec![make_shaped_line(vec![
+            crate::paragraph::LineItem::InlineBox(item),
+        ])])
+    }
+
+    #[test]
+    fn paragraph_owned_inline_boxes_expands_the_scope_owner_paragraph() {
+        let mut d = Drawables::new();
+        // Scope owner 1 owns a paragraph carrying inline box 2, whose
+        // subtree is {3, 4}.
+        d.paragraphs.insert(1, para_with_inline_box(Some(2)));
+        d.inline_box_subtree_descendants.insert(2, vec![3, 4]);
+
+        let skip = paragraph_owned_inline_boxes([1, 3, 4], &d);
+        assert_eq!(
+            skip,
+            [2, 3, 4]
+                .into_iter()
+                .collect::<std::collections::BTreeSet<_>>(),
+            "the box and its recorded subtree are painted by the paragraph",
+        );
+    }
+
+    #[test]
+    fn paragraph_owned_inline_boxes_expands_descendant_paragraphs() {
+        let mut d = Drawables::new();
+        // The scope owner (1) has no paragraph; a descendant (5) does. A
+        // table is exactly this shape — the duplicate originates in a cell.
+        d.paragraphs.insert(5, para_with_inline_box(Some(6)));
+        d.inline_box_subtree_descendants.insert(6, vec![7]);
+
+        let skip = paragraph_owned_inline_boxes([1, 5, 6, 7], &d);
+        assert_eq!(
+            skip,
+            [6, 7]
+                .into_iter()
+                .collect::<std::collections::BTreeSet<_>>(),
+        );
+    }
+
+    #[test]
+    fn paragraph_owned_inline_boxes_ignores_ids_without_a_paragraph() {
+        let mut d = Drawables::new();
+        // 9 is a plain block drawable, not a paragraph — nothing to skip.
+        // This is the block-child case: the id is in the scope's descendant
+        // list but no paragraph paints it, so the walk must still dispatch
+        // it. Skipping it here is what PR #677 got wrong (fulgur-49xw).
+        d.inline_box_subtree_descendants.insert(8, vec![9]);
+
+        let skip = paragraph_owned_inline_boxes([8, 9], &d);
+        assert!(
+            skip.is_empty(),
+            "no paragraph in scope means nothing is paragraph-owned, got {skip:?}",
+        );
+    }
+
+    #[test]
+    fn paragraph_owned_inline_boxes_skips_boxes_without_a_node_id() {
+        let mut d = Drawables::new();
+        d.paragraphs.insert(1, para_with_inline_box(None));
+
+        let skip = paragraph_owned_inline_boxes([1], &d);
+        assert!(
+            skip.is_empty(),
+            "an inline box with no node id has nothing to skip"
+        );
+    }
+
+    #[test]
+    fn paragraph_owned_inline_boxes_handles_a_box_with_no_recorded_subtree() {
+        let mut d = Drawables::new();
+        // `inline_box_subtree_descendants` has no entry for 2 — a leaf
+        // inline box. The box itself is still paragraph-owned.
+        d.paragraphs.insert(1, para_with_inline_box(Some(2)));
+
+        let skip = paragraph_owned_inline_boxes([1], &d);
+        assert_eq!(
+            skip,
+            [2].into_iter().collect::<std::collections::BTreeSet<_>>(),
+        );
+    }
+
     #[test]
     fn para_has_link_runs_image_with_link_returns_true() {
         let span = std::sync::Arc::new(crate::paragraph::LinkSpan {

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -1401,6 +1401,58 @@ fn paint_multicol_paragraph_slices(
     }
 }
 
+/// Collect the inline-box subtrees that paragraphs drawn *inside a scope*
+/// already paint, so the scope's own descendant walk does not paint them a
+/// second time.
+///
+/// `scope_ids` must yield the scope owner plus every id in the walk's
+/// descendant list: any paragraph in that subtree is drawn inside the
+/// scope, so whatever inline boxes it carries are its to paint.
+///
+/// This is deliberately narrower than `Drawables::inline_box_subtree_skip`.
+/// That set is global, which is right for the top-level dispatch loop —
+/// every member is painted by *some* paragraph — but wrong inside a scope.
+/// A scoped inline-block's own subtree lands in the global set only because
+/// the inline-block is an inline box in its *parent's* paragraph; when the
+/// inline-block has no paragraph of its own, as in
+///
+/// ```html
+/// <div style="display:inline-block;overflow:hidden">
+///   <div style="background:red"></div>
+/// </div>
+/// ```
+///
+/// the scope walk is the only thing that would paint that child. Skipping
+/// it there drops the content outright — the regression PR #677 shipped by
+/// reaching for the global set here (fulgur-49xw).
+fn paragraph_owned_inline_boxes(
+    scope_ids: impl IntoIterator<Item = usize>,
+    drawables: &Drawables,
+) -> std::collections::BTreeSet<usize> {
+    let mut skip = std::collections::BTreeSet::new();
+    for id in scope_ids {
+        let Some(para) = drawables.paragraphs.get(&id) else {
+            continue;
+        };
+        for item in para.lines.iter().flat_map(|line| line.items.iter()) {
+            let crate::paragraph::LineItem::InlineBox(ib) = item else {
+                continue;
+            };
+            let Some(ib_id) = ib.node_id else {
+                continue;
+            };
+            // `paragraph::draw_shaped_lines` hands the box to
+            // `dispatch_inline_box_content`, which paints the box itself
+            // and walks `inline_box_subtree_descendants[ib_id]`.
+            skip.insert(ib_id);
+            if let Some(descs) = drawables.inline_box_subtree_descendants.get(&ib_id) {
+                skip.extend(descs.iter().copied());
+            }
+        }
+    }
+    skip
+}
+
 /// Push the transform onto the surface + link collector, dispatch the
 /// wrapper node's own payload and every descendant fragment that lands
 /// on `page_index`, then pop:
@@ -1524,10 +1576,20 @@ fn draw_under_transform(
         .filter_map(|id| drawables.block_styles.get(id))
         .flat_map(|b| b.opacity_descendants.iter().copied())
         .collect();
+    // Inline boxes carried by paragraphs inside this transform are painted
+    // by those paragraphs' `LineItem::InlineBox` arms. Re-dispatching them
+    // here paints them twice — and because the duplicate re-enters
+    // `draw_under_transform` for a nested transformed inline-block, the
+    // cost doubles per nesting level rather than staying constant.
+    let paragraph_ib_skip = paragraph_owned_inline_boxes(
+        std::iter::once(node_id).chain(tx.descendants.iter().copied()),
+        drawables,
+    );
     for &desc_id in &tx.descendants {
         if nested_skip.contains(&desc_id)
             || clip_skip.contains(&desc_id)
             || opacity_skip.contains(&desc_id)
+            || paragraph_ib_skip.contains(&desc_id)
         {
             continue;
         }
@@ -1940,21 +2002,20 @@ fn draw_under_clip(
             .filter_map(|id| drawables.block_styles.get(id))
             .flat_map(|b| b.opacity_descendants.iter().copied())
             .collect();
+        // Inline boxes carried by paragraphs inside this clip are painted
+        // by those paragraphs' `LineItem::InlineBox` arms. Re-dispatching
+        // them here paints them twice — and because the duplicate re-enters
+        // `draw_under_clip` for a nested clipped inline-block, the cost
+        // doubles per nesting level rather than staying constant.
+        let paragraph_ib_skip = paragraph_owned_inline_boxes(
+            std::iter::once(node_id).chain(block.clip_descendants.iter().copied()),
+            drawables,
+        );
         for &desc_id in &block.clip_descendants {
             if transform_skip.contains(&desc_id)
                 || nested_clip_skip.contains(&desc_id)
                 || nested_opacity_skip.contains(&desc_id)
-                // Mirrors the top-level dispatch loop's
-                // `inline_box_subtree_skip` guard: inline-box content is
-                // painted exclusively by `paragraph::draw_shaped_lines`'s
-                // `LineItem::InlineBox` arm. This block's own paragraph is
-                // drawn above, inside the same clip group, and that draw
-                // already dispatched these nodes. Re-dispatching here
-                // paints them twice — and because the second dispatch
-                // re-enters `draw_under_clip` for a nested clipped
-                // inline-block, the duplication compounds exponentially
-                // with nesting depth rather than linearly.
-                || drawables.inline_box_subtree_skip.contains(&desc_id)
+                || paragraph_ib_skip.contains(&desc_id)
             {
                 continue;
             }
@@ -2294,15 +2355,20 @@ fn draw_under_opacity(
             .filter_map(|id| drawables.block_styles.get(id))
             .flat_map(|b| b.opacity_descendants.iter().copied())
             .collect();
+        // Same narrowing as `draw_under_clip`: paragraphs inside this
+        // opacity group paint their own inline boxes, so the walk must not
+        // paint them again. Unlike the clip and transform paths this
+        // duplicate does not compound — `draw_under_opacity` has no
+        // self-recursive arm — but it is still a double paint.
+        let paragraph_ib_skip = paragraph_owned_inline_boxes(
+            std::iter::once(node_id).chain(block.opacity_descendants.iter().copied()),
+            drawables,
+        );
         for &desc_id in &block.opacity_descendants {
             if transform_skip.contains(&desc_id)
                 || nested_clip_skip.contains(&desc_id)
                 || nested_opacity_skip.contains(&desc_id)
-                // Same `inline_box_subtree_skip` guard as `draw_under_clip`
-                // and the top-level dispatch loop — this block's paragraph,
-                // drawn above inside the `draw_with_opacity` group, already
-                // dispatched its inline-box content.
-                || drawables.inline_box_subtree_skip.contains(&desc_id)
+                || paragraph_ib_skip.contains(&desc_id)
             {
                 continue;
             }
@@ -2921,10 +2987,16 @@ fn draw_under_clip_table(
             .flat_map(|b| b.opacity_descendants.iter().copied())
             .collect();
 
+        // A table has no paragraph of its own, so the skip set comes purely
+        // from the cell paragraphs inside `clip_descendants` — that is
+        // where the duplicate paint of a cell's inline box originates.
+        let paragraph_ib_skip =
+            paragraph_owned_inline_boxes(table.clip_descendants.iter().copied(), drawables);
         for &desc_id in &table.clip_descendants {
             if transform_skip.contains(&desc_id)
                 || nested_clip_skip.contains(&desc_id)
                 || nested_opacity_skip.contains(&desc_id)
+                || paragraph_ib_skip.contains(&desc_id)
             {
                 continue;
             }

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -1634,16 +1634,16 @@ fn nested_inline_blocks(depth: usize, scope: &str) -> String {
     s
 }
 
-/// Regression: an inline root that needs an `overflow` clip or an opacity
-/// wrapper must not paint its inline-box subtree twice.
+/// Regression: an inline root that needs an `overflow` clip, an opacity
+/// wrapper, or a `transform` must not paint its inline-box subtree twice.
 ///
 /// `paragraph::draw_shaped_lines` dispatches `LineItem::InlineBox` content
-/// itself, so `render::draw_under_clip` / `draw_under_opacity` must filter
-/// `inline_box_subtree_skip` out of their descendant walks — exactly like
-/// the top-level dispatch loop does. Without that filter the subtree paints
-/// once per scope, and because the duplicate re-enters `draw_under_clip`
-/// for the *next* nested clipped inline-block, the cost doubles per level:
-/// depth 22 produced a 10.7 MB PDF in ~4.8 s from a ~1 KB input.
+/// itself, so every descendant walk in `render` must filter
+/// `inline_box_subtree_skip` — exactly like the top-level dispatch loop
+/// does. Without that filter the subtree paints once per scope, and where
+/// the duplicate re-enters the *same* helper for the next nested wrapper,
+/// the cost doubles per level: depth 22 produced a 10.7 MB PDF in ~4.8 s
+/// (clip) and a 28.6 MB PDF in ~4.4 s (transform) from a ~2 KB input.
 ///
 /// The assertion compares growth *rate* across two equal-width depth
 /// windows rather than absolute size, because some nesting genuinely costs
@@ -1652,12 +1652,12 @@ fn nested_inline_blocks(depth: usize, scope: &str) -> String {
 /// keeps the two windows comparable; doubling-per-level makes the upper
 /// window ~2^8 times the lower one.
 ///
-/// Only the clip scope compounds today: `draw_under_clip` recurses into
-/// itself for a nested clipped block, whereas the opacity duplicate stays
-/// a constant factor (measured linear both before and after the fix). The
-/// opacity scope is still asserted here so that if `draw_under_opacity`
-/// ever grows an equivalent recursive arm, it cannot silently inherit the
-/// same blowup.
+/// The clip and transform scopes are the ones that compound, because
+/// `draw_under_clip` / `draw_under_transform` recurse into themselves for
+/// a nested clipped / transformed block. The opacity duplicate stays a
+/// constant factor (measured linear both before and after the fix); it is
+/// asserted here anyway so that if `draw_under_opacity` ever grows an
+/// equivalent recursive arm, it cannot silently inherit the same blowup.
 #[test]
 fn nested_clipped_inline_blocks_do_not_amplify_output() {
     let render_at = |depth: usize, scope: &str| {
@@ -1668,7 +1668,11 @@ fn nested_clipped_inline_blocks_do_not_amplify_output() {
             .len()
     };
 
-    for scope in ["overflow:hidden;", "opacity:0.5;"] {
+    for scope in [
+        "overflow:hidden;",
+        "opacity:0.5;",
+        "transform:rotate(1deg);",
+    ] {
         let (d8, d12, d16, d20) = (
             render_at(8, scope),
             render_at(12, scope),
@@ -1687,6 +1691,211 @@ fn nested_clipped_inline_blocks_do_not_amplify_output() {
              depths 16→20 was {upper} bytes vs {lower} bytes over 8→12 \
              (allowed <= {bound}). The inline-box subtree is being dispatched \
              both by the paragraph draw and by the clip/opacity descendant walk.",
+        );
+    }
+}
+
+/// Count the `rg` (non-stroking RGB) operators selecting pure red in one
+/// decoded content stream.
+fn count_red_in_content(bytes: &[u8]) -> usize {
+    let Ok(content) = lopdf::content::Content::decode(bytes) else {
+        return 0;
+    };
+    content
+        .operations
+        .iter()
+        .filter(|op| op.operator == "rg" && op.operands.len() == 3)
+        .filter(|op| {
+            let channels: Vec<f32> = op
+                .operands
+                .iter()
+                .filter_map(|o| match o {
+                    lopdf::Object::Integer(i) => Some(*i as f32),
+                    lopdf::Object::Real(f) => Some(*f),
+                    _ => None,
+                })
+                .collect();
+            channels.len() == 3 && channels[0] > 0.9 && channels[1] < 0.1 && channels[2] < 0.1
+        })
+        .count()
+}
+
+/// Count pure-red fills across page content streams *and* form XObjects.
+///
+/// The XObject sweep is required for the opacity scope: `draw_with_opacity`
+/// paints into a transparency group, which krilla emits as a separate
+/// `/Subtype /Form` stream rather than inline in the page content.
+fn count_red_fill_ops(pdf: &[u8]) -> usize {
+    let doc = lopdf::Document::load_mem(pdf).expect("PDF must parse");
+    let mut count = 0;
+    for (_, page_id) in doc.get_pages() {
+        let bytes = doc
+            .get_page_content(page_id)
+            .expect("page content stream readable");
+        count += count_red_in_content(&bytes);
+    }
+    for obj in doc.objects.values() {
+        let lopdf::Object::Stream(stream) = obj else {
+            continue;
+        };
+        let is_form = matches!(
+            stream.dict.get(b"Subtype").and_then(lopdf::Object::as_name),
+            Ok(b"Form")
+        );
+        if !is_form {
+            continue;
+        }
+        if let Ok(bytes) = stream.decompressed_content() {
+            count += count_red_in_content(&bytes);
+        }
+    }
+    count
+}
+
+/// Regression: the inline-box subtree paints exactly once under *every*
+/// wrapping scope, not just the ones that amplify.
+///
+/// `nested_clipped_inline_blocks_do_not_amplify_output` catches the
+/// self-recursive helpers (clip, transform) by their growth rate, but a
+/// duplicate that stays a constant factor — the opacity wrapper, and a
+/// `<table>` with `overflow:hidden` around a cell's inline-block — is
+/// invisible to a rate test. Counting the red fill operator pins the
+/// invariant directly: one leaf, one `1 0 0 rg`.
+///
+/// Before the fix the `overflow:hidden` table emitted the leaf twice
+/// (once from the cell's paragraph draw, once from
+/// `draw_under_clip_table`'s `clip_descendants` walk).
+#[test]
+fn inline_box_subtree_paints_once_under_every_scope() {
+    for scope in [
+        "",
+        "overflow:hidden;",
+        "opacity:0.5;",
+        "transform:rotate(1deg);",
+    ] {
+        let pdf = Engine::builder()
+            .build()
+            .render(&nested_inline_blocks(1, scope))
+            .expect("render");
+        let reds = count_red_fill_ops(&pdf);
+        assert_eq!(
+            reds, 1,
+            "inline-block leaf under `{scope}` painted {reds} times, expected 1 \
+             — the inline-box subtree is dispatched both by the paragraph draw \
+             and by a descendant walk",
+        );
+    }
+}
+
+/// The other shape the skip has to get right: the scope sits on a *block*
+/// wrapper, and the inline box is inside that block's paragraph.
+///
+/// Here the descendant walk dispatches the `<p>`, and the paragraph draw is
+/// what paints the inline box — so skipping the subtree in the walk must
+/// still leave exactly one paint. This variant guards the opposite failure
+/// mode from the amplification test: an over-eager skip makes the leaf paint
+/// *zero* times, and neither a growth-rate assertion nor a byte-identical
+/// VRT golden would notice content that simply vanished.
+#[test]
+fn inline_box_under_block_scope_paints_exactly_once() {
+    for scope in [
+        "",
+        "overflow:hidden;",
+        "opacity:0.5;",
+        "transform:rotate(1deg);",
+    ] {
+        let html = format!(
+            "<!DOCTYPE html><html><body>\
+             <div style=\"width:300px;height:200px;{scope}\">\
+             <p>text {} tail</p></div></body></html>",
+            r#"<span style="display:inline-block;width:20px;height:20px;background:#ff0000"></span>"#,
+        );
+        let pdf = Engine::builder().build().render(&html).expect("render");
+        let reds = count_red_fill_ops(&pdf);
+        assert_eq!(
+            reds, 1,
+            "inline box inside a paragraph under block scope `{scope}` painted \
+             {reds} times, expected 1 (0 = the descendant-walk skip swallowed \
+             content the paragraph draw was supposed to paint; 2 = it is \
+             painted by both)",
+        );
+    }
+}
+
+/// Regression: a scoped inline-block whose child is a *block* must still
+/// paint that child.
+///
+/// This is the shape that makes `Drawables::inline_box_subtree_skip` the
+/// wrong predicate for a scope walk. The global set contains every drawable
+/// under every inline box, so it contains this red child — but only because
+/// the wrapper is an inline box in the *body's* paragraph. The wrapper has
+/// no paragraph carrying the child, so nothing else paints it, and the
+/// scope walk skipping it drops the content outright.
+///
+/// PR #677 shipped exactly that regression on the clip and opacity paths
+/// (verified against `c36efebf`: the red child was emitted 0 times under
+/// `overflow:hidden` and `opacity`, and 1 time before #677). The fix is
+/// `paragraph_owned_inline_boxes`, which skips only what a paragraph drawn
+/// inside the scope actually paints.
+#[test]
+fn block_child_of_scoped_inline_block_still_paints() {
+    for scope in [
+        "",
+        "overflow:hidden;",
+        "opacity:0.5;",
+        "transform:rotate(1deg);",
+    ] {
+        for wrapper_content in ["", "text"] {
+            let html = format!(
+                "<!DOCTYPE html><html><body>\
+                 <div style=\"display:inline-block;width:100px;height:100px;{scope}\">\
+                 {wrapper_content}\
+                 <div style=\"background:#ff0000;width:50px;height:50px\"></div>\
+                 </div></body></html>"
+            );
+            let pdf = Engine::builder().build().render(&html).expect("render");
+            let reds = count_red_fill_ops(&pdf);
+            assert_eq!(
+                reds, 1,
+                "block child of an inline-block under scope `{scope}` \
+                 (wrapper text: {wrapper_content:?}) painted {reds} times, \
+                 expected 1 — 0 means the scope walk's skip predicate \
+                 swallowed a child no paragraph paints",
+            );
+        }
+    }
+}
+
+/// Regression: `draw_under_clip_table`'s `clip_descendants` walk must not
+/// re-paint a cell's inline box, like the three block-level walks.
+///
+/// `convert::table` fills `TableEntry::clip_descendants` from the same
+/// `drawn_since` diff the block paths use, so a cell's inline-box subtree
+/// lands in it. Before the fix the leaf painted twice: once from the cell's
+/// paragraph draw, once from the table's descendant walk. Unlike the clip
+/// and transform paths this duplicate does not compound with nesting, so
+/// the growth-rate assertion above cannot see it.
+#[test]
+fn inline_box_in_clipped_table_cell_paints_once() {
+    // Both cell shapes: a bare inline-block (the cell's inline root is the
+    // box itself) and text around it (the box is one item in a real
+    // paragraph, so the walk dispatches the paragraph instead).
+    for cell in [
+        r#"<span style="display:inline-block;width:20px;height:20px;background:#ff0000"></span>"#,
+        r#"cell text <span style="display:inline-block;width:20px;height:20px;background:#ff0000"></span> tail"#,
+    ] {
+        let html = format!(
+            "<!DOCTYPE html><html><body>\
+             <table style=\"overflow:hidden;width:300px;height:200px\"><tr><td>{cell}</td></tr></table>\
+             </body></html>",
+        );
+        let pdf = Engine::builder().build().render(&html).expect("render");
+        let reds = count_red_fill_ops(&pdf);
+        assert_eq!(
+            reds, 1,
+            "inline-block leaf inside an `overflow:hidden` table painted {reds} times, \
+             expected 1 — `draw_under_clip_table` must skip the inline boxes the \
+             cell paragraphs already paint (cell markup: {cell})",
         );
     }
 }


### PR DESCRIPTION
## 概要

PR #677 のフォローアップですが、**当初想定より範囲が広くなりました**。#677 は
`draw_under_clip` / `draw_under_opacity` の descendant walk に
`Drawables::inline_box_subtree_skip` のガードを足しましたが、

1. **その述語自体が広すぎて、main に描画消失（content loss）を入れています**
2. 同じガードが必要な walk があと 2 本残っていました

本 PR は 4 本すべての walk の述語を正しいものに置き換えます。

## 1. `inline_box_subtree_skip` は scope walk の述語として誤り

この集合はグローバルです（`{ib} ∪ descendants[ib]` を全 inline box で union）。
**top-level dispatch loop では正しい** — メンバーは必ずどれかの paragraph に描かれるからです。
しかし `draw_under_X(N)` の内側では過剰です。`descendants[N]` のメンバーがこの集合に入るのは
**N 自身が親の paragraph の inline box だから**であって、N がそのメンバーを描く paragraph を
持たない場合、skip すると**誰も描きません**。

#677 以前は scope walk が「scoped inline box の subtree を描く指名描画者」でした。
#677 はその責務を取り上げて、再割り当てしなかったことになります。

実測（`<div style="display:inline-block;SCOPE"><div style="background:red">` の赤い `rg` 演算子数）:

| scope | #677 前 (`4362a331`) | main (`c36efebf`) | 本 PR |
|---|---|---|---|
| なし | 1 | 1 | 1 |
| `overflow:hidden` | 1 | **0 ← 消失** | 1 |
| `opacity:0.5` | 1 | **0 ← 消失** | 1 |
| `transform` | 1 | 1 | 1 |

transform 列は、本 PR の最初のコミットが残り 2 本の walk に開けようとしていた同じ穴です。

## 2. 正しい述語

`paragraph_owned_inline_boxes` は判別条件を直接計算します — **「D を skip するのは、
この scope の内側で描かれる paragraph が D を描くときだけ」**。

呼び出し側ごとに `{N} ∪ descendant list` を走査し、`ParagraphEntry` を持つ id から
`LineItem::InlineBox` の node id を集め、それぞれを
`{ib} ∪ inline_box_subtree_descendants[ib]` に展開します
（= `dispatch_inline_box_content` が実際に描く集合）。descendant list は subtree 全体を
含むので、ネストした inline box も再帰なしでカバーされます。

`draw_under_clip_table` には自分の paragraph が無いので descendant list のみ渡します
（重複の出どころはセルの paragraph です）。

## 3. 未 filter だった 2 本の walk

| walk | 場所 | #677 時点 |
|---|---|---|
| top-level dispatch | `render.rs:547` | ✓ |
| `draw_under_clip` | `block.clip_descendants` | ✓（ただし述語が誤り） |
| `draw_under_opacity` | `block.opacity_descendants` | ✓（同上） |
| **`draw_under_transform`** | `tx.descendants` | ✗ |
| **`draw_under_clip_table`** | `table.clip_descendants` | ✗ |

`TransformEntry::descendants` (`convert/mod.rs:606`) も `TableEntry::clip_descendants`
(`convert/table.rs:63`) も block 系と同じ `drawn_since(mark)` の diff で作られるため、
inline-box subtree が同様に混入します。`src/` 全体を grep して descendant walk はこの 5 本
のみと確認しました。

`draw_under_transform` は自己再帰するので duplicate が 1 レベルごとに倍化していました
（入力 2,083 B → **28.6 MB / 4.4 秒** @depth22。#677 が閉じた clip 経路は同 depth で 10.7 MB）。

## 4. narrowing しても増幅は再発しない

| scope | depth 8 | depth 16 | depth 22 |
|---|---|---|---|
| `overflow:hidden` | 1,689 B | 1,700 B | 1,704 B / 4 ms |
| `transform` | 1,659 B | 1,660 B | 1,660 B / 4 ms |
| `opacity` | 5,192 B | 8,648 B | 11,241 B |

opacity の線形増加は transparency group 1 個ぶん（~432 B/level）の正当なコストです。

`layout/inline-block-overflow-hidden` golden は **1,922 バイトのまま** — #677 が二重 AA
エッジを落として re-bless した値です。ここが 1,926 に戻れば narrowing が #677 の直した
重複を取りこぼしたことになるので、この golden が canary として機能します。他の golden も
すべて byte-identical。

## テスト

- `block_child_of_scoped_inline_block_still_paints` — content loss を捕まえる。
  4 scope × wrapper のテキスト有無
- `inline_box_subtree_paints_once_under_every_scope` / `inline_box_under_block_scope_paints_exactly_once`
  / `inline_box_in_clipped_table_cell_paints_once` — 純赤の `rg` 演算子を数えて `== 1`。
  0（消失）と 2（重複）を同時に検出します
- `nested_clipped_inline_blocks_do_not_amplify_output` に transform scope を追加

カウンタは page content stream に加えて **form XObject も走査**します
（`draw_with_opacity` の transparency group は別 stream に出るため）。

`c36efebf` に対して逆検証済み: clip / opacity で 0 paint、transform で 2 paint の両方が落ちます。

## 検証

- `cargo test -p fulgur` — 全 44 スイート green
- `cargo test -p fulgur-vrt` — golden すべて byte-identical
- `cargo test -p fulgur-cli` — examples determinism pass
- `cargo clippy -p fulgur --all-targets -- -D warnings` / `cargo fmt --all --check` — clean
- WPT 全 7 phase を clean main の baseline と突き合わせ済み

Codex Review が PR #679 上で P1 として指摘。Refs fulgur-49xw、Codex Security finding `d6d75291`。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 変換・クリップ・透明度設定を含む複雑なレイアウトで、インライン要素が二重に描画される問題を修正しました。
  * ネストしたインラインブロックや、テーブルセル内の要素が重複表示されるケースを改善しました。
  * インライン要素の子要素が誤って描画から除外される問題を防止しました。
  * 深くネストされたレイアウトでも、不要な再描画による処理負荷を抑えました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->