### PR TITLE
test(column_css): add coverage for break-before, column-fill, and page-name paths

### DIFF
--- a/crates/fulgur/src/column_css.rs
+++ b/crates/fulgur/src/column_css.rs
@@ -2425,4 +2425,87 @@ mod tests {
             "percentage width must drop the declaration"
         );
     }
+
+    // -------- parse_break_before_value: uncovered keyword arms --------
+
+    /// `left`, `right`, `recto`, `verso` in `break-before` collapse to
+    /// `BreakBefore::Page` — same treatment as in `break-after`. The existing
+    /// tests only cover `always`, `page`, and `auto`; this exercises the
+    /// remaining match-arm values.
+    #[test]
+    fn parse_break_before_left_and_right_collapse_to_page() {
+        let p1 = parse_declaration_block("break-before: left");
+        let p2 = parse_declaration_block("break-before: right");
+        assert_eq!(p1.break_before, Some(BreakBefore::Page), "left");
+        assert_eq!(p2.break_before, Some(BreakBefore::Page), "right");
+    }
+
+    #[test]
+    fn parse_break_before_recto_and_verso_collapse_to_page() {
+        let p1 = parse_declaration_block("break-before: recto");
+        let p2 = parse_declaration_block("break-before: verso");
+        assert_eq!(p1.break_before, Some(BreakBefore::Page), "recto");
+        assert_eq!(p2.break_before, Some(BreakBefore::Page), "verso");
+    }
+
+    /// An unrecognised `break-before` value drops the declaration silently,
+    /// leaving siblings unaffected. Exercises the `_` catch-all error arm.
+    #[test]
+    fn parse_break_before_invalid_is_silently_dropped() {
+        let props = parse_declaration_block("break-before: banana");
+        assert_eq!(
+            props.break_before, None,
+            "invalid ident must drop the declaration"
+        );
+    }
+
+    // -------- parse_column_fill_value: error arm --------
+
+    /// An unrecognised `column-fill` value drops the declaration silently.
+    /// Exercises the `else { Err(...) }` branch of `parse_column_fill_value`.
+    #[test]
+    fn parse_column_fill_invalid_is_silently_dropped() {
+        let props = parse_declaration_block("column-fill: spread;");
+        assert_eq!(
+            props.fill, None,
+            "unknown column-fill keyword must drop the declaration"
+        );
+    }
+
+    // -------- parse_page_value: multi-byte UTF-8 char-boundary truncation --------
+
+    /// A page name whose UTF-8 byte length exceeds `MAX_PAGE_NAME_BYTES` is
+    /// truncated at a valid char boundary. This test uses 254 ASCII bytes
+    /// followed by the 3-byte Unicode character '€' (U+20AC) so that the
+    /// natural truncation point (byte 256) falls inside the multi-byte
+    /// sequence. The `while !s.is_char_boundary(end)` loop in
+    /// `parse_page_value` steps back until it reaches the start of '€'
+    /// (byte 254), yielding a truncated name of exactly 254 ASCII bytes.
+    #[test]
+    fn parse_page_name_multibyte_utf8_truncated_at_char_boundary() {
+        // "a" × 254 + "€" + "x" = 254 + 3 + 1 = 258 bytes → exceeds MAX_PAGE_NAME_BYTES (256).
+        // '€' occupies bytes 254–256 (inclusive). Truncation steps back to 254.
+        let long = "a".repeat(254) + "€x";
+        assert!(
+            long.len() > crate::MAX_PAGE_NAME_BYTES,
+            "precondition: name must exceed the cap"
+        );
+        let css = format!("page: {long};");
+        let props = parse_declaration_block(&css);
+        match props.page {
+            Some(PageName::Named(s)) => {
+                assert!(
+                    s.len() <= crate::MAX_PAGE_NAME_BYTES,
+                    "truncated name must not exceed the cap, got {} bytes",
+                    s.len()
+                );
+                // Must end on a valid char boundary (all chars intact).
+                assert!(
+                    s.is_empty() || s.chars().last().is_some(),
+                    "truncated string must be valid UTF-8"
+                );
+            }
+            other => panic!("expected Named page, got {other:?}"),
+        }
+    }
 }

--- a/crates/fulgur/src/column_css.rs
+++ b/crates/fulgur/src/column_css.rs
@@ -2492,17 +2492,13 @@ mod tests {
         );
         let css = format!("page: {long};");
         let props = parse_declaration_block(&css);
+        // '€' straddles bytes 254–256; the loop backs up to 254, keeping only the "a" prefix.
+        let expected = "a".repeat(254);
         match props.page {
             Some(PageName::Named(s)) => {
-                assert!(
-                    s.len() <= crate::MAX_PAGE_NAME_BYTES,
-                    "truncated name must not exceed the cap, got {} bytes",
-                    s.len()
-                );
-                // Must end on a valid char boundary (all chars intact).
-                assert!(
-                    s.is_empty() || s.chars().last().is_some(),
-                    "truncated string must be valid UTF-8"
+                assert_eq!(
+                    s, expected,
+                    "truncation must preserve the maximal valid ASCII prefix"
                 );
             }
             other => panic!("expected Named page, got {other:?}"),


### PR DESCRIPTION
## Summary

`column_css.rs` のカバレッジを改善するテストを追加します。

カバレッジ測定結果 (`cargo llvm-cov --package fulgur --lib`):

| ファイル | 変更前 (行) | 変更後 (行) | 変更前 (ブランチ) | 変更後 (ブランチ) |
|---|---|---|---|---|
| `column_css.rs` | 96.67% | 96.86% | 98.54% | 98.71% |

## Changes

- `parse_break_before_value` の未テスト keyword アーム (`left` / `right` / `recto` / `verso` → `BreakBefore::Page`) をテスト追加。既存の `parse_break_after_left_and_right_collapse_to_page` と対称にする。
- `parse_break_before_value` の無効値エラーアーム (`_` 節) をテスト追加。
- `parse_column_fill_value` の無効値エラーアーム (`else { Err(...) }`) をテスト追加。
- `parse_page_value` の多バイト UTF-8 char-boundary 切り捨てループ (`while !s.is_char_boundary(end) { end -= 1; }`) をテスト追加。254 ASCII バイト + `"€"` (3 バイト) という構成で切り捨て点が多バイト文字の中間になるよう設計。

## 意図的にスキップした未カバー箇所

- `AtRuleParser`・`QualifiedRuleParser` のデフォルト実装メソッド (`ColumnDeclParser` は `RuleBodyParser` 経由でのみ使用されるため、これら trait のデフォルト default メソッドは呼ばれない)。追加コストゼロで覆うことができず、実際の動作にも影響しない。
- `hue_to_rgb` closure の一部のブランチ — 既存テストがすでに多くのカラー組み合わせをカバーしており、残るギャップは compiler の dead-branch 最適化・LLVM インスツルメンテーションの粒度による偽陰性の可能性が高い。

## Test plan

- [x] `cargo test -p fulgur --lib` (2107 tests passed)
- [x] `cargo clippy -p fulgur -- -D warnings`
- [x] `cargo fmt --check`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXvEF5FifsCJNY659DCEcD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * ページ区切り指定（`left`、`right`、`recto`、`verso`）が正しく処理されることを確認。
  * 無効なページ区切り値や段組み設定値が無視されることを確認。
  * マルチバイト文字を含むページ名が、文字境界を維持して安全に切り詰められることを確認。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->