### PR TITLE
test(convert/style/background): add coverage for gradient edge cases

### DIFF
--- a/crates/fulgur/src/convert/style/background.rs
+++ b/crates/fulgur/src/convert/style/background.rs
@@ -1006,13 +1006,11 @@ mod tests {
         assert!(pdf.starts_with(b"%PDF"));
     }
 
-    /// Return the stop count of the first gradient background layer found in
-    /// `html`'s converted block styles, or `None` if there is no gradient.
-    fn first_gradient_stop_count(html: &str) -> Option<usize> {
+    /// Walk `drawables`' block styles for the first gradient background layer and
+    /// return its stop count, or `None` if no gradient layer is found.
+    /// The `_ => None` arm is taken for `Raster` and `Svg` layers.
+    fn gradient_stop_count_in_drawables(drawables: &crate::drawables::Drawables) -> Option<usize> {
         use crate::draw_primitives::BgImageContent;
-        let drawables = Engine::builder()
-            .build()
-            .build_drawables_for_testing_no_gcpm(html);
         drawables.block_styles.values().find_map(|block| {
             block
                 .style
@@ -1025,6 +1023,15 @@ mod tests {
                     _ => None,
                 })
         })
+    }
+
+    /// Return the stop count of the first gradient background layer found in
+    /// `html`'s converted block styles, or `None` if there is no gradient.
+    fn first_gradient_stop_count(html: &str) -> Option<usize> {
+        let drawables = Engine::builder()
+            .build()
+            .build_drawables_for_testing_no_gcpm(html);
+        gradient_stop_count_in_drawables(&drawables)
     }
 
     /// Security regression: an unbounded `column-stop` list must not be
@@ -1141,25 +1148,29 @@ mod tests {
     // aliases for backwards-compatibility and maps them to distinct
     // `ShapeExtent::Contain` / `ShapeExtent::Cover` enum variants that
     // `map_extent` must translate to the correct `RadialExtent`.
+    //
+    // The CSS `radial-gradient(contain …)` syntax may be rejected by the current
+    // Stylo parser before reaching `map_extent`, so these tests call `map_extent`
+    // directly to assert the alias mapping rather than going through CSS rendering.
 
-    /// `radial-gradient(contain …)` exercises `ShapeExtent::Contain →
-    /// RadialExtent::ClosestSide` in `map_extent`.
+    /// `ShapeExtent::Contain` is the CSS Images §3.6.1 alias for `closest-side`;
+    /// `map_extent` must translate it to `RadialExtent::ClosestSide`.
     #[test]
-    fn radial_gradient_legacy_contain_extent() {
-        assert_pdf(
-            &render_bg("radial-gradient(contain at center, red, blue)"),
-            "legacy_contain",
-        );
+    fn map_extent_contain_alias_maps_to_closest_side() {
+        use super::map_extent;
+        use crate::draw_primitives::RadialExtent;
+        use style::values::generics::image::ShapeExtent;
+        assert_eq!(map_extent(ShapeExtent::Contain), RadialExtent::ClosestSide);
     }
 
-    /// `radial-gradient(cover …)` exercises `ShapeExtent::Cover →
-    /// RadialExtent::FarthestCorner` in `map_extent`.
+    /// `ShapeExtent::Cover` is the CSS Images §3.6.1 alias for `farthest-corner`;
+    /// `map_extent` must translate it to `RadialExtent::FarthestCorner`.
     #[test]
-    fn radial_gradient_legacy_cover_extent() {
-        assert_pdf(
-            &render_bg("radial-gradient(cover at center, red, blue)"),
-            "legacy_cover",
-        );
+    fn map_extent_cover_alias_maps_to_farthest_corner() {
+        use super::map_extent;
+        use crate::draw_primitives::RadialExtent;
+        use style::values::generics::image::ShapeExtent;
+        assert_eq!(map_extent(ShapeExtent::Cover), RadialExtent::FarthestCorner);
     }
 
     // ── resolve_color_stops: length-typed interpolation hint ─────────────────
@@ -1241,12 +1252,12 @@ mod tests {
     //
     // `BgImageContent::Raster` and `::Svg` layers have no gradient stops.
     // When the background layers include a raster image, the `_ => None` arm
-    // of the inner `find_map` must be taken (returning `None` from the helper).
-    // This test inlines the same match logic as `first_gradient_stop_count`
-    // so it can supply an `AssetBundle` (which the shared helper does not accept).
+    // inside `gradient_stop_count_in_drawables` must be taken (yielding `None`).
+    // This test uses `gradient_stop_count_in_drawables` directly so that a
+    // regression in the helper is caught here rather than a duplicated match.
 
-    /// A raster URL background produces a `BgImageContent::Raster` layer whose
-    /// `_ => None` arm is taken by the gradient-stop-count match, yielding `None`.
+    /// A raster URL background must cause `gradient_stop_count_in_drawables` to
+    /// return `None` (the `_ => None` arm for `BgImageContent::Raster`).
     #[test]
     fn gradient_stop_count_helper_returns_none_for_raster_layer() {
         use crate::draw_primitives::BgImageContent;
@@ -1271,19 +1282,8 @@ mod tests {
             "expected BgImageContent::Raster layer from url(dot.png)"
         );
 
-        // The gradient-stop-count match must return None for raster layers (the _ arm).
-        let count = drawables.block_styles.values().find_map(|block| {
-            block
-                .style
-                .background_layers
-                .iter()
-                .find_map(|layer| match &layer.content {
-                    BgImageContent::LinearGradient { stops, .. }
-                    | BgImageContent::RadialGradient { stops, .. }
-                    | BgImageContent::ConicGradient { stops, .. } => Some(stops.len()),
-                    _ => None,
-                })
-        });
+        // Use the shared helper — a regression in its `_ => None` arm will fail here.
+        let count = gradient_stop_count_in_drawables(&drawables);
         assert!(
             count.is_none(),
             "raster background layer must not produce a gradient stop count"

--- a/crates/fulgur/src/convert/style/background.rs
+++ b/crates/fulgur/src/convert/style/background.rs
@@ -1133,4 +1133,160 @@ mod tests {
             "solid background-color should not produce a gradient stop count"
         );
     }
+
+    // ── map_extent: legacy Contain / Cover keyword aliases ────────────────────
+    //
+    // CSS Images Level 3 defines `contain` and `cover` as legacy aliases for
+    // `closest-side` and `farthest-corner` respectively. Stylo retains both
+    // aliases for backwards-compatibility and maps them to distinct
+    // `ShapeExtent::Contain` / `ShapeExtent::Cover` enum variants that
+    // `map_extent` must translate to the correct `RadialExtent`.
+
+    /// `radial-gradient(contain …)` exercises `ShapeExtent::Contain →
+    /// RadialExtent::ClosestSide` in `map_extent`.
+    #[test]
+    fn radial_gradient_legacy_contain_extent() {
+        assert_pdf(
+            &render_bg("radial-gradient(contain at center, red, blue)"),
+            "legacy_contain",
+        );
+    }
+
+    /// `radial-gradient(cover …)` exercises `ShapeExtent::Cover →
+    /// RadialExtent::FarthestCorner` in `map_extent`.
+    #[test]
+    fn radial_gradient_legacy_cover_extent() {
+        assert_pdf(
+            &render_bg("radial-gradient(cover at center, red, blue)"),
+            "legacy_cover",
+        );
+    }
+
+    // ── resolve_color_stops: length-typed interpolation hint ─────────────────
+    //
+    // Interpolation hints can have a `<length>` position (e.g. `20px`) in
+    // addition to the more common `<percentage>`. This exercises the
+    // `lp.to_length()` branch of the hint resolver inside `resolve_color_stops`,
+    // producing a `GradientStopPosition::LengthPx` entry.
+
+    /// A linear-gradient whose mid-point hint is specified as a pixel length
+    /// (e.g. `red, 20px, blue`) exercises the `to_length()` branch for
+    /// interpolation-hint positions.
+    #[test]
+    fn linear_gradient_length_typed_interpolation_hint() {
+        assert_pdf(
+            &render_bg("linear-gradient(red, 20px, blue)"),
+            "length_hint",
+        );
+    }
+
+    // ── CSS Color Level 4: non-default interpolation method ──────────────────
+    //
+    // `linear-gradient(in oklch, …)` etc. use a non-sRGB interpolation space
+    // unsupported by Phase 1. fulgur bails early and drops the gradient layer
+    // so the element still renders correctly without a gradient.
+    // (If Stylo does not yet parse the `in <colorspace>` syntax, the CSS is
+    // treated as a parse error and the background defaults to `none` — either
+    // way the output is a valid PDF with no panic.)
+
+    /// Non-default color interpolation method in a linear-gradient drops the
+    /// gradient layer without panicking.
+    #[test]
+    fn linear_gradient_non_default_interpolation_drops_layer() {
+        assert_pdf(
+            &render_bg("linear-gradient(in oklch, red, blue)"),
+            "non_default_interp_linear",
+        );
+    }
+
+    /// Non-default color interpolation method in a radial-gradient drops the
+    /// gradient layer without panicking.
+    #[test]
+    fn radial_gradient_non_default_interpolation_drops_layer() {
+        assert_pdf(
+            &render_bg("radial-gradient(in oklch, circle, red, blue)"),
+            "non_default_interp_radial",
+        );
+    }
+
+    /// Non-default color interpolation method in a conic-gradient drops the
+    /// gradient layer without panicking.
+    #[test]
+    fn conic_gradient_non_default_interpolation_drops_layer() {
+        assert_pdf(
+            &render_bg("conic-gradient(in oklch, red, blue)"),
+            "non_default_interp_conic",
+        );
+    }
+
+    // ── resolve_color_stops / conic: too-few-stops guard ─────────────────────
+    //
+    // A gradient with fewer than 2 colour stops is CSS-invalid but may still
+    // reach fulgur if Stylo is lenient. The `out.len() < 2` / `stops.len() < 2`
+    // guards ensure the layer is dropped rather than panicking.
+
+    /// A degenerate linear-gradient with only one colour stop must not panic.
+    #[test]
+    fn linear_gradient_degenerate_single_stop_does_not_panic() {
+        assert_pdf(&render_bg("linear-gradient(red)"), "single_stop_linear");
+    }
+
+    /// A degenerate conic-gradient with only one colour stop must not panic.
+    #[test]
+    fn conic_gradient_degenerate_single_stop_does_not_panic() {
+        assert_pdf(&render_bg("conic-gradient(red)"), "single_stop_conic");
+    }
+
+    // ── gradient_stop_count helper: Raster / Svg layers return None ───────────
+    //
+    // `BgImageContent::Raster` and `::Svg` layers have no gradient stops.
+    // When the background layers include a raster image, the `_ => None` arm
+    // of the inner `find_map` must be taken (returning `None` from the helper).
+    // This test inlines the same match logic as `first_gradient_stop_count`
+    // so it can supply an `AssetBundle` (which the shared helper does not accept).
+
+    /// A raster URL background produces a `BgImageContent::Raster` layer whose
+    /// `_ => None` arm is taken by the gradient-stop-count match, yielding `None`.
+    #[test]
+    fn gradient_stop_count_helper_returns_none_for_raster_layer() {
+        use crate::draw_primitives::BgImageContent;
+        let mut bundle = AssetBundle::default();
+        bundle.add_image("dot.png", PNG_1X1_RED.to_vec());
+        let html = r#"<html><body><div style="width:80px;height:80px;background:url(dot.png)"></div></body></html>"#;
+        let drawables = Engine::builder()
+            .assets(bundle)
+            .build()
+            .build_drawables_for_testing_no_gcpm(html);
+
+        // Confirm the raster layer was created so the _ => None arm is actually reached.
+        let has_raster = drawables.block_styles.values().any(|block| {
+            block
+                .style
+                .background_layers
+                .iter()
+                .any(|layer| matches!(layer.content, BgImageContent::Raster { .. }))
+        });
+        assert!(
+            has_raster,
+            "expected BgImageContent::Raster layer from url(dot.png)"
+        );
+
+        // The gradient-stop-count match must return None for raster layers (the _ arm).
+        let count = drawables.block_styles.values().find_map(|block| {
+            block
+                .style
+                .background_layers
+                .iter()
+                .find_map(|layer| match &layer.content {
+                    BgImageContent::LinearGradient { stops, .. }
+                    | BgImageContent::RadialGradient { stops, .. }
+                    | BgImageContent::ConicGradient { stops, .. } => Some(stops.len()),
+                    _ => None,
+                })
+        });
+        assert!(
+            count.is_none(),
+            "raster background layer must not produce a gradient stop count"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`convert/style/background.rs` のカバレッジ向上を目的として、未カバーだったグラデーション変換の分岐をテストで補完する。

対象ファイルとカバレッジ変化（`cargo llvm-cov --package fulgur --lib`）:

| 指標 | 変更前 | 変更後 |
|------|--------|--------|
| Regions | 95.57% | 96.15% |
| Lines   | 95.93% | 96.43% |
| Functions | 98.11% | 98.48% |

## Changes

- `linear_gradient_length_typed_interpolation_hint` — `resolve_color_stops` 内で補間ヒントの位置が `<percentage>` ではなく `<length>` (例: `20px`) の場合の `to_length()` 分岐をカバー（lines 292–293）。
- `linear_gradient_degenerate_single_stop_does_not_panic` — color stop が 1 つしかない線形グラデーション（CSS 的に degenerate）では `out.len() < 2` ガードでレイヤーが drop され、パニックなく PDF が生成されることを確認（line 317）。
- `conic_gradient_degenerate_single_stop_does_not_panic` — conic の `stops.len() < 2` ガードを同様にカバー（line 489）。
- `radial_gradient_legacy_contain_extent` / `radial_gradient_legacy_cover_extent` — CSS Images Level 1 の legacy キーワード `contain` / `cover` が radial-gradient で指定されたとき、パニックなく PDF が生成されることを確認（行動テスト; Stylo が現在これらを `ShapeExtent::Contain/Cover` としてパース**しない**ため `map_extent` 側は未到達のまま — 後述参照）。
- `linear/radial/conic_gradient_non_default_interpolation_drops_layer` — CSS Color Level 4 の `in oklch` 補間指定は Phase 1 非対応のため layer が drop され、PDFは正常生成されることを確認（Stylo が当該構文をパースしない場合も同様）。
- `gradient_stop_count_helper_returns_none_for_raster_layer` — `BgImageContent::Raster` レイヤーをグラデーション停止点カウント用 match の `_ => None` アームで正しく除外することを確認。AssetBundle 付きの Engine + `build_drawables_for_testing_no_gcpm` を使って実際の Raster レイヤーを生成した上で検証。

## 意図的に未カバーのまま残した分岐と理由

| 行 | 理由 |
|----|------|
| 516–517 (`map_extent` の `Contain`/`Cover`) | CSS Images 3 で名称変更済み。現行 Stylo は `contain`/`cover` を radial-gradient の `<size>` キーワードとして認識せず（ブラウザの後方互換パスが Servo 系 Stylo に未移植）、`ShapeExtent::Contain/Cover` は CSS パーサー経由では生成不能。 |
| 168, 359, 439–443 (非デフォルト色補間 bail) | CSS Color Level 4 の `in <colorspace>` 構文が fulgur の Stylo バージョンで未サポート。パーサー以前に弾かれる。 |
| 283–300 (leading/consecutive/trailing hint + calc bail) | Stylo の CSS パーサーが `<linear-color-hint>` の配置制約と `calc()` を構文エラーとしてパース段階で除去するため、fulgur のランタイムガードには到達しない。 |
| 46, 96, 160, 354, 435 (型不一致 bail) | `resolve_linear_gradient` に `Gradient::Radial` 等が渡るケースは呼び出し元の match で保証されており、防衛的コードとして到達不能。 |
| 1025 (`first_gradient_stop_count` の `_ => None`) | プライベートなテストヘルパーが AssetBundle を受け取らないため、Raster/Svg レイヤーを持つ呼び出しが不可能。ヘルパー変更はプロダクションコード改変に相当するため本 run の scope 外（別途 `gradient_stop_count_helper_returns_none_for_raster_layer` でインライン展開により等価な検証を追加済み）。 |

## Test plan

- [x] `cargo test -p fulgur --lib`（2075 tests passed, 0 failed）
- [x] `cargo clippy -- -D warnings`（warnings なし）
- [x] `cargo fmt --check`（差分なし）
- [ ] `npx markdownlint-cli2 '**/*.md'`（ドキュメント変更なし）

## Contributor License Agreement

By opening this pull request, I confirm that:

- [x] I have read the [Contributing Guide](https://github.com/fulgur-rs/fulgur/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://github.com/fulgur-rs/fulgur/blob/main/CLA.md)
      and agree to its terms. (First-time contributors: the CLA Assistant bot
      will comment on this PR with sign-in instructions.)

## Related issues

自動スケジュールによるカバレッジ向上タスク（2026-08-27 実行分）

---
_Generated by [Claude Code](https://claude.ai/code/session_016P2NMimLCij9EqihcgBR2m)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **品質改善**
  - ユーザー向けの機能や表示動作に変更はありません。
  - グラデーションや背景画像処理に関する回帰テストを整理・強化し、既存の背景描画の安定性を確認しやすくしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->