### PR TITLE
test(tagging): add coverage for SemanticEntry, PdfTag Clone/Debug, and heading-level clamping

### DIFF
--- a/crates/fulgur/src/tagging.rs
+++ b/crates/fulgur/src/tagging.rs
@@ -369,4 +369,193 @@ mod tests {
             TagKind::Link(_)
         ));
     }
+
+    // --- SemanticEntry construction and derived-trait coverage ---
+
+    #[test]
+    fn semantic_entry_fields_accessible_with_none_parent_and_alt() {
+        let entry = SemanticEntry {
+            tag: PdfTag::P,
+            parent: None,
+            alt_text: None,
+        };
+        assert!(matches!(entry.tag, PdfTag::P));
+        assert!(entry.parent.is_none());
+        assert!(entry.alt_text.is_none());
+    }
+
+    #[test]
+    fn semantic_entry_fields_accessible_with_some_parent_and_alt() {
+        let entry = SemanticEntry {
+            tag: PdfTag::H { level: 2 },
+            parent: Some(42),
+            alt_text: Some("chapter heading".to_owned()),
+        };
+        assert_eq!(entry.parent, Some(42));
+        assert_eq!(entry.alt_text.as_deref(), Some("chapter heading"));
+    }
+
+    #[test]
+    fn semantic_entry_clone_preserves_all_fields() {
+        let entry = SemanticEntry {
+            tag: PdfTag::Figure,
+            parent: Some(7),
+            alt_text: Some("company logo".to_owned()),
+        };
+        let cloned = entry.clone();
+        assert_eq!(cloned.tag, entry.tag);
+        assert_eq!(cloned.parent, entry.parent);
+        assert_eq!(cloned.alt_text, entry.alt_text);
+    }
+
+    #[test]
+    fn semantic_entry_clone_with_none_fields() {
+        let entry = SemanticEntry {
+            tag: PdfTag::Div,
+            parent: None,
+            alt_text: None,
+        };
+        let cloned = entry.clone();
+        assert_eq!(cloned.tag, entry.tag);
+        assert!(cloned.parent.is_none());
+        assert!(cloned.alt_text.is_none());
+    }
+
+    #[test]
+    fn semantic_entry_debug_contains_struct_name_and_tag() {
+        let entry = SemanticEntry {
+            tag: PdfTag::Table,
+            parent: Some(3),
+            alt_text: None,
+        };
+        let s = format!("{entry:?}");
+        assert!(s.contains("SemanticEntry"));
+        assert!(s.contains("Table"));
+    }
+
+    // --- PdfTag Clone coverage for field-carrying variants ---
+
+    #[test]
+    fn pdf_tag_clone_heading_variant() {
+        let original = PdfTag::H { level: 3 };
+        let cloned = original.clone();
+        assert_eq!(original, cloned);
+    }
+
+    #[test]
+    fn pdf_tag_clone_list_variant() {
+        let original = PdfTag::L {
+            numbering: krilla::tagging::ListNumbering::Decimal,
+        };
+        let cloned = original.clone();
+        assert_eq!(original, cloned);
+    }
+
+    #[test]
+    fn pdf_tag_clone_th_variant() {
+        let original = PdfTag::Th {
+            scope: krilla::tagging::TableHeaderScope::Row,
+        };
+        let cloned = original.clone();
+        assert_eq!(original, cloned);
+    }
+
+    #[test]
+    fn pdf_tag_clone_unit_variants() {
+        for tag in [
+            PdfTag::P,
+            PdfTag::Div,
+            PdfTag::Span,
+            PdfTag::Figure,
+            PdfTag::Lbl,
+            PdfTag::LBody,
+            PdfTag::Li,
+            PdfTag::Table,
+            PdfTag::THead,
+            PdfTag::TBody,
+            PdfTag::TFoot,
+            PdfTag::Tr,
+            PdfTag::Td,
+            PdfTag::Link,
+        ] {
+            assert_eq!(tag.clone(), tag);
+        }
+    }
+
+    // --- PdfTag Debug formatting ---
+
+    #[test]
+    fn pdf_tag_debug_unit_variants() {
+        assert!(format!("{:?}", PdfTag::P).contains("P"));
+        assert!(format!("{:?}", PdfTag::Div).contains("Div"));
+        assert!(format!("{:?}", PdfTag::Span).contains("Span"));
+        assert!(format!("{:?}", PdfTag::Figure).contains("Figure"));
+        assert!(format!("{:?}", PdfTag::Lbl).contains("Lbl"));
+        assert!(format!("{:?}", PdfTag::LBody).contains("LBody"));
+        assert!(format!("{:?}", PdfTag::Li).contains("Li"));
+        assert!(format!("{:?}", PdfTag::Table).contains("Table"));
+        assert!(format!("{:?}", PdfTag::THead).contains("THead"));
+        assert!(format!("{:?}", PdfTag::TBody).contains("TBody"));
+        assert!(format!("{:?}", PdfTag::TFoot).contains("TFoot"));
+        assert!(format!("{:?}", PdfTag::Tr).contains("Tr"));
+        assert!(format!("{:?}", PdfTag::Td).contains("Td"));
+        assert!(format!("{:?}", PdfTag::Link).contains("Link"));
+    }
+
+    #[test]
+    fn pdf_tag_debug_field_variants() {
+        assert!(format!("{:?}", PdfTag::H { level: 4 }).contains("4"));
+        assert!(
+            format!(
+                "{:?}",
+                PdfTag::L {
+                    numbering: krilla::tagging::ListNumbering::Disc
+                }
+            )
+            .contains("L")
+        );
+        assert!(
+            format!(
+                "{:?}",
+                PdfTag::Th {
+                    scope: krilla::tagging::TableHeaderScope::Column
+                }
+            )
+            .contains("Th")
+        );
+    }
+
+    // --- pdf_tag_to_krilla_tag heading-level clamping ---
+
+    #[test]
+    fn pdf_tag_to_krilla_tag_heading_level_zero_clamped_to_one() {
+        // level=0 is invalid; clamp(1,6) → 1 so NonZeroU16::new(1).unwrap() is safe.
+        let k = pdf_tag_to_krilla_tag(&PdfTag::H { level: 0 }, None, None);
+        assert!(matches!(k, krilla::tagging::TagKind::Hn(_)));
+    }
+
+    #[test]
+    fn pdf_tag_to_krilla_tag_heading_level_above_max_clamped_to_six() {
+        // level=7 and level=255 are above the PDF maximum H6; both clamp to 6.
+        let k7 = pdf_tag_to_krilla_tag(&PdfTag::H { level: 7 }, None, None);
+        let k255 = pdf_tag_to_krilla_tag(&PdfTag::H { level: 255 }, None, None);
+        assert!(matches!(k7, krilla::tagging::TagKind::Hn(_)));
+        assert!(matches!(k255, krilla::tagging::TagKind::Hn(_)));
+    }
+
+    // --- classify_element edge cases ---
+
+    #[test]
+    fn classify_element_figure_html_element_returns_none() {
+        // HTML <figure> has no mapping; only <img> maps to PdfTag::Figure.
+        assert_eq!(classify_element("figure"), None);
+    }
+
+    #[test]
+    fn classify_element_anchor_and_link_return_none() {
+        // <a> and <link> have no mapping in classify_element;
+        // PdfTag::Link is set by the convert pass directly.
+        assert_eq!(classify_element("a"), None);
+        assert_eq!(classify_element("link"), None);
+    }
 }

--- a/crates/fulgur/src/tagging.rs
+++ b/crates/fulgur/src/tagging.rs
@@ -431,6 +431,33 @@ mod tests {
         let s = format!("{entry:?}");
         assert!(s.contains("SemanticEntry"));
         assert!(s.contains("Table"));
+        // Verify payload values appear in the debug output.
+        assert!(
+            s.contains("Some(3)"),
+            "parent should appear as Some(3), got: {s}"
+        );
+        assert!(s.contains("None"), "alt_text: None should appear, got: {s}");
+        // PdfTag::L and PdfTag::Th field values must also be visible in their debug output.
+        assert!(
+            format!(
+                "{:?}",
+                PdfTag::L {
+                    numbering: krilla::tagging::ListNumbering::Disc
+                }
+            )
+            .contains("Disc"),
+            "PdfTag::L debug must include numbering variant name"
+        );
+        assert!(
+            format!(
+                "{:?}",
+                PdfTag::Th {
+                    scope: krilla::tagging::TableHeaderScope::Column
+                }
+            )
+            .contains("Column"),
+            "PdfTag::Th debug must include scope variant name"
+        );
     }
 
     // --- PdfTag Clone coverage for field-carrying variants ---
@@ -529,18 +556,25 @@ mod tests {
 
     #[test]
     fn pdf_tag_to_krilla_tag_heading_level_zero_clamped_to_one() {
-        // level=0 is invalid; clamp(1,6) → 1 so NonZeroU16::new(1).unwrap() is safe.
+        // level=0 is invalid; clamp(1,6) → 1.  Verify the stored level, not just the variant.
         let k = pdf_tag_to_krilla_tag(&PdfTag::H { level: 0 }, None, None);
-        assert!(matches!(k, krilla::tagging::TagKind::Hn(_)));
+        let krilla::tagging::TagKind::Hn(tag) = k else {
+            panic!("expected TagKind::Hn for level=0");
+        };
+        assert_eq!(tag.level().get(), 1, "level=0 should clamp to H1");
     }
 
     #[test]
     fn pdf_tag_to_krilla_tag_heading_level_above_max_clamped_to_six() {
         // level=7 and level=255 are above the PDF maximum H6; both clamp to 6.
-        let k7 = pdf_tag_to_krilla_tag(&PdfTag::H { level: 7 }, None, None);
-        let k255 = pdf_tag_to_krilla_tag(&PdfTag::H { level: 255 }, None, None);
-        assert!(matches!(k7, krilla::tagging::TagKind::Hn(_)));
-        assert!(matches!(k255, krilla::tagging::TagKind::Hn(_)));
+        // Verify the stored level, not just the variant, to catch a regressed clamp.
+        for input in [7u8, 255u8] {
+            let k = pdf_tag_to_krilla_tag(&PdfTag::H { level: input }, None, None);
+            let krilla::tagging::TagKind::Hn(tag) = k else {
+                panic!("expected TagKind::Hn for level={input}");
+            };
+            assert_eq!(tag.level().get(), 6, "level={input} should clamp to H6");
+        }
     }
 
     // --- classify_element edge cases ---


### PR DESCRIPTION
## Summary

`crates/fulgur/src/tagging.rs` のリージョンカバレッジを **93.72% → 95.09%**（+1.37 pp）に改善しました。

このファイルは最もカバレッジが低いファイルでしたが、その主な原因は以下の 2 点でした：

- `SemanticEntry` 構造体が既存テストで一度も構築されておらず、`#[derive(Debug, Clone)]` で生成されたコードが未カバー
- `PdfTag` の `Debug` 実装（全 16 バリアント）が未呼び出し（`assert_eq!` は `PartialEq` のみ使用し、テストが全部 pass するため `Debug` は呼ばれない）

## Changes

- `SemanticEntry` の構築テスト（`parent` / `alt_text` の Some/None 全組み合わせ）
- `SemanticEntry::clone` の動作確認テスト（フィールドが正しく複製されること）
- `SemanticEntry::Debug` のフォーマットテスト（`format!("{:?}", entry)` を初めて呼び出し）
- `PdfTag::Clone` の全バリアントテスト（unit バリアント 14 種 + フィールド付き 3 種）
- `PdfTag::Debug` のフォーマットテスト（全 16 バリアント）
- `pdf_tag_to_krilla_tag` の heading level clamping edge case テスト（level=0 → H1、level=7/255 → H6）
- `classify_element` の追加 edge case（HTML `<figure>` → `None`、`<a>`/`<link>` → `None` の意図を文書化）

**意図的にカバーしなかった箇所：**
- テストコード内の `assert!(matches!(...))` / `if let` の false 分岐（これらは tests がすべて pass する限り unreachable であり、カバーすることに意味がない）

## Test plan

- [x] `cargo test -p fulgur --lib`（1904 passed）
- [x] `cargo clippy -- -D warnings`（警告なし）
- [x] `cargo fmt --check`（差分なし）
- [ ] `npx markdownlint-cli2 '**/*.md'`（ドキュメント変更なし）

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKQqczGB2sDbKDmLB9qaUZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * `SemanticEntry` の構築時に `parent`／`alt_text` の None/Some が正しく反映されることを検証しました。
  * `SemanticEntry` の `Clone` が全フィールドを保持し、`Debug` 出力に `SemanticEntry` とタグ名が含まれることを確認しました。
  * `PdfTag` の `Clone`（フィールド保持/ユニット）の同一性と、`Debug` 表現の期待文字列を検証しました。
  * 見出しレベルの範囲外入力（0・上限超過）は内部でクランプされても `Hn` 相当になることを確認しました。
  * `classify_element` で `<figure>`、`<a>`、`<link>` が `None` を返すことを追加検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->