### PR TITLE
test(engine): engine.rs の未カバー公開APIにユニットテストを追加

### DIFF
--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -1957,20 +1957,6 @@ mod tests {
         assert!(pdf.starts_with(b"%PDF"));
     }
 
-    // ── render_file: ディスクへのPDF書き出し (engine.rs:736-737) ──────────────
-
-    #[test]
-    fn render_file_writes_valid_pdf_to_disk() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("out.pdf");
-        Engine::builder()
-            .build()
-            .render_file("<p>hello</p>", &path)
-            .expect("render_file should succeed");
-        let bytes = std::fs::read(&path).expect("output file should exist");
-        assert!(bytes.starts_with(b"%PDF"), "output should be a PDF");
-    }
-
     // ── layout: PDF化なしの公開レイアウトAPI (engine.rs:757-781) ──────────────
 
     #[test]
@@ -2000,31 +1986,6 @@ mod tests {
             .layout(html)
             .expect("two-pass layout should succeed");
         assert!(!output.geometry.is_empty(), "layout must produce geometry");
-    }
-
-    // ── 非推奨エイリアス (engine.rs:829-837) ─────────────────────────────────
-
-    #[test]
-    #[allow(deprecated)]
-    fn render_html_deprecated_alias_produces_valid_pdf() {
-        let pdf = Engine::builder()
-            .build()
-            .render_html("<p>legacy</p>")
-            .expect("render_html should succeed");
-        assert!(pdf.starts_with(b"%PDF"));
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    fn render_html_to_file_deprecated_alias_writes_pdf() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("legacy.pdf");
-        Engine::builder()
-            .build()
-            .render_html_to_file("<p>legacy</p>", &path)
-            .expect("render_html_to_file should succeed");
-        let bytes = std::fs::read(&path).expect("file should exist");
-        assert!(bytes.starts_with(b"%PDF"));
     }
 
     // ── render Errパス: 不正なページサイズ (engine.rs:133, 172) ──────────────

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -1956,4 +1956,178 @@ mod tests {
             .unwrap();
         assert!(pdf.starts_with(b"%PDF"));
     }
+
+    // ── render_file: ディスクへのPDF書き出し (engine.rs:736-737) ──────────────
+
+    #[test]
+    fn render_file_writes_valid_pdf_to_disk() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("out.pdf");
+        Engine::builder()
+            .build()
+            .render_file("<p>hello</p>", &path)
+            .expect("render_file should succeed");
+        let bytes = std::fs::read(&path).expect("output file should exist");
+        assert!(bytes.starts_with(b"%PDF"), "output should be a PDF");
+    }
+
+    // ── layout: PDF化なしの公開レイアウトAPI (engine.rs:757-781) ──────────────
+
+    #[test]
+    fn layout_returns_non_empty_output() {
+        let output = Engine::builder()
+            .build()
+            .layout("<p>hello world</p>")
+            .expect("layout should succeed");
+        assert!(
+            !output.drawables.is_empty() || !output.geometry.is_empty(),
+            "layout should produce drawables or geometry for a non-empty document"
+        );
+    }
+
+    #[test]
+    fn layout_two_pass_with_target_text() {
+        // target-text() triggers needs_pass_two, exercising the two-pass branch
+        // inside layout() (engine.rs:762-773).
+        let html = r##"<!doctype html><html><head><style>
+          .ref::after { content: target-text(attr(href), before); }
+        </style></head><body>
+          <p><a class="ref" href="#sec"></a></p>
+          <h2 id="sec">Section</h2>
+        </body></html>"##;
+        let output = Engine::builder()
+            .build()
+            .layout(html)
+            .expect("two-pass layout should succeed");
+        assert!(!output.geometry.is_empty(), "layout must produce geometry");
+    }
+
+    // ── 非推奨エイリアス (engine.rs:829-837) ─────────────────────────────────
+
+    #[test]
+    #[allow(deprecated)]
+    fn render_html_deprecated_alias_produces_valid_pdf() {
+        let pdf = Engine::builder()
+            .build()
+            .render_html("<p>legacy</p>")
+            .expect("render_html should succeed");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn render_html_to_file_deprecated_alias_writes_pdf() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("legacy.pdf");
+        Engine::builder()
+            .build()
+            .render_html_to_file("<p>legacy</p>", &path)
+            .expect("render_html_to_file should succeed");
+        let bytes = std::fs::read(&path).expect("file should exist");
+        assert!(bytes.starts_with(b"%PDF"));
+    }
+
+    // ── render Errパス: 不正なページサイズ (engine.rs:133, 172) ──────────────
+
+    #[test]
+    fn render_returns_err_on_zero_page_width() {
+        let result = Engine::builder()
+            .page_size(PageSize {
+                width: 0.0,
+                height: 841.89,
+            })
+            .build()
+            .render("<p>test</p>");
+        assert!(result.is_err(), "zero-width page must produce an error");
+    }
+
+    #[test]
+    fn render_returns_err_on_nan_page_height() {
+        let result = Engine::builder()
+            .page_size(PageSize {
+                width: 595.28,
+                height: f32::NAN,
+            })
+            .build()
+            .render("<p>test</p>");
+        assert!(result.is_err(), "NaN page height must produce an error");
+    }
+
+    // ── Builder: base_path + assetsでset_base_urlが呼ばれる (engine.rs:1361) ─
+
+    #[test]
+    fn builder_with_assets_and_base_path_renders_successfully() {
+        let bundle = crate::AssetBundle::default();
+        let pdf = Engine::builder()
+            .assets(bundle)
+            .base_path(std::env::temp_dir())
+            .build()
+            .render("<p>hello</p>")
+            .expect("render with base_path + assets should succeed");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // ── スナップショット記録: string-set + bookmarks (engine.rs:348-349) ──────
+
+    #[test]
+    fn render_with_string_set_and_bookmarks_enabled() {
+        // bookmarks(true) + string-set CSS の組み合わせで record_string_snapshots=true
+        // になり、StringSetPassがスナップショット記録付きで実行される (engine.rs:349)。
+        let mut assets = AssetBundle::new();
+        assets.add_css(
+            "h1 { string-set: chap content(text); }\
+             @page { @top-center { content: string(chap); } }",
+        );
+        let html = "<body><h1>Chapter One</h1><p>Body text.</p></body>";
+        let pdf = Engine::builder()
+            .assets(assets)
+            .bookmarks(true)
+            .build()
+            .render(html)
+            .expect("string-set + bookmarks render should succeed");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // ── スナップショット記録: counter + bookmarks (engine.rs:376) ─────────────
+
+    #[test]
+    fn render_with_counter_css_and_bookmarks_enabled() {
+        // bookmarks(true) で record_counter_snapshots=true になり、
+        // CounterPassがスナップショット記録付きで実行される (engine.rs:376)。
+        let mut assets = AssetBundle::new();
+        assets.add_css(
+            "body { counter-reset: section; }\
+             h2::before { counter-increment: section; content: counter(section) \". \"; }",
+        );
+        let html = "<body><h2>Section A</h2><h2>Section B</h2></body>";
+        let pdf = Engine::builder()
+            .assets(assets)
+            .bookmarks(true)
+            .build()
+            .render(html)
+            .expect("counter + bookmarks render should succeed");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // ── (true, true) matchケース: bookmarks AND target-refs同時有効 (engine.rs:427) ─
+
+    #[test]
+    fn render_with_bookmarks_and_target_refs_simultaneously() {
+        // bookmarks=true かつ target-counter() で has_target_refs=true になり、
+        // match (bookmark_active, target_refs_active) の (true, true) アームを通る
+        // (engine.rs:427)。
+        let mut assets = AssetBundle::new();
+        assets.add_css("@page { @bottom-center { content: target-counter(attr(href), page); } }");
+        let html = "<body>\
+            <p><a href=\"#sec\">go to section</a></p>\
+            <h2 id=\"sec\">Section</h2>\
+            </body>";
+        let pdf = Engine::builder()
+            .assets(assets)
+            .bookmarks(true)
+            .build()
+            .render(html)
+            .expect("bookmarks + target-refs render should succeed");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
 }


### PR DESCRIPTION
# Pull Request

## Summary

`engine.rs` の未カバー公開APIおよびブランチにユニットテストを追加し、カバレッジを向上させる。

追加前の行カバレッジ: **95.99%** (1054/1098 行、44行未カバー)

## Changes

- `render_file_writes_valid_pdf_to_disk` — `render_file()` がディスクに有効なPDFを書き出すことを確認 (engine.rs:736–737)
- `layout_returns_non_empty_output` — `layout()` がDrawablesまたはGeometryを返すことを確認 (engine.rs:757–781)
- `layout_two_pass_with_target_text` — `target-text()` CSS で2パスレイアウトが動作することを確認 (engine.rs:762–773)
- `render_html_deprecated_alias_produces_valid_pdf` — 非推奨 `render_html()` エイリアスが機能することを確認 (engine.rs:829–831)
- `render_html_to_file_deprecated_alias_writes_pdf` — 非推奨 `render_html_to_file()` エイリアスが機能することを確認 (engine.rs:835–837)
- `render_returns_err_on_zero_page_width` — ゼロ幅ページで `Err` が返ることを確認 (engine.rs:133, 172)
- `render_returns_err_on_nan_page_height` — NaN高さページで `Err` が返ることを確認 (engine.rs:133, 172)
- `builder_with_assets_and_base_path_renders_successfully` — `assets` + `base_path` の組み合わせで `set_base_url` が呼ばれることを確認 (engine.rs:1361)
- `render_with_string_set_and_bookmarks_enabled` — `string-set` CSS + `bookmarks(true)` でスナップショット記録ブランチが通ることを確認 (engine.rs:348–349)
- `render_with_counter_css_and_bookmarks_enabled` — counter CSS + `bookmarks(true)` でスナップショット記録ブランチが通ることを確認 (engine.rs:376)
- `render_with_bookmarks_and_target_refs_simultaneously` — `bookmarks=true` + `target-counter()` で `(true, true)` の match アームが通ることを確認 (engine.rs:427)

## Test plan

- [x] `cargo test -p fulgur --lib` — 1997テスト全通過
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — フォーマット差分なし

## Contributor License Agreement

By opening this pull request, I confirm that:

- [x] I have read the [Contributing Guide](https://github.com/fulgur-rs/fulgur/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://github.com/fulgur-rs/fulgur/blob/main/CLA.md)
      and agree to its terms. (First-time contributors: the CLA Assistant bot
      will comment on this PR with sign-in instructions.)

## Related issues

カバレッジ定期改善ルーティン (2026-08-10)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzLeTMZtAjixtJ6MC28wYq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * ファイルのレンダリングとレイアウト処理に関する検証を拡充しました。
  * 不正なページサイズ、アセットのパス指定、ブックマーク、ターゲット指定など、さまざまな設定の組み合わせを確認できるようになりました。
  * 文字列設定やカウンター情報を含むページ処理の安定性も検証しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->