### PR TITLE
ci: give each wpt matrix phase its own rust-cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,25 +292,49 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
-          # Give each matrix variant (and this job as a whole) its own cache
-          # slot instead of sharing `ubuntu-latest-fulgur` with the `vrt` job
-          # and every other `wpt` phase. All 6 phases previously restored/
-          # saved the identical key concurrently on push-to-main — observed
-          # once as 3 phases (bugs, opacity-visibility, smoke; the ones
-          # forced to queue behind the other 3 for a runner slot) all
-          # failing identically with `cargo: could not find Cargo.toml`
-          # right after a "Cache restored successfully" that otherwise
-          # looked clean. Root cause not conclusively pinned down (would
-          # need a corrupted/overwritten checkout mid-restore), but a
-          # same-key concurrent save/restore race across 6+ jobs is the
-          # only plausible mechanism and per-phase keys remove it outright
-          # regardless of the exact mechanism.
+          # Gives each of the 7 wpt matrix phases (css-page, multicol-1/2/3,
+          # bugs, opacity-visibility, smoke) its own cache slot instead of
+          # sharing `ubuntu-latest-fulgur` with the `vrt` job and each other.
+          # This is a hygiene improvement (avoids one phase's rebuild
+          # evicting another's cache entry), NOT a confirmed fix for a
+          # specific incident: on one push-to-main run, 3 phases (bugs,
+          # opacity-visibility, smoke — the ones queued behind the other 4
+          # for a runner slot) failed identically with `cargo: could not
+          # find Cargo.toml`, immediately after a "Cache restored
+          # successfully" that otherwise looked like a clean, complete
+          # download.
+          #
+          # Per Swatinem/rust-cache's own docs, the paths it restores are
+          # `~/.cargo/{bin,registry,git,...}` and `<workspace>/target` —
+          # never the checked-out working tree itself — and matrix jobs run
+          # on independent runner VMs with no shared filesystem, so a
+          # same-key concurrent save/restore cannot plausibly overwrite
+          # another job's `actions/checkout` output (Cargo.toml lives at the
+          # repo root, outside every cached path). Flagged by Codex review
+          # on the PR that introduced this comment (fulgur PR #752) — the
+          # real mechanism is still unknown. The "Verify checkout" step
+          # below exists to actually capture that if/when this recurs,
+          # rather than continuing to guess.
           shared-key: ubuntu-latest-fulgur-wpt-${{ matrix.phase }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install poppler-utils
         run: sudo apt-get update && sudo apt-get install -y poppler-utils mold
       - name: Configure mold linker
         run: echo "RUSTFLAGS=-C link-arg=-fuse-ld=mold" >> $GITHUB_ENV
+      - name: Verify checkout
+        # Cheap sanity check requested by Codex review on fulgur PR #752
+        # after an unexplained `cargo: could not find Cargo.toml` failure
+        # on this job. If the workspace is ever missing its manifest again,
+        # dump enough state (cwd, listing, disk usage) to actually diagnose
+        # it instead of failing with cargo's generic error message.
+        run: |
+          if [ ! -f Cargo.toml ]; then
+            echo "::error::Cargo.toml missing from $(pwd) — dumping diagnostics"
+            pwd
+            ls -la
+            df -h .
+            exit 1
+          fi
       - name: Fetch WPT subset
         run: scripts/wpt/fetch.sh
       - name: Run ${{ matrix.phase }} reftests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,20 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ubuntu-latest-fulgur
+          # Give each matrix variant (and this job as a whole) its own cache
+          # slot instead of sharing `ubuntu-latest-fulgur` with the `vrt` job
+          # and every other `wpt` phase. All 6 phases previously restored/
+          # saved the identical key concurrently on push-to-main — observed
+          # once as 3 phases (bugs, opacity-visibility, smoke; the ones
+          # forced to queue behind the other 3 for a runner slot) all
+          # failing identically with `cargo: could not find Cargo.toml`
+          # right after a "Cache restored successfully" that otherwise
+          # looked clean. Root cause not conclusively pinned down (would
+          # need a corrupted/overwritten checkout mid-restore), but a
+          # same-key concurrent save/restore race across 6+ jobs is the
+          # only plausible mechanism and per-phase keys remove it outright
+          # regardless of the exact mechanism.
+          shared-key: ubuntu-latest-fulgur-wpt-${{ matrix.phase }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install poppler-utils
         run: sudo apt-get update && sudo apt-get install -y poppler-utils mold


### PR DESCRIPTION
## 概要

main CI run [34012304474](https://github.com/fulgur-rs/fulgur/actions/runs/34012304474/job/101430129603) にて、`wpt` ジョブの7バリアント (css-page, multicol-1/2/3, bugs, opacity-visibility, smoke) 中3件 (bugs, opacity-visibility, smoke) が

```text
error: could not find `Cargo.toml` in `/home/runner/work/fulgur/fulgur` or any parent directory
```

で即死する現象を発見。同一run・同一コミットで再実行しても**再現**することを確認済み(一過性のflakeではない)。過去の成功run (`33751797877`, `33591882241`, `33468338019`) では同じ3ジョブも問題なく成功しており、長年の一般的なCI不安定性でもない。

## 原因について(Codex reviewでの指摘を反映して訂正)

当初「7ジョブが同一の `Swatinem/rust-cache` キー `ubuntu-latest-fulgur` を共有しているレースが原因」という仮説を立てましたが、**Codex reviewの指摘の通りこれは技術的に成立しません**:

- `Swatinem/rust-cache` が実際に復元するパスは `~/.cargo/{bin,registry,git,...}` と `<workspace>/target` のみで、チェックアウトされた作業ツリー(Cargo.tomlを含むリポジトリ本体)には一切触れない
- 各matrix jobは独立したrunner VM上で動作し、ジョブ間でファイルシステムを共有しない

したがって同一キャッシュキーへの同時save/restoreが他ジョブの`actions/checkout`結果を上書きするというメカニズムは成り立ちません。**根本原因は依然として不明です。**

## 変更内容

1. `wpt` ジョブの `shared-key` を phase毎に分離 (`ubuntu-latest-fulgur-wpt-${{ matrix.phase }}`)。原因究明とは別に、phase間でキャッシュを共有しない方が衛生的という独立した理由で維持。
2. `cargo test` 実行前に `Cargo.toml` の存在を確認する診断ステップを追加。次に再発した際、実際にワークスペースの状態(cwd, ls -la, df -h)を捕捉できるようにする(Codex review提案)。
3. コメント内の誤記 "All 6 phases" → "All 7 phases" (coderabbit指摘)。

## 検証の限界

PR上のCI実行では `save-if` が `github.ref == 'refs/heads/main'` 条件のため、このPRのCI自体はキャッシュを復元するのみ(再保存はしない)。全ジョブが正常に走ることは確認済みだが、これは「原因が直った」証拠ではない(原因が特定できていないため)。次に再発した場合は新設した診断ステップの出力を確認すること。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Web Platform Tests（WPT）のマトリクス説明を7フェーズ構成に更新しました。
  * 各フェーズでRustキャッシュを分離して利用します。
  * キャッシュ対象と独立ランナーの制約を明記し、誤解を招く説明を整理しました。
  * CI実行時に`Cargo.toml`の存在を確認し、欠落時は診断情報を表示して失敗するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->