### PR TITLE
fix(pagination): stop losing lines at a page boundary

### DIFF
--- a/crates/fulgur/src/engine.rs
+++ b/crates/fulgur/src/engine.rs
@@ -1633,6 +1633,7 @@ mod tests {
                 crate::pagination_layout::PaginationGeometry {
                     fragments: vec![frag_on_page(page_index)],
                     is_repeat: false,
+                    line_boundaries: Vec::new(),
                 },
             );
         }
@@ -1750,6 +1751,7 @@ mod tests {
             crate::pagination_layout::PaginationGeometry {
                 fragments: vec![frag_on_page(2)],
                 is_repeat: false,
+                line_boundaries: Vec::new(),
             },
         );
         let map = build_implicit_href_map(&doc, &geometry);

--- a/crates/fulgur/src/gcpm/target_ref.rs
+++ b/crates/fulgur/src/gcpm/target_ref.rs
@@ -447,6 +447,7 @@ mod tests {
                     },
                 ],
                 is_repeat: false,
+                line_boundaries: Vec::new(),
             },
         );
         assert_eq!(page_for_node(&table, 42), Some(3)); // page_index 2 -> 1-based page 3
@@ -467,6 +468,7 @@ mod tests {
             PaginationGeometry {
                 fragments: vec![],
                 is_repeat: false,
+                line_boundaries: Vec::new(),
             },
         );
         assert_eq!(page_for_node(&table, 7), None);

--- a/crates/fulgur/src/pagination_layout.rs
+++ b/crates/fulgur/src/pagination_layout.rs
@@ -116,6 +116,27 @@ pub struct PaginationGeometry {
     /// must treat the fragments as copies of the whole node, never as
     /// slices of it.
     pub is_repeat: bool,
+    /// For an inline root split at line boundaries: the line index each
+    /// fragment starts at, plus a terminating total line count — so
+    /// `fragments[k]` covers lines
+    /// `line_boundaries[k]..line_boundaries[k + 1]`. Empty for every
+    /// other producer.
+    ///
+    /// This exists because the split decision and its consumer were
+    /// measuring in different units. [`fragment_inline_root`] chooses
+    /// the partition from Parley's line metrics, which are rounded to
+    /// whole pixels; `render::paragraph_lines_for_page` then
+    /// *re-derived* that same partition by accumulating
+    /// `ShapedLine::height`, which keeps the fractional height. The two
+    /// disagree, and when they do a line belongs to no fragment at all
+    /// and is dropped from the document with no later fragment to
+    /// recover it from — silently, with the page count short to match.
+    ///
+    /// Publishing the partition the fragmenter actually chose removes
+    /// the second accounting. Consumers must still tolerate an empty
+    /// vector (a paragraph that was strip-sliced whole rather than
+    /// split at line boundaries publishes nothing).
+    pub line_boundaries: Vec<usize>,
 }
 
 impl PaginationGeometry {
@@ -3472,6 +3493,31 @@ fn fragment_inline_root(
     let mut emitted = 0usize;
     let total_lines = line_metrics.len();
 
+    // css-break-3 §3.3: no fragment may be emitted into a strip that
+    // cannot hold even its first line. There is no split point that
+    // helps here — every candidate fragment starts with that line — so
+    // the break belongs BEFORE the paragraph.
+    //
+    // A paragraph starting 10px above the page bottom, with 28px lines,
+    // is the reported case: the loop below has only one split rule
+    // ("this line overflows"), the orphan guard refuses to close a
+    // one-line first fragment, so it accumulates and then emits a 56px
+    // two-line fragment into that 10px gap. Both lines are painted, the
+    // second lands below the page box, and it is gone from the document
+    // with the page count short to match and exit code 0.
+    //
+    // Relaxation (§4.4) is handled separately, in the loop: it is the
+    // right answer when at least one line fits and only the orphan /
+    // widow minimum is unreachable. It cannot help when nothing fits.
+    let first_line_extent = line_metrics[0].1 - line_metrics[0].0;
+    if paragraph_top_in_body > 0.0
+        && paragraph_top_in_body + first_line_extent > page_height_px
+        && page_index + 1 < crate::MAX_PAGES
+    {
+        page_index += 1;
+        paragraph_top_in_body = 0.0;
+    }
+
     for (i, &(_line_top_local, line_bottom_local)) in line_metrics.iter().enumerate() {
         let frag_top_local = line_metrics[fragment_start_idx].0;
         let projected_bottom_in_body = paragraph_top_in_body + (line_bottom_local - frag_top_local);
@@ -3515,7 +3561,12 @@ fn fragment_inline_root(
                 width: width.as_px(),
                 height: frag_h.as_px(),
             };
-            geometry.entry(child_id).or_default().fragments.push(frag);
+            let entry = geometry.entry(child_id).or_default();
+            entry.fragments.push(frag);
+            // Publish the partition rather than leaving the consumer to
+            // rediscover it from fragment heights — see
+            // `PaginationGeometry::line_boundaries`.
+            entry.line_boundaries.push(fragment_start_idx);
             emitted += 1;
 
             page_index += 1;
@@ -3535,7 +3586,15 @@ fn fragment_inline_root(
         width: width.as_px(),
         height: frag_h.as_px(),
     };
-    geometry.entry(child_id).or_default().fragments.push(frag);
+    let entry = geometry.entry(child_id).or_default();
+    entry.fragments.push(frag);
+    entry.line_boundaries.push(fragment_start_idx);
+    // Terminator: `fragments[k]` covers
+    // `line_boundaries[k]..line_boundaries[k + 1]`, so the vector is one
+    // longer than the fragment list and its last element is the total
+    // line count. A consumer can check that last element against the
+    // line vector it holds to prove both sides mean the same lines.
+    entry.line_boundaries.push(total_lines);
     emitted += 1;
 
     let cursor_y = paragraph_top_in_body + frag_h;

--- a/crates/fulgur/src/render.rs
+++ b/crates/fulgur/src/render.rs
@@ -1107,6 +1107,7 @@ pub(crate) fn dispatch_fragment(
             y_pt,
             frag,
             &geom.fragments,
+            &geom.line_boundaries,
             page_index,
             is_split,
             drawables,
@@ -1166,6 +1167,7 @@ pub(crate) fn dispatch_fragment(
                 y_pt,
                 frag,
                 &geom.fragments,
+                &geom.line_boundaries,
                 page_index,
                 is_split,
                 drawables,
@@ -1228,6 +1230,7 @@ pub(crate) fn dispatch_fragment(
             x_pt,
             y_pt,
             &geom.fragments,
+            &geom.line_boundaries,
             page_index,
             is_split,
             drawables,
@@ -1934,6 +1937,7 @@ fn draw_under_clip(
                 inner_x,
                 inner_y,
                 &geom.fragments,
+                &geom.line_boundaries,
                 page_index,
                 is_split,
                 drawables,
@@ -2308,6 +2312,7 @@ fn draw_under_opacity(
                     inner_x,
                     inner_y,
                     &geom.fragments,
+                    &geom.line_boundaries,
                     page_index,
                     is_split,
                     drawables,
@@ -3164,6 +3169,7 @@ fn draw_block_with_inner_content(
     y: f32,
     frag: &crate::pagination_layout::Fragment,
     fragments: &[crate::pagination_layout::Fragment],
+    line_boundaries: &[usize],
     page_index: u32,
     is_split: bool,
     drawables: &Drawables,
@@ -3194,6 +3200,7 @@ fn draw_block_with_inner_content(
                 inner_x,
                 inner_y,
                 fragments,
+                line_boundaries,
                 page_index,
                 is_split,
                 drawables,
@@ -3235,6 +3242,7 @@ fn draw_list_item_with_block(
     y: f32,
     frag: &crate::pagination_layout::Fragment,
     fragments: &[crate::pagination_layout::Fragment],
+    line_boundaries: &[usize],
     page_index: u32,
     is_split: bool,
     drawables: &Drawables,
@@ -3276,6 +3284,7 @@ fn draw_list_item_with_block(
                 inner_x,
                 inner_y,
                 fragments,
+                line_boundaries,
                 page_index,
                 is_split,
                 drawables,
@@ -3379,6 +3388,7 @@ fn draw_paragraph_v2(
     x: f32,
     y: f32,
     fragments: &[crate::pagination_layout::Fragment],
+    line_boundaries: &[usize],
     page_index: u32,
     is_split: bool,
     drawables: &Drawables,
@@ -3394,6 +3404,7 @@ fn draw_paragraph_v2(
             x,
             y,
             fragments,
+            line_boundaries,
             page_index,
             is_split,
             drawables,
@@ -3416,6 +3427,7 @@ fn draw_paragraph_inner_paint(
     x: f32,
     y: f32,
     fragments: &[crate::pagination_layout::Fragment],
+    line_boundaries: &[usize],
     page_index: u32,
     is_split: bool,
     drawables: &Drawables,
@@ -3426,8 +3438,13 @@ fn draw_paragraph_inner_paint(
     if !entry.visible {
         return;
     }
-    let Some(slice) = paragraph_lines_for_page(&entry.lines, fragments, page_index, is_split)
-    else {
+    let Some(slice) = paragraph_lines_for_page(
+        &entry.lines,
+        fragments,
+        line_boundaries,
+        page_index,
+        is_split,
+    ) else {
         return;
     };
     // PR 8g: build an InlineBoxRenderCtx so `draw_shaped_lines` can
@@ -3460,6 +3477,7 @@ fn draw_paragraph_inner_paint(
 fn paragraph_lines_for_page(
     all_lines: &[crate::paragraph::ShapedLine],
     fragments: &[crate::pagination_layout::Fragment],
+    line_boundaries: &[usize],
     page_index: u32,
     is_split: bool,
 ) -> Option<Vec<crate::paragraph::ShapedLine>> {
@@ -3469,35 +3487,37 @@ fn paragraph_lines_for_page(
         return Some(all_lines.to_vec());
     }
 
-    let target_h = fragments[target_pos].height.in_pt();
-    let consumed: crate::units::Pt = fragments[..target_pos]
+    // Preferred path: the fragmenter published the partition it actually
+    // chose, so use it verbatim instead of re-deriving it from fragment
+    // heights in a different unit (see
+    // `PaginationGeometry::line_boundaries`).
+    //
+    // The guards prove both sides are talking about the same line vector:
+    // one boundary per fragment plus a terminator, and that terminator
+    // equal to the number of lines held here. Anything else falls back to
+    // the reconstruction rather than slicing with indices that mean
+    // something else.
+    let published = if line_boundaries.len() == fragments.len() + 1
+        && line_boundaries.last() == Some(&all_lines.len())
+    {
+        let start = line_boundaries[target_pos];
+        Some((start, line_boundaries[target_pos + 1].max(start)))
+    } else {
+        None
+    };
+
+    let (start_idx, end_idx) = match published {
+        Some(range) => range,
+        None => reconstruct_line_partition(all_lines, fragments, target_pos),
+    };
+
+    // Rebase by the lines actually left behind, not by the outgoing
+    // fragments' height budgets: when the two disagree the continuation is
+    // lifted off its fragment's content top by the difference.
+    let consumed: crate::units::Pt = all_lines[..start_idx.min(all_lines.len())]
         .iter()
-        .map(|f| f.height)
-        .sum::<crate::units::Px>()
-        .in_pt();
-
-    let eps = 0.01_f32.as_pt();
-    let mut line_top = crate::units::Pt::ZERO;
-    let mut start_idx = 0usize;
-    while start_idx < all_lines.len() {
-        let next_top = line_top + all_lines[start_idx].height;
-        if next_top > consumed + eps {
-            break;
-        }
-        line_top = next_top;
-        start_idx += 1;
-    }
-
-    let mut end_idx = start_idx;
-    let mut accum = crate::units::Pt::ZERO;
-    while end_idx < all_lines.len() {
-        let line_h = all_lines[end_idx].height;
-        if accum + line_h > target_h + eps {
-            break;
-        }
-        accum += line_h;
-        end_idx += 1;
-    }
+        .map(|l| l.height)
+        .sum();
 
     if end_idx <= start_idx {
         return None;
@@ -3520,6 +3540,58 @@ fn paragraph_lines_for_page(
         })
         .collect();
     Some(sliced)
+}
+
+/// Reconstruct which lines belong to fragment `target_pos` from the
+/// fragment heights alone, for producers that publish no partition (a
+/// paragraph strip-sliced whole rather than split at line boundaries).
+///
+/// Best-effort, not a source of truth: it measures lines in a different
+/// unit than the fragmenter did, so it can under-count. The last fragment
+/// therefore absorbs every remaining line — css-break-3 §4.4, "the UA may
+/// break anywhere in order to avoid losing content off the edge of the
+/// fragmentainer": overflowing a fragment is a layout blemish, while
+/// dropping the tail is content loss with no later fragment to recover it
+/// from.
+fn reconstruct_line_partition(
+    all_lines: &[crate::paragraph::ShapedLine],
+    fragments: &[crate::pagination_layout::Fragment],
+    target_pos: usize,
+) -> (usize, usize) {
+    let target_h = fragments[target_pos].height.in_pt();
+    let consumed: crate::units::Pt = fragments[..target_pos]
+        .iter()
+        .map(|f| f.height)
+        .sum::<crate::units::Px>()
+        .in_pt();
+
+    let eps = 0.01_f32.as_pt();
+    let mut line_top = crate::units::Pt::ZERO;
+    let mut start_idx = 0usize;
+    while start_idx < all_lines.len() {
+        let next_top = line_top + all_lines[start_idx].height;
+        if next_top > consumed + eps {
+            break;
+        }
+        line_top = next_top;
+        start_idx += 1;
+    }
+
+    if target_pos == fragments.len() - 1 {
+        return (start_idx, all_lines.len());
+    }
+
+    let mut end_idx = start_idx;
+    let mut accum = crate::units::Pt::ZERO;
+    while end_idx < all_lines.len() {
+        let line_h = all_lines[end_idx].height;
+        if accum + line_h > target_h + eps {
+            break;
+        }
+        accum += line_h;
+        end_idx += 1;
+    }
+    (start_idx, end_idx)
 }
 
 /// Build krilla Metadata from Config.
@@ -4975,7 +5047,7 @@ mod tests {
         let lines = vec![make_line(16.0, 12.0)];
         let fragments = vec![make_fragment(0, 16.0)];
         // Ask for page 1, which has no fragment.
-        let result = paragraph_lines_for_page(&lines, &fragments, 1, false);
+        let result = paragraph_lines_for_page(&lines, &fragments, &[], 1, false);
         assert!(result.is_none());
     }
 
@@ -4989,7 +5061,7 @@ mod tests {
             make_line(16.0, 44.0),
         ];
         let fragments = vec![make_fragment(0, 64.0)];
-        let result = paragraph_lines_for_page(&lines, &fragments, 0, false);
+        let result = paragraph_lines_for_page(&lines, &fragments, &[], 0, false);
         assert!(result.is_some());
         let sliced = result.unwrap();
         assert_eq!(sliced.len(), 3);
@@ -5009,7 +5081,7 @@ mod tests {
             make_fragment(0, 16.0), // 16px = 12pt → first line
             make_fragment(1, 16.0),
         ];
-        let result = paragraph_lines_for_page(&lines, &fragments, 0, true);
+        let result = paragraph_lines_for_page(&lines, &fragments, &[], 0, true);
         assert!(result.is_some());
         let sliced = result.unwrap();
         assert_eq!(sliced.len(), 1, "page 0 should contain exactly one line");
@@ -5028,7 +5100,7 @@ mod tests {
             make_fragment(0, 16.0), // 16px = 12pt → first line
             make_fragment(1, 16.0),
         ];
-        let result = paragraph_lines_for_page(&lines, &fragments, 1, true);
+        let result = paragraph_lines_for_page(&lines, &fragments, &[], 1, true);
         assert!(result.is_some());
         let sliced = result.unwrap();
         assert_eq!(sliced.len(), 1, "page 1 should contain exactly one line");
@@ -5046,7 +5118,7 @@ mod tests {
             make_fragment(0, 100.0), // page 0 gets the line
             make_fragment(1, 0.0),   // page 1 has zero height
         ];
-        let result = paragraph_lines_for_page(&lines, &fragments, 1, true);
+        let result = paragraph_lines_for_page(&lines, &fragments, &[], 1, true);
         assert!(result.is_none());
     }
 
@@ -5261,6 +5333,7 @@ mod tests {
         let geom = crate::pagination_layout::PaginationGeometry {
             fragments: vec![frag.clone()],
             is_repeat: false,
+            line_boundaries: Vec::new(),
         };
         let (w, h) = table_box_size(&entry, &geom, &frag);
         assert!((w - 120.0).abs() < 0.001, "width from layout_size");
@@ -5281,6 +5354,7 @@ mod tests {
         let geom = crate::pagination_layout::PaginationGeometry {
             fragments: vec![frag.clone(), continuation],
             is_repeat: false,
+            line_boundaries: Vec::new(),
         };
         let (_, h) = table_box_size(&entry, &geom, &frag);
         assert!((h - 30.0).abs() < 0.01, "height = frag.height.in_pt()");
@@ -5294,6 +5368,7 @@ mod tests {
         let geom = crate::pagination_layout::PaginationGeometry {
             fragments: vec![frag.clone()],
             is_repeat: false,
+            line_boundaries: Vec::new(),
         };
         let (w, h) = table_box_size(&entry, &geom, &frag);
         assert!((w - 150.0).abs() < 0.001, "width falls back to entry.width");
@@ -5317,6 +5392,7 @@ mod tests {
         let geom = crate::pagination_layout::PaginationGeometry {
             fragments: vec![frag.clone(), continuation],
             is_repeat: false,
+            line_boundaries: Vec::new(),
         };
         let (_, h) = table_box_size(&entry, &geom, &frag);
         assert!(
@@ -5334,6 +5410,7 @@ mod tests {
         let geom = crate::pagination_layout::PaginationGeometry {
             fragments: vec![frag.clone()],
             is_repeat: false,
+            line_boundaries: Vec::new(),
         };
         let (w, h) = table_box_size(&entry, &geom, &frag);
         assert!((w - 150.0).abs() < 0.001, "width falls back to entry.width");
@@ -5650,7 +5727,7 @@ mod tests {
             make_fragment(0, 16.0), // 16px → 12pt
             make_fragment(1, 16.0),
         ];
-        let result = paragraph_lines_for_page(&[line0, line1], &fragments, 1, true);
+        let result = paragraph_lines_for_page(&[line0, line1], &fragments, &[], 1, true);
         assert!(result.is_some(), "page 1 should yield Some");
         let sliced = result.unwrap();
         assert_eq!(sliced.len(), 1, "one line on page 1");

--- a/crates/fulgur/tests/page_boundary_content_loss.rs
+++ b/crates/fulgur/tests/page_boundary_content_loss.rs
@@ -1,0 +1,219 @@
+use fulgur::engine::Engine;
+use std::io::Write;
+
+/// Total glyphs painted across every page of `html`.
+///
+/// [`fulgur::inspect`] hands back raw glyph ids from the content stream,
+/// not decoded text (the fonts are subset and carry no reverse mapping),
+/// so the words cannot be read back by name. The count is enough: these
+/// tests compare two renders of identical content at identical width, so
+/// line breaking is fixed and only pagination differs.
+fn glyph_count(html: &str) -> usize {
+    let pdf = Engine::builder().build().render(html).expect("render");
+    assert!(!pdf.is_empty(), "render produced no bytes");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("out.pdf");
+    let mut f = std::fs::File::create(&path).expect("create");
+    f.write_all(&pdf).expect("write");
+    drop(f);
+    let result = fulgur::inspect::inspect(&path).expect("inspect");
+    // Glyph ids are 2 bytes each in these subset fonts.
+    result
+        .text_items
+        .iter()
+        .map(|t| t.text.chars().count())
+        .sum()
+}
+
+fn probe_words(n: usize) -> String {
+    (0..n).map(|i| format!("W{i:04} ")).collect()
+}
+
+/// Assert that paginating `body` loses nothing.
+///
+/// Renders it twice at the **same page width** — once on a page tall
+/// enough to hold everything (so nothing splits) and once at `page_h` (so
+/// it does) — and requires the same number of glyphs. Holding the width
+/// fixed keeps line breaking identical between the two, so any difference
+/// is pagination dropping content.
+fn assert_pagination_loses_nothing(style: &str, body: &str, page_h: u32, ctx: &str) {
+    assert_pagination_loses_nothing_at(
+        "size: 400px 20000px; margin: 20px;",
+        &format!("size: 400px {page_h}px; margin: 20px;"),
+        style,
+        body,
+        ctx,
+    );
+}
+
+/// As [`assert_pagination_loses_nothing`], but with both `@page` rules
+/// given explicitly, for shapes whose margins matter. The two must differ
+/// only in page *height*.
+fn assert_pagination_loses_nothing_at(
+    tall_page: &str,
+    short_page: &str,
+    style: &str,
+    body: &str,
+    ctx: &str,
+) {
+    let tall =
+        format!("<!DOCTYPE html><style>@page {{ {tall_page} }} {style}</style><body>{body}</body>");
+    let short = format!(
+        "<!DOCTYPE html><style>@page {{ {short_page} }} {style}</style><body>{body}</body>"
+    );
+    let expected = glyph_count(&tall);
+    let actual = glyph_count(&short);
+    assert!(expected > 0, "{ctx}: reference render painted no glyphs");
+    assert_eq!(
+        actual,
+        expected,
+        "{ctx}: paginating dropped {} of {expected} glyphs — content is being \
+         lost at a page boundary, silently and with exit code 0",
+        expected.saturating_sub(actual)
+    );
+}
+
+/// A paragraph whose first line cannot fit the remaining strip must move to
+/// the next page rather than emit a fragment into a gap too small for it.
+///
+/// `fragment_inline_root`'s only split rule is "this line overflows", and
+/// its orphan guard refuses to close a first fragment shorter than
+/// `ORPHANS_MIN` — so with a 10px gap and 28px lines it accumulated and
+/// emitted a 56px two-line fragment into that 10px gap.
+///
+/// This one asserts on **geometry**, not glyph counts, because here the
+/// lost lines *are* emitted into the content stream — just painted below
+/// the page box, where only a MediaBox-respecting extractor could see
+/// them. `inspect` counts them either way, so the glyph invariant used by
+/// the other tests in this file is blind to it. The fragment overflowing
+/// its own fragmentainer is the defect, and that is directly checkable.
+///
+/// The sweep matters: only offsets where the box actually straddles the
+/// boundary reproduce it, so a single filler value can pass by luck.
+#[test]
+fn paragraph_that_cannot_fit_its_first_line_moves_to_the_next_page() {
+    const PAGE_H: f32 = 1690.0;
+    const MARGIN_TOP: f32 = 190.0;
+    const MARGIN_BOTTOM: f32 = 80.0;
+    // The content strip every fragment must stay inside.
+    const STRIP: f32 = PAGE_H - MARGIN_TOP - MARGIN_BOTTOM;
+    // Taffy rounds line metrics to whole pixels; tolerate that much.
+    const TOLERANCE: f32 = 1.0;
+
+    let words = probe_words(300);
+    for filler in [0u32, 1200, 1380, 1400, 1410, 1415, 1420, 1425, 1430] {
+        let html = format!(
+            r#"<!DOCTYPE html>
+<style>
+  @page {{ size: 1190px {PAGE_H}px; margin: {MARGIN_TOP}px 40px {MARGIN_BOTTOM}px 40px; }}
+  body {{ margin: 0; font-size: 20px; line-height: 1.4; }}
+</style>
+<body>
+  <div style="height:{filler}px"></div>
+  <div>HEAD<div><p>{words}</p><p>TAIL</p></div></div>
+</body>"#
+        );
+        let out = Engine::builder().build().layout(&html).expect("layout");
+        for (node_id, geom) in out.geometry.iter() {
+            if geom.is_repeat {
+                // Repeated content (e.g. `position: fixed`) is a full
+                // redraw per page, not a slice, so its extent is not a
+                // statement about any one strip.
+                continue;
+            }
+            // Only inline roots. A block *container* whose fragment runs
+            // past the strip is a separate, pre-existing behaviour (its
+            // box is sized from content and clipped at paint), and
+            // asserting on it here would fail for reasons this fix has
+            // nothing to do with. The defect under test is an inline
+            // root's own fragment being placed where its lines cannot
+            // fit.
+            // Only *multi-line* inline roots: those are what
+            // `fragment_inline_root` places, and its placement is the
+            // subject here. A single-line paragraph is placed by the
+            // block path, where an overflowing box is a separate,
+            // pre-existing behaviour this fix does not address.
+            let Some(para) = out.drawables.paragraphs.get(node_id) else {
+                continue;
+            };
+            if para.lines.len() < 2 {
+                continue;
+            }
+            for frag in &geom.fragments {
+                let bottom = frag.y.to_f32() + frag.height.to_f32();
+                assert!(
+                    bottom <= STRIP + TOLERANCE,
+                    "filler={filler}px: node {node_id} has a fragment running to \
+                     {bottom}px on a {STRIP}px content strip — it was emitted into \
+                     a gap too small for it, and the lines past the strip are \
+                     painted outside the page box and lost"
+                );
+            }
+        }
+    }
+}
+
+/// A paragraph split at line boundaries must render every line it was
+/// split into.
+///
+/// The fragmenter chose the partition from Parley's line metrics, which
+/// are rounded to whole pixels, while `render::paragraph_lines_for_page`
+/// *re-derived* that same partition by accumulating `ShapedLine::height`,
+/// which keeps the fractional height. Where the two disagreed a line
+/// belonged to no fragment at all and was dropped — 220 probe words across
+/// the shapes below — until `PaginationGeometry::line_boundaries` published
+/// the partition the fragmenter actually chose.
+///
+/// The line height has to be fractional in points for the two accountings
+/// to drift, which is why these combinations are so specific.
+#[test]
+fn a_paragraph_split_across_pages_keeps_every_line() {
+    for (font_px, line_height, n, page_h) in [
+        (11.0, 1.5, 400usize, 300u32),
+        (13.0, 1.3, 500, 300),
+        (9.0, 1.7, 600, 250),
+        (15.0, 1.15, 350, 400),
+        (11.0, 1.5, 900, 200),
+        (12.0, 1.45, 700, 320),
+        (10.0, 1.33, 800, 260),
+        (14.0, 1.25, 450, 280),
+    ] {
+        let words = probe_words(n);
+        let style =
+            format!("body {{ margin: 0; font-size: {font_px}px; line-height: {line_height}; }}");
+        let body = format!("<div>{words}</div>");
+        assert_pagination_loses_nothing(
+            &style,
+            &body,
+            page_h,
+            &format!("font={font_px}px line-height={line_height} page-height={page_h}px"),
+        );
+    }
+}
+
+/// The same divergence reached through the nested walker rather than the
+/// body-direct one, with the paragraph starting partway down the page.
+#[test]
+fn a_nested_paragraph_split_across_pages_keeps_every_line() {
+    for (font_px, line_height, n, page_h) in [
+        (13.0, 1.3, 500usize, 300u32),
+        (9.0, 1.7, 600, 250),
+        (12.0, 1.45, 700, 320),
+        (10.0, 1.33, 800, 260),
+    ] {
+        let words = probe_words(n);
+        let half = page_h / 2;
+        let style =
+            format!("body {{ margin: 0; font-size: {font_px}px; line-height: {line_height}; }}");
+        let body = format!(
+            r#"<div style="height:{half}px"></div>
+  <div>H<div><p>{words}</p></div></div>"#
+        );
+        assert_pagination_loses_nothing(
+            &style,
+            &body,
+            page_h,
+            &format!("nested font={font_px}px lh={line_height} page-height={page_h}px"),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Two independent defects that **delete content from the document silently**.
Both share the signature that makes this class easy to ship: the render
succeeds, exits `0`, emits no warning, and produces a plausible PDF whose page
count matches the content it kept. Only counting the words back out finds the
hole.

Measured on `main` at `b36b5682`, rendering the shape below:

| | |
|---|---|
| page 1 | `W0000` … `W0016` |
| page 2 | `W0034` … `W0299` |
| **`W0017`–`W0033`** | **absent from the document** |

```html
<style>
  @page { size: 1190px 1690px; margin: 190px 40px 80px 40px; }
  body { margin: 0; font-size: 20px; line-height: 1.4; }
</style>
<div style="height:1410px"></div>
<div>HEAD<div><p>W0000 W0001 … W0299</p><p>TAIL</p></div></div>
```

## Defect 1 — a fragment emitted into a strip too small for its first line

`fragment_inline_root` has exactly one split rule ("this line overflows") and an
orphan guard that refuses to close a first fragment shorter than `ORPHANS_MIN`.

A paragraph starting 10px above the page bottom, with 28px lines, therefore
cannot split at line 1 — one line is below the minimum — so the loop keeps
accumulating and emits a **56px two-line fragment into that 10px gap**. Both
lines are painted; the second lands below the page box and is gone.

The existing unit test `fragment_inline_root_nonzero_initial_cursor_y_splits_correctly`
encodes this: it asserts a **50px fragment placed at y=50 on an 80px page**.

**Fix:** break *before* the paragraph when the strip cannot hold even its first
line. That is the single case no split point can help with, because every
candidate fragment begins with that line.

**Deliberately not changed:** relaxing orphans/widows instead (§4.4 permits it)
is the right answer for a *different* case — at least one line fits and only the
minimum is unreachable. `fragment_inline_root`'s "emit whole" fallback is
documented behaviour pinned by `orphan_minimum_blocks_single_line_head_fragment`,
and revisiting it is a larger argument than this fix needs. It is left for a
follow-up.

## Defect 2 — two accountings of one split decision

`fragment_inline_root` chooses the partition from Parley's line metrics, which
are **rounded to whole pixels**. `render::paragraph_lines_for_page` then
*re-derived* that same partition by accumulating `ShapedLine::height`, which
keeps the **fractional** height. Where the two disagree, a line belongs to no
fragment at all and is never emitted.

Swept across eight shapes with fractional line heights:

| | words lost |
|---|--:|
| before | **220** |
| after | **0** |

Page counts are identical in every case, so nothing signals the loss.

**Fix:** `PaginationGeometry::line_boundaries` publishes the partition the
fragmenter actually chose. The consumer uses it verbatim when its terminator
matches the line vector being sliced — proof both sides mean the same lines —
and otherwise falls back to the height reconstruction, now extracted to
`reconstruct_line_partition` with a §4.4 net: the last fragment absorbs every
remaining line, because overflowing a fragment is a layout blemish while
dropping the tail is content loss with no later fragment to recover it from.

## Tests

The two defects need *different* detection, and get it:

- **Defect 2** drops glyphs from the content stream, so it is caught by
  comparing glyph counts between a tall-page and a short-page render of
  identical content at **identical width** — line breaking is then fixed and
  only pagination differs.
- **Defect 1** emits its glyphs and paints them *off-page*, where a glyph count
  is blind. It is caught by asserting no multi-line inline root is placed past
  the content strip.

Both read back through `fulgur::inspect`, so they need no external extractor and
run on every CI platform. (`inspect` returns raw glyph ids, not decoded text —
the fonts are subset — which is why these count glyphs rather than match words.)

The geometry assertion is scoped to *multi-line inline roots* on purpose: a
block container or a single-line paragraph overflowing its strip is separate,
pre-existing behaviour that this fix does not address and should not claim to.

**Non-vacuity confirmed per fix, independently:**

- reverting the guard alone → geometry test fails (a fragment running to 1484px
  on a 1420px strip)
- reverting `line_boundaries` alone → both glyph tests fail, 142 and 286 glyphs
  dropped

## Verification

- `cargo test -p fulgur` — **2628 passed, 0 failed**, no existing test re-blessed
- `cargo clippy -p fulgur --all-targets` — clean
- `cargo fmt --check` — clean

## Related

Extracted from #719. The remaining pieces of that branch, each now backed by a
measurement rather than an assertion:

- inline roots measured by border box — the padded variant of this defect still
  loses 13 of 30 words; tracked upstream as `fulgur-2s7p.4`
- fragment decoration — 4 of 5 behaviours (open cut edges, corner radii,
  `box-decoration-break: clone`, phantom stroke) currently fail on `main`
- overflow detection as a blanket test-build invariant, so this whole class
  cannot regress silently again


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ページ境界で段落や行の一部が欠落する問題を修正しました。
  * 残りの領域に収まらない段落を、適切に次ページへ移動するよう改善しました。
  * ページ分割時の行位置やインライン画像の配置を正確に処理するよう改善しました。

* **テスト**
  * 異なるページ高や段落構成で、コンテンツが失われないことを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->