### PR TITLE
test(multicol_layout): add coverage for resolve_calc_value with mixed calc() padding

### DIFF
--- a/crates/fulgur/src/multicol_layout.rs
+++ b/crates/fulgur/src/multicol_layout.rs
@@ -3643,4 +3643,50 @@ mod tests {
             group.paragraph_splits
         );
     }
+
+    // ── resolve_calc_value: CSS calc() with a percentage component ──────────
+
+    #[test]
+    fn multicol_calc_mixed_padding_triggers_resolve_calc_value() {
+        // `calc(10% + 5px)` mixes a percentage and an absolute length.
+        // Stylo cannot resolve it at computed time, so stylo_taffy stores it
+        // as an opaque calc pointer (`CompactLength::is_calc()` == true).
+        // When `compute_multicol_layout` calls `resolve_or_zero` on the
+        // padding (lines 527-528 of multicol_layout.rs), the closure
+        //   `|val, b| tree.resolve_calc_value(val, b)`
+        // is invoked, which exercises `FulgurLayoutTree::resolve_calc_value`
+        // (lines 389-391) delegating to `BaseDocument::resolve_calc_value`.
+        //
+        // In contrast, a pure-percentage padding (`padding: 10%`) is stored
+        // as `Percent(0.1)` — `is_calc()` is false, the closure is skipped,
+        // and those lines stay uncovered.
+        //
+        // With body margin:0 and viewport 400px the containing block is 400px
+        // wide. `calc(10% + 5px)` resolves to 40 + 5 = 45px on every side.
+        let html = r#"<!doctype html><html><body style="margin:0">
+            <div id="mc" style="column-count: 2; column-gap: 0; padding: calc(10% + 5px);">
+              <p id="a">alpha alpha alpha alpha</p>
+              <p id="b">beta beta beta beta</p>
+            </div>
+        </body></html>"#;
+        let mut doc = crate::blitz_adapter::parse(html, 400.0, &[]);
+        crate::blitz_adapter::resolve(&mut doc);
+        let column_styles = crate::column_css::ColumnStyleTable::new();
+        let mut tree = FulgurLayoutTree::new(&mut doc, &column_styles);
+        tree.layout_multicol_subtrees();
+
+        let a = layout_of_id(&doc, "a");
+        // padding-left = calc(10% + 5px) = 45px → child.x must reflect this inset.
+        assert!(
+            (a.location.x - 45.0).abs() < 2.0,
+            "calc() padding-left expected ≈ 45, got {}",
+            a.location.x
+        );
+        // padding-top = calc(10% + 5px) = 45px → first child.y must reflect this inset.
+        assert!(
+            (a.location.y - 45.0).abs() < 2.0,
+            "calc() padding-top expected ≈ 45, got {}",
+            a.location.y
+        );
+    }
 }


### PR DESCRIPTION
# Pull Request

## Summary

`multicol_layout.rs` の `FulgurLayoutTree::resolve_calc_value`（lines 389-391）および
`compute_multicol_layout` 内の calc クロージャ（lines 527-528）がテストで踏まれていなかった。

これらは、マルチカラムコンテナの `padding` または `border` に **パーセンテージを含む `calc()` 式**
（例: `calc(10% + 5px)`）が指定されたときのみ実行される。Stylo はこの値を計算時に解決できないため、
`stylo_taffy` が Taffy の `CompactLength::calc()` としてオペーク calc ポインタを格納する
（`is_calc()` == true）。`resolve_or_zero` はこのとき初めてクロージャを呼び出す。

純粋なパーセンテージ（`padding: 10%`）は `Percent(f32)` として格納され calc クロージャを
バイパスするため、既存テスト `multicol_percentage_padding_resolves_against_parent_width`
では上記コードパスを踏めていなかった。

## Changes

- `crates/fulgur/src/multicol_layout.rs` の `tests` モジュール末尾に
  `multicol_calc_mixed_padding_triggers_resolve_calc_value` テストを追加
  - `padding: calc(10% + 5px)` をもつ 2 カラムレイアウトを使用
  - ビューポート 400px・body margin:0 のとき `10% × 400 + 5 = 45px` が padding-left/top に
    反映されることを ±2px の許容範囲でアサート

カバレッジ変化（`multicol_layout.rs` のみ）:

| 指標 | 変更前 | 変更後 |
|------|--------|--------|
| lines missed | 71 | 67 |
| regions missed | 101 | 86 |
| functions | 94.74% | 96.08% |

## Test plan

- [x] `cargo test -p fulgur --lib`（2014 passed, 0 failed）
- [x] `cargo clippy -p fulgur -- -D warnings`（警告なし）
- [x] `cargo fmt --check`（差分なし）
- [ ] `npx markdownlint-cli2 '**/*.md'`（ドキュメント変更なし）

## Contributor License Agreement

- [x] I have read the [Contributing Guide](https://github.com/fulgur-rs/fulgur/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://github.com/fulgur-rs/fulgur/blob/main/CLA.md)
      and agree to its terms.

## Related issues

カバレッジ向上の一環（定期自動タスク 2026-08-16）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAWJBdfKQNB83n1KEizAyB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * パーセンテージと絶対値を組み合わせた `padding` のレイアウト計算を検証するテストを追加しました。
  * コンテナ幅に基づいて上下左右の余白が正しく解決され、子要素が期待どおりの位置に配置されることを確認します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->