### PR TITLE
test(convert/mod): add coverage for debug_print_tree

### DIFF
--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -1718,6 +1718,92 @@ mod semantics_tests {
 }
 
 #[cfg(test)]
+mod debug_print_tree_tests {
+    //! Tests that drive the FULGUR_DEBUG-gated `debug_print_tree` path.
+    //! The function only writes to stderr and is only triggered when the env
+    //! var is set, so normal test runs skip it entirely.  The mutex below
+    //! serialises `set_var` / `remove_var` to avoid data-races in the
+    //! parallel test harness (Rust 1.84+ requires `unsafe` for `set_var`).
+
+    use crate::units::F32Units;
+    use std::ops::DerefMut;
+
+    static DEBUG_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn build_drawables(html: &str) -> crate::drawables::Drawables {
+        let mut doc = crate::blitz_adapter::parse_and_layout(
+            html,
+            595.0_f32.as_px(),
+            842.0_f32.as_px(),
+            &[],
+            true,
+        );
+        let column_styles = crate::blitz_adapter::extract_column_style_table(&doc);
+        let multicol_geometry = crate::multicol_layout::run_pass(doc.deref_mut(), &column_styles);
+        let pagination_geometry = crate::pagination_layout::run_pass(doc.deref_mut(), 842.0);
+        let running_store = crate::gcpm::running::RunningElementStore::new();
+        let mut ctx = super::ConvertContext {
+            running_store: &running_store,
+            assets: None,
+            font_cache: Default::default(),
+            string_set_by_node: Default::default(),
+            counter_ops_by_node: Default::default(),
+            bookmark_by_node: Default::default(),
+            column_styles,
+            multicol_geometry,
+            pagination_geometry,
+            link_cache: Default::default(),
+            viewport_size_px: Some((595.0, 842.0)),
+        };
+        super::dom_to_drawables(&doc, &mut ctx)
+    }
+
+    #[test]
+    fn fulgur_debug_env_var_triggers_debug_print_tree_without_panic() {
+        // Sets FULGUR_DEBUG so that dom_to_drawables calls debug_print_tree.
+        // Verifies the function runs without panic for a normal DOM tree,
+        // covering the main body of debug_print_tree (lines 282-309).
+        let _g = DEBUG_ENV_LOCK.lock().unwrap();
+        // SAFETY: serialised by DEBUG_ENV_LOCK; removed before the guard drops.
+        unsafe { std::env::set_var("FULGUR_DEBUG", "1") };
+        let _d = build_drawables(
+            "<!DOCTYPE html><html><body><p>text</p><!-- comment --><div><span>nested</span></div></body></html>",
+        );
+        // SAFETY: serialised by DEBUG_ENV_LOCK.
+        unsafe { std::env::remove_var("FULGUR_DEBUG") };
+        // Reaching here without panic confirms debug_print_tree ran (lines 277-310).
+    }
+
+    #[test]
+    fn fulgur_debug_with_deeply_nested_html_hits_max_depth_guard() {
+        // Builds a 560-level-deep DOM so that debug_print_tree hits the
+        // `depth >= MAX_DOM_DEPTH` guard (line 278-280).  Runs on a
+        // thread with an enlarged stack because 560 recursive calls would
+        // otherwise overflow the default 8 MiB stack.
+        let _g = DEBUG_ENV_LOCK.lock().unwrap();
+        let mut html = String::from("<!DOCTYPE html><html><body>");
+        for _ in 0..560 {
+            html.push_str("<div>");
+        }
+        html.push_str("deep");
+        for _ in 0..560 {
+            html.push_str("</div>");
+        }
+        html.push_str("</body></html>");
+        // SAFETY: serialised by DEBUG_ENV_LOCK; removed before the guard drops.
+        unsafe { std::env::set_var("FULGUR_DEBUG", "1") };
+        std::thread::Builder::new()
+            .stack_size(64 * 1024 * 1024)
+            .spawn(move || build_drawables(&html))
+            .expect("thread spawn")
+            .join()
+            .expect("thread did not panic");
+        // SAFETY: serialised by DEBUG_ENV_LOCK.
+        unsafe { std::env::remove_var("FULGUR_DEBUG") };
+    }
+}
+
+#[cfg(test)]
 mod utility_fn_tests {
     //! Unit tests for pure utility functions in this module.
     //! These exercise branches that the integration tests (semantics_tests,

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -1719,87 +1719,43 @@ mod semantics_tests {
 
 #[cfg(test)]
 mod debug_print_tree_tests {
-    //! Tests that drive the FULGUR_DEBUG-gated `debug_print_tree` path.
-    //! The function only writes to stderr and is only triggered when the env
-    //! var is set, so normal test runs skip it entirely.  The mutex below
-    //! serialises `set_var` / `remove_var` to avoid data-races in the
-    //! parallel test harness (Rust 1.84+ requires `unsafe` for `set_var`).
+    //! Tests that directly exercise `debug_print_tree`.
+    //! Calling the function directly with a parsed `BaseDocument` avoids
+    //! process-global env-var mutation and is safe under the parallel test
+    //! harness (no `set_var` / `remove_var`, no mutex needed).
 
     use crate::units::F32Units;
-    use std::ops::DerefMut;
+    use std::ops::Deref;
 
-    static DEBUG_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    fn build_drawables(html: &str) -> crate::drawables::Drawables {
-        let mut doc = crate::blitz_adapter::parse_and_layout(
+    fn parsed_doc(html: &str) -> blitz_html::HtmlDocument {
+        crate::blitz_adapter::parse_and_layout(
             html,
             595.0_f32.as_px(),
             842.0_f32.as_px(),
             &[],
             true,
-        );
-        let column_styles = crate::blitz_adapter::extract_column_style_table(&doc);
-        let multicol_geometry = crate::multicol_layout::run_pass(doc.deref_mut(), &column_styles);
-        let pagination_geometry = crate::pagination_layout::run_pass(doc.deref_mut(), 842.0);
-        let running_store = crate::gcpm::running::RunningElementStore::new();
-        let mut ctx = super::ConvertContext {
-            running_store: &running_store,
-            assets: None,
-            font_cache: Default::default(),
-            string_set_by_node: Default::default(),
-            counter_ops_by_node: Default::default(),
-            bookmark_by_node: Default::default(),
-            column_styles,
-            multicol_geometry,
-            pagination_geometry,
-            link_cache: Default::default(),
-            viewport_size_px: Some((595.0, 842.0)),
-        };
-        super::dom_to_drawables(&doc, &mut ctx)
+        )
     }
 
     #[test]
-    fn fulgur_debug_env_var_triggers_debug_print_tree_without_panic() {
-        // Sets FULGUR_DEBUG so that dom_to_drawables calls debug_print_tree.
-        // Verifies the function runs without panic for a normal DOM tree,
-        // covering the main body of debug_print_tree (lines 282-309).
-        let _g = DEBUG_ENV_LOCK.lock().unwrap();
-        // SAFETY: serialised by DEBUG_ENV_LOCK; removed before the guard drops.
-        unsafe { std::env::set_var("FULGUR_DEBUG", "1") };
-        let _d = build_drawables(
+    fn debug_print_tree_traverses_dom_without_panic() {
+        // Covers the main body of debug_print_tree: all NodeData arms
+        // (Element, Text, Comment) and the child-recursion loop.
+        let doc = parsed_doc(
             "<!DOCTYPE html><html><body><p>text</p><!-- comment --><div><span>nested</span></div></body></html>",
         );
-        // SAFETY: serialised by DEBUG_ENV_LOCK.
-        unsafe { std::env::remove_var("FULGUR_DEBUG") };
-        // Reaching here without panic confirms debug_print_tree ran (lines 277-310).
+        let root_id = doc.root_element().id;
+        super::debug_print_tree(doc.deref(), root_id, 0);
     }
 
     #[test]
-    fn fulgur_debug_with_deeply_nested_html_hits_max_depth_guard() {
-        // Builds a 560-level-deep DOM so that debug_print_tree hits the
-        // `depth >= MAX_DOM_DEPTH` guard (line 278-280).  Runs on a
-        // thread with an enlarged stack because 560 recursive calls would
-        // otherwise overflow the default 8 MiB stack.
-        let _g = DEBUG_ENV_LOCK.lock().unwrap();
-        let mut html = String::from("<!DOCTYPE html><html><body>");
-        for _ in 0..560 {
-            html.push_str("<div>");
-        }
-        html.push_str("deep");
-        for _ in 0..560 {
-            html.push_str("</div>");
-        }
-        html.push_str("</body></html>");
-        // SAFETY: serialised by DEBUG_ENV_LOCK; removed before the guard drops.
-        unsafe { std::env::set_var("FULGUR_DEBUG", "1") };
-        std::thread::Builder::new()
-            .stack_size(64 * 1024 * 1024)
-            .spawn(move || build_drawables(&html))
-            .expect("thread spawn")
-            .join()
-            .expect("thread did not panic");
-        // SAFETY: serialised by DEBUG_ENV_LOCK.
-        unsafe { std::env::remove_var("FULGUR_DEBUG") };
+    fn debug_print_tree_max_depth_guard_returns_early() {
+        // Pass depth = MAX_DOM_DEPTH directly so the first line of
+        // debug_print_tree hits the early-return guard without building a
+        // pathologically deep DOM or running a large-stack thread.
+        let doc = parsed_doc("<!DOCTYPE html><html><body><p>x</p></body></html>");
+        let root_id = doc.root_element().id;
+        super::debug_print_tree(doc.deref(), root_id, crate::MAX_DOM_DEPTH);
     }
 }
 


### PR DESCRIPTION
# Pull Request

## Summary

`convert/mod.rs` の region カバレッジを 94.65% → 97.19%（+2.54 pp）に引き上げる。

`debug_print_tree` 関数（lines 277–310）は `FULGUR_DEBUG` 環境変数がセットされているときのみ `dom_to_drawables` から呼ばれるため、通常テスト実行では完全にスキップされており、59 missed lines のうち約 35 lines を占めていた。新しい `debug_print_tree_tests` モジュールを追加してこの経路をカバーする。

初期実装では `unsafe set_var` + mutex を使用していたが、CodeRabbit・Codex のレビューを受けて `super::debug_print_tree` を直接呼び出す方式に変更した（`d57e604`）。

## Changes

- `crates/fulgur/src/convert/mod.rs`: `debug_print_tree_tests` テストモジュールを追加
  - `debug_print_tree_traverses_dom_without_panic`: `parse_and_layout` で `HtmlDocument` を構築し、`super::debug_print_tree` を直接呼び出す。Element・Text・Comment の全 `NodeData` アームと子ノード再帰をカバー
  - `debug_print_tree_max_depth_guard_returns_early`: `depth = MAX_DOM_DEPTH` を直接渡すことで早期 return ガード（lines 278–280）を叩く。560 段 DOM の組み立てや大スタックスレッドは不要
  - `set_var` / `remove_var` / `DEBUG_ENV_LOCK` は使用しない。プロセスグローバルな状態を変更しないため並列テストハーネス下でも安全

**カバレッジ変化（`cargo llvm-cov --package fulgur --lib`）:**

| 指標 | Before | After | 差分 |
|------|--------|-------|------|
| Region coverage | 94.65% (93 missed) | 97.19% (51 missed) | +2.54 pp / −42 regions |
| Line coverage | 94.70% (59 missed) | 96.74% (38 missed) | +2.04 pp / −21 lines |

## Test plan

- [x] `cargo test -p fulgur --lib`（1906 tests passed）
- [x] `cargo clippy -p fulgur -- -D warnings`（warnings なし）
- [x] `cargo fmt --check`（差分なし）
- [ ] `npx markdownlint-cli2 '**/*.md'`（ドキュメント変更なし）

## Contributor License Agreement

By opening this pull request, I confirm that:

- [x] I have read the [Contributing Guide](https://github.com/fulgur-rs/fulgur/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://github.com/fulgur-rs/fulgur/blob/main/CLA.md)
      and agree to its terms. (First-time contributors: the CLA Assistant bot
      will comment on this PR with sign-in instructions.)

## Related issues

カバレッジ改善の定期タスク（自動生成 PR）。