### PR TITLE
test(convert): cover uncovered inline_root branches (94.76% → 97.70%)

### DIFF
--- a/crates/fulgur/src/convert/inline_root.rs
+++ b/crates/fulgur/src/convert/inline_root.rs
@@ -1611,4 +1611,100 @@ mod tests {
             .expect("render failed");
         assert!(pdf.starts_with(b"%PDF"));
     }
+
+    // try_convert: pseudo-only (before_inline=Some, paragraph_opt=None) where
+    // needs_block_pre=true via background (has_visual_style), but clipping_pre=false
+    // and opacity_scope_pre=false (opacity=1.0). Exercises the `if needs_block {}`
+    // block insertion at lines 191-203 WITHOUT a pre_mark.
+    #[test]
+    fn smoke_pseudo_only_with_background_covers_needs_block_no_pre_mark() {
+        let pdf = make_engine_with_dot_png()
+            .render(
+                r#"<!doctype html><html><head>
+                <style>
+                  p.marker::before { content: url("dot.png"); width: 10px; height: 10px; }
+                </style>
+                </head><body>
+                <p class="marker" style="background: #eee; padding: 4px;"></p>
+                </body></html>"#,
+            )
+            .expect("render failed");
+        assert!(pdf.starts_with(b"%PDF"));
+        assert!(
+            pdf_has_image(&pdf),
+            "image XObject missing — pseudo-only needs_block (no pre_mark) path may have been skipped"
+        );
+    }
+
+    // try_convert: pseudo-only where needs_block_pre=true and clipping_pre=true
+    // (overflow:hidden). Exercises the pre_mark + clip_descendants path at
+    // lines 204-215 inside the needs_block block.
+    #[test]
+    fn smoke_pseudo_only_with_overflow_hidden_covers_clip_descendants() {
+        let pdf = make_engine_with_dot_png()
+            .render(
+                r#"<!doctype html><html><head>
+                <style>
+                  p.marker::before { content: url("dot.png"); width: 10px; height: 10px; }
+                </style>
+                </head><body>
+                <p class="marker" style="overflow: hidden; height: 20px;"></p>
+                </body></html>"#,
+            )
+            .expect("render failed");
+        assert!(pdf.starts_with(b"%PDF"));
+        assert!(
+            pdf_has_image(&pdf),
+            "image XObject missing — pseudo-only clip_descendants path may have been skipped"
+        );
+    }
+
+    // try_convert: pseudo-only where needs_block_pre=true via background and
+    // opacity_scope_pre=true (opacity<1.0, no overflow:hidden). Exercises the
+    // pre_mark + opacity_descendants path at lines 204-215 inside needs_block.
+    #[test]
+    fn smoke_pseudo_only_with_opacity_covers_opacity_descendants() {
+        let pdf = make_engine_with_dot_png()
+            .render(
+                r#"<!doctype html><html><head>
+                <style>
+                  p.marker::before { content: url("dot.png"); width: 10px; height: 10px; }
+                </style>
+                </head><body>
+                <p class="marker" style="background: #eee; opacity: 0.5;"></p>
+                </body></html>"#,
+            )
+            .expect("render failed");
+        assert!(pdf.starts_with(b"%PDF"));
+        assert!(
+            pdf_has_image(&pdf),
+            "image XObject missing — pseudo-only opacity_descendants path may have been skipped"
+        );
+    }
+
+    // pageable_last_baseline_from_drawables: exercises line 393 (closing `}` of
+    // the `if let Some(inner) = …` arm when the recursive call returns None).
+    // DOM order inside <section>: [div(text), aside(empty)]. Reversed: [aside, div].
+    // The aside yields None from the recursive call (no paragraph, no children),
+    // so the if-let condition is false and its closing `}` is reached. The div
+    // then yields Some and the function returns.
+    #[test]
+    fn pageable_last_baseline_walk_past_empty_sibling_to_find_baseline() {
+        let doc = parse_doc(
+            "<html><body><section><div>text</div><aside></aside></section></body></html>",
+        );
+        let section_id = find_tag(&doc, "section");
+        let div_id = find_tag(&doc, "div");
+        let mut out = crate::drawables::Drawables::new();
+        out.paragraphs.insert(div_id, make_paragraph_entry(&[12.0]));
+        let result = super::pageable_last_baseline_from_drawables(doc.deref(), &out, section_id, 0);
+        assert!(
+            result.is_some(),
+            "must find div paragraph baseline via DOM walk past empty aside sibling"
+        );
+        assert!(
+            result.unwrap().to_f32() >= 12.0,
+            "baseline must be at least the child paragraph's baseline"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`convert/inline_root.rs` had four uncovered production code paths. This PR adds four unit tests that directly exercise those paths, improving line coverage from **94.76% → 97.70%** (53 missed → 24 missed, +29 lines covered). No production code was changed.

## Changes

- `smoke_pseudo_only_with_background_covers_needs_block_no_pre_mark`: pseudo-only element with background/padding (`needs_block_pre=true`, `clipping_pre=false`, `opacity=1.0`) — exercises the `if needs_block {}` block at lines 191-203 without a `pre_mark`.
- `smoke_pseudo_only_with_overflow_hidden_covers_clip_descendants`: pseudo-only element with `overflow:hidden` (`clipping_pre=true`) — exercises the `pre_mark` + `clip_descendants` path at lines 204-215.
- `smoke_pseudo_only_with_opacity_covers_opacity_descendants`: pseudo-only element with background + `opacity:0.5` (`opacity_scope_pre=true`) — exercises the `pre_mark` + `opacity_descendants` path at lines 204-215.
- `pageable_last_baseline_walk_past_empty_sibling_to_find_baseline`: `<section>` with DOM children `[div(text), aside(empty)]`; reversed iteration visits the empty aside first (returns `None`), exercising the closing `}` at line 393, then finds the div's baseline.

## Test plan

- [x] `cargo test -p fulgur --lib` — 1982 passed, 0 failed
- [x] `cargo clippy -p fulgur -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] `npx markdownlint-cli2 '**/*.md'` (no docs changed)

## Contributor License Agreement

By opening this pull request, I confirm that:

- [x] I have read the [Contributing Guide](https://github.com/fulgur-rs/fulgur/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://github.com/fulgur-rs/fulgur/blob/main/CLA.md)
      and agree to its terms. (First-time contributors: the CLA Assistant bot
      will comment on this PR with sign-in instructions.)

## Related issues

<!-- e.g. "Closes #123" or "Part of #456" -->

---
_Generated by [Claude Code](https://claude.ai/code/session_015hscJ6GoAxtTWuJ3UZdifN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 疑似要素のインライン表示における背景、`overflow: hidden`、透明度変更の処理を検証するテストを追加しました。
  * 空の兄弟要素がある場合でも、次の段落のベースラインを正しく取得できることを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->