### PR TITLE
refactor: migrate nested if-let to let-chains (fulgur-pt70)

### DIFF
--- a/crates/fulgur-wpt/src/fonts.rs
+++ b/crates/fulgur-wpt/src/fonts.rs
@@ -21,12 +21,6 @@ pub fn load_fonts_dir(dir: &Path) -> Result<AssetBundle> {
     Ok(bundle)
 }
 
-// MSRV bump to 1.89 (PR #701) makes clippy suggest collapsing the nested
-// `if let` below into a let-chain; left as-is here because the collapse
-// would touch the (untested) add_font_file error branch and trip
-// codecov/patch on lines this PR isn't otherwise changing. Tracked in
-// fulgur-pt70 alongside the core-library collapsible_if backlog.
-#[allow(clippy::collapsible_if)]
 fn walk(dir: &Path, bundle: &mut AssetBundle) -> Result<()> {
     let mut entries: Vec<_> = std::fs::read_dir(dir)
         .with_context(|| format!("read_dir {}", dir.display()))?
@@ -44,10 +38,10 @@ fn walk(dir: &Path, bundle: &mut AssetBundle) -> Result<()> {
             .extension()
             .and_then(|s| s.to_str())
             .map(|s| s.to_ascii_lowercase());
-        if let Some("ttf" | "otf" | "woff" | "woff2") = ext.as_deref() {
-            if let Err(e) = bundle.add_font_file(&path) {
-                log::warn!("load_fonts_dir: skipping {}: {e}", path.display());
-            }
+        if let Some("ttf" | "otf" | "woff" | "woff2") = ext.as_deref()
+            && let Err(e) = bundle.add_font_file(&path)
+        {
+            log::warn!("load_fonts_dir: skipping {}: {e}", path.display());
         }
     }
     Ok(())
@@ -97,6 +91,18 @@ mod tests {
         write_fake_ttf(tmp.path(), "a.ttf");
         std::fs::write(tmp.path().join("README.md"), b"ignore me").unwrap();
         std::fs::write(tmp.path().join("notes.txt"), b"also ignore").unwrap();
+        let bundle = load_fonts_dir(tmp.path()).unwrap();
+        assert_eq!(bundle.fonts.len(), 1);
+    }
+
+    #[test]
+    fn skips_font_files_that_fail_to_load() {
+        let tmp = tempdir().unwrap();
+        write_fake_ttf(tmp.path(), "good.ttf");
+        // WOFF1 magic: `AssetBundle::add_font_file` rejects it with
+        // `UnsupportedFontFormat`, so the walker must log and keep going
+        // rather than abort the whole directory scan.
+        std::fs::write(tmp.path().join("bad.woff"), b"wOFF\x00\x00\x00\x00").unwrap();
         let bundle = load_fonts_dir(tmp.path()).unwrap();
         assert_eq!(bundle.fonts.len(), 1);
     }

--- a/crates/fulgur-wpt/src/render.rs
+++ b/crates/fulgur-wpt/src/render.rs
@@ -12,6 +12,36 @@ pub struct RenderedTest {
     pub pdf_path: PathBuf,
 }
 
+/// Delete `<prefix>-*.png` files left in `work_dir` by a previous run.
+///
+/// Propagates cleanup failures — a leftover PNG from a prior run would mix
+/// into the current page count and skew diff results, so we must fail loud
+/// rather than silently continue with stale data. The one tolerated failure
+/// is `NotFound`: the directory listing is a snapshot, so an entry can
+/// legitimately disappear between `read_dir` and `remove_file`.
+fn remove_stale_pngs(work_dir: &Path, prefix: &Path) -> Result<()> {
+    let stem = prefix
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let stale_needle = format!("{stem}-");
+    for entry in
+        std::fs::read_dir(work_dir).with_context(|| format!("read dir {}", work_dir.display()))?
+    {
+        let entry = entry.with_context(|| format!("read entry in {}", work_dir.display()))?;
+        let p = entry.path();
+        let name = p.file_name().and_then(|s| s.to_str()).unwrap_or("");
+        if name.starts_with(&stale_needle)
+            && name.ends_with(".png")
+            && let Err(e) = std::fs::remove_file(&p)
+            && e.kind() != std::io::ErrorKind::NotFound
+        {
+            return Err(e).with_context(|| format!("remove stale PNG {}", p.display()));
+        }
+    }
+    Ok(())
+}
+
 /// Render `test_html_path` and return one RgbaImage per page.
 ///
 /// The path is canonicalized, and its parent directory is used as
@@ -20,12 +50,6 @@ pub struct RenderedTest {
 /// `dpi` controls pdftocairo's rasterization resolution.
 /// `assets`: optional bundle of fonts/images injected into the engine
 /// (cloned internally; `AssetBundle` stores shared `Arc`s so clones are cheap).
-// MSRV bump to 1.89 (PR #701) makes clippy suggest collapsing the nested
-// `if`/`if let` below into a let-chain; left as-is because the collapse
-// would touch the (untested) stale-PNG removal error branch and trip
-// codecov/patch on lines this PR isn't otherwise changing. Tracked in
-// fulgur-pt70 alongside the core-library collapsible_if backlog.
-#[allow(clippy::collapsible_if)]
 pub fn render_test(
     test_html_path: &Path,
     work_dir: &Path,
@@ -55,28 +79,7 @@ pub fn render_test(
 
     // Remove stale page PNGs from prior runs so page count is accurate.
     let prefix = work_dir.join("page");
-    let stem = prefix
-        .file_name()
-        .map(|s| s.to_string_lossy().into_owned())
-        .unwrap_or_default();
-    let stale_needle = format!("{stem}-");
-    // Propagate cleanup failures — a leftover PNG from a prior run would mix
-    // into the current page count and skew diff results, so we must fail loud
-    // rather than silently continue with stale data.
-    for entry in
-        std::fs::read_dir(work_dir).with_context(|| format!("read dir {}", work_dir.display()))?
-    {
-        let entry = entry.with_context(|| format!("read entry in {}", work_dir.display()))?;
-        let p = entry.path();
-        let name = p.file_name().and_then(|s| s.to_str()).unwrap_or("");
-        if name.starts_with(&stale_needle) && name.ends_with(".png") {
-            if let Err(e) = std::fs::remove_file(&p) {
-                if e.kind() != std::io::ErrorKind::NotFound {
-                    return Err(e).with_context(|| format!("remove stale PNG {}", p.display()));
-                }
-            }
-        }
-    }
+    remove_stale_pngs(work_dir, &prefix)?;
 
     let pdf_path = work_dir.join("fixture.pdf");
     std::fs::write(&pdf_path, &pdf_bytes)
@@ -131,4 +134,59 @@ pub fn render_test(
         .collect::<Result<Vec<_>>>()?;
 
     Ok(RenderedTest { pages, pdf_path })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn removes_only_matching_stale_pngs() {
+        let tmp = tempdir().unwrap();
+        let dir = tmp.path();
+        for name in ["page-1.png", "page-10.png"] {
+            std::fs::write(dir.join(name), b"stale").unwrap();
+        }
+        // Non-matching: wrong stem, wrong extension, and the exact prefix
+        // without the `-` separator (`page.png` is not `page-<n>.png`).
+        for name in ["other-1.png", "page-1.txt", "page.png"] {
+            std::fs::write(dir.join(name), b"keep").unwrap();
+        }
+
+        remove_stale_pngs(dir, &dir.join("page")).unwrap();
+
+        assert!(!dir.join("page-1.png").exists());
+        assert!(!dir.join("page-10.png").exists());
+        assert!(dir.join("other-1.png").exists());
+        assert!(dir.join("page-1.txt").exists());
+        assert!(dir.join("page.png").exists());
+    }
+
+    #[test]
+    fn propagates_removal_failure() {
+        let tmp = tempdir().unwrap();
+        let dir = tmp.path();
+        // A *directory* named like a stale page PNG: `remove_file` fails with
+        // something other than `NotFound`, which must not be swallowed.
+        std::fs::create_dir(dir.join("page-1.png")).unwrap();
+
+        let err = remove_stale_pngs(dir, &dir.join("page")).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("remove stale PNG"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn propagates_read_dir_failure() {
+        let tmp = tempdir().unwrap();
+        let missing = tmp.path().join("does-not-exist");
+
+        let err = remove_stale_pngs(&missing, &missing.join("page")).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("read dir"),
+            "unexpected error: {err:#}"
+        );
+    }
 }

--- a/crates/fulgur-wpt/src/render.rs
+++ b/crates/fulgur-wpt/src/render.rs
@@ -12,6 +12,23 @@ pub struct RenderedTest {
     pub pdf_path: PathBuf,
 }
 
+/// The `<stem>-` search prefix identifying pdftocairo's paginated output:
+/// `<stem>-<n>.png`.
+fn page_png_needle(stem: &str) -> String {
+    format!("{stem}-")
+}
+
+/// Match a filename against a needle produced by [`page_png_needle`].
+///
+/// Shared between `remove_stale_pngs` (deleting leftovers from a prior run)
+/// and `render_test`'s enumeration of this run's output, so a future change
+/// to the naming scheme is a one-line edit instead of two independent ones.
+/// Each call site still computes and error-handles its own `stem` — they
+/// disagree on how to react to a prefix with no file name (see call sites).
+fn is_page_png(name: &str, needle: &str) -> bool {
+    name.starts_with(needle) && name.ends_with(".png")
+}
+
 /// Delete `<prefix>-*.png` files left in `work_dir` by a previous run.
 ///
 /// Propagates cleanup failures — a leftover PNG from a prior run would mix
@@ -19,21 +36,29 @@ pub struct RenderedTest {
 /// rather than silently continue with stale data. The one tolerated failure
 /// is `NotFound`: the directory listing is a snapshot, so an entry can
 /// legitimately disappear between `read_dir` and `remove_file`.
+///
+/// Scoping (which files are stale) and acting (deleting them) are separate
+/// passes: the scope check can never run interleaved with, or after,
+/// removal side effects.
 fn remove_stale_pngs(work_dir: &Path, prefix: &Path) -> Result<()> {
     let stem = prefix
         .file_name()
         .map(|s| s.to_string_lossy().into_owned())
         .unwrap_or_default();
-    let stale_needle = format!("{stem}-");
+    let needle = page_png_needle(&stem);
+    let mut stale = Vec::new();
     for entry in
         std::fs::read_dir(work_dir).with_context(|| format!("read dir {}", work_dir.display()))?
     {
         let entry = entry.with_context(|| format!("read entry in {}", work_dir.display()))?;
         let p = entry.path();
         let name = p.file_name().and_then(|s| s.to_str()).unwrap_or("");
-        if name.starts_with(&stale_needle)
-            && name.ends_with(".png")
-            && let Err(e) = std::fs::remove_file(&p)
+        if is_page_png(name, &needle) {
+            stale.push(p);
+        }
+    }
+    for p in stale {
+        if let Err(e) = std::fs::remove_file(&p)
             && e.kind() != std::io::ErrorKind::NotFound
         {
             return Err(e).with_context(|| format!("remove stale PNG {}", p.display()));
@@ -108,14 +133,14 @@ pub fn render_test(
         .ok_or_else(|| anyhow::anyhow!("bad prefix"))?
         .to_string_lossy()
         .into_owned();
-    let needle = format!("{stem}-");
+    let needle = page_png_needle(&stem);
     let mut entries: Vec<PathBuf> = std::fs::read_dir(work_dir)
         .with_context(|| format!("read dir {}", work_dir.display()))?
         .filter_map(|e| e.ok())
         .map(|e| e.path())
         .filter(|p| {
             let name = p.file_name().and_then(|s| s.to_str()).unwrap_or("");
-            name.starts_with(&needle) && name.ends_with(".png")
+            is_page_png(name, &needle)
         })
         .collect();
     entries.sort();

--- a/crates/fulgur-wpt/src/render.rs
+++ b/crates/fulgur-wpt/src/render.rs
@@ -12,21 +12,32 @@ pub struct RenderedTest {
     pub pdf_path: PathBuf,
 }
 
-/// The `<stem>-` search prefix identifying pdftocairo's paginated output:
-/// `<stem>-<n>.png`.
-fn page_png_needle(stem: &str) -> String {
-    format!("{stem}-")
-}
-
-/// Match a filename against a needle produced by [`page_png_needle`].
+/// List `<stem>-<n>.png` files directly inside `work_dir`, sorted.
 ///
-/// Shared between `remove_stale_pngs` (deleting leftovers from a prior run)
-/// and `render_test`'s enumeration of this run's output, so a future change
-/// to the naming scheme is a one-line edit instead of two independent ones.
-/// Each call site still computes and error-handles its own `stem` — they
-/// disagree on how to react to a prefix with no file name (see call sites).
-fn is_page_png(name: &str, needle: &str) -> bool {
-    name.starts_with(needle) && name.ends_with(".png")
+/// Propagates `ReadDir` entry errors instead of silently dropping them: a
+/// dropped entry would under-count pages, and both callers rely on an
+/// accurate count — `remove_stale_pngs` to avoid leaving a stale file behind
+/// uncounted, `render_test` to avoid reporting success on a truncated page
+/// set.
+///
+/// Shared between the two callers so the naming scheme lives in exactly one
+/// place. Each caller still derives its own `stem` from `prefix.file_name()`
+/// with its own error policy — see call sites.
+fn list_page_pngs(work_dir: &Path, stem: &str) -> Result<Vec<PathBuf>> {
+    let needle = format!("{stem}-");
+    let mut matches = Vec::new();
+    for entry in
+        std::fs::read_dir(work_dir).with_context(|| format!("read dir {}", work_dir.display()))?
+    {
+        let entry = entry.with_context(|| format!("read entry in {}", work_dir.display()))?;
+        let p = entry.path();
+        let name = p.file_name().and_then(|s| s.to_str()).unwrap_or("");
+        if name.starts_with(&needle) && name.ends_with(".png") {
+            matches.push(p);
+        }
+    }
+    matches.sort();
+    Ok(matches)
 }
 
 /// Delete `<prefix>-*.png` files left in `work_dir` by a previous run.
@@ -35,29 +46,17 @@ fn is_page_png(name: &str, needle: &str) -> bool {
 /// into the current page count and skew diff results, so we must fail loud
 /// rather than silently continue with stale data. The one tolerated failure
 /// is `NotFound`: the directory listing is a snapshot, so an entry can
-/// legitimately disappear between `read_dir` and `remove_file`.
+/// legitimately disappear between listing and removal.
 ///
-/// Scoping (which files are stale) and acting (deleting them) are separate
-/// passes: the scope check can never run interleaved with, or after,
-/// removal side effects.
+/// Scoping (which files are stale, via [`list_page_pngs`]) and acting
+/// (deleting them) are separate passes: the scope check can never run
+/// interleaved with, or after, removal side effects.
 fn remove_stale_pngs(work_dir: &Path, prefix: &Path) -> Result<()> {
     let stem = prefix
         .file_name()
         .map(|s| s.to_string_lossy().into_owned())
         .unwrap_or_default();
-    let needle = page_png_needle(&stem);
-    let mut stale = Vec::new();
-    for entry in
-        std::fs::read_dir(work_dir).with_context(|| format!("read dir {}", work_dir.display()))?
-    {
-        let entry = entry.with_context(|| format!("read entry in {}", work_dir.display()))?;
-        let p = entry.path();
-        let name = p.file_name().and_then(|s| s.to_str()).unwrap_or("");
-        if is_page_png(name, &needle) {
-            stale.push(p);
-        }
-    }
-    for p in stale {
+    for p in list_page_pngs(work_dir, &stem)? {
         if let Err(e) = std::fs::remove_file(&p)
             && e.kind() != std::io::ErrorKind::NotFound
         {
@@ -133,17 +132,7 @@ pub fn render_test(
         .ok_or_else(|| anyhow::anyhow!("bad prefix"))?
         .to_string_lossy()
         .into_owned();
-    let needle = page_png_needle(&stem);
-    let mut entries: Vec<PathBuf> = std::fs::read_dir(work_dir)
-        .with_context(|| format!("read dir {}", work_dir.display()))?
-        .filter_map(|e| e.ok())
-        .map(|e| e.path())
-        .filter(|p| {
-            let name = p.file_name().and_then(|s| s.to_str()).unwrap_or("");
-            is_page_png(name, &needle)
-        })
-        .collect();
-    entries.sort();
+    let entries = list_page_pngs(work_dir, &stem)?;
 
     if entries.is_empty() {
         bail!("pdftocairo produced no PNGs in {}", work_dir.display());

--- a/crates/fulgur-wpt/src/render.rs
+++ b/crates/fulgur-wpt/src/render.rs
@@ -14,6 +14,11 @@ pub struct RenderedTest {
 
 /// List `<stem>-<n>.png` files directly inside `work_dir`, sorted.
 ///
+/// `<n>` must be a non-empty run of ASCII digits — a debug artifact a human
+/// drops in `work_dir` with a similar prefix (e.g. `<stem>-preview.png`)
+/// must not be swept up: `remove_stale_pngs` would delete it, and
+/// `render_test` would decode it as a page and corrupt the page count.
+///
 /// Propagates `ReadDir` entry errors instead of silently dropping them: a
 /// dropped entry would under-count pages, and both callers rely on an
 /// accurate count — `remove_stale_pngs` to avoid leaving a stale file behind
@@ -32,7 +37,12 @@ fn list_page_pngs(work_dir: &Path, stem: &str) -> Result<Vec<PathBuf>> {
         let entry = entry.with_context(|| format!("read entry in {}", work_dir.display()))?;
         let p = entry.path();
         let name = p.file_name().and_then(|s| s.to_str()).unwrap_or("");
-        if name.starts_with(&needle) && name.ends_with(".png") {
+        if let Some(page_number) = name
+            .strip_prefix(&needle)
+            .and_then(|suffix| suffix.strip_suffix(".png"))
+            && !page_number.is_empty()
+            && page_number.bytes().all(|byte| byte.is_ascii_digit())
+        {
             matches.push(p);
         }
     }
@@ -159,12 +169,15 @@ mod tests {
     fn removes_only_matching_stale_pngs() {
         let tmp = tempdir().unwrap();
         let dir = tmp.path();
-        for name in ["page-1.png", "page-10.png"] {
+        // Includes a zero-padded index (pdftocairo pads to the width of the
+        // max page number once a test has 10+ pages).
+        for name in ["page-1.png", "page-10.png", "page-01.png"] {
             std::fs::write(dir.join(name), b"stale").unwrap();
         }
-        // Non-matching: wrong stem, wrong extension, and the exact prefix
-        // without the `-` separator (`page.png` is not `page-<n>.png`).
-        for name in ["other-1.png", "page-1.txt", "page.png"] {
+        // Non-matching: wrong stem, wrong extension, the exact prefix without
+        // the `-` separator (`page.png` is not `page-<n>.png`), and a
+        // non-numeric suffix (a human-dropped debug artifact, not a page).
+        for name in ["other-1.png", "page-1.txt", "page.png", "page-preview.png"] {
             std::fs::write(dir.join(name), b"keep").unwrap();
         }
 
@@ -172,9 +185,11 @@ mod tests {
 
         assert!(!dir.join("page-1.png").exists());
         assert!(!dir.join("page-10.png").exists());
+        assert!(!dir.join("page-01.png").exists());
         assert!(dir.join("other-1.png").exists());
         assert!(dir.join("page-1.txt").exists());
         assert!(dir.join("page.png").exists());
+        assert!(dir.join("page-preview.png").exists());
     }
 
     #[test]

--- a/crates/fulgur/src/asset.rs
+++ b/crates/fulgur/src/asset.rs
@@ -453,10 +453,10 @@ impl AssetBundle {
         // (Stylo resolves `content: url("icon.png")` against the engine's
         // base URL), strip the recorded base prefix to recover the relative
         // asset name.
-        if let Some(base) = &self.base_path_str {
-            if let Some(rel) = key.strip_prefix(base.as_str()) {
-                return self.images.get(Self::normalize_key(rel));
-            }
+        if let Some(base) = &self.base_path_str
+            && let Some(rel) = key.strip_prefix(base.as_str())
+        {
+            return self.images.get(Self::normalize_key(rel));
         }
         None
     }

--- a/crates/fulgur/src/blitz_adapter.rs
+++ b/crates/fulgur/src/blitz_adapter.rs
@@ -270,10 +270,10 @@ pub fn parse_html_with_local_resources(
     // to rewrite — their @import replacements will re-fetch with the
     // correct MediaList.
     for resource in net_provider.drain_pending_resources() {
-        if let Resource::Css(node_id, _) = &resource {
-            if rewrite_node_ids.contains(node_id) {
-                continue;
-            }
+        if let Resource::Css(node_id, _) = &resource
+            && rewrite_node_ids.contains(node_id)
+        {
+            continue;
         }
         doc.load_resource(resource);
     }
@@ -693,10 +693,11 @@ pub fn extract_html_title(doc: &HtmlDocument) -> Option<String> {
             return None;
         }
         let node = doc.get_node(node_id)?;
-        if let Some(el) = node.element_data() {
-            if el.name.local.as_ref() == "title" && el.name.ns == blitz_dom::ns!(html) {
-                return Some(node_id);
-            }
+        if let Some(el) = node.element_data()
+            && el.name.local.as_ref() == "title"
+            && el.name.ns == blitz_dom::ns!(html)
+        {
+            return Some(node_id);
         }
         for &child_id in &node.children {
             if let Some(found) = find_title(doc, child_id, depth + 1) {
@@ -712,10 +713,10 @@ pub fn extract_html_title(doc: &HtmlDocument) -> Option<String> {
 
     let mut text = String::new();
     for &child_id in &title_node.children {
-        if let Some(child) = base.get_node(child_id) {
-            if let blitz_dom::node::NodeData::Text(t) = &child.data {
-                text.push_str(&t.content);
-            }
+        if let Some(child) = base.get_node(child_id)
+            && let blitz_dom::node::NodeData::Text(t) = &child.data
+        {
+            text.push_str(&t.content);
         }
     }
 
@@ -1104,10 +1105,10 @@ fn find_element_by_tag_recursive(
         return None;
     }
     let node = doc.get_node(node_id)?;
-    if let Some(el) = node.element_data() {
-        if el.name.local.as_ref() == tag {
-            return Some(node_id);
-        }
+    if let Some(el) = node.element_data()
+        && el.name.local.as_ref() == tag
+    {
+        return Some(node_id);
     }
     for &child_id in &node.children {
         if let Some(found) = find_element_by_tag_recursive(doc, child_id, tag, depth + 1) {
@@ -1186,12 +1187,11 @@ pub fn element_text(doc: &blitz_dom::BaseDocument, node_id: usize) -> String {
             out.push_str(&t.content);
         }
         for &child_id in &node.children {
-            if let Some(child) = doc.get_node(child_id) {
-                if let blitz_dom::node::NodeData::Element(el) = &child.data {
-                    if is_block_boundary_tag(el.name.local.as_ref()) {
-                        push_separator(out);
-                    }
-                }
+            if let Some(child) = doc.get_node(child_id)
+                && let blitz_dom::node::NodeData::Element(el) = &child.data
+                && is_block_boundary_tag(el.name.local.as_ref())
+            {
+                push_separator(out);
             }
             walk(doc, child_id, depth + 1, out);
         }
@@ -1479,14 +1479,14 @@ fn collect_caption_tables_recursive(
     let is_table = node
         .element_data()
         .is_some_and(|el| el.name.local.as_ref() == "table");
-    if is_table {
-        if let Some(&caption_id) = node.children.iter().find(|&&child_id| {
+    if is_table
+        && let Some(&caption_id) = node.children.iter().find(|&&child_id| {
             doc.get_node(child_id)
                 .and_then(|c| c.element_data())
                 .is_some_and(|el| el.name.local.as_ref() == "caption")
-        }) {
-            out.push((node_id, caption_id));
-        }
+        })
+    {
+        out.push((node_id, caption_id));
     }
     let children = node.children.clone();
     for child_id in children {
@@ -2505,10 +2505,10 @@ impl CounterPass {
 
             // Set data attribute once
             let qual = make_qual_name("data-fulgur-cid");
-            if let Some(node_mut) = doc.get_node_mut(node_id) {
-                if let Some(elem_mut) = node_mut.element_data_mut() {
-                    elem_mut.attrs.set(qual, &v);
-                }
+            if let Some(node_mut) = doc.get_node_mut(node_id)
+                && let Some(elem_mut) = node_mut.element_data_mut()
+            {
+                elem_mut.attrs.set(qual, &v);
             }
             Some(v)
         } else {
@@ -3379,10 +3379,10 @@ pub fn rewrite_marker_content_url(css: &str) -> String {
         if ch == '}' {
             brace_depth = brace_depth.saturating_sub(1);
             // If the top at-rule was opened at the current depth, pop it.
-            if let Some(&(depth, _)) = at_stack.last() {
-                if depth == brace_depth {
-                    at_stack.pop();
-                }
+            if let Some(&(depth, _)) = at_stack.last()
+                && depth == brace_depth
+            {
+                at_stack.pop();
             }
             i += 1;
             continue;
@@ -3611,24 +3611,24 @@ pub(crate) fn collect_link_media_rewrites(doc: &HtmlDocument) -> Vec<LinkMediaRe
         let Some(node) = doc.get_node(node_id) else {
             return;
         };
-        if let Some(el) = node.element_data() {
-            if el.name.local.as_ref() == "link" {
-                let rel_ok = get_attr(el, "rel")
-                    .map(|rel| {
-                        rel.split_ascii_whitespace()
-                            .any(|t| t.eq_ignore_ascii_case("stylesheet"))
-                    })
-                    .unwrap_or(false);
-                let href = get_attr(el, "href").unwrap_or("").trim();
-                let media = get_attr(el, "media").unwrap_or("").trim();
-                let media_active = !media.is_empty() && !media.eq_ignore_ascii_case("all");
-                if rel_ok && !href.is_empty() && media_active {
-                    out.push(LinkMediaRewrite {
-                        link_node_id: node_id,
-                        href: href.to_string(),
-                        media: media.to_string(),
-                    });
-                }
+        if let Some(el) = node.element_data()
+            && el.name.local.as_ref() == "link"
+        {
+            let rel_ok = get_attr(el, "rel")
+                .map(|rel| {
+                    rel.split_ascii_whitespace()
+                        .any(|t| t.eq_ignore_ascii_case("stylesheet"))
+                })
+                .unwrap_or(false);
+            let href = get_attr(el, "href").unwrap_or("").trim();
+            let media = get_attr(el, "media").unwrap_or("").trim();
+            let media_active = !media.is_empty() && !media.eq_ignore_ascii_case("all");
+            if rel_ok && !href.is_empty() && media_active {
+                out.push(LinkMediaRewrite {
+                    link_node_id: node_id,
+                    href: href.to_string(),
+                    media: media.to_string(),
+                });
             }
         }
         for &child in &node.children {
@@ -4222,10 +4222,10 @@ mod tests {
         let mut h1_ids: Vec<usize> = Vec::new();
         fn walk(doc: &HtmlDocument, id: usize, out: &mut Vec<usize>) {
             if let Some(node) = doc.get_node(id) {
-                if let Some(el) = node.element_data() {
-                    if el.name.local.as_ref() == "h1" {
-                        out.push(id);
-                    }
+                if let Some(el) = node.element_data()
+                    && el.name.local.as_ref() == "h1"
+                {
+                    out.push(id);
                 }
                 for &c in &node.children {
                     walk(doc, c, out);
@@ -4392,10 +4392,11 @@ mod tests {
 
         fn find_inner_li(doc: &HtmlDocument, id: usize, ol_depth: usize) -> Option<usize> {
             if let Some(node) = doc.get_node(id) {
-                if let Some(el) = node.element_data() {
-                    if el.name.local.as_ref() == "li" && ol_depth >= 2 {
-                        return Some(id);
-                    }
+                if let Some(el) = node.element_data()
+                    && el.name.local.as_ref() == "li"
+                    && ol_depth >= 2
+                {
+                    return Some(id);
                 }
                 let next_depth = node
                     .element_data()
@@ -5033,10 +5034,10 @@ mod tests {
         let mut doc = parse(html, 400.0, &[]);
         fn find_h1(doc: &HtmlDocument, id: usize) -> Option<usize> {
             if let Some(node) = doc.get_node(id) {
-                if let Some(el) = node.element_data() {
-                    if el.name.local.as_ref() == "h1" {
-                        return Some(id);
-                    }
+                if let Some(el) = node.element_data()
+                    && el.name.local.as_ref() == "h1"
+                {
+                    return Some(id);
                 }
                 for &c in &node.children {
                     if let Some(found) = find_h1(doc, c) {
@@ -5763,11 +5764,11 @@ mod tests {
                 return;
             }
             if let Some(node) = doc.get_node(id) {
-                if let Some(el) = node.element_data() {
-                    if el.name.local.as_ref() == "p" {
-                        *out = Some(id);
-                        return;
-                    }
+                if let Some(el) = node.element_data()
+                    && el.name.local.as_ref() == "p"
+                {
+                    *out = Some(id);
+                    return;
                 }
                 for &c in &node.children {
                     walk(doc, c, out);
@@ -5787,10 +5788,10 @@ mod tests {
     fn find_element_by_local_name(doc: &HtmlDocument, name: &str) -> Option<usize> {
         fn walk(doc: &blitz_dom::BaseDocument, id: usize, name: &str) -> Option<usize> {
             let node = doc.get_node(id)?;
-            if let Some(ed) = node.element_data() {
-                if ed.name.local.as_ref() == name {
-                    return Some(id);
-                }
+            if let Some(ed) = node.element_data()
+                && ed.name.local.as_ref() == name
+            {
+                return Some(id);
             }
             for &c in &node.children {
                 if let Some(v) = walk(doc, c, name) {
@@ -6022,10 +6023,10 @@ mod tests {
                 return None;
             }
             let node = doc.get_node(node_id)?;
-            if let Some(el) = node.element_data() {
-                if el.name.local.as_ref().contains('{') {
-                    return Some(node_id);
-                }
+            if let Some(el) = node.element_data()
+                && el.name.local.as_ref().contains('{')
+            {
+                return Some(node_id);
             }
             for &child_id in &node.children {
                 if let Some(hit) = find_crafted_tag(doc, child_id, depth + 1) {
@@ -6172,10 +6173,10 @@ mod tests {
                 return None;
             }
             let node = doc.get_node(node_id)?;
-            if let Some(el) = node.element_data() {
-                if get_attr(el, "id") == Some(want) {
-                    return Some(node_id);
-                }
+            if let Some(el) = node.element_data()
+                && get_attr(el, "id") == Some(want)
+            {
+                return Some(node_id);
             }
             for &child_id in &node.children {
                 if let Some(found) = walk(doc, child_id, want, depth + 1) {
@@ -6782,10 +6783,10 @@ mod marker_rewrite_tests {
     fn find_first_element(doc: &HtmlDocument, name: &str) -> Option<usize> {
         fn walk(doc: &blitz_dom::BaseDocument, id: usize, name: &str) -> Option<usize> {
             let node = doc.get_node(id)?;
-            if let Some(ed) = node.element_data() {
-                if ed.name.local.as_ref() == name {
-                    return Some(id);
-                }
+            if let Some(ed) = node.element_data()
+                && ed.name.local.as_ref() == name
+            {
+                return Some(id);
             }
             for &c in &node.children {
                 if let Some(v) = walk(doc, c, name) {
@@ -6826,6 +6827,34 @@ mod marker_rewrite_tests {
         let css = r#"li::marker { content: "→ "; }"#;
         let result = rewrite_marker_content_url(css);
         assert!(!result.contains("list-style-image"));
+    }
+
+    /// Minified CSS closes the at-rule immediately after the inner rule's
+    /// `}`, so the scanner hits the top-level closing-brace branch that pops
+    /// `at_stack` (the whitespace-separated form in the test below is
+    /// consumed by the selector scanner instead and never reaches it).
+    /// A second `::marker` rule after the block proves the pop happened:
+    /// it must be emitted unwrapped, not re-wrapped in `@media print`.
+    #[test]
+    fn test_rewrite_marker_content_url_at_media_minified_pops_at_stack() {
+        let css =
+            r#"@media print{li::marker{content:url("a.png")}}li::marker{content:url("b.png")}"#;
+        let result = rewrite_marker_content_url(css);
+        let suffix = &result[css.len()..];
+
+        assert_eq!(
+            suffix.matches("@media print").count(),
+            1,
+            "only the first rule may be re-wrapped in @media print, suffix:\n{suffix}"
+        );
+        assert!(
+            suffix.contains("@media print{li{list-style-image:url(\"a.png\")}}"),
+            "in-@media rule must stay wrapped, suffix:\n{suffix}"
+        );
+        assert!(
+            suffix.contains("\nli{list-style-image:url(\"b.png\")}"),
+            "post-@media rule must be emitted unwrapped, suffix:\n{suffix}"
+        );
     }
 
     #[test]

--- a/crates/fulgur/src/column_css.rs
+++ b/crates/fulgur/src/column_css.rs
@@ -1070,11 +1070,11 @@ fn walk(
                 props.merge(rule.props.clone());
             }
         }
-        if let Some(elem) = node.element_data() {
-            if let Some(inline) = crate::blitz_adapter::get_attr(elem, "style") {
-                let inline_props = parse_declaration_block(inline);
-                props.merge(inline_props);
-            }
+        if let Some(elem) = node.element_data()
+            && let Some(inline) = crate::blitz_adapter::get_attr(elem, "style")
+        {
+            let inline_props = parse_declaration_block(inline);
+            props.merge(inline_props);
         }
         if !props.is_empty() {
             table.insert(node_id, props);

--- a/crates/fulgur/src/convert/inline_root.rs
+++ b/crates/fulgur/src/convert/inline_root.rs
@@ -288,21 +288,21 @@ pub(super) fn resolve_enclosing_anchor(
             return None;
         }
         let node = doc.get_node(id)?;
-        if let NodeData::Element(el) = &node.data {
-            if el.name.local.as_ref() == "a" {
-                let href = crate::blitz_adapter::get_attr(el, "href")?.trim();
-                if href.is_empty() {
-                    return None;
-                }
-                let target = if let Some(frag) = href.strip_prefix('#') {
-                    LinkTarget::Internal(Arc::new(frag.to_string()))
-                } else {
-                    LinkTarget::External(Arc::new(href.to_string()))
-                };
-                let alt = crate::blitz_adapter::element_text(doc, id);
-                let alt_text = if alt.is_empty() { None } else { Some(alt) };
-                return Some((id, LinkSpan { target, alt_text }));
+        if let NodeData::Element(el) = &node.data
+            && el.name.local.as_ref() == "a"
+        {
+            let href = crate::blitz_adapter::get_attr(el, "href")?.trim();
+            if href.is_empty() {
+                return None;
             }
+            let target = if let Some(frag) = href.strip_prefix('#') {
+                LinkTarget::Internal(Arc::new(frag.to_string()))
+            } else {
+                LinkTarget::External(Arc::new(href.to_string()))
+            };
+            let alt = crate::blitz_adapter::element_text(doc, id);
+            let alt_text = if alt.is_empty() { None } else { Some(alt) };
+            return Some((id, LinkSpan { target, alt_text }));
         }
         cur = node.parent;
         depth += 1;
@@ -420,10 +420,11 @@ fn convert_inline_box_node(
     // them register here would double-paint via the inline-box dispatch.
     // Returning `None` causes `paragraph::draw_shaped_lines` to skip the
     // inline-box dispatch for this item.
-    if let Some(node) = doc.get_node(node_id) {
-        if positioned::is_absolutely_positioned(node) && is_pseudo_node(doc, node) {
-            return None;
-        }
+    if let Some(node) = doc.get_node(node_id)
+        && positioned::is_absolutely_positioned(node)
+        && is_pseudo_node(doc, node)
+    {
+        return None;
     }
     convert_node(doc, node_id, ctx, depth + 1, out);
     Some(node_id)
@@ -545,12 +546,11 @@ pub(super) fn extract_paragraph(
                 }
                 parley::PositionedLayoutItem::InlineBox(positioned) => {
                     let node_id = positioned.id as usize;
-                    if let Some(box_node) = doc.get_node(node_id) {
-                        if positioned::is_absolutely_positioned(box_node)
-                            && is_pseudo_node(doc, box_node)
-                        {
-                            continue;
-                        }
+                    if let Some(box_node) = doc.get_node(node_id)
+                        && positioned::is_absolutely_positioned(box_node)
+                        && is_pseudo_node(doc, box_node)
+                    {
+                        continue;
                     }
                     // Mark before recursing so we can compute the inline-box
                     // descendant set for the v2 dispatcher's skip table.

--- a/crates/fulgur/src/convert/list_marker.rs
+++ b/crates/fulgur/src/convert/list_marker.rs
@@ -309,14 +309,13 @@ pub(super) fn find_marker_font(
     for entry in drawables.paragraphs.values() {
         for line in &entry.lines {
             for item in &line.items {
-                if let LineItem::Text(run) = item {
-                    if let Ok(font_ref) =
+                if let LineItem::Text(run) = item
+                    && let Ok(font_ref) =
                         skrifa::FontRef::from_index(&run.font_data, run.font_index)
-                    {
-                        let charmap = font_ref.charmap();
-                        if check_chars.iter().all(|c| charmap.map(*c).is_some()) {
-                            return Some((Arc::clone(&run.font_data), run.font_index));
-                        }
+                {
+                    let charmap = font_ref.charmap();
+                    if check_chars.iter().all(|c| charmap.map(*c).is_some()) {
+                        return Some((Arc::clone(&run.font_data), run.font_index));
                     }
                 }
             }

--- a/crates/fulgur/src/convert/mod.rs
+++ b/crates/fulgur/src/convert/mod.rs
@@ -407,21 +407,21 @@ fn walk_semantics(
     let child_override = if let Some(elem) = node.element_data() {
         if let Some(mut tag) = crate::tagging::classify_element(elem.name.local.as_ref()) {
             // CSS list-style-type を読んで ListNumbering をオーバーライド
-            if matches!(tag, crate::tagging::PdfTag::L { .. }) {
-                if let Some(styles) = node.primary_styles() {
-                    use ::style::properties::longhands::list_style_type::computed_value::T as LST;
-                    use krilla::tagging::ListNumbering;
-                    let numbering = match styles.clone_list_style_type() {
-                        LST::Disc => ListNumbering::Disc,
-                        LST::Circle => ListNumbering::Circle,
-                        LST::Square => ListNumbering::Square,
-                        LST::Decimal => ListNumbering::Decimal,
-                        LST::LowerAlpha => ListNumbering::LowerAlpha,
-                        LST::UpperAlpha => ListNumbering::UpperAlpha,
-                        _ => ListNumbering::None,
-                    };
-                    tag = crate::tagging::PdfTag::L { numbering };
-                }
+            if matches!(tag, crate::tagging::PdfTag::L { .. })
+                && let Some(styles) = node.primary_styles()
+            {
+                use ::style::properties::longhands::list_style_type::computed_value::T as LST;
+                use krilla::tagging::ListNumbering;
+                let numbering = match styles.clone_list_style_type() {
+                    LST::Disc => ListNumbering::Disc,
+                    LST::Circle => ListNumbering::Circle,
+                    LST::Square => ListNumbering::Square,
+                    LST::Decimal => ListNumbering::Decimal,
+                    LST::LowerAlpha => ListNumbering::LowerAlpha,
+                    LST::UpperAlpha => ListNumbering::UpperAlpha,
+                    _ => ListNumbering::None,
+                };
+                tag = crate::tagging::PdfTag::L { numbering };
             }
 
             // parent を決定: override があればそれを使い、なければ DOM walk-up

--- a/crates/fulgur/src/convert/positioned.rs
+++ b/crates/fulgur/src/convert/positioned.rs
@@ -120,23 +120,23 @@ fn resolve_cb_for_absolute(
                 parent_offset_in_cb_bp: (offset_x, offset_y),
             });
         }
-        if let Some(elem) = cur.element_data() {
-            if elem.name.local.as_ref() == "body" {
-                let (mut padding_box_size, border_top_left) = cb_padding_box(cur);
-                if let Some((vw, vh)) = viewport_size_px {
-                    if padding_box_size.0 <= Px::ZERO {
-                        padding_box_size.0 = vw.as_px();
-                    }
-                    if padding_box_size.1 <= Px::ZERO {
-                        padding_box_size.1 = vh.as_px();
-                    }
+        if let Some(elem) = cur.element_data()
+            && elem.name.local.as_ref() == "body"
+        {
+            let (mut padding_box_size, border_top_left) = cb_padding_box(cur);
+            if let Some((vw, vh)) = viewport_size_px {
+                if padding_box_size.0 <= Px::ZERO {
+                    padding_box_size.0 = vw.as_px();
                 }
-                body_fallback = Some(AbsCb {
-                    padding_box_size,
-                    border_top_left,
-                    parent_offset_in_cb_bp: (offset_x, offset_y),
-                });
+                if padding_box_size.1 <= Px::ZERO {
+                    padding_box_size.1 = vh.as_px();
+                }
             }
+            body_fallback = Some(AbsCb {
+                padding_box_size,
+                border_top_left,
+                parent_offset_in_cb_bp: (offset_x, offset_y),
+            });
         }
         offset_x += cur.final_layout.location.x;
         offset_y += cur.final_layout.location.y;

--- a/crates/fulgur/src/convert/pseudo.rs
+++ b/crates/fulgur/src/convert/pseudo.rs
@@ -210,41 +210,41 @@ pub(super) fn inject_inline_pseudo_images(
     before: Option<InlineImage>,
     after: Option<InlineImage>,
 ) {
-    if let Some(mut img) = before {
-        if let Some(first_line) = lines.first_mut() {
-            let shift = img.width;
-            for item in &mut first_line.items {
-                match item {
-                    LineItem::Text(run) => run.x_offset += shift,
-                    LineItem::Image(i) => i.x_offset += shift,
-                    LineItem::InlineBox(ib) => ib.x_offset += shift,
-                }
+    if let Some(mut img) = before
+        && let Some(first_line) = lines.first_mut()
+    {
+        let shift = img.width;
+        for item in &mut first_line.items {
+            match item {
+                LineItem::Text(run) => run.x_offset += shift,
+                LineItem::Image(i) => i.x_offset += shift,
+                LineItem::InlineBox(ib) => ib.x_offset += shift,
             }
-            img.x_offset = crate::units::Pt::ZERO;
-            first_line.items.insert(0, LineItem::Image(img));
         }
+        img.x_offset = crate::units::Pt::ZERO;
+        first_line.items.insert(0, LineItem::Image(img));
     }
-    if let Some(mut img) = after {
-        if let Some(last_line) = lines.last_mut() {
-            let last_end = last_line
-                .items
-                .iter()
-                .map(|item| match item {
-                    LineItem::Text(run) => {
-                        run.x_offset
-                            + run
-                                .glyphs
-                                .iter()
-                                .map(|g| g.x_advance * run.font_size)
-                                .sum::<crate::units::Pt>()
-                    }
-                    LineItem::Image(i) => i.x_offset + i.width,
-                    LineItem::InlineBox(ib) => ib.x_offset + ib.width,
-                })
-                .fold(crate::units::Pt::ZERO, crate::units::Pt::max);
-            img.x_offset = last_end;
-            last_line.items.push(LineItem::Image(img));
-        }
+    if let Some(mut img) = after
+        && let Some(last_line) = lines.last_mut()
+    {
+        let last_end = last_line
+            .items
+            .iter()
+            .map(|item| match item {
+                LineItem::Text(run) => {
+                    run.x_offset
+                        + run
+                            .glyphs
+                            .iter()
+                            .map(|g| g.x_advance * run.font_size)
+                            .sum::<crate::units::Pt>()
+                }
+                LineItem::Image(i) => i.x_offset + i.width,
+                LineItem::InlineBox(ib) => ib.x_offset + ib.width,
+            })
+            .fold(crate::units::Pt::ZERO, crate::units::Pt::max);
+        img.x_offset = last_end;
+        last_line.items.push(LineItem::Image(img));
     }
 }
 

--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -1361,10 +1361,10 @@ impl EngineBuilder {
         // When both base_path and assets are set, propagate the canonical
         // file:// base URL to the bundle so get_image can normalize
         // Stylo-resolved absolute file paths back to relative asset names.
-        if let (Some(bundle), Some(path)) = (&mut self.assets, &self.base_path) {
-            if let Some(url_str) = crate::blitz_adapter::canonical_directory_url(path) {
-                bundle.set_base_url(&url_str);
-            }
+        if let (Some(bundle), Some(path)) = (&mut self.assets, &self.base_path)
+            && let Some(url_str) = crate::blitz_adapter::canonical_directory_url(path)
+        {
+            bundle.set_base_url(&url_str);
         }
 
         Engine {

--- a/crates/fulgur/src/gcpm/counter.rs
+++ b/crates/fulgur/src/gcpm/counter.rs
@@ -540,10 +540,10 @@ pub fn resolve_element_policy<'a>(
 
     // Fallback: scan preceding pages for the most recent assignment.
     for prev in (0..page_idx).rev() {
-        if let Some(state) = page_states.get(prev).and_then(|s| s.get(name)) {
-            if let Some(&last_id) = state.instance_ids.last() {
-                return store.get_html(last_id);
-            }
+        if let Some(state) = page_states.get(prev).and_then(|s| s.get(name))
+            && let Some(&last_id) = state.instance_ids.last()
+        {
+            return store.get_html(last_id);
         }
     }
 
@@ -721,11 +721,11 @@ impl CounterState {
     /// growth across pages.
     pub fn reset(&mut self, name: &str, value: i32) {
         let stack = self.stacks.entry(name.to_string()).or_default();
-        if let Some(top) = stack.last_mut() {
-            if top.parent_id == COUNTER_ROOT_PARENT {
-                top.value = value;
-                return;
-            }
+        if let Some(top) = stack.last_mut()
+            && top.parent_id == COUNTER_ROOT_PARENT
+        {
+            top.value = value;
+            return;
         }
         stack.push(CounterInstance {
             parent_id: COUNTER_ROOT_PARENT,

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -240,24 +240,24 @@ impl<'i, 'a> QualifiedRuleParser<'i> for GcpmSheetParser<'a> {
             });
         }
 
-        if let Some(items) = content_items {
-            if let Some(pseudo) = pseudo {
-                self.content_counter_mappings.push(ContentCounterMapping {
-                    parsed: selector.clone(),
-                    pseudo,
-                    content: items,
-                });
-            }
+        if let Some(items) = content_items
+            && let Some(pseudo) = pseudo
+        {
+            self.content_counter_mappings.push(ContentCounterMapping {
+                parsed: selector.clone(),
+                pseudo,
+                content: items,
+            });
         }
 
-        if let Some(text) = static_content {
-            if let Some(pseudo) = pseudo {
-                self.static_content_mappings.push(StaticContentMapping {
-                    parsed: selector.clone(),
-                    pseudo,
-                    text,
-                });
-            }
+        if let Some(text) = static_content
+            && let Some(pseudo) = pseudo
+        {
+            self.static_content_mappings.push(StaticContentMapping {
+                parsed: selector.clone(),
+                pseudo,
+                text,
+            });
         }
 
         // Push a bookmark mapping when either `bookmark-level` or

--- a/crates/fulgur/src/gcpm/running.rs
+++ b/crates/fulgur/src/gcpm/running.rs
@@ -322,10 +322,10 @@ mod tests {
             return None;
         }
         let node = doc.get_node(node_id)?;
-        if let Some(elem) = node.element_data() {
-            if elem.name.local.as_ref() == tag {
-                return Some(node_id);
-            }
+        if let Some(elem) = node.element_data()
+            && elem.name.local.as_ref() == tag
+        {
+            return Some(node_id);
         }
         node.children
             .iter()

--- a/crates/fulgur/src/gcpm/string_set.rs
+++ b/crates/fulgur/src/gcpm/string_set.rs
@@ -96,13 +96,13 @@ fn collect_text(doc: &blitz_dom::BaseDocument, node_id: usize, out: &mut String,
     // Skip non-rendered subtrees so <script>/<style> bodies don't leak into
     // named strings when a broad selector (e.g. `body`) is used as the
     // string-set target.
-    if let Some(elem) = node.element_data() {
-        if matches!(
+    if let Some(elem) = node.element_data()
+        && matches!(
             elem.name.local.as_ref(),
             "head" | "script" | "style" | "link" | "meta" | "title" | "noscript"
-        ) {
-            return;
-        }
+        )
+    {
+        return;
     }
     match &node.data {
         blitz_dom::NodeData::Text(text_data) => out.push_str(&text_data.content),
@@ -134,6 +134,23 @@ fn normalize_whitespace(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `string-set` targets are often broad selectors (`body`, `html`), so
+    /// `collect_text` must not pull `<style>` / `<script>` bodies or `<head>`
+    /// metadata into the named string.
+    #[test]
+    fn extract_text_content_skips_non_rendered_subtrees() {
+        let html = "<html><head><title>TITLETEXT</title></head>\
+                    <body><style>p{color:HIDDENCSS}</style>\
+                    <script>var HIDDENJS = 1;</script>\
+                    <p>VISIBLETEXT</p></body></html>";
+        let doc = crate::blitz_adapter::parse(html, 600.0, &[]);
+        let text = extract_text_content(&doc, doc.root_element().id);
+        assert!(text.contains("VISIBLETEXT"), "body text missing: {text}");
+        assert!(!text.contains("HIDDENCSS"), "<style> leaked: {text}");
+        assert!(!text.contains("HIDDENJS"), "<script> leaked: {text}");
+        assert!(!text.contains("TITLETEXT"), "<head> leaked: {text}");
+    }
 
     #[test]
     fn test_string_set_store_basic() {

--- a/crates/fulgur/src/inspect.rs
+++ b/crates/fulgur/src/inspect.rs
@@ -547,51 +547,51 @@ fn extract_text_items(
                     ty = ctm[1] * tlm_e + ctm[3] * tlm_f + ctm[5];
                 }
                 "Tj" => {
-                    if let Some(text_obj) = operands.first() {
-                        if let Ok(bytes) = text_obj.as_str() {
-                            let text = decode_pdf_string(bytes);
-                            if !text.trim().is_empty() {
-                                let w = estimate_width(&text, font_size);
-                                text_bytes += text.len();
-                                items.push(TextItem {
-                                    page: page_num,
-                                    x: tx,
-                                    y: ty,
-                                    width: w,
-                                    height: font_size,
-                                    text,
-                                    font: font_name.to_string(),
-                                    font_size,
-                                });
-                                tx += w;
-                            }
+                    if let Some(text_obj) = operands.first()
+                        && let Ok(bytes) = text_obj.as_str()
+                    {
+                        let text = decode_pdf_string(bytes);
+                        if !text.trim().is_empty() {
+                            let w = estimate_width(&text, font_size);
+                            text_bytes += text.len();
+                            items.push(TextItem {
+                                page: page_num,
+                                x: tx,
+                                y: ty,
+                                width: w,
+                                height: font_size,
+                                text,
+                                font: font_name.to_string(),
+                                font_size,
+                            });
+                            tx += w;
                         }
                     }
                 }
                 "TJ" => {
-                    if let Some(array_obj) = operands.first() {
-                        if let Ok(array) = array_obj.as_array() {
-                            let mut combined = String::new();
-                            for elem in array {
-                                if let Ok(bytes) = elem.as_str() {
-                                    combined.push_str(&decode_pdf_string(bytes));
-                                }
+                    if let Some(array_obj) = operands.first()
+                        && let Ok(array) = array_obj.as_array()
+                    {
+                        let mut combined = String::new();
+                        for elem in array {
+                            if let Ok(bytes) = elem.as_str() {
+                                combined.push_str(&decode_pdf_string(bytes));
                             }
-                            if !combined.trim().is_empty() {
-                                let w = estimate_width(&combined, font_size);
-                                text_bytes += combined.len();
-                                items.push(TextItem {
-                                    page: page_num,
-                                    x: tx,
-                                    y: ty,
-                                    width: w,
-                                    height: font_size,
-                                    text: combined,
-                                    font: font_name.to_string(),
-                                    font_size,
-                                });
-                                tx += w;
-                            }
+                        }
+                        if !combined.trim().is_empty() {
+                            let w = estimate_width(&combined, font_size);
+                            text_bytes += combined.len();
+                            items.push(TextItem {
+                                page: page_num,
+                                x: tx,
+                                y: ty,
+                                width: w,
+                                height: font_size,
+                                text: combined,
+                                font: font_name.to_string(),
+                                font_size,
+                            });
+                            tx += w;
                         }
                     }
                 }
@@ -648,17 +648,17 @@ fn resolve_page_resources(
             Ok(lopdf::Object::Dictionary(d)) => d,
             _ => return None,
         };
-        if let Ok(res) = dict.get(b"Resources") {
-            if let Ok((id, lopdf::Object::Dictionary(resources))) = doc.dereference(res) {
-                let origin = match id {
-                    // `/Resources N 0 R`: the dictionary *is* object N.
-                    Some(id) => ResourcesOrigin::Object(id),
-                    // A direct dictionary nested inside the object being examined
-                    // — whether that is the page itself or an ancestor node.
-                    None => ResourcesOrigin::DirectIn(owner_id),
-                };
-                return Some((origin, resources));
-            }
+        if let Ok(res) = dict.get(b"Resources")
+            && let Ok((id, lopdf::Object::Dictionary(resources))) = doc.dereference(res)
+        {
+            let origin = match id {
+                // `/Resources N 0 R`: the dictionary *is* object N.
+                Some(id) => ResourcesOrigin::Object(id),
+                // A direct dictionary nested inside the object being examined
+                // — whether that is the page itself or an ancestor node.
+                None => ResourcesOrigin::DirectIn(owner_id),
+            };
+            return Some((origin, resources));
         }
         // Following `/Parent` is a hop against the same budget, so a chain of
         // ancestors and a chain of aliases cannot be spent independently.
@@ -765,39 +765,39 @@ fn collect_image_xobjects(
     budget: &mut usize,
 ) -> (ImageXObjects, bool) {
     let mut image_xobjects = ImageXObjects::new();
-    if let Ok(xo) = resources.get(b"XObject") {
-        if let Ok((_, lopdf::Object::Dictionary(xobjects))) = doc.dereference(xo) {
-            for (name, obj_ref) in xobjects.iter() {
-                // Charged before the dereference and the name clone below, so an
-                // over-budget dictionary stops partway instead of completing.
-                *budget = budget.saturating_sub(PDF_CONTENT_STREAM_COST_FLOOR_BYTES);
-                if *budget == 0 {
-                    return (image_xobjects, false);
-                }
-                if let Ok((_, lopdf::Object::Stream(xobj))) = doc.dereference(obj_ref) {
-                    let subtype = xobj
+    if let Ok(xo) = resources.get(b"XObject")
+        && let Ok((_, lopdf::Object::Dictionary(xobjects))) = doc.dereference(xo)
+    {
+        for (name, obj_ref) in xobjects.iter() {
+            // Charged before the dereference and the name clone below, so an
+            // over-budget dictionary stops partway instead of completing.
+            *budget = budget.saturating_sub(PDF_CONTENT_STREAM_COST_FLOOR_BYTES);
+            if *budget == 0 {
+                return (image_xobjects, false);
+            }
+            if let Ok((_, lopdf::Object::Stream(xobj))) = doc.dereference(obj_ref) {
+                let subtype = xobj
+                    .dict
+                    .get(b"Subtype")
+                    .ok()
+                    .and_then(|o| obj_as_name_str(o))
+                    .unwrap_or_default();
+                if subtype == "Image" {
+                    let fmt = detect_image_format(&xobj.dict);
+                    let w_px = xobj
                         .dict
-                        .get(b"Subtype")
+                        .get(b"Width")
                         .ok()
-                        .and_then(|o| obj_as_name_str(o))
-                        .unwrap_or_default();
-                    if subtype == "Image" {
-                        let fmt = detect_image_format(&xobj.dict);
-                        let w_px = xobj
-                            .dict
-                            .get(b"Width")
-                            .ok()
-                            .and_then(|o| o.as_i64().ok())
-                            .unwrap_or(0) as u32;
-                        let h_px = xobj
-                            .dict
-                            .get(b"Height")
-                            .ok()
-                            .and_then(|o| o.as_i64().ok())
-                            .unwrap_or(0) as u32;
-                        let name_str = String::from_utf8_lossy(name).into_owned();
-                        image_xobjects.insert(name_str, (fmt, w_px, h_px));
-                    }
+                        .and_then(|o| o.as_i64().ok())
+                        .unwrap_or(0) as u32;
+                    let h_px = xobj
+                        .dict
+                        .get(b"Height")
+                        .ok()
+                        .and_then(|o| o.as_i64().ok())
+                        .unwrap_or(0) as u32;
+                    let name_str = String::from_utf8_lossy(name).into_owned();
+                    image_xobjects.insert(name_str, (fmt, w_px, h_px));
                 }
             }
         }
@@ -935,48 +935,47 @@ fn extract_image_items(
                     *ctm_stack.last_mut().unwrap() = concat_matrix(&current, &new_m);
                 }
                 "Do" => {
-                    if let Some(name_obj) = op.operands.first() {
-                        if let Some(name) = obj_as_name_str(name_obj) {
-                            if let Some((fmt, w_px, h_px)) = image_xobjects.get(name) {
-                                let ctm = ctm_stack.last().unwrap_or(&identity);
-                                // PDF images occupy the unit square [0,1]x[0,1].
-                                // Transform all 4 corners through the CTM and take
-                                // the axis-aligned bounding box so rotated/sheared
-                                // images produce correct width/height.
-                                let corners = [
-                                    transform_point(ctm, 0.0, 0.0),
-                                    transform_point(ctm, 1.0, 0.0),
-                                    transform_point(ctm, 0.0, 1.0),
-                                    transform_point(ctm, 1.0, 1.0),
-                                ];
-                                let min_x = corners
-                                    .iter()
-                                    .map(|(x, _)| *x)
-                                    .fold(f32::INFINITY, f32::min);
-                                let max_x = corners
-                                    .iter()
-                                    .map(|(x, _)| *x)
-                                    .fold(f32::NEG_INFINITY, f32::max);
-                                let min_y = corners
-                                    .iter()
-                                    .map(|(_, y)| *y)
-                                    .fold(f32::INFINITY, f32::min);
-                                let max_y = corners
-                                    .iter()
-                                    .map(|(_, y)| *y)
-                                    .fold(f32::NEG_INFINITY, f32::max);
-                                items.push(ImageItem {
-                                    page: page_num,
-                                    x: min_x,
-                                    y: min_y,
-                                    width: max_x - min_x,
-                                    height: max_y - min_y,
-                                    format: fmt.clone(),
-                                    width_px: *w_px,
-                                    height_px: *h_px,
-                                });
-                            }
-                        }
+                    if let Some(name_obj) = op.operands.first()
+                        && let Some(name) = obj_as_name_str(name_obj)
+                        && let Some((fmt, w_px, h_px)) = image_xobjects.get(name)
+                    {
+                        let ctm = ctm_stack.last().unwrap_or(&identity);
+                        // PDF images occupy the unit square [0,1]x[0,1].
+                        // Transform all 4 corners through the CTM and take
+                        // the axis-aligned bounding box so rotated/sheared
+                        // images produce correct width/height.
+                        let corners = [
+                            transform_point(ctm, 0.0, 0.0),
+                            transform_point(ctm, 1.0, 0.0),
+                            transform_point(ctm, 0.0, 1.0),
+                            transform_point(ctm, 1.0, 1.0),
+                        ];
+                        let min_x = corners
+                            .iter()
+                            .map(|(x, _)| *x)
+                            .fold(f32::INFINITY, f32::min);
+                        let max_x = corners
+                            .iter()
+                            .map(|(x, _)| *x)
+                            .fold(f32::NEG_INFINITY, f32::max);
+                        let min_y = corners
+                            .iter()
+                            .map(|(_, y)| *y)
+                            .fold(f32::INFINITY, f32::min);
+                        let max_y = corners
+                            .iter()
+                            .map(|(_, y)| *y)
+                            .fold(f32::NEG_INFINITY, f32::max);
+                        items.push(ImageItem {
+                            page: page_num,
+                            x: min_x,
+                            y: min_y,
+                            width: max_x - min_x,
+                            height: max_y - min_y,
+                            format: fmt.clone(),
+                            width_px: *w_px,
+                            height_px: *h_px,
+                        });
                     }
                 }
                 _ => {}

--- a/crates/fulgur/src/lib.rs
+++ b/crates/fulgur/src/lib.rs
@@ -1,14 +1,3 @@
-// MSRV 1.89 newly enables clippy's MSRV-gated `collapsible_if` suggestion
-// for let-chains (stabilized in Rust 1.88), firing on ~60 pre-existing
-// nested if-let sites across this crate. Suppressed here to keep the MSRV
-// bump (PR #701) a mechanical version-number change rather than a large
-// reindent across 12+ files; tracked for a follow-up migration in
-// fulgur-pt70. (A second lint, `manual_is_multiple_of`, hit 5 sites too,
-// but that one isn't in clippy's table at our 1.89 MSRV floor — `#[allow]`ing
-// an unknown lint is itself a hard error under `-D warnings` on that exact
-// toolchain, so those 5 sites were fixed directly instead of suppressed.)
-#![allow(clippy::collapsible_if)]
-
 /// Maximum DOM tree depth before recursion is cut off. Prevents stack overflow
 /// from pathologically deep HTML input.
 pub(crate) const MAX_DOM_DEPTH: usize = 512;

--- a/crates/fulgur/src/multicol_layout.rs
+++ b/crates/fulgur/src/multicol_layout.rs
@@ -1761,13 +1761,11 @@ mod tests {
         fn find_by_id(doc: &BaseDocument, id: &str) -> Option<usize> {
             fn walk(doc: &BaseDocument, node_id: usize, target: &str) -> Option<usize> {
                 let node = doc.get_node(node_id)?;
-                if let Some(ed) = node.element_data() {
-                    if let Some(attr_id) = ed.attrs().iter().find(|a| a.name.local.as_ref() == "id")
-                    {
-                        if attr_id.value.as_str() == target {
-                            return Some(node_id);
-                        }
-                    }
+                if let Some(ed) = node.element_data()
+                    && let Some(attr_id) = ed.attrs().iter().find(|a| a.name.local.as_ref() == "id")
+                    && attr_id.value.as_str() == target
+                {
+                    return Some(node_id);
                 }
                 for &child in &node.children {
                     if let Some(found) = walk(doc, child, target) {

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -3236,13 +3236,12 @@ fn fragment_block_subtree_inner(
             if !is_float {
                 prev_used_page = Some(used_end.clone());
             }
-            if let Some(ref mut rs) = row_state {
-                if page_index > rs.max_end_page
-                    || (page_index == rs.max_end_page && cursor_y > rs.max_end_cursor_y)
-                {
-                    rs.max_end_page = page_index;
-                    rs.max_end_cursor_y = cursor_y;
-                }
+            if let Some(ref mut rs) = row_state
+                && (page_index > rs.max_end_page
+                    || (page_index == rs.max_end_page && cursor_y > rs.max_end_cursor_y))
+            {
+                rs.max_end_page = page_index;
+                rs.max_end_cursor_y = cursor_y;
             }
             continue;
         }
@@ -3339,13 +3338,12 @@ fn fragment_block_subtree_inner(
         if !is_float {
             prev_used_page = Some(used_end.clone());
         }
-        if let Some(ref mut rs) = row_state {
-            if page_index > rs.max_end_page
-                || (page_index == rs.max_end_page && cursor_y > rs.max_end_cursor_y)
-            {
-                rs.max_end_page = page_index;
-                rs.max_end_cursor_y = cursor_y;
-            }
+        if let Some(ref mut rs) = row_state
+            && (page_index > rs.max_end_page
+                || (page_index == rs.max_end_page && cursor_y > rs.max_end_cursor_y))
+        {
+            rs.max_end_page = page_index;
+            rs.max_end_cursor_y = cursor_y;
         }
     }
 

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -3547,10 +3547,10 @@ fn build_metadata(config: &Config, html_title: Option<&str>) -> krilla::metadata
     if let Some(ref producer) = config.producer {
         metadata = metadata.producer(producer.clone());
     }
-    if let Some(ref date_str) = config.creation_date {
-        if let Some(dt) = parse_datetime(date_str) {
-            metadata = metadata.creation_date(dt);
-        }
+    if let Some(ref date_str) = config.creation_date
+        && let Some(dt) = parse_datetime(date_str)
+    {
+        metadata = metadata.creation_date(dt);
     }
     metadata
 }
@@ -3970,16 +3970,10 @@ impl<'a> MarginBoxRenderer<'a> {
             }
 
             if let Some((drawables, geometry)) = self.render_cache.get(&cache_key) {
-                if let Some(root_id) = drawables.root_id {
-                    if let Some(root_block) = drawables.block_styles.get(&root_id) {
-                        paint_root_block_v2(
-                            canvas,
-                            root_block,
-                            rect.x.to_f32(),
-                            rect.y.to_f32(),
-                            None,
-                        );
-                    }
+                if let Some(root_id) = drawables.root_id
+                    && let Some(root_block) = drawables.block_styles.get(&root_id)
+                {
+                    paint_root_block_v2(canvas, root_block, rect.x.to_f32(), rect.y.to_f32(), None);
                 }
                 // `body_offset_pt` is (0, 0) here because the wrapper HTML fixes
                 // `body { margin: 0; padding: 0; }` via an inline style, which
@@ -4034,22 +4028,21 @@ fn get_body_child_dimension(doc: &blitz_html::HtmlDocument, use_width: bool) -> 
     let px: f32 = 'outer: {
         if let Some(root_node) = base_doc.get_node(root.id) {
             for &child_id in &root_node.children {
-                if let Some(child) = base_doc.get_node(child_id) {
-                    if let blitz_dom::NodeData::Element(elem) = &child.data {
-                        if elem.name.local.as_ref() == "body" {
-                            for &body_child_id in &child.children {
-                                if let Some(body_child) = base_doc.get_node(body_child_id) {
-                                    let size = &body_child.final_layout.size;
-                                    let v = if use_width { size.width } else { size.height };
-                                    if v > 0.0 {
-                                        break 'outer v;
-                                    }
-                                }
+                if let Some(child) = base_doc.get_node(child_id)
+                    && let blitz_dom::NodeData::Element(elem) = &child.data
+                    && elem.name.local.as_ref() == "body"
+                {
+                    for &body_child_id in &child.children {
+                        if let Some(body_child) = base_doc.get_node(body_child_id) {
+                            let size = &body_child.final_layout.size;
+                            let v = if use_width { size.width } else { size.height };
+                            if v > 0.0 {
+                                break 'outer v;
                             }
-                            let size = &child.final_layout.size;
-                            break 'outer if use_width { size.width } else { size.height };
                         }
                     }
+                    let size = &child.final_layout.size;
+                    break 'outer if use_width { size.width } else { size.height };
                 }
             }
         }
@@ -4106,16 +4099,14 @@ fn build_struct_tree(
         if heading_titles.contains_key(&node_id) {
             continue;
         }
-        if let Some(entry) = drawables.semantics.get(&node_id) {
-            if matches!(entry.tag, crate::tagging::PdfTag::H { .. }) {
-                if let Some(title) = drawables
-                    .paragraphs
-                    .get(&node_id)
-                    .and_then(heading_title_of)
-                {
-                    heading_titles.insert(node_id, title);
-                }
-            }
+        if let Some(entry) = drawables.semantics.get(&node_id)
+            && matches!(entry.tag, crate::tagging::PdfTag::H { .. })
+            && let Some(title) = drawables
+                .paragraphs
+                .get(&node_id)
+                .and_then(heading_title_of)
+        {
+            heading_titles.insert(node_id, title);
         }
     }
 
@@ -4270,6 +4261,27 @@ mod tests {
     #[test]
     fn escape_attr_empty_string() {
         assert_eq!(escape_attr(""), "");
+    }
+
+    // --- get_body_child_dimension ---
+
+    /// A margin box whose content produces no laid-out body child (an empty
+    /// `content` string) must fall back to the body box itself rather than
+    /// measuring 0 — otherwise the edge distribution in `compute_edge_layout`
+    /// would collapse the box.
+    #[test]
+    fn get_body_child_dimension_falls_back_to_body_box() {
+        let mut doc = crate::blitz_adapter::parse(
+            r#"<html><body style="width:200px;height:50px"></body></html>"#,
+            400.0,
+            &[],
+        );
+        crate::blitz_adapter::resolve(&mut doc);
+        // 200 CSS px -> 150 pt, 50 CSS px -> 37.5 pt.
+        let w = get_body_child_dimension(&doc, true).to_f32();
+        let h = get_body_child_dimension(&doc, false).to_f32();
+        assert!((w - 150.0).abs() < 0.01, "width fallback: {w}");
+        assert!((h - 37.5).abs() < 0.01, "height fallback: {h}");
     }
 
     // --- strip_display_none ---

--- a/crates/fulgur/src/schema.rs
+++ b/crates/fulgur/src/schema.rs
@@ -142,16 +142,16 @@ fn extract_var_names(expr: &ast::Expr<'_>) -> Vec<String> {
 
 /// Accumulate `set`/`setblock` variable bindings from a statement into the scope.
 fn accumulate_set_in_scope(stmt: &ast::Stmt<'_>, scope: &mut Scope) {
-    if let ast::Stmt::Set(s) = stmt {
-        if let ast::Expr::Var(v) = &s.target {
-            let rhs_path = resolve_expr_path(&s.expr, scope).unwrap_or_default();
-            scope.insert(v.id.to_string(), rhs_path);
-        }
+    if let ast::Stmt::Set(s) = stmt
+        && let ast::Expr::Var(v) = &s.target
+    {
+        let rhs_path = resolve_expr_path(&s.expr, scope).unwrap_or_default();
+        scope.insert(v.id.to_string(), rhs_path);
     }
-    if let ast::Stmt::SetBlock(sb) = stmt {
-        if let ast::Expr::Var(v) = &sb.target {
-            scope.insert(v.id.to_string(), vec![]);
-        }
+    if let ast::Stmt::SetBlock(sb) = stmt
+        && let ast::Expr::Var(v) = &sb.target
+    {
+        scope.insert(v.id.to_string(), vec![]);
     }
 }
 

--- a/crates/fulgur/src/template.rs
+++ b/crates/fulgur/src/template.rs
@@ -53,32 +53,29 @@ fn format_filter(value: &minijinja::Value, spec: &str) -> String {
     }
 
     // ",.Nf" — comma + N decimal places
-    if let Some(rest) = spec.strip_prefix(',') {
-        if let Some(prec_str) = rest.strip_prefix('.').and_then(|s| s.strip_suffix('f')) {
-            if let Ok(prec) = prec_str.parse::<usize>() {
-                if let Some(f) = as_f64 {
-                    return insert_commas(&format!("{:.prec$}", f));
-                }
-            }
-        }
+    if let Some(rest) = spec.strip_prefix(',')
+        && let Some(prec_str) = rest.strip_prefix('.').and_then(|s| s.strip_suffix('f'))
+        && let Ok(prec) = prec_str.parse::<usize>()
+        && let Some(f) = as_f64
+    {
+        return insert_commas(&format!("{:.prec$}", f));
     }
 
     // ".Nf" — N decimal places
-    if let Some(inner) = spec.strip_prefix('.').and_then(|s| s.strip_suffix('f')) {
-        if let Ok(prec) = inner.parse::<usize>() {
-            if let Some(f) = as_f64 {
-                return format!("{:.prec$}", f);
-            }
-        }
+    if let Some(inner) = spec.strip_prefix('.').and_then(|s| s.strip_suffix('f'))
+        && let Ok(prec) = inner.parse::<usize>()
+        && let Some(f) = as_f64
+    {
+        return format!("{:.prec$}", f);
     }
 
     // "0Nd" — zero-padded integer
-    if spec.starts_with('0') && spec.ends_with('d') {
-        if let Ok(width) = spec[..spec.len() - 1].parse::<usize>() {
-            if let Some(n) = as_i64 {
-                return format!("{:0width$}", n);
-            }
-        }
+    if spec.starts_with('0')
+        && spec.ends_with('d')
+        && let Ok(width) = spec[..spec.len() - 1].parse::<usize>()
+        && let Some(n) = as_i64
+    {
+        return format!("{:0width$}", n);
     }
 
     value.to_string()


### PR DESCRIPTION
## 概要

`fulgur-pt70`。MSRV 1.89 bump (#701) で有効になった `clippy::collapsible_if` を、一時的な `#[allow]` で黙らせていたのを解消する。ネストした `if let` 63 箇所を edition 2024 の let-chain に畳み、suppression を全撤去した。

撤去した suppression:

- `crates/fulgur/src/lib.rs` の crate-level `#![allow(clippy::collapsible_if)]`（説明コメント9行込み）
- `crates/fulgur-wpt/src/fonts.rs::walk` の関数単位 `#[allow]`
- `crates/fulgur-wpt/src/render.rs::render_test` の関数単位 `#[allow]`

## レビュー中に追加したハーデニング（`crates/fulgur-wpt/src/render.rs`）

`render_test`/`remove_stale_pngs` の PNG ファイル絞り込みロジックが CodeRabbit のレビューで 3 点指摘され、都度対応した。当初の let-chain 化のみの diff から見るとスコープが広がっているが、いずれも同一ファイル・同一関数群への直接指摘であり、対応の過程で切り出した `list_page_pngs` に集約されている。

1. `remove_stale_pngs` 内でファイル名の絞り込み（scope）と削除実行＋エラー分類（action）が 1 つの let-chain に混在していた点を、scope pass → action pass の 2 段階に分離。
2. `remove_stale_pngs` と `render_test` の PNG 列挙ロジックが重複していた点を `list_page_pngs` ヘルパーへ統合。あわせて `render_test` 側が `filter_map(|e| e.ok())` で `ReadDir` のエントリエラーを握りつぶしていた挙動を修正し、両呼び出し元とも `remove_stale_pngs` の既存方針（fail loud）に統一した。各呼び出し元は `stem` 計算のエラーポリシー（`unwrap_or_default` vs `ok_or_else(...)?`）のみ元のまま維持している。
3. `<stem>-<n>.png` の `<n>` 部分が数値以外にもマッチしていた点（例: `page-preview.png` のような人手のデバッグ用ファイル）を、非空の ASCII 数字列のみ許容するよう限定。誤削除／誤ページカウントを防止。

各対応はユニットテスト（`removes_only_matching_stale_pngs` / `propagates_removal_failure` / `propagates_read_dir_failure`）で固定済み。詳細は該当コミットと PR 上の CodeRabbit スレッドを参照。

## なぜテストが付いているか

fulgur-wpt の 2 箇所が #701 で collapse されずに suppress されたのは、**再インデントによって未テストの error branch が codecov の patch に入ってしまう**のが理由だった。なので先にテストを足してから畳んでいる。

- `render_test` から `remove_stale_pngs()` を純関数として切り出し、ユニットテスト 3 本（`page-*.png` の絞り込み / 非 `NotFound` エラーの伝播 / `read_dir` 失敗）
- `fonts.rs::walk` の `add_font_file` エラー分岐に 1 本（WOFF1 magic のファイルは `UnsupportedFontFormat` で弾かれ、walker は log して走査を続ける）

同じ理由で、core library 側にも再インデントで patch に入る既存の未カバー行が 3 箇所あったので、それぞれ振る舞いを固定するテストを追加した。

- `rewrite_marker_content_url` の at-rule スタック pop — minify された `}}` の形だけが top-level の閉じ括弧分岐に到達する（空白区切りの形は selector スキャナに食われて到達しない）
- `collect_text` の非レンダリングサブツリー skip（`<head>` / `<style>` / `<script>`）
- `get_body_child_dimension` の body ボックスへのフォールバック

## 検証

| ゲート | 結果 |
| --- | --- |
| `cargo fmt --all --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | 警告 0（ローカル 1.97.1 と CI の stable = 1.96.0 の両方で確認） |
| `cargo nextest run --workspace --exclude fulgur-vrt` | 2616 passed |
| VRT（golden PDF のバイト比較） | 全 pass |
| `cargo check --target wasm32-unknown-unknown -p fulgur -p fulgur-wasm` | ok |
| `cargo clippy -p pyfulgur --features extension-module` / `-p fulgur-ruby --features ruby-api` | 警告 0 |
| `cargo clippy -p fulgur --features parallel`（CI 未カバーだが確認） | 警告 0 |
| patch coverage（CI と同じ二重 `cargo llvm-cov nextest` で実測） | 99.57%（project base 96.30%） |
| MSRV 1.89.0 + edition 2024 での let-chain コンパイル | 実機確認済み |

**VRT が byte-identical に通っている**のが振る舞い不変の一番強い根拠。加えて、let-chain 化で唯一意味論が変わりうる「一時変数の drop タイミング」について diff 全体を `.borrow()` / `.borrow_mut()` / `.lock()` / `.read()` / `.write()` / `Guard` で走査したが該当なし。`clippy::collapsible_if` は内側 `if` に `else` が無く、かつ外側ブロックに後続文が無い場合しか発火しないので、それ以外の畳み込みは意味論的に同一。

上記のレビュー対応ハーデニング（`list_page_pngs` 統合とエラーポリシー変更）は 2026-08-30 の push 後に別途 CI green（全 29 チェック）を確認済み。

## 残した既知の未カバー

`crates/fulgur/src/convert/inline_root.rs` の `convert_inline_box_node` にある absolutely-positioned pseudo 抑制分岐（2 行）はカバーできていない。`p::before` / `p::after` / `span::before` / inline-block `div::before` の 4 パターンを `position: absolute` で probe したが、いずれもこの分岐に到達しなかったため、安価にテストできないと判断して現状維持とした。patch coverage 99.57% には影響していない。

## レビュー観点

- 63 箇所は `cargo clippy --fix` の機械適用（警告が出なくなるまで反復）＋ `cargo fmt` で、全 hunk を目視レビュー済み。手で書き換えた箇所は無い。
- collapse で失われたコメントが無いことを diff の削除/追加コメント行の差集合で確認済み（消えたのは suppression の説明コメントのみ）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **不具合修正**
  * WOFF1フォントの読み込み失敗後も、他のフォント処理を継続するよう改善しました。
  * 外部CSSの段組み指定や圧縮CSSのメディアクエリを正しく反映するよう修正しました。
  * 分割テーブル、空のbody、複数ページのマルチカラムレイアウトを改善しました。
  * ページ番号ではない画像ファイルを誤って処理しないよう改善しました。
  * 非表示要素の内容が名前付き文字列へ混入する問題を防止しました。

* **テスト**
  * フォント、CSS、画像整理、文字列抽出、レイアウトに関する検証を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
