### PR TITLE
test(convert/style/background): add coverage for background image and gradient paths

### DIFF
--- a/crates/fulgur/src/convert/style/background.rs
+++ b/crates/fulgur/src/convert/style/background.rs
@@ -1133,4 +1133,76 @@ mod tests {
             "solid background-color should not produce a gradient stop count"
         );
     }
+
+    // ── Image::Url with bundle present but asset missing ─────────────────────
+
+    /// `Image::Url` → AssetBundle is set but does not contain the requested
+    /// asset → `get_image` returns `None` → layer dropped silently.
+    ///
+    /// This covers the `a.get_image(src)?` short-circuit path when the bundle
+    /// is present but the image name was never registered.
+    #[test]
+    fn bg_image_url_missing_from_bundle_skips_layer() {
+        let bundle = AssetBundle::default(); // empty — "missing.png" not registered
+        let html = r#"<html><body><div style="width:80px;height:80px;background:url(missing.png)"></div></body></html>"#;
+        let pdf = Engine::builder()
+            .assets(bundle)
+            .build()
+            .render(html)
+            .expect("render with bundle present but image absent");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // ── calc() gradient center positions ─────────────────────────────────────
+
+    /// `radial-gradient(… at calc(50% + 10px) …)` produces a computed
+    /// `LengthPercentage` that is neither a pure percentage nor a pure length.
+    /// `try_convert_lp_to_bg` returns `None` for such values, causing the
+    /// gradient layer to be dropped (element still renders without the
+    /// background image).
+    #[test]
+    fn radial_gradient_calc_center_position_drops_layer() {
+        let pdf = render_bg("radial-gradient(circle at calc(50% + 10px) 50%,red,blue)");
+        assert_pdf(&pdf, "radial_calc_center");
+    }
+
+    /// Same for `conic-gradient(… at calc(…) …)`: `try_convert_lp_to_bg`
+    /// returns `None` for a mixed-unit calc, so the layer is dropped.
+    #[test]
+    fn conic_gradient_calc_center_position_drops_layer() {
+        let pdf = render_bg("conic-gradient(at calc(50% + 10px) 50%,red,blue)");
+        assert_pdf(&pdf, "conic_calc_center");
+    }
+
+    // ── non-default color interpolation method ───────────────────────────────
+
+    /// A gradient that specifies a non-default color interpolation space
+    /// (`in hsl`) sets the `HAS_DEFAULT_COLOR_INTERPOLATION_METHOD` flag to
+    /// false; `resolve_linear_gradient` bails early and returns `None` so the
+    /// layer is dropped. Element still renders (no background image, but valid
+    /// PDF).
+    #[test]
+    fn linear_gradient_non_default_interpolation_drops_layer() {
+        // `in hsl` is a non-default color-interpolation-method (CSS Color 4).
+        // If Stylo supports this syntax the flag will be absent and the layer
+        // is dropped by fulgur's bail-out. If Stylo doesn't support it yet the
+        // gradient is also silently ignored. Either way the result must be a
+        // valid PDF.
+        let pdf = render_bg("linear-gradient(in hsl,red,blue)");
+        assert_pdf(&pdf, "linear_nondefault_interp");
+    }
+
+    /// Same for radial-gradient with a non-default interpolation method.
+    #[test]
+    fn radial_gradient_non_default_interpolation_drops_layer() {
+        let pdf = render_bg("radial-gradient(in hsl,red,blue)");
+        assert_pdf(&pdf, "radial_nondefault_interp");
+    }
+
+    /// Same for conic-gradient with a non-default interpolation method.
+    #[test]
+    fn conic_gradient_non_default_interpolation_drops_layer() {
+        let pdf = render_bg("conic-gradient(in hsl,red,blue)");
+        assert_pdf(&pdf, "conic_nondefault_interp");
+    }
 }


### PR DESCRIPTION
# Pull Request

## Summary

`crates/fulgur/src/convert/style/background.rs` のカバレッジ改善。測定時点で最低カバレッジ 3 ファイルのうち最もテスト追加が tractable なファイル（95.57%）を対象とし、新規テスト 6 件を追加。

**対象モジュール:** `convert::style::background`
**カバレッジ変化:** 95.57% → 96.15%（region coverage。missed regions: 40 → 37）

## Changes

- `bg_image_url_missing_from_bundle_skips_layer`: `AssetBundle` はセットされているが対象画像が登録されていない場合に `get_image(src)?` が `None` を返してレイヤーが drop されるパス（L49）をカバー
- `radial_gradient_calc_center_position_drops_layer`: `calc(50% + 10px)` など混合単位の center position を持つ radial gradient で `try_convert_lp_to_bg` が `None` を返してレイヤー drop される経路をカバー
- `conic_gradient_calc_center_position_drops_layer`: 同様の conic gradient 版
- `linear_gradient_non_default_interpolation_drops_layer`: CSS Color 4 の `in hsl` 構文など非デフォルト color interpolation method を持つ gradient で fulgur がレイヤーを drop する経路をカバー（Stylo がサポートしない場合は CSS 自体が無視されるが、いずれにせよ valid PDF が出力されることを確認）
- `radial_gradient_non_default_interpolation_drops_layer`: 同様の radial 版
- `conic_gradient_non_default_interpolation_drops_layer`: 同様の conic 版

**意図的に外したブランチと理由:**
- `ComputedUrl::Invalid` 分岐 (L46): Stylo が CSS parse 時に URL を ComputedUrl::Invalid として分類するケースをテスト環境で再現する手段が不明
- `InterpolationHint` の先頭・連続・末尾 hint の bail-out (L283, L287, L313): Stylo が CSS Color Level 3 構文の invalid hint を parse 前に除去するため、該当コードは現行の Stylo バージョンでは到達不能と判断（防御的コード）
- `ComplexColorStop` の `calc()` stop position (L266, L270): Stylo が `calc()` を具体的な percentage/length に評価する場合があり、一貫した再現方法が不明

## Test plan

- [x] `cargo test -p fulgur --lib`（2072 passed, 0 failed）
- [x] `cargo clippy -p fulgur -- -D warnings`（warnings なし）
- [x] `cargo fmt --check`（差分なし）
- [ ] `npx markdownlint-cli2 '**/*.md'`（ドキュメント変更なし）

## Related issues

N/A（自動 coverage 改善ルーティン）

---
_Generated by [Claude Code](https://claude.ai/code/session_01Js5s6HadrxEYBdophmzvaX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * 背景画像アセットが見つからない場合や未対応の背景レイヤーがある場合でも、要素を有効なPDFとして描画できるよう改善しました。
  * 線形・放射・円錐グラデーションの中心位置や色補間方式に関する描画の安定性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->