### PR TITLE
test(pagination_layout): cover inline-root page-advance and break-after paths (2026-08-23)

### DIFF
--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -7289,4 +7289,61 @@ h2 { string-set: chapter-title content(text); }
         assert_eq!(states.len(), 1);
         assert!(states[0].is_empty());
     }
+
+    // ── inline root page-advance (lines 750-752) ─────────────────────────────────
+
+    /// Lines 750-752: a multi-line paragraph (inline root) is pushed to the
+    /// next page when `cursor_y + para_total_h > page_height_px`.
+    ///
+    /// A 60 px spacer occupies most of the 80 px page strip.  The `<br>`
+    /// guarantee guarantees two Parley line boxes regardless of font or
+    /// viewport width, so `para_total_h` is definitively > the remaining 20 px.
+    /// `fragment_pagination_root` must advance `page_index` before delegating
+    /// to `fragment_inline_root` (lines 751-752 execute).
+    #[test]
+    fn inline_root_advances_page_when_para_does_not_fit_remaining_space() {
+        let html = r#"
+            <html><body style="margin:0;padding:0">
+              <div style="height:60px"></div>
+              <p style="margin:0">Line one<br>Line two</p>
+            </body></html>
+        "#;
+        let mut doc = parse(html, 600.0);
+        let table = run_pass(&mut doc, 80.0);
+        let has_page1 = table
+            .values()
+            .flat_map(|g| g.fragments.iter())
+            .any(|f| f.page_index >= 1);
+        assert!(
+            has_page1,
+            "multi-line paragraph overflowing remaining 20 px must advance to page >= 1; \
+             table={table:?}",
+        );
+    }
+
+    // ── inline root break-after: page (lines 772-778) ────────────────────────────
+
+    /// Lines 772-778: `break-after: page` on a multi-line paragraph (inline
+    /// root with `line_metrics.len() > 1`) must increment `page_index` after
+    /// `fragment_inline_root` returns, pushing the next body-direct sibling
+    /// onto page 1.
+    #[test]
+    fn inline_root_break_after_page_advances_page_index() {
+        let html = r#"
+            <html><body style="margin:0;padding:0">
+              <p style="margin:0;break-after:page">Line one<br>Line two</p>
+              <div style="height:50px"></div>
+            </body></html>
+        "#;
+        let mut doc = parse(html, 600.0);
+        let table = blitz_adapter::extract_column_style_table(&doc);
+        let geom = super::run_pass_with_break_styles(doc.deref_mut(), 800.0_f32.as_px(), &table);
+        assert!(
+            geom.values()
+                .flat_map(|g| g.fragments.iter())
+                .any(|f| f.page_index == 1),
+            "break-after: page on a multi-line inline root must push next sibling to page 1; \
+             geom={geom:?}",
+        );
+    }
 }

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -7313,12 +7313,14 @@ h2 { string-set: chapter-title content(text); }
         let para_id = find_by_id(doc.deref_mut(), "p1").expect("p#p1");
         let para_page = table
             .get(&para_id)
-            .and_then(|g| g.fragments.first())
-            .map(|f| f.page_index)
-            .unwrap_or(0);
-        assert!(
-            para_page >= 1,
-            "multi-line paragraph overflowing remaining 20 px must advance to page >= 1; \
+            .expect("p#p1 must appear in geometry table")
+            .fragments
+            .first()
+            .expect("p#p1 must have at least one fragment")
+            .page_index;
+        assert_eq!(
+            para_page, 1,
+            "multi-line paragraph overflowing remaining 20 px must advance to page 1; \
              got page_index={para_page}",
         );
     }
@@ -7343,9 +7345,11 @@ h2 { string-set: chapter-title content(text); }
         let div_id = find_by_id(doc.deref_mut(), "after").expect("div#after");
         let div_page = geom
             .get(&div_id)
-            .and_then(|g| g.fragments.first())
-            .map(|f| f.page_index)
-            .unwrap_or(0);
+            .expect("div#after must appear in geometry table")
+            .fragments
+            .first()
+            .expect("div#after must have at least one fragment")
+            .page_index;
         assert_eq!(
             div_page, 1,
             "break-after: page on a multi-line inline root must push next sibling to page 1; \

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -7305,19 +7305,21 @@ h2 { string-set: chapter-title content(text); }
         let html = r#"
             <html><body style="margin:0;padding:0">
               <div style="height:60px"></div>
-              <p style="margin:0">Line one<br>Line two</p>
+              <p id="p1" style="margin:0">Line one<br>Line two</p>
             </body></html>
         "#;
         let mut doc = parse(html, 600.0);
         let table = run_pass(&mut doc, 80.0);
-        let has_page1 = table
-            .values()
-            .flat_map(|g| g.fragments.iter())
-            .any(|f| f.page_index >= 1);
+        let para_id = find_by_id(doc.deref_mut(), "p1").expect("p#p1");
+        let para_page = table
+            .get(&para_id)
+            .and_then(|g| g.fragments.first())
+            .map(|f| f.page_index)
+            .unwrap_or(0);
         assert!(
-            has_page1,
+            para_page >= 1,
             "multi-line paragraph overflowing remaining 20 px must advance to page >= 1; \
-             table={table:?}",
+             got page_index={para_page}",
         );
     }
 
@@ -7332,18 +7334,22 @@ h2 { string-set: chapter-title content(text); }
         let html = r#"
             <html><body style="margin:0;padding:0">
               <p style="margin:0;break-after:page">Line one<br>Line two</p>
-              <div style="height:50px"></div>
+              <div id="after" style="height:50px"></div>
             </body></html>
         "#;
         let mut doc = parse(html, 600.0);
         let table = blitz_adapter::extract_column_style_table(&doc);
         let geom = super::run_pass_with_break_styles(doc.deref_mut(), 800.0_f32.as_px(), &table);
-        assert!(
-            geom.values()
-                .flat_map(|g| g.fragments.iter())
-                .any(|f| f.page_index == 1),
+        let div_id = find_by_id(doc.deref_mut(), "after").expect("div#after");
+        let div_page = geom
+            .get(&div_id)
+            .and_then(|g| g.fragments.first())
+            .map(|f| f.page_index)
+            .unwrap_or(0);
+        assert_eq!(
+            div_page, 1,
             "break-after: page on a multi-line inline root must push next sibling to page 1; \
-             geom={geom:?}",
+             got page_index={div_page}",
         );
     }
 }

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -3632,8 +3632,10 @@ fn outline_titles(pdf_bytes: &[u8]) -> Vec<String> {
         // an integration test crate.
         if s.starts_with(&[0xFE, 0xFF]) {
             let chars: Vec<u16> = s[2..]
-                .chunks_exact(2)
-                .map(|c| u16::from_be_bytes([c[0], c[1]]))
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .map(|c| u16::from_be_bytes(*c))
                 .collect();
             String::from_utf16_lossy(&chars)
         } else {


### PR DESCRIPTION
## 概要

`pagination_layout.rs` のカバレッジを改善するための 2 つのユニットテストを追加します。

| 指標 | 変更前 | 変更後 |
|------|--------|--------|
| 行カバレッジ (`--lib`) | 96.01% | 96.19% |
| 未カバー行数 | 162 | 156 |

## 追加テスト

### `inline_root_advances_page_when_para_does_not_fit_remaining_space`

対象行: **750–752**

```rust
if cursor_y > 0.0 && cursor_y + para_total_h > self.page_height_px {
    page_index += 1;   // line 751
    cursor_y = 0.0;    // line 752
}
```

80 px のページストリップに 60 px のスペーサーを置き、`<br>` で確実に 2 行に折り返す段落を続けることで、残り 20 px に収まらない状況を再現。  
`fragment_inline_root` を呼ぶ前にページを進める分岐 (lines 751–752) を実行します。

### `inline_root_break_after_page_advances_page_index`

対象行: **772–778**

```rust
if matches!(break_props.break_after, Some(BreakAfter::Page)) {
    page_index += 1;   // line 776
    cursor_y = 0.0;    // line 777
}
```

`break-after: page` を付けた複数行の段落に `run_pass_with_break_styles` を通すことで、`fragment_inline_root` 呼び出し後のページ進行分岐を実行。後続 `<div>` が page 1 に着地することをアサートします。

## テスト設計の選択理由

- **`<br>` で行数を保証**: システムフォントやビューポート幅に依存せず、Parley が必ず 2 つの line box を生成する。`line_metrics.len() > 1` 条件 (line 737) を確実に通します。
- **既存テストインフラ流用**: `parse()` ヘルパー・`run_pass` / `run_pass_with_break_styles` は既存パターンを踏襲。
- **プロダクションコード変更なし**: テストのみ追加。

## チェックリスト

- [x] `cargo test -p fulgur --lib` — 2032 tests passed
- [x] `cargo clippy -p fulgur -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — 差分なし
- [x] カバレッジ再測定: 96.01% → 96.19% (missed 162 → 156)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYcPn9WKuNpaGxvh6KP9WT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * インライン要素のページ送り動作を検証するテストの確認条件を強化しました。
  * 複数行の段落が残りのページ領域に収まらない場合、次のページへ正しく移動することを確認しました。
  * `break-after: page` 指定後の要素が、次のページに配置されることを確認しました。
  * ページ番号を厳密に検証し、タイトル情報のデコード処理が正しく動作することを確認しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->