### PR TITLE
fix(pagination): drop phantom header pages from trailing forced breaks

### DIFF
--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -2221,7 +2221,17 @@ fn fragment_repeating_table(
         remaining_repeat_budget,
     );
 
-    (body_end_page, body_end_cursor + header.band_height_px)
+    // The band only occupies space on pages that kept a table fragment. A
+    // trailing forced break can leave the end page with none (see the `retain`
+    // above), and adding the band here would push the table's next sibling down
+    // by a header that was never drawn.
+    let end_page_carries_band = table_pages.iter().any(|&(page, _)| page == body_end_page);
+    let end_cursor = if end_page_carries_band {
+        body_end_cursor + header.band_height_px
+    } else {
+        body_end_cursor
+    };
+    (body_end_page, end_cursor)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -2202,6 +2202,14 @@ fn fragment_repeating_table(
                     .or_insert(table_top);
             }
         } else {
+            // Drop the continuations that live only on pages the table just
+            // gave up. `draw_block_inner_paint` paints a zero-height fragment
+            // of a split block at its full `layout_size`, so a styled cell or
+            // wrapper left behind would still show — at the offset of a header
+            // that is no longer there, possibly over the following sibling.
+            source
+                .fragments
+                .retain(|fragment| body_content_pages.contains(&fragment.page_index));
             for fragment in &mut source.fragments {
                 fragment.y = (fragment.y.to_f32() + header.band_height_px).as_px();
             }

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -2158,10 +2158,17 @@ fn fragment_repeating_table(
     let body_content_pages: std::collections::BTreeSet<u32> = body_geometry
         .iter()
         .filter(|(node_id, _)| **node_id != header.table_id)
-        .flat_map(|(_, geom)| {
+        .flat_map(|(node_id, geom)| {
+            // A cell's own zero-height fragment is just the continuation the
+            // fragmenter opens on the page it advanced to — no content landed
+            // there. A zero-height fragment for anything *below* a cell is a
+            // box that was actually placed on that page, and it can still
+            // paint (border, background, box-shadow), so the table must keep
+            // its slice and repeated header there.
+            let is_cell = header.body_cell_ids.contains(node_id);
             geom.fragments
                 .iter()
-                .filter(|fragment| fragment.height > crate::units::Px::ZERO)
+                .filter(move |fragment| !is_cell || fragment.height > crate::units::Px::ZERO)
                 .map(|fragment| fragment.page_index)
         })
         .collect();

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -2150,10 +2150,33 @@ fn fragment_repeating_table(
         remaining_repeat_budget,
     );
 
+    // Pages that actually carry body content. A forced break after the last
+    // body block advances the fragmenter and closes the table with a
+    // zero-height fragment on the following page; adding the band to that would
+    // promote it into a real page holding nothing but a cloned header, and
+    // shift everything after the table down by the phantom band.
+    let body_content_pages: std::collections::BTreeSet<u32> = body_geometry
+        .iter()
+        .filter(|(node_id, _)| **node_id != header.table_id)
+        .flat_map(|(_, geom)| {
+            geom.fragments
+                .iter()
+                .filter(|fragment| fragment.height > crate::units::Px::ZERO)
+                .map(|fragment| fragment.page_index)
+        })
+        .collect();
+
     let mut table_pages = BTreeMap::<u32, f32>::new();
     for (node_id, mut source) in body_geometry {
         source.fragments.sort_by_key(|fragment| fragment.page_index);
         if node_id == header.table_id {
+            // Keep a zero-height slice only where body content shares the page
+            // (the occupied-strip case); drop it when the table has nothing
+            // left to show there.
+            source.fragments.retain(|fragment| {
+                fragment.height > crate::units::Px::ZERO
+                    || body_content_pages.contains(&fragment.page_index)
+            });
             for fragment in &mut source.fragments {
                 fragment.height = (fragment.height.to_f32() + header.band_height_px).as_px();
                 let table_top = fragment.y.to_f32();

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -2158,17 +2158,26 @@ fn fragment_repeating_table(
     let body_content_pages: std::collections::BTreeSet<u32> = body_geometry
         .iter()
         .filter(|(node_id, _)| **node_id != header.table_id)
-        .flat_map(|(node_id, geom)| {
-            // A cell's own zero-height fragment is just the continuation the
-            // fragmenter opens on the page it advanced to — no content landed
-            // there. A zero-height fragment for anything *below* a cell is a
-            // box that was actually placed on that page, and it can still
-            // paint (border, background, box-shadow), so the table must keep
-            // its slice and repeated header there.
-            let is_cell = header.body_cell_ids.contains(node_id);
+        .flat_map(|(_, geom)| {
+            // Distinguish a box placed on this page from the empty
+            // continuation the fragmenter opens to close a node that started
+            // earlier. A zero-height fragment counts as content only when the
+            // node has nothing on an earlier page — then it was placed here
+            // and can still paint (border, background, box-shadow). Node
+            // identity is the wrong axis for this: cells and their wrappers
+            // both produce continuations, and both can also be genuinely
+            // placed zero-height boxes.
+            let first_page = geom
+                .fragments
+                .iter()
+                .map(|fragment| fragment.page_index)
+                .min();
             geom.fragments
                 .iter()
-                .filter(move |fragment| !is_cell || fragment.height > crate::units::Px::ZERO)
+                .filter(move |fragment| {
+                    fragment.height > crate::units::Px::ZERO
+                        || Some(fragment.page_index) == first_page
+                })
                 .map(|fragment| fragment.page_index)
         })
         .collect();

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -6561,3 +6561,37 @@ fn table_page_with_only_a_painted_zero_height_box_still_renders() {
         .expect("painted zero-height continuation should render");
     assert!(!pdf.is_empty());
 }
+
+/// When a trailing forced break leaves a page without a table fragment, a
+/// styled wrapper inside the cell must not be left painting there: a
+/// zero-height fragment of a split block draws at its full `layout_size`, so
+/// the orphan would appear at the offset of a header that is no longer drawn.
+#[test]
+fn table_discarded_page_leaves_no_styled_wrapper_behind() {
+    let html = r#"<!doctype html>
+<html><head><style>
+  @page { size: 200px 100px; margin: 0; }
+  html, body { margin: 0; padding: 0; }
+  table { margin: 0; border-spacing: 0; width: 100px; }
+  th, td { box-sizing: border-box; padding: 0; }
+  .m { height: 30px; background: rgb(6,6,6); }
+  #wrap { background: rgb(3,3,3); border: 1px solid rgb(4,4,4); }
+  #last { break-after: page; }
+</style></head><body>
+  <table>
+    <thead><tr><th>H</th></tr></thead>
+    <tbody>
+      <tr><td><section id="wrap">
+        <div class="m"></div>
+        <div class="m" id="last"></div>
+      </section></td></tr>
+    </tbody>
+  </table>
+  <div class="m" id="after"></div>
+</body></html>"#;
+    let pdf = Engine::builder()
+        .build()
+        .render(html)
+        .expect("styled wrapper with a trailing forced break should render");
+    assert!(!pdf.is_empty());
+}

--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -6499,3 +6499,65 @@ fn render_unaffected_by_at_page_only_margin_without_builder_override() {
         .expect("no builder override means Config::validate must not reject @page-only CSS");
     assert!(!pdf.is_empty());
 }
+
+/// A `break-after: page` on the last body block ends the table on the page it
+/// advances to. That page keeps no table fragment, so the band must not be
+/// added to the returned cursor — otherwise the table's next sibling renders
+/// below a header that was never drawn.
+#[test]
+fn table_sibling_after_trailing_forced_break_is_not_offset_by_a_phantom_band() {
+    let html = r#"<!doctype html>
+<html><head><style>
+  @page { size: 200px 100px; margin: 0; }
+  html, body { margin: 0; padding: 0; }
+  table { margin: 0; border-spacing: 0; width: 100px; }
+  th, td { box-sizing: border-box; padding: 0; }
+  .m { height: 30px; background: rgb(6,6,6); }
+  #last { break-after: page; }
+</style></head><body>
+  <table>
+    <thead><tr><th>H</th></tr></thead>
+    <tbody>
+      <tr><td><div class="m"></div></td></tr>
+      <tr><td><div class="m" id="last"></div></td></tr>
+    </tbody>
+  </table>
+  <div class="m" id="after"></div>
+</body></html>"#;
+    let pdf = Engine::builder()
+        .build()
+        .render(html)
+        .expect("table with a trailing forced break should render");
+    assert!(!pdf.is_empty());
+}
+
+/// A zero-height box that still paints — here via `box-shadow` — moved to a
+/// continuation page by a forced break must keep the table slice and repeated
+/// header on that page.
+#[test]
+fn table_page_with_only_a_painted_zero_height_box_still_renders() {
+    let html = r#"<!doctype html>
+<html><head><style>
+  @page { size: 200px 100px; margin: 0; }
+  html, body { margin: 0; padding: 0; }
+  table { margin: 0; border-spacing: 0; width: 100px; }
+  th, td { box-sizing: border-box; padding: 0; }
+  .m { height: 30px; background: rgb(6,6,6); }
+  #ghost { height: 0; break-before: page; box-shadow: 0 0 0 6px rgb(9,9,9); }
+</style></head><body>
+  <table>
+    <thead><tr><th>H</th></tr></thead>
+    <tbody>
+      <tr><td>
+        <div class="m"></div>
+        <div id="ghost"></div>
+      </td></tr>
+    </tbody>
+  </table>
+</body></html>"#;
+    let pdf = Engine::builder()
+        .build()
+        .render(html)
+        .expect("painted zero-height continuation should render");
+    assert!(!pdf.is_empty());
+}

--- a/crates/fulgur/tests/repeating_table_header_probes.rs
+++ b/crates/fulgur/tests/repeating_table_header_probes.rs
@@ -814,7 +814,7 @@ const BREAK_ON_BODY_ROW: &str = r#"<!doctype html>
 </body></html>"#;
 
 #[test]
-#[ignore = "a forced break on a body row or row group is dropped: the body path receives flattened cell ids, so the styled row node is never visited. Executable repro — run with --ignored."]
+#[ignore = "forced breaks on table rows and row groups are not honoured at all — see the sibling no-thead probe. Executable repro — run with --ignored."]
 fn probe_forced_break_on_body_row_is_honoured() {
     let engine = engine_200x100();
     let layout = engine.layout(BREAK_ON_BODY_ROW).expect("layout");
@@ -978,5 +978,21 @@ fn probe_forced_break_on_header_row() {
             > 0,
         "break-after:page on the header row was ignored: d1={d1:?} \
          (same break on a plain row: {plain_d1:?})"
+    );
+}
+
+#[test]
+#[ignore = "forced breaks on table rows and row groups are not honoured at all — see the sibling no-thead probe. Executable repro — run with --ignored."]
+fn probe_forced_break_on_body_row_without_thead() {
+    let engine = engine_200x100();
+    let html = BREAK_ON_BODY_ROW.replace("<thead><tr><th>H</th></tr></thead>", "");
+    let layout = engine.layout(&html).expect("layout");
+    let a1 = block_fragments(&layout, "a1");
+    let a2 = block_fragments(&layout, "a2");
+    println!("[break-row-nothead] a1 = {a1:?}  a2 = {a2:?}");
+    assert!(
+        a2[0].0 > a1[0].0,
+        "break-before:page on a body row is ignored even without a repeating \
+         header, so this is a general table limitation: a1={a1:?}, a2={a2:?}"
     );
 }

--- a/crates/fulgur/tests/repeating_table_header_probes.rs
+++ b/crates/fulgur/tests/repeating_table_header_probes.rs
@@ -847,7 +847,6 @@ const BREAK_AFTER_LAST_ROW: &str = r#"<!doctype html>
 </body></html>"#;
 
 #[test]
-#[ignore = "a break after the last body block closes the table with a zero-height fragment on the next page, and the band is added unconditionally, manufacturing a header-only page. Executable repro — run with --ignored."]
 fn probe_break_after_last_row_makes_no_header_only_page() {
     let engine = engine_200x100();
     let layout = engine.layout(BREAK_AFTER_LAST_ROW).expect("layout");

--- a/crates/fulgur/tests/repeating_table_header_probes.rs
+++ b/crates/fulgur/tests/repeating_table_header_probes.rs
@@ -1006,3 +1006,58 @@ fn probe_forced_break_on_body_row_without_thead() {
          header, so this is a general table limitation: a1={a1:?}, a2={a2:?}"
     );
 }
+
+/// A zero-height body node can still render: an absolutely positioned pseudo
+/// hangs off it. Such a page must keep its table slice and repeated header.
+const ZERO_HEIGHT_ROW_WITH_ABS_PSEUDO: &str = r#"<!doctype html>
+<html><head><style>
+  html, body { margin: 0; padding: 0; }
+  table { margin: 0; border-spacing: 0; width: 100px; }
+  th, td { box-sizing: border-box; padding: 0; }
+  .m { height: 30px; background: rgb(6,6,6); }
+  #ghost { height: 0; position: relative; break-before: page; }
+  #ghost::before {
+    content: "";
+    position: absolute;
+    top: 0; left: 0;
+    width: 40px; height: 12px;
+    background: rgb(7,7,7);
+  }
+</style></head><body>
+  <table id="t">
+    <thead><tr><th>H</th></tr></thead>
+    <tbody>
+      <tr><td><div class="m" id="c1"></div></td></tr>
+      <tr><td><div id="ghost"></div></td></tr>
+    </tbody>
+  </table>
+</body></html>"#;
+
+#[test]
+#[ignore = "premise not reachable yet: break-before:page on a row is not honoured, so the zero-height row never reaches a second page. Executable repro — run with --ignored."]
+fn probe_zero_height_row_with_visible_pseudo_keeps_its_page() {
+    let engine = engine_200x100();
+    let layout = engine
+        .layout(ZERO_HEIGHT_ROW_WITH_ABS_PSEUDO)
+        .expect("layout");
+    let table = table_fragments(&layout, "t");
+    let ghost = block_fragments(&layout, "ghost");
+    println!("[zero-abs] table = {table:?}  ghost = {ghost:?}");
+
+    // Wherever the zero-height row landed, the table must still have a slice
+    // there — its positioned pseudo is painted relative to that box.
+    let table_pages: std::collections::BTreeSet<u32> = table.iter().map(|(p, _, _)| *p).collect();
+    let all_pages: std::collections::BTreeSet<u32> = layout
+        .geometry
+        .iter()
+        .flat_map(|(_, g)| g.fragments.iter().map(|f| f.page_index))
+        .collect();
+    println!("[zero-abs] table_pages={table_pages:?} all_geometry_pages={all_pages:?}");
+    for (page, _, _) in &ghost {
+        assert!(
+            table_pages.contains(page),
+            "page {page} carries a renderable zero-height row but no table slice: \
+             table={table:?}, ghost={ghost:?}"
+        );
+    }
+}

--- a/crates/fulgur/tests/repeating_table_header_probes.rs
+++ b/crates/fulgur/tests/repeating_table_header_probes.rs
@@ -1034,7 +1034,7 @@ const ZERO_HEIGHT_ROW_WITH_ABS_PSEUDO: &str = r#"<!doctype html>
 </body></html>"#;
 
 #[test]
-#[ignore = "premise not reachable yet: break-before:page on a row is not honoured, so the zero-height row never reaches a second page. Executable repro — run with --ignored."]
+#[ignore = "break-before:page at the head of a cell is not honoured, so this shape never reaches a second page. The reachable variant — a break after an in-flow sibling in the same cell — is covered by probe_painted_zero_height_box_keeps_its_table_page. Run with --ignored."]
 fn probe_zero_height_row_with_visible_pseudo_keeps_its_page() {
     let engine = engine_200x100();
     let layout = engine
@@ -1049,14 +1049,55 @@ fn probe_zero_height_row_with_visible_pseudo_keeps_its_page() {
     let table_pages: std::collections::BTreeSet<u32> = table.iter().map(|(p, _, _)| *p).collect();
     let all_pages: std::collections::BTreeSet<u32> = layout
         .geometry
-        .iter()
-        .flat_map(|(_, g)| g.fragments.iter().map(|f| f.page_index))
+        .values()
+        .flat_map(|g| g.fragments.iter().map(|f| f.page_index))
         .collect();
     println!("[zero-abs] table_pages={table_pages:?} all_geometry_pages={all_pages:?}");
     for (page, _, _) in &ghost {
         assert!(
             table_pages.contains(page),
             "page {page} carries a renderable zero-height row but no table slice: \
+             table={table:?}, ghost={ghost:?}"
+        );
+    }
+}
+
+/// A zero-height box that still paints (box-shadow), moved to a continuation
+/// page by a break placed *after* an in-flow sibling in the same cell.
+const ZERO_HEIGHT_PAINTED_AFTER_SIBLING: &str = r#"<!doctype html>
+<html><head><style>
+  html, body { margin: 0; padding: 0; }
+  table { margin: 0; border-spacing: 0; width: 100px; }
+  th, td { box-sizing: border-box; padding: 0; }
+  .m { height: 30px; background: rgb(6,6,6); }
+  #ghost { height: 0; break-before: page; box-shadow: 0 0 0 6px rgb(9,9,9); }
+</style></head><body>
+  <table id="t">
+    <thead><tr><th>H</th></tr></thead>
+    <tbody>
+      <tr><td>
+        <div class="m" id="vis"></div>
+        <div id="ghost"></div>
+      </td></tr>
+    </tbody>
+  </table>
+</body></html>"#;
+
+#[test]
+fn probe_painted_zero_height_box_keeps_its_table_page() {
+    let engine = engine_200x100();
+    let layout = engine
+        .layout(ZERO_HEIGHT_PAINTED_AFTER_SIBLING)
+        .expect("layout");
+    let table = table_fragments(&layout, "t");
+    let ghost = block_fragments(&layout, "ghost");
+    println!("[painted-zero] table = {table:?}  ghost = {ghost:?}");
+
+    let table_pages: std::collections::BTreeSet<u32> = table.iter().map(|(p, _, _)| *p).collect();
+    for (page, _, _) in &ghost {
+        assert!(
+            table_pages.contains(page),
+            "page {page} paints a zero-height box but has no table slice: \
              table={table:?}, ghost={ghost:?}"
         );
     }

--- a/crates/fulgur/tests/repeating_table_header_probes.rs
+++ b/crates/fulgur/tests/repeating_table_header_probes.rs
@@ -844,6 +844,7 @@ const BREAK_AFTER_LAST_ROW: &str = r#"<!doctype html>
       <tr><td><div class="m" id="last"></div></td></tr>
     </tbody>
   </table>
+  <div class="m" id="after"></div>
 </body></html>"#;
 
 #[test]
@@ -866,6 +867,15 @@ fn probe_break_after_last_row_makes_no_header_only_page() {
         phantom.is_empty(),
         "trailing break manufactured header-only page(s) {phantom:?}: table={table:?}, \
          body pages={body_pages:?}"
+    );
+
+    // The sibling after the table must not be offset by a band that was never
+    // drawn: it starts on the page the break moved to, at its top.
+    let after = block_fragments(&layout, "after");
+    println!("[break-after] after = {after:?}");
+    assert!(
+        after[0].1 < 0.5,
+        "sibling placed below a header that was never drawn: after={after:?}"
     );
 }
 

--- a/crates/fulgur/tests/repeating_table_header_probes.rs
+++ b/crates/fulgur/tests/repeating_table_header_probes.rs
@@ -1183,3 +1183,52 @@ fn probe_painted_zero_height_cell_keeps_its_table_page() {
         );
     }
 }
+
+/// A styled wrapper whose empty continuation lands on a page the table no
+/// longer occupies: geometry must not keep the orphan behind.
+const STYLED_WRAPPER_TRAILING_BREAK: &str = r#"<!doctype html>
+<html><head><style>
+  html, body { margin: 0; padding: 0; }
+  table { margin: 0; border-spacing: 0; width: 100px; }
+  th, td { box-sizing: border-box; padding: 0; }
+  .m { height: 30px; background: rgb(6,6,6); }
+  #wrap { background: rgb(3,3,3); border: 1px solid rgb(4,4,4); }
+  #last { break-after: page; }
+</style></head><body>
+  <table id="t">
+    <thead><tr><th>H</th></tr></thead>
+    <tbody>
+      <tr><td><section id="wrap">
+        <div class="m"></div>
+        <div class="m" id="last"></div>
+      </section></td></tr>
+    </tbody>
+  </table>
+  <div class="m" id="after"></div>
+</body></html>"#;
+
+#[test]
+fn probe_discarded_page_keeps_no_descendant_orphans() {
+    let engine = engine_200x100();
+    let layout = engine
+        .layout(STYLED_WRAPPER_TRAILING_BREAK)
+        .expect("layout");
+    let table = table_fragments(&layout, "t");
+    let wrap = block_fragments(&layout, "wrap");
+    println!("[orphan] table = {table:?}  wrap = {wrap:?}");
+    assert!(!table.is_empty(), "table must record geometry");
+
+    // A descendant fragment on a page the table does not occupy has nothing to
+    // sit in: `draw_block_inner_paint` paints a zero-height split fragment at
+    // its full `layout_size`, so a styled wrapper would still show there.
+    let table_pages: std::collections::BTreeSet<u32> = table.iter().map(|(p, _, _)| *p).collect();
+    let orphans: Vec<_> = wrap
+        .iter()
+        .filter(|(page, _, _)| !table_pages.contains(page))
+        .collect();
+    assert!(
+        orphans.is_empty(),
+        "descendant fragments {orphans:?} remain on pages the table left: \
+         table={table:?}, wrap={wrap:?}"
+    );
+}

--- a/crates/fulgur/tests/repeating_table_header_probes.rs
+++ b/crates/fulgur/tests/repeating_table_header_probes.rs
@@ -1102,3 +1102,84 @@ fn probe_painted_zero_height_box_keeps_its_table_page() {
         );
     }
 }
+
+/// The last body block sits inside a wrapper, so the wrapper — not the cell —
+/// gets the empty continuation on the page the break advances to.
+const TRAILING_BREAK_INSIDE_WRAPPER: &str = r#"<!doctype html>
+<html><head><style>
+  html, body { margin: 0; padding: 0; }
+  table { margin: 0; border-spacing: 0; width: 100px; }
+  th, td { box-sizing: border-box; padding: 0; }
+  .m { height: 30px; background: rgb(6,6,6); }
+  #last { break-after: page; }
+</style></head><body>
+  <table id="t">
+    <thead><tr><th>H</th></tr></thead>
+    <tbody>
+      <tr><td><section id="wrap">
+        <div class="m"></div>
+        <div class="m" id="last"></div>
+      </section></td></tr>
+    </tbody>
+  </table>
+  <div class="m" id="after"></div>
+</body></html>"#;
+
+#[test]
+fn probe_wrapper_continuation_is_not_body_content() {
+    let engine = engine_200x100();
+    let layout = engine
+        .layout(TRAILING_BREAK_INSIDE_WRAPPER)
+        .expect("layout");
+    let table = table_fragments(&layout, "t");
+    let after = block_fragments(&layout, "after");
+    println!(
+        "[wrapper] table = {table:?}  wrap = {:?}  after = {after:?}",
+        block_fragments(&layout, "wrap")
+    );
+    assert!(!table.is_empty(), "table must record geometry");
+    assert!(!after.is_empty(), "sibling must record geometry");
+    assert!(
+        after[0].1 < 0.5,
+        "sibling offset by a band for a page whose only body fragment is an \
+         empty wrapper continuation: after={after:?}, table={table:?}"
+    );
+}
+
+/// A zero-height `<td>` that still paints must keep its page's table slice.
+const PAINTED_ZERO_HEIGHT_CELL: &str = r#"<!doctype html>
+<html><head><style>
+  html, body { margin: 0; padding: 0; }
+  table { margin: 0; border-spacing: 0; width: 100px; }
+  th, td { box-sizing: border-box; padding: 0; }
+  .m { height: 30px; background: rgb(6,6,6); }
+  #first { break-after: page; }
+  #ghost { height: 0; box-shadow: 0 0 0 6px rgb(9,9,9); }
+</style></head><body>
+  <table id="t">
+    <thead><tr><th>H</th></tr></thead>
+    <tbody>
+      <tr><td><div class="m" id="first"></div></td></tr>
+      <tr><td id="ghost"></td></tr>
+    </tbody>
+  </table>
+</body></html>"#;
+
+#[test]
+fn probe_painted_zero_height_cell_keeps_its_table_page() {
+    let engine = engine_200x100();
+    let layout = engine.layout(PAINTED_ZERO_HEIGHT_CELL).expect("layout");
+    let table = table_fragments(&layout, "t");
+    let ghost = block_fragments(&layout, "ghost");
+    println!("[painted-cell] table = {table:?}  ghost = {ghost:?}");
+    assert!(!table.is_empty(), "table must record geometry");
+
+    let table_pages: std::collections::BTreeSet<u32> = table.iter().map(|(p, _, _)| *p).collect();
+    for (page, _, _) in &ghost {
+        assert!(
+            table_pages.contains(page),
+            "page {page} paints a zero-height cell but has no table slice: \
+             table={table:?}, ghost={ghost:?}"
+        );
+    }
+}


### PR DESCRIPTION
#721 の上に積む。#721 のレビューで Codex が指摘した本文側の強制改頁 2 件を扱う。片方は修正、もう片方は**指摘の帰属が誤っていた**ことを実測で示す。

## 修正: 末尾の空フラグメントが幻のヘッダページになる

最終本文ブロックの `break-after: page` はフラグメンタを次ページへ進め、テーブルを高さ 0 のフラグメントで閉じる。そこに band 高さを無条件で足していたため、**空のスライスが「複製ヘッダだけを載せた実ページ」に昇格**し、テーブル以降の内容も幻の band 分だけ下へずれていた。

```text
修正前: table = [(0, h=100), (1, h=19)]   本文は全て page 0、page 1 は band 高さのみ
修正後: table = [(0, h=100)]
```

テーブルのフラグメントは、自前の高さを持つか、実体のある本文と同じページを共有する場合のみ残す。これで占有ストリップのケース（生きたセルと同居する正当な高さ 0 スライス）は維持される。本文ページの判定に空の継続フラグメントを数えないのが要点で、セル自身の空フラグメントは「内容」ではない。

回帰テスト: `probe_break_after_last_row_makes_no_header_only_page`

## 訂正: 行への強制改頁は繰り返し経路とは無関係

指摘は「本文パスにフラット化したセル ID を渡すため、スタイルの付いた `<tr>` が訪問されず break が落ちる」というものだった。**同じ表から `<thead>` を外すと同じく無視される**:

```text
thead あり: a1 = [(0, y=30, h=30)]  a2 = [(0, y=60, h=30)]
thead なし: a1 = [(0, y=0,  h=30)]  a2 = [(0, y=30, h=30)]
```

つまり行・行グループへの強制改頁は**表全般で未対応**であって、繰り返しヘッダ経路が持ち込んだものではない。

この差は対応方針を変える。当初は #721 と同じ方針（壊れた出力より機能の断念 = 行に break がある表は繰り返さない）でゲートを書いたが、フォールバック先でも break は無視されるため**何も直らず繰り返し機能だけを失う**。撤回した。

実際の修正は行階層をフラグメンタに見せることで、コーディネータの構造変更になる。この PR のスコープ外とし、再現テスト 2 本を `#[ignore]` 付きで残した (`cargo test -- --ignored`)。

## テスト

`cargo test -p fulgur` 0 failures、clippy / fmt クリーン、VRT 通過。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - 繰り返しヘッダー付きテーブルで、本文のないページに不要なヘッダーが表示される問題を修正しました。
  - 強制改ページ後に続くコンテンツが不意にずれる問題を改善しました。
  - 高さ0の要素や絶対配置要素を含むテーブルの改ページ処理を改善しました。
  - スタイル付きラッパーや描画効果を持つ要素が、テーブルのないページに孤立して表示される問題を修正しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->