### PR TITLE
test(asset): add coverage for combined_css, Default, FontFormat::Debug, error paths

### DIFF
--- a/crates/fulgur/src/asset.rs
+++ b/crates/fulgur/src/asset.rs
@@ -1735,4 +1735,111 @@ mod tests {
              in addition to key+data bytes — otherwise entry count is unbounded"
         );
     }
+
+    // --- combined_css ---
+
+    #[test]
+    fn combined_css_joins_stylesheets_with_newline() {
+        let mut bundle = AssetBundle::new();
+        bundle.add_css("h1 { color: red; }");
+        bundle.add_css("body { margin: 0; }");
+        assert_eq!(
+            bundle.combined_css(),
+            "h1 { color: red; }\nbody { margin: 0; }",
+            "combined_css must join entries with a newline separator"
+        );
+    }
+
+    #[test]
+    fn combined_css_empty_bundle_returns_empty_string() {
+        let bundle = AssetBundle::new();
+        assert_eq!(
+            bundle.combined_css(),
+            "",
+            "empty bundle must yield empty combined CSS"
+        );
+    }
+
+    #[test]
+    fn combined_css_single_entry_has_no_separator() {
+        let mut bundle = AssetBundle::new();
+        bundle.add_css("body { color: blue; }");
+        assert_eq!(bundle.combined_css(), "body { color: blue; }");
+    }
+
+    // --- Default impl ---
+
+    #[test]
+    fn default_bundle_is_equivalent_to_new() {
+        let bundle: AssetBundle = Default::default();
+        assert!(bundle.css.is_empty(), "Default bundle must have no CSS");
+        assert!(bundle.fonts.is_empty(), "Default bundle must have no fonts");
+        assert!(
+            bundle.images.is_empty(),
+            "Default bundle must have no images"
+        );
+    }
+
+    // --- add_css_file: non-UTF-8 content ---
+
+    #[test]
+    fn add_css_file_rejects_non_utf8_content() {
+        use std::io::Write as _;
+        let mut tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        // Write bytes that are invalid UTF-8 (lone continuation byte + overlong sequence).
+        tmp.write_all(&[0xFF, 0xFE, 0x80])
+            .expect("write non-UTF8 bytes");
+        let mut bundle = AssetBundle::new();
+        let err = bundle
+            .add_css_file(tmp.path())
+            .expect_err("non-UTF8 CSS file must be rejected");
+        match err {
+            Error::Io(e) => assert_eq!(
+                e.kind(),
+                std::io::ErrorKind::InvalidData,
+                "expected InvalidData, got {e}"
+            ),
+            other => panic!("expected Error::Io(InvalidData), got {other:?}"),
+        }
+        assert!(
+            bundle.css.is_empty(),
+            "CSS must not be stored after rejection"
+        );
+    }
+
+    // --- set_base_url: URL without file:/// prefix ---
+
+    #[test]
+    fn set_base_url_without_file_prefix_stores_full_string_as_base() {
+        // When the URL does not start with "file:///", strip_prefix returns None
+        // and unwrap_or(url) stores the full string as the base path.
+        let mut bundle = AssetBundle::new();
+        bundle.add_image("logo.png", vec![1, 2, 3]);
+        bundle.set_base_url("project/subdir/");
+        // base_path_str is now Some("project/subdir/"); strip it from the absolute path
+        // to recover the short key.
+        assert!(
+            bundle.get_image("project/subdir/logo.png").is_some(),
+            "get_image must find logo.png via a non-file:// base prefix"
+        );
+        // A path that does not start with the base must still return None.
+        assert!(
+            bundle.get_image("other/logo.png").is_none(),
+            "get_image must not match when the path does not start with the base"
+        );
+    }
+
+    // --- FontFormat Debug derive ---
+
+    #[test]
+    fn font_format_debug_all_variants() {
+        // Exercise the derived Debug impl for every FontFormat variant.
+        // Without this, the generated match arms in Debug::fmt are missed lines.
+        assert!(format!("{:?}", FontFormat::Ttf).contains("Ttf"));
+        assert!(format!("{:?}", FontFormat::Otf).contains("Otf"));
+        assert!(format!("{:?}", FontFormat::Ttc).contains("Ttc"));
+        assert!(format!("{:?}", FontFormat::Woff1).contains("Woff1"));
+        assert!(format!("{:?}", FontFormat::Woff2).contains("Woff2"));
+        assert!(format!("{:?}", FontFormat::Unknown).contains("Unknown"));
+    }
 }


### PR DESCRIPTION
## 対象モジュール

`crates/fulgur/src/asset.rs` — `AssetBundle` と `FontFormat` のカバレッジ改善

## カバレッジ変化

| 指標 | 変化前 | 変化後 |
|------|--------|--------|
| Lines (JSON) | 96.0% (36 行未カバー) | 96.25% (31 行未カバー) |
| Branch (llvm-cov summary) | 98.95% (1 ブランチ未カバー) | 変化なし |

LCOV 解析で実際に未カバーの行番号を特定し、各テストが意味のあるパスを追加していることを確認した。

## 追加したテスト一覧

| テスト名 | カバーした挙動 |
|----------|---------------|
| `combined_css_joins_stylesheets_with_newline` | `combined_css()` が改行区切りで結合することを検証（既存テストから未呼び出しだった） |
| `combined_css_empty_bundle_returns_empty_string` | 空バンドルで空文字列を返すことを検証 |
| `combined_css_single_entry_has_no_separator` | 単一エントリでセパレータなしを検証 |
| `default_bundle_is_equivalent_to_new` | `AssetBundle::default()` が `new()` と等価なことを検証（`Default` impl が未呼び出しだった） |
| `add_css_file_rejects_non_utf8_content` | 非 UTF-8 ファイルを渡したときの `Error::Io(InvalidData)` パスを検証 |
| `set_base_url_without_file_prefix_stores_full_string_as_base` | `file:///` プレフィックスを持たない URL を渡したとき `unwrap_or(url)` が full string を base として保存し、`get_image` がそれを正しく剥がすことを検証 |
| `font_format_debug_all_variants` | `FontFormat` の derive `Debug` impl の全 6 バリアントを網羅（生成されたマッチアームが未実行だった） |

## 意図的に残した未カバー行

| 行 | 理由 |
|----|------|
| `asset.rs:345` — `log::warn!` 内の `key.len()` | Rust の `log` クレートはログレベルが無効のとき format 引数を評価しない。テストハーネスはデフォルトでロガーを設定しないため、このアーギュメントは実行されない。ロガー依存を追加するだけのために coverage を上げることは過剰。 |
| `asset.rs:632-635` — `decode_woff2` のベルト・サスペンダー検証 | WOFF2 ヘッダの `totalSfntSize` を偽り（小さい値を宣言しつつ実際のデコード出力が 64 MiB 超）な WOFF2 ファイルを単体テストで作成するのは非現実的。上位の `woff2_declared_sfnt_size` チェックがすでに宣言値超過を防いでおり、このパスはそれを回避したリアーヘッダーへの防御専用。 |
| 残り ≈26 行 | テストコード内の `other => panic!(...)` アーム。テストが成功するとき実行されない防御的アサーション。これは健全なテスト設計であり、意図的に残す。 |

## チェックリスト

- [x] `cargo test -p fulgur --lib` — 2160 passed, 0 failed
- [x] `cargo clippy -p fulgur -- -D warnings` — 警告なし
- [x] `cargo fmt --check -p fulgur` — 差分なし
- [x] プロダクションコード変更なし（テスト追加のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EU9HYp8Zkbs3AJCzvrWR6H

---
_Generated by [Claude Code](https://claude.ai/code/session_01EU9HYp8Zkbs3AJCzvrWR6H)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **テスト**
  - CSSスタイルシートの結合処理について、複数・空・単一ファイルのケースを検証しました。
  - 初期状態、無効な文字コードのCSS、各種ベースURLでの画像解決を確認しました。
  - フォント形式のデバッグ表示に関するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->