### PR TITLE
test(list_item, background): add coverage for display:list-item variants and radial-gradient stop cap

### DIFF
--- a/crates/fulgur/src/convert/list_item.rs
+++ b/crates/fulgur/src/convert/list_item.rs
@@ -1271,6 +1271,52 @@ mod tests {
         assert!(pdf.starts_with(b"%PDF"));
     }
 
+    // Smoke: a <div> with `display:list-item` AND an explicit numeric
+    // `line-height` renders without crashing.  Empirically Blitz assigns
+    // `list_item_data` with an outside marker layout for this combination, so
+    // the outside-marker path (branch 1) fires rather than the fallback
+    // (branch 2) — but the render path is still exercised end-to-end.
+    #[test]
+    fn smoke_display_list_item_div_with_numeric_line_height() {
+        let pdf = render_list_html(
+            r#"<!doctype html><html><body>
+            <div style="display:list-item;line-height:1.5">Numeric line-height</div>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // Smoke: same as above but with an absolute-length `line-height`.
+    #[test]
+    fn smoke_display_list_item_div_with_length_line_height() {
+        let pdf = render_list_html(
+            r#"<!doctype html><html><body>
+            <div style="display:list-item;line-height:24px">Absolute line-height</div>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // Smoke: a <div> with `display:list-item` and `list-style-image:url(dot.png)`
+    // renders without crashing.  Blitz assigns `list_item_data` with an outside
+    // marker layout for this combination (branch 1), so the outside-marker path
+    // with an image marker is exercised.
+    #[test]
+    fn smoke_display_list_item_div_with_inline_image_marker() {
+        let mut bundle = crate::asset::AssetBundle::default();
+        bundle.add_image("dot.png", RED_1X1_PNG.to_vec());
+        let pdf = crate::engine::Engine::builder()
+            .assets(bundle)
+            .build()
+            .render(
+                r#"<!doctype html><html><body>
+                <div style="display:list-item;list-style-image:url(dot.png)">Image marker</div>
+                </body></html>"#,
+            )
+            .expect("render failed");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
     // try_convert branch 3 (inside marker, non-inline-root, non-empty children):
     // when `list-style-image` is set AND `list-style-position: inside`, and the
     // `<li>` has a block child (making it non-inline-root), the non-empty-children

--- a/crates/fulgur/src/convert/style/background.rs
+++ b/crates/fulgur/src/convert/style/background.rs
@@ -1100,4 +1100,37 @@ mod tests {
             "conic gradient stops must be capped, got {count}"
         );
     }
+
+    /// Same cap on the radial-gradient stop-building path.  Exercises the
+    /// `BgImageContent::RadialGradient { stops, .. }` arm of the
+    /// `first_gradient_stop_count` helper (previously uncovered).
+    #[test]
+    fn radial_gradient_stop_count_is_defensively_capped() {
+        let mut stops = String::new();
+        for i in 0..2000 {
+            stops.push_str(if i % 2 == 0 { "red," } else { "blue," });
+        }
+        stops.push_str("red");
+        let html = format!(
+            r#"<html><body><div style="width:120px;height:80px;background:radial-gradient({stops})"></div></body></html>"#
+        );
+        let count = first_gradient_stop_count(&html).expect("radial gradient layer present");
+        assert!(
+            count <= crate::MAX_GRADIENT_STOPS,
+            "radial gradient stops must be capped, got {count}"
+        );
+    }
+
+    /// A document with only `background-color` (no `background-image`) produces
+    /// no gradient layers; `first_gradient_stop_count` must return `None`.
+    #[test]
+    fn first_gradient_stop_count_returns_none_without_gradient() {
+        let count = first_gradient_stop_count(
+            r#"<html><body><div style="width:80px;height:80px;background-color:red"></div></body></html>"#,
+        );
+        assert!(
+            count.is_none(),
+            "solid background-color should not produce a gradient stop count"
+        );
+    }
 }


### PR DESCRIPTION
## 概要

定期カバレッジ改善タスク（2026-08-15）。カバレッジ計測で低カバレッジだった 2 ファイルにテストを追加。

| ファイル | 変更前 | 変更後 | 差分 |
|---|---|---|---|
| `convert/list_item.rs` | 94.75% | 95.35% | +0.60pp |
| `convert/style/background.rs` | 95.30% | 95.93% | +0.63pp |

## 追加テスト詳細

### `convert/list_item.rs`（3 テスト追加）

`<div style="display:list-item">` に追加 CSS プロパティを組み合わせた際の outside-marker パスを網羅する smoke テスト。

- `smoke_display_list_item_div_with_numeric_line_height`
  — `line-height:1.5`（数値）との組み合わせ。Blitz は `list_item_data` + outside layout を割り当てるため branch 1（outside marker パス）が発火することを確認。
- `smoke_display_list_item_div_with_length_line_height`
  — `line-height:24px`（絶対長）との組み合わせ。同上。
- `smoke_display_list_item_div_with_inline_image_marker`
  — `list-style-image:url(dot.png)` との組み合わせ。`AssetBundle` に 1×1 PNG を登録し、画像マーカー付き outside パスを end-to-end で走行。

**Blitz の挙動メモ**: `display:list-item` に加えて他のプロパティが inline style に含まれると、Blitz は当該 `<div>` に `list_item_data`（outside layout）を設定する。そのため fallback branch 2（lines 71–120）には到達できず、これらのテストは branch 1 を経由している。lines 85–86 および 91–118 の未カバー行は Blitz 内部の条件に依存しており、現状のテストインフラでは直接ヒットできないことを確認済み。

### `convert/style/background.rs`（2 テスト追加）

- `radial_gradient_stop_count_is_defensively_capped`
  — 2000 ストップの `background:radial-gradient(...)` を用いて `BgImageContent::RadialGradient` アームを踏み、`MAX_GRADIENT_STOPS` キャップが適用されることをアサート（line 1023 カバー）。
- `first_gradient_stop_count_returns_none_without_gradient`
  — `background-color:red`（グラジェントなし）のドキュメントで `first_gradient_stop_count` が `None` を返すことを確認。

## テスト実行結果

```text
cargo test -p fulgur --lib
test result: ok. 2013 passed; 0 failed; 0 ignored; 0 measured
```

```text
cargo clippy -p fulgur -- -D warnings
（出力なし = 警告ゼロ）
```

```text
cargo fmt --check
（出力なし = フォーマット差分なし）
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01BVX725TEzbiBCD4ZT1ms32)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * リスト項目の数値・絶対値の行の高さ、および画像によるリストマーカーのPDF描画を検証するスモークテストを追加しました。
  * 放射状グラデーションの色停止数の上限と、単色背景が誤検出されないことを検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->