### PR TITLE
test(pagination_layout): add coverage for break-inside/break-after and zero page height guard

### DIFF
--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -6961,4 +6961,116 @@ h2 { string-set: chapter-title content(text); }
              implied_page_count must be 2 (pages 0 and 1); geom={geom:?}"
         );
     }
+
+    // ── break-inside: avoid (lines 718-720, 732-733) ─────────────────────────
+
+    /// A body-direct element with `break-inside: avoid` must set `avoid_inside`
+    /// and take the `Vec::new()` branch (lines 718-733), suppressing the inline
+    /// split path so the element is treated as an atomic block.
+    #[test]
+    fn break_inside_avoid_suppresses_inline_split() {
+        let html = r#"
+            <html><body style="margin: 0; padding: 0">
+              <p style="break-inside: avoid">first paragraph</p>
+              <p style="break-inside: avoid">second paragraph</p>
+            </body></html>
+        "#;
+        let mut doc = parse(html, 600.0);
+        let table = blitz_adapter::extract_column_style_table(&doc);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 800.0_f32.as_px(), &table);
+        assert_eq!(
+            super::implied_page_count(&geom),
+            1,
+            "two short avoid-inside paragraphs on an 800px page must land on page 0; \
+             geom={geom:?}"
+        );
+    }
+
+    // ── break-after: page after recursive split (lines 876-882) ──────────────
+
+    /// A body-direct element with `break-after: page` that triggers the
+    /// recursion path (children overflow the page) must advance the page cursor
+    /// *after* the subtree is processed, so the following sibling lands two
+    /// pages after where the recursion started (lines 876-882).
+    #[test]
+    fn break_after_page_advances_after_recursive_split() {
+        // 600px page; outer div (break-after: page) has two 400px children —
+        // total 800px overflows the page, so `needs_recursion = true`.
+        // fragment_block_subtree leaves page=1, cursor=400.
+        // break-after fires: page=2, cursor=0.
+        // Trailing 100px sibling must land on page 2.
+        let html = r#"
+            <html><body style="margin: 0; padding: 0">
+              <div style="break-after: page">
+                <div style="height: 400px"></div>
+                <div style="height: 400px"></div>
+              </div>
+              <div id="after" style="height: 100px"></div>
+            </body></html>
+        "#;
+        let mut doc = parse(html, 600.0);
+        let after_id = find_by_id(doc.deref_mut(), "after").expect("div#after");
+        let table = blitz_adapter::extract_column_style_table(&doc);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 600.0_f32.as_px(), &table);
+        let after_geom = geom.get(&after_id).expect("div#after must be in geometry");
+        assert_eq!(after_geom.fragments.len(), 1);
+        assert_eq!(
+            after_geom.fragments[0].page_index, 2,
+            "break-after: page after recursive split must push sibling to page 2; \
+             geom={geom:?}"
+        );
+    }
+
+    // ── break-after: page after oversized slice (lines 1059-1065) ────────────
+
+    /// A body-direct element taller than the page (slice path) with
+    /// `break-after: page` must advance the page cursor after the last slice
+    /// so the following sibling lands on a fresh page (lines 1059-1065).
+    #[test]
+    fn break_after_page_advances_after_oversized_slice() {
+        // 800px page; childless 900px div is sliced: first slice on page 0
+        // (800px), second slice on page 1 (100px), cursor=100.
+        // break-after fires: page=2, cursor=0.
+        // Trailing 100px sibling must land on page 2.
+        let html = r#"
+            <html><body style="margin: 0; padding: 0">
+              <div style="break-after: page; height: 900px"></div>
+              <div id="after" style="height: 100px"></div>
+            </body></html>
+        "#;
+        let mut doc = parse(html, 600.0);
+        let after_id = find_by_id(doc.deref_mut(), "after").expect("div#after");
+        let table = blitz_adapter::extract_column_style_table(&doc);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 800.0_f32.as_px(), &table);
+        let after_geom = geom.get(&after_id).expect("div#after must be in geometry");
+        assert_eq!(after_geom.fragments.len(), 1);
+        assert_eq!(
+            after_geom.fragments[0].page_index, 2,
+            "break-after: page after slice must push sibling to page 2; geom={geom:?}"
+        );
+    }
+
+    // ── zero page height guard (line 412) ─────────────────────────────────────
+
+    /// `fragment_pagination_root` must return 0 immediately and leave the
+    /// geometry table empty when `page_height_px` is zero (line 412 guard).
+    /// `run_pass_with_break_styles` short-circuits before calling
+    /// `fragment_pagination_root`, so this test exercises the guard directly.
+    #[test]
+    fn zero_page_height_guard_returns_empty() {
+        let mut doc = parse(
+            "<html><body><div style=\"height: 100px\"></div></body></html>",
+            600.0,
+        );
+        let mut tree = PaginationLayoutTree::new(doc.deref_mut(), 0.0);
+        let emitted = tree.fragment_pagination_root();
+        assert_eq!(
+            emitted, 0,
+            "zero page height must trigger the early-return guard"
+        );
+        assert!(
+            tree.take_geometry().is_empty(),
+            "zero page height must leave geometry table empty"
+        );
+    }
 }

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -6996,22 +6996,39 @@ h2 { string-set: chapter-title content(text); }
     fn break_after_page_advances_after_recursive_split() {
         // 600px page; outer div (break-after: page) has two 400px children —
         // total 800px overflows the page, so `needs_recursion = true`.
-        // fragment_block_subtree leaves page=1, cursor=400.
+        // fragment_block_subtree places inner1 on page 0, inner2 on page 1,
+        // leaving page=1, cursor=400.
         // break-after fires: page=2, cursor=0.
         // Trailing 100px sibling must land on page 2.
+        //
+        // Discriminant vs the oversized-slice path (which would also produce
+        // page=2 for #after): in the recursion path `fragment_block_subtree`
+        // records inner2 on page 1; in the slice path `record_subtree_descendants`
+        // records both inner children on page 0 (the first slice's page).
         let html = r#"
             <html><body style="margin: 0; padding: 0">
               <div style="break-after: page">
-                <div style="height: 400px"></div>
-                <div style="height: 400px"></div>
+                <div id="inner1" style="height: 400px"></div>
+                <div id="inner2" style="height: 400px"></div>
               </div>
               <div id="after" style="height: 100px"></div>
             </body></html>
         "#;
         let mut doc = parse(html, 600.0);
+        let inner2_id = find_by_id(doc.deref_mut(), "inner2").expect("div#inner2");
         let after_id = find_by_id(doc.deref_mut(), "after").expect("div#after");
         let table = blitz_adapter::extract_column_style_table(&doc);
         let geom = super::run_pass_with_break_styles(doc.deref_mut(), 600.0_f32.as_px(), &table);
+        // Recursion-specific check: fragment_block_subtree records inner2 on
+        // page 1. The slice path would record it on page 0 instead.
+        let inner2_geom = geom
+            .get(&inner2_id)
+            .expect("div#inner2 must be in geometry");
+        assert_eq!(
+            inner2_geom.fragments[0].page_index, 1,
+            "recursion path must place inner2 on page 1; slice path would give page 0; \
+             geom={geom:?}"
+        );
         let after_geom = geom.get(&after_id).expect("div#after must be in geometry");
         assert_eq!(after_geom.fragments.len(), 1);
         assert_eq!(


### PR DESCRIPTION
## 概要

`pagination_layout.rs` の `fragment_pagination_root` 内で未カバーだった4つの分岐にユニットテストを追加します。プロダクションコードの変更はありません。

## 追加したテスト

| テスト名 | カバー対象 |
|---|---|
| `break_inside_avoid_suppresses_inline_split` | 行 718-733: `break-inside: avoid` が `avoid_inside = true` をセットし、`Vec::new()` ブランチ（インラインスプリット抑制）を通ること |
| `break_after_page_advances_after_recursive_split` | 行 876-882: `needs_recursion = true` のサブツリー処理後に `break-after: page` がカーソルを次ページへ進めること |
| `break_after_page_advances_after_oversized_slice` | 行 1059-1065: `child_h > page_height_px + 1.0` のスライスパス後に `break-after: page` がカーソルを次ページへ進めること |
| `zero_page_height_guard_returns_empty` | 行 412: `page_height_px <= 0.0` の早期リターンガード（`run_pass_with_break_styles` は事前にショートサーキットするため `fragment_pagination_root` を直接呼び出してカバー） |

## カバレッジの変化

`pagination_layout.rs`: ライン 95.47% / ブランチ 95.77%

## チェックリスト

- [x] `cargo test -p fulgur --lib` — 1986 件全通過
- [x] `cargo clippy -p fulgur -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — 差分なし
- [x] `cargo llvm-cov --package fulgur --lib --summary-only` — カバレッジ向上確認

---
_Generated by [Claude Code](https://claude.ai/code/session_012APrJWzCBTKZ5zReiRSQDq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * ページ分割時に要素が途中で分割されない動作を検証しました。
  * ページ区切り指定により、後続コンテンツが適切なページへ移動することを確認しました。
  * 大きな要素の分割後もページ構成が正しく維持されることを検証しました。
  * ページの高さがゼロの場合に、不正なレイアウトが生成されないことを確認しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->