### PR TITLE
test(background): render smoke tests for border-radius and gradient tiling paths

### DIFF
--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -6228,9 +6228,11 @@ mod render_smoke_tests {
     #[test]
     fn repeating_radial_gradient_tiling_pattern() {
         // draw_radial_grid クロージャ → draw_gradient_tiling_pattern (lines 710-716) を踏む。
+        // background-size を要素より小さくして複数タイルを強制し、
+        // try_uniform_grid が Some を返す (≥ 2 tiles) ことで Pattern 経路が選ばれる。
         let pdf = render(
             r#"<!doctype html><html><body>
-            <div style="width:120px;height:80px;background:repeating-radial-gradient(circle 20px,red,blue 20px)"></div>
+            <div style="width:120px;height:80px;background:repeating-radial-gradient(circle 20px,red,blue 20px);background-size:30px 30px"></div>
             </body></html>"#,
         );
         assert!(pdf.starts_with(b"%PDF"));
@@ -6239,9 +6241,11 @@ mod render_smoke_tests {
     #[test]
     fn repeating_conic_gradient_tiling_pattern() {
         // draw_conic_grid クロージャ → draw_gradient_tiling_pattern (lines 760-773) を踏む。
+        // background-size を要素より小さくして複数タイルを強制し、
+        // try_uniform_grid が Some を返す (≥ 2 tiles) ことで Pattern 経路が選ばれる。
         let pdf = render(
             r#"<!doctype html><html><body>
-            <div style="width:120px;height:80px;background:repeating-conic-gradient(red 0deg,blue 30deg)"></div>
+            <div style="width:120px;height:80px;background:repeating-conic-gradient(red 0deg,blue 30deg);background-size:40px 40px"></div>
             </body></html>"#,
         );
         assert!(pdf.starts_with(b"%PDF"));

--- a/crates/fulgur/src/background.rs
+++ b/crates/fulgur/src/background.rs
@@ -6180,3 +6180,84 @@ mod tile_position_tests {
         assert_eq!(out.last().unwrap().offset, krilla::num::NormalizedF32::ONE);
     }
 }
+
+#[cfg(test)]
+mod render_smoke_tests {
+    fn render(html: &str) -> Vec<u8> {
+        crate::engine::Engine::builder()
+            .build()
+            .render(html)
+            .expect("render failed")
+    }
+
+    #[test]
+    fn background_color_with_border_radius() {
+        // draw_background_color の border-radius ブランチ (lines 521-526) を踏む:
+        // has_radius() == true → build_rounded_rect_path が呼ばれる経路。
+        let pdf = render(
+            r#"<!doctype html><html><body>
+            <div style="width:120px;height:80px;background-color:red;border-radius:10px"></div>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn box_shadow_with_border_radius() {
+        // draw_single_box_shadow (lines 101-106) と
+        // build_shadow_evenodd_clip (lines 59-65) の border-radius ブランチを踏む。
+        let pdf = render(
+            r#"<!doctype html><html><body>
+            <div style="width:120px;height:80px;box-shadow:4px 4px 0px rgba(0,0,0,0.5);border-radius:8px"></div>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn linear_gradient_with_border_radius() {
+        // draw_background_layer の border-radius クリップ経路 (lines 561-566) を踏む。
+        let pdf = render(
+            r#"<!doctype html><html><body>
+            <div style="width:120px;height:80px;background:linear-gradient(red,blue);border-radius:8px"></div>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn repeating_radial_gradient_tiling_pattern() {
+        // draw_radial_grid クロージャ → draw_gradient_tiling_pattern (lines 710-716) を踏む。
+        let pdf = render(
+            r#"<!doctype html><html><body>
+            <div style="width:120px;height:80px;background:repeating-radial-gradient(circle 20px,red,blue 20px)"></div>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn repeating_conic_gradient_tiling_pattern() {
+        // draw_conic_grid クロージャ → draw_gradient_tiling_pattern (lines 760-773) を踏む。
+        let pdf = render(
+            r#"<!doctype html><html><body>
+            <div style="width:120px;height:80px;background:repeating-conic-gradient(red 0deg,blue 30deg)"></div>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn background_and_box_shadow_combined_with_border_radius() {
+        // 3 つの border-radius 経路を同時に踏む:
+        // draw_background_color (lines 521-526), draw_single_box_shadow (lines 101-106),
+        // build_shadow_evenodd_clip (lines 59-65)。
+        let pdf = render(
+            r#"<!doctype html><html><body>
+            <div style="width:120px;height:80px;background-color:cornflowerblue;
+                        box-shadow:2px 2px 4px rgba(0,0,0,0.4);border-radius:16px"></div>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+}


### PR DESCRIPTION
## 概要

`crates/fulgur/src/background.rs` に `render_smoke_tests` モジュールを追加し、
これまでカバレッジが取れていなかった描画ブランチ 6 経路を端から端まで踏むテストを書きました。

### カバレッジ改善

| ファイル | 変更前（行） | 変更後（行） |
|---|---|---|
| `background.rs` | ~95.5% | 97.2% |

### 追加テスト一覧

| テスト名 | カバーする経路 |
|---|---|
| `background_color_with_border_radius` | `draw_background_color` — `has_radius() == true` → `build_rounded_rect_path` |
| `box_shadow_with_border_radius` | `draw_single_box_shadow` (lines 101-106) と `build_shadow_evenodd_clip` (lines 59-65) の border-radius ブランチ |
| `linear_gradient_with_border_radius` | `draw_background_layer` — border-radius クリップ経路 (lines 561-566) |
| `repeating_radial_gradient_tiling_pattern` | `draw_radial_grid` クロージャ → `draw_gradient_tiling_pattern` (lines 710-716) |
| `repeating_conic_gradient_tiling_pattern` | `draw_conic_grid` クロージャ → `draw_gradient_tiling_pattern` (lines 760-773) |
| `background_and_box_shadow_combined_with_border_radius` | 上記 border-radius 経路 3 本を同時に踏む |

### なぜこれらが未カバーだったか

`crates/fulgur/src/convert/style/background.rs` の既存テストは背景色・グラデーションを
`border-radius` なしで描画しており、`has_radius()` が常に `false` だったため、
各描画関数の rounded-rect 分岐が一度も実行されていませんでした。
繰り返しグラデーション（repeating-radial/conic）のタイリングパターンクロージャも
同様に未テストでした。

## 変更内容

- `crates/fulgur/src/background.rs`: `#[cfg(test)] mod render_smoke_tests { … }` を末尾に追加（81 行）

プロダクションコードの変更はありません。

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmjyNnxBdHKQmWxPu1q3DA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 背景色、角丸ボックスシャドウ、線形・放射・円錐グラデーションの描画を検証するテストを追加しました。
  * 複数の背景効果やボックスシャドウを組み合わせた HTML から PDF への変換を確認できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->