### PR TITLE
test(config): add coverage for Margin::symmetric and page_height landscape

### DIFF
--- a/crates/fulgur/src/config.rs
+++ b/crates/fulgur/src/config.rs
@@ -533,4 +533,63 @@ mod tests {
         let config = Config::builder().pdf_ua(true).build();
         assert!(config.effective_bookmarks());
     }
+
+    // --- Margin::symmetric ---
+
+    #[test]
+    fn margin_symmetric_sets_vertical_and_horizontal() {
+        let m = Margin::symmetric(10.0, 20.0);
+        assert_eq!(m.top, 10.0);
+        assert_eq!(m.bottom, 10.0);
+        assert_eq!(m.right, 20.0);
+        assert_eq!(m.left, 20.0);
+    }
+
+    #[test]
+    fn margin_symmetric_equal_values_matches_uniform() {
+        let sym = Margin::symmetric(15.0, 15.0);
+        let uni = Margin::uniform(15.0);
+        assert_eq!(sym, uni);
+    }
+
+    #[test]
+    fn margin_symmetric_zero_horizontal() {
+        let m = Margin::symmetric(5.0, 0.0);
+        assert_eq!(m.top, 5.0);
+        assert_eq!(m.bottom, 5.0);
+        assert_eq!(m.right, 0.0);
+        assert_eq!(m.left, 0.0);
+    }
+
+    // --- Config::page_height landscape branch ---
+
+    #[test]
+    fn page_height_portrait_returns_portrait_height() {
+        let config = Config::builder()
+            .page_size(PageSize::A4)
+            .landscape(false)
+            .build();
+        // portrait: height = 841.89pt
+        assert!((config.page_height() - PageSize::A4.height).abs() < 0.01);
+    }
+
+    #[test]
+    fn page_height_landscape_returns_flipped_height() {
+        let config = Config::builder()
+            .page_size(PageSize::A4)
+            .landscape(true)
+            .build();
+        // landscape: page is rotated, so physical height = A4 portrait width
+        assert!((config.page_height() - PageSize::A4.width).abs() < 0.01);
+    }
+
+    #[test]
+    fn page_height_landscape_letter() {
+        let config = Config::builder()
+            .page_size(PageSize::LETTER)
+            .landscape(true)
+            .build();
+        // Letter portrait width=612, height=792; landscape flips them
+        assert!((config.page_height() - PageSize::LETTER.width).abs() < 0.01);
+    }
 }

--- a/crates/fulgur/src/config.rs
+++ b/crates/fulgur/src/config.rs
@@ -584,6 +584,15 @@ mod tests {
     }
 
     #[test]
+    fn page_height_portrait_letter() {
+        let config = Config::builder()
+            .page_size(PageSize::LETTER)
+            .landscape(false)
+            .build();
+        assert!((config.page_height() - PageSize::LETTER.height).abs() < 0.01);
+    }
+
+    #[test]
     fn page_height_landscape_letter() {
         let config = Config::builder()
             .page_size(PageSize::LETTER)


### PR DESCRIPTION
## 対象モジュール

`crates/fulgur/src/config.rs`

## カバレッジ変化

| 指標 | 変更前 | 変更後 |
|------|--------|--------|
| Regions | 98.61% (425/431) | **100.00%** (484/484) |
| Functions | 98.28% (57/58) | **100.00%** (64/64) |
| Lines | 97.35% (330/339) | **100.00%** (379/379) |

## 追加したテスト

### `Margin::symmetric` （lines 56–63）

`Margin::symmetric(vertical, horizontal)` は垂直・水平を個別に指定できるコンストラクタで、テストが一切なかった。

| テスト名 | 検証内容 |
|---|---|
| `margin_symmetric_sets_vertical_and_horizontal` | `top/bottom = vertical`, `right/left = horizontal` のフィールド個別アサート |
| `margin_symmetric_equal_values_matches_uniform` | 両値が等しい場合に `Margin::uniform` と一致すること |
| `margin_symmetric_zero_horizontal` | `horizontal=0` を指定したとき `right/left` がゼロになること |

### `Config::page_height` のランドスケープ分岐（line 163）

`page_height()` の `if self.landscape { ... }` 真の腕が未カバーだった。`content_width/content_height` のランドスケープテストは存在したが、`page_height` は呼ばれていなかった。

| テスト名 | 検証内容 |
|---|---|
| `page_height_portrait_returns_portrait_height` | 縦置き時に A4 の portrait height が返ること |
| `page_height_landscape_returns_flipped_height` | 横置き時に A4 の portrait **width** が返ること（物理的な高さが変わる） |
| `page_height_landscape_letter` | Letter サイズでも同様に反転が正しいこと |

## 意図的に除外したブランチ

なし。今回の未カバー行はすべてカバーした。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFe4Zpjv8LD2JjWGB52uYr

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFe4Zpjv8LD2JjWGB52uYr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * 対称マージンの縦・横方向の設定を検証するテストを追加しました。
  * A4およびレターサイズについて、縦向き・横向きページの高さを検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->