### PR TITLE
harden(config): reject non-finite/negative/collapsing page size and margin

### DIFF
--- a/crates/fulgur-cli/src/main.rs
+++ b/crates/fulgur-cli/src/main.rs
@@ -406,6 +406,17 @@ fn parse_margin(s: &str) -> Margin {
         );
         return Margin::default();
     }
+    // `f32::from_str` accepts "nan"/"inf"/"-inf" as valid numbers, and a
+    // bare negative value parses fine syntactically — neither is a usable
+    // margin, so reject explicitly rather than let `Engine::render` reject
+    // it later with a less specific error.
+    if values.iter().any(|v| !v.is_finite() || *v < 0.0) {
+        eprintln!(
+            "Invalid margin '{}': all values must be finite and non-negative (mm). Using default 20mm",
+            s
+        );
+        return Margin::default();
+    }
     let to_pt = |mm: f32| mm * 72.0 / 25.4;
     match values.as_slice() {
         [all] => Margin::uniform(to_pt(*all)),
@@ -881,5 +892,43 @@ mod tests {
             parse_page_size("0ptx100pt").width,
             PageSize::A4.width
         )); // 非正値
+    }
+
+    #[test]
+    fn margin_valid_uniform() {
+        let m = parse_margin("20");
+        assert!(approx(m.top, 20.0 * 72.0 / 25.4));
+        assert_eq!(m.top, m.right);
+        assert_eq!(m.top, m.bottom);
+        assert_eq!(m.top, m.left);
+    }
+
+    #[test]
+    fn margin_rejects_negative_falls_back_to_default() {
+        let m = parse_margin("-5");
+        assert_eq!(m, Margin::default());
+    }
+
+    #[test]
+    fn margin_rejects_nan_falls_back_to_default() {
+        // Rust's f32::from_str accepts "nan"/"inf"/"-inf" as valid numbers,
+        // so these parse successfully as tokens and must be caught by the
+        // finite check rather than the "not a number" branch.
+        let m = parse_margin("nan");
+        assert_eq!(m, Margin::default());
+    }
+
+    #[test]
+    fn margin_rejects_infinite_falls_back_to_default() {
+        let m = parse_margin("inf");
+        assert_eq!(m, Margin::default());
+        let m = parse_margin("-inf");
+        assert_eq!(m, Margin::default());
+    }
+
+    #[test]
+    fn margin_rejects_one_bad_value_among_four() {
+        let m = parse_margin("10 10 10 -10");
+        assert_eq!(m, Margin::default());
     }
 }

--- a/crates/fulgur-wasm/src/lib.rs
+++ b/crates/fulgur-wasm/src/lib.rs
@@ -306,7 +306,12 @@ impl Engine {
     /// `serde_json::from_str` で deserialize する。`serde-wasm-bindgen`
     /// の `Reflect::get` ベースの deserializer は `deny_unknown_fields`
     /// を honor せず typo を silently 通してしまうため、検証ゲートを
-    /// 効かせる経路として JSON 経由を採用している。
+    /// 効かせる経路として JSON 経由を採用している。副次効果として、JS の
+    /// `NaN` / `Infinity` は `JSON.stringify` で `null` に化けるため
+    /// `f32` フィールドの deserialize が型エラーで失敗し、非有限な
+    /// `widthMm` 等はここで弾かれる。負値や margin が content area を
+    /// 潰す組み合わせは構文的に正当な数値なので通るが、`render()` が
+    /// 呼び出す `fulgur::Config::validate` が最終的に弾く。
     pub fn configure(&mut self, options: JsValue) -> Result<(), JsError> {
         let json = js_sys::JSON::stringify(&options)
             .map_err(|_| JsError::new("invalid options: value cannot be converted to JSON"))?;
@@ -448,6 +453,89 @@ mod wasm_tests {
         let mut engine = Engine::new();
         let result = engine.configure(options(r#"{"pageSize":"Foo"}"#));
         assert!(result.is_err(), "unknown page size should be rejected");
+    }
+
+    // `options()` above goes through `JSON.parse`, which cannot represent
+    // `NaN`/`Infinity` as JSON text at all — it can only probe the
+    // `configure_json`-equivalent path. These two tests instead build a
+    // REAL JS object with an actual `NaN`/`Infinity` value, to exercise the
+    // exact `JsValue -> JSON.stringify -> serde_json::from_str` round trip
+    // that `configure` runs in production. JS's `JSON.stringify` replaces
+    // non-finite numbers with `null`, so a `f32`-typed field fails to
+    // deserialize with a type error — these values are rejected before ever
+    // reaching `PageSizeOption::to_page_size`.
+    #[wasm_bindgen_test]
+    fn configure_rejects_real_nan_via_jsvalue() {
+        let mut engine = Engine::new();
+        let opts = js_sys::Object::new();
+        js_sys::Reflect::set(&opts, &"pageSize".into(), &{
+            let ps = js_sys::Object::new();
+            js_sys::Reflect::set(&ps, &"widthMm".into(), &js_sys::Number::from(f64::NAN)).unwrap();
+            js_sys::Reflect::set(&ps, &"heightMm".into(), &js_sys::Number::from(297.0)).unwrap();
+            ps.into()
+        })
+        .unwrap();
+        let result = engine.configure(opts.into());
+        assert!(
+            result.is_err(),
+            "NaN pageSize should be rejected, got {result:?}"
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn configure_rejects_real_infinity_via_jsvalue() {
+        let mut engine = Engine::new();
+        let opts = js_sys::Object::new();
+        js_sys::Reflect::set(&opts, &"pageSize".into(), &{
+            let ps = js_sys::Object::new();
+            js_sys::Reflect::set(&ps, &"widthMm".into(), &js_sys::Number::from(210.0)).unwrap();
+            js_sys::Reflect::set(
+                &ps,
+                &"heightMm".into(),
+                &js_sys::Number::from(f64::INFINITY),
+            )
+            .unwrap();
+            ps.into()
+        })
+        .unwrap();
+        let result = engine.configure(opts.into());
+        assert!(
+            result.is_err(),
+            "Infinity pageSize should be rejected, got {result:?}"
+        );
+    }
+
+    // Negative dimensions and collapsing margins are ordinary finite JSON
+    // numbers, so `configure` itself accepts them (partial merge can't know
+    // the final page size when only a margin is being set). The core
+    // `fulgur::Engine::render` validation catches them instead — this is
+    // exercised through `render`, not `configure`.
+    #[wasm_bindgen_test]
+    fn render_rejects_negative_custom_page_size_via_jsvalue() {
+        let mut engine = Engine::new();
+        engine
+            .configure(options(
+                r#"{"pageSize":{"widthMm":-210.0,"heightMm":297.0}}"#,
+            ))
+            .expect("configure should accept a syntactically valid negative number");
+        let result = engine.render("<p>x</p>");
+        assert!(
+            result.is_err(),
+            "negative custom page size should be rejected at render, got {result:?}"
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn render_rejects_margin_collapsing_content_area_via_jsvalue() {
+        let mut engine = Engine::new();
+        engine
+            .configure(options(r#"{"pageSize":"A4","margin":{"mm":1000.0}}"#))
+            .expect("configure should accept a syntactically valid large margin");
+        let result = engine.render("<p>x</p>");
+        assert!(
+            result.is_err(),
+            "margin collapsing the content area should be rejected at render, got {result:?}"
+        );
     }
 }
 
@@ -662,6 +750,47 @@ mod tests {
             "pageSizeTypo": "A4",
         }));
         assert!(result.is_err(), "unknown field should be rejected");
+    }
+
+    // `serde_json` cannot represent NaN/Infinity (see the module doc comment
+    // on `configure`), so negative and collapsing values — ordinary finite
+    // numbers — are what this path can actually probe. `configure_json`
+    // itself accepts them (it can't know the final page size from a margin
+    // alone), and `render` is where core `fulgur` validation rejects them.
+    #[test]
+    fn configure_json_accepts_negative_dimensions_but_render_rejects() {
+        // Uses `render_impl` (plain `fulgur::Result`), not the `#[wasm_bindgen]`
+        // `render` wrapper: on the error path that wrapper calls
+        // `JsError::new`, which panics on non-wasm targets (see the
+        // `configure_json` doc note above on why native tests route around
+        // wasm-bindgen-imported functions).
+        let mut engine = Engine::new();
+        engine
+            .configure_json(serde_json::json!({
+                "pageSize": { "widthMm": -210.0, "heightMm": 297.0 },
+            }))
+            .expect("configure should accept a syntactically valid negative number");
+        let result = engine.render_impl("<p>x</p>");
+        assert!(
+            result.is_err(),
+            "negative custom page size should be rejected at render"
+        );
+    }
+
+    #[test]
+    fn configure_json_accepts_collapsing_margin_but_render_rejects() {
+        let mut engine = Engine::new();
+        engine
+            .configure_json(serde_json::json!({
+                "pageSize": "A4",
+                "margin": { "mm": 1000.0 },
+            }))
+            .expect("configure should accept a syntactically valid large margin");
+        let result = engine.render_impl("<p>x</p>");
+        assert!(
+            result.is_err(),
+            "margin collapsing the content area should be rejected at render"
+        );
     }
 
     #[test]

--- a/crates/fulgur/src/config.rs
+++ b/crates/fulgur/src/config.rs
@@ -177,6 +177,49 @@ impl Config {
     pub fn effective_bookmarks(&self) -> bool {
         self.bookmarks || self.pdf_ua
     }
+
+    /// Rejects page size / margin combinations that are unsafe to feed into
+    /// Blitz layout and pagination: non-finite or non-positive page
+    /// dimensions, non-finite or negative margins, and margins that leave no
+    /// content area. Called once at the top of the layout pipeline
+    /// (`Engine::layout_to_drawables`) so bad values fail fast with a clear
+    /// error instead of reaching Blitz/Taffy as e.g. a saturated `u32::MAX`
+    /// viewport height.
+    pub(crate) fn validate(&self) -> crate::Result<()> {
+        let ps = if self.landscape {
+            self.page_size.landscape()
+        } else {
+            self.page_size
+        };
+        if !ps.width.is_finite() || ps.width <= 0.0 || !ps.height.is_finite() || ps.height <= 0.0 {
+            return Err(crate::Error::PdfGeneration(format!(
+                "invalid page size: width and height must be finite and positive (got {}x{} pt)",
+                ps.width, ps.height
+            )));
+        }
+        for (name, v) in [
+            ("top", self.margin.top),
+            ("right", self.margin.right),
+            ("bottom", self.margin.bottom),
+            ("left", self.margin.left),
+        ] {
+            if !v.is_finite() || v < 0.0 {
+                return Err(crate::Error::PdfGeneration(format!(
+                    "invalid margin: {name} must be finite and non-negative (got {v})"
+                )));
+            }
+        }
+        if self.content_width() <= 0.0 || self.content_height() <= 0.0 {
+            return Err(crate::Error::PdfGeneration(format!(
+                "invalid margin: margins leave no content area ({}x{} pt page, {}x{} pt content)",
+                ps.width,
+                ps.height,
+                self.content_width(),
+                self.content_height()
+            )));
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -309,6 +352,92 @@ mod tests {
             .build();
         assert!((config.content_width() - (841.89 - 144.0)).abs() < 0.01);
         assert!((config.content_height() - (595.28 - 144.0)).abs() < 0.01);
+    }
+
+    #[test]
+    fn validate_accepts_default_config() {
+        assert!(Config::default().validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_nan_page_width() {
+        let config = Config::builder()
+            .page_size(PageSize::custom(f32::NAN, 297.0))
+            .build();
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_infinite_page_height() {
+        let config = Config::builder()
+            .page_size(PageSize::custom(210.0, f32::INFINITY))
+            .build();
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_non_positive_page_size() {
+        assert!(
+            Config::builder()
+                .page_size(PageSize::custom(-210.0, 297.0))
+                .build()
+                .validate()
+                .is_err()
+        );
+        assert!(
+            Config::builder()
+                .page_size(PageSize::custom(0.0, 297.0))
+                .build()
+                .validate()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn validate_rejects_negative_margin() {
+        let config = Config::builder()
+            .page_size(PageSize::A4)
+            .margin(Margin::uniform(-1.0))
+            .build();
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_non_finite_margin() {
+        let config = Config::builder()
+            .page_size(PageSize::A4)
+            .margin(Margin {
+                top: f32::NAN,
+                right: 20.0,
+                bottom: 20.0,
+                left: 20.0,
+            })
+            .build();
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_margin_collapsing_content_area() {
+        // A4 height is 841.89pt; a 1000pt uniform margin leaves no content
+        // area on any side.
+        let config = Config::builder()
+            .page_size(PageSize::A4)
+            .margin(Margin::uniform(1000.0))
+            .build();
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_accepts_landscape_with_valid_content_area() {
+        // Content-area validation must use the landscape-flipped page size,
+        // not the portrait one, or a legitimate landscape config could be
+        // rejected (or an invalid one wrongly accepted).
+        let config = Config::builder()
+            .page_size(PageSize::A4)
+            .margin(Margin::uniform(72.0))
+            .landscape(true)
+            .build();
+        assert!(config.validate().is_ok());
     }
 
     #[test]

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -166,6 +166,11 @@ impl Engine {
         html: &str,
         anchor_map: Option<&AnchorMap>,
     ) -> Result<LayoutArtifacts> {
+        // Reject non-finite/non-positive page size or margin values before
+        // they reach Blitz parsing below — an unvalidated f32 here can
+        // otherwise saturate to e.g. a u32::MAX viewport height.
+        self.config.validate()?;
+
         let html = crate::blitz_adapter::rewrite_marker_content_url_in_html(html);
 
         let combined_css = self

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -6431,3 +6431,34 @@ fn regex_lite_link_rects(text: &str) -> Vec<(f32, f32, f32, f32)> {
     }
     out
 }
+
+/// `Engine::render` must reject non-finite / non-positive page size and
+/// collapsing margins before they reach Blitz layout, instead of silently
+/// producing a saturated viewport or a krilla PDF-generation error deep in
+/// the pipeline. Exercised through the real `Engine::builder()` entry point
+/// (not a direct `Config::validate` unit call) so the render path itself is
+/// covered for codecov patch attribution — see CLAUDE.md "Coverage scope".
+#[test]
+fn render_rejects_non_finite_custom_page_size() {
+    use fulgur::PageSize;
+
+    let err = Engine::builder()
+        .page_size(PageSize::custom(210.0, f32::INFINITY))
+        .build()
+        .render("<p>x</p>")
+        .expect_err("infinite custom page height should be rejected");
+    assert!(err.to_string().contains("invalid page size"));
+}
+
+#[test]
+fn render_rejects_margin_collapsing_content_area() {
+    use fulgur::{Margin, PageSize};
+
+    let err = Engine::builder()
+        .page_size(PageSize::A4)
+        .margin(Margin::uniform(1000.0))
+        .build()
+        .render("<p>x</p>")
+        .expect_err("margins exceeding the page size should be rejected");
+    assert!(err.to_string().contains("invalid margin"));
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -6462,3 +6462,37 @@ fn render_rejects_margin_collapsing_content_area() {
         .expect_err("margins exceeding the page size should be rejected");
     assert!(err.to_string().contains("invalid margin"));
 }
+
+/// `builder.margin(...)` sets `ConfigOverrides::margin`, which makes it
+/// authoritative over `@page { margin: ... }` (see
+/// `gcpm::page_settings::resolve_page_settings`) — so an invalid explicit
+/// builder margin is never "rescued" by CSS, and `Config::validate` rejecting
+/// it before GCPM resolution runs is correct, not a false positive.
+#[test]
+fn render_rejects_explicit_margin_override_even_with_at_page_css() {
+    use fulgur::Margin;
+
+    let html = r#"<style>@page { size: A4; margin: 20mm; }</style><p>x</p>"#;
+    let err = Engine::builder()
+        .margin(Margin::uniform(1000.0))
+        .build()
+        .render(html)
+        .expect_err("explicit builder margin override must win over @page and be rejected");
+    assert!(err.to_string().contains("invalid margin"));
+}
+
+/// The inverse of the test above: when the caller does *not* call
+/// `builder.margin(...)`, `self.config` stays at its always-valid default,
+/// so `Config::validate` is a no-op regardless of what `@page` declares.
+/// A pathological `@page`-only margin is unaffected by this PR — it is
+/// still handled by the pre-existing
+/// `resolved_content_{width,height}_pt.max(0.0)` clamp in `Engine::render`.
+#[test]
+fn render_unaffected_by_at_page_only_margin_without_builder_override() {
+    let html = r#"<style>@page { size: A4; margin: 1000mm; }</style><p>x</p>"#;
+    let pdf = Engine::builder()
+        .build()
+        .render(html)
+        .expect("no builder override means Config::validate must not reject @page-only CSS");
+    assert!(!pdf.is_empty());
+}


### PR DESCRIPTION
## Summary

Codex security finding (`fc6dd039...`) reported that `fulgur-wasm`'s `Engine.configure()` accepted non-finite (`NaN`/`Infinity`), negative, or content-area-collapsing page size / margin values without validation, letting bad `f32` config reach Blitz layout unchecked — e.g. an infinite page height saturates to `u32::MAX` when cast for the Blitz viewport.

**Triage**: page size / margin passed via `Engine::builder()` (or the WASM `configure()` equivalent) is builder-API configuration — the SaaS-operator/embedder trust level in `docs/security/threat-model.md`, not the documented untrusted HTML-template / JSON-data channel. Reproducing every case from the finding (NaN, Infinity, negative dimensions, `1e30`, margin collapse, and an `@page` CSS-driven huge size for completeness) through the real `Engine::builder()` API found no hang, OOM, or panic — every case either failed cleanly at krilla's existing page-dimension check or rendered a bounded PDF. So: no GHSA advisory, plain public hardening PR.

## Changes

- `Config::validate()` (new, `crates/fulgur/src/config.rs`) rejects non-finite/non-positive page dimensions, non-finite/negative margins, and margins that collapse the content area to ≤ 0. Called once at the top of `Engine::layout_to_drawables`, so every consumer — CLI, WASM, `pyfulgur`, `fulgur-ruby` — gets the check for free without any API break (the entry points already return `Result`).
- Along the way: `fulgur-wasm`'s `configure()` turns out to *already* reject real JS `NaN`/`Infinity` by accident, via the `JSON.stringify` round-trip it uses to make `deny_unknown_fields` work (JS `JSON.stringify` turns non-finite numbers into `null`, which then fails `f32` deserialization). Negative values and margin collapse are ordinary finite JSON numbers, so those were not caught — that's what `Config::validate` now closes. Documented in the `configure()` doc comment and covered by new `wasm-bindgen-test`s that build real `JsValue`s (not JSON-text, which can't represent `NaN`/`Infinity` at all).
- `fulgur-cli`'s `parse_margin` gets the same `is_finite`/non-negative guard `parse_custom_size` already had (`f32::from_str` accepts `"nan"`/`"inf"` as valid tokens).

## Test plan

- [x] `crates/fulgur/src/config.rs`: unit tests for `Config::validate` (NaN/Infinity page size, negative/non-finite margin, margin collapse, landscape content-area correctness)
- [x] `crates/fulgur/tests/render_smoke.rs`: end-to-end `Engine::render` rejection tests (codecov patch-coverage path per CLAUDE.md "Coverage scope")
- [x] `crates/fulgur-wasm/src/lib.rs`: native `configure_json` tests + `wasm-pack test --node` tests for real `JsValue` NaN/Infinity and negative/collapsing values reaching `render`
- [x] `crates/fulgur-cli/src/main.rs`: `parse_margin` unit tests (negative, nan, inf, one-bad-value-among-four)
- [x] `cargo fmt --all --check`, `cargo clippy -p fulgur -p fulgur-cli -p fulgur-wasm --all-targets -- -D warnings`, `cargo test -p fulgur`, `cargo test -p fulgur-cli`, `cargo test -p fulgur-wasm --lib`, `wasm-pack test --node crates/fulgur-wasm` all green

fulgur-rkf8