### PR TITLE
test(convert): LinkCache キャッシュヒット経路のカバレッジを追加

### DIFF
--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -1919,6 +1919,94 @@ mod utility_fn_tests {
         assert_eq!(cb.width, crate::units::Px::ZERO);
         assert_eq!(cb.height, crate::units::Px::ZERO);
     }
+
+    // --- LinkCache::lookup cache hit paths ---
+    //
+    // Two paths through the cache-hit branch of `lookup` (line 1063) are not
+    // reached by integration tests:
+    //   line 1064: `let anchor_id = (*cached)?;` — None short-circuit
+    //   line 1065: `return self.by_anchor.get(&anchor_id).cloned();` — Some hit
+    // Covered here by calling `lookup` twice for the same node id.
+
+    fn find_first_by_tag_in_tests(doc: &BaseDocument, start_id: usize, tag: &str) -> Option<usize> {
+        let node = doc.get_node(start_id)?;
+        if node
+            .element_data()
+            .is_some_and(|e| e.name.local.as_ref() == tag)
+        {
+            return Some(start_id);
+        }
+        for &c in &node.children {
+            if let Some(found) = find_first_by_tag_in_tests(doc, c, tag) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn link_cache_second_lookup_hits_cached_none() {
+        // First call for a node not inside any <a> inserts None into by_start.
+        // Second call finds the cached None and short-circuits at line 1064.
+        let doc = crate::blitz_adapter::parse_and_layout(
+            "<!DOCTYPE html><html><body><p>no anchor here</p></body></html>",
+            595.0_f32.as_px(),
+            842.0_f32.as_px(),
+            &[],
+            false,
+        );
+        let base: &BaseDocument = doc.deref();
+        let root_id = doc.root_element().id;
+
+        let mut cache = LinkCache::default();
+        let first = cache.lookup(base, root_id);
+        // Second call: cache hit → `(*cached)?` at line 1064 returns None.
+        let second = cache.lookup(base, root_id);
+
+        assert!(
+            first.is_none(),
+            "root element should not be inside an anchor"
+        );
+        assert!(
+            second.is_none(),
+            "cached None hit must also return None (line 1064)"
+        );
+    }
+
+    #[test]
+    fn link_cache_second_lookup_returns_cached_arc() {
+        // First call for a node inside <a href="…"> resolves and caches the anchor.
+        // Second call returns the Arc from by_anchor at line 1065.
+        let doc = crate::blitz_adapter::parse_and_layout(
+            r#"<!DOCTYPE html><html><body><a href="https://example.com"><span>link</span></a></body></html>"#,
+            595.0_f32.as_px(),
+            842.0_f32.as_px(),
+            &[],
+            false,
+        );
+        let base: &BaseDocument = doc.deref();
+        let root_id = doc.root_element().id;
+        let span_id = find_first_by_tag_in_tests(base, root_id, "span")
+            .expect("<span> should exist inside <a>");
+
+        let mut cache = LinkCache::default();
+        let first = cache.lookup(base, span_id);
+        // Second call: cache hit → returns Arc from by_anchor at line 1065.
+        let second = cache.lookup(base, span_id);
+
+        assert!(
+            first.is_some(),
+            "span inside <a href> should resolve to Some link"
+        );
+        assert!(
+            second.is_some(),
+            "cached anchor hit must also return Some link (line 1065)"
+        );
+        assert!(
+            Arc::ptr_eq(first.as_ref().unwrap(), second.as_ref().unwrap()),
+            "both calls must return the same Arc (memoization invariant)"
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 概要

`LinkCache::lookup` の 2 つの未到達経路を unit test でカバーします。

### 対象ファイル

`crates/fulgur/src/convert/mod.rs`（変更前 94.27% → 変更後 **94.74%**、regions +0.47 pt）

### 未到達だった経路

```rust
impl LinkCache {
    pub(crate) fn lookup(&mut self, doc: &BaseDocument, start_id: usize) -> Option<Arc<LinkSpan>> {
        if let Some(cached) = self.by_start.get(&start_id) {
            let anchor_id = (*cached)?;           // ← line 1064: None キャッシュヒット（未到達）
            return self.by_anchor.get(&anchor_id).cloned();  // ← line 1065: Arc キャッシュヒット（未到達）
        }
        // ... 初回解決パス（統合テストが到達済み）
    }
}
```

統合テストは初回呼び出しパス（cache miss → 解決 → 挿入）を通るが、同一 node に対して `lookup` を 2 回呼ぶケースがなかったため、キャッシュヒットの 2 経路が未到達だった。

### 追加したテスト（`utility_fn_tests` モジュール）

| テスト名 | カバーする経路 |
|---|---|
| `link_cache_second_lookup_hits_cached_none` | line 1064: `(*cached)?` で None を返す経路 |
| `link_cache_second_lookup_returns_cached_arc` | line 1065: `by_anchor.get()` から Arc を返す経路 |

両テストとも `parse_and_layout` でドキュメントを生成し、同じ node id で `lookup` を 2 回呼んでキャッシュヒットを強制する。`link_cache_second_lookup_returns_cached_arc` は `Arc::ptr_eq` でメモ化不変条件（同一 Arc を返す）を検証する。

### チェックスイート

- `cargo test -p fulgur --lib`: 1928 tests passed（+2）
- `cargo clippy -- -D warnings`: 警告なし
- `cargo fmt --check`: 差分なし

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDCbcuzTKz2nu1nrLr8WRS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * リンクキャッシュの既存データが正しく再利用されることを検証するテストを追加しました。
  * 対象範囲外ではキャッシュ済みの空結果が返り、対象範囲内では同じリンク情報が維持されることを確認します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->