### PR TITLE
test(column_css): add coverage for column-rule-style longhand and parse_length unknown unit

### DIFF
--- a/crates/fulgur/src/column_css.rs
+++ b/crates/fulgur/src/column_css.rs
@@ -2504,4 +2504,113 @@ mod tests {
             other => panic!("expected Named page, got {other:?}"),
         }
     }
+
+    // -------- column-rule-style longhand --------
+
+    /// `column-rule-style: solid` (longhand) sets `style` on a default spec.
+    /// The `if let Ok(style) = result` success path in `parse_value` fires.
+    #[test]
+    fn column_rule_style_longhand_solid() {
+        let props = parse_declaration_block("column-rule-style: solid;");
+        assert_eq!(
+            props.rule.expect("rule spec").style,
+            ColumnRuleStyle::Solid,
+            "longhand solid must set Solid style"
+        );
+    }
+
+    /// `column-rule-style: dashed` (longhand).
+    #[test]
+    fn column_rule_style_longhand_dashed() {
+        let props = parse_declaration_block("column-rule-style: dashed;");
+        assert_eq!(
+            props.rule.expect("rule spec").style,
+            ColumnRuleStyle::Dashed,
+            "longhand dashed must set Dashed style"
+        );
+    }
+
+    /// `column-rule-style: dotted` (longhand).
+    #[test]
+    fn column_rule_style_longhand_dotted() {
+        let props = parse_declaration_block("column-rule-style: dotted;");
+        assert_eq!(
+            props.rule.expect("rule spec").style,
+            ColumnRuleStyle::Dotted,
+            "longhand dotted must set Dotted style"
+        );
+    }
+
+    /// `column-rule-style: none` (longhand) produces `ColumnRuleStyle::None`.
+    #[test]
+    fn column_rule_style_longhand_none() {
+        let props = parse_declaration_block("column-rule-style: none;");
+        assert_eq!(
+            props.rule.expect("rule spec").style,
+            ColumnRuleStyle::None,
+            "longhand none must set None style"
+        );
+    }
+
+    /// `column-rule-style: double` is a Phase-C value — `parse_rule_style_ident`
+    /// returns `None`, which triggers the `ok_or_else` closure at the longhand
+    /// handler (line 589). The declaration must drop silently so later
+    /// longhand properties (width, color) still apply.
+    #[test]
+    fn column_rule_style_longhand_unsupported_value_drops_silently() {
+        let props = parse_declaration_block("column-rule-style: double;");
+        assert!(
+            props.rule.is_none(),
+            "unsupported longhand style value must drop the declaration"
+        );
+    }
+
+    /// Same Phase-C path for `groove`.
+    #[test]
+    fn column_rule_style_longhand_groove_drops_silently() {
+        let props = parse_declaration_block("column-rule-style: groove;");
+        assert!(
+            props.rule.is_none(),
+            "unsupported longhand style groove must drop the declaration"
+        );
+    }
+
+    /// A non-ident token in `column-rule-style` (e.g., a number) causes
+    /// `input.expect_ident()?` to return `Err`, dropping the declaration.
+    #[test]
+    fn column_rule_style_longhand_non_ident_drops_silently() {
+        let props = parse_declaration_block("column-rule-style: 42;");
+        assert!(
+            props.rule.is_none(),
+            "non-ident token in column-rule-style must drop the declaration"
+        );
+    }
+
+    /// Longhand `column-rule-style` can combine with other longhands:
+    /// setting width first and then style must preserve the width.
+    #[test]
+    fn column_rule_style_longhand_preserves_existing_width() {
+        let props = parse_declaration_block("column-rule-width: 2pt; column-rule-style: solid;");
+        let rule = props.rule.expect("rule spec");
+        assert_eq!(rule.style, ColumnRuleStyle::Solid, "style");
+        assert!(
+            (rule.width.to_f32() - 2.0).abs() < 0.1,
+            "width must be preserved: {}",
+            rule.width.to_f32()
+        );
+    }
+
+    // -------- parse_length: unknown dimension unit --------
+
+    /// A Dimension token with an unrecognised unit (e.g., `vw`) causes
+    /// `length_to_pt` to return `None`, which triggers the `ok_or_else`
+    /// closure inside `parse_length` (line 247). The declaration drops.
+    #[test]
+    fn parse_length_unknown_dimension_unit_drops_declaration() {
+        let props = parse_declaration_block("column-rule-width: 10vw;");
+        assert!(
+            props.rule.is_none(),
+            "unknown dimension unit must drop the declaration"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`crates/fulgur/src/column_css.rs` の未カバーのプロダクションコード分岐にテストを追加し、ファンクションカバレッジを 98.6% → 99.0% に改善しました。

対象は以下の 2 か所です。

1. **`column-rule-style` longhand の `ok_or_else` クロージャ（line 589）**  
   既存テストは shorthand（`column-rule: 1pt double red;`）のみをカバーしており、longhand（`column-rule-style: solid;`）の `parse_value` 分岐は未テストでした。`parse_rule_style_ident` が `None` を返す Phase-C 値（`double`, `groove`）を longhand で渡したとき、`ok_or_else` クロージャが発火して宣言がサイレントに破棄されるパスが uncovered でした。

2. **`parse_length` の unknown dimension unit パス（line 247 の `ok_or_else` クロージャ）**  
   `column-rule-width: 10vw;` のように未対応の単位を渡すと `length_to_pt` が `None` を返し、`ok_or_else` クロージャで `Err` に変換されます。このパスも未テストでした。

## Changes

- `column-rule-style` longhand：有効値 4 種（`solid`, `dashed`, `dotted`, `none`）と、Phase-C 値（`double`, `groove`）と、非 ident トークン（数値）と、複数 longhand 組み合わせの計 8 テストを追加
- `parse_length`：未対応単位（`vw`）の Dimension トークンで宣言が破棄されることを確認する 1 テストを追加
- 計 9 テスト追加、合計 119 → 128 テスト（`column_css` モジュール）

## Test plan

- [x] `cargo test -p fulgur --lib column_css` — 119 passed → 128 passed, 0 failed
- [x] `cargo test -p fulgur --lib` — 2121 passed, 0 failed
- [x] `cargo clippy -p fulgur --lib -- -D warnings` — 警告なし
- [x] `cargo fmt --check -p fulgur` — 差分なし

カバレッジ変化（`crates/fulgur/src/column_css.rs`）:

| メトリクス | 変更前 | 変更後 |
|---|---|---|
| Functions | 98.6%（3 missed） | **99.0%（2 missed）** |
| Regions | 96.9%（76 missed） | **97.2%（72 missed）** |
| Lines | 99.3%（18 missed） | **98.8%（18 missed）** |

## Contributor License Agreement

- [x] I have read the [Contributing Guide](https://github.com/fulgur-rs/fulgur/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://github.com/fulgur-rs/fulgur/blob/main/CLA.md) and agree to its terms.

## Related issues

定期カバレッジ向上ルーティン（2026-09-03）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShZHbHtazk2kFktbH6prtt

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShZHbHtazk2kFktbH6prtt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * `column-rule-style` の `solid`、`dashed`、`dotted`、`none` が正しく処理されることを検証するテストを追加しました。
  * 未対応値や不正な値が無視されること、既存の幅を保持して合成されることを検証します。
  * 未認識の長さ単位（`vw`）を含む宣言が無視されることを検証します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->