### PR TITLE
test(pagination_layout): cover is_float guard, break-after:page normal path, has_forced_break_below recursion

### DIFF
--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -6816,4 +6816,127 @@ h2 { string-set: chapter-title content(text); }
             geom.keys().collect::<Vec<_>>()
         );
     }
+
+    // ── has_forced_break_below: recursive return (line 1423) ────────────────────
+
+    /// `has_forced_break_below` must recurse into grandchildren: when a body-
+    /// direct outer div contains a middle div (no direct break) that in turn
+    /// contains an inner div with `break-after: page`, the recursive call at
+    /// line 1422 must return `true` (triggering line 1423) so the outer div
+    /// enters `fragment_block_subtree` and the break fires.
+    #[test]
+    fn has_forced_break_below_recursive_return_detects_grandchild_break() {
+        let html = r#"
+            <html><body style="margin: 0; padding: 0">
+              <div style="height: 300px">
+                <div style="height: 150px">
+                  <div style="height: 50px; break-after: page"></div>
+                  <div style="height: 50px"></div>
+                </div>
+                <div style="height: 100px"></div>
+              </div>
+            </body></html>
+        "#;
+        let mut doc = parse(html, 600.0);
+        let table = blitz_adapter::extract_column_style_table(&doc);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 800.0_f32.as_px(), &table);
+        // The inner div has break-after: page; has_forced_break_below must
+        // recurse through the middle div and detect it, causing the outer
+        // subtree to be split and emitting a page-1 fragment.
+        assert!(
+            geom.values()
+                .flat_map(|g| g.fragments.iter())
+                .any(|f| f.page_index == 1),
+            "has_forced_break_below must recurse into grandchild and detect \
+             break-after: page (line 1423); geom={geom:?}"
+        );
+    }
+
+    // ── break-after: page on a normal-height body-direct block (lines 1118-1124)
+
+    /// A body-direct block with positive height and `break-after: page` must
+    /// advance page_index and reset cursor_y even when the block does NOT
+    /// overflow the page and does NOT need recursion. This exercises lines
+    /// 1118-1124 in `fragment_pagination_root` (the normal-emit path), which
+    /// is distinct from the zero-height path (lines 628-658) and the
+    /// slice/recursion paths that both also carry a `break-after` arm.
+    #[test]
+    fn break_after_page_on_normal_height_body_direct_block_pushes_sibling() {
+        let html = r#"
+            <html><body style="margin: 0; padding: 0">
+              <div style="height: 200px; break-after: page"></div>
+              <div style="height: 100px"></div>
+            </body></html>
+        "#;
+        let mut doc = parse(html, 600.0);
+        let table = blitz_adapter::extract_column_style_table(&doc);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 800.0_f32.as_px(), &table);
+        // The second div must land on page 1 because the first carries
+        // break-after: page; both divs fit in the 800px strip so overflow
+        // logic is not what triggers the break.
+        assert!(
+            geom.values()
+                .flat_map(|g| g.fragments.iter())
+                .any(|f| f.page_index == 1),
+            "break-after: page on a normal-height body-direct block (normal path, \
+             lines 1118-1124) must push the sibling to page 1; geom={geom:?}"
+        );
+    }
+
+    // ── is_float guard in body-direct normal-height path (lines 1108-1110) ──────
+
+    /// A `float: left` body-direct child must be processed by
+    /// `fragment_pagination_root` with `is_float = true`, causing the
+    /// `if !is_float { prev_used_page = ... }` guard (lines 1108-1110) to
+    /// take its false branch. This exercises the normal-height float path;
+    /// the float's sibling must still be recorded correctly on page 0.
+    #[test]
+    fn body_direct_float_child_processed_without_prev_used_page_update() {
+        let html = r#"
+            <html><body style="margin: 0; padding: 0">
+              <div style="float: left; height: 200px; width: 100px"></div>
+              <div style="clear: left; height: 100px"></div>
+            </body></html>
+        "#;
+        let mut doc = parse(html, 600.0);
+        let table = blitz_adapter::extract_column_style_table(&doc);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 800.0_f32.as_px(), &table);
+        // Both elements fit on page 0; the float must appear in geometry and
+        // the following in-flow sibling must also land on page 0.
+        assert_eq!(
+            super::implied_page_count(&geom),
+            1,
+            "float + clear sibling must both be on page 0; geom={geom:?}"
+        );
+        // At least the float and its sibling must be present in geometry.
+        assert!(
+            geom.len() >= 2,
+            "float and its sibling must both appear in geometry; geom={geom:?}"
+        );
+    }
+
+    // ── is_float guard in body-direct slicing path (lines 1056-1058) ────────────
+
+    /// A `float: left` body-direct child whose height exceeds the page height
+    /// must be sliced across pages (the `child_h > page_height_px + 1.0` path)
+    /// with `is_float = true`. This exercises the `if !is_float` guard at
+    /// lines 1056-1058 inside the slicing branch of `fragment_pagination_root`.
+    #[test]
+    fn body_direct_tall_float_sliced_across_pages_is_float_guard() {
+        let html = r#"
+            <html><body style="margin: 0; padding: 0">
+              <div style="float: left; height: 1200px; width: 100px"></div>
+            </body></html>
+        "#;
+        let mut doc = parse(html, 600.0);
+        let table = blitz_adapter::extract_column_style_table(&doc);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 800.0_f32.as_px(), &table);
+        // A 1200px float on an 800px page must be sliced into ≥ 2 fragments.
+        let max_frags = geom.values().map(|g| g.fragments.len()).max().unwrap_or(0);
+        assert!(
+            max_frags >= 2,
+            "a 1200px float on an 800px page must be sliced into ≥ 2 fragments \
+             (exercises lines 1056-1058); max_frags={max_frags}, geom={geom:?}"
+        );
+    }
 }

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -6888,27 +6888,33 @@ h2 { string-set: chapter-title content(text); }
     /// A `float: left` body-direct child must be processed by
     /// `fragment_pagination_root` with `is_float = true`, causing the
     /// `if !is_float { prev_used_page = ... }` guard (lines 1108-1110) to
-    /// take its false branch. This exercises the normal-height float path;
-    /// the float's sibling must still be recorded correctly on page 0.
+    /// take its false branch. This exercises the normal-height float path.
+    ///
+    /// The float carries `page: float-page` so that, without the guard,
+    /// `prev_used_page` would be set to `Some("float-page")`.  The
+    /// following in-flow sibling has the default (unnamed) page, so without
+    /// the guard `page_name_changed` would fire and push the sibling to
+    /// page 1 — causing `implied_page_count` to become 2.  The guard
+    /// suppresses that forced break, keeping both elements on page 0.
     #[test]
     fn body_direct_float_child_processed_without_prev_used_page_update() {
         let html = r#"
             <html><body style="margin: 0; padding: 0">
-              <div style="float: left; height: 200px; width: 100px"></div>
+              <div style="float: left; height: 200px; width: 100px; page: float-page"></div>
               <div style="clear: left; height: 100px"></div>
             </body></html>
         "#;
         let mut doc = parse(html, 600.0);
         let table = blitz_adapter::extract_column_style_table(&doc);
         let geom = super::run_pass_with_break_styles(doc.deref_mut(), 800.0_f32.as_px(), &table);
-        // Both elements fit on page 0; the float must appear in geometry and
-        // the following in-flow sibling must also land on page 0.
+        // The is_float guard prevents the float's named page from being stored
+        // in prev_used_page, so the following in-flow sibling must stay on page 0.
         assert_eq!(
             super::implied_page_count(&geom),
             1,
-            "float + clear sibling must both be on page 0; geom={geom:?}"
+            "is_float guard must prevent float's named page from triggering a \
+             forced break before the sibling; both must remain on page 0; geom={geom:?}"
         );
-        // At least the float and its sibling must be present in geometry.
         assert!(
             geom.len() >= 2,
             "float and its sibling must both appear in geometry; geom={geom:?}"
@@ -6921,22 +6927,38 @@ h2 { string-set: chapter-title content(text); }
     /// must be sliced across pages (the `child_h > page_height_px + 1.0` path)
     /// with `is_float = true`. This exercises the `if !is_float` guard at
     /// lines 1056-1058 inside the slicing branch of `fragment_pagination_root`.
+    ///
+    /// The float carries `page: float-page` so that, without the guard,
+    /// `prev_used_page` would be set to `Some("float-page")` after slicing.
+    /// The following `clear: left` sibling has the default page, so removing
+    /// the guard would trigger `page_name_changed` and advance `page_index`
+    /// to 2, landing the sibling on page 2 instead of page 1.
     #[test]
     fn body_direct_tall_float_sliced_across_pages_is_float_guard() {
         let html = r#"
             <html><body style="margin: 0; padding: 0">
-              <div style="float: left; height: 1200px; width: 100px"></div>
+              <div style="float: left; height: 1200px; width: 100px; page: float-page"></div>
+              <div style="clear: left; height: 100px"></div>
             </body></html>
         "#;
         let mut doc = parse(html, 600.0);
         let table = blitz_adapter::extract_column_style_table(&doc);
         let geom = super::run_pass_with_break_styles(doc.deref_mut(), 800.0_f32.as_px(), &table);
-        // A 1200px float on an 800px page must be sliced into ≥ 2 fragments.
+        // The 1200px float must be sliced into ≥ 2 fragments (slicing path exercised).
         let max_frags = geom.values().map(|g| g.fragments.len()).max().unwrap_or(0);
         assert!(
             max_frags >= 2,
             "a 1200px float on an 800px page must be sliced into ≥ 2 fragments \
              (exercises lines 1056-1058); max_frags={max_frags}, geom={geom:?}"
+        );
+        // The is_float guard must prevent the float's named page from being stored
+        // in prev_used_page after slicing, so the clear sibling stays on page 1
+        // (not forced to page 2 by a spurious page_name_changed).
+        assert_eq!(
+            super::implied_page_count(&geom),
+            2,
+            "is_float guard must keep the clear sibling on page 1, not page 2; \
+             implied_page_count must be 2 (pages 0 and 1); geom={geom:?}"
         );
     }
 }


### PR DESCRIPTION
## 概要

`cargo-llvm-cov` で特定した `pagination_layout.rs` の未カバーパスに対してユニットテストを 4 件追加します。プロダクションコードの変更はありません。

ベースラインカバレッジ（`main` ブランチ）:

| 指標 | 変更前 | 変更後 |
|------|--------|--------|
| 行カバレッジ | 95.23% (3773/3962) | 95.43% (3846/4030) |
| リージョンカバレッジ | 95.09% (5210/5479) | 95.26% (5306/5570) |

## 追加テスト

### 1. `has_forced_break_below_recursive_return_detects_grandchild_break`

**対象行: 1423**（`has_forced_break_below` の再帰リターン）

外側 div → 中間 div（直接 break なし）→ 内側 div（`break-after: page`）という 3 段構造を使用。`has_forced_break_below` が中間 div を再帰的にたどって内側の break を検出し、line 1423 の `return true` を踏むことを確認。

### 2. `break_after_page_on_normal_height_body_direct_block_pushes_sibling`

**対象行: 1118–1124**（ノーマルハイトの body-direct `break-after: page`）

既存テスト `zero_height_body_direct_break_after_page_fires_page_break` は高さ 0 要素のパスをカバー済み。本テストは **高さ > 0 かつページ高さ以下**のブロック（スライスパス・再帰パスを通らない通常パス）に `break-after: page` を設定し、後続要素が page 1 に押し出されることを確認。

### 3. `body_direct_float_child_processed_without_prev_used_page_update`

**対象行: 1108–1110**（通常パスの `is_float` ガード）

`float: left` の body-direct 子要素は `is_float = true` でループを通過する。`if !is_float { prev_used_page = ... }` の偽分岐（lines 1108–1110）が実行されることを確認。

### 4. `body_direct_tall_float_sliced_across_pages_is_float_guard`

**対象行: 1056–1058**（スライスパスの `is_float` ガード）

ページ高さを超える `float: left`（1200px on 800px page）はスライスパス（`child_h > page_height_px + 1.0`）に入る。そのパス内の `if !is_float` ガード（lines 1056–1058）が float で実行されることを確認。

## 変更ファイル

- `crates/fulgur/src/pagination_layout.rs` — テストのみ追加（+123 行、プロダクションコード変更なし）

---
_Generated by [Claude Code](https://claude.ai/code/session_01X92BjetTcdrzH5vygHp2tT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **テスト**
  - ページング処理の回帰テストを追加しました。
  - 深い階層での改ページ指定、通常ブロックや浮動要素の改ページ処理、ページ名の状態更新、ページ高を超える浮動要素の分割を検証します。
  - これにより、複雑なレイアウトにおけるページ分割の安定性を確認できます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->