### PR TITLE
test(schema): add coverage for collect_from_stmt catch-all, guarded GetAttr, and absent data path

### DIFF
--- a/crates/fulgur/src/schema.rs
+++ b/crates/fulgur/src/schema.rs
@@ -1134,8 +1134,8 @@ mod tests {
         assert!(schema["properties"].get("header.html").is_none());
     }
 
-    /// Multiple ignorable statement types (include, extends) all land in the
-    /// catch-all arm and leave surrounding variable collection intact.
+    /// Multiple `include` statements all land in the catch-all arm of
+    /// `collect_from_stmt` and leave surrounding variable collection intact.
     #[test]
     fn multiple_ignored_stmts_do_not_break_collection() {
         let schema = extract_schema(

--- a/crates/fulgur/src/schema.rs
+++ b/crates/fulgur/src/schema.rs
@@ -1131,7 +1131,7 @@ mod tests {
         assert_eq!(schema["properties"]["header_title"]["type"], "string");
         assert_eq!(schema["properties"]["page_body"]["type"], "string");
         // The include target name is a constant, not a variable.
-        assert!(schema["properties"].get("header_title").is_some());
+        assert!(schema["properties"].get("header.html").is_none());
     }
 
     /// Multiple ignorable statement types (include, extends) all land in the

--- a/crates/fulgur/src/schema.rs
+++ b/crates/fulgur/src/schema.rs
@@ -1116,4 +1116,88 @@ mod tests {
         assert_eq!(schema["properties"]["value"]["type"], "string");
         assert_eq!(schema["properties"]["divisor"]["type"], "string");
     }
+
+    // ── collect_from_stmt catch-all `_ => {}` (Include, Extends, etc.) ───────
+
+    /// `{% include %}` hits the catch-all arm in `collect_from_stmt`.
+    /// Variables in surrounding statements must still be collected.
+    #[test]
+    fn include_stmt_does_not_discard_surrounding_variables() {
+        let schema = extract_schema(
+            r#"{{ header_title }}{% include "header.html" %}{{ page_body }}"#,
+            "test.html",
+        )
+        .unwrap();
+        assert_eq!(schema["properties"]["header_title"]["type"], "string");
+        assert_eq!(schema["properties"]["page_body"]["type"], "string");
+        // The include target name is a constant, not a variable.
+        assert!(schema["properties"].get("header_title").is_some());
+    }
+
+    /// Multiple ignorable statement types (include, extends) all land in the
+    /// catch-all arm and leave surrounding variable collection intact.
+    #[test]
+    fn multiple_ignored_stmts_do_not_break_collection() {
+        let schema = extract_schema(
+            r#"{% include "head.html" %}{{ page_title }}{% include "foot.html" %}"#,
+            "test.html",
+        )
+        .unwrap();
+        assert_eq!(schema["properties"]["page_title"]["type"], "string");
+    }
+
+    // ── collect_from_expr: guarded GetAttr arm (filter output attribute) ─────
+
+    /// `(items | first).name`: the base of the GetAttr is a Filter, so
+    /// `resolve_expr_path` returns `None` for the outer GetAttr, triggering
+    /// the guarded arm that recurses into the base expression.
+    #[test]
+    fn getattr_on_filter_output_collects_base_variable() {
+        let schema = extract_schema("{{ (items | first).name }}", "test.html").unwrap();
+        // `items` must be collected — it is the base of the filter.
+        assert!(!schema["properties"]["items"].is_null());
+    }
+
+    /// `(call_result()).attr` — call result attribute access also makes
+    /// `resolve_expr_path` return `None` for the outer GetAttr.
+    #[test]
+    fn getattr_on_call_result_collects_call_base_variable() {
+        // `get_item()` is a function call; the outer `.title` triggers the
+        // guarded GetAttr arm which recurses into the call expression.
+        let schema = extract_schema("{{ get_item().title }}", "test.html").unwrap();
+        // `get_item` is a Var inside the Call; it should be collected.
+        assert!(!schema["properties"]["get_item"].is_null());
+    }
+
+    // ── resolve_expr_path: built-in `self` variable name ────────────────────
+
+    /// `self` is a Jinja built-in; `resolve_expr_path` skips it by name so it
+    /// never appears as a top-level schema property.
+    #[test]
+    fn self_builtin_is_not_collected_as_schema_variable() {
+        let schema = extract_schema("{{ self.title }}", "test.html").unwrap();
+        assert!(
+            schema["properties"]["self"].is_null(),
+            "`self` must not appear as a schema property"
+        );
+    }
+
+    // ── extract_schema_with_data: template variable absent from data ─────────
+
+    /// A template variable that is NOT present in the sample data object must
+    /// be omitted from the generated schema.  This exercises the
+    /// `if let Some(val) = data_map.get(key)` branch that returns `None`.
+    #[test]
+    fn schema_with_data_absent_template_var_is_omitted() {
+        // data has only "title"; the template also uses "author".
+        // For "author", data_map.get("author") returns None → that branch fires.
+        let data = json!({"title": "My Page"});
+        let schema =
+            extract_schema_with_data("{{ title }} by {{ author }}", "test.html", &data).unwrap();
+        assert_eq!(
+            schema["properties"],
+            json!({"title": {"type": "string"}}),
+            "`author` (absent from data) must not appear in the schema"
+        );
+    }
 }


### PR DESCRIPTION
## 概要

`crates/fulgur/src/schema.rs` の未カバーブランチに対してユニットテストを追加した定期カバレッジ改善 PR です。
`cargo-llvm-cov` で計測した結果、同ファイルのミス領域数が **38 → 37**（97.05% → 97.27%）に改善されました。

## 対象モジュール

`crates/fulgur/src/schema.rs` — MiniJinja テンプレートから JSON Schema を推論するモジュール。
Blitz / Krilla 依存がなく純粋なロジックのため、テスト追加が最も tractable でした。

## 追加したテスト（6件）

| テスト名 | カバーした経路 |
|---|---|
| `include_stmt_does_not_discard_surrounding_variables` | `collect_from_stmt` の `_ => {}` catch-all arm（`{% include %}` 等） |
| `multiple_ignored_stmts_do_not_break_collection` | 同上・複数の無視ステートメントが混在するケース |
| `getattr_on_filter_output_collects_base_variable` | `collect_from_expr` の guarded GetAttr arm（`resolve_expr_path` が `None` を返すケース） |
| `getattr_on_call_result_collects_call_base_variable` | 同上・関数呼び出し結果へのアトリビュートアクセス |
| `self_builtin_is_not_collected_as_schema_variable` | `resolve_expr_path` 内の `self` 組み込み変数スキップパス |
| `schema_with_data_absent_template_var_is_omitted` | `extract_schema_with_data` 内の `data_map.get(key)` が `None` を返すブランチ |

## 意図的にスキップしたブランチ

以下のブランチは現行 MiniJinja 2.x では到達不可能なため、テスト追加を見送りました。

- `collect_from_call_arg` の `PosSplat` / `KwargSplat` arm — MiniJinja は `*args` / `**kwargs` 構文を実装していない
- `WithBlock` のタプルターゲット arm — MiniJinja の `with` ブロックはリストターゲット (`[a, b] = pair`) を未サポート
- `collect_from_stmt` の `IfCond` arm — `collect_from_stmts` からは到達しない（内部制御フロー）
- `resolve_path` / `ensure_array_at_path` の `if path.is_empty() { return; }` ガード — 常にパスが 1 要素以上で呼ばれるため

## カバレッジ計測コマンド

```bash
cargo llvm-cov --package fulgur --lib --summary-only --no-fail-fast
```

## チェック結果

- `cargo test -p fulgur --lib schema` — 全 53 テスト pass
- `cargo fmt --check` — pass
- `cargo clippy -p fulgur -- -D warnings` — pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1oaF6ebwUgfSSaZ2dvkve)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * `include` や `extends` の前後でも、テンプレート変数が正しく収集されることを検証するテストを追加しました。
  * フィルターや関数呼び出し結果への属性アクセス、組み込み変数 `self` の扱いを検証するテストを追加しました。
  * 固定のテンプレート名を変数として収集しないことを確認しました。
  * サンプルデータに存在しないテンプレート変数がスキーマから省略されることを確認しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->