### PR TITLE
test(pseudo): add coverage for node_has_inline_pseudo_image and early-return paths

### DIFF
--- a/crates/fulgur/src/convert/pseudo.rs
+++ b/crates/fulgur/src/convert/pseudo.rs
@@ -858,4 +858,182 @@ mod tests {
         );
         assert!(pdf.starts_with(b"%PDF"));
     }
+
+    // build_pseudo_image_entry: `extract_content_image_url` returns None when
+    // the block pseudo's content is a string literal (no url()).
+    // Covers the line 19 `?` short-circuit in build_pseudo_image_entry.
+    #[test]
+    fn smoke_block_pseudo_text_content_skips_image_entry() {
+        let mut bundle = crate::asset::AssetBundle::default();
+        bundle.add_image("dot.png", RED_1X1_PNG.to_vec());
+        bundle.add_css(r#"div::before { content: "arrow"; display: block; }"#);
+        let pdf = render_with_assets(
+            r#"<!DOCTYPE html><html><body><div>Text</div></body></html>"#,
+            bundle,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // build_pseudo_image_entry: `ImageRender::detect_format` returns None when
+    // the registered image bytes are not a recognised format.
+    // Covers the line 22 `?` short-circuit in build_pseudo_image_entry.
+    #[test]
+    fn smoke_block_pseudo_unrecognized_format_skips_entry() {
+        let mut bundle = crate::asset::AssetBundle::default();
+        bundle.add_image("bad.bin", vec![0xDE, 0xAD, 0xBE, 0xEF]);
+        bundle.add_css(
+            r#"div::before { content: url("bad.bin"); display: block; width: 10px; height: 10px; }"#,
+        );
+        let pdf = render_with_assets(
+            r#"<!DOCTYPE html><html><body><div>Text</div></body></html>"#,
+            bundle,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // build_inline_pseudo_image: `get_image` returns None when the inline
+    // pseudo's url() is not registered in the bundle (covers line 171 `?`).
+    #[test]
+    fn smoke_inline_pseudo_image_url_not_in_bundle() {
+        let mut bundle = crate::asset::AssetBundle::default();
+        bundle.add_image("other.png", RED_1X1_PNG.to_vec());
+        bundle.add_css(r#"p::before { content: url("missing.png"); }"#);
+        let pdf = render_with_assets(
+            r#"<!DOCTYPE html><html><body><p>Paragraph</p></body></html>"#,
+            bundle,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // build_inline_pseudo_image: `detect_format` returns None for unrecognised
+    // bytes in the bundle (covers line 172 `?`).
+    #[test]
+    fn smoke_inline_pseudo_unrecognized_format_skips() {
+        let mut bundle = crate::asset::AssetBundle::default();
+        bundle.add_image("bad.bin", vec![0xDE, 0xAD, 0xBE, 0xEF]);
+        bundle.add_css(r#"p::before { content: url("bad.bin"); }"#);
+        let pdf = render_with_assets(
+            r#"<!DOCTYPE html><html><body><p>Paragraph</p></body></html>"#,
+            bundle,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // ── node_has_inline_pseudo_image direct unit tests ───────────────────────
+    // The function is #[allow(dead_code)] because v2 inline-root no longer
+    // calls it, but it mirrors node_has_block_pseudo_image and its semantics
+    // warrant direct coverage.
+
+    fn parse_doc_for_inline_pseudo_tests(html: &str) -> blitz_html::HtmlDocument {
+        crate::blitz_adapter::parse_and_layout(
+            html,
+            595.0_f32.as_px(),
+            842.0_f32.as_px(),
+            &[],
+            false,
+        )
+    }
+
+    fn find_elem_by_tag_in_pseudo_tests<'a>(
+        base: &'a crate::blitz_adapter::BaseDocument,
+        start_id: usize,
+        tag: &str,
+    ) -> Option<&'a crate::blitz_adapter::Node> {
+        let node = base.get_node(start_id)?;
+        if node
+            .element_data()
+            .is_some_and(|e| e.name.local.as_ref() == tag)
+        {
+            return Some(node);
+        }
+        for &child in &node.children {
+            if let Some(found) = find_elem_by_tag_in_pseudo_tests(base, child, tag) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn node_has_inline_pseudo_image_true_for_before_with_url() {
+        use std::ops::Deref;
+        let doc = parse_doc_for_inline_pseudo_tests(
+            r#"<!DOCTYPE html><html><head><style>
+            div::before { content: url("dot.png"); }
+            </style></head><body><div>Text</div></body></html>"#,
+        );
+        let base = doc.deref();
+        let div_node = find_elem_by_tag_in_pseudo_tests(base, doc.root_element().id, "div")
+            .expect("div element must be present");
+        assert!(
+            super::node_has_inline_pseudo_image(base, div_node),
+            "inline ::before with url() must return true"
+        );
+    }
+
+    #[test]
+    fn node_has_inline_pseudo_image_true_for_after_with_url() {
+        use std::ops::Deref;
+        let doc = parse_doc_for_inline_pseudo_tests(
+            r#"<!DOCTYPE html><html><head><style>
+            div::after { content: url("dot.png"); }
+            </style></head><body><div>Text</div></body></html>"#,
+        );
+        let base = doc.deref();
+        let div_node = find_elem_by_tag_in_pseudo_tests(base, doc.root_element().id, "div")
+            .expect("div element must be present");
+        assert!(
+            super::node_has_inline_pseudo_image(base, div_node),
+            "inline ::after with url() must return true"
+        );
+    }
+
+    #[test]
+    fn node_has_inline_pseudo_image_false_when_before_is_block() {
+        use std::ops::Deref;
+        let doc = parse_doc_for_inline_pseudo_tests(
+            r#"<!DOCTYPE html><html><head><style>
+            div::before { content: url("dot.png"); display: block; }
+            </style></head><body><div>Text</div></body></html>"#,
+        );
+        let base = doc.deref();
+        let div_node = find_elem_by_tag_in_pseudo_tests(base, doc.root_element().id, "div")
+            .expect("div element must be present");
+        assert!(
+            !super::node_has_inline_pseudo_image(base, div_node),
+            "block ::before must not be reported as inline pseudo image"
+        );
+    }
+
+    #[test]
+    fn node_has_inline_pseudo_image_false_when_no_pseudo() {
+        use std::ops::Deref;
+        let doc = parse_doc_for_inline_pseudo_tests(
+            r#"<!DOCTYPE html><html><body><div>No pseudo here</div></body></html>"#,
+        );
+        let base = doc.deref();
+        let div_node = find_elem_by_tag_in_pseudo_tests(base, doc.root_element().id, "div")
+            .expect("div element must be present");
+        assert!(
+            !super::node_has_inline_pseudo_image(base, div_node),
+            "element with no pseudo must return false"
+        );
+    }
+
+    #[test]
+    fn node_has_inline_pseudo_image_false_when_before_has_text_content() {
+        use std::ops::Deref;
+        let doc = parse_doc_for_inline_pseudo_tests(
+            r#"<!DOCTYPE html><html><head><style>
+            div::before { content: "arrow"; }
+            </style></head><body><div>Text</div></body></html>"#,
+        );
+        let base = doc.deref();
+        let div_node = find_elem_by_tag_in_pseudo_tests(base, doc.root_element().id, "div")
+            .expect("div element must be present");
+        assert!(
+            !super::node_has_inline_pseudo_image(base, div_node),
+            "::before with text content must return false (no url())"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`convert/pseudo.rs` はカバレッジ計測で最も低い 3 モジュールのうちの 1 つ（region カバレッジ 94.83%、3 位）だった。  
このPRはユニットテスト 9 件を追加し、coverage を 94.83% → 97.50%（region）、95.73% → 97.71%（line）、96.59% → 100.00%（function）に引き上げる。

**対象モジュール**: `crates/fulgur/src/convert/pseudo.rs`

**カバレッジ変化**:

| 指標 | Before | After | Δ |
|------|--------|-------|---|
| Regions | 94.83% (42 missed) | 97.50% (25 missed) | +2.67% |
| Lines | 95.73% (25 missed) | 97.71% (16 missed) | +1.98% |
| Functions | 96.59% (1 missed) | 100.00% (0 missed) | +3.41% |

## Changes

- `node_has_inline_pseudo_image` の直接ユニットテスト 5 件を追加（`parse_and_layout` で Blitz DOM を構築して呼び出す）：
  - `::before` に `content: url(...)` がある場合 → `true`
  - `::after` に `content: url(...)` がある場合 → `true`
  - `::before` が `display: block` の場合 → `false`
  - 疑似要素なしの場合 → `false`
  - `::before` がテキスト content の場合 → `false`（URL なし）
- スモークテスト 4 件を追加（`build_pseudo_image_entry` / `build_inline_pseudo_image` の `?` short-circuit パス）：
  - ブロック疑似要素の content がテキスト文字列でイメージ URL なし（line 19 `?`）
  - ブロック疑似要素のイメージデータが未知フォーマット（line 22 `?`）
  - インライン疑似要素の URL がバンドルに未登録（line 171 `?`）
  - インライン疑似要素のイメージデータが未知フォーマット（line 172 `?`）

**意図的に残したカバレッジ外ブランチ**（残り 7 non-test 未カバー領域）：
- `pseudo_node.primary_styles()?` の None パス（line 24, 174）: Blitz が正常にレイアウト済みの疑似要素に styles を付けない状況は構成困難
- `doc.get_node(id)?` の None パス（line 146）: 有効な pseudo_id が DOM に存在しない内部不整合状態

## Test plan

- [x] `cargo test -p fulgur --lib`（1966 tests, 0 failed）
- [x] `cargo clippy -- -D warnings`（警告なし）
- [x] `cargo fmt --check`（差分なし）
- [ ] `npx markdownlint-cli2 '**/*.md'`（ドキュメント変更なし）

## Contributor License Agreement

By opening this pull request, I confirm that:

- [x] I have read the [Contributing Guide](https://github.com/fulgur-rs/fulgur/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://github.com/fulgur-rs/fulgur/blob/main/CLA.md)
      and agree to its terms. (First-time contributors: the CLA Assistant bot
      will comment on this PR with sign-in instructions.)

## Related issues

自動スケジュールによるカバレッジ改善ルーティンの一環。

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqERdUsBhuqtkSsSYWkYQN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 疑似要素の画像処理について、未登録アセット、不正な画像形式、URL以外のコンテンツを安全にスキップできることを確認するテストを追加しました。
  * `::before`／`::after` のURL画像、ブロック表示、疑似要素がない場合、テキストコンテンツなど、さまざまな表示条件を検証するテストを拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->