### PR TITLE
test(gcpm/parser): add coverage for counter-style aliases and non-page at-rules

### DIFF
--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -3659,8 +3659,10 @@ mod tests {
             Some(PageSizeDecl::Keyword("A4".to_string()))
         );
         assert!(
-            ctx.cleaned_css.contains("@media"),
-            "non-page at-rule must survive: {:?}",
+            ctx.cleaned_css.contains("@media print")
+                && ctx.cleaned_css.contains("body")
+                && ctx.cleaned_css.contains("margin: 0"),
+            "complete @media rule must survive in cleaned_css: {:?}",
             ctx.cleaned_css
         );
         assert!(

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -3577,4 +3577,119 @@ mod tests {
         assert_no_page_settings("@page { size: 0pt; }");
         assert_no_page_settings("@page { size: 0mm 200pt; }");
     }
+
+    // ── parse_counter_style: upper-alpha / upper-latin / lower-latin aliases ──
+
+    #[test]
+    fn test_counter_upper_alpha_style() {
+        // `upper-alpha` → CounterStyle::UpperAlpha.
+        // The `"upper-alpha" | "upper-latin"` match arm (line ~974) was not
+        // previously exercised by any test.
+        let css = r#"@page { @bottom-center { content: counter(chapter, upper-alpha); } }"#;
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.margin_boxes.len(), 1);
+        assert_eq!(
+            ctx.margin_boxes[0].content,
+            vec![ContentItem::Counter {
+                name: "chapter".into(),
+                style: CounterStyle::UpperAlpha,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_counter_upper_latin_style_alias() {
+        // `upper-latin` is an alias for `upper-alpha` (same match arm, line ~974).
+        let css = r#"@page { @bottom-center { content: counter(chapter, upper-latin); } }"#;
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.margin_boxes.len(), 1);
+        assert_eq!(
+            ctx.margin_boxes[0].content,
+            vec![ContentItem::Counter {
+                name: "chapter".into(),
+                style: CounterStyle::UpperAlpha,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_counter_lower_latin_style_alias() {
+        // `lower-latin` is an alias for `lower-alpha` (line ~975).
+        let css = r#"@page { @bottom-center { content: counter(section, lower-latin); } }"#;
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.margin_boxes.len(), 1);
+        assert_eq!(
+            ctx.margin_boxes[0].content,
+            vec![ContentItem::Counter {
+                name: "section".into(),
+                style: CounterStyle::LowerAlpha,
+            }]
+        );
+    }
+
+    // ── GcpmSheetParser::parse_prelude: non-@page at-rule error path ──────────
+
+    #[test]
+    fn test_non_page_at_rule_does_not_crash_and_is_preserved() {
+        // An at-rule other than `@page` must not be extracted as a page rule
+        // and must survive verbatim in `cleaned_css`.
+        // Exercises the early-return error path in `GcpmSheetParser::parse_prelude`
+        // (the `!name.eq_ignore_ascii_case("page")` guard).
+        let css = "@media screen { body { color: red; } }";
+        let ctx = parse_gcpm(css);
+        assert!(ctx.margin_boxes.is_empty());
+        assert!(ctx.page_settings.is_empty());
+        assert!(ctx.running_mappings.is_empty());
+        assert!(
+            ctx.cleaned_css.contains("@media"),
+            "non-page at-rule must survive in cleaned_css: {:?}",
+            ctx.cleaned_css
+        );
+    }
+
+    #[test]
+    fn test_non_page_at_rule_mixed_with_gcpm() {
+        // A `@media` rule alongside real GCPM content: `@media` must survive
+        // in `cleaned_css` while `@page` is removed.
+        let css = "@media print { body { margin: 0; } } @page { size: A4; }";
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.page_settings.len(), 1);
+        assert_eq!(
+            ctx.page_settings[0].size,
+            Some(PageSizeDecl::Keyword("A4".to_string()))
+        );
+        assert!(
+            ctx.cleaned_css.contains("@media"),
+            "non-page at-rule must survive: {:?}",
+            ctx.cleaned_css
+        );
+        assert!(
+            !ctx.cleaned_css.contains("@page"),
+            "@page must be removed: {:?}",
+            ctx.cleaned_css
+        );
+    }
+
+    // ── parse_counter_style: upper-alpha / upper-latin via pseudo-element ─────
+
+    #[test]
+    fn test_pseudo_counter_upper_alpha_style() {
+        // Same `upper-alpha` arm, but accessed through a pseudo-element
+        // `content:` declaration to confirm `parse_content_value` routes it
+        // through `parse_counter_style` correctly.
+        let css = r#"li::before { content: counter(item, upper-alpha) ". "; }"#;
+        let ctx = parse_gcpm(css);
+        assert_eq!(ctx.content_counter_mappings.len(), 1);
+        let items = &ctx.content_counter_mappings[0].content;
+        assert!(
+            items.iter().any(|i| matches!(
+                i,
+                ContentItem::Counter {
+                    style: CounterStyle::UpperAlpha,
+                    ..
+                }
+            )),
+            "expected UpperAlpha counter in items: {items:?}"
+        );
+    }
 }

--- a/crates/fulgur/src/gcpm/parser.rs
+++ b/crates/fulgur/src/gcpm/parser.rs
@@ -3659,9 +3659,8 @@ mod tests {
             Some(PageSizeDecl::Keyword("A4".to_string()))
         );
         assert!(
-            ctx.cleaned_css.contains("@media print")
-                && ctx.cleaned_css.contains("body")
-                && ctx.cleaned_css.contains("margin: 0"),
+            ctx.cleaned_css
+                .contains("@media print { body { margin: 0; } }"),
             "complete @media rule must survive in cleaned_css: {:?}",
             ctx.cleaned_css
         );


### PR DESCRIPTION
## Summary

`crates/fulgur/src/gcpm/parser.rs` のカバレッジを 97.26% → 97.35% に改善する。
以前は実行されていなかった以下のコードパスにテストを追加した。

## 対象モジュール

`gcpm/parser.rs`（CSS GCPM パーサー）

- **カバレッジ変化**: 97.26% → 97.35% (region)
- ミス領域: 101 → 100

## Changes

- `test_counter_upper_alpha_style` — `counter(name, upper-alpha)` が `CounterStyle::UpperAlpha` を返すことを確認（`parse_counter_style` 内 `"upper-alpha" | "upper-latin"` match arm が未テストだった）
- `test_counter_upper_latin_style_alias` — `upper-latin` エイリアスが同じ `UpperAlpha` に解決されることを確認
- `test_counter_lower_latin_style_alias` — `lower-latin` エイリアスが `CounterStyle::LowerAlpha` に解決されることを確認
- `test_non_page_at_rule_does_not_crash_and_is_preserved` — `@media` 等の非 `@page` at-rule が `GcpmSheetParser::parse_prelude` のエラーパス（`!name.eq_ignore_ascii_case("page")` ガード）を通り、クラッシュせず `cleaned_css` に保持されることを確認
- `test_non_page_at_rule_mixed_with_gcpm` — 非 `@page` と `@page` の混在で、両者の処理が独立して正しく動くことを確認
- `test_pseudo_counter_upper_alpha_style` — `parse_content_value` を経由した場合にも `upper-alpha` が正しく解析されることを確認（疑似要素 `content:` の経路）

## 意図的にカバーしなかったパス

- `parse_counter_style` 内の hyphenated ident 分割パス（`if input.try_parse(|input| input.expect_delim('-')).is_ok()`）: cssparser は `upper-roman` 等の hyphenated ident を常に単一の `Ident` トークンとして生成するため、このブランチは到達不能な dead code とみなした
- `AtRuleParser`・`QualifiedRuleParser` のデフォルト trait メソッド実装（`parse_prelude`/`parse_block` on `MarginBoxParser`, `StyleRuleParser`, `PageRuleParser`): `RuleBodyItemParser::parse_qualified()` が `false` を返すため、フレームワークはこれらを呼び出さない。13 個の missed function はこれらに起因する

## Test plan

- [x] `cargo test -p fulgur --lib` — 2030 tests passed
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo llvm-cov --package fulgur --lib --summary-only` で改善を確認

## Related issues

Daily coverage improvement run (automated, 2026-08-20).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXvJZJsfX9c4XXZcVxm7yF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * カウンタースタイルの別名（`upper-alpha`、`upper-latin`、`lower-latin`）に関する検証を追加しました。
  * `@page` ルールとその他のアットルールが混在する場合の処理を確認しました。
  * 疑似要素内でのカウンター処理に対するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->