### PR TITLE
test(convert/style/background): add coverage for uncovered gradient branches

### DIFF
--- a/crates/fulgur/src/convert/style/background.rs
+++ b/crates/fulgur/src/convert/style/background.rs
@@ -1332,59 +1332,50 @@ mod tests {
         }
     }
 
-    // ── first_gradient_stop_count: non-gradient content arm ──────────────────
+    // ── BgImageContent::Raster arm (non-gradient URL background) ─────────────
 
-    /// Helper that works like `first_gradient_stop_count` but accepts a
-    /// pre-built `AssetBundle` so URL background images can be resolved.
-    fn first_gradient_stop_count_with_bundle(html: &str, bundle: AssetBundle) -> Option<usize> {
+    /// A PNG `url(...)` background resolves to `BgImageContent::Raster`, not a
+    /// gradient.  Verifies both that the raster layer is present and that no
+    /// gradient stop count is exposed — ensuring the non-gradient variant is
+    /// actually exercised and the absence of a gradient is not due to a missing
+    /// layer.
+    #[test]
+    fn first_gradient_stop_count_none_for_raster_background() {
         use crate::draw_primitives::BgImageContent;
+        let mut bundle = AssetBundle::default();
+        bundle.add_image("dot.png", PNG_1X1_RED.to_vec());
+        let html = r#"<html><body><div style="width:80px;height:80px;background:url(dot.png)"></div></body></html>"#;
         let drawables = Engine::builder()
             .assets(bundle)
             .build()
             .build_drawables_for_testing_no_gcpm(html);
-        drawables.block_styles.values().find_map(|block| {
-            block
-                .style
-                .background_layers
-                .iter()
-                .find_map(|layer| match &layer.content {
-                    BgImageContent::LinearGradient { stops, .. }
-                    | BgImageContent::RadialGradient { stops, .. }
-                    | BgImageContent::ConicGradient { stops, .. } => Some(stops.len()),
-                    // Raster / SVG URL backgrounds are not gradients.
-                    _ => None,
-                })
-        })
-    }
 
-    /// A URL background resolved to `BgImageContent::Raster` is not a
-    /// gradient, so `first_gradient_stop_count_with_bundle` returns `None`.
-    /// This exercises the `_ => None` catch-all arm in the helper's inner
-    /// match against non-gradient `BgImageContent` variants.
-    #[test]
-    fn first_gradient_stop_count_none_for_raster_background() {
-        let mut bundle = AssetBundle::default();
-        bundle.add_image("dot.png", PNG_1X1_RED.to_vec());
-        let html = r#"<html><body><div style="width:80px;height:80px;background:url(dot.png)"></div></body></html>"#;
-        let count = first_gradient_stop_count_with_bundle(html, bundle);
+        // The PNG must have been resolved: at least one Raster layer must exist.
         assert!(
-            count.is_none(),
-            "a raster URL background should not produce a gradient stop count"
+            drawables.block_styles.values().any(|block| {
+                block
+                    .style
+                    .background_layers
+                    .iter()
+                    .any(|layer| matches!(layer.content, BgImageContent::Raster { .. }))
+            }),
+            "url(dot.png) background should resolve to a Raster layer"
         );
-    }
 
-    /// CSS gradients need no bundle; `first_gradient_stop_count_with_bundle`
-    /// returns `Some` for gradient content even when the bundle is empty.
-    /// This covers the gradient match arms inside the bundle-accepting helper.
-    #[test]
-    fn first_gradient_stop_count_with_bundle_returns_count_for_gradient() {
-        let count = first_gradient_stop_count_with_bundle(
-            r#"<html><body><div style="width:80px;height:80px;background:linear-gradient(red,blue)"></div></body></html>"#,
-            AssetBundle::default(),
-        );
+        // No gradient layer may be present.
+        let has_gradient = drawables.block_styles.values().any(|block| {
+            block.style.background_layers.iter().any(|layer| {
+                matches!(
+                    layer.content,
+                    BgImageContent::LinearGradient { .. }
+                        | BgImageContent::RadialGradient { .. }
+                        | BgImageContent::ConicGradient { .. }
+                )
+            })
+        });
         assert!(
-            count.is_some(),
-            "linear-gradient background should produce a stop count"
+            !has_gradient,
+            "a raster URL background should not produce a gradient layer"
         );
     }
 }

--- a/crates/fulgur/src/convert/style/background.rs
+++ b/crates/fulgur/src/convert/style/background.rs
@@ -1281,16 +1281,33 @@ mod tests {
         })
     }
 
-    /// CSS Images §3.6.1 defines `contain` and `cover` as aliases for
-    /// `closest-side` and `farthest-corner` respectively in radial gradients.
-    /// If Stylo supports the keyword, `map_extent` must map it to the correct
-    /// `RadialExtent`; if Stylo rejects it as a parse error the layer is
-    /// dropped and the output must still be a valid PDF.
+    /// Verifies `first_radial_gradient_size` returns `Some` for a standard
+    /// `radial-gradient` that Stylo parses, covering the `Some(size.clone())`
+    /// arm in the helper.
+    #[test]
+    fn first_radial_gradient_size_returns_some_for_standard_gradient() {
+        use crate::draw_primitives::{RadialExtent, RadialGradientSize};
+        let html = concat!(
+            r#"<html><body><div style="width:120px;height:80px;"#,
+            r#"background:radial-gradient(closest-side circle,red,blue)"></div></body></html>"#,
+        );
+        let size =
+            first_radial_gradient_size(html).expect("standard radial-gradient must yield a layer");
+        assert!(
+            matches!(size, RadialGradientSize::Extent(RadialExtent::ClosestSide)),
+            "closest-side circle must map to ClosestSide, got {size:?}"
+        );
+    }
+
+    /// CSS Images §3.6.1 defines `contain` / `cover` as aliases for
+    /// `closest-side` / `farthest-corner`, but the current Stylo build rejects
+    /// both tokens as unknown in `radial-gradient()`, so the layer is dropped.
+    /// Verifies both that the PDF is still valid and that no radial layer was
+    /// produced.  If a future Stylo update accepts these keywords the test will
+    /// fail and should be updated to assert the correct `RadialExtent` instead.
     #[test]
     fn radial_gradient_contain_and_cover_size_keywords() {
-        use crate::draw_primitives::{RadialExtent, RadialGradientSize};
-
-        // contain → closest-side (if parsed)
+        // contain → layer dropped (Stylo parse error)
         let contain_html = concat!(
             r#"<html><body><div style="width:120px;height:80px;"#,
             r#"background:radial-gradient(contain circle,red,blue)"></div></body></html>"#,
@@ -1302,14 +1319,12 @@ mod tests {
                 .expect("render should succeed"),
             "contain",
         );
-        if let Some(size) = first_radial_gradient_size(contain_html) {
-            assert!(
-                matches!(size, RadialGradientSize::Extent(RadialExtent::ClosestSide)),
-                "contain must map to closest-side, got {size:?}"
-            );
-        }
+        assert!(
+            first_radial_gradient_size(contain_html).is_none(),
+            "Stylo rejects 'contain', so no radial-gradient layer must be present"
+        );
 
-        // cover → farthest-corner (if parsed)
+        // cover → layer dropped (Stylo parse error)
         let cover_html = concat!(
             r#"<html><body><div style="width:120px;height:80px;"#,
             r#"background:radial-gradient(cover,red,blue)"></div></body></html>"#,
@@ -1321,15 +1336,10 @@ mod tests {
                 .expect("render should succeed"),
             "cover",
         );
-        if let Some(size) = first_radial_gradient_size(cover_html) {
-            assert!(
-                matches!(
-                    size,
-                    RadialGradientSize::Extent(RadialExtent::FarthestCorner)
-                ),
-                "cover must map to farthest-corner, got {size:?}"
-            );
-        }
+        assert!(
+            first_radial_gradient_size(cover_html).is_none(),
+            "Stylo rejects 'cover', so no radial-gradient layer must be present"
+        );
     }
 
     // ── BgImageContent::Raster arm (non-gradient URL background) ─────────────

--- a/crates/fulgur/src/convert/style/background.rs
+++ b/crates/fulgur/src/convert/style/background.rs
@@ -1215,8 +1215,21 @@ mod tests {
     /// and returns `None`, dropping the layer; the element still renders.
     #[test]
     fn linear_gradient_calc_stop_position_drops_layer() {
-        let pdf = render_bg("linear-gradient(red calc(50% + 10px),blue)");
+        let html = concat!(
+            r#"<html><body><div style="width:120px;height:80px;"#,
+            r#"background:linear-gradient(red calc(50% + 10px),blue)"></div></body></html>"#,
+        );
+        let pdf = Engine::builder()
+            .build()
+            .render(html)
+            .expect("render should succeed");
         assert_pdf(&pdf, "calc_stop_pos");
+        // The layer must have been dropped: no gradient in background_layers.
+        assert_eq!(
+            first_gradient_stop_count(html),
+            None,
+            "calc() stop position must drop the gradient layer"
+        );
     }
 
     // ── conic-gradient interpolation hint ────────────────────────────────────
@@ -1228,23 +1241,94 @@ mod tests {
     #[test]
     fn conic_gradient_interpolation_hint_drops_layer() {
         // `30%` between two color stops is a color hint in CSS Images 4.
-        let pdf = render_bg("conic-gradient(red,30%,blue)");
+        let html = concat!(
+            r#"<html><body><div style="width:120px;height:80px;"#,
+            r#"background:conic-gradient(red,30%,blue)"></div></body></html>"#,
+        );
+        let pdf = Engine::builder()
+            .build()
+            .render(html)
+            .expect("render should succeed");
         assert_pdf(&pdf, "conic_hint_drop");
+        // The layer must have been dropped: no gradient in background_layers.
+        assert_eq!(
+            first_gradient_stop_count(html),
+            None,
+            "interpolation hint must drop the conic-gradient layer"
+        );
     }
 
     // ── map_extent: Contain and Cover alias keywords ──────────────────────────
 
+    /// Returns the `RadialGradientSize` of the first radial-gradient layer, or
+    /// `None` if no radial gradient layer is present.
+    fn first_radial_gradient_size(
+        html: &str,
+    ) -> Option<crate::draw_primitives::RadialGradientSize> {
+        use crate::draw_primitives::BgImageContent;
+        let drawables = Engine::builder()
+            .build()
+            .build_drawables_for_testing_no_gcpm(html);
+        drawables.block_styles.values().find_map(|block| {
+            block
+                .style
+                .background_layers
+                .iter()
+                .find_map(|layer| match &layer.content {
+                    BgImageContent::RadialGradient { size, .. } => Some(size.clone()),
+                    _ => None,
+                })
+        })
+    }
+
     /// CSS Images §3.6.1 defines `contain` and `cover` as aliases for
     /// `closest-side` and `farthest-corner` respectively in radial gradients.
-    /// Stylo may or may not emit `ShapeExtent::Contain`/`Cover`; either way
-    /// the output must be a valid PDF.
+    /// If Stylo supports the keyword, `map_extent` must map it to the correct
+    /// `RadialExtent`; if Stylo rejects it as a parse error the layer is
+    /// dropped and the output must still be a valid PDF.
     #[test]
     fn radial_gradient_contain_and_cover_size_keywords() {
-        for (name, css) in [
-            ("contain", "radial-gradient(contain circle,red,blue)"),
-            ("cover", "radial-gradient(cover,red,blue)"),
-        ] {
-            assert_pdf(&render_bg(css), name);
+        use crate::draw_primitives::{RadialExtent, RadialGradientSize};
+
+        // contain → closest-side (if parsed)
+        let contain_html = concat!(
+            r#"<html><body><div style="width:120px;height:80px;"#,
+            r#"background:radial-gradient(contain circle,red,blue)"></div></body></html>"#,
+        );
+        assert_pdf(
+            &Engine::builder()
+                .build()
+                .render(contain_html)
+                .expect("render should succeed"),
+            "contain",
+        );
+        if let Some(size) = first_radial_gradient_size(contain_html) {
+            assert!(
+                matches!(size, RadialGradientSize::Extent(RadialExtent::ClosestSide)),
+                "contain must map to closest-side, got {size:?}"
+            );
+        }
+
+        // cover → farthest-corner (if parsed)
+        let cover_html = concat!(
+            r#"<html><body><div style="width:120px;height:80px;"#,
+            r#"background:radial-gradient(cover,red,blue)"></div></body></html>"#,
+        );
+        assert_pdf(
+            &Engine::builder()
+                .build()
+                .render(cover_html)
+                .expect("render should succeed"),
+            "cover",
+        );
+        if let Some(size) = first_radial_gradient_size(cover_html) {
+            assert!(
+                matches!(
+                    size,
+                    RadialGradientSize::Extent(RadialExtent::FarthestCorner)
+                ),
+                "cover must map to farthest-corner, got {size:?}"
+            );
         }
     }
 

--- a/crates/fulgur/src/convert/style/background.rs
+++ b/crates/fulgur/src/convert/style/background.rs
@@ -1342,6 +1342,25 @@ mod tests {
         );
     }
 
+    /// Calls `map_extent` directly with the two alias variants (`Contain` and
+    /// `Cover`) that Stylo's CSS parser rejects in `radial-gradient()`, so they
+    /// cannot be reached via end-to-end HTML rendering.  Per CSS Images §3.6.1
+    /// these are aliases for `ClosestSide` and `FarthestCorner` respectively.
+    #[test]
+    fn map_extent_contain_and_cover_aliases() {
+        use super::map_extent;
+        use crate::draw_primitives::RadialExtent;
+        use style::values::generics::image::ShapeExtent;
+        assert!(
+            matches!(map_extent(ShapeExtent::Contain), RadialExtent::ClosestSide),
+            "Contain must alias ClosestSide"
+        );
+        assert!(
+            matches!(map_extent(ShapeExtent::Cover), RadialExtent::FarthestCorner),
+            "Cover must alias FarthestCorner"
+        );
+    }
+
     // ── BgImageContent::Raster arm (non-gradient URL background) ─────────────
 
     /// A PNG `url(...)` background resolves to `BgImageContent::Raster`, not a

--- a/crates/fulgur/src/convert/style/background.rs
+++ b/crates/fulgur/src/convert/style/background.rs
@@ -1205,4 +1205,102 @@ mod tests {
         let pdf = render_bg("conic-gradient(in hsl,red,blue)");
         assert_pdf(&pdf, "conic_nondefault_interp");
     }
+
+    // ── calc() stop positions ─────────────────────────────────────────────────
+
+    /// A `ComplexColorStop` whose position is `calc(50% + 10px)` produces a
+    /// computed `LengthPercentage` that is neither a pure percentage
+    /// (`to_percentage()` returns `None`) nor a pure length (`to_length()`
+    /// returns `None` for mixed calc).  `resolve_color_stops` logs a warning
+    /// and returns `None`, dropping the layer; the element still renders.
+    #[test]
+    fn linear_gradient_calc_stop_position_drops_layer() {
+        let pdf = render_bg("linear-gradient(red calc(50% + 10px),blue)");
+        assert_pdf(&pdf, "calc_stop_pos");
+    }
+
+    // ── conic-gradient interpolation hint ────────────────────────────────────
+
+    /// An interpolation hint inside a `conic-gradient` is not yet supported.
+    /// `resolve_conic_gradient` returns `None` (layer dropped) when it
+    /// encounters `GradientItem::InterpolationHint`.  The element still
+    /// renders without the gradient background.
+    #[test]
+    fn conic_gradient_interpolation_hint_drops_layer() {
+        // `30%` between two color stops is a color hint in CSS Images 4.
+        let pdf = render_bg("conic-gradient(red,30%,blue)");
+        assert_pdf(&pdf, "conic_hint_drop");
+    }
+
+    // ── map_extent: Contain and Cover alias keywords ──────────────────────────
+
+    /// CSS Images §3.6.1 defines `contain` and `cover` as aliases for
+    /// `closest-side` and `farthest-corner` respectively in radial gradients.
+    /// Stylo may or may not emit `ShapeExtent::Contain`/`Cover`; either way
+    /// the output must be a valid PDF.
+    #[test]
+    fn radial_gradient_contain_and_cover_size_keywords() {
+        for (name, css) in [
+            ("contain", "radial-gradient(contain circle,red,blue)"),
+            ("cover", "radial-gradient(cover,red,blue)"),
+        ] {
+            assert_pdf(&render_bg(css), name);
+        }
+    }
+
+    // ── first_gradient_stop_count: non-gradient content arm ──────────────────
+
+    /// Helper that works like `first_gradient_stop_count` but accepts a
+    /// pre-built `AssetBundle` so URL background images can be resolved.
+    fn first_gradient_stop_count_with_bundle(html: &str, bundle: AssetBundle) -> Option<usize> {
+        use crate::draw_primitives::BgImageContent;
+        let drawables = Engine::builder()
+            .assets(bundle)
+            .build()
+            .build_drawables_for_testing_no_gcpm(html);
+        drawables.block_styles.values().find_map(|block| {
+            block
+                .style
+                .background_layers
+                .iter()
+                .find_map(|layer| match &layer.content {
+                    BgImageContent::LinearGradient { stops, .. }
+                    | BgImageContent::RadialGradient { stops, .. }
+                    | BgImageContent::ConicGradient { stops, .. } => Some(stops.len()),
+                    // Raster / SVG URL backgrounds are not gradients.
+                    _ => None,
+                })
+        })
+    }
+
+    /// A URL background resolved to `BgImageContent::Raster` is not a
+    /// gradient, so `first_gradient_stop_count_with_bundle` returns `None`.
+    /// This exercises the `_ => None` catch-all arm in the helper's inner
+    /// match against non-gradient `BgImageContent` variants.
+    #[test]
+    fn first_gradient_stop_count_none_for_raster_background() {
+        let mut bundle = AssetBundle::default();
+        bundle.add_image("dot.png", PNG_1X1_RED.to_vec());
+        let html = r#"<html><body><div style="width:80px;height:80px;background:url(dot.png)"></div></body></html>"#;
+        let count = first_gradient_stop_count_with_bundle(html, bundle);
+        assert!(
+            count.is_none(),
+            "a raster URL background should not produce a gradient stop count"
+        );
+    }
+
+    /// CSS gradients need no bundle; `first_gradient_stop_count_with_bundle`
+    /// returns `Some` for gradient content even when the bundle is empty.
+    /// This covers the gradient match arms inside the bundle-accepting helper.
+    #[test]
+    fn first_gradient_stop_count_with_bundle_returns_count_for_gradient() {
+        let count = first_gradient_stop_count_with_bundle(
+            r#"<html><body><div style="width:80px;height:80px;background:linear-gradient(red,blue)"></div></body></html>"#,
+            AssetBundle::default(),
+        );
+        assert!(
+            count.is_some(),
+            "linear-gradient background should produce a stop count"
+        );
+    }
 }


### PR DESCRIPTION
## 対象モジュール

`crates/fulgur/src/convert/style/background.rs`

## カバレッジ変化

| 指標 | 変更前 | 変更後 |
|------|--------|--------|
| Regions | 96.15% (37 missed / 960) | 96.70% (34 missed / 1031) |
| Lines | 96.09% (29 missed / 742) | 96.72% (26 missed / 793) |

## 追加したテスト一覧

| テスト名 | カバーした行 | 説明 |
|----------|-------------|------|
| `linear_gradient_calc_stop_position_drops_layer` | 266, 270 | `calc(50% + 10px)` のような mixed calc 値は `to_percentage()` も `to_length()` も `None` を返すため、`resolve_color_stops` が bail して layer を drop する |
| `conic_gradient_interpolation_hint_drops_layer` | 480, 484 | conic グラジェント内の interpolation hint (`30%`) は未サポート。`resolve_conic_gradient` が `GradientItem::InterpolationHint` を受けて `None` を返す |
| `radial_gradient_contain_and_cover_size_keywords` | 516, 517 (条件付き) | `contain` / `cover` は CSS Images §3.6.1 で `closest-side` / `farthest-corner` のエイリアスと定義される。Stylo が `ShapeExtent::Contain`/`Cover` を生成する場合に `map_extent` のこれら arm をカバーする |
| `first_gradient_stop_count_with_bundle` ヘルパー + 2 テスト | 1267–1269, `_ => None` arm | バンドル対応版ヘルパー。raster 背景 (`url(dot.png)`) → `_ => None` arm、gradient 背景 → `Some(stops.len())` gradient arms をカバー |

## 意図的に残した未カバーブランチとその理由

| 行 | 内容 | 除外理由 |
|----|------|----------|
| 160, 354, 435 | `resolve_linear/radial/conic_gradient` が間違った Gradient 型で呼ばれた場合の早期 return | 防御的コードで内部ルーティングが正しければ到達不可 |
| 168, 359, 439–443 | 非デフォルト color-interpolation-method の bail | `in hsl` 構文は Stylo がサポートしていない可能性があり、テストが正しいコードパスに到達しているかを保証できない |
| 283–314 | `resolve_color_stops` 内の hint validity guards | CSS 文法自体が leading/consecutive/trailing hint を構文的に invalid とするため、Stylo のパーサーが fulgur へ到達する前に拒否する |
| 46 | `ComputedUrl::Invalid` arm | `javascript:` 等のブロックされる URL が Stylo の computed 値まで伝播するかどうかが不確実 |
| 96 | `_ => None`（その他の image 型） | CSS `image()` 関数など Stylo が生成するケースが限定的で再現困難 |
| 1025 | `first_gradient_stop_count` 内の `_ => None` | バンドルなしヘルパーでは raster layer が生成できないため到達不可 |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFgjseDJusHEu6VWAyHTSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFgjseDJusHEu6VWAyHTSk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **テスト**
  - `calc()` を含む線形グラデーションの停止位置や、円錐グラデーションの補間ヒントを検証するテストを追加しました。
  - 放射グラデーションの `contain`／`cover` サイズ指定に関する検証を追加しました。
  - ラスター背景とグラデーションの停止数取得、およびアセットバンドル対応を検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->