### PR TITLE
test(convert/list_item): add coverage for inline pseudo-image anchor link and inside-marker paths

### DIFF
--- a/crates/fulgur/src/convert/list_item.rs
+++ b/crates/fulgur/src/convert/list_item.rs
@@ -1376,4 +1376,101 @@ mod tests {
         );
         assert!(pdf.starts_with(b"%PDF"));
     }
+
+    // build_list_item_body (outside marker, inline-root): the <li> has an
+    // <a href="..."> ancestor so `attach_link_to_inline_image` (pseudo.rs)
+    // finds the enclosing anchor and sets `img.link = Some(...)`.
+    // Covers the `if let Some((_, span)) = resolve_enclosing_anchor(...)` body
+    // in pseudo::attach_link_to_inline_image.
+    #[test]
+    fn smoke_outside_marker_before_image_with_anchor_ancestor() {
+        let mut bundle = crate::asset::AssetBundle::default();
+        bundle.add_image("dot.png", RED_1X1_PNG.to_vec());
+        bundle.add_css(r#"li::before { content: url("dot.png"); width: 8px; height: 8px; }"#);
+        let pdf = crate::engine::Engine::builder()
+            .assets(bundle)
+            .build()
+            .render(
+                r#"<!doctype html><html><body>
+                <a href="https://example.com"><ul><li>Linked item with before image</li></ul></a>
+                </body></html>"#,
+            )
+            .expect("render failed");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // Same as above but with a ::after inline image.  Both `before_inline`
+    // and `after_inline` go through `attach_link_to_inline_image` on the
+    // (outside marker, inline-root) path; verifying the after slot also
+    // correctly picks up the anchor ancestor.
+    #[test]
+    fn smoke_outside_marker_after_image_with_anchor_ancestor() {
+        let mut bundle = crate::asset::AssetBundle::default();
+        bundle.add_image("dot.png", RED_1X1_PNG.to_vec());
+        bundle.add_css(r#"li::after { content: url("dot.png"); width: 8px; height: 8px; }"#);
+        let pdf = crate::engine::Engine::builder()
+            .assets(bundle)
+            .build()
+            .render(
+                r#"<!doctype html><html><body>
+                <a href="https://example.com"><ul><li>Linked item with after image</li></ul></a>
+                </body></html>"#,
+            )
+            .expect("render failed");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // build_list_item_body (outside marker, inline-root): ::before image with
+    // an internal fragment anchor (`#target`).  The same
+    // `attach_link_to_inline_image` → `resolve_enclosing_anchor` path runs,
+    // this time producing a `LinkTarget::Internal` span.
+    #[test]
+    fn smoke_outside_marker_before_image_with_internal_anchor_ancestor() {
+        let mut bundle = crate::asset::AssetBundle::default();
+        bundle.add_image("dot.png", RED_1X1_PNG.to_vec());
+        bundle.add_css(r#"li::before { content: url("dot.png"); width: 8px; height: 8px; }"#);
+        let pdf = crate::engine::Engine::builder()
+            .assets(bundle)
+            .build()
+            .render(
+                r##"<!doctype html><html><body>
+                <a href="#section"><ul><li>Internal link item</li></ul></a>
+                <h2 id="section">Section</h2>
+                </body></html>"##,
+            )
+            .expect("render failed");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // try_convert branch 3 (inside marker, non-inline-root): apply
+    // `list-style-position: inside` directly on the <li> element rather than
+    // inheriting it from the <ul>.  Exercises the same code paths as the
+    // inherited variants but gives the style resolution a direct target.
+    #[test]
+    fn smoke_inside_marker_style_on_li_directly_with_block_child() {
+        let pdf = render_list_html(
+            r#"<!doctype html><html><body>
+            <ul><li style="list-style-position: inside">
+                <p>Block child makes li non-inline-root</p>
+            </li></ul>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // try_convert branch 3 (inside marker, non-inline-root): `list-style-type:
+    // none` suppresses the marker entirely, so `marker_item = None` and the
+    // block_styles.insert at the end of the non-empty-children path is reached
+    // without the marker injection branch being taken.
+    #[test]
+    fn smoke_inside_marker_list_style_none_with_block_child() {
+        let pdf = render_list_html(
+            r#"<!doctype html><html><body>
+            <ul style="list-style-position: inside; list-style-type: none">
+                <li><p>Block child, no marker</p></li>
+            </ul>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
 }


### PR DESCRIPTION
## 概要

`crates/fulgur/src/convert/list_item.rs` のリージョンカバレッジ向上を目的として、スモークテスト 5 件を追加しました。

**対象モジュール:** `convert/list_item`（副次的恩恵: `convert/pseudo`）

| モジュール | 変更前 (region) | 変更後 (region) |
|---|---|---|
| `convert/list_item.rs` | 92.98% | 94.75% |
| `convert/pseudo.rs` | 94.46% | 94.83% |

## 追加したテスト

1. **`smoke_outside_marker_before_image_with_anchor_ancestor`**
   `<a href="https://example.com">` が `<ul><li>` を包む構造で、`::before` 疑似要素に `content: url(...)` を設定。
   `pseudo::attach_link_to_inline_image` 内の `img.link = Some(Arc::new(span))` 代入行 (pseudo.rs:202) を初めてカバー。

2. **`smoke_outside_marker_after_image_with_anchor_ancestor`**
   同上だが `::after` 疑似要素を使用。

3. **`smoke_outside_marker_before_image_with_internal_anchor_ancestor`**
   `href="#section"` の内部フラグメントアンカーを持つ `<a>` 祖先経由で `LinkTarget::Internal` パスをカバー。

4. **`smoke_inside_marker_style_on_li_directly_with_block_child`**
   `<li style="list-style-position: inside">` に `<p>` ブロック子を持たせ、`try_convert` の inside-marker・非 inline-root 分岐（ブランチ 3）を刺激。

5. **`smoke_inside_marker_list_style_none_with_block_child`**
   `list-style-type: none` と `list-style-position: inside` を親 `<ul>` に指定し、マーカー非表示ケースをカバー。

## 意図的に対象外とした未カバーブランチ

| ブランチ | 理由 |
|---|---|
| `try_convert` ブランチ 2（list_item_data が None の場合、行 71–120）| Blitz は `display: list-item` の要素に必ず `list_item_data` を設定するため、現状の Blitz では到達不能と判断。テストを書いても分岐が実行されない。 |
| `inject_marker_into_first_paragraph` の 2 番目の `Err(item)` パス（行 309）| 「ParagraphDraw が存在すれば必ず 1 件以上の行がある」という不変条件により保護されたデッドコード。到達させるにはその不変条件を壊す必要があり、テスト追加で対応するのは不適切。 |
| `let X = expr else { panic!(...) }` パターン各所 | `panic!` ブランチはテストが通る限りカバー不可。意図的に除外。 |

## 変更内容

- `crates/fulgur/src/convert/list_item.rs` — テスト追加のみ（プロダクションコード変更なし）

---
_Generated by [Claude Code](https://claude.ai/code/session_016AHNS2xN4m8ssZWBWxG9yA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * リスト項目の疑似要素画像、アンカー参照、フラグメント参照を含むケースを追加しました。
  * リストマーカーの位置指定や非表示設定に関するPDF生成テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->