### PR TITLE
test(render): add coverage for margin-box declarations, tagged multicol, multi-page multicol

### DIFF
--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -7094,8 +7094,10 @@ mod tests {
 
     #[test]
     fn render_smoke_multicol_multi_page_partition() {
-        // A tall multicol container spanning multiple pages triggers the
+        // A column-span:all child forces the multicol container to be treated as
+        // split across pages (container_geom.is_split() = true), triggering the
         // above/below/straddles partition filter in paint_multicol_paragraph_slices.
+        // Without column-span:all the container stays atomic and is_split remains false.
         let pdf = render_html(
             r#"<!doctype html><html><body>
             <div style="column-count:2;column-gap:20px;width:400px">
@@ -7103,11 +7105,13 @@ mod tests {
                  mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega.</p>
               <p>Second long paragraph to push content across page boundaries:
                  lorem ipsum dolor sit amet consectetur adipiscing elit sed.</p>
-              <div style="height:900px"></div>
+              <div style="column-span:all;height:900px"></div>
               <p>Third paragraph after tall spacer ensures multi-page layout.</p>
             </div>
             </body></html>"#,
         );
         assert!(pdf.starts_with(b"%PDF"));
+        let page_count = pdf.windows(11).filter(|w| *w == b"/Type /Page").count();
+        assert!(page_count >= 2, "expected at least 2 pages, got {page_count}");
     }
 }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -7124,6 +7124,9 @@ mod tests {
                         .is_some_and(|next| !next.is_ascii_alphanumeric())
             })
             .count();
-        assert!(page_count >= 2, "expected at least 2 pages, got {page_count}");
+        assert!(
+            page_count >= 2,
+            "expected at least 2 pages, got {page_count}"
+        );
     }
 }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -7052,4 +7052,62 @@ mod tests {
         );
         assert!(pdf.starts_with(b"%PDF"));
     }
+
+    #[test]
+    fn render_smoke_margin_box_with_css_declarations() {
+        // `color: red` in @bottom-center populates MarginBoxRule.declarations,
+        // triggering the format!("<div style=\"{}\">...</div>") wrapper path.
+        let pdf = render_html(
+            r#"<!doctype html><html><head><style>
+            @page {
+              size: A4; margin: 20mm;
+              @bottom-center {
+                content: "Footer text";
+                color: red;
+                font-size: 10pt;
+              }
+            }
+            </style></head><body><p>Body content.</p></body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn render_smoke_tagged_multicol_paragraph_with_link() {
+        // Tagged mode + multicol + paragraph with <a href> triggers
+        // use_run_tagging=true in paint_multicol_paragraph_slices.
+        let pdf = crate::engine::Engine::builder()
+            .tagged(true)
+            .lang("en")
+            .build()
+            .render(
+                r#"<!doctype html><html><body>
+                <div style="column-count:2;column-gap:20px;width:400px">
+                  <p>Go to <a href="https://example.com">example.com</a> for info.</p>
+                  <p>Also visit <a href="https://other.org">other.org</a> too.</p>
+                </div>
+                </body></html>"#,
+            )
+            .expect("render");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn render_smoke_multicol_multi_page_partition() {
+        // A tall multicol container spanning multiple pages triggers the
+        // above/below/straddles partition filter in paint_multicol_paragraph_slices.
+        let pdf = render_html(
+            r#"<!doctype html><html><body>
+            <div style="column-count:2;column-gap:20px;width:400px">
+              <p>Alpha beta gamma delta epsilon zeta eta theta iota kappa lambda
+                 mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega.</p>
+              <p>Second long paragraph to push content across page boundaries:
+                 lorem ipsum dolor sit amet consectetur adipiscing elit sed.</p>
+              <div style="height:900px"></div>
+              <p>Third paragraph after tall spacer ensures multi-page layout.</p>
+            </div>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
 }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -7111,7 +7111,19 @@ mod tests {
             </body></html>"#,
         );
         assert!(pdf.starts_with(b"%PDF"));
-        let page_count = pdf.windows(11).filter(|w| *w == b"/Type /Page").count();
+        // Use a 12-byte window to distinguish /Type /Page (individual page) from
+        // /Type /Pages (page-tree node): the byte after "Page" must be non-alphanumeric.
+        let prefix = b"/Type /Page";
+        let page_count = pdf
+            .windows(prefix.len())
+            .enumerate()
+            .filter(|(i, window)| {
+                *window == prefix
+                    && pdf
+                        .get(*i + prefix.len())
+                        .is_some_and(|next| !next.is_ascii_alphanumeric())
+            })
+            .count();
         assert!(page_count >= 2, "expected at least 2 pages, got {page_count}");
     }
 }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -7111,8 +7111,8 @@ mod tests {
             </body></html>"#,
         );
         assert!(pdf.starts_with(b"%PDF"));
-        // Use a 12-byte window to distinguish /Type /Page (individual page) from
-        // /Type /Pages (page-tree node): the byte after "Page" must be non-alphanumeric.
+        // Scan the 11-byte /Type /Page prefix and check the following byte to
+        // distinguish individual pages from the /Type /Pages tree node.
         let prefix = b"/Type /Page";
         let page_count = pdf
             .windows(prefix.len())


### PR DESCRIPTION
## 概要

`crates/fulgur/src/render.rs` の未カバーブランチに対してスモークテストを3本追加しました。
`render.rs` のカバレッジが **95.03% → 95.21%** に向上しています。

## 対象モジュール

`crates/fulgur/src/render.rs`（カバレッジ改善前: 95.03%、改善後: 95.21%）

## 追加テスト

| テスト名 | カバーする経路 |
|---|---|
| `render_smoke_margin_box_with_css_declarations` | `@page` margin box に `content:` 以外の CSS プロパティ（`color`, `font-size`）を指定したとき、`MarginBoxRule.declarations` が非空になり `format!("<div style=\"{}\">...</div>")` ラッパーを通るパス |
| `render_smoke_tagged_multicol_paragraph_with_link` | tagged モード + `column-count:2` + `<a href>` を含む段落の組み合わせで `paint_multicol_paragraph_slices` 内の `use_run_tagging=true` ブランチを通るパス |
| `render_smoke_multicol_multi_page_partition` | 高さが大きく複数ページにまたがる multicol コンテナで、`paint_multicol_paragraph_slices` の `above \|\| below \|\| straddles` パーティションフィルタを通るパス |

## スキップした未カバーブランチ（理由付き）

- `dispatch_inline_box_content` の opacity/descendants パス（L747–890）: Blitz DOM の `opacity_descendants` を持つインラインボックスの構築が困難
- `try_start_tagged` の早期リターン（L1001）: `canvas.in_marked_content` フラグを直接制御するインターフェースがない
- `get_body_child_dimension`（L4012–4022）: Blitz `BaseDocument` を必要とし、unit test から呼び出せない

## 検証

```text
cargo test -p fulgur --lib   → 2027 passed; 0 failed
cargo clippy -- -D warnings  → 警告なし
cargo fmt --check            → 差分なし
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01B4t2p7edHQCoAmwNg37Bbf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * マージンボックスを含むCSS、タグ付きマルチカラム段落内のリンク、`column-span: all`による複数ページ分割のPDF生成テストを追加しました。
  * PDFが正常に生成されることを確認し、複数ページ分割では2ページ以上に出力されることも検証できるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->