### PR TITLE
fix(gradient): harden stop resolution against non-finite geometry

### DIFF
--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -869,6 +869,12 @@ fn corner_to_angle_rad(
 /// 入力: monotonically non-decreasing position の `(pos, rgba)` ベクタ。
 /// `pos` は ℝ で、範囲外 (`-0.5` や `1.5` など) も許容する。
 ///
+/// **前提条件: `pos` は全て有限であること。** `color_at` は position が全順序を
+/// 持つことを前提に区間を線形探索し、どれにも該当しなければ `unreachable!()` に
+/// 落ちる。NaN は「どの比較も false」なので、一つ混ざるだけでこの不変条件を破る。
+/// これは呼び出し側 (`resolve_gradient_stops`) が choke point で保証する契約で、
+/// ここを NaN 耐性にして握り潰すべきではない (fulgur-0vzf)。
+///
 /// 出力: `pos` が `[0, 1]` に収まる `(pos, rgba)` ベクタ。Krilla の
 /// `NormalizedF32` 制約をそのまま満たす。
 ///
@@ -1046,10 +1052,14 @@ fn resolve_gradient_stops(
     if stops.len() < 2 {
         return None;
     }
-    if line_length <= Px::ZERO {
+    if !line_length.is_finite() || line_length <= Px::ZERO {
         // length-typed stop が一つでもあれば解決不能。fraction-only でも
         // 退化した gradient なので Layer drop 相当 (caller で先に early
         // return しているため通常到達しない)。
+        //
+        // `is_finite` を先に見るのは `<= Px::ZERO` が NaN-blind だから:
+        // NaN との比較は全て false なので、NaN はこの符号ガードを素通りして
+        // `px / line_length` を NaN offset に変えてしまう (fulgur-0vzf)。
         return None;
     }
 
@@ -1106,6 +1116,18 @@ fn resolve_gradient_stops(
         i = end;
     }
 
+    // 有限性の choke point (fulgur-0vzf)。ここから下流 (hint 展開 → 周期展開
+    // → renormalize) は position が全順序を持つ前提で書かれている。NaN が
+    // 一つ混ざると `renormalize_stops_to_unit_range` の `color_at` で
+    // どの区間比較も成立せず `unreachable!()` に落ちる。
+    //
+    // 入力ではなく *解決後* の値を検査するのが要点: offset は入力由来の
+    // NaN だけでなく、個別には有限な `px / line_length` が f32 の表現域を
+    // 超えて `inf` に飽和する経路でも壊れる。
+    if !positions.iter().flatten().all(|p| p.is_finite()) {
+        return None;
+    }
+
     let resolved: Vec<ResolvedStop> = stops
         .iter()
         .zip(positions)
@@ -1133,10 +1155,15 @@ fn resolve_gradient_stops(
 
     // renormalize: 範囲外 fraction は端点合成で [0, 1] 内表現に変換 (fulgur-n3zk)
     let renormalized = renormalize_stops_to_unit_range(expanded);
-    debug_assert!(
-        renormalized.len() >= 2,
-        "renormalize_stops_to_unit_range guarantees len >= 2"
-    );
+
+    // 退化ケースの runtime guard。helper は有限 position に対しては常に
+    // len >= 2 を返すが、krilla の gradient は 2 stops 以上を要求するので、
+    // release build でも縮退した stop 列を krilla に渡さない (fulgur-0vzf)。
+    // 668f2031 で `debug_assert!` に落としたものを戻した: debug_assert は
+    // release で消えるため、不変条件が破れたときに保護が効かなかった。
+    if renormalized.len() < 2 {
+        return None;
+    }
 
     Some(
         renormalized
@@ -1249,7 +1276,10 @@ fn draw_linear_gradient(
     let cos_neg = -angle_rad.cos();
 
     let length = (ow * sin).abs() + (oh * cos_neg).abs();
-    if length <= 0.0 {
+    // `length <= 0.0` だけでは NaN を落とせない (NaN との比較は常に false)。
+    // NaN な gradient line は下流で NaN offset と NaN 座標の両方を生むので、
+    // ここで Layer drop する (fulgur-0vzf)。
+    if !length.is_finite() || length <= 0.0 {
         return;
     }
 
@@ -1384,7 +1414,8 @@ fn draw_radial_gradient(
         }
     };
 
-    if rx <= 0.0 || ry <= 0.0 {
+    // 符号ガードは NaN-blind なので、有限性を明示的に検査する (fulgur-0vzf)。
+    if !rx.is_finite() || !ry.is_finite() || rx <= 0.0 || ry <= 0.0 {
         return;
     }
 
@@ -3945,6 +3976,82 @@ mod resolve_gradient_stops_tests {
         ];
         let out = resolve_gradient_stops(&stops, 0.0_f32.as_px(), false);
         assert!(out.is_none());
+    }
+
+    // ─── non-finite hardening (fulgur-0vzf) ──────────────────────────────
+    //
+    // 下の各ケースは、以前は `renormalize_stops_to_unit_range` 内の
+    // `color_at` で NaN 比較が全て false になり `unreachable!()` に落ちて
+    // panic していた。choke point で弾いて `None` (= Layer drop) を返す。
+    //
+    // Stylo は computed angle / length を有限域に clamp するので、現時点で
+    // CSS からこの入力は作れない。`BgImageContent` の stops は pub なので
+    // ライブラリ利用者が直接構築する経路と、将来の上流変更に対する防御。
+
+    #[test]
+    fn line_length_nan_returns_none() {
+        let stops = vec![
+            stop(px(50.0), [255, 0, 0, 255]),
+            stop(fr(1.0), [0, 0, 255, 255]),
+        ];
+        assert!(resolve_gradient_stops(&stops, f32::NAN.as_px(), false).is_none());
+    }
+
+    #[test]
+    fn line_length_infinite_returns_none() {
+        let stops = vec![
+            stop(px(50.0), [255, 0, 0, 255]),
+            stop(fr(1.0), [0, 0, 255, 255]),
+        ];
+        assert!(resolve_gradient_stops(&stops, f32::INFINITY.as_px(), false).is_none());
+    }
+
+    #[test]
+    fn nan_fraction_stop_returns_none() {
+        let stops = vec![
+            stop(fr(f32::NAN), [255, 0, 0, 255]),
+            stop(fr(1.0), [0, 0, 255, 255]),
+        ];
+        assert!(resolve_gradient_stops(&stops, 100.0_f32.as_px(), false).is_none());
+    }
+
+    #[test]
+    fn nan_length_stop_returns_none() {
+        let stops = vec![
+            stop(px(f32::NAN), [255, 0, 0, 255]),
+            stop(fr(1.0), [0, 0, 255, 255]),
+        ];
+        assert!(resolve_gradient_stops(&stops, 100.0_f32.as_px(), false).is_none());
+    }
+
+    #[test]
+    fn infinite_length_stop_returns_none() {
+        let stops = vec![
+            stop(px(f32::INFINITY), [255, 0, 0, 255]),
+            stop(fr(1.0), [0, 0, 255, 255]),
+        ];
+        assert!(resolve_gradient_stops(&stops, 100.0_f32.as_px(), false).is_none());
+    }
+
+    /// `px / line_length` が f32 の表現域を超えて `inf` に飽和するケース。
+    /// 入力側の `LengthPx` / `line_length` は個別には有限なので、除算 *後* の
+    /// offset を検査しないと素通りする。
+    #[test]
+    fn length_stop_overflowing_to_infinity_returns_none() {
+        let stops = vec![
+            stop(px(f32::MAX), [255, 0, 0, 255]),
+            stop(fr(1.0), [0, 0, 255, 255]),
+        ];
+        assert!(resolve_gradient_stops(&stops, f32::MIN_POSITIVE.as_px(), false).is_none());
+    }
+
+    #[test]
+    fn nan_stop_in_repeating_gradient_returns_none() {
+        let stops = vec![
+            stop(fr(f32::NAN), [255, 0, 0, 255]),
+            stop(fr(0.25), [0, 0, 255, 255]),
+        ];
+        assert!(resolve_gradient_stops(&stops, 100.0_f32.as_px(), true).is_none());
     }
 
     /// `repeating-linear-gradient(red 0%, blue 25%)`: period = 0.25。

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -869,11 +869,15 @@ fn corner_to_angle_rad(
 /// 入力: monotonically non-decreasing position の `(pos, rgba)` ベクタ。
 /// `pos` は ℝ で、範囲外 (`-0.5` や `1.5` など) も許容する。
 ///
-/// **前提条件: `pos` は全て有限であること。** `color_at` は position が全順序を
+/// **前提条件: `pos` に NaN を含まないこと。** `color_at` は position が全順序を
 /// 持つことを前提に区間を線形探索し、どれにも該当しなければ `unreachable!()` に
 /// 落ちる。NaN は「どの比較も false」なので、一つ混ざるだけでこの不変条件を破る。
 /// これは呼び出し側 (`resolve_gradient_stops`) が choke point で保証する契約で、
 /// ここを NaN 耐性にして握り潰すべきではない (fulgur-0vzf)。
+///
+/// `±inf` は比較が正しく順序づくので不変条件は破らない (端点合成に落ちて有限な
+/// 出力になる)。ただし `p1 - p0` が `inf` に飽和する極端な入力では補間 alpha が
+/// 0 に潰れて色が不正確になる — caller 側で非有限を弾いているのはこのため。
 ///
 /// 出力: `pos` が `[0, 1]` に収まる `(pos, rgba)` ベクタ。Krilla の
 /// `NormalizedF32` 制約をそのまま満たす。
@@ -1142,6 +1146,16 @@ fn resolve_gradient_stops(
     // marker stop を 8 個の中間 stop (累乗カーブ) に展開する。hint を含まない
     // 入力は素通り。
     let after_hints: Vec<(f32, [u8; 4])> = expand_interpolation_hints(resolved);
+
+    // hint 展開は stop を減らしうる: `is_hint` だけの入力 (convert 段の
+    // validation を通らない直接構築) は全 marker が defensively skip されて
+    // 空ベクタになる。下流の `expand_repeating_stops` は `first()/last()` を
+    // `expect("len >= 2")` で剥がすので、ここで止めないと release build でも
+    // panic する (fulgur-0vzf)。非 repeating 側も `renormalize` の
+    // `debug_assert!` を踏むので同じ地点で弾く。
+    if after_hints.len() < 2 {
+        return None;
+    }
 
     // 周期展開: repeating-* gradient は first/last stop 間の差を周期に取り、
     // `[0, 1]` を覆うように copy を平行移動して並べる。renormalize 段で
@@ -1415,7 +1429,15 @@ fn draw_radial_gradient(
     };
 
     // 符号ガードは NaN-blind なので、有限性を明示的に検査する (fulgur-0vzf)。
-    if !rx.is_finite() || !ry.is_finite() || rx <= 0.0 || ry <= 0.0 {
+    // 中心座標も併せて見る: 半径が有限でも `position_x` / `position_y` 由来の
+    // cx / cy が非有限なら、そのまま krilla の focal / center 座標に流れる。
+    if !rx.is_finite()
+        || !ry.is_finite()
+        || !cx.is_finite()
+        || !cy.is_finite()
+        || rx <= 0.0
+        || ry <= 0.0
+    {
         return;
     }
 
@@ -1437,7 +1459,14 @@ fn draw_radial_gradient(
     // `from_row(sx, ky, kx, sy, tx, ty)` で行列直接構築する。
     let transform = if (rx - ry).abs() > f32::EPSILON {
         let scale_y = ry / rx;
-        krilla::geom::Transform::from_row(1.0, 0.0, 0.0, scale_y, 0.0, cy * (1.0 - scale_y))
+        let ty = cy * (1.0 - scale_y);
+        // 両オペランドが有限でも比が f32 の表現域を超えることがある
+        // (`ry = f32::MAX` / `rx = f32::MIN_POSITIVE` など)。派生値も検査して
+        // 非有限な行列を krilla に渡さない (fulgur-0vzf)。
+        if !scale_y.is_finite() || !ty.is_finite() {
+            return;
+        }
+        krilla::geom::Transform::from_row(1.0, 0.0, 0.0, scale_y, 0.0, ty)
     } else {
         krilla::geom::Transform::default()
     };
@@ -4052,6 +4081,26 @@ mod resolve_gradient_stops_tests {
             stop(fr(0.25), [0, 0, 255, 255]),
         ];
         assert!(resolve_gradient_stops(&stops, 100.0_f32.as_px(), true).is_none());
+    }
+
+    /// 全 stop が `is_hint` の入力は、hint 展開が全 marker を defensively skip
+    /// して空ベクタを返す。以前は `expand_repeating_stops` の
+    /// `expect("len >= 2")` を release build でも踏んで panic していた
+    /// (非 repeating 側は `renormalize` の `debug_assert!`)。
+    #[test]
+    fn all_hint_stops_return_none() {
+        let hint = |p: GradientStopPosition| GradientStop {
+            position: p,
+            rgba: [255, 0, 0, 255],
+            is_hint: true,
+        };
+        for repeating in [false, true] {
+            let stops = vec![hint(fr(0.0)), hint(fr(1.0))];
+            assert!(
+                resolve_gradient_stops(&stops, 100.0_f32.as_px(), repeating).is_none(),
+                "repeating={repeating}"
+            );
+        }
     }
 
     /// `repeating-linear-gradient(red 0%, blue 25%)`: period = 0.25。

--- a/crates/fulgur/src/units.rs
+++ b/crates/fulgur/src/units.rs
@@ -194,6 +194,19 @@ impl Px {
     pub fn min(self, other: Px) -> Px {
         Px(self.0.min(other.0))
     }
+
+    /// `true` if this length is neither infinite nor NaN. Mirrors
+    /// `f32::is_finite`.
+    ///
+    /// Needed because the usual sign guards (`x <= Px::ZERO`) are NaN-blind:
+    /// every comparison against NaN is `false`, so a NaN slips through a
+    /// `<= 0` rejection and only surfaces later as a violated ordering
+    /// invariant. Validate with `is_finite` at the boundary where an
+    /// untyped `f32` first becomes a `Px`.
+    #[inline]
+    pub fn is_finite(self) -> bool {
+        self.0.is_finite()
+    }
 }
 
 impl Pt {


### PR DESCRIPTION
# Pull Request

## Summary

Codex Security finding「NaN gradient stop renormalization can panic」(medium) のトリアージ結果に基づく hardening。

gradient stop 解決経路のガードが全て `<= 0.0` の符号比較で書かれており、**NaN との比較は常に false** なので NaN が素通りしていた。NaN な `line_length` / 解決後 offset が `renormalize_stops_to_unit_range` に届くと、`color_at` がどの区間にも該当せず `unreachable!()` に落ちて render が panic する。

### 到達可能性: CSS からは到達しない

finding は `linear-gradient(1e999deg, red 1px, blue)` で `sin`/`cos` が NaN になると主張していたが、**実測では再現しない**。`Engine::render` 経由で以下を検証し、全て gradient が正常に描画された (`/Shading` 出力を確認、panic なし):

- 角度: `1e999deg` / 巨大リテラル / `calc(infinity * 1deg)` / `calc(NaN * 1deg)`
- stop: `calc(infinity * 1px)` / `calc(NaN * 1px)` / `calc(NaN * 1%)` / `1e999px` / `calc(0px / 0)`
- 要素サイズ: `width: 1e999px` × `0deg` (`inf * 0 = NaN` 狙い) / `calc(infinity * 1px)` 等

Stylo が computed angle / length を有限域に clamp するため。よって **GHSA advisory は起票しない** (D1 の第一ゲート「文書化された想定用途で実際に刺さるか」= no)。

注: 上記 probe のうち radial / conic の spelling は gradient 自体が描画されなかった (`shading=false`) ため、その 2 経路は probe で exercise できていない。ただし今回の修正は全 caller 共通の choke point に入れているので、どの経路から来ても弾ける。

一方、panic 機構そのものは実在する。private helper への直接 unit probe で、NaN `line_length` / NaN `Fraction` / NaN 入力の 3 経路とも `unreachable!()` で panic することを確認した。

**訂正**: 初版の本文では「`BgImageContent` の stops は `pub` なのでライブラリ利用者が直接構築する経路が残る」と書いたが、これは誤り。型は `pub` だが、**caller が構築した `BgImageContent` / `BackgroundLayer` / `Drawables` を受け取る公開 API は存在しない** (`Engine` の入口は `render` / `render_file` / `render_template` / `render_batch` で全て HTML かテンプレートのみ、drawables は内部構築)。したがって現時点では **CSS からも公開 API からも到達しない**。

修正の価値は (1) latent な panic 機構を choke point で閉じること、(2) 後述の `debug_assert!` 退化を戻すこと、の 2 点であって、既存利用者の曝露を塞ぐことではない。

### 併せて修正: release build で消えていたガード

`668f2031` が `if renormalized.len() < 2 { return None; }` の runtime guard を `debug_assert!` に落としていた。debug_assert は release build で消えるため、不変条件が破れた場合に縮退した stop 列がそのまま krilla に渡る状態だった。runtime guard に戻す。

## Changes

- `resolve_gradient_stops`: 入口で非有限 `line_length` を拒否。さらに fixup 後の **解決済み** offset の有限性を検査する choke point を追加。入力ではなく解決後を見るのが要点で、両オペランドが個別には有限でも `px / line_length` が `inf` に飽和する経路を拾える
- `draw_linear_gradient` / `draw_radial_gradient`: gradient line length と radial 半径の NaN-blind な符号ガードを閉じる
- `renormalize_stops_to_unit_range`: `len < 2` の runtime guard を復活 (`668f2031` の `debug_assert!` 化を revert)
- `Px::is_finite` を追加 (`max`/`min` と同じく `f32` のセマンティクスをミラー)
- `renormalize_stops_to_unit_range` の doc に「position は全て有限」の前提条件を明記

`color_at` を NaN 耐性にする方向は採らなかった。壊れた precondition を握り潰すことになり、`unreachable!()` が持つ「検証済みの不変条件」という意味を失うため。既存の `expand_repeating_stops` の `if period <= 0.0 || !period.is_finite()` と同じ house idiom に揃えた。

## Test plan

- [x] `cargo test -p fulgur` — 1911 lib tests + 全 integration green
- [x] `cargo clippy -p fulgur --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo test -p fulgur-vrt` (byte 比較) — golden 差分なし。有限入力の出力が完全に不変であることを確認
- [x] TDD: 追加した 7 test が修正前は fail (うち 4 件は `background.rs:915` の `unreachable!()` で panic)、修正後 pass

追加した unit test (`resolve_gradient_stops_tests`):

| test | 経路 |
|---|---|
| `line_length_nan_returns_none` | NaN `line_length` |
| `line_length_infinite_returns_none` | 無限 `line_length` |
| `nan_fraction_stop_returns_none` | NaN `Fraction` |
| `nan_length_stop_returns_none` | NaN `LengthPx` |
| `infinite_length_stop_returns_none` | 無限 `LengthPx` |
| `length_stop_overflowing_to_infinity_returns_none` | 有限同士の除算が `inf` に飽和 |
| `nan_stop_in_repeating_gradient_returns_none` | repeating 経路 |

**e2e smoke test は追加していない**: 上記の通り CSS からこの入力を作れないので、`Engine::render` 経由のテストは経路を exercise できず vacuous になる。CLAUDE.md の "Coverage scope" gotcha は VRT だけでカバーされる新規 draw arm が対象で、今回は draw arm を追加していないため該当しない。

なお `if renormalized.len() < 2 { return None; }` の `return None` 行はテストで到達できない (有限 position に対して helper は常に `len >= 2` を返すことが構造上示せる)。意図的に残した defense-in-depth のため、patch coverage で 1 行落ちる想定。

## レビュー対応 (2026-07-31)

CodeRabbit 1 件 + Codex 6 件 (全て P2)。実測で検証した上で、panic を含むものと `krilla` に非有限値が漏れるものを本 PR で修正し、色の正確さに留まるものを fulgur-yevv に分離した。

**修正 (`e2d9707c`)**:

| 指摘 | 実測結果 | 対応 |
|---|---|---|
| Guard the stop count before renormalization | **repeating / 非 repeating 両方で panic**。repeating は `expand_repeating_stops` の `expect("len >= 2")` を release でも踏む。非 repeating は `renormalize` の `debug_assert!` (release では復活させた `len < 2` ガードが受ける) | hint 展開直後に `after_hints.len() < 2` を検査 |
| Validate radial center coordinates | 半径が有限でも `position_x`/`position_y` 由来の `cx`/`cy` が krilla の focal / center に流れる | 境界チェックに `cx`/`cy` を追加 |
| Validate the derived radial transform scale | `ry = f32::MAX` / `rx = f32::MIN_POSITIVE` で `ry / rx` が `inf` に飽和 | `scale_y` / `ty` の有限性を検査 |

**分離 (fulgur-yevv)** — いずれも panic せず、出力は well-formed:

- **conic path**: 別経路 (`normalize_conic_stops` → `sample_conic_color`) でこの resolver を通らない。`Fraction(NaN)` は透明の黒 `[0,0,0,0]` を返す (色が誤るだけ)。指摘どおり本関数は linear / radial の choke point であって gradient 全体のものではない
- **interpolation の overflow**: `-f32::MAX` / `f32::MAX` で `p1 - p0` が `inf` に飽和し alpha が 0 に潰れる。修正には数値表現の作り直しが要り、hardening PR に混ぜると VRT golden への影響評価が濁る

**doc の訂正**: 「`pos` は全て有限であること」は強すぎた。`color_at` の不変条件を壊すのは NaN だけ (全比較が false になる) で、`±inf` は正しく順序づくので `unreachable!()` には到達しない。precondition を NaN に narrow し、`inf` で補間精度が落ちることを caller が非有限を弾く理由として別記した。

**CodeRabbit の draw 関数テスト要求は skip**: 上記のとおり CSS からも公開 API からもこの分岐を発火させる入力を作れないため、smoke test は分岐を通らないまま pass する (vacuous)。判定ロジック自体は純関数側 (`resolve_gradient_stops`) の 8 test でカバー済み。

## Contributor License Agreement

- [x] I have read the [Contributing Guide](https://github.com/fulgur-rs/fulgur/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://github.com/fulgur-rs/fulgur/blob/main/CLA.md) and agree to its terms.

## Related issues

Closes fulgur-0vzf
