### PR TITLE
test(render): cover dispatch_inline_box_content opacity/descendants branches

### DIFF
--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -7269,4 +7269,80 @@ mod tests {
         );
         assert!(pdf.starts_with(b"%PDF"));
     }
+
+    // --- dispatch_inline_box_content: opacity branch (lines 829-843) ---
+
+    #[test]
+    fn render_smoke_inline_block_with_opacity_and_block_child() {
+        // An inline-block with fractional `opacity` containing a block-level
+        // `<div>` child. During convert, the span becomes an opacity scope with
+        // the inner div in `opacity_descendants`. In `dispatch_inline_box_content`
+        // the `!block.opacity_descendants.is_empty()` guard fires, routing through
+        // `draw_under_opacity` (lines 829-843).
+        //
+        // NOTE: outer container MUST be <div>, not <p>. The HTML5 parser
+        // implicitly closes an open <p> when it encounters a block-level <div>
+        // start tag, which would place the <span> outside the paragraph and
+        // prevent the inline-box dispatch path from being exercised.
+        let pdf = render_html(
+            r#"<!doctype html><html><body>
+            <div>Before
+              <span style="display:inline-block;opacity:0.5;
+                           width:60px;height:40px">
+                <div style="width:50px;height:30px;background:#cef">inner</div>
+              </span>
+            after</div>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // --- dispatch_inline_box_content: plain subtree descendants (lines 864-892) ---
+
+    #[test]
+    fn render_smoke_inline_block_plain_with_block_descendant() {
+        // An inline-block with NO transform, NO overflow:hidden, NO opacity but
+        // containing a block-level `<div>` child. The child is recorded in
+        // `inline_box_subtree_descendants` so `dispatch_inline_box_content` falls
+        // through to the plain descendant dispatch loop (lines 862-892) after
+        // calling `dispatch_fragment` for the inline-block itself.
+        //
+        // NOTE: outer container MUST be <div> (not <p>) for the same HTML-parser
+        // reason explained in render_smoke_inline_block_with_opacity_and_block_child.
+        let pdf = render_html(
+            r#"<!doctype html><html><body>
+            <div>Before
+              <span style="display:inline-block;width:60px;height:40px">
+                <div style="width:50px;height:20px;background:#fce">child</div>
+              </span>
+            after</div>
+            </body></html>"#,
+        );
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    // --- paint_multicol_paragraph_slices: multi-page multicol partition (lines 1396-1401) ---
+
+    #[test]
+    fn render_smoke_multicol_tall_paragraph_spanning_pages() {
+        // A narrow multicol container on a small page forces the column content
+        // to span multiple page fragments. `paint_multicol_paragraph_slices`'s
+        // `needs_partition = true` branch (lines 1386-1401) filters slices by
+        // the visible range on each page, exercising the `above || below ||
+        // straddles` continue guard.
+        let pdf = crate::engine::Engine::builder()
+            .page_size(crate::config::PageSize::custom(80.0, 60.0))
+            .build()
+            .render(
+                r#"<!doctype html><html><body style="margin:0">
+                <div style="column-count:2;column-gap:5px;width:80mm;font-size:10px">
+                  <p>Alpha beta gamma delta epsilon zeta eta theta iota kappa lambda
+                     mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega.
+                     Lorem ipsum dolor sit amet consectetur adipiscing elit.</p>
+                </div>
+                </body></html>"#,
+            )
+            .expect("render");
+        assert!(pdf.starts_with(b"%PDF"));
+    }
 }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -7330,18 +7330,30 @@ mod tests {
         // `needs_partition = true` branch (lines 1386-1401) filters slices by
         // the visible range on each page, exercising the `above || below ||
         // straddles` continue guard.
+        //
+        // Page: 80 mm × 40 mm with zero PDF margins so the full 40 mm is usable
+        // (PageSize::custom takes mm; Margin::uniform takes pt). At font-size:10px
+        // (≈ 7.5 pt) with 1.2 line-height a 37 mm column holds roughly 13 lines.
+        // The paragraph is repeated 8 times (~640 words) so it reliably overflows
+        // across at least 3 pages in the 2-column layout.
+        let sentence = "Alpha beta gamma delta epsilon zeta eta theta iota kappa \
+                        lambda mu nu xi omicron pi rho sigma tau upsilon phi chi \
+                        psi omega. Lorem ipsum dolor sit amet consectetur adipiscing \
+                        elit sed do eiusmod tempor incididunt ut labore et dolore \
+                        magna aliqua ut enim ad minim veniam quis nostrud. ";
+        let long_text = sentence.repeat(8);
+        let html = format!(
+            r#"<!doctype html><html><body style="margin:0">
+            <div style="column-count:2;column-gap:5px;width:80mm;font-size:10px">
+              <p>{long_text}</p>
+            </div>
+            </body></html>"#,
+        );
         let pdf = crate::engine::Engine::builder()
-            .page_size(crate::config::PageSize::custom(80.0, 60.0))
+            .page_size(crate::config::PageSize::custom(80.0, 40.0))
+            .margin(crate::config::Margin::uniform(0.0))
             .build()
-            .render(
-                r#"<!doctype html><html><body style="margin:0">
-                <div style="column-count:2;column-gap:5px;width:80mm;font-size:10px">
-                  <p>Alpha beta gamma delta epsilon zeta eta theta iota kappa lambda
-                     mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega.
-                     Lorem ipsum dolor sit amet consectetur adipiscing elit.</p>
-                </div>
-                </body></html>"#,
-            )
+            .render(&html)
             .expect("render");
         assert!(pdf.starts_with(b"%PDF"));
     }

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -7325,26 +7325,31 @@ mod tests {
 
     #[test]
     fn render_smoke_multicol_tall_paragraph_spanning_pages() {
-        // A narrow multicol container on a small page forces the column content
-        // to span multiple page fragments. `paint_multicol_paragraph_slices`'s
-        // `needs_partition = true` branch (lines 1386-1401) filters slices by
-        // the visible range on each page, exercising the `above || below ||
-        // straddles` continue guard.
+        // A multicol container with a `column-span: all` direct child forces
+        // the fragmenter (pagination_layout.rs:835-842) to split the container
+        // across pages, giving `container_geom.is_split() = true` and therefore
+        // `needs_partition = true` in `paint_multicol_paragraph_slices`.
         //
-        // Page: 80 mm × 40 mm with zero PDF margins so the full 40 mm is usable
-        // (PageSize::custom takes mm; Margin::uniform takes pt). At font-size:10px
-        // (≈ 7.5 pt) with 1.2 line-height a 37 mm column holds roughly 13 lines.
-        // The paragraph is repeated 8 times (~640 words) so it reliably overflows
-        // across at least 3 pages in the 2-column layout.
+        // Without `column-span: all` the fragmenter treats the multicol box as
+        // atomic (lines 827-845) and `is_split()` stays false, which skips the
+        // visibility-range filter at lines 1386-1401 entirely.
+        //
+        // Page: 80 mm × 40 mm with zero PDF margins (PageSize::custom = mm;
+        // Margin::uniform = pt). The first paragraph fills the first column group,
+        // the span-all heading forces a new fragment, and the second paragraph
+        // fills subsequent pages — ensuring at least two fragments and therefore
+        // the `needs_partition = true` branch.
         let sentence = "Alpha beta gamma delta epsilon zeta eta theta iota kappa \
                         lambda mu nu xi omicron pi rho sigma tau upsilon phi chi \
                         psi omega. Lorem ipsum dolor sit amet consectetur adipiscing \
                         elit sed do eiusmod tempor incididunt ut labore et dolore \
                         magna aliqua ut enim ad minim veniam quis nostrud. ";
-        let long_text = sentence.repeat(8);
+        let long_text = sentence.repeat(4);
         let html = format!(
             r#"<!doctype html><html><body style="margin:0">
             <div style="column-count:2;column-gap:5px;width:80mm;font-size:10px">
+              <p>{long_text}</p>
+              <div style="column-span:all;background:#eee;padding:2px">Spanning heading</div>
               <p>{long_text}</p>
             </div>
             </body></html>"#,


### PR DESCRIPTION
## Summary

`render.rs` の `dispatch_inline_box_content` 関数において、2 つのブランチが未カバーだった問題を修正します。

- **opacity ブランチ (lines 829-843)**: inline-block 要素が `opacity_descendants` を持つ場合に `draw_under_opacity` へルーティングするパス
- **plain サブツリー descendants ブランチ (lines 862-892)**: transform/clip/opacity なしで block-level 子要素を持つ inline-block の dispatch ループ

**ブランチ名について**: ブランチ名が `convert-style-background` になっているのは、セッション開始時点でのターゲット候補名を使ったためです。実際のターゲットは `render.rs` です。

## Changes

- `crates/fulgur/src/render.rs` のテストブロックに smoke test 3 件を追加
  - `render_smoke_inline_block_with_opacity_and_block_child`: opacity ブランチカバー
  - `render_smoke_inline_block_plain_with_block_descendant`: plain descendants ブランチカバー
  - `render_smoke_multicol_tall_paragraph_spanning_pages`: multicol パーティション分割カバー

**根本原因と修正**: 旧テストは外側コンテナに `<p>` を使っていたため、HTML5 パーサが block-level `<div>` スタートタグを検出した際に `<p>` を自動クローズし、inline-block `<span>` が段落の外に配置されていた。外側コンテナを `<div>` に変更することで正しい DOM 構造が生成され、`<span>` が Parley の InlineBox として `dispatch_inline_box_content` を経由するパスが正常に動作する。

## Test plan

- [x] `cargo test -p fulgur --lib` — 2124 tests passed
- [x] `cargo clippy` — warnings なし
- [x] `cargo fmt --check` — クリーン
- [ ] `npx markdownlint-cli2 '**/*.md'` (docs 変更なし)

**カバレッジ改善**:
- `render.rs` リージョンカバレッジ: 95.13% → 96.71% (+1.58pp)
- 全体リージョンカバレッジ: 97.57%

## Contributor License Agreement

By opening this pull request, I confirm that:

- [x] I have read the [Contributing Guide](https://github.com/fulgur-rs/fulgur/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://github.com/fulgur-rs/fulgur/blob/main/CLA.md)
      and agree to its terms. (First-time contributors: the CLA Assistant bot
      will comment on this PR with sign-in instructions.)

## Related issues

定期カバレッジ改善ルーティン (2026-09-06)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZ8ZpsxbnZKmjH2M1UAF32

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZ8ZpsxbnZKmjH2M1UAF32)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * 不透明度付きのブロック要素を含むインラインブロックの描画を検証。
  * ラッパー効果のないインラインブロックで、子孫要素が描画されることを検証。
  * `column-span: all` を含む複数段落のマルチカラムレイアウトについて、コンテナ分割と可視範囲の処理を検証。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->