### PR TITLE
harden(examples): scope wasm-demo HTTP server to examples/, not repo root

### DIFF
--- a/examples/wasm-demo/README.md
+++ b/examples/wasm-demo/README.md
@@ -65,14 +65,17 @@ For a quick iteration build (no size tuning, ~37 MB), use `--dev` instead.
 ## Run
 
 ES modules require a real HTTP origin (file:// will not work). The demo
-also fetches assets from `../.fonts/` and `../image/`, so you must serve
-the **repository root** (not just `examples/wasm-demo/`) so the relative
-paths resolve:
+also fetches assets from `../.fonts/` and `../image/`, so the document
+root must be `examples/` (not just `examples/wasm-demo/`) so the relative
+paths resolve. Do **not** serve the repository root — it would expose
+`.git/`, any local `.env` files, and other repo-root content over HTTP.
+`--directory` scopes the doc root to `examples/`, and `--bind` keeps the
+server off the network:
 
 ```bash
 # from repo root
-python3 -m http.server 8000
-# then visit http://localhost:8000/examples/wasm-demo/
+python3 -m http.server 8000 --directory examples --bind 127.0.0.1
+# then visit http://127.0.0.1:8000/wasm-demo/
 ```
 
 Edit the HTML in the textarea and click "Render PDF". The generated PDF is


### PR DESCRIPTION
## 概要

- WASM demo の README が `../.fonts/` / `../image/` の相対パス解決のために
  `python3 -m http.server` を**リポジトリルート**から起動するよう指示していた。
  これはチェックアウト全体（`.git/`、ローカルの `.env` があればそれも含む）を
  無認証で HTTP 越しに公開してしまう。
- ドキュメントルートを `examples/`（`.fonts/` / `image/` / `wasm-demo/` の共通
  親ディレクトリ）に `--directory` で絞り、`--bind 127.0.0.1` でローカル以外
  からの到達を遮断するよう変更。demo が使う相対パスはそのまま解決する。

## 検証

- `python3 -m http.server --directory examples --bind 127.0.0.1` を起動し、
  `.env` / `.git/config` へのリクエストが 404（ドキュメントルート外）になる
  一方、`.fonts/NotoSans-Regular.ttf` / `image/icon.png` / `wasm-demo/README.md`
  は 200 で取得できることを確認。
- `npx markdownlint-cli2 examples/wasm-demo/README.md` — 0 issues。

Codex Security finding (`fd2d15a1d964819186f4b27b20f9dc7d`, medium) への対応。
demo ドキュメントの誤設定によるローカル情報漏えいであり、fulgur ライブラリ
自体の untrusted HTML 処理経路には影響しないため GHSA advisory は起票せず、
公開 PR による hardening 修正とする。

## Test plan

- [x] `python3 -m http.server --directory examples --bind 127.0.0.1` で
      repo-root ファイル（`.env`/`.git/config`）が到達不能、demo アセットは
      到達可能なことを確認
- [x] `npx markdownlint-cli2 examples/wasm-demo/README.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * 開発サーバーの起動手順を更新しました。
  * アクセスURLを `/wasm-demo/` に変更しました。
  * ローカルホストのみで公開する設定と、安全なドキュメントルートに関する注意事項を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->