### PR TITLE
fix(ci): stop rust-cache from corrupting the wpt checkout via target/wpt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,26 +295,32 @@ jobs:
           # Gives each of the 7 wpt matrix phases (css-page, multicol-1/2/3,
           # bugs, opacity-visibility, smoke) its own cache slot instead of
           # sharing `ubuntu-latest-fulgur` with the `vrt` job and each other.
-          # This is a hygiene improvement (avoids one phase's rebuild
-          # evicting another's cache entry), NOT a confirmed fix for a
-          # specific incident: on one push-to-main run, 3 phases (bugs,
-          # opacity-visibility, smoke — the ones queued behind the other 4
-          # for a runner slot) failed identically with `cargo: could not
-          # find Cargo.toml`, immediately after a "Cache restored
-          # successfully" that otherwise looked like a clean, complete
-          # download.
+          # Real hygiene improvement, but NOT what fixes the `cargo: could
+          # not find Cargo.toml` failure this comment used to describe as
+          # unexplained (fulgur PR #752) — confirmed root cause, tracked in
+          # fulgur-5x02:
           #
-          # Per Swatinem/rust-cache's own docs, the paths it restores are
-          # `~/.cargo/{bin,registry,git,...}` and `<workspace>/target` —
-          # never the checked-out working tree itself — and matrix jobs run
-          # on independent runner VMs with no shared filesystem, so a
-          # same-key concurrent save/restore cannot plausibly overwrite
-          # another job's `actions/checkout` output (Cargo.toml lives at the
-          # repo root, outside every cached path). Flagged by Codex review
-          # on the PR that introduced this comment (fulgur PR #752) — the
-          # real mechanism is still unknown. The "Verify checkout" step
-          # below exists to actually capture that if/when this recurs,
-          # rather than continuing to guess.
+          # This job's "Cache Paths" is the whole `<workspace>/target`
+          # (this repo doesn't scope rust-cache to subpaths), and
+          # `scripts/wpt/fetch.sh` creates a nested git repo at
+          # `target/wpt/.git`. That nested `.git` gets swept into the
+          # rust-cache tarball and, on a cache hit, restored via
+          # `tar -x ... -C <workspace>` — but doesn't survive that
+          # round-trip as a fully valid repo. `git -C target/wpt ...` then
+          # fails to recognize `target/wpt` as its own root, discovery
+          # falls through to the enclosing fulgur checkout, and
+          # `checkout --detach FETCH_HEAD` replaces fulgur's own working
+          # tree (Cargo.toml included) with WPT's sparse subset — while
+          # still exiting 0, so `Fetch WPT subset` reports success and
+          # `Verify checkout` (which runs *before* that step) never sees
+          # the damage. Cache hit correlated with this failure on every
+          # job checked, no exceptions; per-phase keys alone don't prevent
+          # it since the corrupted payload is per-key already.
+          #
+          # fetch.sh now verifies `target/wpt` really is its own git root
+          # before reusing it (reinitializing otherwise), and the step
+          # below strips `target/wpt` before this action's post-job save
+          # runs, so a WPT checkout never re-enters the cache at all.
           shared-key: ubuntu-latest-fulgur-wpt-${{ matrix.phase }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install poppler-utils
@@ -361,6 +367,15 @@ jobs:
           name: wpt-${{ matrix.phase }}-report
           path: target/wpt-report/${{ matrix.phase }}
           if-no-files-found: warn
+      - name: Evict WPT checkout from the build-artifact cache
+        # Swatinem/rust-cache saves this whole `target/` dir (see the
+        # comment on that step above) via a post-job hook that runs after
+        # every explicit step here regardless of ordering. target/wpt is a
+        # git checkout, not a build artifact, and round-tripping it through
+        # the cache tarball is what caused fulgur-5x02 — so make sure it's
+        # gone before that save happens.
+        if: always()
+        run: rm -rf target/wpt
 
   bindings-check:
     name: Bindings type-check

--- a/scripts/wpt/fetch.sh
+++ b/scripts/wpt/fetch.sh
@@ -16,6 +16,25 @@ if [ -z "$SHA" ]; then
   exit 1
 fi
 
+# A $WPT_DIR/.git that exists but isn't a genuine standalone repo root is
+# more dangerous than a missing one: every `git -C "$WPT_DIR"` call below
+# would silently fall through git's repo discovery to the *enclosing*
+# fulgur checkout, and `checkout --detach FETCH_HEAD` at the bottom of this
+# script would then replace fulgur's own working tree (Cargo.toml included)
+# with WPT's sparse subset while still reporting success. This happens in
+# CI when Swatinem/rust-cache caches the whole `target/` dir (this repo
+# doesn't scope it to subpaths) and a restored `.git` doesn't survive the
+# tar round-trip intact (see fulgur-5x02). Verify the directory is really
+# its own git root before trusting it as already-initialized.
+if [ -d "$WPT_DIR/.git" ]; then
+  wpt_toplevel="$(git -C "$WPT_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
+  wpt_dir_real="$(cd "$WPT_DIR" && pwd -P)"
+  if [ "$wpt_toplevel" != "$wpt_dir_real" ]; then
+    echo "warning: $WPT_DIR/.git is present but not a valid repo root (resolved to '$wpt_toplevel') — reinitializing" >&2
+    rm -rf "$WPT_DIR"
+  fi
+fi
+
 if [ ! -d "$WPT_DIR/.git" ]; then
   mkdir -p "$WPT_DIR"
   git -C "$WPT_DIR" init -q


### PR DESCRIPTION
## 概要

`wpt` matrix job の全7フェーズが `Fetch WPT subset` (`scripts/wpt/fetch.sh`) 成功直後の
`cargo test` で `error: could not find Cargo.toml in .../fulgur or any parent directory`
(exit 101) で落ちる問題を修正する。fulgur-5x02 参照。

## 根本原因

`Swatinem/rust-cache` はこの job の "Cache Paths" として `<workspace>/target` を丸ごと
キャッシュしている（サブパス指定なし）。`scripts/wpt/fetch.sh` は WPT のスパースチェック
アウト用に `target/wpt/.git` という nested git repo を作るため、これがキャッシュの tar に
巻き込まれる。cache hit で復元された `.git` は tar round-trip を経て完全な状態では戻らず、
`git -C target/wpt ...` が `target/wpt` を自分自身のリポジトリルートとして認識できなくなる。
結果として git のリポジトリ探索が外側の fulgur 本体まで遡り、`checkout --detach FETCH_HEAD`
が **fulgur 本体の作業ツリー（Cargo.toml 含む）を WPT のスパースサブセットで上書き** する
—— しかも git 的には成功として exit 0 を返すため、`Fetch WPT subset` は "WPT ready" と表示
してそのまま先に進んでしまう。

cache hit/miss と成功/失敗の相関をチェックした全 job log で例外なく一致することを確認済み
（hit → 7/7 fail、miss → 7/7 pass、混在した run でもフェーズ単位で厳密に対応）。

2026-09-09 (PR #752) に一度発生し、「rust-cache の同一キーによる並行 save/restore race」
という仮説で per-phase cache key 化の修正が入ったが、これは誤診断で、今回もキーが
phase 毎に分離された状態のまま再発した。

## 変更内容

- `scripts/wpt/fetch.sh`: 既存の `target/wpt/.git` を無条件に「初期化済み」とみなさず、
  `git rev-parse --show-toplevel` で本当に `target/wpt` 自身がリポジトリルートかを検証。
  一致しない場合は破損とみなして `rm -rf` の上で再初期化する（サンドボックスで、
  破損した nested `.git` から実際に外側リポジトリへ解決が抜けるケースを再現し、
  検出 → 再初期化 → 外側リポジトリは無傷、まで確認済み）。
- `.github/workflows/ci.yml`: job 終了前に `target/wpt` を削除するステップを追加し、
  そもそも WPT checkout がキャッシュに二度と混入しないようにした。`Swatinem/rust-cache`
  ステップの古いコメント（PR #752 由来の「race 未確証」という記述）も、確定した根本原因の
  説明に更新。

## 影響範囲

`wpt` job は `continue-on-error: true` の reporting 専用ジョブで、必須チェックには入って
いない。今回の変更は CI 設定と WPT fetch スクリプトのみで、Rust 側のコードは変更していない。

## Test plan

- [x] `bash -n scripts/wpt/fetch.sh` / `shellcheck scripts/wpt/fetch.sh` — clean
- [x] YAML 構文チェック (`python3 -c "import yaml; yaml.safe_load(...)"`) — OK
- [x] サンドボックスで cold fetch → idempotent 再実行（fast path 維持を確認）→
      nested `.git` を意図的に破損させて再実行し、警告を出して再初期化、外側リポジトリ
      （Cargo.toml・git status）が無傷であることを確認
- [ ] この PR 自体の `wpt` job が実際に green で通ることを CI 上で確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - WPTテスト実行時のキャッシュ復元によるリポジトリ認識エラーを防止しました。
  - 不正な状態のWPT作業領域を検出し、再初期化できるようにしました。
  - テスト完了後に一時的なWPT作業領域を削除し、次回実行への影響を防ぎます。

- **ドキュメント**
  - WPTジョブで発生するキャッシュ障害の原因と対処方法を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->