### PR TITLE
test(pagination_layout): add coverage for collect_counter_states and is_split

### DIFF
--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -7090,4 +7090,203 @@ h2 { string-set: chapter-title content(text); }
             "zero page height must leave geometry table empty"
         );
     }
+
+    // ── PaginationGeometry::is_split ──────────────────────────────────────────
+
+    #[test]
+    fn is_split_empty_fragments_returns_false() {
+        let geom = PaginationGeometry::default();
+        assert!(!geom.is_split());
+    }
+
+    #[test]
+    fn is_split_single_fragment_not_repeat_returns_false() {
+        let mut geom = PaginationGeometry::default();
+        geom.fragments.push(Fragment {
+            page_index: 0,
+            x: 0.0_f32.as_px(),
+            y: 0.0_f32.as_px(),
+            width: 100.0_f32.as_px(),
+            height: 50.0_f32.as_px(),
+        });
+        assert!(!geom.is_split());
+    }
+
+    #[test]
+    fn is_split_two_fragments_not_repeat_returns_true() {
+        let mut geom = PaginationGeometry::default();
+        for page in [0_u32, 1] {
+            geom.fragments.push(Fragment {
+                page_index: page,
+                x: 0.0_f32.as_px(),
+                y: 0.0_f32.as_px(),
+                width: 100.0_f32.as_px(),
+                height: 50.0_f32.as_px(),
+            });
+        }
+        assert!(geom.is_split());
+    }
+
+    #[test]
+    fn is_split_two_fragments_is_repeat_returns_false() {
+        let mut geom = PaginationGeometry {
+            is_repeat: true,
+            ..Default::default()
+        };
+        for page in [0_u32, 1] {
+            geom.fragments.push(Fragment {
+                page_index: page,
+                x: 0.0_f32.as_px(),
+                y: 0.0_f32.as_px(),
+                width: 100.0_f32.as_px(),
+                height: 50.0_f32.as_px(),
+            });
+        }
+        assert!(
+            !geom.is_split(),
+            "is_repeat=true prevents split classification"
+        );
+    }
+
+    // ── collect_counter_states ───────────────────────────────────────────────
+
+    #[test]
+    fn counter_states_empty_geometry_returns_one_empty_page() {
+        let geom = PaginationGeometryTable::new();
+        let ops: BTreeMap<usize, Vec<crate::gcpm::CounterOp>> = BTreeMap::new();
+        let states = collect_counter_states(&geom, &ops);
+        assert_eq!(states.len(), 1);
+        assert!(states[0].is_empty());
+    }
+
+    #[test]
+    fn counter_states_reset_op_sets_counter_value() {
+        let mut geom = PaginationGeometryTable::new();
+        geom.entry(10).or_default().fragments.push(Fragment {
+            page_index: 0,
+            x: 0.0_f32.as_px(),
+            y: 0.0_f32.as_px(),
+            width: 100.0_f32.as_px(),
+            height: 50.0_f32.as_px(),
+        });
+        let mut ops: BTreeMap<usize, Vec<crate::gcpm::CounterOp>> = BTreeMap::new();
+        ops.insert(
+            10,
+            vec![crate::gcpm::CounterOp::Reset {
+                name: "chapter".into(),
+                value: 3,
+            }],
+        );
+        let states = collect_counter_states(&geom, &ops);
+        assert_eq!(states.len(), 1);
+        assert_eq!(states[0].get("chapter").copied(), Some(3));
+    }
+
+    #[test]
+    fn counter_states_increment_op_adds_to_counter() {
+        let mut geom = PaginationGeometryTable::new();
+        for (node_id, page) in [(10_usize, 0_u32), (20, 0)] {
+            geom.entry(node_id).or_default().fragments.push(Fragment {
+                page_index: page,
+                x: 0.0_f32.as_px(),
+                y: 0.0_f32.as_px(),
+                width: 100.0_f32.as_px(),
+                height: 50.0_f32.as_px(),
+            });
+        }
+        let mut ops: BTreeMap<usize, Vec<crate::gcpm::CounterOp>> = BTreeMap::new();
+        ops.insert(
+            10,
+            vec![crate::gcpm::CounterOp::Reset {
+                name: "chapter".into(),
+                value: 0,
+            }],
+        );
+        ops.insert(
+            20,
+            vec![crate::gcpm::CounterOp::Increment {
+                name: "chapter".into(),
+                value: 1,
+            }],
+        );
+        let states = collect_counter_states(&geom, &ops);
+        assert_eq!(states.len(), 1);
+        assert_eq!(states[0].get("chapter").copied(), Some(1));
+    }
+
+    #[test]
+    fn counter_states_set_op_forces_counter_value() {
+        let mut geom = PaginationGeometryTable::new();
+        geom.entry(10).or_default().fragments.push(Fragment {
+            page_index: 0,
+            x: 0.0_f32.as_px(),
+            y: 0.0_f32.as_px(),
+            width: 100.0_f32.as_px(),
+            height: 50.0_f32.as_px(),
+        });
+        let mut ops: BTreeMap<usize, Vec<crate::gcpm::CounterOp>> = BTreeMap::new();
+        ops.insert(
+            10,
+            vec![
+                crate::gcpm::CounterOp::Reset {
+                    name: "idx".into(),
+                    value: 99,
+                },
+                crate::gcpm::CounterOp::Set {
+                    name: "idx".into(),
+                    value: 7,
+                },
+            ],
+        );
+        let states = collect_counter_states(&geom, &ops);
+        assert_eq!(states.len(), 1);
+        assert_eq!(states[0].get("idx").copied(), Some(7));
+    }
+
+    #[test]
+    fn counter_states_carries_across_pages() {
+        let mut geom = PaginationGeometryTable::new();
+        geom.entry(10).or_default().fragments.push(Fragment {
+            page_index: 0,
+            x: 0.0_f32.as_px(),
+            y: 0.0_f32.as_px(),
+            width: 100.0_f32.as_px(),
+            height: 50.0_f32.as_px(),
+        });
+        geom.entry(20).or_default().fragments.push(Fragment {
+            page_index: 1,
+            x: 0.0_f32.as_px(),
+            y: 0.0_f32.as_px(),
+            width: 100.0_f32.as_px(),
+            height: 50.0_f32.as_px(),
+        });
+        let mut ops: BTreeMap<usize, Vec<crate::gcpm::CounterOp>> = BTreeMap::new();
+        ops.insert(
+            10,
+            vec![crate::gcpm::CounterOp::Reset {
+                name: "chapter".into(),
+                value: 1,
+            }],
+        );
+        let states = collect_counter_states(&geom, &ops);
+        assert_eq!(states.len(), 2);
+        assert_eq!(states[0].get("chapter").copied(), Some(1));
+        assert_eq!(states[1].get("chapter").copied(), Some(1));
+    }
+
+    #[test]
+    fn counter_states_node_without_ops_is_skipped() {
+        let mut geom = PaginationGeometryTable::new();
+        geom.entry(99).or_default().fragments.push(Fragment {
+            page_index: 0,
+            x: 0.0_f32.as_px(),
+            y: 0.0_f32.as_px(),
+            width: 100.0_f32.as_px(),
+            height: 50.0_f32.as_px(),
+        });
+        let ops: BTreeMap<usize, Vec<crate::gcpm::CounterOp>> = BTreeMap::new();
+        let states = collect_counter_states(&geom, &ops);
+        assert_eq!(states.len(), 1);
+        assert!(states[0].is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

`pagination_layout.rs` のカバレッジ改善を目的とした自動カバレッジ追加 PR です（定期スケジュールタスク `coverage/<module>-YYYY-MM-DD` による）。

`collect_counter_states` の `CounterOp::Reset / Increment / Set` マッチアーム、および `PaginationGeometry::is_split()` の `is_repeat=true` ブランチが既存テストでまったく実行されていなかったため、対象の純関数に対してユニットテストを追加しました。プロダクションコードの変更はありません。

## Changes

- `pagination_layout::tests` に 10 個のテストを追加:
  - `is_split_empty_fragments_returns_false` — 空フラグメント + `is_repeat=false` → `false`
  - `is_split_single_fragment_not_repeat_returns_false` — 単一フラグメント + `is_repeat=false` → `false`
  - `is_split_two_fragments_not_repeat_returns_true` — 2 フラグメント + `is_repeat=false` → `true`
  - `is_split_two_fragments_is_repeat_returns_false` — 2 フラグメント + `is_repeat=true` → `false`（ここが未カバーブランチ）
  - `counter_states_empty_geometry_returns_one_empty_page` — 空ジオメトリ → 1 ページ分の空スナップショット
  - `counter_states_reset_op_sets_counter_value` — `CounterOp::Reset` アームを実行
  - `counter_states_increment_op_adds_to_counter` — `CounterOp::Increment` アームを実行
  - `counter_states_set_op_forces_counter_value` — `CounterOp::Set` アームを実行
  - `counter_states_carries_across_pages` — ページをまたぐキャリー動作を検証
  - `counter_states_node_without_ops_is_skipped` — ops マップにないノードをスキップするブランチを実行

カバレッジ変化（`pagination_layout.rs`）：regions 95.76% → 96.02%（未カバー regions: 241 → 235）

## Test plan

- [x] `cargo test -p fulgur --lib` — 2024 テスト全通過（うち新規 10 テスト）
- [x] `cargo clippy -p fulgur -- -D warnings` — 警告なし
- [x] `cargo fmt --check -p fulgur` — 差分なし
- [ ] `npx markdownlint-cli2 '**/*.md'` (Markdown 変更なし、省略)

## Contributor License Agreement

By opening this pull request, I confirm that:

- [x] I have read the [Contributing Guide](https://github.com/fulgur-rs/fulgur/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://github.com/fulgur-rs/fulgur/blob/main/CLA.md)
      and agree to its terms. (First-time contributors: the CLA Assistant bot
      will comment on this PR with sign-in instructions.)

## Related issues

自動カバレッジ追加タスク（2026-08-17）

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7erVj62ishcfQDdy33EB4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * ページネーションの分割判定について、空・単一・複数要素および繰り返し設定のケースを追加検証しました。
  * カウンター状態の初期化、増分、設定、ページ間の引き継ぎを確認しました。
  * 操作のない要素が適切にスキップされることを検証しました。
  * 空のページ構成を含む各種エッジケースのテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->