### PR TITLE
test(render): cover three uncovered paths in render.rs (+2.46 pp)

### DIFF
--- a/crates/fulgur/tests/render_smoke.rs
+++ b/crates/fulgur/tests/render_smoke.rs
@@ -6714,3 +6714,93 @@ body { margin:0; font-size:14px; line-height:1.4; }</style>
          a spurious extra page, got {pages}"
     );
 }
+
+#[test]
+fn tagged_padded_paragraph_with_link_uses_run_tagging_in_dispatch() {
+    // Covers render.rs lines 1152-1153 — `use_run_tagging=true` in
+    // `dispatch_fragment`'s block+para arm.
+    //
+    // A `<p>` with `padding` triggers `needs_block_wrapper()=true`, creating
+    // both `block_styles[p_id]` AND `paragraphs[p_id]` at the same node_id.
+    // In tagged mode with a link run, `run_tag_target` returns Some for `<p>`
+    // (it has `PdfTag::P` in the semantic map), so `use_run_tagging=true` and
+    // `canvas.link_run_node_id` is set instead of `try_start_tagged`.
+    let html = r#"<!DOCTYPE html><html><body>
+        <p style="padding: 8px"><a href="https://example.com">link text</a></p>
+    </body></html>"#;
+    let pdf = Engine::builder()
+        .tagged(true)
+        .build()
+        .render(html)
+        .expect("tagged padded p with link must render");
+    assert!(!pdf.is_empty());
+    let s = String::from_utf8_lossy(&pdf);
+    assert!(
+        s.contains("/S /Link") || s.contains("/S/Link"),
+        "must have /Link structure element"
+    );
+    assert!(s.contains("/Annots"), "must have link annotation on page");
+}
+
+#[test]
+fn tagged_multicol_spanning_text_with_link_uses_run_tagging_in_paint_slices() {
+    // Covers render.rs lines 1374-1380 — `use_run_tagging=true` inside
+    // `paint_multicol_paragraph_slices`.
+    //
+    // The text is long enough to span both columns of the narrow container,
+    // so `paragraph_slices` is populated and `paint_multicol_paragraph_slices`
+    // is called. In tagged mode with a link run and a semantic node for the
+    // source paragraph, `use_run_tagging=true` and `canvas.link_run_node_id`
+    // is set inside the function.
+    //
+    // The existing `tagged_pdf_link_in_multicol_produces_link_struct_element`
+    // test uses a short `<p>` that fits in one column and therefore does not
+    // create paragraph slices; this test uses enough text to guarantee spanning.
+    let html = r#"<!DOCTYPE html><html><body>
+        <div style="columns:2;column-gap:10px;width:160px;font-size:10px">
+            Lorem ipsum dolor sit amet consectetur adipiscing elit sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua ut enim
+            ad minim veniam quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat and here is
+            <a href="https://example.com">a link</a> in the middle of enough
+            text to overflow the first column into the second column of this
+            narrow two-column container so that paragraph slices are created.
+        </div>
+    </body></html>"#;
+    let pdf = Engine::builder()
+        .tagged(true)
+        .build()
+        .render(html)
+        .expect("tagged multicol spanning text with link must render");
+    assert!(!pdf.is_empty());
+}
+
+#[test]
+fn opacity_inline_root_with_pseudo_image_reaches_para_for_block_in_draw_under_opacity() {
+    // Covers render.rs lines 2295-2321 — `para_for_block = Some` inside
+    // `draw_under_opacity`'s else branch.
+    //
+    // A `<p>` with opacity + visual style (background + padding) is BOTH an
+    // inline root (giving `paragraphs[p_id]`) and a styled block (giving
+    // `block_styles[p_id]`). The `::before` pseudo image registers as a
+    // separate drawable that goes into `opacity_descendants`, causing
+    // `draw_under_opacity` to be called for `p_id`. Inside the function,
+    // `para_for_block = drawables.paragraphs.get(&p_id) = Some`, reaching
+    // lines 2295-2321. Tagged mode with a link run also exercises the
+    // `use_run_tagging=true` sub-path at lines 2299-2301.
+    let mut bundle = AssetBundle::default();
+    bundle.add_image("dot.png", PR290_PSEUDO_PNG.to_vec());
+    let html = r#"<!DOCTYPE html><html><head><style>
+        .fancy::before { content: url("dot.png"); }
+        .fancy { opacity: 0.5; background: #eee; padding: 4px; }
+    </style></head><body>
+        <p class="fancy"><a href="https://example.com">link text</a></p>
+    </body></html>"#;
+    let pdf = Engine::builder()
+        .tagged(true)
+        .assets(bundle)
+        .build()
+        .render(html)
+        .expect("opacity inline root with pseudo image must render");
+    assert!(!pdf.is_empty());
+}


### PR DESCRIPTION
## 概要

`cargo-llvm-cov` でカバレッジを測定したところ、`render.rs` に3つの実行されていないブランチが見つかった。それぞれをターゲットにした smoke test を `crates/fulgur/tests/render_smoke.rs` に追加する。

**render.rs の行カバレッジ: 96.05% → 98.51% (+2.46 pp)**

プロダクションコードの変更はなし。テストのみ。

---

## 追加したテスト

### 1. `tagged_padded_paragraph_with_link_uses_run_tagging_in_dispatch`

**対象: render.rs 行 1152–1153** — `dispatch_fragment` の block+para パスにある `use_run_tagging=true` アーム。

`padding` 付きの `<p>` は `needs_block_wrapper()=true` を引き起こし、同じ `node_id` に `block_styles[p_id]` と `paragraphs[p_id]` の両方を作成する。タグ付きモード + リンクラン + セマンティックノード (`PdfTag::P`) により `use_run_tagging=true` となり、`try_start_tagged` の代わりに `canvas.link_run_node_id` がセットされるパスを通る。

### 2. `tagged_multicol_spanning_text_with_link_uses_run_tagging_in_paint_slices`

**対象: render.rs 行 1374–1380** — `paint_multicol_paragraph_slices` 内の `use_run_tagging=true` アーム。

既存の `tagged_pdf_link_in_multicol_produces_link_struct_element` テストは短いテキストを使っているため1カラムに収まり、paragraph slices が作られず `paint_multicol_paragraph_slices` がタグ付きモードで呼ばれない。このテストは狭いコンテナ (160px 幅) と長いテキストを使い、実際に複数カラムへのスパンを保証する。

### 3. `opacity_inline_root_with_pseudo_image_reaches_para_for_block_in_draw_under_opacity`

**対象: render.rs 行 2295–2321** — `draw_under_opacity` の else ブランチにある `if let Some(p) = para_for_block` パス。

opacity + visual style を持つ `<p>` はインライン root (`paragraphs[p_id]`) とスタイル付きブロック (`block_styles[p_id]`) を兼ねる。`::before` 擬似要素の画像が `opacity_descendants` に独立エントリとして登録され、`draw_under_opacity` が `p_id` で呼び出される。内部で `para_for_block = Some` となり、未カバーのブランチに到達する。タグ付きモード + リンクにより `use_run_tagging=true` のサブパス (行 2299–2301) も合わせてカバーする。

---

## 確認事項

- `cargo test -p fulgur --lib`: 2162 tests passed ✓
- `cargo clippy -- -D warnings`: clean ✓
- `cargo fmt --check`: clean ✓
- カバレッジ再測定: render.rs 96.05% → 98.51% (+2.46 pp) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ayC4T9WUYxCdppU3Zhwrc

---
_Generated by [Claude Code](https://claude.ai/code/session_016ayC4T9WUYxCdppU3Zhwrc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **テスト**
  - タグ付きPDFのリンク処理を検証するエンドツーエンドテストを追加しました。
  - 複数カラムにまたがる段落スライスのPDF生成を検証するテストを追加しました。
  - 透明度付き段落と疑似要素画像の描画完了を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->