### PR TITLE
test(convert): cover table comment-node guard and get_text_color fallback

### DIFF
--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -2007,6 +2007,30 @@ mod utility_fn_tests {
             "both calls must return the same Arc (memoization invariant)"
         );
     }
+
+    // --- get_text_color fallback ---
+    //
+    // Production callers always pass valid, styled node ids, so the fallback
+    // path at mod.rs:1110 (when `doc.get_node` returns None) is only reachable
+    // via an out-of-range id. Tested here directly on the private function.
+
+    #[test]
+    fn get_text_color_falls_back_to_black_for_missing_node() {
+        let doc = crate::blitz_adapter::parse_and_layout(
+            "<!DOCTYPE html><html><body><p>text</p></body></html>",
+            595.0_f32.as_px(),
+            842.0_f32.as_px(),
+            &[],
+            false,
+        );
+        use std::ops::Deref;
+        let base: &BaseDocument = doc.deref();
+        assert_eq!(
+            get_text_color(base, usize::MAX),
+            [0, 0, 0, 255],
+            "get_text_color must return opaque black for an out-of-range node id"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/fulgur/src/convert/table.rs
+++ b/crates/fulgur/src/convert/table.rs
@@ -203,5 +203,16 @@ mod tests {
             !d.tables.is_empty(),
             "table entry must be present in drawables even when tbody has a leading comment"
         );
+        // Stronger assertion: the cell content must also have been converted.
+        // `collect_table_cells` inserts `<td>` content via `convert_node`, which
+        // produces paragraph entries for inline text. A non-empty `paragraphs`
+        // map proves `collect_table_cells` walked past the comment and processed
+        // the real `<tr><td>` — something `!d.tables.is_empty()` alone cannot
+        // verify, since `TableEntry` is inserted before the child walk.
+        assert!(
+            !d.paragraphs.is_empty(),
+            "cell content must be converted to paragraph drawables, \
+             proving collect_table_cells walked past the comment node"
+        );
     }
 }

--- a/crates/fulgur/src/convert/table.rs
+++ b/crates/fulgur/src/convert/table.rs
@@ -131,3 +131,77 @@ fn collect_table_cells(
         convert_node(doc, child_id, ctx, depth + 1, out);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    // --- comment node inside <tbody> ---
+    //
+    // HTML5 keeps comment nodes inside their table-section parent rather than
+    // foster-parenting them. `collect_table_cells` must skip them via the
+    // `NodeData::Comment` guard (table.rs:104) rather than trying to lay them
+    // out, so the real cell content still reaches the drawable maps.
+    #[test]
+    fn table_comment_in_tbody_produces_valid_pdf() {
+        let html = "<!DOCTYPE html><html><body>\
+            <table>\
+                <tbody>\
+                    <!-- comment node exercises NodeData::Comment guard -->\
+                    <tr><td>Cell</td></tr>\
+                </tbody>\
+            </table>\
+            </body></html>";
+        let pdf = crate::engine::Engine::builder()
+            .build()
+            .render(html)
+            .expect("render");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // Regression: a table entry must be created even when the only content
+    // before the first real row is an HTML comment.
+    #[test]
+    fn table_comment_before_rows_still_registers_table_entry() {
+        use crate::units::F32Units;
+        use std::ops::DerefMut;
+
+        let html = "<!DOCTYPE html><html><body>\
+            <table>\
+                <tbody>\
+                    <!-- comment before rows -->\
+                    <tr><td style=\"width:50px;height:20px\">A</td></tr>\
+                </tbody>\
+            </table>\
+            </body></html>";
+
+        let mut doc = crate::blitz_adapter::parse_and_layout(
+            html,
+            595.0_f32.as_px(),
+            842.0_f32.as_px(),
+            &[],
+            true,
+        );
+        let column_styles = crate::blitz_adapter::extract_column_style_table(&doc);
+        let multicol_geometry = crate::multicol_layout::run_pass(doc.deref_mut(), &column_styles);
+        let pagination_geometry = crate::pagination_layout::run_pass(doc.deref_mut(), 842.0);
+        let running_store = crate::gcpm::running::RunningElementStore::new();
+        let mut ctx = crate::convert::ConvertContext {
+            running_store: &running_store,
+            assets: None,
+            font_cache: Default::default(),
+            string_set_by_node: Default::default(),
+            counter_ops_by_node: Default::default(),
+            bookmark_by_node: Default::default(),
+            column_styles,
+            multicol_geometry,
+            pagination_geometry,
+            link_cache: Default::default(),
+            viewport_size_px: Some((595.0, 842.0)),
+        };
+        let d = crate::convert::dom_to_drawables(&doc, &mut ctx);
+
+        assert!(
+            !d.tables.is_empty(),
+            "table entry must be present in drawables even when tbody has a leading comment"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`convert/table.rs` と `convert/mod.rs` に対してカバレッジが低かった 2 つの防御ガードパスをユニットテストでカバーする。

- **`convert/table.rs` line 104** — `collect_table_cells` の `NodeData::Comment` ガード: HTML5 はコメントノードをテーブルセクション要素（`<tbody>` 等）の子としてそのまま保持する（フォスターペアレンティングしない）。このガードがないとコメントを「セル」として処理しようとしてパニックする可能性がある。
- **`convert/mod.rs` line 1110** — `get_text_color` の不在ノードフォールバック: 存在しないノード ID を渡した場合に `if-let` チェーンが抜けてデフォルトの不透明黒 `[0, 0, 0, 255]` を返すパス。

## Changes

- `crates/fulgur/src/convert/table.rs` に `#[cfg(test)] mod tests` を新設
  - `table_comment_in_tbody_produces_valid_pdf` — `Engine::render` スモークテスト: コメント入り `<tbody>` から有効な PDF が生成されることを確認
  - `table_comment_before_rows_still_registers_table_entry` — 構造テスト: コメントが先頭に来てもテーブルエントリが `Drawables` に登録されることを `dom_to_drawables` で検証
- `crates/fulgur/src/convert/mod.rs` の `utility_fn_tests` に追加
  - `get_text_color_falls_back_to_black_for_missing_node` — `usize::MAX` を渡して `[0, 0, 0, 255]` が返ることを確認

カバレッジ変化 (`cargo llvm-cov --package fulgur --lib`):
- `convert/table.rs`: **95.00% → 96.70%**（ブランチカバレッジ: **100%**）
- `convert/mod.rs`: **94.74% → 94.87%**

## Test plan

- [x] `cargo test -p fulgur --lib` — 1931 passed, 0 failed
- [x] `cargo clippy -p fulgur -- -D warnings` — 警告なし
- [x] `cargo fmt --check -p fulgur` — 差分なし

---
_Generated by [Claude Code](https://claude.ai/code/session_01JiB3dADhTcLKDeMunvTzNs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * 存在しないノードIDに対する文字色のフォールバック動作を検証するテストを追加しました。
  * コメントを含むテーブルから有効なPDFを生成できることを確認する回帰テストを追加しました。
  * 先頭にコメントがあるテーブルが正しく登録され、セル内容が変換されることを検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->