### PR TITLE
test(convert/style/background): add coverage for resolve_color_stops hints, map_extent aliases

### DIFF
--- a/crates/fulgur/src/convert/style/background.rs
+++ b/crates/fulgur/src/convert/style/background.rs
@@ -626,6 +626,7 @@ fn convert_bg_clip(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::{AssetBundle, Engine};
 
     /// 1×1 red PNG (minimal valid file with correct CRC sums).
@@ -1204,5 +1205,196 @@ mod tests {
     fn conic_gradient_non_default_interpolation_drops_layer() {
         let pdf = render_bg("conic-gradient(in hsl,red,blue)");
         assert_pdf(&pdf, "conic_nondefault_interp");
+    }
+
+    // ── map_extent: Contain / Cover alias arms ────────────────────────────────
+
+    /// `ShapeExtent::Contain` and `ShapeExtent::Cover` are CSS-compat aliases
+    /// for `closest-side` and `farthest-corner` respectively (CSS Images §3.6.1).
+    /// They are not produced by the standard `radial-gradient` syntax but exist
+    /// in Stylo for compatibility; the match arms must be tested directly.
+    #[test]
+    fn map_extent_contain_and_cover_alias_correctly() {
+        use crate::draw_primitives::RadialExtent;
+        use style::values::generics::image::ShapeExtent;
+        assert_eq!(
+            map_extent(ShapeExtent::Contain),
+            RadialExtent::ClosestSide,
+            "Contain must alias to ClosestSide"
+        );
+        assert_eq!(
+            map_extent(ShapeExtent::Cover),
+            RadialExtent::FarthestCorner,
+            "Cover must alias to FarthestCorner"
+        );
+    }
+
+    // ── resolve_color_stops: direct unit tests ────────────────────────────────
+    //
+    // The CSS parser (Stylo) rejects syntactically-invalid gradient stop lists
+    // (leading/trailing/consecutive hints, <1 stop) before they reach
+    // `resolve_color_stops`, so these edge-case guard paths cannot be triggered
+    // through the normal render pipeline. Direct calls with hand-constructed
+    // Stylo values are the only way to cover them.
+
+    /// Fewer than 2 colour stops: the CSS spec requires at least 2 distinct
+    /// stops; `resolve_color_stops` returns `None` for 0 or 1 stop.
+    #[test]
+    fn resolve_color_stops_fewer_than_two_stops_returns_none() {
+        use style::color::AbsoluteColor;
+        use style::values::computed::{Color, LengthPercentage};
+        use style::values::generics::image::GradientItem;
+        let cc = AbsoluteColor::BLACK;
+        // 0 stops
+        let result =
+            resolve_color_stops(&[] as &[GradientItem<Color, LengthPercentage>], &cc, "test");
+        assert!(result.is_none(), "0 stops must return None");
+        // 1 stop
+        let result =
+            resolve_color_stops(&[GradientItem::SimpleColorStop(Color::BLACK)], &cc, "test");
+        assert!(result.is_none(), "1 stop must return None");
+    }
+
+    /// A leading interpolation hint (before the first colour stop) is invalid.
+    /// `resolve_color_stops` logs a warning and returns `None`.
+    #[test]
+    fn resolve_color_stops_leading_hint_returns_none() {
+        use style::color::AbsoluteColor;
+        use style::values::computed::{Color, LengthPercentage, Percentage};
+        use style::values::generics::image::GradientItem;
+        let cc = AbsoluteColor::BLACK;
+        let items: Vec<GradientItem<Color, LengthPercentage>> = vec![
+            GradientItem::InterpolationHint(LengthPercentage::new_percent(Percentage(0.3))),
+            GradientItem::SimpleColorStop(Color::BLACK),
+            GradientItem::SimpleColorStop(Color::WHITE),
+        ];
+        assert!(
+            resolve_color_stops(&items, &cc, "linear-gradient").is_none(),
+            "leading hint must return None"
+        );
+    }
+
+    /// Two consecutive interpolation hints (no colour stop between them) are
+    /// invalid; `resolve_color_stops` returns `None`.
+    #[test]
+    fn resolve_color_stops_consecutive_hints_return_none() {
+        use style::color::AbsoluteColor;
+        use style::values::computed::{Color, LengthPercentage, Percentage};
+        use style::values::generics::image::GradientItem;
+        let cc = AbsoluteColor::BLACK;
+        let items: Vec<GradientItem<Color, LengthPercentage>> = vec![
+            GradientItem::SimpleColorStop(Color::BLACK),
+            GradientItem::InterpolationHint(LengthPercentage::new_percent(Percentage(0.3))),
+            GradientItem::InterpolationHint(LengthPercentage::new_percent(Percentage(0.6))),
+            GradientItem::SimpleColorStop(Color::WHITE),
+        ];
+        assert!(
+            resolve_color_stops(&items, &cc, "linear-gradient").is_none(),
+            "consecutive hints must return None"
+        );
+    }
+
+    /// A trailing interpolation hint (after the last colour stop) is invalid;
+    /// `resolve_color_stops` returns `None`.
+    #[test]
+    fn resolve_color_stops_trailing_hint_returns_none() {
+        use style::color::AbsoluteColor;
+        use style::values::computed::{Color, LengthPercentage, Percentage};
+        use style::values::generics::image::GradientItem;
+        let cc = AbsoluteColor::BLACK;
+        let items: Vec<GradientItem<Color, LengthPercentage>> = vec![
+            GradientItem::SimpleColorStop(Color::BLACK),
+            GradientItem::SimpleColorStop(Color::WHITE),
+            GradientItem::InterpolationHint(LengthPercentage::new_percent(Percentage(0.7))),
+        ];
+        assert!(
+            resolve_color_stops(&items, &cc, "linear-gradient").is_none(),
+            "trailing hint must return None"
+        );
+    }
+
+    /// An interpolation hint with a pixel-length position (not a percentage)
+    /// is valid; `resolve_color_stops` must accept it and produce a stop with
+    /// `GradientStopPosition::LengthPx`. This exercises the `to_length()` branch
+    /// inside the hint arm of `resolve_color_stops`.
+    #[test]
+    fn resolve_color_stops_length_hint_is_accepted() {
+        use crate::draw_primitives::GradientStopPosition;
+        use style::color::AbsoluteColor;
+        use style::values::computed::{Color, Length, LengthPercentage};
+        use style::values::generics::image::GradientItem;
+        let cc = AbsoluteColor::BLACK;
+        let items: Vec<GradientItem<Color, LengthPercentage>> = vec![
+            GradientItem::SimpleColorStop(Color::BLACK),
+            GradientItem::InterpolationHint(LengthPercentage::new_length(Length::new(50.0))),
+            GradientItem::SimpleColorStop(Color::WHITE),
+        ];
+        let stops = resolve_color_stops(&items, &cc, "linear-gradient")
+            .expect("length-positioned hint must be accepted");
+        assert!(
+            stops.iter().any(|s| s.is_hint),
+            "the hint stop must be retained with is_hint=true"
+        );
+        assert!(
+            stops
+                .iter()
+                .any(|s| { s.is_hint && matches!(s.position, GradientStopPosition::LengthPx(_)) }),
+            "hint position must be LengthPx"
+        );
+    }
+
+    // ── Image::None in a multi-layer background ───────────────────────────────
+
+    /// `background: linear-gradient(red, blue), none` produces a two-entry
+    /// computed image list: `[Gradient(...), None]`. The outer loop in `apply_to`
+    /// iterates all entries; when it reaches `Image::None` it hits the `_ => None`
+    /// catch-all arm (line 96). Element still renders (gradient layer present).
+    #[test]
+    fn multi_layer_background_with_none_layer_renders() {
+        assert_pdf(
+            &render_bg("linear-gradient(red, blue), none"),
+            "gradient_and_none_layers",
+        );
+    }
+
+    // ── first_gradient_stop_count: raster / svg background layer (line 1025) ──
+
+    /// Inner helper shared by `first_gradient_stop_count` and the raster test
+    /// below. Separating it lets us supply an asset bundle without modifying the
+    /// no-bundle fast path used by most gradient-cap tests.
+    fn gradient_stop_count_from_drawables(
+        drawables: &crate::drawables::Drawables,
+    ) -> Option<usize> {
+        use crate::draw_primitives::BgImageContent;
+        drawables.block_styles.values().find_map(|block| {
+            block
+                .style
+                .background_layers
+                .iter()
+                .find_map(|layer| match &layer.content {
+                    BgImageContent::LinearGradient { stops, .. }
+                    | BgImageContent::RadialGradient { stops, .. }
+                    | BgImageContent::ConicGradient { stops, .. } => Some(stops.len()),
+                    _ => None,
+                })
+        })
+    }
+
+    /// A document whose only background layer is a raster image (`Raster` variant)
+    /// should return `None` from the stop-count helper — no gradient is present.
+    /// This exercises the `_ => None` arm in `gradient_stop_count_from_drawables`.
+    #[test]
+    fn gradient_stop_count_is_none_for_raster_background_layer() {
+        let mut bundle = AssetBundle::default();
+        bundle.add_image("dot.png", PNG_1X1_RED.to_vec());
+        let html = r#"<html><body><div style="width:80px;height:80px;background:url(dot.png)"></div></body></html>"#;
+        let drawables = Engine::builder()
+            .assets(bundle)
+            .build()
+            .build_drawables_for_testing_no_gcpm(html);
+        assert!(
+            gradient_stop_count_from_drawables(&drawables).is_none(),
+            "raster background must not count as gradient stops"
+        );
     }
 }

--- a/crates/fulgur/src/convert/style/background.rs
+++ b/crates/fulgur/src/convert/style/background.rs
@@ -1351,9 +1351,18 @@ mod tests {
     /// catch-all arm (line 96). Element still renders (gradient layer present).
     #[test]
     fn multi_layer_background_with_none_layer_renders() {
-        assert_pdf(
-            &render_bg("linear-gradient(red, blue), none"),
-            "gradient_and_none_layers",
+        let css = "linear-gradient(red, blue), none";
+        assert_pdf(&render_bg(css), "gradient_and_none_layers");
+        // Confirm the gradient layer was actually retained (not silently dropped).
+        let html = format!(
+            r#"<html><body><div style="width:120px;height:80px;background:{css}"></div></body></html>"#
+        );
+        let drawables = Engine::builder()
+            .build()
+            .build_drawables_for_testing_no_gcpm(&html);
+        assert!(
+            gradient_stop_count_from_drawables(&drawables).is_some(),
+            "linear-gradient layer must be retained in a multi-layer background containing `none`"
         );
     }
 
@@ -1392,6 +1401,19 @@ mod tests {
             .assets(bundle)
             .build()
             .build_drawables_for_testing_no_gcpm(html);
+        // First confirm a Raster layer was actually produced (rules out empty-layers false-pass).
+        let has_raster = drawables.block_styles.values().any(|block| {
+            block
+                .style
+                .background_layers
+                .iter()
+                .any(|layer| matches!(layer.content, BgImageContent::Raster { .. }))
+        });
+        assert!(
+            has_raster,
+            "raster background must produce a BgImageContent::Raster layer"
+        );
+        // Then confirm the gradient stop-count helper returns None for that layer.
         assert!(
             gradient_stop_count_from_drawables(&drawables).is_none(),
             "raster background must not count as gradient stops"

--- a/crates/fulgur/src/convert/style/background.rs
+++ b/crates/fulgur/src/convert/style/background.rs
@@ -1397,7 +1397,7 @@ mod tests {
                 .style
                 .background_layers
                 .iter()
-                .any(|layer| matches!(layer.content, BgImageContent::Raster { .. }))
+                .any(|layer| matches!(&layer.content, BgImageContent::Raster { .. }))
         });
         assert!(
             has_raster,

--- a/crates/fulgur/src/convert/style/background.rs
+++ b/crates/fulgur/src/convert/style/background.rs
@@ -1009,23 +1009,13 @@ mod tests {
 
     /// Return the stop count of the first gradient background layer found in
     /// `html`'s converted block styles, or `None` if there is no gradient.
+    /// Delegates to [`gradient_stop_count_from_drawables`] so the matching
+    /// logic is defined in one place.
     fn first_gradient_stop_count(html: &str) -> Option<usize> {
-        use crate::draw_primitives::BgImageContent;
         let drawables = Engine::builder()
             .build()
             .build_drawables_for_testing_no_gcpm(html);
-        drawables.block_styles.values().find_map(|block| {
-            block
-                .style
-                .background_layers
-                .iter()
-                .find_map(|layer| match &layer.content {
-                    BgImageContent::LinearGradient { stops, .. }
-                    | BgImageContent::RadialGradient { stops, .. }
-                    | BgImageContent::ConicGradient { stops, .. } => Some(stops.len()),
-                    _ => None,
-                })
-        })
+        gradient_stop_count_from_drawables(&drawables)
     }
 
     /// Security regression: an unbounded `column-stop` list must not be
@@ -1368,9 +1358,9 @@ mod tests {
 
     // ── first_gradient_stop_count: raster / svg background layer (line 1025) ──
 
-    /// Inner helper shared by `first_gradient_stop_count` and the raster test
-    /// below. Separating it lets us supply an asset bundle without modifying the
-    /// no-bundle fast path used by most gradient-cap tests.
+    /// Shared matcher used by [`first_gradient_stop_count`] and the raster test
+    /// below. Separating it lets callers supply pre-built drawables (e.g. with
+    /// an asset bundle) without duplicating the match logic.
     fn gradient_stop_count_from_drawables(
         drawables: &crate::drawables::Drawables,
     ) -> Option<usize> {


### PR DESCRIPTION
## 概要

`crates/fulgur/src/convert/style/background.rs` のカバレッジ改善 PR です。  
Region カバレッジ **96.15% → 97.35%（+1.20 pp）**、Line カバレッジ **96.15% → 97.60%（+1.45 pp）** を達成しました。

## 背景

Stylo の CSS パーサーは構文的に不正なグラデーション記述（先頭/末尾/連続した補間ヒント、ストップ数 < 2）をパース時に弾くため、これらのガード条件は通常の `render()` 経由のテストでは到達不可能でした。  
また `ShapeExtent::Contain` / `ShapeExtent::Cover` は CSS 後方互換エイリアスであり、Stylo が `radial-gradient` 構文の解析時に正規値（`ClosestSide` / `FarthestCorner`）に変換してしまうため、CSS 文字列経由では腕を踏めません。  
これらを `mod tests { use super::*; }` 経由で Stylo 型を直接構築して呼び出すことでカバーしました。

## 変更内容（テストのみ）

| テスト関数 | カバーする行 / 条件 |
|---|---|
| `map_extent_contain_and_cover_alias_correctly` | `ShapeExtent::Contain → ClosestSide`、`ShapeExtent::Cover → FarthestCorner`（line 516–517） |
| `resolve_color_stops_fewer_than_two_stops_returns_none` | ストップ数 < 2 ガード（line 317） |
| `resolve_color_stops_leading_hint_returns_none` | 先頭が `InterpolationHint` のガード（lines 283–284） |
| `resolve_color_stops_consecutive_hints_return_none` | 連続する 2 つの `InterpolationHint` ガード（lines 287–288） |
| `resolve_color_stops_trailing_hint_returns_none` | 末尾が `InterpolationHint` のガード（lines 313–314） |
| `resolve_color_stops_length_hint_is_accepted` | `Length` 位置付き補間ヒントが受け入れられ `LengthPx` ストップを生成（lines 292–293） |
| `multi_layer_background_with_none_layer_renders` | イメージ種別 match の `_ => None` 腕（line 96）を `none` レイヤー付きグラデーション CSS で踏む |
| `gradient_stop_count_is_none_for_raster_background_layer` | `first_gradient_stop_count` の `_ => None` 腕（line 1025）をラスター画像背景で踏む |

## チェックリスト

- [x] `cargo test -p fulgur --lib` 全 2161 件パス
- [x] `cargo clippy -p fulgur -- -D warnings` 警告なし
- [x] `cargo fmt --check -p fulgur` 差分なし
- [x] テストのみ変更（プロダクションコード変更なし）
- [x] カバレッジ改善を `cargo llvm-cov` で確認済み

## カバレッジ計測結果

```text
# before
convert/style/background.rs  Region 96.15%  Line 96.15%

# after
convert/style/background.rs  Region 97.35%  Line 97.60%
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPXCdE27RnBspgBNA8H6x1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPXCdE27RnBspgBNA8H6x1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **テスト**
  - グラデーション範囲の別名、停止点の不正な配置や長さ指定を検証するテストを追加しました。
  - `none` レイヤーを含む複合背景で、線形グラデーションが正しく保持されることを確認しました。
  - ラスター背景の停止点が集計対象から除外されることを確認しました。
- **バグ修正**
  - 事前に構築された描画データでも、グラデーション停止点が一貫して判定されるよう改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->