### PR TITLE
test(multicol_layout): cover three uncovered branches (+2.76pp line coverage)

### DIFF
--- a/crates/fulgur/src/multicol_layout.rs
+++ b/crates/fulgur/src/multicol_layout.rs
@@ -3559,4 +3559,88 @@ mod tests {
             "single item: expected ideal budget=5.0, got {budget}"
         );
     }
+
+    // ── resolve_column_layout: fits_count denom ≤ 0 branch ──────────────
+
+    #[test]
+    fn resolve_column_layout_negative_gap_clamps_fits_count_to_one() {
+        // When column-gap magnitude exceeds column-width, the denominator in
+        // fits_count (= w + gap) is ≤ 0. The defensive branch returns 1 to
+        // avoid division-by-zero or negative counts.
+        // gap=-2.0, width=1.0: denom = 1.0 + (-2.0) = -1.0 ≤ 0 → fits_count = 1.
+        let (n, w) = resolve_column_layout(300.0, None, Some(1.0), -2.0);
+        assert_eq!(n, 1);
+        // With n=1 and gap contributing nothing, col_w = avail = 300.
+        assert!((w - 300.0).abs() < 1e-3, "col_w={w}");
+    }
+
+    // ── layout_column_group: zero total_h → balance budget zero ─────────
+
+    #[test]
+    fn zero_height_children_give_zero_balance_budget() {
+        // A multicol container whose block children all measure to height=0
+        // drives total_h to 0.0 in layout_column_group, exercising the
+        // `total_h <= 0.0 → budget = 0` Balance-mode branch (line 1071).
+        let html = r#"<!doctype html><html><body>
+            <div style="column-count: 2; column-gap: 0;">
+              <div></div>
+            </div>
+        </body></html>"#;
+        let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
+        crate::blitz_adapter::resolve(&mut doc);
+
+        let column_styles = crate::column_css::ColumnStyleTable::new();
+        let mut tree = FulgurLayoutTree::new(&mut doc, &column_styles);
+        let laid_out = tree.layout_multicol_subtrees();
+        assert_eq!(laid_out, 1);
+
+        let geom = tree.take_geometry();
+        assert_eq!(geom.len(), 1);
+        let mc_geom = geom.values().next().unwrap();
+        let group = &mc_geom.groups[0];
+        assert_eq!(group.n, 2);
+        assert!(
+            group.col_heights.iter().all(|h| h.to_f32() <= 0.01),
+            "zero-height children must produce near-zero column heights: {:?}",
+            group.col_heights
+        );
+    }
+
+    // ── parley_layout_is_glyph_run_only: InlineBox arm ──────────────────
+
+    #[test]
+    fn case_a_multicol_with_inline_block_falls_back_to_atomic_placement() {
+        // A multicol container that IS an inline root (Case A) containing an
+        // inline-block element (which Parley represents as an InlineBox) must
+        // not be split column-by-column, since GlyphRun materialisation would
+        // silently drop InlineBox content. The layout hook falls back:
+        // geometry is recorded but `paragraph_splits` is empty (whole
+        // paragraph stays atomic in column 0). Covers lines 847-902 and 1494.
+        let html = r#"<!doctype html><html><body>
+            <div style="column-count: 2; column-gap: 0;">
+              text <span style="display: inline-block; width: 20px; height: 20px;"></span> more
+            </div>
+        </body></html>"#;
+        let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
+        crate::blitz_adapter::resolve(&mut doc);
+
+        let column_styles = crate::column_css::ColumnStyleTable::new();
+        let mut tree = FulgurLayoutTree::new(&mut doc, &column_styles);
+        let laid_out = tree.layout_multicol_subtrees();
+        assert_eq!(laid_out, 1);
+
+        let geom = tree.take_geometry();
+        assert_eq!(
+            geom.len(),
+            1,
+            "geometry must be recorded even on the fallback path"
+        );
+        let mc_geom = geom.values().next().unwrap();
+        let group = &mc_geom.groups[0];
+        assert!(
+            group.paragraph_splits.is_empty(),
+            "InlineBox fallback must not produce paragraph splits, got: {:?}",
+            group.paragraph_splits
+        );
+    }
 }


### PR DESCRIPTION
## 概要

`crates/fulgur/src/multicol_layout.rs` に 3 つのユニットテストを追加し、
カバレッジ計測で見つかった未カバーブランチを埋めました。

**変更前後のカバレッジ（`multicol_layout.rs`）**

| 指標 | 変更前 | 変更後 | 改善 |
|------|--------|--------|------|
| 行カバレッジ | 93.85%（missed 126） | 96.61%（missed 71） | +2.76pp |
| リージョンカバレッジ | — | 96.93% | — |

## 追加したテスト

### 1. `resolve_column_layout_negative_gap_clamps_fits_count_to_one`

- **対象行**: line 437 (`fits_count` クロージャ内の `denom <= 0` 防御ブランチ)
- **内容**: `column-gap` が `column-width` より大きい負値のとき、
  分母 `w + gap` が ≤ 0 になる。ゼロ除算・負カウントを避けるために
  `fits_count = 1` を返すブランチを検証。

### 2. `zero_height_children_give_zero_balance_budget`

- **対象行**: line 1071 (`layout_column_group` Balance モードの `total_h <= 0.0 → budget = 0` 分岐)
- **内容**: ブロック子要素の高さが 0 の multicol コンテナで、
  `total_h` が 0.0 になるケースを統合テストで再現。

### 3. `case_a_multicol_with_inline_block_falls_back_to_atomic_placement`

- **対象行**: lines 847–902（`layout_self_inline_root_container` の InlineBox フォールバック）および line 1494（`parley_layout_is_glyph_run_only` の `InlineBox` アーム）
- **内容**: Case A multicol（コンテナ自体がインラインルート）に `display: inline-block` な
  子要素が含まれる場合、Parley が `InlineBox` を生成するため GlyphRun-only
  マテリアライザでは内容が消える。フォールバックパスが走り、
  `paragraph_splits` が空になることを確認。

## スキップしたブランチ（理由付き）

| 対象 | 行 | スキップ理由 |
|------|----|-------------|
| `TraversePartialTree::child_ids` / `child_count` / `get_child_id` | 324–335 | `compute_multicol_layout` は `tree.doc.get_node()` 経由で子を辿るため、Taffy からこれらのメソッドが呼ばれることがない。テストなしで到達不可能。 |
| `CacheTree::cache_get` / `cache_store` / `cache_clear` | 340–370 | 同上。Taffy のキャッシュトラバーサルが当該ラッパーを経由しない。 |
| `propagate_height_delta` 防御 `break` | 1575, 1578 | 無限ループ防止のサーキットブレーカー。ノードグラフが壊れていないかぎり到達しない。 |
| `clear_subtree_cache_inner` 防御パス | 1545, 1553 | 同種の防御コード。 |

## テスト実行結果

```text
cargo test -p fulgur --lib: 1918 passed; 0 failed
cargo clippy -p fulgur -- -D warnings: clean
cargo fmt -p fulgur --check: clean
```

---
_Generated by [Claude Code](https://claude.ai/code/session_016R5YHQTXdsqhBNPR6pJhVB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 負の列間隔や高さ0のコンテンツを含むマルチカラムレイアウトで、列幅や列数が不正になる問題を修正しました。
  * インライン要素を含むレイアウトで、段落分割を行わず適切なジオメトリを記録するフォールバック処理を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->