### PR TITLE
feat(cli): install a stderr logger so library warnings are visible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,6 +1140,7 @@ dependencies = [
  "clap",
  "fulgur",
  "libc",
+ "log",
  "serde_json",
  "tempfile",
  "which",

--- a/README.md
+++ b/README.md
@@ -131,6 +131,27 @@ fulgur render --pdf-ua --language en -o report.pdf report.html
 | `--pdf-ua` | Enable PDF/UA-1 conformance (implies `--tagged` and `--bookmarks`) | false |
 | `--stdin` | Read HTML from stdin | false |
 
+#### Diagnostics
+
+Fulgur reports non-fatal problems — missing assets, unparseable CSS, and
+content laid out past the page box — through the `log` facade. The CLI
+installs a stderr logger for these, so a render that would otherwise drop
+content off the paper and still exit `0` now says so.
+
+Set the verbosity with `RUST_LOG`:
+
+```bash
+RUST_LOG=info fulgur render input.html -o out.pdf
+```
+
+| Aspect | Behaviour |
+|---|---|
+| Default | `warn` |
+| Accepted values | a single level: `error`, `warn`, `info`, `debug`, `trace`, `off` |
+| Target filters | **not** supported — `fulgur=debug` and multi-directive strings such as `warn,fulgur=debug` fall back to the default |
+| Invalid values | fall back to the default; logging configuration never fails a render |
+| Stream | always stderr, so `-o -` PDF bytes on stdout stay uncorrupted |
+
 ## Library Usage
 
 ```rust

--- a/crates/fulgur-cli/Cargo.toml
+++ b/crates/fulgur-cli/Cargo.toml
@@ -20,6 +20,7 @@ fulgur = { version = "0.40.0", path = "../fulgur" }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 which = "8"
+log = "0.4"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/fulgur-cli/src/main.rs
+++ b/crates/fulgur-cli/src/main.rs
@@ -465,7 +465,13 @@ impl log::Log for StderrLogger {
 
     fn log(&self, record: &log::Record<'_>) {
         if self.enabled(record.metadata()) {
-            eprintln!(
+            // `eprintln!` panics on a write failure (e.g. a broken pipe);
+            // a logging failure must never abort an otherwise-successful
+            // render (CodeRabbit review, PR #719), so write directly and
+            // ignore the `Result`.
+            use std::io::Write;
+            let _ = writeln!(
+                std::io::stderr(),
                 "{}: {}",
                 record.level().as_str().to_lowercase(),
                 record.args()

--- a/crates/fulgur-cli/src/main.rs
+++ b/crates/fulgur-cli/src/main.rs
@@ -440,7 +440,57 @@ fn parse_margin(s: &str) -> Margin {
     }
 }
 
+/// Minimal `log` sink that writes to **stderr**.
+///
+/// `crates/fulgur` reports non-fatal problems through the `log` facade —
+/// missing assets (`asset.rs`), unparseable CSS (`column_css.rs`), and
+/// fragments placed past the page box (`pagination_layout.rs`). A
+/// facade with no installed logger silently drops every one of them, so
+/// until this existed the CLI showed the user nothing: a render that
+/// paints content off the paper and loses it exits `0` with no output.
+///
+/// stderr, not stdout: `-o -` writes PDF bytes to stdout and any other
+/// byte there corrupts the stream (see [`StdoutIsolator`]).
+///
+/// Deliberately not `env_logger` — that pulls a regex / ANSI stack in
+/// for what is one `writeln!`, and `RUST_LOG=<level>` covers the whole
+/// need here. Unrecognised values fall back to the default rather than
+/// erroring, since logging configuration must never fail a render.
+struct StderrLogger;
+
+impl log::Log for StderrLogger {
+    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+        metadata.level() <= log::max_level()
+    }
+
+    fn log(&self, record: &log::Record<'_>) {
+        if self.enabled(record.metadata()) {
+            eprintln!(
+                "{}: {}",
+                record.level().as_str().to_lowercase(),
+                record.args()
+            );
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+/// Install [`StderrLogger`], honouring `RUST_LOG` (default: `warn`).
+fn init_logging() {
+    let level = std::env::var("RUST_LOG")
+        .ok()
+        .and_then(|v| v.trim().parse::<log::LevelFilter>().ok())
+        .unwrap_or(log::LevelFilter::Warn);
+    // Only fails if a logger is already installed, which cannot happen
+    // here — but a logging failure must never abort a render.
+    if log::set_logger(&StderrLogger).is_ok() {
+        log::set_max_level(level);
+    }
+}
+
 fn main() {
+    init_logging();
     let cli = Cli::parse();
 
     match cli.command {

--- a/crates/fulgur-cli/src/main.rs
+++ b/crates/fulgur-cli/src/main.rs
@@ -1010,6 +1010,18 @@ mod tests {
 
     // --- logging ---
 
+    /// `log::set_max_level` is process-global and `cargo test` runs these in
+    /// parallel, so every test that sets or asserts on the level takes this
+    /// lock. Without it, `init_logging` (which sets the level from `RUST_LOG`)
+    /// can land between another test's `set_max_level` and its assertion.
+    static LOG_LEVEL_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Take [`LOG_LEVEL_LOCK`], ignoring poisoning: a panic in one level test
+    /// must not cascade into spurious failures in the others.
+    fn log_level_guard() -> std::sync::MutexGuard<'static, ()> {
+        LOG_LEVEL_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     /// The documented default: nothing set, or nothing parseable, is `warn`.
     #[test]
     fn parse_log_level_defaults_to_warn() {
@@ -1074,6 +1086,7 @@ mod tests {
     #[test]
     fn stderr_logger_enabled_follows_max_level() {
         use log::Log;
+        let _guard = log_level_guard();
         log::set_max_level(log::LevelFilter::Warn);
         let warn = log::Metadata::builder().level(log::Level::Warn).build();
         let info = log::Metadata::builder().level(log::Level::Info).build();
@@ -1081,6 +1094,56 @@ mod tests {
         assert!(
             !StderrLogger.enabled(&info),
             "info is below the warn filter"
+        );
+    }
+
+    /// `log` itself: exercise both arms of its `enabled` gate and `flush`.
+    /// Called directly on the unit struct rather than through the `log`
+    /// facade, so this needs no globally installed logger — the record it
+    /// writes goes to the test harness's captured stderr.
+    #[test]
+    fn stderr_logger_log_writes_only_when_enabled() {
+        use log::Log;
+        let _guard = log_level_guard();
+        log::set_max_level(log::LevelFilter::Warn);
+
+        // Enabled: at the filter level, so this takes the writing arm.
+        StderrLogger.log(
+            &log::Record::builder()
+                .level(log::Level::Warn)
+                .args(format_args!("covered warn line"))
+                .build(),
+        );
+        // Disabled: below the filter, so this takes the early-out arm.
+        StderrLogger.log(
+            &log::Record::builder()
+                .level(log::Level::Trace)
+                .args(format_args!("must not be written"))
+                .build(),
+        );
+
+        // A no-op, but it is part of the trait surface and must not panic.
+        StderrLogger.flush();
+    }
+
+    /// `init_logging` installs the process-global logger. It is idempotent by
+    /// construction — `set_logger` returns `Err` once a logger exists, and the
+    /// guard skips `set_max_level` — so calling it twice here is safe and
+    /// pins that a repeat call cannot panic or reset the filter.
+    ///
+    /// Deliberately does not assert a specific level: `RUST_LOG` may be set in
+    /// the surrounding environment, and mutating it would race the other tests
+    /// in this binary. The parsing contract is covered by `parse_log_level`.
+    #[test]
+    fn init_logging_installs_a_logger_and_is_idempotent() {
+        let _guard = log_level_guard();
+        init_logging();
+        let after_first = log::max_level();
+        init_logging();
+        assert_eq!(
+            log::max_level(),
+            after_first,
+            "a second init_logging must not change the filter"
         );
     }
 }

--- a/crates/fulgur-cli/src/main.rs
+++ b/crates/fulgur-cli/src/main.rs
@@ -472,9 +472,8 @@ impl log::Log for StderrLogger {
             use std::io::Write;
             let _ = writeln!(
                 std::io::stderr(),
-                "{}: {}",
-                record.level().as_str().to_lowercase(),
-                record.args()
+                "{}",
+                format_log_line(record.level(), record.args())
             );
         }
     }
@@ -484,15 +483,36 @@ impl log::Log for StderrLogger {
 
 /// Install [`StderrLogger`], honouring `RUST_LOG` (default: `warn`).
 fn init_logging() {
-    let level = std::env::var("RUST_LOG")
-        .ok()
-        .and_then(|v| v.trim().parse::<log::LevelFilter>().ok())
-        .unwrap_or(log::LevelFilter::Warn);
+    let level = parse_log_level(std::env::var("RUST_LOG").ok().as_deref());
     // Only fails if a logger is already installed, which cannot happen
     // here — but a logging failure must never abort a render.
     if log::set_logger(&StderrLogger).is_ok() {
         log::set_max_level(level);
     }
+}
+
+/// Render one log record as the line [`StderrLogger`] writes.
+///
+/// Split out from `log` so the formatting is testable without installing a
+/// global logger or capturing the process's stderr.
+fn format_log_line(level: log::Level, args: &std::fmt::Arguments<'_>) -> String {
+    format!("{}: {}", level.as_str().to_lowercase(), args)
+}
+
+/// Resolve the `RUST_LOG` value to a level filter.
+///
+/// Accepts exactly one level name (case-insensitive). Anything else —
+/// absent, empty, a target directive like `fulgur=debug`, or a
+/// multi-directive string like `warn,fulgur=debug` — falls back to `warn`
+/// rather than erroring, because logging configuration must never fail a
+/// render. Surrounding whitespace is tolerated.
+///
+/// Split out from [`init_logging`] so the contract is testable without
+/// mutating process-wide environment or logger state.
+fn parse_log_level(value: Option<&str>) -> log::LevelFilter {
+    value
+        .and_then(|v| v.trim().parse::<log::LevelFilter>().ok())
+        .unwrap_or(log::LevelFilter::Warn)
 }
 
 fn main() {
@@ -986,5 +1006,81 @@ mod tests {
     fn margin_rejects_one_bad_value_among_four() {
         let m = parse_margin("10 10 10 -10");
         assert_eq!(m, Margin::default());
+    }
+
+    // --- logging ---
+
+    /// The documented default: nothing set, or nothing parseable, is `warn`.
+    #[test]
+    fn parse_log_level_defaults_to_warn() {
+        assert_eq!(parse_log_level(None), log::LevelFilter::Warn);
+        assert_eq!(parse_log_level(Some("")), log::LevelFilter::Warn);
+        assert_eq!(parse_log_level(Some("nonsense")), log::LevelFilter::Warn);
+    }
+
+    #[test]
+    fn parse_log_level_accepts_each_single_level() {
+        for (text, expected) in [
+            ("error", log::LevelFilter::Error),
+            ("warn", log::LevelFilter::Warn),
+            ("info", log::LevelFilter::Info),
+            ("debug", log::LevelFilter::Debug),
+            ("trace", log::LevelFilter::Trace),
+            ("off", log::LevelFilter::Off),
+        ] {
+            assert_eq!(parse_log_level(Some(text)), expected, "level {text}");
+            assert_eq!(
+                parse_log_level(Some(&text.to_uppercase())),
+                expected,
+                "level {text} uppercased"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_log_level_tolerates_surrounding_whitespace() {
+        assert_eq!(parse_log_level(Some("  debug \n")), log::LevelFilter::Debug);
+    }
+
+    /// `env_logger`-style directives are NOT supported, and silently fall back
+    /// to the default rather than erroring. This is the documented contract
+    /// (README) and the likeliest user surprise, so pin it.
+    #[test]
+    fn parse_log_level_falls_back_on_target_directives() {
+        assert_eq!(
+            parse_log_level(Some("fulgur=debug")),
+            log::LevelFilter::Warn
+        );
+        assert_eq!(
+            parse_log_level(Some("warn,fulgur=debug")),
+            log::LevelFilter::Warn
+        );
+    }
+
+    #[test]
+    fn format_log_line_lowercases_the_level() {
+        assert_eq!(
+            format_log_line(log::Level::Warn, &format_args!("missing asset {}", 3)),
+            "warn: missing asset 3"
+        );
+        assert_eq!(
+            format_log_line(log::Level::Error, &format_args!("boom")),
+            "error: boom"
+        );
+    }
+
+    /// `enabled` gates on the globally installed max level. Set it explicitly
+    /// so the assertion does not depend on whether `init_logging` has run.
+    #[test]
+    fn stderr_logger_enabled_follows_max_level() {
+        use log::Log;
+        log::set_max_level(log::LevelFilter::Warn);
+        let warn = log::Metadata::builder().level(log::Level::Warn).build();
+        let info = log::Metadata::builder().level(log::Level::Info).build();
+        assert!(StderrLogger.enabled(&warn));
+        assert!(
+            !StderrLogger.enabled(&info),
+            "info is below the warn filter"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`crates/fulgur` reports non-fatal problems through the `log` facade — missing
assets (`asset.rs`), unparseable CSS (`column_css.rs`), and fragments placed
past the page box (`pagination_layout.rs`). A facade with **no installed
logger silently drops every one of them**, so today the CLI shows the user
nothing: a render that paints content off the paper and loses it exits `0`
with no output at all.

This installs a minimal stderr logger in `fulgur-cli` so those diagnostics
actually reach the user.

## Changes

- `StderrLogger`, a ~20-line `log::Log` sink, installed from `main()`.
  - **stderr, not stdout** — `-o -` writes PDF bytes to stdout and any other
    byte there corrupts the stream (see `StdoutIsolator`).
  - Deliberately not `env_logger`: that pulls a regex/ANSI stack in for what
    is one `writeln!`, and a single `RUST_LOG` level covers the need here.
  - Writes via `writeln!` with the `Result` explicitly ignored rather than
    `eprintln!`, which panics on a broken pipe — a logging failure must never
    abort an otherwise-successful render.
  - `log::set_max_level` is only called if `set_logger` succeeded.
- `RUST_LOG` handling documented in the README next to the CLI options.

## The `RUST_LOG` contract

Worth being explicit, because the parser is deliberately narrow and the
failure mode is silent:

| Aspect | Behaviour |
|---|---|
| Default | `warn` |
| Accepted values | a single level: `error`, `warn`, `info`, `debug`, `trace`, `off` |
| Target filters | **not** supported — `fulgur=debug` and multi-directive strings such as `warn,fulgur=debug` fall back to the default |
| Invalid values | fall back to the default; logging configuration never fails a render |
| Stream | always stderr |

`fulgur=debug` is what a user familiar with `env_logger` will try first, and
it quietly does nothing — hence documenting it rather than leaving it to be
discovered.

## Test plan

- `cargo build -p fulgur-cli`, `cargo test -p fulgur-cli` — 57 tests pass
- `cargo clippy -p fulgur-cli --all-targets` — clean
- `cargo fmt --check` — clean
- `npx markdownlint-cli2 README.md` — clean

## Related

Extracted from #719, which is blocked on a larger reconciliation with `main`.
This part is self-contained (`crates/fulgur-cli` + README only), touches no
file `main` has changed since that branch diverged, and is useful on its own.

Behaviour change for users: documents that previously rendered with silent
asset/CSS/overflow problems will now print `warn:` lines on stderr.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * アセット不足、CSS解析エラー、レイアウト警告などの非致命的な問題を、標準エラー出力に表示する診断ログを追加。
  * `RUST_LOG` でログの詳細度を設定可能（既定値: `warn`）。

* **ドキュメント**
  * 診断ログの対象、設定方法、対応するログレベルをREADMEに追加。
  * PDFを標準出力へ出力する場合も、PDFデータにログが混入しないことを明記。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->