### PR TITLE
test(convert/list_item): add coverage for branch-2 list-style-type:none paths

### DIFF
--- a/crates/fulgur/src/convert/list_item.rs
+++ b/crates/fulgur/src/convert/list_item.rs
@@ -1488,6 +1488,55 @@ mod tests {
         assert!(pdf.starts_with(b"%PDF"));
     }
 
+    // try_convert branch 2 (fallback display:list-item, line_height Number arm):
+    // Blitz sets `list_item_data = None` when `list-style-type: none`, which
+    // routes the element through branch 2 instead of branch 1.  Combined with
+    // a numeric `line-height`, the `LineHeight::Number` arm (line 85) is taken.
+    // `resolve_list_marker` returns Some (list-style-image in bundle) so the
+    // success path (lines 91-118) is also executed.
+    #[test]
+    fn smoke_branch2_list_style_none_with_image_number_line_height() {
+        let mut bundle = crate::asset::AssetBundle::default();
+        bundle.add_image("dot.png", RED_1X1_PNG.to_vec());
+        let pdf = crate::engine::Engine::builder()
+            .assets(bundle)
+            .build()
+            .render(
+                r#"<!doctype html><html><body>
+                <ul>
+                    <li style="list-style-type:none;list-style-image:url('dot.png');line-height:1.5">
+                        Item without text marker, numeric line-height
+                    </li>
+                </ul>
+                </body></html>"#,
+            )
+            .expect("render failed");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // try_convert branch 2 (fallback display:list-item, line_height Length arm):
+    // Same as above but with an absolute-length `line-height` so the
+    // `LineHeight::Length` arm (line 86) is taken.
+    #[test]
+    fn smoke_branch2_list_style_none_with_image_length_line_height() {
+        let mut bundle = crate::asset::AssetBundle::default();
+        bundle.add_image("dot.png", RED_1X1_PNG.to_vec());
+        let pdf = crate::engine::Engine::builder()
+            .assets(bundle)
+            .build()
+            .render(
+                r#"<!doctype html><html><body>
+                <ul>
+                    <li style="list-style-type:none;list-style-image:url('dot.png');line-height:24px">
+                        Item without text marker, absolute line-height
+                    </li>
+                </ul>
+                </body></html>"#,
+            )
+            .expect("render failed");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
     // try_convert branch 3 (inside marker, non-inline-root): apply
     // `list-style-position: inside` directly on the <li> element rather than
     // inheriting it from the <ul>.  Exercises the same code paths as the


### PR DESCRIPTION
## Summary

`convert/list_item.rs` の `try_convert` branch 2（`display:list-item` だが `list_item_data` が None の要素向けフォールバック）をカバーするスモークテスト2本を追加した。

branch 2 に入るためには `list_item_data = None` が必要。Blitz は `list-style-type: none` のとき `list_item_data` を明示的に `None` に設定する（blitz-dom `layout/list.rs:32`）。この挙動を利用して初めて branch 2 が到達可能になる。

既存の `smoke_fallback_display_list_item_number_line_height` / `_length_line_height` は `display:list-item` の `<div>` を使っているが、Blitz はこれらに Outside レイアウトの `list_item_data` を割り当てるため、実際には branch 1（outside marker）を通っており、branch 2 の `LineHeight::Number` / `LineHeight::Length` アームが未カバーのままだった。

## Changes

- `smoke_branch2_list_style_none_with_image_number_line_height` を追加
  - `list-style-type:none` + `list-style-image:url('dot.png')` + `line-height:1.5` の `<li>`
  - branch 2 `LineHeight::Number` アーム（旧 line 85）および branch 2 成功パス（旧 lines 91-118）をカバー
- `smoke_branch2_list_style_none_with_image_length_line_height` を追加
  - 同上だが `line-height:24px`（絶対長）で `LineHeight::Length` アーム（旧 line 86）をカバー

カバレッジ結果（`convert/list_item.rs`）:

| 指標 | 変更前 | 変更後 | 差分 |
|------|--------|--------|------|
| Regions | 94.87% (79 missed) | 98.41% (25 missed) | +3.54 pp |
| Lines | 95.35% (48 missed) | 98.13% (20 missed) | +2.78 pp |

## Test plan

- [x] `cargo test -p fulgur --lib` — 2035 tests passed
- [x] `cargo clippy` — 警告なし
- [x] `cargo fmt --check` — 差分なし

## Contributor License Agreement

By opening this pull request, I confirm that:

- [x] I have read the [Contributing Guide](https://github.com/fulgur-rs/fulgur/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://github.com/fulgur-rs/fulgur/blob/main/CLA.md)
      and agree to its terms.

## Related issues

カバレッジ改善の継続的な取り組みの一環。

---
_Generated by [Claude Code](https://claude.ai/code/session_012MtTvbqQcVfJPU9Sne3vDc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * リスト項目のフォールバック表示に関するスモークテストを追加しました。
  * 数値指定および絶対長指定の行の高さを使用した場合でも、PDFを正常に生成できることを確認しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->